### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,13 @@ mvn clean package -Dmaven.test.skip=true docker:build
 or
 
 ```
-docker pull apacherocketmq/rocketmq-console
+docker pull apacherocketmq/rocketmq-console:2.0.0
 ```
 
 > currently the newest available docker image is apacherocketmq/rocketmq-console:2.0.0
 
 
 * run it (change namesvrAddr and port yourself)
-
-```
-docker run -e "JAVA_OPTS=-Drocketmq.namesrv.addr=127.0.0.1:9876 -Dcom.rocketmq.sendMessageWithVIPChannel=false" -p 8080:8080 -t apacherocketmq/rocketmq-console
-```
-
-or 
 
 ```
 docker run -e "JAVA_OPTS=-Drocketmq.namesrv.addr=127.0.0.1:9876 -Dcom.rocketmq.sendMessageWithVIPChannel=false" -p 8080:8080 -t apacherocketmq/rocketmq-console:2.0.0

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ docker pull apacherocketmq/rocketmq-console
 * run it (change namesvrAddr and port yourself)
 
 ```
-docker run -e "JAVA_OPTS=-Drocketmq.namesrv.addr=127.0.0.1:9876 -Dcom.rocketmq.sendMessageWithVIPChannel=false" -p 8080:8080 -t apacherocketmq/rocketmq-console-ng
+docker run -e "JAVA_OPTS=-Drocketmq.namesrv.addr=127.0.0.1:9876 -Dcom.rocketmq.sendMessageWithVIPChannel=false" -p 8080:8080 -t apacherocketmq/rocketmq-console
 ```
 
 or 
 
 ```
-docker run -e "JAVA_OPTS=-Drocketmq.namesrv.addr=127.0.0.1:9876 -Dcom.rocketmq.sendMessageWithVIPChannel=false" -p 8080:8080 -t apacherocketmq/rocketmq-console-ng:2.0.0
+docker run -e "JAVA_OPTS=-Drocketmq.namesrv.addr=127.0.0.1:9876 -Dcom.rocketmq.sendMessageWithVIPChannel=false" -p 8080:8080 -t apacherocketmq/rocketmq-console:2.0.0
 ```
 
 ### Without Docker


### PR DESCRIPTION
fixed small typo error

## What is the purpose of the change

fixed small type error

## Brief changelog
1. change "apacherocketmq/rocketmq-console-ng"  to "apacherocketmq/rocketmq-console" in README.md;
2. change "apacherocketmq/rocketmq-console-ng:2.0.0" to "apacherocketmq/rocketmq-console:2.0.0" in README.md;

## Verifying this change
Have checked the correct image name in docker hub (https://hub.docker.com/r/apacherocketmq/rocketmq-console)


Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
