### PR TITLE
[ISSUE #58]Supports adding namesrvAddr cluster management

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/controller/OpsController.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/controller/OpsController.java
@@ -16,7 +16,9 @@
  */
 package org.apache.rocketmq.dashboard.controller;
 
+import com.google.common.base.Preconditions;
 import javax.annotation.Resource;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.rocketmq.dashboard.permisssion.Permission;
 import org.apache.rocketmq.dashboard.service.OpsService;
 import org.springframework.stereotype.Controller;
@@ -46,6 +48,15 @@ public class OpsController {
         return true;
     }
 
+    @RequestMapping(value = "/addNameSvrAddr.do", method = RequestMethod.POST)
+    @ResponseBody
+    public Object addNameSvrAddr(@RequestParam String newNamesrvAddr) {
+        Preconditions.checkArgument(StringUtils.isNotEmpty(newNamesrvAddr),
+            "namesrvAddr can not be blank");
+        opsService.addNameSvrAddr(newNamesrvAddr);
+        return true;
+    }
+
     @RequestMapping(value = "/updateIsVIPChannel.do", method = RequestMethod.POST)
     @ResponseBody
     public Object updateIsVIPChannel(@RequestParam String useVIPChannel) {
@@ -53,13 +64,11 @@ public class OpsController {
         return true;
     }
 
-
     @RequestMapping(value = "/rocketMqStatus.query", method = RequestMethod.GET)
     @ResponseBody
     public Object clusterStatus() {
         return opsService.rocketMqStatusCheck();
     }
-
 
     @RequestMapping(value = "/updateUseTLS.do", method = RequestMethod.POST)
     @ResponseBody

--- a/src/main/java/org/apache/rocketmq/dashboard/service/OpsService.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/OpsService.java
@@ -31,4 +31,6 @@ public interface OpsService {
     boolean updateIsVIPChannel(String useVIPChannel);
 
     boolean updateUseTLS(boolean useTLS);
+
+    void addNameSvrAddr(String namesrvAddr);
 }

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/OpsServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/OpsServiceImpl.java
@@ -73,7 +73,8 @@ public class OpsServiceImpl extends AbstractCommonService implements OpsService 
         return checkResultMap;
     }
 
-    @Override public boolean updateIsVIPChannel(String useVIPChannel) {
+    @Override
+    public boolean updateIsVIPChannel(String useVIPChannel) {
         configure.setIsVIPChannel(useVIPChannel);
         mqAdminExtPool.clear();
         return true;
@@ -84,5 +85,14 @@ public class OpsServiceImpl extends AbstractCommonService implements OpsService 
         configure.setUseTLS(useTLS);
         mqAdminExtPool.clear();
         return true;
+    }
+
+    @Override
+    public void addNameSvrAddr(String namesrvAddr) {
+        List<String> namesrvAddrs = configure.getNamesrvAddrs();
+        if (namesrvAddrs != null && !namesrvAddrs.contains(namesrvAddr)) {
+            namesrvAddrs.add(namesrvAddr);
+        }
+        configure.setNamesrvAddrs(namesrvAddrs);
     }
 }

--- a/src/main/resources/static/src/ops.js
+++ b/src/main/resources/static/src/ops.js
@@ -22,6 +22,7 @@ app.controller('opsController', ['$scope', '$location', '$http', 'Notification',
     $scope.userRole = $window.sessionStorage.getItem("userrole");
     $scope.writeOperationEnabled =  $scope.userRole == null ? true : ($scope.userRole == 1 ? true : false);
     $scope.inputReadonly = !$scope.writeOperationEnabled;
+    $scope.newNamesrvAddr = "";
     $http({
         method: "GET",
         url: "ops/homePage.query"
@@ -53,6 +54,26 @@ app.controller('opsController', ['$scope', '$location', '$http', 'Notification',
             }
         });
     };
+
+    $scope.addNameSvrAddr = function () {
+        $http({
+            method: "POST",
+            url: "ops/addNameSvrAddr.do",
+            params: {newNamesrvAddr: $scope.newNamesrvAddr}
+        }).success(function (resp) {
+            if (resp.status == 0) {
+                if ($scope.namesvrAddrList.indexOf($scope.newNamesrvAddr) == -1) {
+                    $scope.namesvrAddrList.push($scope.newNamesrvAddr);
+                }
+                $("#namesrvAddr").val("");
+                $scope.newNamesrvAddr = "";
+                Notification.info({message: "SUCCESS", delay: 2000});
+            } else {
+                Notification.error({message: resp.errMsg, delay: 2000});
+            }
+        });
+    };
+
     $scope.updateIsVIPChannel = function () {
         $http({
             method: "POST",

--- a/src/main/resources/static/view/pages/ops.html
+++ b/src/main/resources/static/view/pages/ops.html
@@ -28,6 +28,15 @@
                     ng-click="updateNameSvrAddr()">{{'UPDATE' | translate}}
             </button>
         </div>
+        <form class="form-inline pull-left" style="margin-left: 20px" ng-show="{{writeOperationEnabled}}">
+            <div class="form-group" style="margin: 0">
+                <label for="namesrvAddr">NamesrvAddr:</label>
+                <input id="namesrvAddr" class="form-control" style="width: 300px; margin: 0 10px 0 10px" type="text" ng-model="newNamesrvAddr" required/>
+                <button class="btn btn-raised btn-sm btn-primary" type="button"
+                        ng-click="addNameSvrAddr()"> {{ 'ADD' | translate}}
+                </button>
+            </div>
+        </form>
         <br/>
         <br/>
         <h2 class="md-title">IsUseVIPChannel</h2>

--- a/src/test/java/org/apache/rocketmq/dashboard/controller/BaseControllerTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/controller/BaseControllerTest.java
@@ -63,7 +63,7 @@ public abstract class BaseControllerTest extends BaseTest {
         when(configure.getAccessKey()).thenReturn("12345678");
         when(configure.getSecretKey()).thenReturn("rocketmq");
         when(configure.getNamesrvAddr()).thenReturn("127.0.0.1:9876");
-        when(configure.getNamesrvAddrs()).thenReturn(Lists.asList("127.0.0.1:9876", new String[] {"127.0.0.2:9876"}));
+        when(configure.getNamesrvAddrs()).thenReturn(Lists.newArrayList("127.0.0.1:9876", "127.0.0.2:9876"));
         when(configure.isACLEnabled()).thenReturn(true);
         when(configure.isUseTLS()).thenReturn(false);
     }

--- a/src/test/java/org/apache/rocketmq/dashboard/controller/OpsControllerTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/controller/OpsControllerTest.java
@@ -35,6 +35,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -81,6 +82,20 @@ public class OpsControllerTest extends BaseControllerTest {
         perform.andExpect(status().isOk())
             .andExpect(jsonPath("$.data").value(true));
         Assert.assertEquals(configure.getNamesrvAddr(), "127.0.0.1:9876");
+    }
+
+    @Test
+    public void testAddNameSvrAddr() throws Exception {
+        final String url = "/ops/addNameSvrAddr.do";
+        {
+            doNothing().when(configure).setNamesrvAddrs(any());
+        }
+        requestBuilder = MockMvcRequestBuilders.post(url);
+        requestBuilder.param("newNamesrvAddr", "127.0.0.3:9876");
+        perform = mockMvc.perform(requestBuilder);
+        perform.andExpect(status().isOk())
+            .andExpect(jsonPath("$.data").value(true));
+        Assert.assertEquals(configure.getNamesrvAddrs().size(), 3);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

#58 
The Dashboard platform supports the management of multiple clusters, which can be added dynamically on the page in addition to the namesrvAddr list configured at application startup
![image](https://user-images.githubusercontent.com/18254437/148713719-a12df8df-6d9e-4007-9644-e8e80f7c65a9.png)


## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
