### PR TITLE
feat: add support for Casdoor authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,10 +94,10 @@
         <rocketmq.version>4.9.3</rocketmq.version>
         <surefire.version>2.19.1</surefire.version>
         <aspectj.version>1.9.6</aspectj.version>
-        <lombok.version>1.18.12</lombok.version>
+        <lombok.version>1.18.20</lombok.version>
         <main.basedir>${basedir}/../..</main.basedir>
         <docker.image.prefix>apacherocketmq</docker.image.prefix>
-        <spring.boot.version>2.6.0</spring.boot.version>
+        <spring.boot.version>2.5.2</spring.boot.version>
         <mockito-inline.version>3.3.3</mockito-inline.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <commons-pool2.version>2.4.3</commons-pool2.version>
@@ -274,7 +274,11 @@
             <artifactId>snakeyaml</artifactId>
             <version>${snakeyaml.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.casbin</groupId>
+            <artifactId>casdoor-spring-boot-starter</artifactId>
+            <version>1.4.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/org/apache/rocketmq/dashboard/controller/LoginController.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/controller/LoginController.java
@@ -94,7 +94,7 @@ public class LoginController {
     @RequestMapping(value = "/casdoor-login-url", method = RequestMethod.POST)
     @ResponseBody
     public JsonResult<String> getCasdoorUrl(HttpServletRequest request,
-                                            HttpServletResponse response){
+                                            HttpServletResponse response) {
         String origin = request.getParameter("origin");
         return new JsonResult<>(casdoorAuthService.getSigninUrl(origin));
     }
@@ -102,13 +102,13 @@ public class LoginController {
     @RequestMapping(value = "/casdoor-login", method = RequestMethod.POST)
     @ResponseBody
     public Object CasdoorLogin(HttpServletRequest request,
-                                            HttpServletResponse response){
+                                            HttpServletResponse response) {
         String code = request.getParameter("code");
         String state = request.getParameter("state");
         String token = casdoorAuthService.getOAuthToken(code, state);
         CasdoorUser casdoorUser = casdoorAuthService.parseJwtToken(token);
         int type = 0;
-        if(casdoorUser.isAdmin()){
+        if (casdoorUser.isAdmin()) {
             type = 1;
         }
         User user = new User(casdoorUser.getName(),null,type);

--- a/src/main/java/org/apache/rocketmq/dashboard/controller/LoginController.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/controller/LoginController.java
@@ -25,6 +25,8 @@ import org.apache.rocketmq.dashboard.model.UserInfo;
 import org.apache.rocketmq.dashboard.service.UserService;
 import org.apache.rocketmq.dashboard.support.JsonResult;
 import org.apache.rocketmq.dashboard.util.WebUtil;
+import org.casbin.casdoor.entity.CasdoorUser;
+import org.casbin.casdoor.service.CasdoorAuthService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,6 +51,9 @@ public class LoginController {
 
     @Autowired
     private UserService userService;
+
+    @Autowired
+    private CasdoorAuthService casdoorAuthService;
 
     @Value("${server.servlet.context-path:/}")
     private String contextPath;
@@ -84,6 +89,35 @@ public class LoginController {
             LoginResult result = new LoginResult(username, user.getType(), contextPath);
             return result;
         }
+    }
+
+    @RequestMapping(value = "/casdoor-login-url", method = RequestMethod.POST)
+    @ResponseBody
+    public JsonResult<String> getCasdoorUrl(HttpServletRequest request,
+                                            HttpServletResponse response){
+        String origin = request.getParameter("origin");
+        return new JsonResult<>(casdoorAuthService.getSigninUrl(origin));
+    }
+
+    @RequestMapping(value = "/casdoor-login", method = RequestMethod.POST)
+    @ResponseBody
+    public Object CasdoorLogin(HttpServletRequest request,
+                                            HttpServletResponse response){
+        String code = request.getParameter("code");
+        String state = request.getParameter("state");
+        String token = casdoorAuthService.getOAuthToken(code, state);
+        CasdoorUser casdoorUser = casdoorAuthService.parseJwtToken(token);
+        int type = 0;
+        if(casdoorUser.isAdmin()){
+            type = 1;
+        }
+        User user = new User(casdoorUser.getName(),null,type);
+        UserInfo userInfo = WebUtil.setLoginInfo(request, response, user);
+        WebUtil.setSessionValue(request, WebUtil.USER_INFO, userInfo);
+        WebUtil.setSessionValue(request, WebUtil.USER_NAME, user.getName());
+        userInfo.setSessionId(WebUtil.getSessionId(request));
+        LoginResult result = new LoginResult(user.getName(), user.getType(), contextPath);
+        return result;
     }
 
     @RequestMapping(value = "/logout.do", method = RequestMethod.POST)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,3 +67,40 @@ threadpool:
     maxSize: 10
     keepAliveTime: 3000
     queueSize: 5000
+
+casdoor:
+  endpoint: "http://localhost:7001"
+  client-id: "df80fe5fcb9e0209545c"
+  client-secret: "08cfb1fbd2feb31a4ee0af68b12f2d282e0221e5"
+  organization-name: "mq"
+  application-name: "mq"
+  certificate: "\
+-----BEGIN CERTIFICATE-----\n\
+MIIE+TCCAuGgAwIBAgIDAeJAMA0GCSqGSIb3DQEBCwUAMDYxHTAbBgNVBAoTFENh\n\
+c2Rvb3IgT3JnYW5pemF0aW9uMRUwEwYDVQQDEwxDYXNkb29yIENlcnQwHhcNMjEx\n\
+MDE1MDgxMTUyWhcNNDExMDE1MDgxMTUyWjA2MR0wGwYDVQQKExRDYXNkb29yIE9y\n\
+Z2FuaXphdGlvbjEVMBMGA1UEAxMMQ2FzZG9vciBDZXJ0MIICIjANBgkqhkiG9w0B\n\
+AQEFAAOCAg8AMIICCgKCAgEAsInpb5E1/ym0f1RfSDSSE8IR7y+lw+RJjI74e5ej\n\
+rq4b8zMYk7HeHCyZr/hmNEwEVXnhXu1P0mBeQ5ypp/QGo8vgEmjAETNmzkI1NjOQ\n\
+CjCYwUrasO/f/MnI1C0j13vx6mV1kHZjSrKsMhYY1vaxTEP3+VB8Hjg3MHFWrb07\n\
+uvFMCJe5W8+0rKErZCKTR8+9VB3janeBz//zQePFVh79bFZate/hLirPK0Go9P1g\n\
+OvwIoC1A3sarHTP4Qm/LQRt0rHqZFybdySpyWAQvhNaDFE7mTstRSBb/wUjNCUBD\n\
+PTSLVjC04WllSf6Nkfx0Z7KvmbPstSj+btvcqsvRAGtvdsB9h62Kptjs1Yn7GAuo\n\
+I3qt/4zoKbiURYxkQJXIvwCQsEftUuk5ew5zuPSlDRLoLByQTLbx0JqLAFNfW3g/\n\
+pzSDjgd/60d6HTmvbZni4SmjdyFhXCDb1Kn7N+xTojnfaNkwep2REV+RMc0fx4Gu\n\
+hRsnLsmkmUDeyIZ9aBL9oj11YEQfM2JZEq+RVtUx+wB4y8K/tD1bcY+IfnG5rBpw\n\
+IDpS262boq4SRSvb3Z7bB0w4ZxvOfJ/1VLoRftjPbLIf0bhfr/AeZMHpIKOXvfz4\n\
+yE+hqzi68wdF0VR9xYc/RbSAf7323OsjYnjjEgInUtRohnRgCpjIk/Mt2Kt84Kb0\n\
+wn8CAwEAAaMQMA4wDAYDVR0TAQH/BAIwADANBgkqhkiG9w0BAQsFAAOCAgEAn2lf\n\
+DKkLX+F1vKRO/5gJ+Plr8P5NKuQkmwH97b8CS2gS1phDyNgIc4/LSdzuf4Awe6ve\n\
+C06lVdWSIis8UPUPdjmT2uMPSNjwLxG3QsrimMURNwFlLTfRem/heJe0Zgur9J1M\n\
+8haawdSdJjH2RgmFoDeE2r8NVRfhbR8KnCO1ddTJKuS1N0/irHz21W4jt4rxzCvl\n\
+2nR42Fybap3O/g2JXMhNNROwZmNjgpsF7XVENCSuFO1jTywLaqjuXCg54IL7XVLG\n\
+omKNNNcc8h1FCeKj/nnbGMhodnFWKDTsJcbNmcOPNHo6ixzqMy/Hqc+mWYv7maAG\n\
+Jtevs3qgMZ8F9Qzr3HpUc6R3ZYYWDY/xxPisuKftOPZgtH979XC4mdf0WPnOBLqL\n\
+2DJ1zaBmjiGJolvb7XNVKcUfDXYw85ZTZQ5b9clI4e+6bmyWqQItlwt+Ati/uFEV\n\
+XzCj70B4lALX6xau1kLEpV9O1GERizYRz5P9NJNA7KoO5AVMp9w0DQTkt+LbXnZE\n\
+HHnWKy8xHQKZF9sR7YBPGLs/Ac6tviv5Ua15OgJ/8dLRZ/veyFfGo2yZsI+hKVU5\n\
+nCCJHBcAyFnm1hdvdwEdH33jDBjNB6ciotJZrf/3VYaIWSalADosHAgMWfXuWP+h\n\
+8XKXmzlxuHbTMQYtZPDgspS5aK+S4Q9wb8RRAYo=\n\
+-----END CERTIFICATE-----"

--- a/src/main/resources/static/src/login.js
+++ b/src/main/resources/static/src/login.js
@@ -42,4 +42,36 @@ app.controller('loginController', ['$scope', '$location', '$http', 'Notification
             }
         });
     };
+    $scope.toCasdoorLogin = function () {
+        $http({
+            method: "POST",
+            url: "login/casdoor-login-url",
+            params: {origin: window.location.origin}
+        }).success(function (resp){
+            window.location.href=resp.data;
+        })
+    };
+    $scope.casdoorLogin = function () {
+        const url = window.document.location.href
+        const u = new URL(url)
+        let code = u.searchParams.get('code')
+        let state = u.searchParams.get('state')
+        if(code != null && state != null){
+            $http({
+                method: "POST",
+                url: "login/casdoor-login",
+                params: {code: code,state: state}
+            }).success(function (resp){
+                if (resp.status == 0) {
+                    Notification.info({message: 'Login successful, redirect now', delay: 2000});
+                    $window.sessionStorage.setItem("username", resp.data.loginUserName);
+                    $window.sessionStorage.setItem("userrole", resp.data.loginUserRole);
+                    window.location = resp.data.contextPath;
+                    initFlag = false;
+                } else {
+                    Notification.error({message: resp.errMsg, delay: 2000});
+                }
+            })
+        }
+    }
 }]);

--- a/src/main/resources/static/view/pages/login.html
+++ b/src/main/resources/static/view/pages/login.html
@@ -46,8 +46,9 @@
                 </div>
             </div>
             </form>
-            <div class="modal-footer">
+            <div class="modal-footer" ng-controller="casdoorLogin">
                 <button class="btn btn-raised btn-sm btn-primary" type="button" ng-click="login()">{{'LOGIN' | translate}}</button>
+                <button class="btn btn-raised btn-sm btn-primary" type="button" ng-click="toCasdoorLogin()">{{'LoginWithCasdoor' | translate}}</button>
             </div>
         </div>
     </div>
@@ -57,3 +58,4 @@ $(function(){
 	 //$("#loginModal").modal("hide");
 })
 </script>
+


### PR DESCRIPTION
## What is the purpose of the change

add support for Casdoor authentication

Use [Casdoor](https://github.com/casdoor/casdoor) for auth.

Features:

Support OIDC, OAuth 2.0, SAML, LDAP
With [Casbin](https://casbin.org/) based authorization management, Casdoor supports ACL, RBAC, ABAC, RESTful accessing control models
Front-end and back-end separate architecture, Casdoor supports high concurrency, provides web-based managing UI and have mature solution for springboot project https://casdoor.org/docs/integration/spring-boot
Casdoor supports Github, Google, QQ, WeChat third-party applications login, and support the extension of third-party login with plugins.
Phone verification code, email verification code and forget password features.
Accessing logs auditing and recording.
Casdoor supports integration with existing systems using db sync method, users can transition to Casdoor smoothly.
Casdoor supports mainstream databases: MySQL, PostgreSQL, SQL Server etc, and support the extension of new database with plugins.
