### PR TITLE
[ISSUE #148] Throwables.propagate is deprecated for making runtime exception more verbose

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/AbstractCommonService.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/AbstractCommonService.java
@@ -38,7 +38,8 @@ public abstract class AbstractCommonService {
                 }
             }
             catch (Exception e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
         if (CollectionUtils.isNotEmpty(brokerNameList)) {

--- a/src/main/java/org/apache/rocketmq/dashboard/service/client/MQAdminExtImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/client/MQAdminExtImpl.java
@@ -140,7 +140,7 @@ public class MQAdminExtImpl implements MQAdminExt {
     }
 
     @Override
-    public SubscriptionGroupConfig examineSubscriptionGroupConfig(String addr, String group) {
+    public SubscriptionGroupConfig examineSubscriptionGroupConfig(String addr, String group) throws MQBrokerException {
         RemotingClient remotingClient = MQAdminInstance.threadLocalRemotingClient();
         RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_ALL_SUBSCRIPTIONGROUP_CONFIG, null);
         RemotingCommand response = null;
@@ -148,7 +148,8 @@ public class MQAdminExtImpl implements MQAdminExt {
             response = remotingClient.invokeSync(addr, request, 3000);
         }
         catch (Exception err) {
-            throw Throwables.propagate(err);
+            Throwables.throwIfUnchecked(err);
+            throw new RuntimeException(err);
         }
         assert response != null;
         switch (response.getCode()) {
@@ -157,12 +158,12 @@ public class MQAdminExtImpl implements MQAdminExt {
                 return subscriptionGroupWrapper.getSubscriptionGroupTable().get(group);
             }
             default:
-                throw Throwables.propagate(new MQBrokerException(response.getCode(), response.getRemark()));
+                throw new MQBrokerException(response.getCode(), response.getRemark());
         }
     }
 
     @Override
-    public TopicConfig examineTopicConfig(String addr, String topic) {
+    public TopicConfig examineTopicConfig(String addr, String topic) throws MQBrokerException {
         RemotingClient remotingClient = MQAdminInstance.threadLocalRemotingClient();
         RemotingCommand request = RemotingCommand.createRequestCommand(RequestCode.GET_ALL_TOPIC_CONFIG, null);
         RemotingCommand response = null;
@@ -170,7 +171,8 @@ public class MQAdminExtImpl implements MQAdminExt {
             response = remotingClient.invokeSync(addr, request, 3000);
         }
         catch (Exception err) {
-            throw Throwables.propagate(err);
+            Throwables.throwIfUnchecked(err);
+            throw new RuntimeException(err);
         }
         switch (response.getCode()) {
             case ResponseCode.SUCCESS: {
@@ -178,7 +180,7 @@ public class MQAdminExtImpl implements MQAdminExt {
                 return topicConfigSerializeWrapper.getTopicConfigTable().get(topic);
             }
             default:
-                throw Throwables.propagate(new MQBrokerException(response.getCode(), response.getRemark()));
+                throw new MQBrokerException(response.getCode(), response.getRemark());
         }
     }
 

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/AclServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/AclServiceImpl.java
@@ -68,7 +68,8 @@ public class AclServiceImpl extends AbstractCommonService implements AclService 
             }
         } catch (Exception e) {
             log.error("getAclConfig error.", e);
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         AclConfig aclConfig = new AclConfig();
         aclConfig.setGlobalWhiteAddrs(Collections.emptyList());
@@ -100,7 +101,8 @@ public class AclServiceImpl extends AbstractCommonService implements AclService 
                 mqAdminExt.createAndUpdatePlainAccessConfig(addr, config);
             }
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
 
     }
@@ -116,7 +118,8 @@ public class AclServiceImpl extends AbstractCommonService implements AclService 
                 log.info("Delete acl [{}] from broker [{}] complete", config.getAccessKey(), addr);
             }
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -142,7 +145,8 @@ public class AclServiceImpl extends AbstractCommonService implements AclService 
                 mqAdminExt.createAndUpdatePlainAccessConfig(addr, config);
             }
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -174,7 +178,8 @@ public class AclServiceImpl extends AbstractCommonService implements AclService 
                 }
             }
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -206,7 +211,8 @@ public class AclServiceImpl extends AbstractCommonService implements AclService 
                 }
             }
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -249,7 +255,8 @@ public class AclServiceImpl extends AbstractCommonService implements AclService 
                 }
             }
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
 
     }
@@ -261,7 +268,8 @@ public class AclServiceImpl extends AbstractCommonService implements AclService 
                 mqAdminExt.createAndUpdatePlainAccessConfig(addr, config);
             }
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -281,7 +289,8 @@ public class AclServiceImpl extends AbstractCommonService implements AclService 
                 mqAdminExt.updateGlobalWhiteAddrConfig(addr, StringUtils.join(aclConfig.getGlobalWhiteAddrs(), ","));
             }
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -297,7 +306,8 @@ public class AclServiceImpl extends AbstractCommonService implements AclService 
                 mqAdminExt.updateGlobalWhiteAddrConfig(addr, StringUtils.join(aclConfig.getGlobalWhiteAddrs(), ","));
             }
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -311,7 +321,8 @@ public class AclServiceImpl extends AbstractCommonService implements AclService 
                 mqAdminExt.updateGlobalWhiteAddrConfig(addr, StringUtils.join(whiteList, ","));
             }
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/ClusterServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/ClusterServiceImpl.java
@@ -59,7 +59,8 @@ public class ClusterServiceImpl implements ClusterService {
             return resultMap;
         }
         catch (Exception err) {
-            throw Throwables.propagate(err);
+            Throwables.throwIfUnchecked(err);
+            throw new RuntimeException(err);
         }
     }
 
@@ -70,7 +71,8 @@ public class ClusterServiceImpl implements ClusterService {
             return mqAdminExt.getBrokerConfig(brokerAddr);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
@@ -73,8 +73,6 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Service;
 
-import static com.google.common.base.Throwables.propagate;
-
 @Service
 public class ConsumerServiceImpl extends AbstractCommonService implements ConsumerService, InitializingBean, DisposableBean {
     private Logger logger = LoggerFactory.getLogger(ConsumerServiceImpl.class);
@@ -131,7 +129,8 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             }
         }
         catch (Exception err) {
-            throw Throwables.propagate(err);
+            Throwables.throwIfUnchecked(err);
+            throw new RuntimeException(err);
         }
         List<GroupConsumeInfo> groupConsumeInfoList = Collections.synchronizedList(Lists.newArrayList());
         CountDownLatch countDownLatch = new CountDownLatch(consumerGroupSet.size());
@@ -218,7 +217,8 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             consumeStats = mqAdminExt.examineConsumeStats(groupName, topic);
         }
         catch (Exception e) {
-            throw propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         List<MessageQueue> mqList = Lists.newArrayList(Iterables.filter(consumeStats.getOffsetTable().keySet(), new Predicate<MessageQueue>() {
             @Override
@@ -278,7 +278,8 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             return group2ConsumerInfoMap;
         }
         catch (Exception e) {
-            throw propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -341,7 +342,8 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             }
         }
         catch (Exception e) {
-            throw propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         return consumerConfigInfoList;
     }
@@ -366,7 +368,8 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             }
         }
         catch (Exception e) {
-            throw propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         return true;
     }
@@ -393,7 +396,8 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             }
         }
         catch (Exception err) {
-            throw Throwables.propagate(err);
+            Throwables.throwIfUnchecked(err);
+            throw new RuntimeException(err);
         }
         return true;
     }
@@ -408,7 +412,8 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             }
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         return brokerNameSet;
 
@@ -420,7 +425,8 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             return mqAdminExt.examineConsumerConnectionInfo(consumerGroup);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -430,7 +436,8 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             return mqAdminExt.getConsumerRunningInfo(consumerGroup, clientId, jstack);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/DashboardCollectServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/DashboardCollectServiceImpl.java
@@ -107,7 +107,8 @@ public class DashboardCollectServiceImpl implements DashboardCollectService {
             strings = Files.readLines(file, Charsets.UTF_8);
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         StringBuffer sb = new StringBuffer();
         for (String string : strings) {

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/DlqMessageServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/DlqMessageServiceImpl.java
@@ -62,10 +62,12 @@ public class DlqMessageServiceImpl implements DlqMessageService {
                 && e.getResponseCode() == ResponseCode.TOPIC_NOT_EXIST) {
                 return new MessagePage(new PageImpl<>(messageViews, page, 0), query.getTaskId());
             } else {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         return messageService.queryMessageByPage(query);
     }

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImpl.java
@@ -115,7 +115,8 @@ public class MessageServiceImpl implements MessageService {
             if (err instanceof MQClientException) {
                 throw new ServiceException(-1, ((MQClientException) err).getErrorMessage());
             }
-            throw Throwables.propagate(err);
+            Throwables.throwIfUnchecked(err);
+            throw new RuntimeException(err);
         }
     }
 
@@ -185,7 +186,8 @@ public class MessageServiceImpl implements MessageService {
             });
             return messageViewList;
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         } finally {
             consumer.shutdown();
         }
@@ -209,7 +211,8 @@ public class MessageServiceImpl implements MessageService {
             try {
                 return mqAdminExt.consumeMessageDirectly(consumerGroup, clientId, topic, msgId);
             } catch (Exception e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -223,7 +226,8 @@ public class MessageServiceImpl implements MessageService {
                 return mqAdminExt.consumeMessageDirectly(consumerGroup, connection.getClientId(), topic, msgId);
             }
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         throw new IllegalStateException("NO CONSUMER");
 
@@ -388,7 +392,8 @@ public class MessageServiceImpl implements MessageService {
             PageImpl<MessageView> page = new PageImpl<>(messageViews, query.page(), total);
             return new MessagePageTask(page, queueOffsetInfos);
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         } finally {
             consumer.shutdown();
         }
@@ -455,7 +460,8 @@ public class MessageServiceImpl implements MessageService {
             }
             return new PageImpl<>(messageViews, query.page(), total);
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         } finally {
             consumer.shutdown();
         }

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/MonitorServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/MonitorServiceImpl.java
@@ -82,7 +82,8 @@ public class MonitorServiceImpl implements MonitorService {
             MixAll.string2File(dataStr, path);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/ProducerServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/ProducerServiceImpl.java
@@ -35,7 +35,8 @@ public class ProducerServiceImpl implements ProducerService {
             return mqAdminExt.examineProducerConnectionInfo(producerGroup, topic);
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/TopicServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/TopicServiceImpl.java
@@ -84,7 +84,8 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
             allTopics.getTopicList().addAll(topics);
             return allTopics;
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -93,7 +94,8 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
         try {
             return mqAdminExt.examineTopicStats(topic);
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -102,7 +104,8 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
         try {
             return mqAdminExt.examineTopicRouteInfo(topic);
         } catch (Exception ex) {
-            throw Throwables.propagate(ex);
+            Throwables.throwIfUnchecked(ex);
+            throw new RuntimeException(ex);
         }
     }
 
@@ -111,7 +114,8 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
         try {
             return mqAdminExt.queryTopicConsumeByWho(topic);
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -126,7 +130,8 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
                 mqAdminExt.createAndUpdateTopicConfig(clusterInfo.getBrokerAddrTable().get(brokerName).selectBrokerAddr(), topicConfig);
             }
         } catch (Exception err) {
-            throw Throwables.propagate(err);
+            Throwables.throwIfUnchecked(err);
+            throw new RuntimeException(err);
         }
     }
 
@@ -137,7 +142,8 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
             clusterInfo = mqAdminExt.examineBrokerClusterInfo();
             return mqAdminExt.examineTopicConfig(clusterInfo.getBrokerAddrTable().get(brokerName).selectBrokerAddr(), topic);
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -170,7 +176,8 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
             }
             mqAdminExt.deleteTopicInNameServer(nameServerSet, topic);
         } catch (Exception err) {
-            throw Throwables.propagate(err);
+            Throwables.throwIfUnchecked(err);
+            throw new RuntimeException(err);
         }
         return true;
     }
@@ -181,7 +188,8 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
         try {
             clusterInfo = mqAdminExt.examineBrokerClusterInfo();
         } catch (Exception err) {
-            throw Throwables.propagate(err);
+            Throwables.throwIfUnchecked(err);
+            throw new RuntimeException(err);
         }
         for (String clusterName : clusterInfo.getClusterAddrTable().keySet()) {
             deleteTopic(topic, clusterName);
@@ -197,11 +205,13 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
             try {
                 clusterInfo = mqAdminExt.examineBrokerClusterInfo();
             } catch (Exception e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
             mqAdminExt.deleteTopicInBroker(Sets.newHashSet(clusterInfo.getBrokerAddrTable().get(brokerName).selectBrokerAddr()), topic);
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         return true;
     }
@@ -230,7 +240,8 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
             producer.start();
             return producer.getDefaultMQProducerImpl().getmQClientFactory().getMQClientAPIImpl().getSystemTopicList(20000L);
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         } finally {
             producer.shutdown();
         }
@@ -258,7 +269,8 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
             );
             return producer.send(msg);
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         } finally {
             waitSendTraceFinish(producer, sendTopicMessageRequest.isTraceEnabled());
             producer.shutdown();

--- a/src/main/java/org/apache/rocketmq/dashboard/task/CollectTaskRunnble.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/task/CollectTaskRunnble.java
@@ -93,7 +93,8 @@ public class CollectTaskRunnble implements Runnable {
             try {
                 list = dashboardCollectService.getTopicMap().get(topic);
             } catch (ExecutionException e) {
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
             if (null == list) {
                 list = Lists.newArrayList();

--- a/src/main/java/org/apache/rocketmq/dashboard/task/DashboardCollectTask.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/task/DashboardCollectTask.java
@@ -84,7 +84,8 @@ public class DashboardCollectTask {
             }
         }
         catch (Exception err) {
-            throw Throwables.propagate(err);
+            Throwables.throwIfUnchecked(err);
+            throw new RuntimeException(err);
         }
     }
 
@@ -128,7 +129,8 @@ public class DashboardCollectTask {
             log.debug("Broker Collected Data in memory = {}" + JsonUtil.obj2String(dashboardCollectService.getBrokerMap().asMap()));
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -144,10 +146,12 @@ public class DashboardCollectTask {
                 Thread.sleep(1000);
             }
             catch (InterruptedException e1) {
-                throw Throwables.propagate(e1);
+                Throwables.throwIfUnchecked(e1);
+                throw new RuntimeException(e1);
             }
             fetchBrokerRuntimeStats(brokerAddr, retryTime - 1);
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -197,7 +201,8 @@ public class DashboardCollectTask {
 
         }
         catch (IOException e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/test/java/org/apache/rocketmq/dashboard/testbase/RocketMQConsoleTestBase.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/testbase/RocketMQConsoleTestBase.java
@@ -78,7 +78,8 @@ public abstract class RocketMQConsoleTestBase {
                     }
                 }
             }
-            throw Throwables.propagate(exception);
+            Throwables.throwIfUnchecked(exception);
+            throw new RuntimeException(exception);
         }
     }
 
@@ -91,7 +92,8 @@ public abstract class RocketMQConsoleTestBase {
             producer.start();
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -137,7 +139,8 @@ public abstract class RocketMQConsoleTestBase {
             consumer.start();
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
…n more verbose

## What is the purpose of the change
#148 
**The Throwables.propagate() method has been deprecated in Guava version 21.0 because it can lead to confusion and make it difficult to track down the root cause of an exception.**

Code Changes from :-
`Throwables.propagate(e)`

code changes to:- 
`Throwables.throwIfUnchecked(e);`
  `throw new RuntimeException(e);`
