### PR TITLE
[ISSUE #209] make CID_DefaultHeartbeatSyncerTopic to be system group

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
@@ -121,6 +121,7 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
         SYSTEM_GROUP_SET.add(MixAll.CID_ONSAPI_PERMISSION_GROUP);
         SYSTEM_GROUP_SET.add(MixAll.CID_ONSAPI_OWNER_GROUP);
         SYSTEM_GROUP_SET.add(MixAll.CID_SYS_RMQ_TRANS);
+        SYSTEM_GROUP_SET.add("CID_DefaultHeartBeatSyncerTopic");
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

fix #209 

## Brief changelog
ProxyConifg中heartbeatSyncerTopic默认为“”，所以不直接读取proxyconfig.heartbeatSyncerTopic设置为系统group，而是
手动将默认消费组设置为系统Group

如果在proxyconfig中配置了group name则会识别为普通group