### PR TITLE
[ISSUE #218] support query consumer client form proxy

### DIFF
--- a/src/main/resources/static/src/consumer.js
+++ b/src/main/resources/static/src/consumer.js
@@ -267,7 +267,7 @@ module.controller('consumerController', ['$scope', 'ngDialog', '$http', 'Notific
         $http({
             method: "GET",
             url: "consumer/consumerConnection.query",
-            params: {consumerGroup: consumerGroupName, address: address}
+            params: {consumerGroup: consumerGroupName, address: localStorage.getItem('isV5') ? localStorage.getItem('proxyAddr') : address}
         }).success(function (resp) {
             if (resp.status == 0) {
                 console.log(resp);


### PR DESCRIPTION
## What is the purpose of the change

In rocketmq 5.x, broker don't have consumer channel info but proxy have, So the query addr should be proxy addr.

## Brief changelog

Support query consumer client form proxy.
