### PR TITLE
rocketmq.config.namesrvAddrs 默认设置为空

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ rocketmq:
     # if this value is empty,use env value rocketmq.config.namesrvAddr  NAMESRV_ADDR | now, default localhost:9876
     # configure multiple namesrv addresses to manage multiple different clusters
     namesrvAddrs:
-      - 127.0.0.1:9876
+#      - 127.0.0.1:9876
     #      - 127.0.0.2:9876
     #      - 10.151.47.32:9876;10.151.47.33:9876;10.151.47.34:9876
     #      - 10.151.47.30:9876


### PR DESCRIPTION
## What is the purpose of the change

rocketmq.config.namesrvAddrs默认值为127.0.0.1:9876,默认打出的jar包运行无法设置namesrv
