### PR TITLE
[ISSUE #399] Use AbstractFileStore.class for resource loading

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/AbstractFileStore.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/AbstractFileStore.java
@@ -34,7 +34,7 @@ public abstract class AbstractFileStore {
         filePath = configure.getRocketMqDashboardDataPath() + File.separator + fileName;
         if (!new File(filePath).exists()) {
             // Use the default path
-            InputStream inputStream = getClass().getResourceAsStream("/" + fileName);
+            InputStream inputStream = AbstractFileStore.class.getResourceAsStream("/" + fileName);
             if (inputStream == null) {
                 log.error(String.format("Can not found the file %s in Spring Boot jar", fileName));
                 System.exit(1);


### PR DESCRIPTION
## What is the purpose of the change

This PR makes resource loading in `AbstractFileStore` use an explicit class reference instead of `getClass()`.

The current code uses:

`getClass().getResourceAsStream("/" + fileName)`

Since `AbstractFileStore` is designed to be extended, this makes the lookup depend on the runtime subclass, which can introduce inheritance-related ambiguity and make the behavior less explicit for future maintenance.

Using `AbstractFileStore.class.getResourceAsStream(...)` makes the resource lookup context explicit and stable.

## Brief changelog

- Replace `getClass().getResourceAsStream("/" + fileName)` with `AbstractFileStore.class.getResourceAsStream("/" + fileName)` in `AbstractFileStore`

## Verifying this change

- Verified that the project still compiles after the change
- Verified by running `mvn test`