### PR TITLE
[ISSUE #411] Fix NPE when getAllSubscriptionGroup returns null

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
@@ -180,6 +180,10 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             ClusterInfo clusterInfo = clusterInfoService.get();
             for (BrokerData brokerData : clusterInfo.getBrokerAddrTable().values()) {
                 subscriptionGroupWrapper = mqAdminExt.getAllSubscriptionGroup(brokerData.selectBrokerAddr(), 30000L);
+                if (subscriptionGroupWrapper == null) {
+                    logger.warn("getAllSubscriptionGroup returned null for broker: {}", brokerData.selectBrokerAddr());
+                    continue;
+                }
                 for (String groupName : subscriptionGroupWrapper.getSubscriptionGroupTable().keySet()) {
                     if (!consumerGroupMap.containsKey(groupName)) {
                         consumerGroupMap.putIfAbsent(groupName, new ArrayList<>());
@@ -194,7 +198,7 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             throw new RuntimeException(err);
         }
 
-        if (subscriptionGroupWrapper != null && subscriptionGroupWrapper.getSubscriptionGroupTable().isEmpty()) {
+        if (subscriptionGroupWrapper == null || subscriptionGroupWrapper.getSubscriptionGroupTable().isEmpty()) {
             logger.warn("No subscription group information available");
             isCacheBeingBuilt = false;
             return;


### PR DESCRIPTION
## Which Issue(s) This PR Fixes

Fixes #411

## Brief Description

When `mqAdminExt.getAllSubscriptionGroup()` returns `null` (e.g. broker not reachable, ACL denied, or 5.x Proxy mode where the call is not supported), the code at line 183 calls `subscriptionGroupWrapper.getSubscriptionGroupTable()` which throws:

```
Cannot invoke "SubscriptionGroupWrapper.getSubscriptionGroupTable()" because "subscriptionGroupWrapper" is null
```

**Root cause**: No null check on the return value of `getAllSubscriptionGroup()` before accessing its methods.

**Fix**:
1. Add null check inside the broker loop — if `getAllSubscriptionGroup` returns null, log a warning and skip to the next broker instead of crashing.
2. Fix the post-loop null check (line 197): the original condition `subscriptionGroupWrapper != null && ...isEmpty()` would fall through to line 202 and NPE if `subscriptionGroupWrapper` was null (e.g. empty broker table). Changed to `subscriptionGroupWrapper == null || ...isEmpty()` to handle both cases.

## How Did You Test This Change?

Manual code review against the issue stack trace. The fix follows the same null-guard pattern already used elsewhere in the codebase (e.g. `examineSubscriptionGroupConfig` fallback at line 218).