### PR TITLE
[ISSUE #390] Fix addProxyAddr failure caused by Content-Type header overwritten in _fetch

### DIFF
--- a/frontend-new/src/api/remoteApi/remoteApi.js
+++ b/frontend-new/src/api/remoteApi/remoteApi.js
@@ -61,8 +61,8 @@ const remoteApi = {
 
     _fetch: async (url, options = {}) => {
         const headers = {
-            ...options.headers,
             'Content-Type': 'application/json',
+            ...options.headers,
         };
 
 

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
@@ -180,6 +180,10 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             ClusterInfo clusterInfo = clusterInfoService.get();
             for (BrokerData brokerData : clusterInfo.getBrokerAddrTable().values()) {
                 subscriptionGroupWrapper = mqAdminExt.getAllSubscriptionGroup(brokerData.selectBrokerAddr(), 30000L);
+                if (subscriptionGroupWrapper == null) {
+                    logger.warn("getAllSubscriptionGroup returned null for broker: {}", brokerData.selectBrokerAddr());
+                    continue;
+                }
                 for (String groupName : subscriptionGroupWrapper.getSubscriptionGroupTable().keySet()) {
                     if (!consumerGroupMap.containsKey(groupName)) {
                         consumerGroupMap.putIfAbsent(groupName, new ArrayList<>());
@@ -194,7 +198,7 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             throw new RuntimeException(err);
         }
 
-        if (subscriptionGroupWrapper != null && subscriptionGroupWrapper.getSubscriptionGroupTable().isEmpty()) {
+        if (subscriptionGroupWrapper == null || subscriptionGroupWrapper.getSubscriptionGroupTable().isEmpty()) {
             logger.warn("No subscription group information available");
             isCacheBeingBuilt = false;
             return;


### PR DESCRIPTION
Fixes #390. The _fetch method overwrites caller-specified Content-Type with application/json, causing addProxyAddr form-urlencoded body to be unparseable by Spring MVC @RequestParam. Fix by putting default Content-Type before spread operator.