### PR TITLE
[ISSUE #410] Make CORS allowed origins configurable

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/config/SecurityConfig.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/config/SecurityConfig.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.dashboard.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -36,6 +37,10 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    @Value("${rocketmq.config.corsAllowedOrigins:http://localhost:3003}")
+    private String corsAllowedOrigins;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -57,7 +62,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3003"));
+        configuration.setAllowedOrigins(Arrays.asList(corsAllowedOrigins.split(",")));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("content-type", "Authorization", "X-Requested-With", "Origin", "Accept", "X-XSRF-TOKEN"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/org/apache/rocketmq/dashboard/config/SecurityConfig.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/config/SecurityConfig.java
@@ -62,7 +62,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList(corsAllowedOrigins.split(",")));
+        configuration.setAllowedOrigins(Arrays.stream(corsAllowedOrigins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toArray(String[]::new));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("content-type", "Authorization", "X-Requested-With", "Origin", "Accept", "X-XSRF-TOKEN"));
         configuration.setAllowCredentials(true);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,6 +77,8 @@ rocketmq:
     # Default: file
     authMode: file
     useTLS: false
+    # Comma-separated list of allowed CORS origins. Default: http://localhost:3003
+    corsAllowedOrigins: http://localhost:3003
     proxyAddr: 127.0.0.1:8080
     proxyAddrs:
       - 127.0.0.1:8080


### PR DESCRIPTION
## What is the purpose of the change

Fixes #410

The CORS allowed origin was hardcoded to `http://localhost:3003` in `SecurityConfig.java`, making it impossible to deploy in production environments with different frontend domains.

## Brief changelog

- Added `@Value("${rocketmq.config.corsAllowedOrigins:http://localhost:3003}")` to make CORS origins configurable
- Support comma-separated values for multiple origins
- Added `corsAllowedOrigins` property to `application.yml` with documentation
- Default value maintains backward compatibility

## Verifying this change

Set `rocketmq.config.corsAllowedOrigins` in `application.yml` to verify different origins are accepted.