### PR TITLE
[ISSUE #401 #405] Support runtime API base URL configuration for Docker

### DIFF
--- a/frontend-new/public/env-config.js
+++ b/frontend-new/public/env-config.js
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+window.__ENV__ = window.__ENV__ || {};
+window.__ENV__.API_BASE_URL = "";

--- a/frontend-new/public/index.html
+++ b/frontend-new/public/index.html
@@ -25,6 +25,7 @@
     <meta name="keywords" content=""/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <title>RocketMQ Dashboard</title>
+    <script src="./env-config.js"></script>
 </head>
 <body>
 <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend-new/src/api/remoteApi/remoteApi.js
+++ b/frontend-new/src/api/remoteApi/remoteApi.js
@@ -16,7 +16,7 @@
  */
 
 const appConfig = {
-    apiBaseUrl: process.env.REACT_APP_API_BASE_URL || window.location.origin
+    apiBaseUrl: (window.__ENV__ && window.__ENV__.API_BASE_URL) || process.env.REACT_APP_API_BASE_URL || window.location.origin
 };
 
 let _redirectHandler = null;

--- a/src/main/docker/env-config-entrypoint.sh
+++ b/src/main/docker/env-config-entrypoint.sh
@@ -1,4 +1,4 @@
-#
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,14 +13,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-FROM eclipse-temurin:17.0.16_8-jre-ubi9-minimal
-VOLUME /tmp
-ADD rocketmq-dashboard-*.jar rocketmq-dashboard.jar
-RUN sh -c 'touch /rocketmq-dashboard.jar'
-ENV JAVA_OPTS=""
-ENV API_BASE_URL=""
-COPY env-config-entrypoint.sh /env-config-entrypoint.sh
-RUN chmod +x /env-config-entrypoint.sh
-ENTRYPOINT [ "/env-config-entrypoint.sh" ]
+# If API_BASE_URL is set, extract env-config.js from the jar and update it
+if [ -n "$API_BASE_URL" ]; then
+    TMP_DIR=$(mktemp -d)
+    cd "$TMP_DIR"
+    jar xf /rocketmq-dashboard.jar BOOT-INF/classes/static/env-config.js
+    cat > BOOT-INF/classes/static/env-config.js << EOF
+window.__ENV__ = window.__ENV__ || {};
+window.__ENV__.API_BASE_URL = "$API_BASE_URL";
+EOF
+    jar uf /rocketmq-dashboard.jar BOOT-INF/classes/static/env-config.js
+    cd /
+    rm -rf "$TMP_DIR"
+fi
+
+exec java $JAVA_OPTS -jar /rocketmq-dashboard.jar


### PR DESCRIPTION
## What is the purpose of the change

Fixes #401, fixes #405

The frontend API base URL was hardcoded at build time. When deployed via Docker, the built image always points to `localhost:8082`, making it impossible to use the dashboard from other hosts without rebuilding.

## Brief changelog

- Added `env-config.js` loaded before React app, providing `window.__ENV__.API_BASE_URL`
- Updated `remoteApi.js` to check runtime config first, then build-time env var, then `window.location.origin`
- Added Docker entrypoint script that patches `env-config.js` at container startup when `API_BASE_URL` env var is set
- Updated Dockerfile to use the new entrypoint

## How to use

```yaml
# docker-compose.yml
services:
  rocketmq-dashboard:
    image: apacherocketmq/rocketmq-dashboard:latest
    environment:
      - API_BASE_URL=http://your-host:8082
```

When `API_BASE_URL` is not set, the frontend defaults to `window.location.origin` (same-origin), preserving backward compatibility.