### PR TITLE
[ISSUE #404] Clarify default dashboard port is 8082

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ docker pull apacherocketmq/rocketmq-dashboard:latest
 
 #### Run it (use your own `rocketmq.namesrv.addr` and `port`)
 
+The default dashboard port is **8082**. You can change it by setting the `SERVER_PORT` environment variable or mapping a different host port:
+
 ```shell
 docker run -d --name rocketmq-dashboard -e "JAVA_OPTS=-Drocketmq.namesrv.addr=127.0.0.1:9876" -p 8082:8082 -t apacherocketmq/rocketmq-dashboard:latest
 ```

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@
 #
 
 server:
-  port: 8082
+  port: 8082 # Default dashboard port. Change via server.port property or SERVER_PORT env var.
   servlet:
     encoding:
       charset: UTF-8


### PR DESCRIPTION
Fixes #404. Add note in README that default port is 8082 and how to customize it.