### PR TITLE
[ISSUE #381 #402] Add proxy fallback for gRPC consumer stats and request codes 106/206/208

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/ClusterInfoService.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/ClusterInfoService.java
@@ -18,6 +18,8 @@ package org.apache.rocketmq.dashboard.service;
 
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.dashboard.config.RMQConfigure;
+import org.apache.rocketmq.dashboard.service.client.ProxyAdmin;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +37,12 @@ public class ClusterInfoService {
 
     @Autowired
     private MQAdminExt mqAdminExt;
+
+    @Autowired
+    private ProxyAdmin proxyAdmin;
+
+    @Autowired
+    private RMQConfigure configure;
 
     @Value("${rocketmq.cluster.cache.expire:60000}")
     private long cacheExpireMs;
@@ -61,7 +69,17 @@ public class ClusterInfoService {
             cachedRef.set(fresh);
             return fresh;
         } catch (Exception e) {
-            log.warn("Refresh cluster info failed", e);
+            log.warn("Refresh cluster info via mqAdminExt failed, trying proxy: {}", e.getMessage());
+            try {
+                String proxyAddr = configure.getProxyAddr();
+                if (proxyAddr != null && !proxyAddr.isEmpty()) {
+                    ClusterInfo fresh = proxyAdmin.getBrokerClusterInfo(proxyAddr);
+                    cachedRef.set(fresh);
+                    return fresh;
+                }
+            } catch (Exception proxyEx) {
+                log.warn("Refresh cluster info via proxy also failed", proxyEx);
+            }
             ClusterInfo old = cachedRef.get();
             if (old != null) {
                 return old;

--- a/src/main/java/org/apache/rocketmq/dashboard/service/client/ProxyAdmin.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/client/ProxyAdmin.java
@@ -20,9 +20,18 @@ import org.apache.rocketmq.client.exception.MQBrokerException;
 import org.apache.rocketmq.remoting.exception.RemotingConnectException;
 import org.apache.rocketmq.remoting.exception.RemotingSendRequestException;
 import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
+import org.apache.rocketmq.remoting.protocol.admin.ConsumeStats;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.ConsumerConnection;
+import org.apache.rocketmq.remoting.protocol.body.TopicList;
 
 public interface ProxyAdmin {
 
     ConsumerConnection examineConsumerConnectionInfo(String addr, String consumerGroup) throws RemotingConnectException, RemotingSendRequestException, RemotingTimeoutException, InterruptedException, MQBrokerException;
+
+    ClusterInfo getBrokerClusterInfo(String addr) throws RemotingConnectException, RemotingSendRequestException, RemotingTimeoutException, InterruptedException, MQBrokerException;
+
+    TopicList getAllTopicListFromNameServer(String addr) throws RemotingConnectException, RemotingSendRequestException, RemotingTimeoutException, InterruptedException, MQBrokerException;
+
+    ConsumeStats examineConsumeStats(String addr, String consumerGroup) throws RemotingConnectException, RemotingSendRequestException, RemotingTimeoutException, InterruptedException, MQBrokerException;
 }

--- a/src/main/java/org/apache/rocketmq/dashboard/service/client/ProxyAdminImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/client/ProxyAdminImpl.java
@@ -23,10 +23,17 @@ import org.apache.rocketmq.remoting.exception.RemotingConnectException;
 import org.apache.rocketmq.remoting.exception.RemotingSendRequestException;
 import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.remoting.protocol.admin.ConsumeStats;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.ConsumerConnection;
+import org.apache.rocketmq.remoting.protocol.body.TopicList;
 import org.apache.rocketmq.remoting.protocol.header.GetConsumerConnectionListRequestHeader;
+import org.apache.rocketmq.remoting.protocol.header.GetConsumeStatsRequestHeader;
 import org.springframework.stereotype.Service;
 
+import static org.apache.rocketmq.remoting.protocol.RequestCode.GET_BROKER_CLUSTER_INFO;
+import static org.apache.rocketmq.remoting.protocol.RequestCode.GET_ALL_TOPIC_LIST_FROM_NAMESERVER;
+import static org.apache.rocketmq.remoting.protocol.RequestCode.GET_CONSUME_STATS;
 import static org.apache.rocketmq.remoting.protocol.RequestCode.GET_CONSUMER_CONNECTION_LIST;
 
 @Slf4j
@@ -49,6 +56,62 @@ public class ProxyAdminImpl implements ProxyAdmin {
             }
         } catch (Exception e) {
             log.error("examineConsumerConnectionInfo error", e);
+            throw e;
+        }
+    }
+
+    @Override
+    public ClusterInfo getBrokerClusterInfo(String addr) throws RemotingConnectException, RemotingSendRequestException, RemotingTimeoutException, InterruptedException, MQBrokerException {
+        try {
+            RemotingClient remotingClient = MQAdminInstance.threadLocalRemotingClient();
+            RemotingCommand request = RemotingCommand.createRequestCommand(GET_BROKER_CLUSTER_INFO, null);
+            RemotingCommand response = remotingClient.invokeSync(addr, request, 3000);
+            switch (response.getCode()) {
+                case 0:
+                    return ClusterInfo.decode(response.getBody(), ClusterInfo.class);
+                default:
+                    throw new MQBrokerException(response.getCode(), response.getRemark(), addr);
+            }
+        } catch (Exception e) {
+            log.error("getBrokerClusterInfo error", e);
+            throw e;
+        }
+    }
+
+    @Override
+    public TopicList getAllTopicListFromNameServer(String addr) throws RemotingConnectException, RemotingSendRequestException, RemotingTimeoutException, InterruptedException, MQBrokerException {
+        try {
+            RemotingClient remotingClient = MQAdminInstance.threadLocalRemotingClient();
+            RemotingCommand request = RemotingCommand.createRequestCommand(GET_ALL_TOPIC_LIST_FROM_NAMESERVER, null);
+            RemotingCommand response = remotingClient.invokeSync(addr, request, 3000);
+            switch (response.getCode()) {
+                case 0:
+                    return TopicList.decode(response.getBody(), TopicList.class);
+                default:
+                    throw new MQBrokerException(response.getCode(), response.getRemark(), addr);
+            }
+        } catch (Exception e) {
+            log.error("getAllTopicListFromNameServer error", e);
+            throw e;
+        }
+    }
+
+    @Override
+    public ConsumeStats examineConsumeStats(String addr, String consumerGroup) throws RemotingConnectException, RemotingSendRequestException, RemotingTimeoutException, InterruptedException, MQBrokerException {
+        try {
+            RemotingClient remotingClient = MQAdminInstance.threadLocalRemotingClient();
+            GetConsumeStatsRequestHeader requestHeader = new GetConsumeStatsRequestHeader();
+            requestHeader.setConsumerGroup(consumerGroup);
+            RemotingCommand request = RemotingCommand.createRequestCommand(GET_CONSUME_STATS, requestHeader);
+            RemotingCommand response = remotingClient.invokeSync(addr, request, 3000);
+            switch (response.getCode()) {
+                case 0:
+                    return ConsumeStats.decode(response.getBody(), ConsumeStats.class);
+                default:
+                    throw new MQBrokerException(response.getCode(), response.getRemark(), addr);
+            }
+        } catch (Exception e) {
+            log.error("examineConsumeStats error", e);
             throw e;
         }
     }

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/ClusterServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/ClusterServiceImpl.java
@@ -21,7 +21,9 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import jakarta.annotation.Resource;
 import org.apache.rocketmq.common.attribute.TopicMessageType;
+import org.apache.rocketmq.dashboard.config.RMQConfigure;
 import org.apache.rocketmq.dashboard.service.ClusterService;
+import org.apache.rocketmq.dashboard.service.client.ProxyAdmin;
 import org.apache.rocketmq.dashboard.util.JsonUtil;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.KVTable;
@@ -41,12 +43,26 @@ public class ClusterServiceImpl implements ClusterService {
     private Logger logger = LoggerFactory.getLogger(ClusterServiceImpl.class);
     @Resource
     private MQAdminExt mqAdminExt;
+    @Resource
+    private ProxyAdmin proxyAdmin;
+    @Resource
+    private RMQConfigure configure;
 
     @Override
     public Map<String, Object> list() {
         try {
             Map<String, Object> resultMap = Maps.newHashMap();
-            ClusterInfo clusterInfo = mqAdminExt.examineBrokerClusterInfo();
+            ClusterInfo clusterInfo;
+            try {
+                clusterInfo = mqAdminExt.examineBrokerClusterInfo();
+            } catch (Exception e) {
+                logger.warn("examineBrokerClusterInfo failed, trying proxy: {}", e.getMessage());
+                String proxyAddr = configure.getProxyAddr();
+                if (proxyAddr == null || proxyAddr.isEmpty()) {
+                    throw e;
+                }
+                clusterInfo = proxyAdmin.getBrokerClusterInfo(proxyAddr);
+            }
             logger.info("op=look_clusterInfo {}", JsonUtil.obj2String(clusterInfo));
             Map<String/*brokerName*/, Map<Long/* brokerId */, Object/* brokerDetail */>> brokerServer = Maps.newHashMap();
             for (BrokerData brokerData : clusterInfo.getBrokerAddrTable().values()) {

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
@@ -252,7 +252,15 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             try {
                 consumeStats = mqAdminExt.examineConsumeStats(consumerGroup);
             } catch (Exception e) {
-                logger.warn("examineConsumeStats exception to consumerGroup {}, response [{}]", consumerGroup, e.getMessage());
+                logger.warn("examineConsumeStats exception to consumerGroup {}, trying proxy: {}", consumerGroup, e.getMessage());
+                try {
+                    String proxyAddr = configure.getProxyAddr();
+                    if (StringUtils.isNotEmpty(proxyAddr)) {
+                        consumeStats = proxyAdmin.examineConsumeStats(proxyAddr, consumerGroup);
+                    }
+                } catch (Exception proxyEx) {
+                    logger.warn("examineConsumeStats via proxy also failed for consumerGroup {}", consumerGroup, proxyEx);
+                }
             }
             if (consumeStats != null) {
                 groupConsumeInfo.setConsumeTps((int) consumeStats.getConsumeTps());

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/TopicServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/TopicServiceImpl.java
@@ -38,6 +38,7 @@ import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.topic.TopicValidator;
 import org.apache.rocketmq.dashboard.config.RMQConfigure;
+import org.apache.rocketmq.dashboard.service.client.ProxyAdmin;
 import org.apache.rocketmq.dashboard.model.request.SendTopicMessageRequest;
 import org.apache.rocketmq.dashboard.model.request.TopicConfigInfo;
 import org.apache.rocketmq.dashboard.model.request.TopicTypeList;
@@ -90,10 +91,23 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
     @Autowired
     private RMQConfigure configure;
 
+    @Autowired
+    private ProxyAdmin proxyAdmin;
+
     @Override
     public TopicList fetchAllTopicList(boolean skipSysProcess, boolean skipRetryAndDlq) {
         try {
-            TopicList allTopics = mqAdminExt.fetchAllTopicList();
+            TopicList allTopics;
+            try {
+                allTopics = mqAdminExt.fetchAllTopicList();
+            } catch (Exception e) {
+                logger.warn("fetchAllTopicList failed, trying proxy: {}", e.getMessage());
+                String proxyAddr = configure.getProxyAddr();
+                if (proxyAddr == null || proxyAddr.isEmpty()) {
+                    throw e;
+                }
+                allTopics = proxyAdmin.getAllTopicListFromNameServer(proxyAddr);
+            }
             TopicList sysTopics = getSystemTopicList();
             Set<String> topics =
                     allTopics.getTopicList().stream().map(topic -> {


### PR DESCRIPTION
Fixes #381, fixes #402. Add proxy fallback for examineConsumeStats (208), getBrokerClusterInfo (106), and getAllTopicListFromNameServer (206) when standard mqAdminExt methods fail in proxy mode.