### PR TITLE
[ISSUE #403] Fix NPE in AclInfo.copyFrom when actions or sourceIps is null

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/model/AclInfo.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/model/AclInfo.java
@@ -191,8 +191,12 @@ public class AclInfo {
                     for (org.apache.rocketmq.remoting.protocol.body.AclInfo.PolicyEntryInfo entry : policy.getEntries()) {
                         PolicyEntryInfo copiedEntry = new PolicyEntryInfo();
                         copiedEntry.setResource(entry.getResource());
-                        copiedEntry.setActions(new ArrayList<>(entry.getActions()));
-                        copiedEntry.setSourceIps(new ArrayList<>(entry.getSourceIps()));
+                        if (entry.getActions() != null) {
+                            copiedEntry.setActions(new ArrayList<>(entry.getActions()));
+                        }
+                        if (entry.getSourceIps() != null) {
+                            copiedEntry.setSourceIps(new ArrayList<>(entry.getSourceIps()));
+                        }
                         copiedEntry.setDecision(entry.getDecision());
                         copiedEntries.add(copiedEntry);
                     }


### PR DESCRIPTION
Fixes #403. When the broker returns AclInfo with null actions or sourceIps fields, copyFrom throws NPE due to new ArrayList<>(null). Added null checks.