### PR TITLE
[ISSUE #441] Validate audit query and cleanup parameters

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/ops/audit/AuditService.java
+++ b/server/src/main/java/com/rocketmq/studio/ops/audit/AuditService.java
@@ -17,6 +17,7 @@
 package com.rocketmq.studio.ops.audit;
 
 import com.rocketmq.studio.common.domain.PageResult;
+import com.rocketmq.studio.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -38,6 +39,7 @@ public class AuditService {
     public PageResult<AuditRecordVO> queryLogs(int page, int pageSize, String search,
                                              String operationType, String startDate,
                                              String endDate, String result) {
+        validatePagination(page, pageSize);
         log.info("Querying audit logs, page={}, pageSize={}, search={}, operationType={}, result={}",
                 page, pageSize, search, operationType, result);
 
@@ -47,8 +49,9 @@ public class AuditService {
         List<AuditRecordVO> allRecords = auditRepository.findAll(search, operationType, start, end, result);
         long total = allRecords.size();
 
-        int fromIndex = Math.min((page - 1) * pageSize, allRecords.size());
-        int toIndex = Math.min(fromIndex + pageSize, allRecords.size());
+        long offset = (long) (page - 1) * pageSize;
+        int fromIndex = (int) Math.min(offset, allRecords.size());
+        int toIndex = (int) Math.min((long) fromIndex + pageSize, allRecords.size());
         List<AuditRecordVO> pageRecords = allRecords.subList(fromIndex, toIndex);
 
         return PageResult.of(pageRecords, total, page, pageSize);
@@ -56,9 +59,21 @@ public class AuditService {
 
 
     public int cleanupLogs(int beforeDays) {
+        if (beforeDays <= 0) {
+            throw new BusinessException(400, "beforeDays must be greater than 0");
+        }
         log.info("Cleaning up audit logs older than {} days", beforeDays);
         LocalDateTime cutoff = LocalDateTime.now().minusDays(beforeDays);
         return auditRepository.deleteBefore(cutoff);
+    }
+
+    private void validatePagination(int page, int pageSize) {
+        if (page <= 0) {
+            throw new BusinessException(400, "page must be greater than 0");
+        }
+        if (pageSize <= 0) {
+            throw new BusinessException(400, "pageSize must be greater than 0");
+        }
     }
 
     private LocalDateTime parseDate(String dateStr, boolean startOfDay) {

--- a/server/src/test/java/com/rocketmq/studio/ops/audit/AuditServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/ops/audit/AuditServiceTest.java
@@ -17,6 +17,7 @@
 package com.rocketmq.studio.ops.audit;
 
 import com.rocketmq.studio.common.domain.PageResult;
+import com.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -30,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -102,6 +104,35 @@ class AuditServiceTest {
                 .thenReturn(List.of(r1));
 
         PageResult<AuditRecordVO> result = auditService.queryLogs(5, 10, null, null, null, null, null);
+
+        assertThat(result.getItems()).isEmpty();
+        assertThat(result.getTotal()).isEqualTo(1);
+    }
+
+    @Test
+    void queryLogsShouldRejectNonPositivePage() {
+        assertThatThrownBy(() -> auditService.queryLogs(0, 10, null, null, null, null, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("page must be greater than 0")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+    }
+
+    @Test
+    void queryLogsShouldRejectNonPositivePageSize() {
+        assertThatThrownBy(() -> auditService.queryLogs(1, 0, null, null, null, null, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("pageSize must be greater than 0")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+    }
+
+    @Test
+    void queryLogsShouldAvoidOffsetOverflow() {
+        AuditRecordVO record = AuditRecordVO.builder().operationType("CREATE").build();
+        when(auditRepository.findAll(isNull(), isNull(), isNull(), isNull(), isNull()))
+                .thenReturn(List.of(record));
+
+        PageResult<AuditRecordVO> result = auditService.queryLogs(
+                Integer.MAX_VALUE, Integer.MAX_VALUE, null, null, null, null, null);
 
         assertThat(result.getItems()).isEmpty();
         assertThat(result.getTotal()).isEqualTo(1);
@@ -189,6 +220,18 @@ class AuditServiceTest {
         int result = auditService.cleanupLogs(90);
 
         assertThat(result).isZero();
+    }
+
+    @Test
+    void cleanupLogsShouldRejectNonPositiveRetention() {
+        assertThatThrownBy(() -> auditService.cleanupLogs(0))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("beforeDays must be greater than 0")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        assertThatThrownBy(() -> auditService.cleanupLogs(-1))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("beforeDays must be greater than 0");
     }
 
     @Test


### PR DESCRIPTION
### Summary

- validate audit query pagination before reading repository data
- use `long` arithmetic for pagination bounds to avoid integer overflow
- reject zero or negative audit cleanup retention values
- add regression tests for invalid and extreme inputs

### Problem and root cause

`AuditService.queryLogs` used unchecked `int` values directly in `subList` index calculations. Non-positive inputs could produce invalid indices, and multiplying large positive page values could overflow. `cleanupLogs` similarly accepted non-positive retention periods, allowing a cutoff at the current time or in the future and risking deletion of recent audit entries.

### Impact

Invalid requests now fail predictably with `BusinessException` code 400 before repository work begins. Valid large pagination inputs no longer overflow, and cleanup always requires a positive retention period.

### Verification

- `mvn -o -B -ntp -Dtest=AuditServiceTest test` — 16 tests passed
- `mvn -o -B -ntp test` — 161 tests passed
- Checkstyle — 0 violations
- `git diff --cached --check` — passed

Fixes #441
