### PR TITLE
[Studio] chore: fix Dockerfile missing style/ copy and standardize pr-review skill

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -11,7 +11,8 @@ description: RocketMQ Studio 的 PR 评审助手。输入一个 GitHub PR 链接
 
 - 已安装并登录 `gh`（`gh auth status` 确认）。
 - 已安装 `docker`（含 `docker compose`）、`node`(>=20)、`npm`、`mvn`(JDK 21)。
-- 当前工作目录为 `project/rocketmq-studio`（项目根，含 `server/`、`web/`、`deploy/`）。
+- 当前工作目录为项目根目录（含 `server/`、`web/`、`deploy/`）。
+- 后端构建需要 JDK 21（`JAVA_HOME` 指向 JDK 21，或使用 `mvn -B -ntp` 配合系统 JDK 21）。
 
 > 端口约定（**禁止修改**）：前端 6789（Nginx）、后端 8888（Spring Boot）、NameServer 9876、Broker 10911、Proxy 8080/8081。
 
@@ -21,9 +22,28 @@ description: RocketMQ Studio 的 PR 评审助手。输入一个 GitHub PR 链接
 
 从链接中解析出 PR 编号 `<PR>`（URL 最后一段数字）。
 
-## 执行步骤
+## 标准流程（Pipeline）
 
-### 1. 拉取 PR 元信息
+评审按以下 8 个阶段顺序执行。每个阶段独立产出结果，任一阶段失败不阻断后续步骤，但需在总结中标记 ❌。
+
+```
+Stage 1  拉取元信息        gh pr view → JSON + diff
+Stage 2  标题规范检查       正则校验 [Studio] type: description
+Stage 3  关联 Issue        gh issue view（若有 Closes/Fixes 引用）
+Stage 4  切出评审分支       gh pr checkout → pr-review-<PR>
+Stage 5  预检 & 修复        Dockerfile style/ 目录修复（已知问题）
+Stage 6  编译后端           mvn package -DskipTests（含 checkstyle）
+Stage 7  编译前端           npm ci && npm run build（tsc + vite）
+Stage 8  Docker 部署        docker compose up -d --build + 健康检查
+```
+
+**完成后**：复原工作区（切回原分支 + stash pop）。
+
+---
+
+## 各阶段详细步骤
+
+### Stage 1: 拉取 PR 元信息
 
 ```bash
 gh pr view <PR> --repo apache/rocketmq-dashboard \
@@ -41,16 +61,16 @@ gh pr view <PR> --repo apache/rocketmq-dashboard \
 gh pr diff <PR> --repo apache/rocketmq-dashboard > /tmp/pr-<PR>.diff
 ```
 
-### 1.5 检查 PR 标题是否规范
+### Stage 2: 检查 PR 标题是否规范
 
-规范来源：`docs/contributing.md`「提交规范」+ `README.md`「Commit Format」+ 本仓库既有 commit 历史，统一遵循 [Conventional Commits](https://www.conventionalcommits.org/)。
+规范来源：`docs/contributing.md`「提交规范」+ `README.md`「Commit Format」+ 本仓库既有 PR/commit 历史，基于 [Conventional Commits](https://www.conventionalcommits.org/) 并带项目前缀。
 
-**格式**：`<type>: <description>`
+**格式**：`[Studio] <type>: <description>`
 
+- **`[Studio]`** 为项目前缀（必须，大小写敏感，首字母大写 `Studio`）。
 - **type** 必须为以下之一（小写）：`feat`（新功能）、`fix`（修复 Bug）、`docs`（文档）、`refactor`（重构）、`test`（测试）、`chore`（构建/工具）、`perf`（性能）。
-- type 后紧跟半角冒号 `:` 加一个空格，再接 **description**。
+- `[Studio]` 与 `type` 之间有一个空格；type 后紧跟半角冒号 `:` 加一个空格，再接 **description**。
 - description 用英文小写祈使句，简洁描述改动，结尾不加句号。
-- 可选 scope：`type(scope): description`（scope 为小写模块名，如 `fix(web):`）。
 - squash 合并后 GitHub 会在标题末尾追加 ` (#PR号)`，属正常现象，检查时应先剥离该后缀。
 
 校验正则（先去掉可能存在的 ` (#N)` 尾巴）：
@@ -58,18 +78,23 @@ gh pr diff <PR> --repo apache/rocketmq-dashboard > /tmp/pr-<PR>.diff
 ```bash
 TITLE=$(gh pr view <PR> --repo apache/rocketmq-dashboard --json title -q .title)
 CLEAN=$(printf '%s' "$TITLE" | sed -E 's/ \(#[0-9]+\)$//')
-if printf '%s' "$CLEAN" | grep -Eq '^(feat|fix|docs|refactor|test|chore|perf)(\([a-z0-9-]+\))?: .+'; then
+if printf '%s' "$CLEAN" | grep -Eq '^\[Studio\] (feat|fix|docs|refactor|test|chore|perf): .+'; then
   echo "标题规范 ✅: $TITLE"
 else
   echo "标题不规范 ❌: $TITLE"
 fi
 ```
 
-对照参考（本仓库历史）：`fix: align frontend API success response handling (#429)`、`feat: implement backend cluster management module`、`chore: initialize project with license and git config`。
+对照参考（本仓库历史）：
+- `[Studio] fix: validate audit query and cleanup parameters` ✅
+- `[Studio] fix: connect K8s certificate page to backend APIs` ✅
+- `[Studio] feat: add i18n language context with useLanguage alias` ✅
+- `[Studio][fix] Connect K8s certificate page to backend APIs` ❌（type 应在冒号前，不应使用 `[fix]` 方括号）
+- `[studio] feat: extend translation keys` ❌（`studio` 应为 `Studio`，首字母大写）
 
-不规范时在总结中明确指出问题（type 非法 / 缺冒号或空格 / 用了中文或首字母大写 / 结尾多余标点等）并给出建议标题。
+不规范时在总结中明确指出问题并给出建议标题。
 
-### 2. 拉取关联 Issue（若有）
+### Stage 3: 拉取关联 Issue（若有）
 
 若 `closingIssuesReferences` 非空，或 PR 正文中出现 `#N` / `Closes #N` / `Fixes #N` 引用，逐个拉取：
 
@@ -80,13 +105,13 @@ gh issue view <ISSUE> --repo apache/rocketmq-dashboard \
 
 用于判断 PR 是否真正解决了 Issue 描述的问题（需求对齐度）。
 
-### 3. 本地切出评审分支
+### Stage 4: 本地切出评审分支
 
 不要污染当前分支。用 `gh` 直接 checkout PR 分支（会自动创建本地分支）：
 
 ```bash
 # 记录当前分支以便复原
-git rev-parse --abbrev-ref HEAD
+ORIGINAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git stash push -u -m "pr-review-stash" 2>/dev/null || true
 
 gh pr checkout <PR> --repo apache/rocketmq-dashboard --branch pr-review-<PR>
@@ -95,11 +120,29 @@ gh pr checkout <PR> --repo apache/rocketmq-dashboard --branch pr-review-<PR>
 若因权限/fork 无法直接 checkout，退化为手动 fetch：
 
 ```bash
-git fetch apache pull/<PR>/head:pr-review-<PR>
+git fetch origin pull/<PR>/head:pr-review-<PR>
 git checkout pr-review-<PR>
 ```
 
-### 4. 编译后端
+### Stage 5: 预检 & 修复（Dockerfile style/ 目录）
+
+**已知问题**：`server/Dockerfile` 在基准分支上缺少 `COPY style ./style`，导致 Maven checkstyle 插件在构建阶段找不到 `style/rmq_checkstyle.xml` 而报错，docker compose 无法启动。
+
+每次评审前检查并修复：
+
+```bash
+if ! grep -q 'COPY style' server/Dockerfile; then
+  # 在 "COPY src ./src" 后插入 "COPY style ./style"
+  sed -i '/^COPY src \.\/src$/a COPY style ./style' server/Dockerfile
+  echo "✅ 已修复 Dockerfile: 添加 COPY style ./style"
+else
+  echo "✅ Dockerfile 已包含 style/ 目录复制"
+fi
+```
+
+> 此修复仅用于本地评审，不影响 PR diff。若 PR 本身已修复此问题，此步为 no-op。
+
+### Stage 6: 编译后端
 
 严格对齐 `server/Dockerfile` 的构建方式（`mvn package -DskipTests`，含 checkstyle 校验）：
 
@@ -112,7 +155,7 @@ cd ..
 - 编译失败 → 记录报错（编译错误 / checkstyle 违规），标记后端为 ❌，仍继续后续步骤并如实汇报。
 - 通过 → 标记 ✅。
 
-### 5. 编译前端
+### Stage 7: 编译前端
 
 对齐 `web/Dockerfile`（`npm ci && npm run build`，即 `tsc -b && vite build`）：
 
@@ -126,12 +169,13 @@ cd ..
 - 出现 TypeScript 类型错误或构建失败 → 标记前端 ❌，记录关键报错。
 - 通过 → 标记 ✅。
 
-### 6. docker compose 拉起项目
+### Stage 8: Docker 部署
 
 使用项目自带 compose 文件，**不修改任何端口**：
 
 ```bash
 cd deploy
+docker compose down 2>/dev/null || true
 docker compose up -d --build
 cd ..
 ```
@@ -152,15 +196,19 @@ docker compose -f deploy/docker-compose.yml ps
 docker compose -f deploy/docker-compose.yml down
 ```
 
-### 7. 复原工作区
+---
+
+## 复原工作区
 
 评审完成后切回原分支并恢复暂存：
 
 ```bash
-git checkout <原分支>
+git checkout "$ORIGINAL_BRANCH"
 git stash pop 2>/dev/null || true
 # 如需删除评审分支：git branch -D pr-review-<PR>
 ```
+
+---
 
 ## 输出：PR 分析总结
 
@@ -190,7 +238,7 @@ git stash pop 2>/dev/null || true
 - 按模块归类改动（前端页面/组件、后端 controller/service/domain、部署、文档等）。
 - 结合六边形架构（server 用 ArchUnit 约束）判断分层是否合理。
 - i18n：新增前端文案是否中英文双语（`web/src/i18n/`）。
-- 提交规范：commit message 是否符合 Conventional Commits。
+- 提交规范：commit message 是否符合 `[Studio] type: description` 格式。
 
 ### 5. 风险与建议
 - 潜在逻辑问题、边界情况、安全风险（如凭据明文、公网暴露）。
@@ -199,6 +247,8 @@ git stash pop 2>/dev/null || true
 
 ### 6. 评审结论
 给出倾向：**Approve** / **Request Changes** / **Comment**，并用一句话说明理由。
+
+---
 
 ## 自由发挥补充能力
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline
 COPY src ./src
+COPY style ./style
 RUN mvn package -DskipTests
 
 # Stage 2: Runtime


### PR DESCRIPTION
## Summary

Two changes bundled into one PR:

### 1. Fix `server/Dockerfile` missing `style/` copy

The Dockerfile was missing `COPY style ./style` before `RUN mvn package -DskipTests`. This caused Maven checkstyle to fail during `docker compose build` because it could not find `style/rmq_checkstyle.xml`.

**Fix**: Add `COPY style ./style` after `COPY src ./src`.

### 2. Standardize pr-review skill document

Rewrote `.claude/skills/pr-review/SKILL.md` with:

- **8-stage pipeline checklist** — clear sequential flow from metadata fetch → title check → issue fetch → branch checkout → pre-flight fix → backend build → frontend build → docker deploy
- **Stage 5: Dockerfile pre-flight fix** — automatic detection and patching of the missing `style/` copy on PR branches that don't have it
- **Title format spec** — standardized `[Studio] type: description` format with regex validation and examples
- **Consistent stage naming** — each step is now a named `Stage N` for easier reference
