### PR TITLE
[Studio] fix: connect audit logs page to APIs

### DIFF
--- a/web/src/api/audit.test.ts
+++ b/web/src/api/audit.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+import client from './client';
+import { cleanupAuditLogs, listAuditRecords } from './ops';
+
+const mock = new MockAdapter(client);
+
+afterEach(() => {
+  mock.reset();
+});
+
+describe('audit log API', () => {
+  it('uses the backend PageResult contract for filtered audit queries', async () => {
+    mock.onGet('/audit-logs').reply((config) => {
+      expect(config.params).toEqual({ page: 2, pageSize: 10, result: 'SUCCESS' });
+      return [200, { code: 200, data: { items: [], total: 12, page: 2, size: 10 } }];
+    });
+
+    await expect(listAuditRecords({ page: 2, pageSize: 10, result: 'SUCCESS' })).resolves.toEqual({
+      items: [],
+      total: 12,
+      page: 2,
+      size: 10,
+    });
+  });
+
+  it('returns the backend cleanup count', async () => {
+    mock.onPost('/audit-logs/cleanup', { beforeDays: 30 }).reply(200, {
+      code: 200,
+      data: { deleted: 3 },
+    });
+
+    await expect(cleanupAuditLogs(30)).resolves.toEqual({ deleted: 3 });
+  });
+});

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -37,6 +37,23 @@ export interface AuditRecord {
   result: string;
 }
 
+export interface PageResult<T> {
+  items: T[];
+  total: number;
+  page: number;
+  size: number;
+}
+
+export interface AuditQuery {
+  page?: number;
+  pageSize?: number;
+  search?: string;
+  operationType?: string;
+  startDate?: string;
+  endDate?: string;
+  result?: string;
+}
+
 // ─── Alert Rules ────────────────────────────────────────────────
 export async function listAlertRules() {
   const res = await client.get<{ data: AlertRule[] }>('/alert-rules');
@@ -74,13 +91,14 @@ export async function clearAcknowledgedAlerts() {
 }
 
 // ─── Audit Logs ─────────────────────────────────────────────────
-export async function listAuditRecords(params?: Record<string, unknown>) {
-  const res = await client.get<{ data: { list: AuditRecord[]; total: number } }>('/audit-logs', {
+export async function listAuditRecords(params?: AuditQuery) {
+  const res = await client.get<{ data: PageResult<AuditRecord> }>('/audit-logs', {
     params,
   });
   return res.data.data;
 }
 
 export async function cleanupAuditLogs(beforeDays: number) {
-  await client.post('/audit-logs/cleanup', { beforeDays });
+  const res = await client.post<{ data: { deleted: number } }>('/audit-logs/cleanup', { beforeDays });
+  return res.data.data;
 }

--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useState, useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Card,
   Table,
@@ -32,11 +32,11 @@ import {
 } from 'antd';
 import { Trash } from '@phosphor-icons/react';
 import type { ColumnsType } from 'antd/es/table';
-import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
 import PageHeader from '../../components/PageHeader';
-import { mockAuditRecords, type AuditRecord } from '../../mock/audit';
 import { useLang } from '../../i18n/LangContext';
+import type { AuditRecord } from '../../api/ops';
+import { cleanupAuditLogs, listAuditRecords } from '../../services/opsService';
 
 const operationTypeColors: Record<string, string> = {
   创建Topic: 'blue',
@@ -60,7 +60,12 @@ const operationTypeOptions = [
 
 const AuditPage: React.FC = () => {
   const { t } = useLang();
-  const [records, setRecords] = useState<AuditRecord[]>([...mockAuditRecords] as AuditRecord[]);
+  const [records, setRecords] = useState<AuditRecord[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [loading, setLoading] = useState(true);
+  const [refreshKey, setRefreshKey] = useState(0);
   const [searchText, setSearchText] = useState('');
   const [selectedType, setSelectedType] = useState<string | undefined>(undefined);
   const [dateRange, setDateRange] = useState<[Dayjs | null, Dayjs | null] | null>(null);
@@ -68,42 +73,49 @@ const AuditPage: React.FC = () => {
   const [cleanupModalOpen, setCleanupModalOpen] = useState(false);
   const [cleanupDays, setCleanupDays] = useState(30);
 
-  const filteredRecords = useMemo(() => {
-    return records.filter((record) => {
-      if (searchText) {
-        const lower = searchText.toLowerCase();
-        if (
-          !record.operator.toLowerCase().includes(lower) &&
-          !record.target.toLowerCase().includes(lower)
-        ) {
-          return false;
-        }
-      }
-      if (selectedType && record.operationType !== selectedType) {
-        return false;
-      }
-      if (dateRange && dateRange[0] && dateRange[1]) {
-        const recordTime = dayjs(record.timestamp);
-        const start = dateRange[0].startOf('day');
-        const end = dateRange[1].endOf('day');
-        if (recordTime.isBefore(start) || recordTime.isAfter(end)) {
-          return false;
-        }
-      }
-      if (resultFilter !== 'all' && record.result !== resultFilter) {
-        return false;
-      }
-      return true;
-    });
-  }, [records, searchText, selectedType, dateRange, resultFilter]);
+  useEffect(() => {
+    let cancelled = false;
+    const startDate = dateRange?.[0]?.format('YYYY-MM-DD');
+    const endDate = dateRange?.[1]?.format('YYYY-MM-DD');
+
+    void listAuditRecords({
+      page,
+      pageSize,
+      search: searchText || undefined,
+      operationType: selectedType,
+      startDate,
+      endDate,
+      result: resultFilter === 'all' ? undefined : resultFilter,
+    })
+      .then((result) => {
+        if (cancelled) return;
+        setRecords(result.items);
+        setTotal(result.total);
+      })
+      .catch(() => {
+        if (!cancelled) message.error('审计日志加载失败，请稍后重试');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [page, pageSize, searchText, selectedType, dateRange, resultFilter, refreshKey]);
 
   const { Text } = Typography;
 
-  const handleCleanup = () => {
-    const cutoff = dayjs().subtract(cleanupDays, 'day');
-    setRecords((prev) => prev.filter((r) => dayjs(r.timestamp).isAfter(cutoff)));
-    message.success(t('audit.cleanupSuccess', { n: cleanupDays }));
-    setCleanupModalOpen(false);
+  const handleCleanup = async () => {
+    try {
+      await cleanupAuditLogs(cleanupDays);
+      setPage(1);
+      setRefreshKey((key) => key + 1);
+      message.success(t('audit.cleanupSuccess', { n: cleanupDays }));
+      setCleanupModalOpen(false);
+    } catch {
+      message.error('清理审计日志失败，请稍后重试');
+    }
   };
 
   const columns: ColumnsType<AuditRecord> = [
@@ -144,7 +156,7 @@ const AuditPage: React.FC = () => {
       dataIndex: 'result',
       width: 80,
       render: (result: string) =>
-        result === 'success' ? (
+        result.toUpperCase() === 'SUCCESS' ? (
           <Tag color="green">{t('common.success')}</Tag>
         ) : (
           <Tag color="red">{t('common.failure')}</Tag>
@@ -163,7 +175,10 @@ const AuditPage: React.FC = () => {
           <Input.Search
             placeholder={t('audit.searchPlaceholder')}
             value={searchText}
-            onChange={(e) => setSearchText(e.target.value)}
+            onChange={(e) => {
+              setPage(1);
+              setSearchText(e.target.value);
+            }}
             style={{ width: 240 }}
             allowClear
           />
@@ -172,21 +187,30 @@ const AuditPage: React.FC = () => {
             allowClear
             style={{ width: 180 }}
             value={selectedType}
-            onChange={setSelectedType}
+            onChange={(value) => {
+              setPage(1);
+              setSelectedType(value);
+            }}
             options={operationTypeOptions.map((opt) => ({ label: opt, value: opt }))}
           />
           <DatePicker.RangePicker
             value={dateRange as [Dayjs | null, Dayjs | null] | null}
-            onChange={(vals) => setDateRange(vals as [Dayjs | null, Dayjs | null] | null)}
+            onChange={(vals) => {
+              setPage(1);
+              setDateRange(vals as [Dayjs | null, Dayjs | null] | null);
+            }}
           />
           <Select
             value={resultFilter}
-            onChange={setResultFilter}
+            onChange={(value) => {
+              setPage(1);
+              setResultFilter(value);
+            }}
             style={{ width: 120 }}
             options={[
               { label: t('common.all'), value: 'all' },
-              { label: t('common.success'), value: 'success' },
-              { label: t('common.failure'), value: 'failure' },
+              { label: t('common.success'), value: 'SUCCESS' },
+              { label: t('common.failure'), value: 'FAILURE' },
             ]}
           />
         </Flex>
@@ -200,9 +224,19 @@ const AuditPage: React.FC = () => {
         <Table
           size="small"
           columns={columns}
-          dataSource={filteredRecords}
+          dataSource={records}
           rowKey="id"
-          pagination={{ pageSize: 20 }}
+          loading={loading}
+          pagination={{
+            current: page,
+            pageSize,
+            total,
+            showSizeChanger: true,
+            onChange: (nextPage, nextPageSize) => {
+              setPage(nextPage);
+              setPageSize(nextPageSize);
+            },
+          }}
         />
       </Card>
 

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -1,9 +1,11 @@
 import { USE_MOCK } from '../config';
 import * as opsApi from '../api/ops';
-import type { AlertRule, SystemAlert, AuditRecord } from '../api/ops';
+import type { AlertRule, SystemAlert, AuditQuery, AuditRecord, PageResult } from '../api/ops';
 import { mockAlertRules } from '../mock/alerts';
 import { mockAuditRecords } from '../mock/audit';
 import { systemAlerts as mockSystemAlerts } from '../mock/dashboard';
+
+let auditRecordsState = mockAuditRecords as unknown as AuditRecord[];
 
 export async function listAlertRules(): Promise<AlertRule[]> {
   if (USE_MOCK) return mockAlertRules as unknown as AlertRule[];
@@ -51,9 +53,39 @@ export async function acknowledgeAlert(id: string): Promise<void> {
 }
 
 export async function listAuditRecords(
-  _params?: Record<string, unknown>,
-): Promise<{ list: AuditRecord[]; total: number }> {
-  if (USE_MOCK)
-    return { list: mockAuditRecords as unknown as AuditRecord[], total: mockAuditRecords.length };
-  return opsApi.listAuditRecords(_params);
+  params: AuditQuery = {},
+): Promise<PageResult<AuditRecord>> {
+  if (!USE_MOCK) return opsApi.listAuditRecords(params);
+
+  const page = params.page ?? 1;
+  const pageSize = params.pageSize ?? 20;
+  const records = auditRecordsState.filter((record) => {
+    const search = params.search?.trim().toLowerCase();
+    if (
+      search &&
+      !record.operator.toLowerCase().includes(search) &&
+      !record.target.toLowerCase().includes(search) &&
+      !record.detail.toLowerCase().includes(search)
+    ) {
+      return false;
+    }
+    if (params.operationType && record.operationType !== params.operationType) return false;
+    if (params.startDate && record.timestamp < params.startDate) return false;
+    if (params.endDate && record.timestamp > `${params.endDate} 23:59:59`) return false;
+    return !params.result || record.result.toUpperCase() === params.result.toUpperCase();
+  });
+  const from = (page - 1) * pageSize;
+  return { items: records.slice(from, from + pageSize), total: records.length, page, size: pageSize };
+}
+
+export async function cleanupAuditLogs(beforeDays: number): Promise<number> {
+  if (USE_MOCK) {
+    const cutoff = new Date(Date.now() - beforeDays * 24 * 60 * 60 * 1000);
+    const remaining = auditRecordsState.filter((record) => new Date(record.timestamp) >= cutoff);
+    const deleted = auditRecordsState.length - remaining.length;
+    auditRecordsState = remaining;
+    return deleted;
+  }
+  const result = await opsApi.cleanupAuditLogs(beforeDays);
+  return result.deleted;
 }


### PR DESCRIPTION
## Summary

- load audit records from the existing `/api/audit-logs` endpoint, including server-side filters and pagination
- use the backend `PageResult` (`items`, `total`, `page`, `size`) and cleanup response (`deleted`) contracts
- persist cleanup operations through `/api/audit-logs/cleanup` and cover the API contracts with unit tests

## Validation

- `npm.cmd test -- audit.test.ts`
- `npm.cmd run lint` (existing warnings only)
- `npx.cmd tsc -b`
- `npx.cmd vite build`
