### PR TITLE
[Studio] fix: connect alert rules page to APIs

### DIFF
--- a/web/src/api/alertRules.test.ts
+++ b/web/src/api/alertRules.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import {
+  createAlertRule,
+  deleteAlertRule,
+  listAlertRules,
+  toggleAlertRule,
+  updateAlertRule,
+} from './ops';
+import type { AlertRule } from './ops';
+
+const mock = new MockAdapter(client);
+const rule: AlertRule = {
+  id: 'rule-1',
+  name: 'Disk usage',
+  metric: '磁盘使用率',
+  operator: '>',
+  threshold: 80,
+  thresholdUnit: '%',
+  duration: '5分钟',
+  channels: ['email'],
+  enabled: true,
+  lastTriggered: null,
+  description: 'Warn before disk exhaustion',
+};
+
+describe('alert rules API', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('loads and unwraps alert rules', async () => {
+    mock.onGet('/alert-rules').reply(200, { code: 200, data: [rule] });
+
+    await expect(listAlertRules()).resolves.toEqual([rule]);
+  });
+
+  it('returns the backend records for create, update, and toggle', async () => {
+    const updated = { ...rule, threshold: 90, enabled: false };
+    mock.onPost('/alert-rules/create').reply((config) => {
+      expect(JSON.parse(config.data)).toMatchObject({ name: rule.name });
+      return [200, { code: 200, data: rule }];
+    });
+    mock.onPost('/alert-rules/update').reply((config) => {
+      expect(JSON.parse(config.data)).toMatchObject({ id: rule.id, threshold: 90 });
+      return [200, { code: 200, data: updated }];
+    });
+    mock.onPost('/alert-rules/toggle').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ id: rule.id, enabled: false });
+      return [200, { code: 200, data: updated }];
+    });
+
+    await expect(createAlertRule({ name: rule.name })).resolves.toEqual(rule);
+    await expect(updateAlertRule(updated)).resolves.toEqual(updated);
+    await expect(toggleAlertRule(rule.id, false)).resolves.toEqual(updated);
+  });
+
+  it('sends the rule id when deleting', async () => {
+    mock.onPost('/alert-rules/delete').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ id: rule.id });
+      return [200, { code: 200, data: null }];
+    });
+
+    await expect(deleteAlertRule(rule.id)).resolves.toBeUndefined();
+  });
+});

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -44,15 +44,18 @@ export async function listAlertRules() {
 }
 
 export async function createAlertRule(data: Partial<AlertRule>) {
-  await client.post('/alert-rules/create', data);
+  const res = await client.post<{ data: AlertRule }>('/alert-rules/create', data);
+  return res.data.data;
 }
 
-export async function updateAlertRule(data: Partial<AlertRule>) {
-  await client.post('/alert-rules/update', data);
+export async function updateAlertRule(data: AlertRule) {
+  const res = await client.post<{ data: AlertRule }>('/alert-rules/update', data);
+  return res.data.data;
 }
 
 export async function toggleAlertRule(id: string, enabled: boolean) {
-  await client.post('/alert-rules/toggle', { id, enabled });
+  const res = await client.post<{ data: AlertRule }>('/alert-rules/toggle', { id, enabled });
+  return res.data.data;
 }
 
 export async function deleteAlertRule(id: string) {

--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Plus, Pencil, Trash } from '@phosphor-icons/react';
 import {
   Button,
@@ -34,8 +34,15 @@ import {
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import PageHeader from '../../components/PageHeader';
-import { mockAlertRules, type AlertRule } from '../../mock/alerts';
 import { useLang } from '../../i18n/LangContext';
+import type { AlertRule } from '../../api/ops';
+import {
+  createAlertRule,
+  deleteAlertRule,
+  listAlertRules,
+  toggleAlertRule,
+  updateAlertRule,
+} from '../../services/opsService';
 
 const { TextArea } = Input;
 
@@ -49,10 +56,22 @@ const metricOptions = ['磁盘使用率', '消费堆积量', 'TPS 异常', 'Brok
 
 const durationOptions = ['1分钟', '5分钟', '15分钟', '30分钟'];
 
+const thresholdUnits: Record<string, string> = {
+  磁盘使用率: '%',
+  消费堆积量: '条',
+  'TPS 异常': 'TPS',
+  'Broker 离线': '个',
+  'Proxy 连接数': '个',
+};
+
 const AlertsPage = () => {
   const { t } = useLang();
-  const [rules, setRules] = useState<AlertRule[]>([...mockAlertRules]);
+  const [rules, setRules] = useState<AlertRule[]>([]);
+  const [loading, setLoading] = useState(true);
   const [modalVisible, setModalVisible] = useState(false);
+  const [editingRule, setEditingRule] = useState<AlertRule | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [actionId, setActionId] = useState<string | null>(null);
   const [form] = Form.useForm();
 
   const channelLabels: Record<string, string> = {
@@ -61,6 +80,25 @@ const AlertsPage = () => {
     sms: 'SMS',
   };
 
+  useEffect(() => {
+    let cancelled = false;
+
+    void listAlertRules()
+      .then((nextRules) => {
+        if (!cancelled) setRules(nextRules);
+      })
+      .catch(() => {
+        if (!cancelled) message.error('告警规则加载失败，请稍后重试');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const enabledCount = rules.filter((r) => r.enabled).length;
 
   // eslint-disable-next-line react-hooks/purity
@@ -68,6 +106,43 @@ const AlertsPage = () => {
   const triggered24h = rules.filter(
     (r) => r.lastTriggered && new Date(r.lastTriggered).getTime() > dayAgo,
   ).length;
+
+  const openCreateModal = () => {
+    setEditingRule(null);
+    form.resetFields();
+    setModalVisible(true);
+  };
+
+  const openEditModal = (rule: AlertRule) => {
+    setEditingRule(rule);
+    form.setFieldsValue(rule);
+    setModalVisible(true);
+  };
+
+  const handleToggle = async (rule: AlertRule, enabled: boolean) => {
+    setActionId(`toggle-${rule.id}`);
+    try {
+      const updated = await toggleAlertRule(rule.id, enabled);
+      setRules((previous) => previous.map((item) => (item.id === rule.id ? updated : item)));
+    } catch {
+      message.error('更新告警规则状态失败，请稍后重试');
+    } finally {
+      setActionId(null);
+    }
+  };
+
+  const handleDelete = async (rule: AlertRule) => {
+    setActionId(`delete-${rule.id}`);
+    try {
+      await deleteAlertRule(rule.id);
+      setRules((previous) => previous.filter((item) => item.id !== rule.id));
+      message.success('告警规则已删除');
+    } catch {
+      message.error('删除告警规则失败，请稍后重试');
+    } finally {
+      setActionId(null);
+    }
+  };
 
   const columns: ColumnsType<AlertRule> = [
     {
@@ -103,11 +178,8 @@ const AlertsPage = () => {
       render: (_, record) => (
         <Switch
           checked={record.enabled}
-          onChange={() => {
-            setRules((prev) =>
-              prev.map((r) => (r.id === record.id ? { ...r, enabled: !r.enabled } : r)),
-            );
-          }}
+          loading={actionId === `toggle-${record.id}`}
+          onChange={(enabled) => void handleToggle(record, enabled)}
         />
       ),
     },
@@ -128,6 +200,7 @@ const AlertsPage = () => {
             size="small"
             icon={<Pencil size={14} />}
             style={{ borderColor: '#1890ff', color: '#1890ff' }}
+            onClick={() => openEditModal(record)}
           >
             {t('common.edit')}
           </Button>
@@ -135,8 +208,9 @@ const AlertsPage = () => {
             size="small"
             icon={<Trash size={14} />}
             danger
+            loading={actionId === `delete-${record.id}`}
             style={{ borderColor: '#ff4d4f', color: '#ff4d4f' }}
-            onClick={() => setRules((prev) => prev.filter((r) => r.id !== record.id))}
+            onClick={() => void handleDelete(record)}
           >
             {t('common.delete')}
           </Button>
@@ -146,10 +220,30 @@ const AlertsPage = () => {
   ];
 
   const handleSubmit = async () => {
-    await form.validateFields();
-    message.success(t('alerts.ruleCreated'));
-    setModalVisible(false);
-    form.resetFields();
+    try {
+      const values = await form.validateFields();
+      setSubmitting(true);
+      if (editingRule) {
+        const updated = await updateAlertRule({ ...editingRule, ...values });
+        setRules((previous) =>
+          previous.map((rule) => (rule.id === editingRule.id ? updated : rule)),
+        );
+        message.success('告警规则已更新');
+      } else {
+        const created = await createAlertRule({
+          ...values,
+          thresholdUnit: thresholdUnits[values.metric] ?? '',
+        });
+        setRules((previous) => [...previous, created]);
+        message.success(t('alerts.ruleCreated'));
+      }
+      setModalVisible(false);
+      form.resetFields();
+    } catch {
+      message.error('保存告警规则失败，请稍后重试');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -178,7 +272,7 @@ const AlertsPage = () => {
                 {triggered24h}
               </span>
             </Flex>
-            <Button type="primary" icon={<Plus />} onClick={() => setModalVisible(true)}>
+            <Button type="primary" icon={<Plus />} onClick={openCreateModal}>
               {t('alerts.newRule')}
             </Button>
           </Flex>
@@ -192,19 +286,22 @@ const AlertsPage = () => {
           dataSource={rules}
           rowKey="id"
           size="small"
+          loading={loading}
           pagination={false}
         />
       </Card>
 
       <Modal
-        title={t('alerts.newRule')}
+        title={editingRule ? t('common.edit') : t('alerts.newRule')}
         open={modalVisible}
         onOk={handleSubmit}
+        confirmLoading={submitting}
         onCancel={() => {
           setModalVisible(false);
+          setEditingRule(null);
           form.resetFields();
         }}
-        okText={t('common.create')}
+        okText={editingRule ? t('common.edit') : t('common.create')}
         cancelText={t('common.cancel')}
       >
         <Form form={form} layout="vertical">

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -5,32 +5,58 @@ import { mockAlertRules } from '../mock/alerts';
 import { mockAuditRecords } from '../mock/audit';
 import { systemAlerts as mockSystemAlerts } from '../mock/dashboard';
 
+const alertRulesState = mockAlertRules as unknown as AlertRule[];
+
 export async function listAlertRules(): Promise<AlertRule[]> {
-  if (USE_MOCK) return mockAlertRules as unknown as AlertRule[];
+  if (USE_MOCK) return alertRulesState;
   return opsApi.listAlertRules();
 }
 
-export async function createAlertRule(data: Partial<AlertRule>): Promise<void> {
+export async function createAlertRule(data: Partial<AlertRule>): Promise<AlertRule> {
   if (USE_MOCK) {
-    mockAlertRules.push(data as never);
-    return;
+    const rule: AlertRule = {
+      id: `alert-${Date.now()}`,
+      name: '',
+      metric: '',
+      operator: '>',
+      threshold: 0,
+      thresholdUnit: '',
+      duration: '',
+      channels: [],
+      enabled: true,
+      lastTriggered: null,
+      description: '',
+      ...data,
+    };
+    alertRulesState.push(rule);
+    return rule;
   }
   return opsApi.createAlertRule(data);
 }
 
-export async function toggleAlertRule(id: string, enabled: boolean): Promise<void> {
+export async function updateAlertRule(data: AlertRule): Promise<AlertRule> {
   if (USE_MOCK) {
-    const r = mockAlertRules.find((r: Record<string, unknown>) => r.id === id);
-    if (r) (r as Record<string, unknown>).enabled = enabled;
-    return;
+    const index = alertRulesState.findIndex((rule) => rule.id === data.id);
+    if (index >= 0) alertRulesState[index] = data;
+    return data;
+  }
+  return opsApi.updateAlertRule(data);
+}
+
+export async function toggleAlertRule(id: string, enabled: boolean): Promise<AlertRule> {
+  if (USE_MOCK) {
+    const rule = alertRulesState.find((item) => item.id === id);
+    if (!rule) throw new Error(`Alert rule not found: ${id}`);
+    rule.enabled = enabled;
+    return rule;
   }
   return opsApi.toggleAlertRule(id, enabled);
 }
 
 export async function deleteAlertRule(id: string): Promise<void> {
   if (USE_MOCK) {
-    const idx = mockAlertRules.findIndex((r: Record<string, unknown>) => r.id === id);
-    if (idx >= 0) mockAlertRules.splice(idx, 1);
+    const idx = alertRulesState.findIndex((rule) => rule.id === id);
+    if (idx >= 0) alertRulesState.splice(idx, 1);
     return;
   }
   return opsApi.deleteAlertRule(id);


### PR DESCRIPTION
## Summary

- replace the alert-rules page's mock-only state with the existing alert-rules API
- persist rule creation, editing, enabling/disabling, and deletion; display API failures to the operator
- return the server's canonical rule after mutations and add API contract coverage

## Validation

- `npm.cmd test -- alertRules.test.ts`
- `npm.cmd run lint` (existing warnings only)
- `npx.cmd tsc -b`
- `npx.cmd vite build`
