### PR TITLE
[Studio] fix: connect DLQ page to APIs

### DIFF
--- a/web/src/api/dlq.test.ts
+++ b/web/src/api/dlq.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import { listDLQGroups, resendDLQ } from './message';
+import type { DLQGroup } from './message';
+
+const mock = new MockAdapter(client);
+const group: DLQGroup = {
+  groupName: 'order-consumer',
+  dlqTopic: '%DLQ%order-consumer',
+  messageCount: 3,
+  lastEnqueueTime: '2026-07-17T00:00:00Z',
+  retryCount: 16,
+  status: 'active',
+};
+
+describe('DLQ API', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('loads and unwraps DLQ groups', async () => {
+    mock.onGet('/dlq').reply(200, { code: 200, data: [group] });
+
+    await expect(listDLQGroups()).resolves.toEqual([group]);
+  });
+
+  it('sends epoch milliseconds for the resend time range', async () => {
+    const payload = {
+      groupName: group.groupName,
+      startTime: 1784246400000,
+      endTime: 1784332800000,
+      targetTopic: 'orders-retry',
+    };
+    mock.onPost('/dlq/resend').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual(payload);
+      return [200, { code: 200, data: null }];
+    });
+
+    await expect(resendDLQ(payload)).resolves.toBeUndefined();
+  });
+});

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -72,8 +72,8 @@ export async function listDLQGroups() {
 
 export async function resendDLQ(data: {
   groupName: string;
-  startTime: string;
-  endTime: string;
+  startTime: number;
+  endTime: number;
   targetTopic?: string;
 }) {
   await client.post('/dlq/resend', data);

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useState, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Card,
   Table,
@@ -34,8 +34,8 @@ import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
-import { mockDLQGroups } from '../../mock/dlq';
-import type { DLQGroup } from '../../mock/dlq';
+import type { DLQGroup } from '../../api/message';
+import { listDLQGroups, resendDLQ } from '../../services/messageService';
 
 const { Text } = Typography;
 const { RangePicker } = DatePicker;
@@ -53,6 +53,9 @@ const formatDateTime = (iso: string): string => {
    ═══════════════════════════════════════════ */
 const DLQPage = () => {
   const { t } = useLang();
+  const [groups, setGroups] = useState<DLQGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshKey, setRefreshKey] = useState(0);
   const [search, setSearch] = useState('');
   const [retryModalOpen, setRetryModalOpen] = useState(false);
   const [retryGroup, setRetryGroup] = useState<DLQGroup | null>(null);
@@ -61,15 +64,35 @@ const DLQPage = () => {
     dayjs(),
   ]);
   const [retryTargetTopic, setRetryTargetTopic] = useState('');
+  const [retrySubmitting, setRetrySubmitting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void listDLQGroups()
+      .then((nextGroups) => {
+        if (!cancelled) setGroups(nextGroups);
+      })
+      .catch(() => {
+        if (!cancelled) message.error('死信队列加载失败，请稍后重试');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
 
   /* ─── Filtering ─── */
   const filtered = useMemo(() => {
-    if (!search) return mockDLQGroups;
-    return mockDLQGroups.filter(
+    if (!search) return groups;
+    return groups.filter(
       (g) =>
         g.groupName.includes(search) || g.dlqTopic.toLowerCase().includes(search.toLowerCase()),
     );
-  }, [search]);
+  }, [groups, search]);
 
   /* ─── Handlers ─── */
   const openRetryModal = (group: DLQGroup) => {
@@ -79,14 +102,30 @@ const DLQPage = () => {
     setRetryModalOpen(true);
   };
 
-  const handleRetry = () => {
+  const handleRetry = async () => {
     if (!retryTargetTopic) {
       message.warning('请输入目标 Topic');
       return;
     }
-    message.success(`已提交重投任务：${retryGroup?.groupName} → ${retryTargetTopic}（模拟）`);
-    setRetryModalOpen(false);
-    setRetryGroup(null);
+    if (!retryGroup) return;
+
+    setRetrySubmitting(true);
+    try {
+      await resendDLQ({
+        groupName: retryGroup.groupName,
+        startTime: retryRange[0].valueOf(),
+        endTime: retryRange[1].valueOf(),
+        targetTopic: retryTargetTopic,
+      });
+      setRefreshKey((key) => key + 1);
+      message.success(`已提交重投任务：${retryGroup.groupName} → ${retryTargetTopic}`);
+      setRetryModalOpen(false);
+      setRetryGroup(null);
+    } catch {
+      message.error('提交重投任务失败，请稍后重试');
+    } finally {
+      setRetrySubmitting(false);
+    }
   };
 
   const handleExport = (group: DLQGroup) => {
@@ -210,6 +249,7 @@ const DLQPage = () => {
           columns={columns}
           dataSource={filtered}
           rowKey="groupName"
+          loading={loading}
           pagination={{
             pageSize: 20,
             showSizeChanger: true,
@@ -235,6 +275,7 @@ const DLQPage = () => {
           setRetryGroup(null);
         }}
         onOk={handleRetry}
+        confirmLoading={retrySubmitting}
         okText="确认重投"
         cancelText="取消"
         width={520}

--- a/web/src/services/messageService.ts
+++ b/web/src/services/messageService.ts
@@ -29,8 +29,8 @@ export async function listDLQGroups(): Promise<DLQGroup[]> {
 
 export async function resendDLQ(data: {
   groupName: string;
-  startTime: string;
-  endTime: string;
+  startTime: number;
+  endTime: number;
   targetTopic?: string;
 }): Promise<void> {
   if (USE_MOCK) return;


### PR DESCRIPTION
## Summary

- load DLQ group data from the existing `/api/dlq` endpoint instead of direct mock imports
- submit resends to `/api/dlq/resend`, refresh the list after success, and report request failures
- align resend timestamps with the backend's epoch-millisecond contract and cover it with API tests

## Validation

- `npm.cmd test -- dlq.test.ts`
- `npm.cmd run lint` (existing warnings only)
- `npx.cmd tsc -b`
- `npx.cmd vite build`
