### PR TITLE
[Studio] fix: connect clients page to APIs

### DIFF
--- a/web/src/api/connections.test.ts
+++ b/web/src/api/connections.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import { listConnections } from './connections';
+import type { ClientConnection } from './connections';
+
+const mock = new MockAdapter(client);
+const connection: ClientConnection = {
+  clientId: 'producer-001',
+  type: 'Producer',
+  groupOrTopic: 'orders',
+  protocol: 'gRPC',
+  address: '127.0.0.1:8081',
+  language: 'Java',
+  version: '5.1.0',
+  connectedAt: '2026-07-17T00:00:00',
+  clusterName: 'production-cluster',
+};
+
+describe('client connections API', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the query parameters supported by the backend', async () => {
+    mock.onGet('/clients').reply((config) => {
+      expect(config.params).toEqual({ clusterId: 'production-cluster', type: 'Producer' });
+      return [200, { code: 200, data: [connection] }];
+    });
+
+    await expect(
+      listConnections({ clusterId: 'production-cluster', type: 'Producer' }),
+    ).resolves.toEqual([connection]);
+  });
+});

--- a/web/src/api/connections.ts
+++ b/web/src/api/connections.ts
@@ -13,11 +13,12 @@ export interface ClientConnection {
   clusterName: string;
 }
 
-export async function listConnections(params?: {
-  keyword?: string;
+export interface ClientConnectionQuery {
+  clusterId?: string;
   type?: string;
-  language?: string;
-}) {
+}
+
+export async function listConnections(params?: ClientConnectionQuery) {
   const res = await client.get<{ data: ClientConnection[] }>('/clients', { params });
   return res.data.data;
 }

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -15,16 +15,15 @@
  * limitations under the License.
  */
 
-import { useState, useMemo } from 'react';
-import { Table, Card, Tag, Space, Input, Select, Flex, Typography } from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+import { Table, Card, Tag, Space, Input, Select, Flex, Typography, message } from 'antd';
 import { MagnifyingGlass } from '@phosphor-icons/react';
 import type { ColumnsType } from 'antd/es/table';
 
 import PageHeader from '../../components/PageHeader';
-import { mockClients } from '../../mock/clients';
-import type { ClientConnection } from '../../mock/clients';
-import clusters from '../../mock/clusters';
 import { useLang } from '../../i18n/LangContext';
+import type { ClientConnection } from '../../api/connections';
+import { listConnections } from '../../services/connectionsService';
 
 const { Text } = Typography;
 
@@ -52,20 +51,42 @@ const languageConfig: Record<string, { color: string; label: string }> = {
    ═══════════════════════════════════════════ */
 const ClientsPage = () => {
   const { t } = useLang();
+  const [connections, setConnections] = useState<ClientConnection[]>([]);
+  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [clusterFilter, setClusterFilter] = useState<string>('ALL');
 
+  useEffect(() => {
+    let cancelled = false;
+
+    void listConnections()
+      .then((nextConnections) => {
+        if (!cancelled) setConnections(nextConnections);
+      })
+      .catch(() => {
+        if (!cancelled) message.error('客户端连接加载失败，请稍后重试');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   /* ─── Cluster options using nsClusterName ─── */
   const clusterOptions = useMemo(() => {
+    const clusterNames = [...new Set(connections.map((connection) => connection.clusterName))].sort();
     return [
       { value: 'ALL', label: t('clients.allClusters') },
-      ...clusters.map((c) => ({ value: c.nsClusterName, label: c.nsClusterName })),
+      ...clusterNames.map((name) => ({ value: name, label: name })),
     ];
-  }, []);
+  }, [connections, t]);
 
   /* ─── Filtered data (search + cluster only, table handles column filters) ─── */
   const filtered = useMemo(() => {
-    let data = mockClients.filter(
+    let data = connections.filter(
       (c) => c.clientId.toLowerCase().includes(search.toLowerCase()) || c.address.includes(search),
     );
 
@@ -74,7 +95,7 @@ const ClientsPage = () => {
     }
 
     return data;
-  }, [search, clusterFilter]);
+  }, [connections, search, clusterFilter]);
 
   /* ═══════════════════════════════════════════
      Table Columns (with built-in filters)
@@ -85,7 +106,9 @@ const ClientsPage = () => {
       dataIndex: 'clusterName',
       key: 'clusterName',
       width: 130,
-      filters: clusters.map((c) => ({ text: c.nsClusterName, value: c.nsClusterName })),
+      filters: clusterOptions
+        .filter((option) => option.value !== 'ALL')
+        .map((option) => ({ text: option.label, value: option.value })),
       onFilter: (value, record) => record.clusterName === value,
       render: (name: string) => (
         <Tag color="blue" style={{ fontSize: 12 }}>
@@ -236,6 +259,7 @@ const ClientsPage = () => {
           columns={columns}
           dataSource={filtered}
           rowKey="clientId"
+          loading={loading}
           scroll={{ x: 1320 }}
           pagination={{
             pageSize: 20,

--- a/web/src/services/connectionsService.ts
+++ b/web/src/services/connectionsService.ts
@@ -1,25 +1,15 @@
 import { USE_MOCK } from '../config';
 import * as connApi from '../api/connections';
-import type { ClientConnection } from '../api/connections';
+import type { ClientConnection, ClientConnectionQuery } from '../api/connections';
 import { mockClients } from '../mock/clients';
 
-export async function listConnections(params?: {
-  keyword?: string;
-  type?: string;
-  language?: string;
-}): Promise<ClientConnection[]> {
+export async function listConnections(params?: ClientConnectionQuery): Promise<ClientConnection[]> {
   if (USE_MOCK) {
     let result = [...mockClients];
-    if (params?.keyword) {
-      const kw = params.keyword.toLowerCase();
-      result = result.filter(
-        (c) => c.clientId.toLowerCase().includes(kw) || c.address.toLowerCase().includes(kw),
-      );
-    }
-    if (params?.type && params.type !== 'all')
+    if (params?.clusterId)
+      result = result.filter((connection) => connection.clusterName === params.clusterId);
+    if (params?.type)
       result = result.filter((c) => c.type === params.type);
-    if (params?.language && params.language !== 'all')
-      result = result.filter((c) => c.language === params.language);
     return result as unknown as ClientConnection[];
   }
   return connApi.listConnections(params);


### PR DESCRIPTION
## Summary

- load the clients page from the existing `/api/clients` endpoint instead of direct mock imports
- derive cluster filters from the returned connection data and show request failures in the UI
- align the API wrapper and mock service with the backend's supported `clusterId` and `type` query parameters

## Validation

- `npm.cmd test -- connections.test.ts`
- `npm.cmd run lint` (existing warnings only)
- `npx.cmd tsc -b`
- `npx.cmd vite build`
