### PR TITLE
[Studio] fix: align cluster API response contract

### DIFF
--- a/web/src/api/cluster.ts
+++ b/web/src/api/cluster.ts
@@ -21,29 +21,23 @@ import client from './client';
 export interface ClusterInfo {
   id: string;
   name: string;
+  nsClusterName: string;
   type: string;
+  endpoint: string;
   status: string;
   version: string;
-  brokers: number;
-  proxies: number;
-  topics: number;
-  groups: number;
-  tpsIn: number;
-  tpsOut: number;
-}
-
-export interface ClusterDetail extends ClusterInfo {
-  brokerList: BrokerInfo[];
-  proxyList: ProxyInfo[];
-  nameServerList: NameServerInfo[];
+  brokers: BrokerInfo[];
+  proxies: ProxyInfo[];
+  nameServers: NameServerInfo[];
   config: ClusterConfig;
+  topicCount: number;
+  groupCount: number;
+  tpsHistory: number[];
 }
 
 export interface BrokerInfo {
   addr: string;
-  brokerName: string;
-  brokerId: number;
-  clusterName: string;
+  name: string;
   status: string;
   tpsIn: number;
   tpsOut: number;
@@ -53,7 +47,6 @@ export interface BrokerInfo {
 
 export interface ProxyInfo {
   addr: string;
-  clusterName: string;
   status: string;
   connections: number;
   grpcPort: number;
@@ -62,9 +55,7 @@ export interface ProxyInfo {
 
 export interface NameServerInfo {
   addr: string;
-  clusterName: string;
   status: string;
-  version: string;
 }
 
 export interface ClusterConfig {
@@ -72,10 +63,12 @@ export interface ClusterConfig {
   autoCreateTopicEnable: boolean;
   autoCreateSubscriptionGroup: boolean;
   maxMessageSize: number;
+  msgTraceTopicName: string;
   fileReservedTime: number;
   writeQueueNums: number;
   readQueueNums: number;
   brokerPermission: number;
+  deleteWhen: string;
 }
 
 export interface K8sCertInfo {
@@ -99,7 +92,7 @@ export async function listClusters() {
 }
 
 export async function getCluster(id: string) {
-  const res = await client.get<{ data: ClusterDetail }>(`/clusters/${id}`);
+  const res = await client.get<{ data: ClusterInfo }>(`/clusters/${id}`);
   return res.data.data;
 }
 

--- a/web/src/api/clusterContract.test.ts
+++ b/web/src/api/clusterContract.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import { getCluster, listClusters } from './cluster';
+import type { ClusterInfo } from './cluster';
+
+const mock = new MockAdapter(client);
+const cluster: ClusterInfo = {
+  id: 'cluster-a',
+  name: 'cluster-a',
+  nsClusterName: 'production',
+  type: 'V5_PROXY_CLUSTER',
+  endpoint: '127.0.0.1:9876',
+  status: 'RUNNING',
+  version: '5.3.0',
+  brokers: [{ name: 'broker-a', addr: '127.0.0.1:10911', status: 'RUNNING', tpsIn: 1, tpsOut: 2, diskUsage: 10, version: '5.3.0' }],
+  proxies: [{ addr: '127.0.0.1:8080', status: 'RUNNING', connections: 3, grpcPort: 8081, remotingPort: 8080 }],
+  nameServers: [{ addr: '127.0.0.1:9876', status: 'RUNNING' }],
+  config: { flushDiskType: 'ASYNC_FLUSH', autoCreateTopicEnable: true, autoCreateSubscriptionGroup: true, maxMessageSize: 4194304, msgTraceTopicName: 'TRACE_TOPIC', fileReservedTime: 72, writeQueueNums: 8, readQueueNums: 8, brokerPermission: 6, deleteWhen: '04' },
+  topicCount: 10,
+  groupCount: 4,
+  tpsHistory: [1, 2],
+};
+
+describe('cluster API contract', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('unwraps the backend ClusterVO shape for list and detail endpoints', async () => {
+    mock.onGet('/clusters').reply(200, { code: 200, data: [cluster] });
+    mock.onGet('/clusters/cluster-a').reply(200, { code: 200, data: cluster });
+
+    await expect(listClusters()).resolves.toEqual([cluster]);
+    await expect(getCluster(cluster.id)).resolves.toEqual(cluster);
+  });
+});

--- a/web/src/services/clusterService.ts
+++ b/web/src/services/clusterService.ts
@@ -13,15 +13,18 @@ export async function listClusters(): Promise<ClusterInfo[]> {
     return clusters.map((c) => ({
       id: c.id,
       name: c.name,
+      nsClusterName: c.nsClusterName,
       type: c.type,
+      endpoint: c.endpoint,
       status: c.status,
       version: c.version,
-      brokers: c.brokers.length,
-      proxies: c.proxies.length,
-      topics: c.topicCount,
-      groups: c.groupCount,
-      tpsIn: c.brokers.reduce((s, b) => s + b.tpsIn, 0),
-      tpsOut: c.brokers.reduce((s, b) => s + b.tpsOut, 0),
+      brokers: c.brokers.map((broker) => ({ ...broker })),
+      proxies: c.proxies.map((proxy) => ({ ...proxy })),
+      nameServers: c.nameServers.map((nameServer) => ({ ...nameServer })),
+      config: { ...c.config },
+      topicCount: c.topicCount,
+      groupCount: c.groupCount,
+      tpsHistory: [...c.tpsHistory],
     }));
   }
   return clusterApi.listClusters();


### PR DESCRIPTION
## Summary

- align the frontend cluster API types with the backend `ClusterVO` response
- preserve broker, proxy, NameServer, configuration, and aggregate fields in mock mode as well
- add a contract test for both cluster list and detail responses

## Validation

- `npm.cmd test -- clusterContract.test.ts`
- `npm.cmd run lint` (existing warnings only)
- `npx.cmd tsc -b`
- `npx.cmd vite build`
