### PR TITLE
[Studio] fix: align ACL API contract

### DIFF
--- a/web/src/api/acl.test.ts
+++ b/web/src/api/acl.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import { createAclRule, createAclUser, listAclRules } from './acl';
+
+const mock = new MockAdapter(client);
+
+describe('ACL API contract', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the controller-supported ACL rule filters', async () => {
+    const params = { clusterId: 'cluster-a', principal: 'orders' };
+    mock.onGet('/acl/rules').reply((config) => {
+      expect(config.params).toEqual(params);
+      return [200, { code: 200, data: [] }];
+    });
+
+    await expect(listAclRules(params)).resolves.toEqual([]);
+  });
+
+  it('returns records created by rule and user APIs', async () => {
+    const rule = { id: 'rule-1', principal: 'orders', resource: 'orders-*', resourceType: 'Topic', resourcePattern: 'PREFIX', actions: ['PUB'], decision: 'ALLOW', scope: 'cluster', aclVersion: 2, createdAt: '2026-07-17T00:00:00Z' };
+    const user = { id: 'user-1', username: 'orders', accessKey: 'ak', secretKey: 'sk', admin: false, clusters: ['cluster-a'], createdAt: '2026-07-17T00:00:00Z' };
+    mock.onPost('/acl/rules/create').reply(200, { code: 200, data: rule });
+    mock.onPost('/acl/users/create').reply(200, { code: 200, data: user });
+
+    await expect(createAclRule({ principal: rule.principal })).resolves.toEqual(rule);
+    await expect(createAclUser({ username: user.username })).resolves.toEqual(user);
+  });
+});

--- a/web/src/api/acl.ts
+++ b/web/src/api/acl.ts
@@ -10,8 +10,13 @@ export interface AclRule {
   actions: string[];
   decision: string;
   scope: string;
-  aclVersion: string;
+  aclVersion: number;
   createdAt: string;
+}
+
+export interface AclRuleQuery {
+  clusterId?: string;
+  principal?: string;
 }
 
 export interface AclUser {
@@ -24,17 +29,14 @@ export interface AclUser {
   createdAt: string;
 }
 
-export async function listAclRules(params?: {
-  keyword?: string;
-  version?: string;
-  decision?: string;
-}) {
+export async function listAclRules(params?: AclRuleQuery) {
   const res = await client.get<{ data: AclRule[] }>('/acl/rules', { params });
   return res.data.data;
 }
 
 export async function createAclRule(data: Partial<AclRule>) {
-  await client.post('/acl/rules/create', data);
+  const res = await client.post<{ data: AclRule }>('/acl/rules/create', data);
+  return res.data.data;
 }
 
 export async function deleteAclRule(id: string) {
@@ -47,7 +49,8 @@ export async function listAclUsers(params?: { keyword?: string }) {
 }
 
 export async function createAclUser(data: Partial<AclUser>) {
-  await client.post('/acl/users/create', data);
+  const res = await client.post<{ data: AclUser }>('/acl/users/create', data);
+  return res.data.data;
 }
 
 export async function deleteAclUser(id: string) {

--- a/web/src/services/aclService.ts
+++ b/web/src/services/aclService.ts
@@ -1,71 +1,87 @@
 import { USE_MOCK } from '../config';
 import * as aclApi from '../api/acl';
-import type { AclRule, AclUser } from '../api/acl';
+import type { AclRule, AclRuleQuery, AclUser } from '../api/acl';
 import { aclRules as mockRules, aclUsers as mockUsers } from '../mock/acl';
 
-export async function listAclRules(params?: {
-  keyword?: string;
-  version?: string;
-  decision?: string;
-}): Promise<AclRule[]> {
+const aclRulesState = mockRules as unknown as AclRule[];
+const aclUsersState = mockUsers as unknown as AclUser[];
+
+export async function listAclRules(params?: AclRuleQuery): Promise<AclRule[]> {
   if (USE_MOCK) {
-    let result = [...mockRules];
-    if (params?.keyword) {
-      const kw = params.keyword.toLowerCase();
-      result = result.filter(
-        (r) => r.principal.toLowerCase().includes(kw) || r.resource.toLowerCase().includes(kw),
-      );
+    let result = [...aclRulesState];
+    if (params?.principal) {
+      const principal = params.principal.toLowerCase();
+      result = result.filter((rule) => rule.principal.toLowerCase().includes(principal));
     }
-    if (params?.version && params.version !== 'all')
-      result = result.filter((r) => r.aclVersion === params.version);
-    if (params?.decision && params.decision !== 'all')
-      result = result.filter((r) => r.decision === params.decision);
-    return result as unknown as AclRule[];
+    return result;
   }
   return aclApi.listAclRules(params);
 }
 
 export async function listAclUsers(params?: { keyword?: string }): Promise<AclUser[]> {
   if (USE_MOCK) {
-    let result = [...mockUsers];
+    let result = [...aclUsersState];
     if (params?.keyword) {
       const kw = params.keyword.toLowerCase();
       result = result.filter((u) => u.username.toLowerCase().includes(kw));
     }
-    return result as unknown as AclUser[];
+    return result;
   }
   return aclApi.listAclUsers(params);
 }
 
-export async function createAclRule(data: Partial<AclRule>): Promise<void> {
+export async function createAclRule(data: Partial<AclRule>): Promise<AclRule> {
   if (USE_MOCK) {
-    mockRules.push(data as never);
-    return;
+    const rule: AclRule = {
+      id: `acl-${Date.now()}`,
+      principal: '',
+      resource: '',
+      resourceType: '',
+      resourcePattern: '',
+      actions: [],
+      decision: '',
+      scope: '',
+      aclVersion: 2,
+      createdAt: new Date().toISOString(),
+      ...data,
+    };
+    aclRulesState.push(rule);
+    return rule;
   }
   return aclApi.createAclRule(data);
 }
 
 export async function deleteAclRule(id: string): Promise<void> {
   if (USE_MOCK) {
-    const idx = mockRules.findIndex((r) => r.id === id);
-    if (idx >= 0) mockRules.splice(idx, 1);
+    const idx = aclRulesState.findIndex((rule) => rule.id === id);
+    if (idx >= 0) aclRulesState.splice(idx, 1);
     return;
   }
   return aclApi.deleteAclRule(id);
 }
 
-export async function createAclUser(data: Partial<AclUser>): Promise<void> {
+export async function createAclUser(data: Partial<AclUser>): Promise<AclUser> {
   if (USE_MOCK) {
-    mockUsers.push(data as never);
-    return;
+    const user: AclUser = {
+      id: `user-${Date.now()}`,
+      username: '',
+      accessKey: '',
+      secretKey: '',
+      admin: false,
+      clusters: [],
+      createdAt: new Date().toISOString(),
+      ...data,
+    };
+    aclUsersState.push(user);
+    return user;
   }
   return aclApi.createAclUser(data);
 }
 
 export async function deleteAclUser(id: string): Promise<void> {
   if (USE_MOCK) {
-    const idx = mockUsers.findIndex((u) => u.id === id);
-    if (idx >= 0) mockUsers.splice(idx, 1);
+    const idx = aclUsersState.findIndex((user) => user.id === id);
+    if (idx >= 0) aclUsersState.splice(idx, 1);
     return;
   }
   return aclApi.deleteAclUser(id);


### PR DESCRIPTION
## Summary

- align ACL rule query fields and ACL version types with `AclController` and `AclRuleVO`
- return persisted ACL rules and users from creation APIs, including in mock mode
- add request and response contract coverage for ACL endpoints

## Validation

- `npm.cmd test -- acl.test.ts`
- `npm.cmd run lint` (existing warnings only)
- `npx.cmd tsc -b`
- `npx.cmd vite build`
