### PR TITLE
[Studio] fix: align consumer group API contract

### DIFF
--- a/web/src/api/consumerGroups.test.ts
+++ b/web/src/api/consumerGroups.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import { getConsumerGroup, listConsumerGroups, resetConsumerOffset } from './metadata';
+
+const mock = new MockAdapter(client);
+const group = {
+  name: 'orders',
+  namespace: 'default',
+  clusterId: 'cluster-a',
+  subscriptionMode: 'Push',
+  consumeType: 'CLUSTERING',
+  onlineInstances: 1,
+  totalLag: 0,
+  subscribedTopics: ['orders'],
+  subscriptionDataType: 'NORMAL',
+  retryMaxTimes: 16,
+  createdAt: '2026-07-17T00:00:00Z',
+  updatedAt: '2026-07-17T00:00:00Z',
+  delaySeconds: 0,
+  instances: [],
+};
+
+describe('consumer groups API contract', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the controller-supported list query fields', async () => {
+    const params = { clusterId: 'cluster-a', search: 'orders' };
+    mock.onGet('/groups').reply((config) => {
+      expect(config.params).toEqual(params);
+      return [200, { code: 200, data: [group] }];
+    });
+
+    await expect(listConsumerGroups(params)).resolves.toEqual([group]);
+  });
+
+  it('unwraps detail records and sends numeric reset timestamps', async () => {
+    const reset = { name: group.name, topic: 'orders', timestamp: 1784246400000 };
+    mock.onGet('/groups/orders').reply(200, { code: 200, data: group });
+    mock.onPost('/groups/reset-offset').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual(reset);
+      return [200, { code: 200, data: null }];
+    });
+
+    await expect(getConsumerGroup(group.name)).resolves.toEqual(group);
+    await expect(resetConsumerOffset(reset)).resolves.toBeUndefined();
+  });
+});

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -52,13 +52,18 @@ export interface ConsumerGroup {
   deliveryOrderType?: string;
   retryMaxTimes: number;
   createdAt: string;
+  updatedAt: string;
+  delaySeconds: number;
+  instances: ConsumerInstance[];
 }
 
 export interface ConsumerInstance {
   clientId: string;
-  clientAddr: string;
-  language: string;
-  version: string;
+  protocol: string;
+  address: string;
+  subscribedTopics: string[];
+  lastHeartbeat: string;
+  topicLag: Record<string, number>;
 }
 
 export interface QueueProgress {
@@ -75,6 +80,17 @@ export interface SubscriptionEntry {
   type: string;
   filterMode: string;
   consistency: string;
+}
+
+export interface ConsumerGroupQuery {
+  clusterId?: string;
+  search?: string;
+}
+
+export interface ResetConsumerOffsetRequest {
+  name: string;
+  timestamp: number;
+  topic?: string;
 }
 
 // ─── Topic API ──────────────────────────────────────────────────
@@ -126,15 +142,13 @@ export async function sendTopicMessage(data: SendTopicMessageRequest) {
 }
 
 // ─── Consumer Group API ─────────────────────────────────────────
-export async function listConsumerGroups(params?: { keyword?: string }) {
+export async function listConsumerGroups(params?: ConsumerGroupQuery) {
   const res = await client.get<{ data: ConsumerGroup[] }>('/groups', { params });
   return res.data.data;
 }
 
 export async function getConsumerGroup(name: string) {
-  const res = await client.get<{ data: ConsumerGroup & { instances: ConsumerInstance[] } }>(
-    `/groups/${name}`,
-  );
+  const res = await client.get<{ data: ConsumerGroup }>(`/groups/${name}`);
   return res.data.data;
 }
 
@@ -149,14 +163,15 @@ export async function getConsumerSubscriptions(name: string) {
 }
 
 export async function createConsumerGroup(data: Partial<ConsumerGroup>) {
-  await client.post('/groups/create', data);
+  const res = await client.post<{ data: ConsumerGroup }>('/groups/create', data);
+  return res.data.data;
 }
 
 export async function deleteConsumerGroup(name: string) {
   await client.post('/groups/delete', { name });
 }
 
-export async function resetConsumerOffset(data: Record<string, unknown>) {
+export async function resetConsumerOffset(data: ResetConsumerOffsetRequest) {
   await client.post('/groups/reset-offset', data);
 }
 

--- a/web/src/services/consumerService.ts
+++ b/web/src/services/consumerService.ts
@@ -1,18 +1,36 @@
 import { USE_MOCK } from '../config';
 import * as metadataApi from '../api/metadata';
-import type { ConsumerGroup, QueueProgress, SubscriptionEntry } from '../api/metadata';
+import type {
+  ConsumerGroup,
+  ConsumerGroupQuery,
+  QueueProgress,
+  ResetConsumerOffsetRequest,
+  SubscriptionEntry,
+} from '../api/metadata';
 import { mockConsumerGroups, mockQueueProgress, mockSubscriptions } from '../mock/consumers';
 
-export async function listConsumerGroups(params?: { keyword?: string }): Promise<ConsumerGroup[]> {
+const consumerGroupsState = mockConsumerGroups as unknown as ConsumerGroup[];
+
+export async function listConsumerGroups(params?: ConsumerGroupQuery): Promise<ConsumerGroup[]> {
   if (USE_MOCK) {
-    let result = [...mockConsumerGroups];
-    if (params?.keyword) {
-      const kw = params.keyword.toLowerCase();
+    let result = [...consumerGroupsState];
+    if (params?.clusterId) result = result.filter((group) => group.clusterId === params.clusterId);
+    if (params?.search) {
+      const kw = params.search.toLowerCase();
       result = result.filter((g) => g.name.toLowerCase().includes(kw));
     }
-    return result as unknown as ConsumerGroup[];
+    return result;
   }
   return metadataApi.listConsumerGroups(params);
+}
+
+export async function getConsumerGroup(name: string): Promise<ConsumerGroup> {
+  if (USE_MOCK) {
+    const group = consumerGroupsState.find((item) => item.name === name);
+    if (!group) throw new Error(`Consumer group not found: ${name}`);
+    return group;
+  }
+  return metadataApi.getConsumerGroup(name);
 }
 
 export async function getConsumerProgress(name: string): Promise<QueueProgress[]> {
@@ -25,15 +43,35 @@ export async function getConsumerSubscriptions(name: string): Promise<Subscripti
   return metadataApi.getConsumerSubscriptions(name);
 }
 
-export async function createConsumerGroup(data: Partial<ConsumerGroup>): Promise<void> {
-  if (USE_MOCK) return;
+export async function createConsumerGroup(data: Partial<ConsumerGroup>): Promise<ConsumerGroup> {
+  if (USE_MOCK) {
+    const group: ConsumerGroup = {
+      name: '',
+      namespace: 'default',
+      clusterId: '',
+      subscriptionMode: 'Push',
+      consumeType: 'CLUSTERING',
+      onlineInstances: 0,
+      totalLag: 0,
+      subscribedTopics: [],
+      subscriptionDataType: 'NORMAL',
+      retryMaxTimes: 16,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      delaySeconds: 0,
+      instances: [],
+      ...data,
+    };
+    consumerGroupsState.push(group);
+    return group;
+  }
   return metadataApi.createConsumerGroup(data);
 }
 
 export async function deleteConsumerGroup(name: string): Promise<void> {
   if (USE_MOCK) {
-    const idx = mockConsumerGroups.findIndex((g) => g.name === name);
-    if (idx >= 0) mockConsumerGroups.splice(idx, 1);
+    const idx = consumerGroupsState.findIndex((group) => group.name === name);
+    if (idx >= 0) consumerGroupsState.splice(idx, 1);
     return;
   }
   return metadataApi.deleteConsumerGroup(name);
@@ -44,4 +82,9 @@ export async function batchDeleteConsumerGroups(names: string[]): Promise<void> 
   for (const name of names) {
     await deleteConsumerGroup(name);
   }
+}
+
+export async function resetConsumerOffset(data: ResetConsumerOffsetRequest): Promise<void> {
+  if (USE_MOCK) return;
+  return metadataApi.resetConsumerOffset(data);
 }


### PR DESCRIPTION
## Summary

- align consumer-group query parameters and detail fields with `ConsumerGroupController` and its DTOs
- return created groups and expose detail/reset-offset operations through the service layer
- use numeric epoch milliseconds for reset-offset requests and add API contract tests

## Validation

- `npm.cmd test -- consumerGroups.test.ts`
- `npm.cmd run lint` (existing warnings only)
- `npx.cmd tsc -b`
- `npx.cmd vite build`
