### PR TITLE
[Studio] feat: add login and auth page

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/auth/AuthController.java
+++ b/server/src/main/java/com/rocketmq/studio/auth/AuthController.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rocketmq.studio.auth;
+
+import com.rocketmq.studio.common.domain.Result;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public Result<LoginVO> login(@RequestBody LoginDTO request) {
+        return Result.ok(authService.login(request));
+    }
+
+    @PostMapping("/logout")
+    public Result<Void> logout() {
+        authService.logout();
+        return Result.ok();
+    }
+}

--- a/server/src/main/java/com/rocketmq/studio/auth/AuthService.java
+++ b/server/src/main/java/com/rocketmq/studio/auth/AuthService.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rocketmq.studio.auth;
+
+import com.rocketmq.studio.common.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class AuthService {
+
+    public LoginVO login(LoginDTO request) {
+        log.info("Login attempt for user: {}", request.getUsername());
+
+        if (request.getUsername() == null || request.getUsername().isBlank()) {
+            throw new BusinessException(400, "Username is required");
+        }
+        if (request.getPassword() == null || request.getPassword().isBlank()) {
+            throw new BusinessException(400, "Password is required");
+        }
+
+        // Mock authentication — accept any non-empty credentials
+        String token = "mock-jwt-" + UUID.randomUUID();
+        boolean isAdmin = "admin".equals(request.getUsername());
+
+        LoginVO response = LoginVO.builder()
+                .token(token)
+                .expiresIn(86400)
+                .user(LoginVO.UserInfo.builder()
+                        .username(request.getUsername())
+                        .admin(isAdmin)
+                        .build())
+                .build();
+
+        log.info("User {} logged in successfully, admin={}", request.getUsername(), isAdmin);
+        return response;
+    }
+
+    public void logout() {
+        log.info("User logged out");
+    }
+}

--- a/server/src/main/java/com/rocketmq/studio/auth/LoginDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/auth/LoginDTO.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rocketmq.studio.auth;
+
+import lombok.Data;
+
+@Data
+public class LoginDTO {
+    private String username;
+    private String password;
+}

--- a/server/src/main/java/com/rocketmq/studio/auth/LoginVO.java
+++ b/server/src/main/java/com/rocketmq/studio/auth/LoginVO.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rocketmq.studio.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginVO {
+    private String token;
+    private int expiresIn;
+    private UserInfo user;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserInfo {
+        private String username;
+        private boolean admin;
+    }
+}

--- a/server/src/main/java/com/rocketmq/studio/auth/SecurityConfig.java
+++ b/server/src/main/java/com/rocketmq/studio/auth/SecurityConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rocketmq.studio.auth;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SecurityConfig {
+    // TODO: Add Spring Security configuration when Spring Security dependency is added
+}

--- a/server/src/test/java/com/rocketmq/studio/auth/AuthControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/auth/AuthControllerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rocketmq.studio.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void loginShouldReturnTokenOnValidRequest() throws Exception {
+        LoginVO mockResponse = LoginVO.builder()
+                .token("mock-jwt-abc123")
+                .expiresIn(86400)
+                .user(LoginVO.UserInfo.builder()
+                        .username("testuser")
+                        .admin(false)
+                        .build())
+                .build();
+
+        when(authService.login(any(LoginDTO.class))).thenReturn(mockResponse);
+
+        LoginDTO request = new LoginDTO();
+        request.setUsername("testuser");
+        request.setPassword("testpass");
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data.token").value("mock-jwt-abc123"))
+                .andExpect(jsonPath("$.data.expiresIn").value(86400))
+                .andExpect(jsonPath("$.data.user.username").value("testuser"))
+                .andExpect(jsonPath("$.data.user.admin").value(false));
+    }
+
+    @Test
+    void loginShouldReturnAdminUserWhenAdminLogsIn() throws Exception {
+        LoginVO mockResponse = LoginVO.builder()
+                .token("mock-jwt-admin")
+                .expiresIn(86400)
+                .user(LoginVO.UserInfo.builder()
+                        .username("admin")
+                        .admin(true)
+                        .build())
+                .build();
+
+        when(authService.login(any(LoginDTO.class))).thenReturn(mockResponse);
+
+        LoginDTO request = new LoginDTO();
+        request.setUsername("admin");
+        request.setPassword("adminpass");
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.user.username").value("admin"))
+                .andExpect(jsonPath("$.data.user.admin").value(true));
+    }
+
+    @Test
+    void logoutShouldReturnSuccess() throws Exception {
+        doNothing().when(authService).logout();
+
+        mockMvc.perform(post("/api/auth/logout"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"));
+
+        verify(authService).logout();
+    }
+}

--- a/server/src/test/java/com/rocketmq/studio/auth/AuthServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/auth/AuthServiceTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rocketmq.studio.auth;
+
+import com.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService();
+    }
+
+    @Test
+    void loginShouldReturnTokenForValidCredentials() {
+        LoginDTO request = new LoginDTO();
+        request.setUsername("testuser");
+        request.setPassword("testpass");
+
+        LoginVO response = authService.login(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getToken()).startsWith("mock-jwt-");
+        assertThat(response.getExpiresIn()).isEqualTo(86400);
+        assertThat(response.getUser()).isNotNull();
+        assertThat(response.getUser().getUsername()).isEqualTo("testuser");
+        assertThat(response.getUser().isAdmin()).isFalse();
+    }
+
+    @Test
+    void loginShouldReturnAdminFlagForAdminUser() {
+        LoginDTO request = new LoginDTO();
+        request.setUsername("admin");
+        request.setPassword("adminpass");
+
+        LoginVO response = authService.login(request);
+
+        assertThat(response.getUser().getUsername()).isEqualTo("admin");
+        assertThat(response.getUser().isAdmin()).isTrue();
+    }
+
+    @Test
+    void loginShouldThrowWhenUsernameIsNull() {
+        LoginDTO request = new LoginDTO();
+        request.setUsername(null);
+        request.setPassword("password");
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Username is required");
+    }
+
+    @Test
+    void loginShouldThrowWhenUsernameIsBlank() {
+        LoginDTO request = new LoginDTO();
+        request.setUsername("   ");
+        request.setPassword("password");
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Username is required");
+    }
+
+    @Test
+    void loginShouldThrowWhenPasswordIsNull() {
+        LoginDTO request = new LoginDTO();
+        request.setUsername("testuser");
+        request.setPassword(null);
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Password is required");
+    }
+
+    @Test
+    void loginShouldThrowWhenPasswordIsBlank() {
+        LoginDTO request = new LoginDTO();
+        request.setUsername("testuser");
+        request.setPassword("   ");
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Password is required");
+    }
+
+    @Test
+    void logoutShouldCompleteWithoutError() {
+        authService.logout();
+    }
+}


### PR DESCRIPTION
## Summary
Add login and authentication module for RocketMQ Studio, providing user login/logout REST API with JWT token support and Spring Security configuration placeholder.

## Files Changed
7 files modified, total 427 line insertions

### Source Files (5)
| File | Lines | Description |
|------|-------|-------------|
| auth/AuthController.java | 44 | REST controller, provides POST /api/auth/login and POST /api/auth/logout interfaces |
| auth/AuthService.java | 60 | Authentication service layer, implements credential verification, mock JWT token generation and admin identity judgment logic |
| auth/LoginDTO.java | 26 | Login request DTO, contains username and password fields |
| auth/LoginVO.java | 42 | Login response VO, carries token, expiration time and nested user information (username, admin identity flag) |
| auth/SecurityConfig.java | 25 | Spring Security configuration class marked with @Configuration, reserved placeholder (TODO: complete after introducing related dependencies) |

### Test Files (2)
| File | Lines | Description |
|------|-------|-------------|
| auth/AuthControllerTest.java | 115 | WebMvcTest for controller layer: verify normal login token return, admin identity identification and logout success logic |
| auth/AuthServiceTest.java | 115 | Mockito unit test for service layer: verify valid credential login, admin flag judgment, empty username/password parameter verification and logout logic |

## Key Design
1. API Endpoints
- `POST /api/auth/login`: Return unified response `Result<LoginVO>` carrying mock JWT token
- `POST /api/auth/logout`: Return unified empty response `Result<Void>`
2. Parameter Validation
Throw `BusinessException` with error code 400 when username or password is null or blank
3. Mock Authentication Logic
- Accept any non-empty username and password combination to generate mock token in format `mock-jwt-{UUID}`
- Mark user as admin if username is exactly `admin`
4. Unified Response Standard
Reuse `Result<T>` wrapper and global `BusinessException` defined in common module to keep consistent API return format

## Dependencies
Depends on PR#1 (feature/studio-common-foundation), relies on the unified response `Result` and global business exception `BusinessException` provided by the common foundation module

## Test Coverage
- AuthControllerTest: 3 test cases (normal login, admin user login, logout)
- AuthServiceTest: 7 test cases (valid login, admin identity judgment, 4 parameter validation error scenarios, logout)

## PR Title Rule Reminder
All PR and Issue titles of this project must start with `[studio]` for community quick filtering and tracking.
Example: `[studio] feat: add login and JWT authentication module`