### PR TITLE
[Studio] feat: add cluster broker overview page

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/cluster/broker/BrokerVO.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/broker/BrokerVO.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.broker;
+
+import com.rocketmq.studio.common.domain.enums.BrokerStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrokerVO {
+    private String name;
+    private String addr;
+    private String version;
+    private BrokerStatus status;
+    private double diskUsage;
+    private int tpsIn;
+    private int tpsOut;
+}

--- a/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterController.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterController.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.broker;
+
+import com.rocketmq.studio.cluster.config.UpdateConfigDTO;
+
+import com.rocketmq.studio.common.domain.Result;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/clusters")
+@RequiredArgsConstructor
+public class ClusterController {
+
+    private final ClusterService clusterService;
+
+    @GetMapping
+    public Result<List<ClusterVO>> listClusters() {
+        return Result.ok(clusterService.listClusters());
+    }
+
+    @GetMapping("/{id}")
+    public Result<ClusterVO> getCluster(@PathVariable String id) {
+        return Result.ok(clusterService.getCluster(id));
+    }
+
+    @PostMapping("/config/update")
+    public Result<ClusterVO> updateClusterConfig(@RequestBody UpdateConfigDTO command) {
+        return Result.ok(clusterService.updateClusterConfig(command));
+    }
+
+    @PostMapping("/{clusterId}/brokers/{name}/restart")
+    public Result<Map<String, Object>> restartBroker(@PathVariable String clusterId,
+                                                     @PathVariable String name) {
+        boolean success = clusterService.restartBroker(clusterId, name);
+        return Result.ok(Map.of(
+                "success", success,
+                "message", "Broker restart initiated for " + name
+        ));
+    }
+}

--- a/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterProvider.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.broker;
+
+
+import java.util.List;
+
+public interface ClusterProvider {
+
+    List<ClusterVO> discoverClusters();
+
+    ClusterVO refreshClusterDetail(String clusterId);
+}

--- a/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterProviderStub.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterProviderStub.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.broker;
+
+import com.rocketmq.studio.cluster.nameserver.NameServerVO;
+import com.rocketmq.studio.cluster.proxy.ProxyVO;
+
+import com.rocketmq.studio.common.domain.enums.BrokerStatus;
+import com.rocketmq.studio.common.domain.enums.ClusterStatus;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ClusterProviderStub implements ClusterProvider {
+
+    @Override
+    public List<ClusterVO> discoverClusters() {
+        return List.of(buildSampleCluster());
+    }
+
+    @Override
+    public ClusterVO refreshClusterDetail(String clusterId) {
+        return buildSampleCluster();
+    }
+
+    private ClusterVO buildSampleCluster() {
+        return ClusterVO.builder()
+                .name("rmq-cluster-01")
+                .brokers(List.of(
+                        BrokerVO.builder()
+                                .name("broker-a")
+                                .addr("10.0.0.1:10911")
+                                .version("5.2.0")
+                                .status(BrokerStatus.running)
+                                .diskUsage(45.2)
+                                .tpsIn(1200)
+                                .tpsOut(800)
+                                .build(),
+                        BrokerVO.builder()
+                                .name("broker-b")
+                                .addr("10.0.0.2:10911")
+                                .version("5.2.0")
+                                .status(BrokerStatus.running)
+                                .diskUsage(38.7)
+                                .tpsIn(980)
+                                .tpsOut(750)
+                                .build()
+                ))
+                .proxies(List.of(
+                        ProxyVO.builder()
+                                .addr("10.0.0.10:8081")
+                                .status(ClusterStatus.healthy)
+                                .connections(156)
+                                .grpcPort(8081)
+                                .remotingPort(10911)
+                                .build()
+                ))
+                .nameServers(List.of(
+                        NameServerVO.builder()
+                                .addr("10.0.0.20:9876")
+                                .status(ClusterStatus.healthy)
+                                .build(),
+                        NameServerVO.builder()
+                                .addr("10.0.0.21:9876")
+                                .status(ClusterStatus.healthy)
+                                .build()
+                ))
+                .build();
+    }
+}

--- a/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterRepository.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.broker;
+
+import com.rocketmq.studio.cluster.config.ClusterConfigVO;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ClusterRepository {
+
+    List<ClusterVO> findAll();
+
+    Optional<ClusterVO> findById(String id);
+
+    void updateConfig(String clusterId, ClusterConfigVO config);
+}

--- a/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.broker;
+
+import com.rocketmq.studio.cluster.config.ClusterConfigVO;
+import com.rocketmq.studio.cluster.nameserver.NameServerVO;
+import com.rocketmq.studio.cluster.proxy.ProxyVO;
+
+import com.rocketmq.studio.common.domain.enums.BrokerStatus;
+import com.rocketmq.studio.common.domain.enums.ClusterStatus;
+import com.rocketmq.studio.common.domain.enums.ClusterType;
+import com.rocketmq.studio.common.domain.enums.FlushDiskType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Repository
+public class ClusterRepositoryImpl implements ClusterRepository {
+
+    private final Map<String, ClusterVO> store = new ConcurrentHashMap<>();
+
+    public ClusterRepositoryImpl() {
+        initStubData();
+    }
+
+    @Override
+    public List<ClusterVO> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    @Override
+    public Optional<ClusterVO> findById(String id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public void updateConfig(String clusterId, ClusterConfigVO config) {
+        ClusterVO cluster = store.get(clusterId);
+        if (cluster != null) {
+            cluster.setConfig(config);
+            cluster.setUpdatedAt(LocalDateTime.now());
+            log.info("Config updated for cluster: {}", clusterId);
+        }
+    }
+
+    private void initStubData() {
+        ClusterConfigVO config = ClusterConfigVO.builder()
+                .writeQueueNums(16)
+                .readQueueNums(16)
+                .maxMessageSize(4194304)
+                .msgTraceTopicName("RMQ_SYS_TRACE_TOPIC")
+                .autoCreateTopicEnable(true)
+                .autoCreateSubscriptionGroup(true)
+                .deleteWhen("04")
+                .fileReservedTime(72)
+                .flushDiskType(FlushDiskType.ASYNC_FLUSH)
+                .brokerPermission(6)
+                .build();
+
+        ClusterVO cluster1 = ClusterVO.builder()
+                .name("rmq-cluster-prod")
+                .nsClusterName("rmq-cluster-prod-ns")
+                .type(ClusterType.V5_PROXY_CLUSTER)
+                .endpoint("10.0.0.1:9876")
+                .status(ClusterStatus.healthy)
+                .version("5.2.0")
+                .brokers(List.of(
+                        BrokerVO.builder()
+                                .name("broker-a")
+                                .addr("10.0.0.1:10911")
+                                .version("5.2.0")
+                                .status(BrokerStatus.running)
+                                .diskUsage(45.2)
+                                .tpsIn(1200)
+                                .tpsOut(800)
+                                .build(),
+                        BrokerVO.builder()
+                                .name("broker-b")
+                                .addr("10.0.0.2:10911")
+                                .version("5.2.0")
+                                .status(BrokerStatus.running)
+                                .diskUsage(38.7)
+                                .tpsIn(980)
+                                .tpsOut(750)
+                                .build()
+                ))
+                .proxies(List.of(
+                        ProxyVO.builder()
+                                .addr("10.0.0.10:8081")
+                                .status(ClusterStatus.healthy)
+                                .connections(156)
+                                .grpcPort(8081)
+                                .remotingPort(10911)
+                                .build()
+                ))
+                .nameServers(List.of(
+                        NameServerVO.builder()
+                                .addr("10.0.0.20:9876")
+                                .status(ClusterStatus.healthy)
+                                .build(),
+                        NameServerVO.builder()
+                                .addr("10.0.0.21:9876")
+                                .status(ClusterStatus.healthy)
+                                .build()
+                ))
+                .config(config)
+                .topicCount(128)
+                .groupCount(45)
+                .tpsHistory(List.of(1200, 1350, 1100, 1450, 1280, 1500, 1380, 1420, 1300, 1550))
+                .build();
+        cluster1.setId("cluster-001");
+        cluster1.setCreatedAt(LocalDateTime.now().minusDays(30));
+        cluster1.setUpdatedAt(LocalDateTime.now());
+
+        ClusterVO cluster2 = ClusterVO.builder()
+                .name("rmq-cluster-staging")
+                .nsClusterName("rmq-cluster-staging-ns")
+                .type(ClusterType.V5_PROXY_LOCAL)
+                .endpoint("10.1.0.1:9876")
+                .status(ClusterStatus.warning)
+                .version("5.1.4")
+                .brokers(List.of(
+                        BrokerVO.builder()
+                                .name("broker-staging-0")
+                                .addr("10.1.0.1:10911")
+                                .version("5.1.4")
+                                .status(BrokerStatus.running)
+                                .diskUsage(72.1)
+                                .tpsIn(320)
+                                .tpsOut(210)
+                                .build()
+                ))
+                .proxies(List.of(
+                        ProxyVO.builder()
+                                .addr("10.1.0.10:8081")
+                                .status(ClusterStatus.warning)
+                                .connections(23)
+                                .grpcPort(8081)
+                                .remotingPort(10911)
+                                .build()
+                ))
+                .nameServers(List.of(
+                        NameServerVO.builder()
+                                .addr("10.1.0.20:9876")
+                                .status(ClusterStatus.healthy)
+                                .build()
+                ))
+                .config(ClusterConfigVO.builder()
+                        .writeQueueNums(8)
+                        .readQueueNums(8)
+                        .maxMessageSize(4194304)
+                        .msgTraceTopicName("RMQ_SYS_TRACE_TOPIC")
+                        .autoCreateTopicEnable(true)
+                        .autoCreateSubscriptionGroup(false)
+                        .deleteWhen("04")
+                        .fileReservedTime(48)
+                        .flushDiskType(FlushDiskType.SYNC_FLUSH)
+                        .brokerPermission(6)
+                        .build())
+                .topicCount(32)
+                .groupCount(12)
+                .tpsHistory(List.of(320, 280, 350, 310, 290, 340, 300, 330, 310, 350))
+                .build();
+        cluster2.setId("cluster-002");
+        cluster2.setCreatedAt(LocalDateTime.now().minusDays(15));
+        cluster2.setUpdatedAt(LocalDateTime.now().minusHours(3));
+
+        store.put(cluster1.getId(), cluster1);
+        store.put(cluster2.getId(), cluster2);
+    }
+}

--- a/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterService.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.broker;
+
+import com.rocketmq.studio.cluster.config.ClusterConfigVO;
+import com.rocketmq.studio.cluster.config.UpdateConfigDTO;
+import com.rocketmq.studio.cluster.nameserver.CreateNameServerDTO;
+import com.rocketmq.studio.cluster.nameserver.DeleteNameServerDTO;
+import com.rocketmq.studio.cluster.nameserver.NameServerVO;
+import com.rocketmq.studio.cluster.nameserver.RestartNameServerDTO;
+import com.rocketmq.studio.cluster.nameserver.UpdateNameServerDTO;
+import com.rocketmq.studio.cluster.nameserver.UpgradeNameServerDTO;
+import com.rocketmq.studio.cluster.proxy.RestartProxyDTO;
+
+import com.rocketmq.studio.common.domain.enums.ClusterStatus;
+import com.rocketmq.studio.common.domain.enums.FlushDiskType;
+import com.rocketmq.studio.common.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ClusterService {
+
+    private final ClusterRepository clusterRepository;
+    private final ClusterProvider clusterProvider;
+
+    public List<ClusterVO> listClusters() {
+        log.info("Listing all clusters");
+        return clusterRepository.findAll();
+    }
+
+    public ClusterVO getCluster(String id) {
+        log.info("Getting cluster detail: {}", id);
+        return clusterRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + id));
+    }
+
+    public ClusterVO updateClusterConfig(UpdateConfigDTO command) {
+        log.info("Updating cluster config for: {}", command.getId());
+        ClusterVO cluster = clusterRepository.findById(command.getId())
+                .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getId()));
+
+        ClusterConfigVO config = cluster.getConfig();
+        if (config == null) {
+            config = new ClusterConfigVO();
+        }
+
+        if (command.getFlushDiskType() != null) {
+            config.setFlushDiskType(FlushDiskType.valueOf(command.getFlushDiskType()));
+        }
+        if (command.getAutoCreateTopicEnable() != null) {
+            config.setAutoCreateTopicEnable(command.getAutoCreateTopicEnable());
+        }
+        if (command.getAutoCreateSubscriptionGroup() != null) {
+            config.setAutoCreateSubscriptionGroup(command.getAutoCreateSubscriptionGroup());
+        }
+        if (command.getMaxMessageSize() != null) {
+            config.setMaxMessageSize(command.getMaxMessageSize());
+        }
+        if (command.getFileReservedTime() != null) {
+            config.setFileReservedTime(command.getFileReservedTime());
+        }
+        if (command.getWriteQueueNums() != null) {
+            config.setWriteQueueNums(command.getWriteQueueNums());
+        }
+        if (command.getReadQueueNums() != null) {
+            config.setReadQueueNums(command.getReadQueueNums());
+        }
+        if (command.getBrokerPermission() != null) {
+            config.setBrokerPermission(command.getBrokerPermission());
+        }
+
+        cluster.setConfig(config);
+        clusterRepository.updateConfig(command.getId(), config);
+        log.info("Cluster config updated successfully for: {}", command.getId());
+        return cluster;
+    }
+
+    public boolean restartBroker(String clusterId, String brokerName) {
+        log.info("Restarting broker: {} in cluster: {}", brokerName, clusterId);
+        clusterRepository.findById(clusterId)
+                .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + clusterId));
+        log.info("Broker restart initiated for: {} in cluster: {}", brokerName, clusterId);
+        return true;
+    }
+
+    public NameServerVO createNameServer(CreateNameServerDTO command) {
+        log.info("Creating NameServer for cluster: {}", command.getClusterId());
+        clusterRepository.findById(command.getClusterId())
+                .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
+        NameServerVO ns = NameServerVO.builder()
+                .addr(command.getAddr())
+                .status(ClusterStatus.healthy)
+                .build();
+        log.info("NameServer created: {}", command.getAddr());
+        return ns;
+    }
+
+    public void updateNameServer(UpdateNameServerDTO command) {
+        log.info("Updating NameServer: {} in cluster: {}", command.getAddr(), command.getClusterId());
+        clusterRepository.findById(command.getClusterId())
+                .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
+        log.info("NameServer updated: {}", command.getAddr());
+    }
+
+    public boolean restartNameServer(RestartNameServerDTO command) {
+        log.info("Restarting NameServer: {} in cluster: {}", command.getAddr(), command.getClusterId());
+        clusterRepository.findById(command.getClusterId())
+                .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
+        log.info("NameServer restart initiated: {}", command.getAddr());
+        return true;
+    }
+
+    public boolean upgradeNameServer(UpgradeNameServerDTO command) {
+        log.info("Upgrading NameServer: {} to version: {} in cluster: {}",
+                command.getAddr(), command.getTargetVersion(), command.getClusterId());
+        clusterRepository.findById(command.getClusterId())
+                .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
+        log.info("NameServer upgrade initiated: {}", command.getAddr());
+        return true;
+    }
+
+    public boolean deleteNameServer(DeleteNameServerDTO command) {
+        log.info("Deleting NameServer: {} from cluster: {}", command.getAddr(), command.getClusterId());
+        clusterRepository.findById(command.getClusterId())
+                .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
+        log.info("NameServer deleted: {}", command.getAddr());
+        return true;
+    }
+
+    public boolean restartProxy(RestartProxyDTO command) {
+        log.info("Restarting Proxy: {} in cluster: {}", command.getAddr(), command.getClusterId());
+        clusterRepository.findById(command.getClusterId())
+                .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
+        log.info("Proxy restart initiated: {}", command.getAddr());
+        return true;
+    }
+}

--- a/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterVO.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterVO.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.broker;
+
+import com.rocketmq.studio.cluster.config.ClusterConfigVO;
+import com.rocketmq.studio.cluster.nameserver.NameServerVO;
+import com.rocketmq.studio.cluster.proxy.ProxyVO;
+
+import com.rocketmq.studio.common.domain.BaseEntity;
+import com.rocketmq.studio.common.domain.enums.ClusterStatus;
+import com.rocketmq.studio.common.domain.enums.ClusterType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class ClusterVO extends BaseEntity {
+    private String name;
+    private String nsClusterName;
+    private ClusterType type;
+    private String endpoint;
+    private ClusterStatus status;
+    private String version;
+    private List<BrokerVO> brokers;
+    private List<ProxyVO> proxies;
+    private List<NameServerVO> nameServers;
+    private ClusterConfigVO config;
+    private int topicCount;
+    private int groupCount;
+    private List<Integer> tpsHistory;
+}

--- a/server/src/main/java/com/rocketmq/studio/cluster/config/ClusterConfigVO.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/config/ClusterConfigVO.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.config;
+
+import com.rocketmq.studio.common.domain.enums.FlushDiskType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClusterConfigVO {
+    private int writeQueueNums;
+    private int readQueueNums;
+    private int maxMessageSize;
+    private String msgTraceTopicName;
+    private boolean autoCreateTopicEnable;
+    private boolean autoCreateSubscriptionGroup;
+    private String deleteWhen;
+    private int fileReservedTime;
+    private FlushDiskType flushDiskType;
+    private int brokerPermission;
+}

--- a/server/src/main/java/com/rocketmq/studio/cluster/config/UpdateConfigDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/config/UpdateConfigDTO.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateConfigDTO {
+    private String id;
+    private String flushDiskType;
+    private Boolean autoCreateTopicEnable;
+    private Boolean autoCreateSubscriptionGroup;
+    private Integer maxMessageSize;
+    private Integer fileReservedTime;
+    private Integer writeQueueNums;
+    private Integer readQueueNums;
+    private Integer brokerPermission;
+}

--- a/server/src/test/java/com/rocketmq/studio/cluster/broker/ClusterControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/cluster/broker/ClusterControllerTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.broker;
+
+import com.rocketmq.studio.cluster.config.ClusterConfigVO;
+import com.rocketmq.studio.cluster.config.UpdateConfigDTO;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rocketmq.studio.common.domain.enums.ClusterStatus;
+import com.rocketmq.studio.common.domain.enums.ClusterType;
+import com.rocketmq.studio.common.domain.enums.FlushDiskType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ClusterController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ClusterControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ClusterService clusterService;
+
+    @Test
+    void listClustersShouldReturnAllClusters() throws Exception {
+        ClusterVO cluster1 = buildCluster("cluster-1", "production-cluster", ClusterStatus.healthy);
+        ClusterVO cluster2 = buildCluster("cluster-2", "staging-cluster", ClusterStatus.warning);
+        when(clusterService.listClusters()).thenReturn(Arrays.asList(cluster1, cluster2));
+
+        mockMvc.perform(get("/api/clusters"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].id").value("cluster-1"))
+                .andExpect(jsonPath("$.data[0].name").value("production-cluster"))
+                .andExpect(jsonPath("$.data[0].status").value("healthy"))
+                .andExpect(jsonPath("$.data[1].id").value("cluster-2"))
+                .andExpect(jsonPath("$.data[1].name").value("staging-cluster"));
+    }
+
+    @Test
+    void listClustersShouldReturnEmptyArrayWhenNoClusters() throws Exception {
+        when(clusterService.listClusters()).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/clusters"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    void getClusterShouldReturnClusterDetail() throws Exception {
+        ClusterVO cluster = buildCluster("cluster-1", "production-cluster", ClusterStatus.healthy);
+        cluster.setConfig(ClusterConfigVO.builder()
+                .flushDiskType(FlushDiskType.SYNC_FLUSH)
+                .writeQueueNums(8)
+                .readQueueNums(8)
+                .maxMessageSize(4194304)
+                .autoCreateTopicEnable(true)
+                .build());
+        when(clusterService.getCluster("cluster-1")).thenReturn(cluster);
+
+        mockMvc.perform(get("/api/clusters/cluster-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.id").value("cluster-1"))
+                .andExpect(jsonPath("$.data.name").value("production-cluster"))
+                .andExpect(jsonPath("$.data.status").value("healthy"))
+                .andExpect(jsonPath("$.data.type").value("V5_PROXY_CLUSTER"))
+                .andExpect(jsonPath("$.data.config.flushDiskType").value("SYNC_FLUSH"))
+                .andExpect(jsonPath("$.data.config.writeQueueNums").value(8));
+    }
+
+    @Test
+    void updateConfigShouldReturnUpdatedCluster() throws Exception {
+        ClusterVO updated = buildCluster("cluster-1", "production-cluster", ClusterStatus.healthy);
+        updated.setConfig(ClusterConfigVO.builder()
+                .flushDiskType(FlushDiskType.SYNC_FLUSH)
+                .writeQueueNums(16)
+                .readQueueNums(16)
+                .build());
+        when(clusterService.updateClusterConfig(any(UpdateConfigDTO.class))).thenReturn(updated);
+
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .flushDiskType("SYNC_FLUSH")
+                .writeQueueNums(16)
+                .readQueueNums(16)
+                .build();
+
+        mockMvc.perform(post("/api/clusters/config/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(command)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.id").value("cluster-1"))
+                .andExpect(jsonPath("$.data.config.flushDiskType").value("SYNC_FLUSH"))
+                .andExpect(jsonPath("$.data.config.writeQueueNums").value(16))
+                .andExpect(jsonPath("$.data.config.readQueueNums").value(16));
+    }
+
+    @Test
+    void restartBrokerShouldReturnSuccess() throws Exception {
+        when(clusterService.restartBroker("cluster-1", "broker-0")).thenReturn(true);
+
+        mockMvc.perform(post("/api/clusters/cluster-1/brokers/broker-0/restart"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.success").value(true))
+                .andExpect(jsonPath("$.data.message").value("Broker restart initiated for broker-0"));
+    }
+
+    private ClusterVO buildCluster(String id, String name, ClusterStatus status) {
+        ClusterVO cluster = ClusterVO.builder()
+                .name(name)
+                .type(ClusterType.V5_PROXY_CLUSTER)
+                .endpoint("10.0.0.1:9876")
+                .status(status)
+                .version("5.1.0")
+                .brokers(Collections.emptyList())
+                .proxies(Collections.emptyList())
+                .nameServers(Collections.emptyList())
+                .topicCount(10)
+                .groupCount(5)
+                .build();
+        cluster.setId(id);
+        return cluster;
+    }
+}

--- a/server/src/test/java/com/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.broker;
+
+import com.rocketmq.studio.cluster.config.ClusterConfigVO;
+import com.rocketmq.studio.cluster.config.UpdateConfigDTO;
+
+import com.rocketmq.studio.common.domain.enums.ClusterStatus;
+import com.rocketmq.studio.common.domain.enums.ClusterType;
+import com.rocketmq.studio.common.domain.enums.FlushDiskType;
+import com.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterServiceTest {
+
+    @Mock
+    private ClusterRepository clusterRepository;
+
+    @Mock
+    private ClusterProvider clusterProvider;
+
+    @InjectMocks
+    private ClusterService clusterService;
+
+    private ClusterVO sampleCluster;
+
+    @BeforeEach
+    void setUp() {
+        sampleCluster = ClusterVO.builder()
+                .name("test-cluster")
+                .nsClusterName("ns-test-cluster")
+                .type(ClusterType.V5_PROXY_CLUSTER)
+                .endpoint("10.0.0.1:9876")
+                .status(ClusterStatus.healthy)
+                .version("5.1.0")
+                .brokers(Collections.emptyList())
+                .proxies(Collections.emptyList())
+                .nameServers(Collections.emptyList())
+                .config(ClusterConfigVO.builder()
+                        .flushDiskType(FlushDiskType.ASYNC_FLUSH)
+                        .writeQueueNums(8)
+                        .readQueueNums(8)
+                        .maxMessageSize(4194304)
+                        .autoCreateTopicEnable(true)
+                        .autoCreateSubscriptionGroup(true)
+                        .fileReservedTime(72)
+                        .brokerPermission(6)
+                        .build())
+                .topicCount(10)
+                .groupCount(5)
+                .build();
+        sampleCluster.setId("cluster-1");
+    }
+
+    @Test
+    void listClustersShouldReturnAllClusters() {
+        ClusterVO secondCluster = ClusterVO.builder()
+                .name("second-cluster")
+                .status(ClusterStatus.warning)
+                .build();
+        secondCluster.setId("cluster-2");
+
+        when(clusterRepository.findAll()).thenReturn(Arrays.asList(sampleCluster, secondCluster));
+
+        List<ClusterVO> result = clusterService.listClusters();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getName()).isEqualTo("test-cluster");
+        assertThat(result.get(1).getName()).isEqualTo("second-cluster");
+        verify(clusterRepository).findAll();
+    }
+
+    @Test
+    void listClustersShouldReturnEmptyListWhenNoClusters() {
+        when(clusterRepository.findAll()).thenReturn(Collections.emptyList());
+
+        List<ClusterVO> result = clusterService.listClusters();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getClusterShouldReturnClusterWhenFound() {
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+
+        ClusterVO result = clusterService.getCluster("cluster-1");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo("cluster-1");
+        assertThat(result.getName()).isEqualTo("test-cluster");
+        assertThat(result.getStatus()).isEqualTo(ClusterStatus.healthy);
+        assertThat(result.getType()).isEqualTo(ClusterType.V5_PROXY_CLUSTER);
+    }
+
+    @Test
+    void getClusterShouldThrowWhenNotFound() {
+        when(clusterRepository.findById("nonexistent")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> clusterService.getCluster("nonexistent"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Cluster not found: nonexistent")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
+    }
+
+    @Test
+    void updateConfigShouldUpdateFlushDiskType() {
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .flushDiskType("SYNC_FLUSH")
+                .build();
+
+        ClusterVO result = clusterService.updateClusterConfig(command);
+
+        assertThat(result.getConfig().getFlushDiskType()).isEqualTo(FlushDiskType.SYNC_FLUSH);
+        verify(clusterRepository).updateConfig(eq("cluster-1"), any(ClusterConfigVO.class));
+    }
+
+    @Test
+    void updateConfigShouldUpdateMultipleFields() {
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .flushDiskType("SYNC_FLUSH")
+                .autoCreateTopicEnable(false)
+                .autoCreateSubscriptionGroup(false)
+                .maxMessageSize(8388608)
+                .fileReservedTime(168)
+                .writeQueueNums(16)
+                .readQueueNums(16)
+                .brokerPermission(4)
+                .build();
+
+        ClusterVO result = clusterService.updateClusterConfig(command);
+
+        ClusterConfigVO config = result.getConfig();
+        assertThat(config.getFlushDiskType()).isEqualTo(FlushDiskType.SYNC_FLUSH);
+        assertThat(config.isAutoCreateTopicEnable()).isFalse();
+        assertThat(config.isAutoCreateSubscriptionGroup()).isFalse();
+        assertThat(config.getMaxMessageSize()).isEqualTo(8388608);
+        assertThat(config.getFileReservedTime()).isEqualTo(168);
+        assertThat(config.getWriteQueueNums()).isEqualTo(16);
+        assertThat(config.getReadQueueNums()).isEqualTo(16);
+        assertThat(config.getBrokerPermission()).isEqualTo(4);
+    }
+
+    @Test
+    void updateConfigShouldPreserveExistingValuesWhenCommandFieldsAreNull() {
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .flushDiskType("SYNC_FLUSH")
+                .build();
+
+        ClusterVO result = clusterService.updateClusterConfig(command);
+
+        ClusterConfigVO config = result.getConfig();
+        assertThat(config.getFlushDiskType()).isEqualTo(FlushDiskType.SYNC_FLUSH);
+        assertThat(config.getWriteQueueNums()).isEqualTo(8);
+        assertThat(config.getReadQueueNums()).isEqualTo(8);
+        assertThat(config.isAutoCreateTopicEnable()).isTrue();
+    }
+
+    @Test
+    void updateConfigShouldThrowWhenClusterNotFound() {
+        when(clusterRepository.findById("missing")).thenReturn(Optional.empty());
+
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("missing")
+                .flushDiskType("SYNC_FLUSH")
+                .build();
+
+        assertThatThrownBy(() -> clusterService.updateClusterConfig(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Cluster not found: missing");
+    }
+
+    @Test
+    void updateConfigShouldCreateConfigWhenNull() {
+        ClusterVO clusterWithNullConfig = ClusterVO.builder()
+                .name("null-config-cluster")
+                .status(ClusterStatus.healthy)
+                .config(null)
+                .build();
+        clusterWithNullConfig.setId("cluster-nc");
+
+        when(clusterRepository.findById("cluster-nc")).thenReturn(Optional.of(clusterWithNullConfig));
+
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("cluster-nc")
+                .flushDiskType("ASYNC_FLUSH")
+                .build();
+
+        ClusterVO result = clusterService.updateClusterConfig(command);
+
+        assertThat(result.getConfig()).isNotNull();
+        assertThat(result.getConfig().getFlushDiskType()).isEqualTo(FlushDiskType.ASYNC_FLUSH);
+    }
+
+    @Test
+    void restartBrokerShouldReturnTrue() {
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+
+        boolean result = clusterService.restartBroker("cluster-1", "broker-0");
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void restartBrokerShouldThrowWhenClusterNotFound() {
+        when(clusterRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> clusterService.restartBroker("missing", "broker-0"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Cluster not found: missing");
+    }
+}


### PR DESCRIPTION
## Summary
Implement cluster and broker management module, providing core APIs including cluster list query, cluster detail retrieval, cluster configuration update, and broker restart. The module adopts a layered architecture (Controller → Service → Repository/Provider), with in-memory stub data implementation and full unit test coverage.

## Files Changed
12 files modified, total 1141 line insertions

### Controller Layer
#### ClusterController.java
Annotated with `@RestController` and `@RequestMapping("/api/clusters")`, exposes 4 API endpoints:
- `GET /api/clusters`: Query cluster list
- `GET /api/clusters/{id}`: Get single cluster details
- `POST /api/clusters/config/update`: Update cluster configurations
- `POST /api/clusters/{clusterId}/brokers/{name}/restart`: Trigger broker restart

### Service Layer
#### ClusterService.java
Annotated with `@Service`, contains core business logic:
1. Query methods: `listClusters()`, `getCluster(id)`
   - Throws `BusinessException` with 404 code when target cluster cannot be found
2. `updateClusterConfig(UpdateConfigDTO)`
   - Supports incremental update of 8 configuration fields
   - Automatically creates empty config record if incoming config is null
3. `restartBroker(clusterId, brokerName)`
   - Validates target cluster existence before execution
4. Reserved methods for NameServer & Proxy operations:
   `createNameServer`, `updateNameServer`, `restartNameServer`, `upgradeNameServer`, `deleteNameServer`, `restartProxy`
   - References DTOs from nameserver and proxy packages for future extension

### Repository Layer
#### ClusterRepository.java
Repository interface with methods:
`findAll()`, `findById(id)`, `updateConfig(id, config)`

#### ClusterRepositoryImpl.java
Annotated with `@Repository`
- Uses `ConcurrentHashMap` for in-memory data storage
- Preloads 2 stub clusters (prod & staging) with complete embedded Broker, Proxy, NameServer and configuration data

### Provider Layer
#### ClusterProvider.java
Provider interface with methods:
`discoverClusters()`, `refreshClusterDetail(id)`

#### ClusterProviderStub.java
Annotated with `@Component`
- Returns static single-cluster stub mock data

### VO & DTO Model Files
1. `ClusterVO.java`
   - Extends `BaseEntity`
   - Fields: name, type, endpoint, status, brokers, proxies, nameServers, config, topicCount, groupCount, tpsHistory
2. `BrokerVO.java`
   - Fields: name, addr, version, status, diskUsage, tpsIn, tpsOut
3. `ClusterConfigVO.java`
   - Contains 10 configuration entries: writeQueueNums, readQueueNums, maxMessageSize, flushDiskType, etc.
4. `UpdateConfigDTO.java`
   - Command object for partial config update
   - All fields use wrapped types (Boolean / Integer), optional to support incremental patch

### Test Files
#### ClusterControllerTest.java
- Annotated with `@WebMvcTest`
- 5 test cases: 2 for cluster list query, 1 for cluster detail query, 1 for config update, 1 for broker restart

#### ClusterServiceTest.java
- Annotated with `@ExtendWith(MockitoExtension)`
- 11 test cases: 2 list queries, 2 detail queries, 5 incremental config updates, 2 broker restart logics
- Uses AssertJ for fluent assertion

## Key Design
1. Clear layered architecture: Controller → Service → Repository + Provider with separated responsibilities
2. Incremental configuration update
   All fields in `UpdateConfigDTO` are nullable wrapped types; null fields will not overwrite existing values to support partial patch
3. Stub mock data strategy
   `ClusterRepositoryImpl` and `ClusterProviderStub` provide in-memory mock data to facilitate front-end local development and debugging
4. Unified global exception handling
   Relies on common foundation module: throws `BusinessException` (404 Not Found), captured uniformly by `GlobalExceptionHandler`
5. Cross-module forward compatibility
   `ClusterService` references VO/DTO from nameserver and proxy modules, reserving interfaces for follow-up PR development

## Dependencies
Depends on branch `feature/studio-common-foundation`:
Reuses `BaseEntity`, unified response `Result`, `BusinessException`, `GlobalExceptionHandler` and business enums (ClusterStatus, ClusterType, BrokerStatus, FlushDiskType)

Cross-module reference:
This module imports VO/DTO classes from nameserver and proxy submodules

## Test Coverage
- Controller layer: 5 test cases covering all 4 API endpoints (including empty list boundary case)
- Service layer: 11 test cases covering normal flow, 404 exception flow, incremental config patch and empty config creation logic
- Total: 16 test methods, 417 lines of test code

## PR Title Specification Reminder
All PR and Issue titles of this project must start with `[studio]` to help community quickly filter and track related work items.
Example:
`[studio] feat: implement cluster and broker management module with stub data`