### PR TITLE
[Studio] fix: connect general settings to APIs

### DIFF
--- a/web/src/api/generalSettings.test.ts
+++ b/web/src/api/generalSettings.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import { getGeneralSettings, saveGeneralSettings } from './settings';
+import type { GeneralSettings } from './settings';
+
+const mock = new MockAdapter(client);
+const settings: GeneralSettings = {
+  theme: 'dark',
+  compact: true,
+  desktopNotify: true,
+  notifySound: false,
+  sessionTimeout: 60,
+  requireLogin: true,
+  llmProvider: 'openai',
+  apiKey: 'sk-test',
+  model: 'gpt-5',
+  baseUrl: 'https://api.example.com/v1',
+};
+
+describe('general settings API', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('loads the settings shape returned by GeneralSettingsVO', async () => {
+    mock.onGet('/settings/general').reply(200, { code: 200, data: settings });
+
+    await expect(getGeneralSettings()).resolves.toEqual(settings);
+  });
+
+  it('persists all editable settings fields', async () => {
+    mock.onPost('/settings/general/save').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual(settings);
+      return [200, { code: 200, data: null }];
+    });
+
+    await expect(saveGeneralSettings(settings)).resolves.toBeUndefined();
+  });
+});

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -19,13 +19,16 @@ import client from './client';
 
 // ─── Types ──────────────────────────────────────────────────────
 export interface GeneralSettings {
-  siteName: string;
-  language: string;
   theme: string;
-  autoRefreshInterval: number;
-  notificationChannels: string[];
+  compact: boolean;
+  desktopNotify: boolean;
+  notifySound: boolean;
+  sessionTimeout: number;
+  requireLogin: boolean;
   llmProvider: string;
-  llmModel: string;
+  apiKey: string;
+  model: string;
+  baseUrl: string;
 }
 
 export interface DataSource {

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Button,
   Descriptions,
@@ -49,6 +49,8 @@ import type { ColumnsType } from 'antd/es/table';
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
 import StatusBadge from '../../components/StatusBadge';
+import { getGeneralSettings, saveGeneralSettings } from '../../api/settings';
+import type { GeneralSettings } from '../../api/settings';
 
 const { Title, Text, Link: TypoLink } = Typography;
 
@@ -102,6 +104,38 @@ const typeTagColor: Record<string, string> = {
 
 const GeneralSettingsTab = () => {
   const [form] = Form.useForm();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getGeneralSettings()
+      .then((settings) => {
+        if (!cancelled) form.setFieldsValue(settings);
+      })
+      .catch(() => {
+        if (!cancelled) message.error('通用设置加载失败，请稍后重试');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [form]);
+
+  const handleFinish = async (values: GeneralSettings) => {
+    setSaving(true);
+    try {
+      await saveGeneralSettings(values);
+      message.success('设置已保存');
+    } catch {
+      message.error('设置保存失败，请稍后重试');
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <Form
@@ -109,17 +143,7 @@ const GeneralSettingsTab = () => {
       layout="horizontal"
       labelCol={{ span: 4 }}
       wrapperCol={{ span: 14 }}
-      initialValues={{
-        theme: 'light',
-        compact: false,
-        desktopNotify: true,
-        notifySound: false,
-        sessionTimeout: 30,
-        requireLogin: true,
-        llmProvider: 'qwen',
-        model: 'qwen-max',
-      }}
-      onFinish={() => message.success('设置已保存')}
+      onFinish={handleFinish}
       style={{ maxWidth: 800 }}
     >
       {/* ── 外观 ── */}
@@ -208,7 +232,7 @@ const GeneralSettingsTab = () => {
 
       {/* ── Submit ── */}
       <Form.Item wrapperCol={{ offset: 4, span: 14 }}>
-        <Button type="primary" htmlType="submit">
+        <Button type="primary" htmlType="submit" loading={saving} disabled={loading}>
           保存设置
         </Button>
       </Form.Item>


### PR DESCRIPTION
## Summary

- load the general-settings form from `/api/settings/general` and persist changes through `/api/settings/general/save`
- align the frontend settings type with `GeneralSettingsVO`
- show loading, saving, and request-error feedback; add API contract coverage

## Validation

- `npm.cmd test -- generalSettings.test.ts`
- `npm.cmd run lint` (existing warnings only)
- `tsc -p tsconfig.app.json --noEmit`
- `npx.cmd vite build`
