### PR TITLE
[Studio] fix: show dashboard loading failures

### DIFF
--- a/web/src/api/metrics.test.ts
+++ b/web/src/api/metrics.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import { getDashboard, queryMetrics } from './metrics';
+
+const mock = new MockAdapter(client);
+const dashboard = {
+  stats: {
+    totalClusters: 1,
+    healthyClusters: 1,
+    totalBrokers: 2,
+    totalProxies: 1,
+    totalNameServers: 1,
+    totalTopics: 4,
+    totalConsumerGroups: 3,
+    totalMessagesToday: 100,
+    messagesPerSecond: 10,
+    tpsIn: 8,
+    tpsOut: 7,
+  },
+  clusters: [],
+};
+
+describe('metrics API', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('loads dashboard data from the dashboard endpoint', async () => {
+    mock.onGet('/dashboard').reply(200, { code: 200, data: dashboard });
+
+    await expect(getDashboard()).resolves.toEqual(dashboard);
+  });
+
+  it('posts a metrics query and returns its result', async () => {
+    const query = { metric: 'TPS_IN', start: 1, end: 2, step: '1m' };
+    mock.onPost('/metrics/query').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual(query);
+      return [200, { code: 200, data: [{ timestamp: 1, value: 8 }] }];
+    });
+
+    await expect(queryMetrics(query)).resolves.toEqual([{ timestamp: 1, value: 8 }]);
+  });
+});

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Row, Col, Card, Statistic, Table, Tag, Typography } from 'antd';
+import { Alert, Button, Card, Col, Row, Skeleton, Statistic, Table, Tag, Typography } from 'antd';
 import { ClusterOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { ListDashes, ArrowDown } from '@phosphor-icons/react';
 import PageHeader from '../../components/PageHeader';
@@ -17,12 +17,52 @@ const DashboardPage = () => {
   const navigate = useNavigate();
   const { t } = useLang();
   const [dashboard, setDashboard] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
 
-  useEffect(() => {
-    getDashboard().then(setDashboard).catch(console.error);
+  const loadDashboard = useCallback(async () => {
+    setLoading(true);
+    setLoadError(false);
+    try {
+      setDashboard(await getDashboard());
+    } catch {
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  if (!dashboard) return null;
+  useEffect(() => {
+    void Promise.resolve().then(loadDashboard);
+  }, [loadDashboard]);
+
+  if (loading && !dashboard) {
+    return (
+      <div style={{ padding: 24 }}>
+        <PageHeader title={t('dashboard.title')} subtitle={t('dashboard.subtitle')} />
+        <Skeleton active paragraph={{ rows: 8 }} />
+      </div>
+    );
+  }
+
+  if (loadError || !dashboard) {
+    return (
+      <div style={{ padding: 24 }}>
+        <PageHeader title={t('dashboard.title')} subtitle={t('dashboard.subtitle')} />
+        <Alert
+          type="error"
+          showIcon
+          message="仪表盘加载失败"
+          description="无法获取集群概览，请检查网络连接后重试。"
+          action={
+            <Button size="small" onClick={() => void loadDashboard()} loading={loading}>
+              重试
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
 
   const { stats, clusters } = dashboard;
 


### PR DESCRIPTION
## Summary

- keep the dashboard visible while data is loading instead of rendering a blank page
- provide a clear error state with a retry action when the dashboard request fails
- add request-contract coverage for the dashboard and metrics endpoints

## Validation

- `npm.cmd test -- metrics.test.ts`
- `npm.cmd run lint` (5 existing warnings, no errors)
- `./node_modules/.bin/tsc.cmd -p tsconfig.app.json --noEmit`
- `npx.cmd vite build`
