### PR TITLE
[Studio] fix: connect user logout to API

### DIFF
--- a/web/src/api/auth.test.ts
+++ b/web/src/api/auth.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import { login, logout } from './auth';
+
+const mock = new MockAdapter(client);
+
+describe('auth API', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('submits login credentials and returns the authenticated user', async () => {
+    mock.onPost('/auth/login').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ username: 'studio', password: 'secret' });
+      return [200, { code: 200, data: { token: 'token', username: 'studio', role: 'ADMIN' } }];
+    });
+
+    await expect(login('studio', 'secret')).resolves.toEqual({
+      token: 'token',
+      username: 'studio',
+      role: 'ADMIN',
+    });
+  });
+
+  it('posts to the logout endpoint', async () => {
+    mock.onPost('/auth/logout').reply(200, { code: 200, data: null });
+
+    await expect(logout()).resolves.toBeUndefined();
+  });
+});

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -24,6 +24,7 @@ import {
   Dropdown,
   Input,
   Modal,
+  message,
 } from 'antd';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import {
@@ -48,6 +49,8 @@ import {
 } from '@phosphor-icons/react';
 import { useLang } from '../i18n/LangContext';
 import { useTheme } from '../theme/ThemeContext';
+import { logout as requestLogout } from '../api/auth';
+import useAuthStore from '../stores/authStore';
 
 const { Sider, Content } = Layout;
 
@@ -60,6 +63,24 @@ const MainLayout = () => {
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchText, setSearchText] = useState('');
   const { lang, setLang, t } = useLang();
+  const clearAuth = useAuthStore((state) => state.logout);
+
+  const handleUserMenuClick = async ({ key }: { key: string }) => {
+    if (key === 'profile') {
+      navigate('/settings');
+      return;
+    }
+    if (key !== 'logout') return;
+
+    try {
+      await requestLogout();
+    } catch {
+      message.warning('服务端退出失败，已清除本地登录状态');
+    } finally {
+      clearAuth();
+      navigate('/');
+    }
+  };
 
   const menuItems = [
     { key: '/', icon: <House size={iconSize} weight="duotone" />, label: t('nav.home') },
@@ -138,6 +159,7 @@ const MainLayout = () => {
   ];
 
   const userMenu = {
+    onClick: handleUserMenuClick,
     items: [
       { key: 'profile', icon: <UserGear size={14} />, label: t('user.profile') },
       { type: 'divider' as const },


### PR DESCRIPTION
## Summary

- wire the account dropdown's logout action to the existing backend logout endpoint
- clear the local authentication state even when the backend is unreachable, preventing a stale client session
- make the profile menu entry open the settings page and add auth request-contract coverage

## Validation

- `npm.cmd test -- auth.test.ts`
- The local lint and TypeScript commands were retried separately but timed out without diagnostics on this Windows host; no Node child process remained afterward.
