### PR TITLE
[Studio] feat: follow system theme changes

### DIFF
--- a/web/src/theme/ThemeContext.tsx
+++ b/web/src/theme/ThemeContext.tsx
@@ -16,6 +16,11 @@
  */
 
 import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
+import {
+  getStoredThemePreference,
+  getSystemDarkMode,
+  persistThemePreference,
+} from './themePreference';
 
 interface ThemeContextType {
   darkMode: boolean;
@@ -23,41 +28,45 @@ interface ThemeContextType {
   toggleTheme: () => void;
 }
 
-const THEME_STORAGE_KEY = 'rocketmq-studio-theme';
-
 const ThemeContext = createContext<ThemeContextType>({
   darkMode: false,
   setDarkMode: () => {},
   toggleTheme: () => {},
 });
 
-/** Read initial theme preference from localStorage, fall back to system preference. */
-const getInitialDarkMode = (): boolean => {
-  try {
-    const stored = localStorage.getItem(THEME_STORAGE_KEY);
-    if (stored !== null) return stored === 'dark';
-  } catch {
-    // localStorage unavailable
-  }
-  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false;
-};
-
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [darkMode, setDarkMode] = useState<boolean>(getInitialDarkMode);
+  const [themeState, setThemeState] = useState(() => {
+    const preference = getStoredThemePreference();
+    return {
+      darkMode: preference ? preference === 'dark' : getSystemDarkMode(),
+      followsSystem: preference === null,
+    };
+  });
 
-  // Persist theme choice to localStorage
+  const setDarkMode = (darkMode: boolean) => {
+    persistThemePreference(darkMode);
+    setThemeState({ darkMode, followsSystem: false });
+  };
+
+  const toggleTheme = () => setDarkMode(!themeState.darkMode);
+
   useEffect(() => {
-    try {
-      localStorage.setItem(THEME_STORAGE_KEY, darkMode ? 'dark' : 'light');
-    } catch {
-      // localStorage unavailable
-    }
-  }, [darkMode]);
+    if (!themeState.followsSystem || !window.matchMedia) return;
 
-  const toggleTheme = () => setDarkMode((prev) => !prev);
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const updateTheme = (event: MediaQueryListEvent) => {
+      setThemeState((current) =>
+        current.followsSystem ? { ...current, darkMode: event.matches } : current,
+      );
+    };
+    mediaQuery.addEventListener('change', updateTheme);
+    return () => mediaQuery.removeEventListener('change', updateTheme);
+  }, [themeState.followsSystem]);
 
   return (
-    <ThemeContext.Provider value={{ darkMode, setDarkMode, toggleTheme }}>
+    <ThemeContext.Provider
+      value={{ darkMode: themeState.darkMode, setDarkMode, toggleTheme }}
+    >
       {children}
     </ThemeContext.Provider>
   );

--- a/web/src/theme/themePreference.test.ts
+++ b/web/src/theme/themePreference.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getStoredThemePreference,
+  persistThemePreference,
+  THEME_STORAGE_KEY,
+} from './themePreference';
+
+describe('theme preference', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('uses no explicit preference for missing or invalid stored values', () => {
+    expect(getStoredThemePreference()).toBeNull();
+    localStorage.setItem(THEME_STORAGE_KEY, 'system');
+    expect(getStoredThemePreference()).toBeNull();
+  });
+
+  it('persists manual light and dark theme choices', () => {
+    persistThemePreference(true);
+    expect(getStoredThemePreference()).toBe('dark');
+
+    persistThemePreference(false);
+    expect(getStoredThemePreference()).toBe('light');
+  });
+});

--- a/web/src/theme/themePreference.ts
+++ b/web/src/theme/themePreference.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ThemePreference = 'dark' | 'light';
+
+export const THEME_STORAGE_KEY = 'rocketmq-studio-theme';
+
+export function getStoredThemePreference(): ThemePreference | null {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    return stored === 'dark' || stored === 'light' ? stored : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getSystemDarkMode(): boolean {
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false;
+}
+
+export function persistThemePreference(darkMode: boolean): void {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, darkMode ? 'dark' : 'light');
+  } catch {
+    // The active theme still changes when browser storage is unavailable.
+  }
+}


### PR DESCRIPTION
## Summary

- follow operating-system theme changes when the user has not explicitly chosen a theme
- preserve explicit light or dark choices and stop automatic synchronization after a manual toggle
- isolate browser-storage helpers and cover stored preference validation

## Validation

- `npm.cmd test -- themePreference.test.ts`
- `npm.cmd run lint` (5 existing warnings, no errors)
- `./node_modules/.bin/tsc.cmd -p tsconfig.app.json --noEmit`
