### PR TITLE
[Studio] fix: implement namespace listing

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/topic/MetadataService.java
@@ -24,7 +24,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -112,6 +116,24 @@ public class MetadataService {
 
 
     public List<NamespaceVO> listNamespaces() {
-        throw new UnsupportedOperationException("Not implemented");
+        return metadataProvider.listTopics(null, null, null).stream()
+                .filter(topic -> topic.getNamespace() != null && !topic.getNamespace().isBlank())
+                .map(topic -> {
+                    NamespaceVO namespace = new NamespaceVO();
+                    namespace.setName(topic.getNamespace());
+                    namespace.setClusterId(topic.getClusterId());
+                    return namespace;
+                })
+                .collect(Collectors.toMap(
+                        namespace -> new NamespaceKey(namespace.getName(), namespace.getClusterId()),
+                        Function.identity(),
+                        (first, ignored) -> first))
+                .values().stream()
+                .sorted(Comparator.comparing(NamespaceVO::getName)
+                        .thenComparing(namespace -> Objects.toString(namespace.getClusterId(), "")))
+                .toList();
+    }
+
+    private record NamespaceKey(String name, String clusterId) {
     }
 }

--- a/server/src/test/java/com/rocketmq/studio/instance/topic/MetadataServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/topic/MetadataServiceTest.java
@@ -141,4 +141,35 @@ class MetadataServiceTest {
         assertThat(result).isEmpty();
         verify(metadataProvider).listConsumerGroups(null, "order");
     }
+
+    @Test
+    void listNamespacesShouldDeriveSortedUniqueNamespacesFromTopics() {
+        TopicVO tradeClusterA = new TopicVO();
+        tradeClusterA.setNamespace("trade");
+        tradeClusterA.setClusterId("cluster-a");
+        TopicVO duplicateTradeClusterA = new TopicVO();
+        duplicateTradeClusterA.setNamespace("trade");
+        duplicateTradeClusterA.setClusterId("cluster-a");
+        TopicVO tradeClusterB = new TopicVO();
+        tradeClusterB.setNamespace("trade");
+        tradeClusterB.setClusterId("cluster-b");
+        TopicVO userClusterA = new TopicVO();
+        userClusterA.setNamespace("user");
+        userClusterA.setClusterId("cluster-a");
+        TopicVO unnamed = new TopicVO();
+        unnamed.setNamespace(" ");
+
+        when(metadataProvider.listTopics(null, null, null))
+                .thenReturn(List.of(userClusterA, duplicateTradeClusterA, unnamed, tradeClusterB, tradeClusterA));
+
+        List<NamespaceVO> namespaces = metadataService.listNamespaces();
+
+        assertThat(namespaces)
+                .extracting(NamespaceVO::getName, NamespaceVO::getClusterId)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("trade", "cluster-a"),
+                        org.assertj.core.groups.Tuple.tuple("trade", "cluster-b"),
+                        org.assertj.core.groups.Tuple.tuple("user", "cluster-a"));
+        verify(metadataProvider).listTopics(null, null, null);
+    }
 }


### PR DESCRIPTION
## Summary

- implement the previously unsupported namespace listing operation behind `GET /api/namespaces`
- derive unique namespaces from topic metadata while retaining cluster identity and skipping blank namespaces
- return namespace records in deterministic name and cluster order, with service-level coverage

## Validation

- `git diff --check`
- The current Windows host does not have Java, Maven, or a Maven Wrapper available, so the new `MetadataServiceTest` could not be executed locally.
