### PR TITLE
[Studio] feat: complete consumer group service APIs

### DIFF
--- a/web/src/api/metadata.test.ts
+++ b/web/src/api/metadata.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import {
+  createConsumerGroup,
+  getConsumerGroup,
+  resetConsumerOffset,
+} from './metadata';
+
+const mock = new MockAdapter(client);
+const group = {
+  name: 'cg-orders',
+  namespace: 'trade',
+  clusterId: 'cluster-a',
+  subscriptionMode: 'Push',
+  consumeType: 'CLUSTERING',
+  onlineInstances: 1,
+  totalLag: 0,
+  subscribedTopics: ['orders'],
+  subscriptionDataType: 'NORMAL',
+  retryMaxTimes: 16,
+  createdAt: '2026-07-19T00:00:00Z',
+};
+
+describe('consumer group API', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns a consumer group with its online instances', async () => {
+    const detail = { ...group, instances: [{ clientId: 'client-1', clientAddr: '127.0.0.1', language: 'JAVA', version: '5.0' }] };
+    mock.onGet(`/groups/${group.name}`).reply(200, { code: 200, data: detail });
+
+    await expect(getConsumerGroup(group.name)).resolves.toEqual(detail);
+  });
+
+  it('returns the persisted consumer group after create', async () => {
+    mock.onPost('/groups/create').reply((config) => {
+      expect(JSON.parse(config.data)).toMatchObject({ name: group.name, namespace: group.namespace });
+      return [200, { code: 200, data: group }];
+    });
+
+    await expect(createConsumerGroup({ name: group.name, namespace: group.namespace })).resolves.toEqual(group);
+  });
+
+  it('sends typed reset-offset payloads', async () => {
+    const payload = { name: group.name, timestamp: 1_752_883_200_000, topic: 'orders' };
+    mock.onPost('/groups/reset-offset').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual(payload);
+      return [200, { code: 200, data: null }];
+    });
+
+    await expect(resetConsumerOffset(payload)).resolves.toBeUndefined();
+  });
+});

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -61,6 +61,10 @@ export interface ConsumerInstance {
   version: string;
 }
 
+export interface ConsumerGroupDetail extends ConsumerGroup {
+  instances: ConsumerInstance[];
+}
+
 export interface QueueProgress {
   broker: string;
   queueId: number;
@@ -132,9 +136,7 @@ export async function listConsumerGroups(params?: { keyword?: string }) {
 }
 
 export async function getConsumerGroup(name: string) {
-  const res = await client.get<{ data: ConsumerGroup & { instances: ConsumerInstance[] } }>(
-    `/groups/${name}`,
-  );
+  const res = await client.get<{ data: ConsumerGroupDetail }>(`/groups/${name}`);
   return res.data.data;
 }
 
@@ -149,14 +151,21 @@ export async function getConsumerSubscriptions(name: string) {
 }
 
 export async function createConsumerGroup(data: Partial<ConsumerGroup>) {
-  await client.post('/groups/create', data);
+  const res = await client.post<{ data: ConsumerGroup }>('/groups/create', data);
+  return res.data.data;
 }
 
 export async function deleteConsumerGroup(name: string) {
   await client.post('/groups/delete', { name });
 }
 
-export async function resetConsumerOffset(data: Record<string, unknown>) {
+export interface ResetConsumerOffsetRequest {
+  name: string;
+  timestamp: number;
+  topic?: string;
+}
+
+export async function resetConsumerOffset(data: ResetConsumerOffsetRequest) {
   await client.post('/groups/reset-offset', data);
 }
 

--- a/web/src/services/consumerService.ts
+++ b/web/src/services/consumerService.ts
@@ -1,6 +1,12 @@
 import { USE_MOCK } from '../config';
 import * as metadataApi from '../api/metadata';
-import type { ConsumerGroup, QueueProgress, SubscriptionEntry } from '../api/metadata';
+import type {
+  ConsumerGroup,
+  ConsumerGroupDetail,
+  QueueProgress,
+  ResetConsumerOffsetRequest,
+  SubscriptionEntry,
+} from '../api/metadata';
 import { mockConsumerGroups, mockQueueProgress, mockSubscriptions } from '../mock/consumers';
 
 export async function listConsumerGroups(params?: { keyword?: string }): Promise<ConsumerGroup[]> {
@@ -20,13 +26,40 @@ export async function getConsumerProgress(name: string): Promise<QueueProgress[]
   return metadataApi.getConsumerProgress(name);
 }
 
+export async function getConsumerGroup(name: string): Promise<ConsumerGroupDetail> {
+  if (USE_MOCK) {
+    const group = mockConsumerGroups.find((item) => item.name === name);
+    if (!group) throw new Error(`Consumer group not found: ${name}`);
+    return group as unknown as ConsumerGroupDetail;
+  }
+  return metadataApi.getConsumerGroup(name);
+}
+
 export async function getConsumerSubscriptions(name: string): Promise<SubscriptionEntry[]> {
   if (USE_MOCK) return (mockSubscriptions[name] as unknown as SubscriptionEntry[]) ?? [];
   return metadataApi.getConsumerSubscriptions(name);
 }
 
-export async function createConsumerGroup(data: Partial<ConsumerGroup>): Promise<void> {
-  if (USE_MOCK) return;
+export async function createConsumerGroup(data: Partial<ConsumerGroup>): Promise<ConsumerGroup> {
+  if (USE_MOCK) {
+    const now = new Date().toISOString();
+    const group = {
+      name: data.name ?? '',
+      namespace: data.namespace ?? 'default',
+      clusterId: data.clusterId ?? '',
+      subscriptionMode: data.subscriptionMode ?? 'Push',
+      consumeType: data.consumeType ?? 'CLUSTERING',
+      onlineInstances: 0,
+      totalLag: 0,
+      subscribedTopics: data.subscribedTopics ?? [],
+      subscriptionDataType: data.subscriptionDataType ?? 'NORMAL',
+      retryMaxTimes: data.retryMaxTimes ?? 16,
+      createdAt: now,
+      instances: [],
+    };
+    mockConsumerGroups.unshift(group as never);
+    return group as ConsumerGroup;
+  }
   return metadataApi.createConsumerGroup(data);
 }
 
@@ -37,6 +70,11 @@ export async function deleteConsumerGroup(name: string): Promise<void> {
     return;
   }
   return metadataApi.deleteConsumerGroup(name);
+}
+
+export async function resetConsumerOffset(data: ResetConsumerOffsetRequest): Promise<void> {
+  if (USE_MOCK) return;
+  return metadataApi.resetConsumerOffset(data);
 }
 
 // Batch delete: loop through single delete calls


### PR DESCRIPTION
## Summary

- expose consumer-group detail, typed offset-reset, and created-record responses through the frontend service layer
- make mock-mode creation produce a realistic, immediately queryable group
- add request-contract coverage for group detail, create, and reset-offset operations

## Validation

- `npm.cmd test -- metadata.test.ts`
- `npm.cmd run lint` was attempted separately but timed out without diagnostics on this Windows host.
