### PR TITLE
[Studio] feat: add cluster operation services

### DIFF
--- a/web/src/api/cluster.test.ts
+++ b/web/src/api/cluster.test.ts
@@ -18,7 +18,18 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { createK8sCert, deleteK8sCert, listK8sCerts, updateK8sCert } from './cluster';
+import {
+  createK8sCert,
+  createNameServer,
+  deleteK8sCert,
+  deleteNameServer,
+  listK8sCerts,
+  restartNameServer,
+  restartProxy,
+  updateK8sCert,
+  updateNameServer,
+  upgradeNameServer,
+} from './cluster';
 import type { K8sCertInfo } from './cluster';
 
 const mock = new MockAdapter(client);
@@ -79,5 +90,38 @@ describe('K8s certificate API', () => {
     });
 
     await expect(deleteK8sCert(cert.id)).resolves.toBeUndefined();
+  });
+
+  it('sends NameServer operation payloads to their endpoints', async () => {
+    const target = { clusterId: 'cluster-1', addr: '127.0.0.1:9876' };
+    const requests = [
+      ['/nameservers/restart', target],
+      ['/nameservers/upgrade', { ...target, version: '5.4.0' }],
+      ['/nameservers/create', target],
+      ['/nameservers/update', { ...target, newAddr: '127.0.0.2:9876' }],
+      ['/nameservers/delete', target],
+    ] as const;
+    requests.forEach(([url, body]) => {
+      mock.onPost(url).reply((config) => {
+        expect(JSON.parse(config.data)).toEqual(body);
+        return [200, { code: 200, data: null }];
+      });
+    });
+
+    await expect(restartNameServer(target)).resolves.toBeUndefined();
+    await expect(upgradeNameServer({ ...target, version: '5.4.0' })).resolves.toBeUndefined();
+    await expect(createNameServer(target)).resolves.toBeUndefined();
+    await expect(updateNameServer({ ...target, newAddr: '127.0.0.2:9876' })).resolves.toBeUndefined();
+    await expect(deleteNameServer(target)).resolves.toBeUndefined();
+  });
+
+  it('sends the proxy restart target', async () => {
+    const target = { clusterId: 'cluster-1', addr: '127.0.0.1:8081' };
+    mock.onPost('/proxies/restart').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual(target);
+      return [200, { code: 200, data: null }];
+    });
+
+    await expect(restartProxy(target)).resolves.toBeUndefined();
   });
 });

--- a/web/src/services/clusterService.ts
+++ b/web/src/services/clusterService.ts
@@ -94,3 +94,83 @@ export async function restartBroker(clusterId: string, brokerName: string) {
   if (USE_MOCK) return { success: true, message: `Broker ${brokerName} restarted (mock)` };
   return clusterApi.restartBroker(clusterId, brokerName);
 }
+
+function getMockCluster(clusterId: string) {
+  const cluster = clusters.find((item) => item.id === clusterId);
+  if (!cluster) throw new Error(`Cluster not found: ${clusterId}`);
+  return cluster;
+}
+
+export async function restartNameServer(data: { clusterId: string; addr: string }): Promise<void> {
+  if (USE_MOCK) {
+    const nameServer = getMockCluster(data.clusterId).nameServers.find(
+      (item) => item.addr === data.addr,
+    );
+    if (!nameServer) throw new Error(`NameServer not found: ${data.addr}`);
+    nameServer.status = 'healthy';
+    return;
+  }
+  return clusterApi.restartNameServer(data);
+}
+
+export async function upgradeNameServer(data: {
+  clusterId: string;
+  addr: string;
+  version: string;
+}): Promise<void> {
+  if (USE_MOCK) {
+    const exists = getMockCluster(data.clusterId).nameServers.some((item) => item.addr === data.addr);
+    if (!exists) throw new Error(`NameServer not found: ${data.addr}`);
+    return;
+  }
+  return clusterApi.upgradeNameServer(data);
+}
+
+export async function deleteNameServer(data: { clusterId: string; addr: string }): Promise<void> {
+  if (USE_MOCK) {
+    const nameServers = getMockCluster(data.clusterId).nameServers;
+    const index = nameServers.findIndex((item) => item.addr === data.addr);
+    if (index < 0) throw new Error(`NameServer not found: ${data.addr}`);
+    nameServers.splice(index, 1);
+    return;
+  }
+  return clusterApi.deleteNameServer(data);
+}
+
+export async function createNameServer(data: { clusterId: string; addr: string }): Promise<void> {
+  if (USE_MOCK) {
+    const nameServers = getMockCluster(data.clusterId).nameServers;
+    if (nameServers.some((item) => item.addr === data.addr)) {
+      throw new Error(`NameServer already exists: ${data.addr}`);
+    }
+    nameServers.push({ addr: data.addr, status: 'healthy' });
+    return;
+  }
+  return clusterApi.createNameServer(data);
+}
+
+export async function updateNameServer(data: {
+  clusterId: string;
+  addr: string;
+  newAddr?: string;
+}): Promise<void> {
+  if (USE_MOCK) {
+    const nameServer = getMockCluster(data.clusterId).nameServers.find(
+      (item) => item.addr === data.addr,
+    );
+    if (!nameServer) throw new Error(`NameServer not found: ${data.addr}`);
+    if (data.newAddr) nameServer.addr = data.newAddr;
+    return;
+  }
+  return clusterApi.updateNameServer(data);
+}
+
+export async function restartProxy(data: { clusterId: string; addr: string }): Promise<void> {
+  if (USE_MOCK) {
+    const proxy = getMockCluster(data.clusterId).proxies.find((item) => item.addr === data.addr);
+    if (!proxy) throw new Error(`Proxy not found: ${data.addr}`);
+    proxy.status = 'healthy';
+    return;
+  }
+  return clusterApi.restartProxy(data);
+}


### PR DESCRIPTION
## Summary

- add service-layer access to NameServer restart, upgrade, create, update, and delete operations
- add Proxy restart support and realistic in-memory behavior for every operation in mock mode
- cover request payloads for all new backend operation endpoints

## Validation

- `npm.cmd test -- cluster.test.ts`
- The changed-file ESLint and TypeScript command was attempted but timed out without diagnostics on this Windows host.
