### PR TITLE
[Studio] feat: pass home prompts to AI chat

### DIFF
--- a/web/src/pages/ai/chatDraft.test.ts
+++ b/web/src/pages/ai/chatDraft.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getChatDraft } from './chatDraft';
+
+describe('AI chat draft navigation state', () => {
+  it('normalizes a prompt and preserves a selected model', () => {
+    expect(getChatDraft({ prompt: '  检查集群状态  ', model: 'qwen3.7-max' })).toEqual({
+      prompt: '检查集群状态',
+      model: 'qwen3.7-max',
+    });
+  });
+
+  it('rejects invalid or empty navigation state', () => {
+    expect(getChatDraft(null)).toBeNull();
+    expect(getChatDraft({ prompt: '   ' })).toBeNull();
+    expect(getChatDraft({ prompt: 42 })).toBeNull();
+  });
+});

--- a/web/src/pages/ai/chatDraft.ts
+++ b/web/src/pages/ai/chatDraft.ts
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ChatDraft {
+  prompt: string;
+  model?: string;
+}
+
+export function getChatDraft(state: unknown): ChatDraft | null {
+  if (typeof state !== 'object' || state === null) return null;
+  const candidate = state as Record<string, unknown>;
+  if (typeof candidate.prompt !== 'string' || !candidate.prompt.trim()) return null;
+
+  return {
+    prompt: candidate.prompt.trim(),
+    ...(typeof candidate.model === 'string' && candidate.model ? { model: candidate.model } : {}),
+  };
+}

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -16,6 +16,7 @@
  */
 
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   Card,
   Button,
@@ -33,6 +34,7 @@ import {
 import { ArrowUp, Sparkle, SlidersHorizontal, CaretDown } from '@phosphor-icons/react';
 import type { ColumnsType } from 'antd/es/table';
 import { useLang } from '../../i18n/LangContext';
+import { getChatDraft } from './chatDraft';
 
 const { Text, Paragraph } = Typography;
 
@@ -346,12 +348,15 @@ const AiMessage = ({ msg }: { msg: Message }) => (
 
 const AiPage = () => {
   const { t } = useLang();
+  const location = useLocation();
+  const navigate = useNavigate();
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [inputValue, setInputValue] = useState('');
   const [loading, setLoading] = useState(false);
   const [selectedModel, setSelectedModel] = useState('qwen3.7-max');
   const chatEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const consumedDraftRef = useRef(false);
 
   const scrollToBottom = useCallback(() => {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -360,6 +365,19 @@ const AiPage = () => {
   useEffect(() => {
     scrollToBottom();
   }, [messages, scrollToBottom]);
+
+  useEffect(() => {
+    const draft = getChatDraft(location.state);
+    if (!draft || consumedDraftRef.current) return;
+    consumedDraftRef.current = true;
+
+    void Promise.resolve().then(() => {
+      setInputValue(draft.prompt);
+      if (draft.model) setSelectedModel(draft.model);
+      navigate('/ai', { replace: true, state: null });
+      textareaRef.current?.focus();
+    });
+  }, [location.state, navigate]);
 
   /* ─── Auto-resize textarea ─── */
   useEffect(() => {

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -66,6 +66,7 @@ const modelOptions = [
 const HomePage = () => {
   const [activeMode, setActiveMode] = useState('query');
   const [selectedModel, setSelectedModel] = useState('qwen3.7-max');
+  const [inputValue, setInputValue] = useState('');
   const [indicatorStyle, setIndicatorStyle] = useState({ width: 83, left: 6 });
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const modeBarRef = useRef<HTMLDivElement>(null);
@@ -117,8 +118,13 @@ const HomePage = () => {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      navigate('/ai');
+      handlePromptSubmit();
     }
+  };
+
+  const handlePromptSubmit = () => {
+    const prompt = inputValue.trim();
+    navigate('/ai', { state: prompt ? { prompt, model: selectedModel } : null });
   };
 
   return (
@@ -321,6 +327,8 @@ const HomePage = () => {
                     ref={textareaRef}
                     className="chat-input"
                     placeholder="向 RocketMQ Bot 提问，全程加密、安全、可信"
+                    value={inputValue}
+                    onChange={(event) => setInputValue(event.target.value)}
                     onKeyDown={handleKeyDown}
                   />
                   <RobotOutlined
@@ -359,7 +367,7 @@ const HomePage = () => {
                       <div className="shrink-0 flex items-center gap-1">
                         <button
                           className="flex items-center justify-center w-9 h-9 rounded-full bg-gradient-to-r from-purple-500 to-violet-600 text-white shadow-lg hover:shadow-xl transition-all hover:scale-105"
-                          onClick={() => navigate('/ai')}
+                          onClick={handlePromptSubmit}
                         >
                           <ArrowUp size={19} weight="bold" />
                         </button>


### PR DESCRIPTION
## Summary

- preserve a question typed on the home page when navigating to AI Chat
- forward the selected model with the prompt, focus the AI input, and clear one-time router state after consumption
- make the home input controlled so Enter and the send button share the same behavior

## Validation

- `npm.cmd test -- chatDraft.test.ts`
- `./node_modules/.bin/eslint.cmd src/pages/home/index.tsx src/pages/ai/index.tsx src/pages/ai/chatDraft.ts src/pages/ai/chatDraft.test.ts`
- `./node_modules/.bin/tsc.cmd -p tsconfig.app.json --noEmit`
