### PR TITLE
[Studio] fix: restore persisted auth sessions

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -17,6 +17,7 @@
 
 import axios from 'axios';
 import { message } from 'antd';
+import { clearAuthSession, TOKEN_STORAGE_KEY } from '../stores/authStorage';
 
 const SUCCESS_BUSINESS_CODES = new Set([0, 200]);
 
@@ -47,7 +48,7 @@ const client = axios.create({
 // Request interceptor: attach Authorization header
 client.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem(TOKEN_STORAGE_KEY);
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -68,7 +69,7 @@ client.interceptors.response.use(
   },
   (error) => {
     if (error.response?.status === 401) {
-      localStorage.removeItem('token');
+      clearAuthSession();
       window.location.href = '/';
     }
     return Promise.reject(error);

--- a/web/src/stores/authStorage.test.ts
+++ b/web/src/stores/authStorage.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  clearAuthSession,
+  persistAuthSession,
+  readAuthSession,
+  TOKEN_STORAGE_KEY,
+  USER_STORAGE_KEY,
+} from './authStorage';
+
+describe('auth session storage', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('persists the token and user together', () => {
+    persistAuthSession('token-1', 'studio-admin');
+
+    expect(readAuthSession()).toEqual({ token: 'token-1', user: 'studio-admin' });
+  });
+
+  it('does not restore an orphaned user without a token', () => {
+    localStorage.setItem(USER_STORAGE_KEY, 'studio-admin');
+
+    expect(readAuthSession()).toEqual({ token: null, user: null });
+  });
+
+  it('clears every persisted session key', () => {
+    persistAuthSession('token-1', 'studio-admin');
+    clearAuthSession();
+
+    expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(USER_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/web/src/stores/authStorage.ts
+++ b/web/src/stores/authStorage.ts
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const TOKEN_STORAGE_KEY = 'token';
+export const USER_STORAGE_KEY = 'rocketmq-studio-user';
+
+export interface AuthSession {
+  token: string | null;
+  user: string | null;
+}
+
+export function readAuthSession(): AuthSession {
+  try {
+    const token = localStorage.getItem(TOKEN_STORAGE_KEY);
+    return {
+      token,
+      user: token ? localStorage.getItem(USER_STORAGE_KEY) : null,
+    };
+  } catch {
+    return { token: null, user: null };
+  }
+}
+
+export function persistAuthSession(token: string, user: string): void {
+  try {
+    localStorage.setItem(TOKEN_STORAGE_KEY, token);
+    localStorage.setItem(USER_STORAGE_KEY, user);
+  } catch {
+    // The in-memory store remains usable when browser storage is unavailable.
+  }
+}
+
+export function clearAuthSession(): void {
+  try {
+    localStorage.removeItem(TOKEN_STORAGE_KEY);
+    localStorage.removeItem(USER_STORAGE_KEY);
+  } catch {
+    // The caller still clears the in-memory store.
+  }
+}

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -16,6 +16,7 @@
  */
 
 import { create } from 'zustand';
+import { clearAuthSession, persistAuthSession, readAuthSession } from './authStorage';
 
 interface AuthState {
   user: string | null;
@@ -24,15 +25,17 @@ interface AuthState {
   logout: () => void;
 }
 
+const initialSession = readAuthSession();
+
 const useAuthStore = create<AuthState>((set) => ({
-  user: null,
-  token: null,
+  user: initialSession.user,
+  token: initialSession.token,
   login: (token: string, user: string) => {
-    localStorage.setItem('token', token);
+    persistAuthSession(token, user);
     set({ token, user });
   },
   logout: () => {
-    localStorage.removeItem('token');
+    clearAuthSession();
     set({ token: null, user: null });
   },
 }));


### PR DESCRIPTION
## Summary

- persist both authentication token and username, then restore the session when the application reloads
- clear the complete persisted session from the user action and from API 401 handling
- centralize session-storage behavior and cover persistence, orphaned data, and cleanup

## Validation

- `npm.cmd test -- authStorage.test.ts`
- `./node_modules/.bin/eslint.cmd src/api/client.ts src/stores/authStore.ts src/stores/authStorage.ts src/stores/authStorage.test.ts`
- `./node_modules/.bin/tsc.cmd -p tsconfig.app.json --noEmit`
