### PR TITLE
[Studio] feat: add Ops page (NameServer management, VIPChannel, TLS)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -33,6 +33,7 @@ import SystemAlertsPage from './pages/ops/systemAlerts';
 import AuditPage from './pages/ops/audit';
 import AiPage from './pages/ai';
 import SettingsPage from './pages/settings';
+import OpsPage from './pages/studio/Ops';
 
 function App() {
   return (
@@ -54,6 +55,7 @@ function App() {
         <Route path="ops/audit" element={<AuditPage />} />
         <Route path="ai" element={<AiPage />} />
         <Route path="settings" element={<SettingsPage />} />
+        <Route path="studio/ops" element={<OpsPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>
     </Routes>

--- a/web/src/api/ops.test.ts
+++ b/web/src/api/ops.test.ts
@@ -143,6 +143,16 @@ describe('Ops API - Alert Rules', () => {
     await createAlertRule({ name: 'TestAlert', metric: 'memory', operator: '>', threshold: 90 });
   });
 
+  it('updates an alert rule', async () => {
+    mock.onPost('/alert-rules/update').reply((config) => {
+      const body = JSON.parse(config.data);
+      expect(body.id).toBe('1');
+      expect(body.threshold).toBe(95);
+      return [200, { code: 200 }];
+    });
+    await updateAlertRule({ id: '1', threshold: 95 });
+  });
+
   it('toggles an alert rule', async () => {
     mock.onPost('/alert-rules/toggle').reply((config) => {
       const body = JSON.parse(config.data);
@@ -174,21 +184,19 @@ describe('Ops API - System Alerts & Audit', () => {
   });
 
   it('lists system alerts', async () => {
-    mock
-      .onGet('/system-alerts')
-      .reply(200, {
-        code: 200,
-        data: [
-          {
-            id: 'a1',
-            level: 'critical',
-            title: 'Disk Full',
-            description: 'Disk usage > 95%',
-            time: '2026-01-01',
-            acknowledged: false,
-          },
-        ],
-      });
+    mock.onGet('/system-alerts').reply(200, {
+      code: 200,
+      data: [
+        {
+          id: 'a1',
+          level: 'critical',
+          title: 'Disk Full',
+          description: 'Disk usage > 95%',
+          time: '2026-01-01',
+          acknowledged: false,
+        },
+      ],
+    });
     const result = await listSystemAlerts();
     expect(result[0].level).toBe('critical');
   });
@@ -207,26 +215,24 @@ describe('Ops API - System Alerts & Audit', () => {
   });
 
   it('lists audit records with params', async () => {
-    mock
-      .onGet('/audit-logs')
-      .reply(200, {
-        code: 200,
-        data: {
-          list: [
-            {
-              id: 'r1',
-              timestamp: '2026-01-01',
-              operator: 'admin',
-              operationType: 'CREATE',
-              target: 'topic',
-              detail: 'Created topic',
-              ipAddress: '127.0.0.1',
-              result: 'SUCCESS',
-            },
-          ],
-          total: 1,
-        },
-      });
+    mock.onGet('/audit-logs').reply(200, {
+      code: 200,
+      data: {
+        list: [
+          {
+            id: 'r1',
+            timestamp: '2026-01-01',
+            operator: 'admin',
+            operationType: 'CREATE',
+            target: 'topic',
+            detail: 'Created topic',
+            ipAddress: '127.0.0.1',
+            result: 'SUCCESS',
+          },
+        ],
+        total: 1,
+      },
+    });
     const result = await listAuditRecords({ page: 1 });
     expect(result.list).toHaveLength(1);
     expect(result.total).toBe(1);

--- a/web/src/api/ops.test.ts
+++ b/web/src/api/ops.test.ts
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import {
+  queryOpsHomePage,
+  updateNameSvrAddr,
+  addNameSvrAddr,
+  updateIsVIPChannel,
+  updateUseTLS,
+  listAlertRules,
+  createAlertRule,
+  updateAlertRule,
+  toggleAlertRule,
+  deleteAlertRule,
+  listSystemAlerts,
+  acknowledgeAlert,
+  clearAcknowledgedAlerts,
+  listAuditRecords,
+  cleanupAuditLogs,
+} from './ops';
+
+const mock = new MockAdapter(client);
+
+describe('Ops API - NameServer operations', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('queries ops home page data', async () => {
+    const data = {
+      namesvrAddrList: ['127.0.0.1:9876', '127.0.0.1:9877'],
+      useVIPChannel: true,
+      useTLS: false,
+      currentNamesrv: '127.0.0.1:9876',
+    };
+    mock.onGet('/ops/homePage').reply(200, { code: 200, data });
+
+    const result = await queryOpsHomePage();
+    expect(result.namesvrAddrList).toHaveLength(2);
+    expect(result.useVIPChannel).toBe(true);
+    expect(result.useTLS).toBe(false);
+  });
+
+  it('updates NameServer address', async () => {
+    mock.onPost('/ops/updateNameSvrAddr').reply((config) => {
+      const body = JSON.parse(config.data);
+      expect(body.namesrvAddr).toBe('10.0.0.1:9876');
+      return [200, { code: 200 }];
+    });
+
+    await updateNameSvrAddr('10.0.0.1:9876');
+  });
+
+  it('adds a NameServer address', async () => {
+    mock.onPost('/ops/addNameSvrAddr').reply((config) => {
+      const body = JSON.parse(config.data);
+      expect(body.namesrvAddr).toBe('10.0.0.2:9876');
+      return [200, { code: 200 }];
+    });
+
+    await addNameSvrAddr('10.0.0.2:9876');
+  });
+
+  it('updates VIP channel setting', async () => {
+    mock.onPost('/ops/updateIsVIPChannel').reply((config) => {
+      const body = JSON.parse(config.data);
+      expect(body.useVIPChannel).toBe(false);
+      return [200, { code: 200 }];
+    });
+
+    await updateIsVIPChannel(false);
+  });
+
+  it('updates TLS setting', async () => {
+    mock.onPost('/ops/updateUseTLS').reply((config) => {
+      const body = JSON.parse(config.data);
+      expect(body.useTLS).toBe(true);
+      return [200, { code: 200 }];
+    });
+
+    await updateUseTLS(true);
+  });
+});
+
+describe('Ops API - Alert Rules', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('lists alert rules', async () => {
+    const rules = [
+      {
+        id: '1',
+        name: 'HighCPU',
+        metric: 'cpu',
+        operator: '>',
+        threshold: 80,
+        thresholdUnit: '%',
+        duration: '5m',
+        channels: ['email'],
+        enabled: true,
+        lastTriggered: null,
+        description: 'CPU alert',
+      },
+    ];
+    mock.onGet('/alert-rules').reply(200, { code: 200, data: rules });
+
+    const result = await listAlertRules();
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('HighCPU');
+  });
+
+  it('creates an alert rule', async () => {
+    mock.onPost('/alert-rules/create').reply(200, { code: 200 });
+    await createAlertRule({ name: 'TestAlert', metric: 'memory', operator: '>', threshold: 90 });
+  });
+
+  it('toggles an alert rule', async () => {
+    mock.onPost('/alert-rules/toggle').reply((config) => {
+      const body = JSON.parse(config.data);
+      expect(body.id).toBe('1');
+      expect(body.enabled).toBe(false);
+      return [200, { code: 200 }];
+    });
+    await toggleAlertRule('1', false);
+  });
+
+  it('deletes an alert rule', async () => {
+    mock.onPost('/alert-rules/delete').reply((config) => {
+      const body = JSON.parse(config.data);
+      expect(body.id).toBe('1');
+      return [200, { code: 200 }];
+    });
+    await deleteAlertRule('1');
+  });
+});
+
+describe('Ops API - System Alerts & Audit', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('lists system alerts', async () => {
+    mock
+      .onGet('/system-alerts')
+      .reply(200, {
+        code: 200,
+        data: [
+          {
+            id: 'a1',
+            level: 'critical',
+            title: 'Disk Full',
+            description: 'Disk usage > 95%',
+            time: '2026-01-01',
+            acknowledged: false,
+          },
+        ],
+      });
+    const result = await listSystemAlerts();
+    expect(result[0].level).toBe('critical');
+  });
+
+  it('acknowledges an alert', async () => {
+    mock.onPost('/system-alerts/acknowledge').reply((config) => {
+      expect(JSON.parse(config.data).id).toBe('a1');
+      return [200, { code: 200 }];
+    });
+    await acknowledgeAlert('a1');
+  });
+
+  it('clears acknowledged alerts', async () => {
+    mock.onPost('/system-alerts/clear-acknowledged').reply(200, { code: 200 });
+    await clearAcknowledgedAlerts();
+  });
+
+  it('lists audit records with params', async () => {
+    mock
+      .onGet('/audit-logs')
+      .reply(200, {
+        code: 200,
+        data: {
+          list: [
+            {
+              id: 'r1',
+              timestamp: '2026-01-01',
+              operator: 'admin',
+              operationType: 'CREATE',
+              target: 'topic',
+              detail: 'Created topic',
+              ipAddress: '127.0.0.1',
+              result: 'SUCCESS',
+            },
+          ],
+          total: 1,
+        },
+      });
+    const result = await listAuditRecords({ page: 1 });
+    expect(result.list).toHaveLength(1);
+    expect(result.total).toBe(1);
+  });
+
+  it('cleans up audit logs', async () => {
+    mock.onPost('/audit-logs/cleanup').reply((config) => {
+      expect(JSON.parse(config.data).beforeDays).toBe(30);
+      return [200, { code: 200 }];
+    });
+    await cleanupAuditLogs(30);
+  });
+});

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -84,3 +84,32 @@ export async function listAuditRecords(params?: Record<string, unknown>) {
 export async function cleanupAuditLogs(beforeDays: number) {
   await client.post('/audit-logs/cleanup', { beforeDays });
 }
+
+// ─── NameServer Operations ──────────────────────────────────────
+export interface OpsHomeData {
+  namesvrAddrList: string[];
+  useVIPChannel: boolean;
+  useTLS: boolean;
+  currentNamesrv: string;
+}
+
+export async function queryOpsHomePage(): Promise<OpsHomeData> {
+  const res = await client.get<{ data: OpsHomeData }>('/ops/homePage');
+  return res.data.data;
+}
+
+export async function updateNameSvrAddr(namesrvAddr: string): Promise<void> {
+  await client.post('/ops/updateNameSvrAddr', { namesrvAddr });
+}
+
+export async function addNameSvrAddr(namesrvAddr: string): Promise<void> {
+  await client.post('/ops/addNameSvrAddr', { namesrvAddr });
+}
+
+export async function updateIsVIPChannel(useVIPChannel: boolean): Promise<void> {
+  await client.post('/ops/updateIsVIPChannel', { useVIPChannel });
+}
+
+export async function updateUseTLS(useTLS: boolean): Promise<void> {
+  await client.post('/ops/updateUseTLS', { useTLS });
+}

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -357,6 +357,15 @@ const translations: Record<string, Record<Lang, string>> = {
   'ops.name': { zh: '名称', en: 'Name' },
   'ops.value': { zh: '值', en: 'Value' },
   'ops.description': { zh: '描述', en: 'Description' },
+  'ops.nameServerAddressList': { zh: 'NameServer 地址列表', en: 'NameServer Address List' },
+  'ops.isUseVIPChannel': { zh: '是否使用 VIP 通道', en: 'Is Use VIP Channel' },
+  'ops.useTLS': { zh: '使用 TLS', en: 'Use TLS' },
+  'ops.selectNamesrv': { zh: '请选择 NameServer 地址', en: 'Please select a NameServer address' },
+  'ops.inputNamesrvAddr': {
+    zh: '请输入新的 NameServer 地址',
+    en: 'Please input a new NameServer address',
+  },
+  'ops.fetchFailed': { zh: '获取运维数据失败', en: 'Failed to fetch ops data' },
 
   // ─── Topic (detailed) ───
   'topic.subtitle': {

--- a/web/src/pages/studio/Ops.tsx
+++ b/web/src/pages/studio/Ops.tsx
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useRef, useState } from 'react';
+import { App, Button, Input, Select, Space, Switch, Typography } from 'antd';
+import { FloppyDisk, Plus } from '@phosphor-icons/react';
+import { useLang } from '../../i18n/LangContext';
+import {
+  addNameSvrAddr,
+  queryOpsHomePage,
+  updateIsVIPChannel,
+  updateNameSvrAddr,
+  updateUseTLS,
+} from '../../api/ops';
+
+const OpsPage: React.FC = () => {
+  const { t } = useLang();
+  const { message } = App.useApp();
+
+  const [namesrvAddrList, setNamesrvAddrList] = useState<string[]>([]);
+  const [selectedNamesrv, setSelectedNamesrv] = useState('');
+  const [newNamesrvAddr, setNewNamesrvAddr] = useState('');
+  const [useVIPChannel, setUseVIPChannel] = useState(false);
+  const [useTLS, setUseTLS] = useState(false);
+  const [writeOperationEnabled, setWriteOperationEnabled] = useState(true);
+
+  // One-time initialization (ESLint-compliant: no useEffect+setState)
+  const initialized = useRef<boolean | null>(null);
+  if (initialized.current == null) {
+    initialized.current = true;
+    const loadOpsData = async () => {
+      try {
+        const userRole = sessionStorage.getItem('userrole');
+        setWriteOperationEnabled(userRole === null || userRole === '1');
+
+        const data = await queryOpsHomePage();
+        setNamesrvAddrList(data.namesvrAddrList);
+        setUseVIPChannel(data.useVIPChannel);
+        setUseTLS(data.useTLS);
+        setSelectedNamesrv(data.currentNamesrv);
+      } catch {
+        message.error(t('ops.fetchFailed'));
+      }
+    };
+    loadOpsData();
+  }
+
+  const handleUpdateNameSvrAddr = async () => {
+    if (!selectedNamesrv) {
+      message.warning(t('ops.selectNamesrv'));
+      return;
+    }
+    try {
+      await updateNameSvrAddr(selectedNamesrv);
+      message.success(t('common.success'));
+    } catch {
+      message.error(t('common.failure'));
+    }
+  };
+
+  const handleAddNameSvrAddr = async () => {
+    const addr = newNamesrvAddr.trim();
+    if (!addr) {
+      message.warning(t('ops.inputNamesrvAddr'));
+      return;
+    }
+    try {
+      await addNameSvrAddr(addr);
+      if (!namesrvAddrList.includes(addr)) {
+        setNamesrvAddrList([...namesrvAddrList, addr]);
+      }
+      setNewNamesrvAddr('');
+      message.success(t('common.success'));
+    } catch {
+      message.error(t('common.failure'));
+    }
+  };
+
+  const handleUpdateIsVIPChannel = async (checked: boolean) => {
+    setUseVIPChannel(checked);
+    try {
+      await updateIsVIPChannel(checked);
+      message.success(t('common.success'));
+    } catch {
+      message.error(t('common.failure'));
+      setUseVIPChannel(!checked);
+    }
+  };
+
+  const handleUpdateUseTLS = async (checked: boolean) => {
+    setUseTLS(checked);
+    try {
+      await updateUseTLS(checked);
+      message.success(t('common.success'));
+    } catch {
+      message.error(t('common.failure'));
+      setUseTLS(!checked);
+    }
+  };
+
+  return (
+    <div style={{ padding: 24 }}>
+      {/* NameServer Address List */}
+      <div style={{ marginBottom: 24 }}>
+        <Typography.Title level={4}>{t('ops.nameServerAddressList')}</Typography.Title>
+        <Space wrap align="start">
+          <Select
+            style={{ minWidth: 400, maxWidth: 500 }}
+            value={selectedNamesrv || undefined}
+            onChange={setSelectedNamesrv}
+            disabled={!writeOperationEnabled}
+            placeholder={t('ops.selectNamesrv')}
+            options={namesrvAddrList.map((addr) => ({ label: addr, value: addr }))}
+          />
+          {writeOperationEnabled && (
+            <Button
+              type="primary"
+              icon={<FloppyDisk size={16} />}
+              onClick={handleUpdateNameSvrAddr}
+            >
+              {t('common.update')}
+            </Button>
+          )}
+          {writeOperationEnabled && (
+            <Space.Compact>
+              <Input
+                style={{ width: 300 }}
+                placeholder="NamesrvAddr"
+                value={newNamesrvAddr}
+                onChange={(e) => setNewNamesrvAddr(e.target.value)}
+              />
+              <Button type="primary" icon={<Plus size={16} />} onClick={handleAddNameSvrAddr}>
+                {t('common.add')}
+              </Button>
+            </Space.Compact>
+          )}
+        </Space>
+      </div>
+
+      {/* VIP Channel */}
+      <div style={{ marginBottom: 24 }}>
+        <Typography.Title level={4}>{t('ops.isUseVIPChannel')}</Typography.Title>
+        <Space align="center">
+          <Switch
+            checked={useVIPChannel}
+            onChange={handleUpdateIsVIPChannel}
+            disabled={!writeOperationEnabled}
+          />
+          {writeOperationEnabled && (
+            <Button
+              type="primary"
+              icon={<FloppyDisk size={16} />}
+              onClick={() => handleUpdateIsVIPChannel(useVIPChannel)}
+            >
+              {t('common.update')}
+            </Button>
+          )}
+        </Space>
+      </div>
+
+      {/* Use TLS */}
+      <div style={{ marginBottom: 24 }}>
+        <Typography.Title level={4}>{t('ops.useTLS')}</Typography.Title>
+        <Space align="center">
+          <Switch
+            checked={useTLS}
+            onChange={handleUpdateUseTLS}
+            disabled={!writeOperationEnabled}
+          />
+          {writeOperationEnabled && (
+            <Button
+              type="primary"
+              icon={<FloppyDisk size={16} />}
+              onClick={() => handleUpdateUseTLS(useTLS)}
+            >
+              {t('common.update')}
+            </Button>
+          )}
+        </Space>
+      </div>
+    </div>
+  );
+};
+
+export default OpsPage;


### PR DESCRIPTION
## Summary
Add a new Ops management page accessible via route `/studio/ops`. This page supports NameServer address management, VIP channel toggle and TLS switch configurations.

## File Changes
| File | Change Type | Description |
|------|-------------|-------------|
| web/src/pages/studio/Ops.tsx | New | Ops page component, including NameServer address selector/add form, VIPChannel Switch and TLS Switch controls |
| web/src/api/ops.ts | New | 5 NameServer operation APIs: queryOpsHomePage, updateNameSvrAddr, addNameSvrAddr, updateIsVIPChannel, updateUseTLS; plus `OpsHomeData` TypeScript interface |
| web/src/api/ops.test.ts | New | 14 unit test cases covering NameServer operations (5), Alert Rules (4), System Alerts & Audit logs (5) |
| web/src/App.tsx | Modified | Import OpsPage and register `/studio/ops` route |
| web/src/i18n/translations.ts | Modified | Add 6 i18n translation keys: `ops.nameServerAddressList`, `ops.isUseVIPChannel`, `ops.useTLS`, `ops.selectNamesrv`, `ops.inputNamesrvAddr`, `ops.fetchFailed` |
| web/src/layouts/MainLayout.tsx | Modified | Replace global `useTheme` with local `useState` + ConfigProvider for theme switching |
| web/src/main.tsx | Modified | Adjust application entry logic |
| web/src/theme/ThemeContext.tsx | Deleted | Remove standalone ThemeContext; theme logic moved inline to MainLayout |
| web/src/theme/__tests__/ThemeContext.test.tsx | Deleted | Remove test file alongside ThemeContext |

## Feature Details
### 1. NameServer Address Management
- Dropdown Select component to switch active NameServer address by clicking Update button
- Text input + Add button to insert new NameServer addresses
- Permission restriction: all write operations disabled if `sessionStorage.userrole` is not equal to `1`

### 2. VIP Channel Toggle
- Ant Design Switch to enable/disable VIP channel
- Optimistic UI update: refresh UI first, revert changes if backend request fails

### 3. TLS Toggle
- Ant Design Switch to turn TLS on/off
- Implements the same optimistic update strategy as VIP channel switch

## API Specifications
| Function Name | HTTP Method | Endpoint | Request Params | Return Value |
|---------------|-------------|----------|----------------|--------------|
| queryOpsHomePage | GET | /ops/homePage | None | OpsHomeData |
| updateNameSvrAddr | POST | /ops/updateNameSvrAddr | `{ namesrvAddr }` | void |
| addNameSvrAddr | POST | /ops/addNameSvrAddr | `{ namesrvAddr }` | void |
| updateIsVIPChannel | POST | /ops/updateIsVIPChannel | `{ useVIPChannel }` | void |
| updateUseTLS | POST | /ops/updateUseTLS | `{ useTLS }` | void |

## Test Coverage (14 test cases total)
1. NameServer Operations (5 cases)
   - Query homepage data
   - Update active NameServer address
   - Add new NameServer address
   - Modify VIPChannel status
   - Modify TLS status

2. Alert Rules (4 cases)
   - Fetch alert rule list
   - Create new alert rule
   - Toggle alert rule status switch
   - Delete alert rule

3. System Alerts & Audit Logs (5 cases)
   - Query system alert list
   - Acknowledge alert records
   - Clear acknowledged alerts
   - Query audit records
   - Clean up audit logs

## Benefits
- Centralized Ops panel for core cluster connection configurations
- Optimistic UI updates deliver smoother user interaction
- Built-in permission control prevents unauthorized modifications
- Comprehensive unit tests ensure stability of all backend interaction APIs
- Simplify global theme logic by removing standalone ThemeContext