### PR TITLE
[Studio] feat: add namespace management page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -33,6 +33,7 @@ import SystemAlertsPage from './pages/ops/systemAlerts';
 import AuditPage from './pages/ops/audit';
 import AiPage from './pages/ai';
 import SettingsPage from './pages/settings';
+import NamespacePage from './pages/studio/Namespace';
 
 function App() {
   return (
@@ -54,6 +55,7 @@ function App() {
         <Route path="ops/audit" element={<AuditPage />} />
         <Route path="ai" element={<AiPage />} />
         <Route path="settings" element={<SettingsPage />} />
+        <Route path="studio/namespace" element={<NamespacePage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>
     </Routes>

--- a/web/src/api/namespace.test.ts
+++ b/web/src/api/namespace.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import client from './client';
+import {
+  queryNamespaceList,
+  queryNamespaceDetail,
+  createNamespace,
+  updateNamespace,
+  deleteNamespace,
+  queryNamespaceCapability,
+  type NamespaceItem,
+} from './namespace';
+
+const mock = new MockAdapter(client);
+
+const sampleNs: NamespaceItem = {
+  namespaceName: 'production',
+  displayName: 'Production',
+  description: 'Production namespace',
+  clusterName: 'prod-cluster',
+  status: 'active',
+  defaultNamespace: false,
+  createTime: Date.now(),
+  quotaConfig: { maxTopicCount: 500, maxConsumerGroupCount: 200 },
+};
+
+describe('Namespace API', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('queries namespace list', async () => {
+    mock.onGet('/namespace/list').reply(200, { code: 200, data: [sampleNs] });
+
+    const result = await queryNamespaceList();
+    expect(result).toHaveLength(1);
+    expect(result[0].namespaceName).toBe('production');
+  });
+
+  it('queries namespace detail by name', async () => {
+    mock.onGet('/namespace/production').reply(200, { code: 200, data: sampleNs });
+
+    const result = await queryNamespaceDetail('production');
+    expect(result.namespaceName).toBe('production');
+    expect(result.quotaConfig?.maxTopicCount).toBe(500);
+  });
+
+  it('creates a namespace', async () => {
+    mock.onPost('/namespace/create').reply((config) => {
+      const body = JSON.parse(config.data);
+      expect(body.namespaceName).toBe('staging');
+      expect(body.displayName).toBe('Staging');
+      return [200, { code: 200 }];
+    });
+
+    await createNamespace({ namespaceName: 'staging', displayName: 'Staging' });
+  });
+
+  it('updates a namespace', async () => {
+    mock.onPut('/namespace/update').reply((config) => {
+      const body = JSON.parse(config.data);
+      expect(body.namespaceName).toBe('production');
+      expect(body.description).toBe('Updated description');
+      return [200, { code: 200 }];
+    });
+
+    await updateNamespace({ namespaceName: 'production', description: 'Updated description' });
+  });
+
+  it('deletes a namespace by name', async () => {
+    mock.onDelete('/namespace/staging').reply(200, { code: 200 });
+
+    await deleteNamespace('staging');
+  });
+
+  it('queries namespace capability as supported', async () => {
+    mock
+      .onGet('/namespace/capability')
+      .reply(200, { code: 200, data: { namespaceSupported: true } });
+
+    const result = await queryNamespaceCapability();
+    expect(result.namespaceSupported).toBe(true);
+  });
+
+  it('queries namespace capability as unsupported', async () => {
+    mock
+      .onGet('/namespace/capability')
+      .reply(200, { code: 200, data: { namespaceSupported: false } });
+
+    const result = await queryNamespaceCapability();
+    expect(result.namespaceSupported).toBe(false);
+  });
+});

--- a/web/src/api/namespace.ts
+++ b/web/src/api/namespace.ts
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import client from './client';
+
+export interface QuotaConfig {
+  maxTopicCount?: number;
+  maxConsumerGroupCount?: number;
+  storageQuotaGB?: number;
+  qpsLimit?: number;
+  connectionLimit?: number;
+}
+
+export interface NamespaceItem {
+  namespaceName: string;
+  displayName?: string;
+  description?: string;
+  clusterName?: string;
+  status: string;
+  defaultNamespace?: boolean;
+  createTime?: number;
+  quotaConfig?: QuotaConfig;
+}
+
+export interface NamespaceCapability {
+  namespaceSupported: boolean;
+}
+
+export async function queryNamespaceList(): Promise<NamespaceItem[]> {
+  const res = await client.get<{ data: NamespaceItem[] }>('/namespace/list');
+  return res.data.data;
+}
+
+export async function queryNamespaceDetail(name: string): Promise<NamespaceItem> {
+  const res = await client.get<{ data: NamespaceItem }>(`/namespace/${encodeURIComponent(name)}`);
+  return res.data.data;
+}
+
+export async function createNamespace(payload: Partial<NamespaceItem>): Promise<void> {
+  await client.post('/namespace/create', payload);
+}
+
+export async function updateNamespace(payload: Partial<NamespaceItem>): Promise<void> {
+  await client.put('/namespace/update', payload);
+}
+
+export async function deleteNamespace(name: string): Promise<void> {
+  await client.delete(`/namespace/${encodeURIComponent(name)}`);
+}
+
+export async function queryNamespaceCapability(): Promise<NamespaceCapability> {
+  const res = await client.get<{ data: NamespaceCapability }>('/namespace/capability');
+  return res.data.data;
+}

--- a/web/src/pages/studio/Namespace.tsx
+++ b/web/src/pages/studio/Namespace.tsx
@@ -1,0 +1,525 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useRef, useState } from 'react';
+import {
+  Card,
+  Table,
+  Button,
+  Space,
+  Tag,
+  Modal,
+  Form,
+  Input,
+  InputNumber,
+  Spin,
+  Row,
+  Col,
+  Statistic,
+  Descriptions,
+  Popconfirm,
+  Tooltip,
+  Alert,
+  App,
+} from 'antd';
+import {
+  Plus,
+  ArrowClockwise,
+  Pencil,
+  Trash,
+  Eye,
+  Database,
+  CheckCircle,
+  XCircle,
+  CloudWarning,
+} from '@phosphor-icons/react';
+import type { ColumnsType } from 'antd/es/table';
+import PageHeader from '../../components/PageHeader';
+import { useLang } from '../../i18n/LangContext';
+import {
+  queryNamespaceList,
+  queryNamespaceCapability,
+  createNamespace,
+  updateNamespace,
+  deleteNamespace,
+  type NamespaceItem,
+} from '../../api/namespace';
+
+const NamespacePage: React.FC = () => {
+  const { t } = useLang();
+  const { message: msg } = App.useApp();
+  const [form] = Form.useForm();
+
+  const [loading, setLoading] = useState(false);
+  const [namespaces, setNamespaces] = useState<NamespaceItem[]>([]);
+  const [namespaceSupported, setNamespaceSupported] = useState(true);
+  const [detailModalVisible, setDetailModalVisible] = useState(false);
+  const [formModalVisible, setFormModalVisible] = useState(false);
+  const [selectedNamespace, setSelectedNamespace] = useState<NamespaceItem | null>(null);
+  const [isEdit, setIsEdit] = useState(false);
+  const [stats, setStats] = useState({
+    totalNamespaces: 0,
+    enabledNamespaces: 0,
+    totalTopicQuota: 0,
+    totalGroupQuota: 0,
+  });
+
+  const initialized = useRef<boolean | null>(null);
+  if (initialized.current == null) {
+    initialized.current = true;
+    const loadData = async () => {
+      try {
+        const cap = await queryNamespaceCapability();
+        setNamespaceSupported(cap.namespaceSupported);
+      } catch {
+        // capability check failed, assume supported
+      }
+      await loadNamespaces();
+    };
+    loadData();
+  }
+
+  const loadNamespaces = async () => {
+    setLoading(true);
+    try {
+      const list = await queryNamespaceList();
+      setNamespaces(list);
+      const enabledCount = list.filter((ns) => ns.status === 'ENABLED').length;
+      const totalTopicQuota = list.reduce(
+        (sum, ns) => sum + (ns.quotaConfig?.maxTopicCount || 0),
+        0,
+      );
+      const totalGroupQuota = list.reduce(
+        (sum, ns) => sum + (ns.quotaConfig?.maxConsumerGroupCount || 0),
+        0,
+      );
+      setStats({
+        totalNamespaces: list.length,
+        enabledNamespaces: enabledCount,
+        totalTopicQuota,
+        totalGroupQuota,
+      });
+    } catch {
+      msg.error(t('ns.fetchFailed'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreate = () => {
+    setIsEdit(false);
+    setSelectedNamespace(null);
+    form.resetFields();
+    setFormModalVisible(true);
+  };
+
+  const handleEdit = (record: NamespaceItem) => {
+    setIsEdit(true);
+    setSelectedNamespace(record);
+    form.setFieldsValue({
+      namespaceName: record.namespaceName,
+      displayName: record.displayName,
+      description: record.description,
+      clusterName: record.clusterName,
+      maxTopicCount: record.quotaConfig?.maxTopicCount,
+      maxConsumerGroupCount: record.quotaConfig?.maxConsumerGroupCount,
+      storageQuotaGB: record.quotaConfig?.storageQuotaGB,
+      qpsLimit: record.quotaConfig?.qpsLimit,
+      connectionLimit: record.quotaConfig?.connectionLimit,
+    });
+    setFormModalVisible(true);
+  };
+
+  const handleView = (record: NamespaceItem) => {
+    setSelectedNamespace(record);
+    setDetailModalVisible(true);
+  };
+
+  const handleDelete = async (name: string) => {
+    setLoading(true);
+    try {
+      await deleteNamespace(name);
+      msg.success(t('ns.deleteSuccess'));
+      await loadNamespaces();
+    } catch {
+      msg.error(t('ns.deleteFailed'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    try {
+      const values = await form.validateFields();
+      setLoading(true);
+      const payload: Partial<NamespaceItem> = {
+        namespaceName: values.namespaceName,
+        displayName: values.displayName,
+        description: values.description,
+        clusterName: values.clusterName,
+        status: 'ENABLED',
+        quotaConfig: {
+          maxTopicCount: values.maxTopicCount,
+          maxConsumerGroupCount: values.maxConsumerGroupCount,
+          storageQuotaGB: values.storageQuotaGB,
+          qpsLimit: values.qpsLimit,
+          connectionLimit: values.connectionLimit,
+        },
+      };
+
+      if (isEdit) {
+        await updateNamespace(payload);
+        msg.success(t('ns.updateSuccess'));
+      } else {
+        await createNamespace(payload);
+        msg.success(t('ns.createSuccess'));
+      }
+      setFormModalVisible(false);
+      form.resetFields();
+      await loadNamespaces();
+    } catch {
+      msg.error(isEdit ? t('ns.updateFailed') : t('ns.createFailed'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const columns: ColumnsType<NamespaceItem> = [
+    {
+      title: t('ns.name'),
+      dataIndex: 'namespaceName',
+      key: 'namespaceName',
+      render: (text: string, record: NamespaceItem) => (
+        <Space>
+          <span style={{ fontWeight: 500 }}>{text}</span>
+          {record.defaultNamespace && <Tag color="blue">{t('ns.default')}</Tag>}
+        </Space>
+      ),
+    },
+    {
+      title: t('ns.displayName'),
+      dataIndex: 'displayName',
+      key: 'displayName',
+      render: (text: string) => text || '-',
+    },
+    {
+      title: t('ns.cluster'),
+      dataIndex: 'clusterName',
+      key: 'clusterName',
+      render: (text: string) => text || '-',
+    },
+    {
+      title: t('common.status'),
+      dataIndex: 'status',
+      key: 'status',
+      render: (status: string) => (
+        <Tag
+          color={status === 'ENABLED' ? 'success' : 'default'}
+          icon={status === 'ENABLED' ? <CheckCircle size={12} /> : <XCircle size={12} />}
+        >
+          {status || 'UNKNOWN'}
+        </Tag>
+      ),
+    },
+    {
+      title: t('ns.topicLimit'),
+      key: 'topicLimit',
+      render: (_: unknown, record: NamespaceItem) => record.quotaConfig?.maxTopicCount || '-',
+    },
+    {
+      title: t('ns.groupLimit'),
+      key: 'groupLimit',
+      render: (_: unknown, record: NamespaceItem) =>
+        record.quotaConfig?.maxConsumerGroupCount || '-',
+    },
+    {
+      title: t('ns.storage'),
+      key: 'storage',
+      render: (_: unknown, record: NamespaceItem) => record.quotaConfig?.storageQuotaGB || '-',
+    },
+    {
+      title: t('common.actions'),
+      key: 'operation',
+      render: (_: unknown, record: NamespaceItem) => (
+        <Space size="small">
+          <Tooltip title={t('ns.viewDetail')}>
+            <Button
+              type="link"
+              size="small"
+              icon={<Eye size={16} />}
+              onClick={() => handleView(record)}
+            />
+          </Tooltip>
+          {!record.defaultNamespace && (
+            <>
+              <Tooltip title={t('common.edit')}>
+                <Button
+                  type="link"
+                  size="small"
+                  icon={<Pencil size={16} />}
+                  onClick={() => handleEdit(record)}
+                />
+              </Tooltip>
+              <Popconfirm
+                title={t('ns.confirmDelete')}
+                onConfirm={() => handleDelete(record.namespaceName)}
+                okText={t('common.yes')}
+                cancelText={t('common.no')}
+              >
+                <Tooltip title={t('common.delete')}>
+                  <Button type="link" size="small" danger icon={<Trash size={16} />} />
+                </Tooltip>
+              </Popconfirm>
+            </>
+          )}
+        </Space>
+      ),
+    },
+  ];
+
+  if (!namespaceSupported) {
+    return (
+      <div style={{ padding: 24 }}>
+        <Alert
+          message={t('ns.notSupported')}
+          description={t('ns.notSupportedDesc')}
+          type="warning"
+          showIcon
+          icon={<CloudWarning size={24} />}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 24, minHeight: 'calc(100vh - 120px)' }}>
+      <PageHeader title={t('ns.title')} />
+
+      <Spin spinning={loading} tip={t('common.loading')}>
+        {/* Stats Cards */}
+        <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
+          <Col xs={24} sm={12} md={6}>
+            <Card>
+              <Statistic
+                title={t('ns.total')}
+                value={stats.totalNamespaces}
+                prefix={<Database size={20} />}
+                valueStyle={{ color: '#1890ff' }}
+              />
+            </Card>
+          </Col>
+          <Col xs={24} sm={12} md={6}>
+            <Card>
+              <Statistic
+                title={t('ns.enabled')}
+                value={stats.enabledNamespaces}
+                suffix={`/ ${stats.totalNamespaces}`}
+                valueStyle={{ color: '#3f8600' }}
+              />
+            </Card>
+          </Col>
+          <Col xs={24} sm={12} md={6}>
+            <Card>
+              <Statistic
+                title={t('ns.totalTopicQuota')}
+                value={stats.totalTopicQuota}
+                valueStyle={{ color: '#1890ff' }}
+              />
+            </Card>
+          </Col>
+          <Col xs={24} sm={12} md={6}>
+            <Card>
+              <Statistic
+                title={t('ns.totalGroupQuota')}
+                value={stats.totalGroupQuota}
+                valueStyle={{ color: '#1890ff' }}
+              />
+            </Card>
+          </Col>
+        </Row>
+
+        {/* Action Bar */}
+        <Card style={{ marginBottom: 16 }}>
+          <Space>
+            <Button icon={<ArrowClockwise size={16} />} onClick={loadNamespaces}>
+              {t('common.refresh')}
+            </Button>
+            <Button type="primary" icon={<Plus size={16} />} onClick={handleCreate}>
+              {t('ns.create')}
+            </Button>
+          </Space>
+        </Card>
+
+        {/* Namespace Table */}
+        <Card title={t('ns.list')}>
+          <Table
+            columns={columns}
+            dataSource={namespaces}
+            rowKey="namespaceName"
+            pagination={false}
+            size="middle"
+          />
+        </Card>
+      </Spin>
+
+      {/* Detail Modal */}
+      <Modal
+        title={`${t('ns.detail')} - ${selectedNamespace?.namespaceName}`}
+        open={detailModalVisible}
+        onCancel={() => setDetailModalVisible(false)}
+        footer={[
+          <Button key="close" onClick={() => setDetailModalVisible(false)}>
+            {t('common.close')}
+          </Button>,
+        ]}
+        width={700}
+      >
+        {selectedNamespace && (
+          <Descriptions bordered column={2} size="small">
+            <Descriptions.Item label={t('ns.name')} span={2}>
+              {selectedNamespace.namespaceName}
+            </Descriptions.Item>
+            <Descriptions.Item label={t('ns.displayName')}>
+              {selectedNamespace.displayName || '-'}
+            </Descriptions.Item>
+            <Descriptions.Item label={t('common.status')}>
+              <Tag color={selectedNamespace.status === 'ENABLED' ? 'success' : 'default'}>
+                {selectedNamespace.status}
+              </Tag>
+            </Descriptions.Item>
+            <Descriptions.Item label={t('ns.cluster')} span={2}>
+              {selectedNamespace.clusterName || '-'}
+            </Descriptions.Item>
+            <Descriptions.Item label={t('ns.description')} span={2}>
+              {selectedNamespace.description || '-'}
+            </Descriptions.Item>
+            <Descriptions.Item label={t('ns.default')}>
+              {selectedNamespace.defaultNamespace ? t('common.yes') : t('common.no')}
+            </Descriptions.Item>
+            <Descriptions.Item label={t('ns.createTime')}>
+              {selectedNamespace.createTime
+                ? new Date(selectedNamespace.createTime).toLocaleString()
+                : '-'}
+            </Descriptions.Item>
+            {selectedNamespace.quotaConfig && (
+              <>
+                <Descriptions.Item label={t('ns.quotaSection')} span={2}>
+                  <strong>{t('ns.quotaSection')}</strong>
+                </Descriptions.Item>
+                <Descriptions.Item label={t('ns.topicLimit')}>
+                  {selectedNamespace.quotaConfig.maxTopicCount || '-'}
+                </Descriptions.Item>
+                <Descriptions.Item label={t('ns.groupLimit')}>
+                  {selectedNamespace.quotaConfig.maxConsumerGroupCount || '-'}
+                </Descriptions.Item>
+                <Descriptions.Item label={t('ns.storage')}>
+                  {selectedNamespace.quotaConfig.storageQuotaGB || '-'}
+                </Descriptions.Item>
+                <Descriptions.Item label={t('ns.qpsLimit')}>
+                  {selectedNamespace.quotaConfig.qpsLimit || '-'}
+                </Descriptions.Item>
+                <Descriptions.Item label={t('ns.connLimit')}>
+                  {selectedNamespace.quotaConfig.connectionLimit || '-'}
+                </Descriptions.Item>
+              </>
+            )}
+          </Descriptions>
+        )}
+      </Modal>
+
+      {/* Create/Edit Modal */}
+      <Modal
+        title={isEdit ? t('ns.edit') : t('ns.create')}
+        open={formModalVisible}
+        onCancel={() => {
+          setFormModalVisible(false);
+          form.resetFields();
+        }}
+        onOk={handleSubmit}
+        okText={isEdit ? t('common.update') : t('common.create')}
+        cancelText={t('common.cancel')}
+        width={600}
+      >
+        <Form form={form} layout="vertical">
+          <Form.Item
+            name="namespaceName"
+            label={t('ns.name')}
+            rules={[
+              { required: true, message: t('ns.nameRequired') },
+              {
+                pattern: /^[a-zA-Z0-9_-]+$/,
+                message: t('ns.namePattern'),
+              },
+            ]}
+          >
+            <Input placeholder={t('ns.namePlaceholder')} disabled={isEdit} />
+          </Form.Item>
+
+          <Row gutter={16}>
+            <Col span={12}>
+              <Form.Item name="displayName" label={t('ns.displayName')}>
+                <Input placeholder={t('ns.displayNamePlaceholder')} />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item name="clusterName" label={t('ns.cluster')}>
+                <Input placeholder={t('ns.clusterPlaceholder')} />
+              </Form.Item>
+            </Col>
+          </Row>
+
+          <Form.Item name="description" label={t('ns.description')}>
+            <Input.TextArea rows={2} placeholder={t('ns.descPlaceholder')} />
+          </Form.Item>
+
+          <Row gutter={16}>
+            <Col span={8}>
+              <Form.Item name="maxTopicCount" label={t('ns.topicLimit')}>
+                <InputNumber min={1} style={{ width: '100%' }} placeholder="1000" />
+              </Form.Item>
+            </Col>
+            <Col span={8}>
+              <Form.Item name="maxConsumerGroupCount" label={t('ns.groupLimit')}>
+                <InputNumber min={1} style={{ width: '100%' }} placeholder="500" />
+              </Form.Item>
+            </Col>
+            <Col span={8}>
+              <Form.Item name="storageQuotaGB" label={t('ns.storage')}>
+                <InputNumber min={1} style={{ width: '100%' }} placeholder="100" />
+              </Form.Item>
+            </Col>
+          </Row>
+
+          <Row gutter={16}>
+            <Col span={12}>
+              <Form.Item name="qpsLimit" label={t('ns.qpsLimit')}>
+                <InputNumber min={1} style={{ width: '100%' }} placeholder="10000" />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item name="connectionLimit" label={t('ns.connLimit')}>
+                <InputNumber min={1} style={{ width: '100%' }} placeholder="5000" />
+              </Form.Item>
+            </Col>
+          </Row>
+        </Form>
+      </Modal>
+    </div>
+  );
+};
+
+export default NamespacePage;


### PR DESCRIPTION
## Basic Info
Branch: feature/studio-namespace-page (target repo: rocketmq-studio)
Total commits: 2
1. 9d7ca83 [studio] feat: add Namespace page
2. 28e69b5 [studio] test: add Namespace API unit tests

## Changed Files
Total 4 files modified, +711 lines of code
| File | Line Changes | Description |
|------|--------------|-------------|
| web/src/App.tsx | +2 | Register route `/studio/namespace` mapped to NamespacePage |
| web/src/api/namespace.ts | +68 | Namespace API layer with complete TypeScript type definitions |
| web/src/api/namespace.test.ts | +116 | 7 unit test cases for Namespace APIs |
| web/src/pages/studio/Namespace.tsx | +525 | Namespace management page component |

## API Layer (namespace.ts)
| Function | HTTP Method | Endpoint | Return Type |
|----------|-------------|----------|-------------|
| queryNamespaceList() | GET | /namespace/list | NamespaceItem[] |
| queryNamespaceDetail(name) | GET | /namespace/{name} | NamespaceItem |
| createNamespace(payload) | POST | /namespace/create | void |
| updateNamespace(payload) | PUT | /namespace/update | void |
| deleteNamespace(name) | DELETE | /namespace/{name} | void |
| queryNamespaceCapability() | GET | /namespace/capability | NamespaceCapability |

### TypeScript Interfaces
1. `QuotaConfig`
Contains: maxTopicCount, maxConsumerGroupCount, storageQuotaGB, qpsLimit, connectionLimit
2. `NamespaceItem`
Contains: namespaceName, displayName, description, clusterName, status, defaultNamespace, createTime, quotaConfig
3. `NamespaceCapability`
Contains: namespaceSupported

## Page Functionalities
1. Capability Check
Call `queryNamespaceCapability()` on page mount; show Alert warning if namespace feature is unsupported.

2. Statistics Cards
Display total namespaces count / enabled namespaces / total topic quota / total consumer group quota.

3. Namespace Data Table
Columns: namespace name, display name, cluster, status, topic quota limit, group quota limit, storage quota, action buttons.

4. Create & Edit Modal
Form fields:
- namespaceName (disabled in edit mode)
- displayName
- clusterName
- description
- 5 quota configuration items

5. Detail Drawer/Modal
Use Descriptions component to render full namespace info including quota configuration panel.

6. Default Namespace Protection
Hide edit and delete buttons for default namespace to prevent modification or removal.

7. Delete Confirmation
Popconfirm secondary confirmation popup before executing deletion request.

## Test Coverage (7 test cases)
1. queries namespace list
Verify the API returns namespace list and validates `namespaceName` field
2. queries namespace detail by name
Fetch single namespace detail and validate `quotaConfig.maxTopicCount`
3. creates a namespace
Send POST /namespace/create and verify request body carries namespaceName & displayName
4. updates a namespace
Send PUT /namespace/update and validate namespaceName & description in payload
5. deletes a namespace by name
Call DELETE /namespace/{name} successfully
6. queries namespace capability as supported
Assert `namespaceSupported: true` from capability API response
7. queries namespace capability as unsupported
Assert `namespaceSupported: false` from capability API response

## Build & Test Validation
✅ Pass `npm run build` compilation without errors
✅ All 35 test cases across 6 test files pass