### PR TITLE
[Studio] feat: configure API endpoint from env

### DIFF
--- a/web/.env
+++ b/web/.env
@@ -1,2 +1,6 @@
 # Set to "true" to use mock data, "false" to use real API
 VITE_USE_MOCK=true
+# Optional local development proxy target (defaults to http://localhost:8888)
+# VITE_API_PROXY_TARGET=http://localhost:8888
+# Optional browser API prefix or absolute API URL (defaults to /api)
+# VITE_API_BASE_URL=/api

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -17,6 +17,7 @@
 
 import axios from 'axios';
 import { message } from 'antd';
+import { API_BASE_URL } from '../config';
 
 const SUCCESS_BUSINESS_CODES = new Set([0, 200]);
 
@@ -40,7 +41,7 @@ function getBusinessError(data: unknown): string | null {
 }
 
 const client = axios.create({
-  baseURL: '/api',
+  baseURL: API_BASE_URL,
   timeout: 30000,
 });
 

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -5,3 +5,6 @@
  */
 
 export const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true';
+
+/** API prefix for browser requests. Defaults to the reverse-proxy friendly `/api`. */
+export const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '/api').replace(/\/$/, '');

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,21 +1,25 @@
 import { defineConfig } from 'vitest/config';
+import { loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8888',
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+    server: {
+      port: 5173,
+      proxy: {
+        '/api': {
+          target: env.VITE_API_PROXY_TARGET || 'http://localhost:8888',
+          changeOrigin: true,
+        },
       },
     },
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: './src/test/setup.ts',
-    css: true,
-  },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: './src/test/setup.ts',
+      css: true,
+    },
+  };
 });


### PR DESCRIPTION
## Summary

- support configurable browser API base URLs and Vite development proxy targets
- retain `/api` and `http://localhost:8888` as backwards-compatible defaults
- document the new environment variables for reverse-proxy and container deployments

## Validation

- `npm.cmd test -- client.test.ts` (6 passed)
