### PR TITLE
ci: raise stale action operations-per-run to 200

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
+          operations-per-run: 200
           days-before-stale: 7
           days-before-close: 0
           stale-issue-label: stale


### PR DESCRIPTION
## Motivation

The `Close Stale Issues and PRs` workflow currently relies on the default `operations-per-run: 30` of `actions/stale`. Because `days-before-close: 0` makes each stale item consume ~2 API operations (add `stale` label + close), a single daily run can only close ~15 issues/PRs and then exits with:

```
No more operations left! Exiting...
If you think that not enough issues were processed you could try to increase
the operations-per-run option which is currently set to 30
```

As a result the existing backlog of stale issues/PRs is cleared very slowly and looks like the workflow "isn't working".

## Change

Set `operations-per-run: 200` explicitly so each daily run can process up to ~100 stale items and drain the backlog quickly.

## Test plan

- [x] YAML change is minimal and only adds one option
- [ ] Observe the next scheduled run closes significantly more stale issues/PRs without hitting the operations cap