### PR TITLE
[Studio] fix: include remaining consolidated frontend changes

### DIFF
--- a/web/src/services/topicService.ts
+++ b/web/src/services/topicService.ts
@@ -2,6 +2,7 @@ import { USE_MOCK } from '../config';
 import * as metadataApi from '../api/metadata';
 import type {
   Topic,
+  TopicQuery,
   BrokerRoute,
   ConsumerGroupInfo,
   SendTopicMessageRequest,
@@ -9,19 +10,15 @@ import type {
 } from '../api/metadata';
 import { topics as mockTopics, topicRoutes, topicConsumers } from '../mock/topics';
 
-export async function listTopics(params?: {
-  keyword?: string;
-  type?: string;
-  namespace?: string;
-}): Promise<Topic[]> {
+export async function listTopics(params?: TopicQuery): Promise<Topic[]> {
   if (USE_MOCK) {
     let result = [...mockTopics];
-    if (params?.keyword) {
-      const kw = params.keyword.toLowerCase();
+    if (params?.search) {
+      const kw = params.search.toLowerCase();
       result = result.filter((t) => t.name.toLowerCase().includes(kw));
     }
     if (params?.type) result = result.filter((t) => t.type === params.type);
-    if (params?.namespace) result = result.filter((t) => t.namespace === params.namespace);
+    if (params?.clusterId) result = result.filter((t) => t.clusterId === params.clusterId);
     return result as unknown as Topic[];
   }
   return metadataApi.listTopics(params);
@@ -43,11 +40,12 @@ export async function createTopic(data: Partial<Topic>): Promise<Topic> {
   return metadataApi.createTopic(data);
 }
 
-export async function updateTopic(data: Partial<Topic>): Promise<void> {
+export async function updateTopic(data: Partial<Topic>): Promise<Topic> {
   if (USE_MOCK) {
     const idx = mockTopics.findIndex((t) => t.name === data.name);
-    if (idx >= 0) Object.assign(mockTopics[idx], data, { updatedAt: new Date().toISOString() });
-    return;
+    if (idx < 0) throw new Error(`Topic not found: ${data.name}`);
+    Object.assign(mockTopics[idx], data, { updatedAt: new Date().toISOString() });
+    return mockTopics[idx] as unknown as Topic;
   }
   return metadataApi.updateTopic(data);
 }

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -16,6 +16,7 @@
  */
 
 import { create } from 'zustand';
+import { clearAuthSession, persistAuthSession, readAuthSession } from './authStorage';
 
 interface AuthState {
   user: string | null;
@@ -24,15 +25,17 @@ interface AuthState {
   logout: () => void;
 }
 
+const initialSession = readAuthSession();
+
 const useAuthStore = create<AuthState>((set) => ({
-  user: null,
-  token: null,
+  user: initialSession.user,
+  token: initialSession.token,
   login: (token: string, user: string) => {
-    localStorage.setItem('token', token);
+    persistAuthSession(token, user);
     set({ token, user });
   },
   logout: () => {
-    localStorage.removeItem('token');
+    clearAuthSession();
     set({ token: null, user: null });
   },
 }));

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,21 +1,25 @@
 import { defineConfig } from 'vitest/config';
+import { loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8888',
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, '.', '');
+  return {
+    plugins: [react()],
+    server: {
+      port: 5173,
+      proxy: {
+        '/api': {
+          target: env.VITE_API_PROXY_TARGET || 'http://localhost:8888',
+          changeOrigin: true,
+        },
       },
     },
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: './src/test/setup.ts',
-    css: true,
-  },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: './src/test/setup.ts',
+      css: true,
+    },
+  };
 });


### PR DESCRIPTION
Follow-up to the consolidated PRs (#445/#462/#465): includes three files that were inadvertently omitted — topic API contract (topicService), persisted auth session (authStore), and env-based API endpoint config (vite.config). Authored by @Loyal-Young.