### PR TITLE
[Studio] fix: Use runtime DNS resolver for Nginx API proxy

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,6 +8,8 @@ RUN npm run build
 
 # Stage 2: Serve
 FROM nginx:alpine
+ENV NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1 \
+    NGINX_ENVSUBST_FILTER=^NGINX_LOCAL_RESOLVERS$
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 EXPOSE 80

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -9,7 +9,7 @@ server {
     }
 
     location /api/ {
-        resolver 10.89.0.1 valid=10s;
+        resolver ${NGINX_LOCAL_RESOLVERS} valid=10s;
         set $backend http://rocketmq-server:8888;
         proxy_pass $backend;
         proxy_set_header Host $host;


### PR DESCRIPTION
## What is the purpose of the change

Fixes #493 

Fix Nginx API proxy failures caused by a hardcoded DNS resolver and support both Docker and Podman environments.

## Brief changelog

- Read the DNS resolver from the container runtime.
- Render the NGINX configuration during container startup.

## Verifying this change

- Docker image build passed.
- NGINX configuration validation passed.
- API proxy continued working after the backend IP changed.