### PR TITLE
[Studio] test: fix frontend baseline assertions

### DIFF
--- a/web/src/api/ops.test.ts
+++ b/web/src/api/ops.test.ts
@@ -218,7 +218,7 @@ describe('Ops API - System Alerts & Audit', () => {
     mock.onGet('/audit-logs').reply(200, {
       code: 200,
       data: {
-        list: [
+        items: [
           {
             id: 'r1',
             timestamp: '2026-01-01',
@@ -231,11 +231,15 @@ describe('Ops API - System Alerts & Audit', () => {
           },
         ],
         total: 1,
+        page: 1,
+        size: 20,
       },
     });
     const result = await listAuditRecords({ page: 1 });
     expect(result.items).toHaveLength(1);
     expect(result.total).toBe(1);
+    expect(result.page).toBe(1);
+    expect(result.size).toBe(20);
   });
 
   it('cleans up audit logs', async () => {

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -56,12 +56,12 @@ const renderWithProviders = (ui: React.ReactElement) => {
 describe('BrokerCluster Page', () => {
   it('should render the page title', () => {
     renderWithProviders(<BrokerCluster />);
-    expect(screen.getByText('RocketMQ 集群')).toBeInTheDocument();
+    expect(screen.getByText('Broker 集群')).toBeInTheDocument();
   });
 
   it('should render create cluster button', () => {
     renderWithProviders(<BrokerCluster />);
-    expect(screen.getByText('新建集群')).toBeInTheDocument();
+    expect(screen.getByText('创建集群')).toBeInTheDocument();
   });
 
   it('should render reset button', () => {


### PR DESCRIPTION
## Summary
- align ops audit test data with the backend PageResult contract
- update BrokerCluster test assertions to match the current Studio i18n labels

## Verification
- npm test -- src/api/ops.test.ts src/api/audit.test.ts src/pages/studio/__tests__/BrokerCluster.test.tsx
- npm test
- npm run lint
- npm run build