### PR TITLE
[Studio] fix: initialize deploy helpers before validation

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -10,6 +10,18 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# ─── 颜色输出 ───
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[✓]${NC} $*"; }
+info() { echo -e "${CYAN}[→]${NC} $*"; }
+warn() { echo -e "${YELLOW}[!]${NC} $*"; }
+err()  { echo -e "${RED}[✗]${NC} $*"; exit 1; }
+
 # 加载配置
 if [[ -f "$SCRIPT_DIR/.env" ]]; then
   set -a
@@ -25,18 +37,6 @@ NETWORK="${PODMAN_NETWORK:-rocketmq-studio}"
 TMP_DIR="/tmp/rocketmq-studio-deploy"
 
 TARGET="${1:-all}"  # all | server | web
-
-# ─── 颜色输出 ───
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log()  { echo -e "${GREEN}[✓]${NC} $*"; }
-info() { echo -e "${CYAN}[→]${NC} $*"; }
-warn() { echo -e "${YELLOW}[!]${NC} $*"; }
-err()  { echo -e "${RED}[✗]${NC} $*"; exit 1; }
 
 # ─── 前置检查 ───
 check_prereqs() {


### PR DESCRIPTION
## Summary
- move deploy logging/error helper initialization before configuration validation
- keep deployment behavior unchanged while restoring the intended REMOTE_HOST error path

## Verification
- bash -n deploy/deploy.sh
- bash deploy/deploy.sh exits with code 1 and prints `REMOTE_HOST 未配置，请在 deploy/.env 中设置` when deploy/.env or REMOTE_HOST is missing