### PR TITLE
[Studio] ci: build frontend Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,13 @@ jobs:
 
       - name: Build frontend
         run: npm run build
+
+  frontend-docker-build:
+    name: Frontend Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build frontend Docker image
+        run: docker build -t rocketmq-studio-web-ci ./web


### PR DESCRIPTION
## Summary
- add a dedicated CI job that builds the Studio frontend Docker image
- cover the Dockerfile/nginx deployment path in addition to the existing Node build

## Verification
- docker build -t rocketmq-studio-web-ci ./web
- parsed .github/workflows/ci.yml and verified the frontend-docker-build job command

Note: actionlint is not installed in the local environment, so stricter GitHub Actions lint was not run.