### PR TITLE
[Studio] fix: load producer topics from Studio API response

### DIFF
--- a/web/src/api/producer.test.ts
+++ b/web/src/api/producer.test.ts
@@ -33,7 +33,17 @@ describe('Producer API', () => {
     vi.unstubAllGlobals();
   });
 
-  it('fetches topic list sorted alphabetically', async () => {
+  it('fetches Studio topic records sorted alphabetically', async () => {
+    mock.onGet('/topics').reply(200, {
+      code: 200,
+      data: [{ name: 'order-events' }, { name: 'user-signup' }, { name: 'batch-process' }],
+    });
+
+    const result = await fetchTopicList();
+    expect(result).toEqual(['batch-process', 'order-events', 'user-signup']);
+  });
+
+  it('keeps compatibility with legacy topicList responses', async () => {
     mock.onGet('/topics').reply(200, {
       topicList: ['order-events', 'user-signup', 'batch-process'],
     });

--- a/web/src/api/producer.ts
+++ b/web/src/api/producer.ts
@@ -25,12 +25,22 @@ export interface ProducerConnection {
   versionDesc: string;
 }
 
+interface TopicRecord {
+  name: string;
+}
+
+interface TopicListResponse {
+  data?: TopicRecord[];
+  topicList?: string[];
+}
+
 // ─── API ────────────────────────────────────────────────────────
 
 /** Fetch all topic names */
 export async function fetchTopicList(): Promise<string[]> {
-  const res = await client.get<{ topicList: string[] }>('/topics');
-  return (res.data?.topicList ?? []).sort();
+  const res = await client.get<TopicListResponse>('/topics');
+  const topics = res.data.data?.map((topic) => topic.name) ?? res.data.topicList ?? [];
+  return topics.sort();
 }
 
 /** Query producer connections by topic and group */


### PR DESCRIPTION
## Summary
- read Producer page topic options from the Studio `/topics` Result payload (`data: [{ name }]`)
- keep compatibility with the legacy `topicList` response shape
- add API tests for both response contracts

## Verification
- npm test -- src/api/producer.test.ts
- npm run lint
- npm run build

Note: full frontend test is not used as this branch's blocking signal because the current base still has the stale assertions fixed separately by #498.