### PR TITLE
[ISSUE #239] Deduplicate messages by msgId in queryMessageByTopic

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImpl.java
@@ -65,7 +65,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -178,6 +180,15 @@ public class MessageServiceImpl implements MessageService {
                     }
                 }
             }
+            // Dedup by msgId: the same queue may be returned under
+            // different broker names (stale route, proxy re-registration),
+            // so the same message can be pulled twice.
+            Map<String, MessageView> dedupMap = new LinkedHashMap<>();
+            for (MessageView mv : messageViewList) {
+                dedupMap.putIfAbsent(mv.getMsgId(), mv);
+            }
+            messageViewList = new ArrayList<>(dedupMap.values());
+
             Collections.sort(messageViewList, new Comparator<MessageView>() {
                 @Override
                 public int compare(MessageView o1, MessageView o2) {

--- a/src/test/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImplTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImplTest.java
@@ -222,6 +222,35 @@ public class MessageServiceImplTest {
     }
 
     @Test
+    public void testQueryMessageByTopicDeduplicatesByMsgId() throws Exception {
+        // Simulate the route returning the same logical queue under different broker
+        // names (stale route after a brokerName change, proxy re-registration), so
+        // the same physical message is pulled twice.
+        Set<MessageQueue> messageQueues = new HashSet<>();
+        messageQueues.add(new MessageQueue(TOPIC, "broker-1", 0));
+        messageQueues.add(new MessageQueue(TOPIC, "broker-1-replica", 0));
+
+        when(defaultMQPullConsumer.fetchSubscribeMessageQueues(TOPIC)).thenReturn(messageQueues);
+
+        PullResult dupResult = createPullResult(PullStatus.FOUND,
+                Collections.singletonList(createMessageExt("dup-id", TOPIC, "body", 1500)),
+                0, 10);
+        PullResult emptyResult = createPullResult(PullStatus.NO_NEW_MSG, Collections.emptyList(), 10, 10);
+
+        when(defaultMQPullConsumer.pull(any(MessageQueue.class), anyString(), anyLong(), anyInt()))
+                .thenReturn(dupResult).thenReturn(emptyResult)
+                .thenReturn(dupResult).thenReturn(emptyResult);
+
+        long beginTime = 1000;
+        long endTime = 3000;
+        List<MessageView> result = messageService.queryMessageByTopic(TOPIC, beginTime, endTime);
+
+        // The same message must appear only once even if pulled from duplicate queues.
+        assertEquals(1, result.size());
+        assertEquals("dup-id", result.get(0).getMsgId());
+    }
+
+    @Test
     public void testQueryMessageByTopicWithOutOfRangeTimestamps() throws Exception {
         // Setup message queues
         Set<MessageQueue> messageQueues = new HashSet<>();


### PR DESCRIPTION
  ## What is the purpose of the change
  Fixes #239. On the Message page, querying a topic by time can display the same message twice. `queryMessageByTopic` accumulates pulled messages with `addAll` without deduplicating by msgId; when the same queue
  is enumerated under different broker names (stale route after a brokerName change, proxy re-registration, etc.), the same message is pulled twice.

  ## Brief changelog
  - `MessageServiceImpl#queryMessageByTopic`: deduplicate the result list by `msgId` (order-preserving `LinkedHashMap`) before returning.
  - Add unit test `MessageServiceImplTest#testQueryMessageByTopicDeduplicatesByMsgId`.

  ## Verifying this change
  `mvn test -Dtest='MessageServiceImplTest#testQueryMessageByTopicDeduplicatesByMsgId'`
  - Before fix: fails with `expected:<1> but was:<2>`
  - After fix: `Tests run: 1, Failures: 0`
  Existing `testQueryMessageByTopic` / `testQueryMessageByTopicWithOutOfRangeTimestamps` still pass.