### PR TITLE
[Studio] Test Prometheus data source connections

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/com/rocketmq/studio/settings/SettingsService.java
@@ -16,20 +16,51 @@
  */
 package com.rocketmq.studio.settings;
 
-import lombok.RequiredArgsConstructor;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class SettingsService {
 
+    private static final Set<String> PROMETHEUS_COMPATIBLE_TYPES = Set.of(
+            "prometheus", "victoriametrics", "thanos", "mimir");
+    private static final String PROMETHEUS_TEST_QUERY = "up";
+    private static final Duration DATA_SOURCE_TEST_CONNECT_TIMEOUT = Duration.ofSeconds(3);
+    private static final Duration DATA_SOURCE_TEST_READ_TIMEOUT = Duration.ofSeconds(5);
+
     private final SettingsRepository settingsRepository;
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    public SettingsService(SettingsRepository settingsRepository, RestClient.Builder restClientBuilder,
+                           ObjectMapper objectMapper) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(DATA_SOURCE_TEST_CONNECT_TIMEOUT);
+        requestFactory.setReadTimeout(DATA_SOURCE_TEST_READ_TIMEOUT);
+        this.settingsRepository = settingsRepository;
+        this.restClient = restClientBuilder.requestFactory(requestFactory).build();
+        this.objectMapper = objectMapper;
+    }
 
 
     public GeneralSettingsVO getGeneralSettings() {
@@ -77,11 +108,106 @@ public class SettingsService {
 
 
     public DataSourceTestResultVO testDataSource(DataSourceTestDTO request) {
-        log.info("Testing data source connection: url={}, type={}", request.getUrl(), request.getType());
-        // Stub: always return success for now
+        log.info("Testing data source connection: type={}", request == null ? null : request.getType());
+        if (request == null) {
+            return failed("Data source test request is required");
+        }
+        if (!isPrometheusCompatible(request.getType())) {
+            return failed("Unsupported data source type: " + request.getType());
+        }
+
+        try {
+            JsonNode response = restClient.get()
+                    .uri(prometheusQueryUri(request.getUrl()))
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .body(JsonNode.class);
+            return prometheusSuccess(response);
+        } catch (IllegalArgumentException | URISyntaxException exception) {
+            return failed(exception.getMessage());
+        } catch (RestClientResponseException exception) {
+            return failed(prometheusErrorMessage(exception));
+        } catch (ResourceAccessException exception) {
+            if (hasCause(exception, SocketTimeoutException.class)) {
+                return failed("Prometheus connection timed out");
+            }
+            return failed("Failed to connect to Prometheus");
+        } catch (RestClientException exception) {
+            if (hasCause(exception, SocketTimeoutException.class)) {
+                return failed("Prometheus connection timed out");
+            }
+            return failed("Prometheus connection failed");
+        }
+    }
+
+    private boolean isPrometheusCompatible(String type) {
+        return StringUtils.hasText(type)
+                && PROMETHEUS_COMPATIBLE_TYPES.contains(type.replaceAll("\\s+", "").toLowerCase());
+    }
+
+    private URI prometheusQueryUri(String baseUrl) throws URISyntaxException {
+        if (!StringUtils.hasText(baseUrl)) {
+            throw new IllegalArgumentException("Data source URL is required");
+        }
+        String normalized = baseUrl.strip();
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+
+        URI baseUri = new URI(normalized);
+        if (!"http".equalsIgnoreCase(baseUri.getScheme()) && !"https".equalsIgnoreCase(baseUri.getScheme())) {
+            throw new IllegalArgumentException("Data source URL must start with http:// or https://");
+        }
+        return UriComponentsBuilder.fromUriString(normalized + "/api/v1/query")
+                .queryParam("query", PROMETHEUS_TEST_QUERY)
+                .build()
+                .toUri();
+    }
+
+    private DataSourceTestResultVO prometheusSuccess(JsonNode response) {
+        if (response != null && "success".equals(response.path("status").asText())) {
+            return DataSourceTestResultVO.builder()
+                    .success(true)
+                    .message("Connection successful")
+                    .build();
+        }
+        return failed(prometheusBodyError(response));
+    }
+
+    private String prometheusErrorMessage(RestClientResponseException exception) {
+        try {
+            return prometheusBodyError(objectMapper.readTree(exception.getResponseBodyAsString()));
+        } catch (IOException ignored) {
+            return "Prometheus query failed";
+        }
+    }
+
+    private String prometheusBodyError(JsonNode response) {
+        String errorType = response == null ? "" : response.path("errorType").asText();
+        String error = response == null ? "" : response.path("error").asText();
+        if (StringUtils.hasText(error)) {
+            return StringUtils.hasText(errorType)
+                    ? "Prometheus query failed (" + errorType + "): " + error
+                    : "Prometheus query failed: " + error;
+        }
+        return "Prometheus query failed";
+    }
+
+    private DataSourceTestResultVO failed(String message) {
         return DataSourceTestResultVO.builder()
-                .success(true)
-                .message("Connection successful")
+                .success(false)
+                .message(message)
                 .build();
+    }
+
+    private boolean hasCause(Throwable throwable, Class<? extends Throwable> causeType) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (causeType.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 }

--- a/server/src/test/java/com/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/settings/SettingsServiceTest.java
@@ -16,15 +16,23 @@
  */
 package com.rocketmq.studio.settings;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,8 +46,23 @@ class SettingsServiceTest {
     @Mock
     private SettingsRepository settingsRepository;
 
-    @InjectMocks
     private SettingsService settingsService;
+
+    private HttpServer prometheusServer;
+    private String prometheusBaseUrl;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        settingsService = new SettingsService(settingsRepository, RestClient.builder(), new ObjectMapper());
+        prometheusServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        prometheusBaseUrl = "http://127.0.0.1:" + prometheusServer.getAddress().getPort();
+        prometheusServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        prometheusServer.stop(0);
+    }
 
     @Test
     void getGeneralSettingsShouldReturnCurrentSettings() {
@@ -207,29 +230,60 @@ class SettingsServiceTest {
     }
 
     @Test
-    void testConnectionShouldReturnSuccess() {
+    void testConnectionShouldQueryPrometheusEndpoint() {
+        AtomicReference<String> requestPath = new AtomicReference<>();
+        AtomicReference<String> requestQuery = new AtomicReference<>();
+        prometheusServer.createContext("/api/v1/query", exchange -> {
+            requestPath.set(exchange.getRequestURI().getPath());
+            requestQuery.set(exchange.getRequestURI().getRawQuery());
+            respond(exchange, 200, "{\"status\":\"success\",\"data\":{\"resultType\":\"vector\",\"result\":[]}}");
+        });
         DataSourceTestDTO request = DataSourceTestDTO.builder()
-                .url("localhost:9876")
-                .type("rocketmq")
+                .url(prometheusBaseUrl)
+                .type("Prometheus")
                 .build();
 
         DataSourceTestResultVO result = settingsService.testDataSource(request);
 
         assertThat(result.isSuccess()).isTrue();
         assertThat(result.getMessage()).isEqualTo("Connection successful");
+        assertThat(requestPath.get()).isEqualTo("/api/v1/query");
+        assertThat(requestQuery.get()).isEqualTo("query=up");
     }
 
     @Test
-    void testConnectionShouldReturnSuccessForAnyInput() {
+    void testConnectionShouldReturnPrometheusErrorDetails() {
+        prometheusServer.createContext("/api/v1/query", exchange -> respond(exchange, 422,
+                "{\"status\":\"error\",\"errorType\":\"bad_data\",\"error\":\"invalid query\"}"));
         DataSourceTestDTO request = DataSourceTestDTO.builder()
-                .url("invalid-host:9999")
-                .type("unknown")
-                .auth("bad-auth")
+                .url(prometheusBaseUrl)
+                .type("VictoriaMetrics")
                 .build();
 
         DataSourceTestResultVO result = settingsService.testDataSource(request);
 
-        assertThat(result.isSuccess()).isTrue();
-        assertThat(result.getMessage()).isEqualTo("Connection successful");
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getMessage()).isEqualTo(
+                "Prometheus query failed (bad_data): invalid query");
+    }
+
+    @Test
+    void testConnectionShouldRejectInvalidUrl() {
+        DataSourceTestResultVO result = settingsService.testDataSource(DataSourceTestDTO.builder()
+                .url("ftp://example.com")
+                .type("Prometheus")
+                .build());
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getMessage()).isEqualTo(
+                "Data source URL must start with http:// or https://");
+    }
+
+    private void respond(HttpExchange exchange, int statusCode, String body) throws IOException {
+        byte[] response = body.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(statusCode, response.length);
+        exchange.getResponseBody().write(response);
+        exchange.close();
     }
 }


### PR DESCRIPTION
### Motivation

This is a small follow-up for #431. The Settings data source test endpoint still returned a fixed success response, so users could not validate whether a configured Prometheus-compatible source was actually reachable.

### Changes

- Replace the fixed success response in `SettingsService.testDataSource` with a real Prometheus-compatible HTTP API probe.
- Query `/api/v1/query?query=up` for Prometheus, VictoriaMetrics, Thanos, and Mimir style data sources.
- Return explicit failure messages for invalid URLs, upstream Prometheus errors, connection failures, and timeouts.
- Avoid logging the full data source URL during connection tests.
- Add regression tests with a local mock HTTP server.

### Non-goals

This PR does not add credential fields or replace dashboard charts. It only makes the existing test endpoint validate the configured Prometheus-compatible URL.

### Verification

- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -B -ntp -Dtest=SettingsServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -B -ntp test`
