### PR TITLE
[Studio] Align metrics API contract test

### DIFF
--- a/web/src/api/metrics.test.ts
+++ b/web/src/api/metrics.test.ts
@@ -57,11 +57,26 @@ describe('metrics API', () => {
 
   it('posts a metrics query and returns its result', async () => {
     const query = { metric: 'TPS_IN', start: 1, end: 2, step: '1m' };
+    const result = {
+      resultType: 'matrix',
+      series: [
+        {
+          labels: {
+            __name__: 'rocketmq_messages_in_total',
+            cluster: 'rmq-cn-v5-prod-01',
+          },
+          values: [{ timestamp: 1, value: '8' }],
+          histograms: [],
+        },
+      ],
+      warnings: [],
+    };
+
     mock.onPost('/metrics/query').reply((config) => {
       expect(JSON.parse(config.data)).toEqual(query);
-      return [200, { code: 200, data: [{ timestamp: 1, value: 8 }] }];
+      return [200, { code: 200, data: result }];
     });
 
-    await expect(queryMetrics(query)).resolves.toEqual([{ timestamp: 1, value: 8 }]);
+    await expect(queryMetrics(query)).resolves.toEqual(result);
   });
 });


### PR DESCRIPTION
## Summary
- align the frontend metrics API unit test with the current Prometheus-style MetricData contract
- cover resultType, labels, values, histograms, and warnings returned by /metrics/query

## Verification
- npm test -- metrics.test.ts
- npm test -- src/api

Part of the RocketMQ Studio METRICS-01 observability work.