### PR TITLE
[Studio] Add dashboard summary AI tool

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/ops/ai/tool/DashboardSummaryToolHandler.java
+++ b/server/src/main/java/com/rocketmq/studio/ops/ai/tool/DashboardSummaryToolHandler.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.ops.ai.tool;
+
+import com.rocketmq.studio.common.exception.BusinessException;
+import com.rocketmq.studio.ops.dashboard.ClusterOverviewVO;
+import com.rocketmq.studio.ops.dashboard.DashboardDataVO;
+import com.rocketmq.studio.ops.dashboard.DashboardService;
+import com.rocketmq.studio.ops.dashboard.DashboardStatsVO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class DashboardSummaryToolHandler implements ToolHandler {
+
+    private static final String NAME = "rmq.dashboard.summary";
+
+    private final DashboardService dashboardService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public Object execute(Map<String, Object> input) {
+        String clusterId = (String) input.get("cluster");
+        DashboardDataVO dashboard = dashboardService.getDashboard();
+        ClusterOverviewVO cluster = clusters(dashboard).stream()
+                .filter(item -> clusterId.equals(item.getId()))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(
+                        404, "Dashboard cluster not found: " + clusterId));
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("cluster", clusterProjection(cluster));
+        result.put("stats", statsProjection(dashboard.getStats()));
+        return result;
+    }
+
+    private static List<ClusterOverviewVO> clusters(DashboardDataVO dashboard) {
+        if (dashboard == null || dashboard.getClusters() == null) {
+            return List.of();
+        }
+        return dashboard.getClusters();
+    }
+
+    private static Map<String, Object> clusterProjection(ClusterOverviewVO cluster) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("id", cluster.getId());
+        result.put("name", cluster.getName());
+        result.put("type", requiredEnumName(cluster.getType(), "type", cluster.getId()));
+        result.put("status", requiredEnumName(
+                cluster.getStatus(), "status", cluster.getId()));
+        result.put("brokers", cluster.getBrokers());
+        result.put("proxies", cluster.getProxies());
+        result.put("topics", cluster.getTopics());
+        result.put("groups", cluster.getGroups());
+        result.put("tpsIn", cluster.getTpsIn());
+        result.put("tpsOut", cluster.getTpsOut());
+        result.put("version", cluster.getVersion());
+        result.put("throughput", cluster.getThroughput() == null
+                ? List.of()
+                : cluster.getThroughput());
+        return result;
+    }
+
+    private static Map<String, Object> statsProjection(DashboardStatsVO stats) {
+        DashboardStatsVO safeStats = stats == null ? new DashboardStatsVO() : stats;
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("totalClusters", safeStats.getTotalClusters());
+        result.put("healthyClusters", safeStats.getHealthyClusters());
+        result.put("totalBrokers", safeStats.getTotalBrokers());
+        result.put("totalProxies", safeStats.getTotalProxies());
+        result.put("totalNameServers", safeStats.getTotalNameServers());
+        result.put("totalTopics", safeStats.getTotalTopics());
+        result.put("totalConsumerGroups", safeStats.getTotalConsumerGroups());
+        result.put("totalMessagesToday", safeStats.getTotalMessagesToday());
+        result.put("messagesPerSecond", safeStats.getMessagesPerSecond());
+        result.put("tpsIn", safeStats.getTpsIn());
+        result.put("tpsOut", safeStats.getTpsOut());
+        return result;
+    }
+
+    private static String requiredEnumName(Enum<?> value, String field, String clusterId) {
+        if (value == null) {
+            throw new IllegalStateException(
+                    "Cluster " + field + " is unavailable: " + clusterId);
+        }
+        return value.name();
+    }
+}

--- a/server/src/main/resources/tool-catalog/rmq-tools.yaml
+++ b/server/src/main/resources/tool-catalog/rmq-tools.yaml
@@ -74,3 +74,110 @@ tools:
             type: string
     viewHint: object
     deprecated: false
+  - name: rmq.dashboard.summary
+    cli:
+      resource: dashboard
+      verb: summary
+    description: Get the Studio dashboard summary for one RocketMQ cluster.
+    riskLevel: L1
+    permission: dashboard:read
+    requiredCapabilities: []
+    inputSchema:
+      type: object
+      required:
+        - cluster
+      additionalProperties: false
+      properties:
+        cluster:
+          type: string
+          minLength: 1
+    outputSchema:
+      type: object
+      required:
+        - cluster
+        - stats
+      additionalProperties: false
+      properties:
+        cluster:
+          type: object
+          required:
+            - id
+            - name
+            - type
+            - status
+            - brokers
+            - proxies
+            - topics
+            - groups
+            - tpsIn
+            - tpsOut
+            - version
+            - throughput
+          additionalProperties: false
+          properties:
+            id:
+              type: string
+            name:
+              type: string
+            type:
+              type: string
+            status:
+              type: string
+            brokers:
+              type: integer
+            proxies:
+              type: integer
+            topics:
+              type: integer
+            groups:
+              type: integer
+            tpsIn:
+              type: integer
+            tpsOut:
+              type: integer
+            version:
+              type: string
+            throughput:
+              type: array
+              items:
+                type: integer
+        stats:
+          type: object
+          required:
+            - totalClusters
+            - healthyClusters
+            - totalBrokers
+            - totalProxies
+            - totalNameServers
+            - totalTopics
+            - totalConsumerGroups
+            - totalMessagesToday
+            - messagesPerSecond
+            - tpsIn
+            - tpsOut
+          additionalProperties: false
+          properties:
+            totalClusters:
+              type: integer
+            healthyClusters:
+              type: integer
+            totalBrokers:
+              type: integer
+            totalProxies:
+              type: integer
+            totalNameServers:
+              type: integer
+            totalTopics:
+              type: integer
+            totalConsumerGroups:
+              type: integer
+            totalMessagesToday:
+              type: integer
+            messagesPerSecond:
+              type: integer
+            tpsIn:
+              type: integer
+            tpsOut:
+              type: integer
+    viewHint: object
+    deprecated: false

--- a/server/src/test/java/com/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
+++ b/server/src/test/java/com/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
@@ -38,7 +38,10 @@ class ToolCatalogTest {
         assertThat(catalog.getMinimumClientVersion()).isEqualTo("1.0.0");
         assertThat(catalog.getDigest()).matches("[0-9a-f]{64}");
         assertThat(catalog.list()).extracting(ToolDefinition::getName)
-                .containsExactly("rmq.cluster.list", "rmq.capabilities");
+                .containsExactly(
+                        "rmq.cluster.list",
+                        "rmq.capabilities",
+                        "rmq.dashboard.summary");
         assertThat(catalog.find("rmq.cluster.list")).isPresent();
         assertThat(catalog.find("rmq.unknown")).isEmpty();
     }

--- a/server/src/test/java/com/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -23,6 +23,10 @@ import com.rocketmq.studio.common.domain.enums.ClusterStatus;
 import com.rocketmq.studio.common.domain.enums.ClusterType;
 import com.rocketmq.studio.common.exception.BusinessException;
 import com.rocketmq.studio.ops.ai.AiToolVO;
+import com.rocketmq.studio.ops.dashboard.ClusterOverviewVO;
+import com.rocketmq.studio.ops.dashboard.DashboardDataVO;
+import com.rocketmq.studio.ops.dashboard.DashboardService;
+import com.rocketmq.studio.ops.dashboard.DashboardStatsVO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ByteArrayResource;
@@ -43,19 +47,24 @@ class ToolGatewayServiceTest {
 
     private ToolCatalog catalog;
     private ClusterService clusterService;
+    private DashboardService dashboardService;
     private CapabilityResolver capabilityResolver;
     private ClusterListToolHandler clusterListHandler;
     private CapabilitiesToolHandler capabilitiesHandler;
+    private DashboardSummaryToolHandler dashboardSummaryHandler;
     private ToolGatewayService gateway;
 
     @BeforeEach
     void setUp() {
         catalog = canonicalCatalog();
         clusterService = mock(ClusterService.class);
+        dashboardService = mock(DashboardService.class);
         capabilityResolver = new CapabilityResolver(clusterService);
         clusterListHandler = new ClusterListToolHandler(clusterService);
         capabilitiesHandler = new CapabilitiesToolHandler(clusterService, capabilityResolver);
-        gateway = gateway(catalog, clusterListHandler, capabilitiesHandler);
+        dashboardSummaryHandler = new DashboardSummaryToolHandler(dashboardService);
+        gateway = gateway(
+                catalog, clusterListHandler, capabilitiesHandler, dashboardSummaryHandler);
     }
 
     @Test
@@ -72,7 +81,10 @@ class ToolGatewayServiceTest {
 
         assertThat(gateway.discover("cluster-v5"))
                 .extracting(AiToolVO::getName)
-                .containsExactly("rmq.cluster.list", "rmq.capabilities");
+                .containsExactly(
+                        "rmq.cluster.list",
+                        "rmq.capabilities",
+                        "rmq.dashboard.summary");
     }
 
     @Test
@@ -111,6 +123,73 @@ class ToolGatewayServiceTest {
                         "POP",
                         "REMOTING",
                         "ROCKETMQ_5")));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void executesDashboardSummaryWithADataMinimizingProjection() {
+        when(dashboardService.getDashboard()).thenReturn(DashboardDataVO.builder()
+                .stats(DashboardStatsVO.builder()
+                        .totalClusters(1)
+                        .healthyClusters(1)
+                        .totalBrokers(2)
+                        .totalProxies(1)
+                        .totalNameServers(1)
+                        .totalTopics(3)
+                        .totalConsumerGroups(4)
+                        .totalMessagesToday(500L)
+                        .messagesPerSecond(6L)
+                        .tpsIn(7L)
+                        .tpsOut(8L)
+                        .build())
+                .clusters(List.of(ClusterOverviewVO.builder()
+                        .id("cluster-v5")
+                        .name("test")
+                        .type(ClusterType.V5_PROXY_CLUSTER)
+                        .status(ClusterStatus.healthy)
+                        .brokers(2)
+                        .proxies(1)
+                        .topics(3)
+                        .groups(4)
+                        .tpsIn(7)
+                        .tpsOut(8)
+                        .version("5.2.0")
+                        .throughput(List.of(1, 2, 3))
+                        .build()))
+                .build());
+
+        Object output = gateway.execute(
+                "rmq.dashboard.summary", Map.of("cluster", "cluster-v5"));
+
+        Map<String, Object> result = (Map<String, Object>) output;
+        assertThat(result).containsOnlyKeys("cluster", "stats");
+        Map<String, Object> cluster = (Map<String, Object>) result.get("cluster");
+        assertThat(cluster).containsEntry("id", "cluster-v5");
+        assertThat(cluster).containsEntry("name", "test");
+        assertThat(cluster).containsEntry("type", "V5_PROXY_CLUSTER");
+        assertThat(cluster).containsEntry("status", "healthy");
+        assertThat(cluster).containsEntry("brokers", 2);
+        assertThat(cluster).containsEntry("proxies", 1);
+        assertThat(cluster).containsEntry("topics", 3);
+        assertThat(cluster).containsEntry("groups", 4);
+        assertThat(cluster).containsEntry("tpsIn", 7);
+        assertThat(cluster).containsEntry("tpsOut", 8);
+        assertThat(cluster).containsEntry("version", "5.2.0");
+        assertThat(cluster).containsEntry("throughput", List.of(1, 2, 3));
+        assertThat(cluster).doesNotContainKeys("endpoint");
+        assertThat((Map<String, Object>) result.get("stats")).containsAllEntriesOf(Map.of(
+                "totalMessagesToday", 500L,
+                "messagesPerSecond", 6L,
+                "tpsIn", 7L,
+                "tpsOut", 8L));
+    }
+
+    @Test
+    void rejectsDashboardSummaryWithoutRequiredClusterBeforeHandlerRuns() {
+        assertThatThrownBy(() -> gateway.execute("rmq.dashboard.summary", Map.of()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("input validation failed");
+        verifyNoInteractions(dashboardService);
     }
 
     @Test
@@ -201,7 +280,8 @@ class ToolGatewayServiceTest {
         ToolCatalog l2Catalog = ToolCatalog.load(
                 new ByteArrayResource(yaml.getBytes(StandardCharsets.UTF_8)),
                 new ClassPathResource("tool-catalog/rmq-tools.schema.json"));
-        ToolGatewayService l2Gateway = gateway(l2Catalog, clusterListHandler, capabilitiesHandler);
+        ToolGatewayService l2Gateway = gateway(
+                l2Catalog, clusterListHandler, capabilitiesHandler, dashboardSummaryHandler);
 
         assertThatThrownBy(() -> l2Gateway.execute("rmq.cluster.list", Map.of()))
                 .isInstanceOf(BusinessException.class)
@@ -212,7 +292,11 @@ class ToolGatewayServiceTest {
     @Test
     void failsStartupForDuplicateHandlerNames() {
         assertThatThrownBy(() -> gateway(
-                catalog, clusterListHandler, clusterListHandler, capabilitiesHandler))
+                catalog,
+                clusterListHandler,
+                clusterListHandler,
+                capabilitiesHandler,
+                dashboardSummaryHandler))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("duplicate handler");
     }
@@ -241,7 +325,10 @@ class ToolGatewayServiceTest {
                 new ClassPathResource("tool-catalog/rmq-tools.schema.json"));
 
         assertThatThrownBy(() -> gateway(
-                invalidCatalog, clusterListHandler, capabilitiesHandler))
+                invalidCatalog,
+                clusterListHandler,
+                capabilitiesHandler,
+                dashboardSummaryHandler))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("input schema")
                 .hasMessageContaining("rmq.cluster.list");
@@ -263,7 +350,10 @@ class ToolGatewayServiceTest {
                 new ClassPathResource("tool-catalog/rmq-tools.schema.json"));
 
         assertThatThrownBy(() -> gateway(
-                invalidCatalog, clusterListHandler, capabilitiesHandler))
+                invalidCatalog,
+                clusterListHandler,
+                capabilitiesHandler,
+                dashboardSummaryHandler))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("input schema")
                 .hasMessageContaining("rmq.cluster.list");
@@ -283,7 +373,10 @@ class ToolGatewayServiceTest {
             }
         };
         ToolGatewayService invalidGateway = gateway(
-                catalog, invalidClusterListHandler, capabilitiesHandler);
+                catalog,
+                invalidClusterListHandler,
+                capabilitiesHandler,
+                dashboardSummaryHandler);
 
         assertThatThrownBy(() -> invalidGateway.execute("rmq.cluster.list", Map.of()))
                 .isInstanceOf(IllegalStateException.class)


### PR DESCRIPTION
## Summary
- add the L1 read-only rmq.dashboard.summary tool to the Studio AI tool catalog
- expose a schema-validated dashboard summary projection for a selected cluster
- cover catalog loading, discovery, input validation, and output validation in tool gateway tests

## Scope
- Track 3 / RIP-3 AI Native tool surface
- Related to #513

## Tests
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=ToolCatalogTest,ToolGatewayServiceTest,AiControllerTest,AiServiceTest test
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn test
- git diff --check