### PR TITLE
[Studio] Load namespaces for topic management

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/topic/CloudMetadataProvider.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/topic/CloudMetadataProvider.java
@@ -29,6 +29,15 @@ import java.util.List;
 @Component
 public class CloudMetadataProvider implements MetadataProvider {
 
+    private static final String DEFAULT_NAMESPACE = "default";
+
+    @Override
+    public List<NamespaceVO> listNamespaces() {
+        NamespaceVO namespace = new NamespaceVO();
+        namespace.setName(DEFAULT_NAMESPACE);
+        return List.of(namespace);
+    }
+
     @Override
     public List<TopicVO> listTopics(String clusterId, String type, String search) {
         throw new UnsupportedOperationException("Not implemented");

--- a/server/src/main/java/com/rocketmq/studio/instance/topic/MetadataProvider.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/topic/MetadataProvider.java
@@ -23,6 +23,7 @@ import com.rocketmq.studio.instance.group.SubscriptionEntryVO;
 import java.util.List;
 
 public interface MetadataProvider {
+    List<NamespaceVO> listNamespaces();
     List<TopicVO> listTopics(String clusterId, String type, String search);
     List<ConsumerGroupVO> listConsumerGroups(String clusterId, String search);
     List<BrokerRouteVO> getTopicRoutes(String name);

--- a/server/src/main/java/com/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/topic/MetadataService.java
@@ -112,6 +112,6 @@ public class MetadataService {
 
 
     public List<NamespaceVO> listNamespaces() {
-        throw new UnsupportedOperationException("Not implemented");
+        return metadataProvider.listNamespaces();
     }
 }

--- a/server/src/test/java/com/rocketmq/studio/instance/topic/MetadataServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/topic/MetadataServiceTest.java
@@ -69,6 +69,21 @@ class MetadataServiceTest {
     }
 
     @Test
+    void listNamespacesShouldReturnNamespacesFromProvider() {
+        NamespaceVO namespace = new NamespaceVO();
+        namespace.setName("trade");
+        namespace.setClusterId("cluster-1");
+
+        when(metadataProvider.listNamespaces()).thenReturn(List.of(namespace));
+
+        List<NamespaceVO> result = metadataService.listNamespaces();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("trade");
+        verify(metadataProvider).listNamespaces();
+    }
+
+    @Test
     void createTopicShouldDelegateToAdminClient() {
         TopicVO input = new TopicVO();
         input.setName("new-topic");

--- a/server/src/test/java/com/rocketmq/studio/instance/topic/NamespaceControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/topic/NamespaceControllerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rocketmq.studio.instance.topic;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NamespaceController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class NamespaceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MetadataService metadataService;
+
+    @Test
+    void listNamespacesShouldReturnNamespaces() throws Exception {
+        NamespaceVO namespace = new NamespaceVO();
+        namespace.setName("trade");
+        namespace.setClusterId("cluster-1");
+
+        when(metadataService.listNamespaces()).thenReturn(List.of(namespace));
+
+        mockMvc.perform(get("/api/namespaces"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data[0].name").value("trade"))
+                .andExpect(jsonPath("$.data[0].clusterId").value("cluster-1"));
+    }
+}

--- a/web/src/api/metadata.test.ts
+++ b/web/src/api/metadata.test.ts
@@ -18,7 +18,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { createTopic, deleteTopic, listTopics, sendTopicMessage } from './metadata';
+import { createTopic, deleteTopic, listNamespaces, listTopics, sendTopicMessage } from './metadata';
 
 const mock = new MockAdapter(client);
 
@@ -41,6 +41,13 @@ describe('topic metadata API', () => {
     });
 
     await expect(listTopics(params)).resolves.toEqual([]);
+  });
+
+  it('loads namespaces from the backend contract', async () => {
+    const namespaces = [{ name: 'trade', clusterId: 'cluster-a' }];
+    mock.onGet('/namespaces').reply(200, { code: 200, data: namespaces });
+
+    await expect(listNamespaces()).resolves.toEqual(namespaces);
   });
 
   it('persists topic creation, deletion, and sending through API endpoints', async () => {

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -28,6 +28,14 @@ export interface TopicQuery {
   search?: string;
 }
 
+export interface Namespace {
+  name: string;
+  clusterId?: string;
+  id?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
 export interface BrokerRoute {
   brokerName: string;
   brokerAddr: string;
@@ -106,6 +114,11 @@ export interface ResetConsumerOffsetRequest {
 // ─── Topic API ──────────────────────────────────────────────────
 export async function listTopics(params?: TopicQuery) {
   const res = await client.get<{ data: Topic[] }>('/topics', { params });
+  return res.data.data;
+}
+
+export async function listNamespaces() {
+  const res = await client.get<{ data: Namespace[] }>('/namespaces');
   return res.data.data;
 }
 

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -61,6 +61,7 @@ import {
   deleteTopic,
   getTopicConsumers,
   getTopicRoutes,
+  listNamespaces,
   listTopics,
   sendTopicMessage,
 } from '../../services/topicService';
@@ -73,15 +74,23 @@ const CLUSTER_NAME_MAP: Record<string, { name: string; type: string }> = {
   'rmq-cn-v4-prod-02': { name: 'rmq-cn-v4-prod-02', type: 'V4_DIRECT' },
 };
 
-// ─── Namespace options ────────────────────────────────────────────
-const NAMESPACE_OPTIONS = [
+const DEFAULT_NAMESPACE = 'default';
+const DEFAULT_NAMESPACE_OPTIONS = [
   { label: '全部', value: '' },
-  { label: 'trade', value: 'trade' },
-  { label: 'user', value: 'user' },
-  { label: 'message', value: 'message' },
-  { label: 'supply', value: 'supply' },
-  { label: 'ai', value: 'ai' },
+  { label: DEFAULT_NAMESPACE, value: DEFAULT_NAMESPACE },
 ];
+
+const buildNamespaceOptions = (namespaces: { name: string }[]) => {
+  const names = new Set([DEFAULT_NAMESPACE]);
+  namespaces.forEach((namespace) => {
+    if (namespace.name) names.add(namespace.name);
+  });
+
+  return [
+    { label: '全部', value: '' },
+    ...[...names].map((name) => ({ label: name, value: name })),
+  ];
+};
 
 const TYPE_OPTIONS = [
   { label: '全部', value: '' },
@@ -223,6 +232,7 @@ const TopicPage = () => {
   const [searchText, setSearchText] = useState('');
   const [typeFilter, setTypeFilter] = useState('');
   const [nsFilter, setNsFilter] = useState('');
+  const [namespaceOptions, setNamespaceOptions] = useState(DEFAULT_NAMESPACE_OPTIONS);
   const [viewMode, setViewMode] = useState<string>('列表');
   const [detailModalOpen, setDetailModalOpen] = useState(false);
   const [selectedTopic, setSelectedTopic] = useState<Topic | null>(null);
@@ -236,12 +246,22 @@ const TopicPage = () => {
 
   useEffect(() => {
     let cancelled = false;
-    void listTopics()
-      .then((nextTopics) => {
-        if (!cancelled) setTopics(nextTopics);
-      })
-      .catch(() => {
-        if (!cancelled) message.error('Topic 列表加载失败，请稍后重试');
+    void Promise.allSettled([listTopics(), listNamespaces()])
+      .then(([topicsResult, namespacesResult]) => {
+        if (cancelled) return;
+
+        if (topicsResult.status === 'fulfilled') {
+          setTopics(topicsResult.value);
+        } else {
+          message.error('Topic 列表加载失败，请稍后重试');
+        }
+
+        if (namespacesResult.status === 'fulfilled') {
+          setNamespaceOptions(buildNamespaceOptions(namespacesResult.value));
+        } else {
+          setNamespaceOptions(DEFAULT_NAMESPACE_OPTIONS);
+          message.warning('命名空间加载失败，已使用默认命名空间');
+        }
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -637,7 +657,7 @@ const TopicPage = () => {
             placeholder="命名空间"
             value={nsFilter}
             onChange={setNsFilter}
-            options={NAMESPACE_OPTIONS}
+            options={namespaceOptions}
             style={{ width: 140 }}
           />
           <Segmented
@@ -814,7 +834,7 @@ const TopicPage = () => {
           <Row gutter={16}>
             <Col span={12}>
               <Form.Item label="命名空间" name="namespace" rules={[{ required: true }]}>
-                <Select disabled options={[{ label: 'default', value: 'default' }]} />
+                <Select options={namespaceOptions.filter((option) => option.value)} />
               </Form.Item>
             </Col>
             <Col span={12}>

--- a/web/src/services/topicService.ts
+++ b/web/src/services/topicService.ts
@@ -1,14 +1,35 @@
 import { USE_MOCK } from '../config';
 import * as metadataApi from '../api/metadata';
 import type {
-  Topic,
-  TopicQuery,
   BrokerRoute,
   ConsumerGroupInfo,
+  Namespace,
   SendTopicMessageRequest,
   SendTopicMessageResult,
+  Topic,
+  TopicQuery,
 } from '../api/metadata';
 import { topics as mockTopics, topicRoutes, topicConsumers } from '../mock/topics';
+
+const DEFAULT_NAMESPACE = 'default';
+
+const namespaceFromTopic = (topic: Topic): Namespace => ({
+  name: topic.namespace || DEFAULT_NAMESPACE,
+  clusterId: topic.clusterId,
+});
+
+export async function listNamespaces(): Promise<Namespace[]> {
+  if (USE_MOCK) {
+    const namespaces = new Map<string, Namespace>();
+    namespaces.set(DEFAULT_NAMESPACE, { name: DEFAULT_NAMESPACE });
+    (mockTopics as unknown as Topic[]).forEach((topic) => {
+      const namespace = namespaceFromTopic(topic);
+      namespaces.set(namespace.name, namespace);
+    });
+    return [...namespaces.values()];
+  }
+  return metadataApi.listNamespaces();
+}
 
 export async function listTopics(params?: TopicQuery): Promise<Topic[]> {
   if (USE_MOCK) {


### PR DESCRIPTION
## Summary
- expose the metadata provider namespace list through `/api/namespaces`
- wire topic management API/service calls to load namespace options
- keep Topic management aligned with META-01 namespace-first resource modeling

## Scope
- RocketMQ Studio contest scope: Track 1 / META-01 Namespace resource domain
- Related to #427 and #180

## Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=MetadataServiceTest,NamespaceControllerTest,TopicControllerTest test`
- `npm test -- --run src/api/metadata.test.ts`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn test`
- `npm test`
- `npm run build`
- `git diff --check`