### PR TITLE
[Studio] Validate DLQ resend requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/dlq/DLQController.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/dlq/DLQController.java
@@ -17,6 +17,7 @@
 package com.rocketmq.studio.instance.dlq;
 
 import com.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/dlq")
@@ -41,12 +41,9 @@ public class DLQController {
     }
 
     @PostMapping("/resend")
-    public Result<Void> resendMessages(@RequestBody Map<String, Object> request) {
-        String groupName = (String) request.get("groupName");
-        Long startTime = request.get("startTime") != null ? ((Number) request.get("startTime")).longValue() : null;
-        Long endTime = request.get("endTime") != null ? ((Number) request.get("endTime")).longValue() : null;
-        String targetTopic = (String) request.get("targetTopic");
-        dlqService.resendMessages(groupName, startTime, endTime, targetTopic);
+    public Result<Void> resendMessages(@Valid @RequestBody DLQResendRequestDTO request) {
+        dlqService.resendMessages(
+                request.getGroupName(), request.getStartTime(), request.getEndTime(), request.getTargetTopic());
         return Result.ok();
     }
 }

--- a/server/src/main/java/com/rocketmq/studio/instance/dlq/DLQResendRequestDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/dlq/DLQResendRequestDTO.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.instance.dlq;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DLQResendRequestDTO {
+    @NotBlank(message = "groupName is required")
+    private String groupName;
+    private Long startTime;
+    private Long endTime;
+    private String targetTopic;
+}

--- a/server/src/main/java/com/rocketmq/studio/instance/dlq/DLQService.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/dlq/DLQService.java
@@ -16,9 +16,12 @@
  */
 package com.rocketmq.studio.instance.dlq;
 
+import com.rocketmq.studio.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -35,7 +38,29 @@ public class DLQService {
     }
 
     public void resendMessages(String groupName, Long startTime, Long endTime, String targetTopic) {
+        validateResendRequest(groupName, startTime, endTime);
         log.info("Resending DLQ messages: group={}, targetTopic={}", groupName, targetTopic);
         dlqProvider.resendMessages(groupName, startTime, endTime, targetTopic);
+    }
+
+    private void validateResendRequest(String groupName, Long startTime, Long endTime) {
+        if (!StringUtils.hasText(groupName)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), "groupName is required");
+        }
+        if ((startTime == null) != (endTime == null)) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST.value(), "startTime and endTime must be provided together");
+        }
+        if (startTime == null) {
+            return;
+        }
+        if (startTime <= 0 || endTime <= 0) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST.value(), "startTime and endTime must be positive");
+        }
+        if (endTime < startTime) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST.value(), "endTime must not be earlier than startTime");
+        }
     }
 }

--- a/server/src/test/java/com/rocketmq/studio/instance/dlq/DLQControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/dlq/DLQControllerTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -121,5 +122,42 @@ class DLQControllerTest {
 
         verify(dlqService).resendMessages(
                 eq("test-group"), isNull(), isNull(), eq("target-topic"));
+    }
+
+    @Test
+    void resendMessagesShouldRejectMissingGroupName() throws Exception {
+        Map<String, Object> body = Map.of(
+                "startTime", 1000,
+                "endTime", 2000,
+                "targetTopic", "target-topic"
+        );
+
+        mockMvc.perform(post("/api/dlq/resend")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("groupName is required"));
+
+        verifyNoInteractions(dlqService);
+    }
+
+    @Test
+    void resendMessagesShouldRejectInvalidTimeType() throws Exception {
+        Map<String, Object> body = Map.of(
+                "groupName", "test-group",
+                "startTime", "invalid",
+                "endTime", 2000,
+                "targetTopic", "target-topic"
+        );
+
+        mockMvc.perform(post("/api/dlq/resend")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Invalid request body"));
+
+        verifyNoInteractions(dlqService);
     }
 }

--- a/server/src/test/java/com/rocketmq/studio/instance/dlq/DLQServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/dlq/DLQServiceTest.java
@@ -26,7 +26,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -86,5 +88,37 @@ class DLQServiceTest {
         dlqService.resendMessages("group-1", null, null, "target-topic");
 
         verify(dlqProvider).resendMessages("group-1", null, null, "target-topic");
+    }
+
+    @Test
+    void resendMessagesShouldRejectBlankGroupName() {
+        assertThatThrownBy(() -> dlqService.resendMessages(" ", 1000L, 2000L, "target-topic"))
+                .hasMessage("groupName is required");
+
+        verifyNoInteractions(dlqProvider);
+    }
+
+    @Test
+    void resendMessagesShouldRejectPartialTimeRange() {
+        assertThatThrownBy(() -> dlqService.resendMessages("group-1", 1000L, null, "target-topic"))
+                .hasMessage("startTime and endTime must be provided together");
+
+        verifyNoInteractions(dlqProvider);
+    }
+
+    @Test
+    void resendMessagesShouldRejectNonPositiveTimeRange() {
+        assertThatThrownBy(() -> dlqService.resendMessages("group-1", 0L, 2000L, "target-topic"))
+                .hasMessage("startTime and endTime must be positive");
+
+        verifyNoInteractions(dlqProvider);
+    }
+
+    @Test
+    void resendMessagesShouldRejectReversedTimeRange() {
+        assertThatThrownBy(() -> dlqService.resendMessages("group-1", 2000L, 1000L, "target-topic"))
+                .hasMessage("endTime must not be earlier than startTime");
+
+        verifyNoInteractions(dlqProvider);
     }
 }


### PR DESCRIPTION
## Summary
- replace the DLQ resend request map parsing with a typed request DTO
- validate required groupName and coherent resend time ranges before reaching the provider
- return structured 400 responses for invalid JSON field types and invalid resend parameters

## Scope
- RocketMQ Studio contest scope: Track 1 / BASE-01 DLQ resend baseline hardening
- Does not introduce Namespace behavior

## Tests
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=DLQServiceTest,DLQControllerTest test
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn test
- git diff --check