### PR TITLE
[Studio] Validate consumer reset offset requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/group/ConsumerGroupController.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/group/ConsumerGroupController.java
@@ -19,6 +19,7 @@ package com.rocketmq.studio.instance.group;
 import com.rocketmq.studio.instance.topic.MetadataService;
 
 import com.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -80,11 +81,8 @@ public class ConsumerGroupController {
     }
 
     @PostMapping("/reset-offset")
-    public Result<Void> resetOffset(@RequestBody Map<String, Object> request) {
-        String name = (String) request.get("name");
-        long timestamp = ((Number) request.get("timestamp")).longValue();
-        String topic = (String) request.get("topic");
-        metadataService.resetOffset(name, timestamp, topic);
+    public Result<Void> resetOffset(@Valid @RequestBody ResetConsumerOffsetDTO request) {
+        metadataService.resetOffset(request.getName(), request.getTimestamp(), request.getTopic());
         return Result.ok();
     }
 }

--- a/server/src/main/java/com/rocketmq/studio/instance/group/ResetConsumerOffsetDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/group/ResetConsumerOffsetDTO.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.instance.group;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResetConsumerOffsetDTO {
+    @NotBlank(message = "name is required")
+    private String name;
+
+    @NotNull(message = "timestamp is required")
+    @Positive(message = "timestamp must be positive")
+    private Long timestamp;
+
+    private String topic;
+}

--- a/server/src/test/java/com/rocketmq/studio/instance/group/ConsumerGroupControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/group/ConsumerGroupControllerTest.java
@@ -17,19 +17,26 @@
 
 package com.rocketmq.studio.instance.group;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rocketmq.studio.instance.topic.MetadataService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -39,6 +46,9 @@ class ConsumerGroupControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockBean
     private MetadataService metadataService;
@@ -75,5 +85,93 @@ class ConsumerGroupControllerTest {
                 .andExpect(jsonPath("$.data.threads[0].threadName").value("ConsumeMessageThread_1"))
                 .andExpect(jsonPath("$.data.threads[0].stackTrace[0]")
                         .value("org.apache.rocketmq.client.impl.consumer.ConsumeMessageConcurrentlyService.run"));
+    }
+
+    @Test
+    void resetOffsetShouldPassValidatedRequest() throws Exception {
+        Map<String, Object> body = Map.of(
+                "name", "cg-orders",
+                "topic", "orders",
+                "timestamp", 1784246400000L
+        );
+
+        mockMvc.perform(post("/api/groups/reset-offset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"));
+
+        verify(metadataService).resetOffset(eq("cg-orders"), eq(1784246400000L), eq("orders"));
+    }
+
+    @Test
+    void resetOffsetShouldRejectMissingName() throws Exception {
+        Map<String, Object> body = Map.of(
+                "topic", "orders",
+                "timestamp", 1784246400000L
+        );
+
+        mockMvc.perform(post("/api/groups/reset-offset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("name is required"));
+
+        verifyNoInteractions(metadataService);
+    }
+
+    @Test
+    void resetOffsetShouldRejectMissingTimestamp() throws Exception {
+        Map<String, Object> body = Map.of(
+                "name", "cg-orders",
+                "topic", "orders"
+        );
+
+        mockMvc.perform(post("/api/groups/reset-offset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("timestamp is required"));
+
+        verifyNoInteractions(metadataService);
+    }
+
+    @Test
+    void resetOffsetShouldRejectNonPositiveTimestamp() throws Exception {
+        Map<String, Object> body = Map.of(
+                "name", "cg-orders",
+                "topic", "orders",
+                "timestamp", 0L
+        );
+
+        mockMvc.perform(post("/api/groups/reset-offset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("timestamp must be positive"));
+
+        verifyNoInteractions(metadataService);
+    }
+
+    @Test
+    void resetOffsetShouldRejectInvalidTimestampType() throws Exception {
+        Map<String, Object> body = Map.of(
+                "name", "cg-orders",
+                "topic", "orders",
+                "timestamp", "invalid"
+        );
+
+        mockMvc.perform(post("/api/groups/reset-offset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Invalid request body"));
+
+        verifyNoInteractions(metadataService);
     }
 }


### PR DESCRIPTION
## Summary
- replace ad hoc reset-offset request map parsing with a typed DTO
- validate required consumer group name and positive reset timestamp before invoking metadata admin operations
- return structured 400 responses for missing fields and invalid timestamp JSON types

## Scope
- RocketMQ Studio contest scope: Track 1 / BASE-01 Consumer Group reset offset baseline hardening
- Does not introduce Namespace behavior

## Tests
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=ConsumerGroupControllerTest test
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn test
- git diff --check