### PR TITLE
[Studio] Validate topic delete requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/topic/DeleteTopicDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/topic/DeleteTopicDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.instance.topic;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteTopicDTO {
+    @NotBlank(message = "name is required")
+    private String name;
+}

--- a/server/src/main/java/com/rocketmq/studio/instance/topic/TopicController.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/topic/TopicController.java
@@ -17,6 +17,7 @@
 package com.rocketmq.studio.instance.topic;
 
 import com.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,7 +28,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/topics")
@@ -55,8 +55,8 @@ public class TopicController {
     }
 
     @PostMapping("/delete")
-    public Result<Void> deleteTopic(@RequestBody Map<String, String> request) {
-        metadataService.deleteTopic(request.get("name"));
+    public Result<Void> deleteTopic(@Valid @RequestBody DeleteTopicDTO request) {
+        metadataService.deleteTopic(request.getName());
         return Result.ok();
     }
 

--- a/server/src/test/java/com/rocketmq/studio/instance/topic/TopicControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/topic/TopicControllerTest.java
@@ -27,11 +27,13 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -129,5 +131,41 @@ class TopicControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.msgId").value("msg-001"))
                 .andExpect(jsonPath("$.data.offsetMsgId").value("offset-001"));
+    }
+
+    @Test
+    void deleteTopicShouldReturnSuccess() throws Exception {
+        mockMvc.perform(post("/api/topics/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("name", "test-topic"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"));
+
+        verify(metadataService).deleteTopic("test-topic");
+    }
+
+    @Test
+    void deleteTopicShouldRejectMissingName() throws Exception {
+        mockMvc.perform(post("/api/topics/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("name is required"));
+
+        verifyNoInteractions(metadataService);
+    }
+
+    @Test
+    void deleteTopicShouldRejectBlankName() throws Exception {
+        mockMvc.perform(post("/api/topics/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("name", " "))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("name is required"));
+
+        verifyNoInteractions(metadataService);
     }
 }


### PR DESCRIPTION
## Summary
- replace topic delete map parsing with a typed request DTO
- validate the required topic name before invoking metadata delete operations
- return structured 400 responses for missing or blank topic names

## Scope
- RocketMQ Studio contest scope: Track 1 / BASE-01 Topic management hardening
- Does not introduce Namespace behavior

## Tests
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=TopicControllerTest test
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn test
- git diff --check