### PR TITLE
[Studio] Validate alert rule action requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/ops/alert/AlertRuleController.java
+++ b/server/src/main/java/com/rocketmq/studio/ops/alert/AlertRuleController.java
@@ -17,6 +17,7 @@
 package com.rocketmq.studio.ops.alert;
 
 import com.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,7 +26,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/alert-rules")
@@ -50,15 +50,13 @@ public class AlertRuleController {
     }
 
     @PostMapping("/toggle")
-    public Result<AlertRuleVO> toggleRule(@RequestBody Map<String, Object> request) {
-        String id = (String) request.get("id");
-        boolean enabled = (Boolean) request.get("enabled");
-        return Result.ok(alertService.toggleRule(id, enabled));
+    public Result<AlertRuleVO> toggleRule(@Valid @RequestBody ToggleAlertRuleDTO request) {
+        return Result.ok(alertService.toggleRule(request.getId(), request.getEnabled()));
     }
 
     @PostMapping("/delete")
-    public Result<Void> deleteRule(@RequestBody Map<String, String> request) {
-        alertService.deleteRule(request.get("id"));
+    public Result<Void> deleteRule(@Valid @RequestBody DeleteAlertRuleDTO request) {
+        alertService.deleteRule(request.getId());
         return Result.ok();
     }
 }

--- a/server/src/main/java/com/rocketmq/studio/ops/alert/DeleteAlertRuleDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/ops/alert/DeleteAlertRuleDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.ops.alert;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteAlertRuleDTO {
+    @NotBlank(message = "id is required")
+    private String id;
+}

--- a/server/src/main/java/com/rocketmq/studio/ops/alert/ToggleAlertRuleDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/ops/alert/ToggleAlertRuleDTO.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.ops.alert;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ToggleAlertRuleDTO {
+    @NotBlank(message = "id is required")
+    private String id;
+
+    @NotNull(message = "enabled is required")
+    private Boolean enabled;
+}

--- a/server/src/test/java/com/rocketmq/studio/ops/alert/AlertRuleControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/ops/alert/AlertRuleControllerTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.ops.alert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AlertRuleController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AlertRuleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AlertService alertService;
+
+    @Test
+    void listRulesShouldReturnRules() throws Exception {
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .id("rule-1")
+                .name("High Lag")
+                .metric("rocketmq_consumer_lag_messages")
+                .enabled(true)
+                .build();
+        when(alertService.listRules()).thenReturn(List.of(rule));
+
+        mockMvc.perform(get("/api/alert-rules"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data[0].id").value("rule-1"))
+                .andExpect(jsonPath("$.data[0].enabled").value(true));
+    }
+
+    @Test
+    void createRuleShouldReturnCreatedRule() throws Exception {
+        AlertRuleVO request = AlertRuleVO.builder()
+                .name("High Lag")
+                .metric("rocketmq_consumer_lag_messages")
+                .enabled(true)
+                .build();
+        AlertRuleVO created = AlertRuleVO.builder()
+                .id("rule-1")
+                .name("High Lag")
+                .metric("rocketmq_consumer_lag_messages")
+                .enabled(true)
+                .build();
+        when(alertService.createRule(any(AlertRuleVO.class))).thenReturn(created);
+
+        mockMvc.perform(post("/api/alert-rules/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value("rule-1"))
+                .andExpect(jsonPath("$.data.name").value("High Lag"));
+    }
+
+    @Test
+    void toggleRuleShouldPassValidatedRequest() throws Exception {
+        AlertRuleVO toggled = AlertRuleVO.builder()
+                .id("rule-1")
+                .name("High Lag")
+                .enabled(false)
+                .build();
+        when(alertService.toggleRule("rule-1", false)).thenReturn(toggled);
+
+        mockMvc.perform(post("/api/alert-rules/toggle")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", "rule-1", "enabled", false))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.id").value("rule-1"))
+                .andExpect(jsonPath("$.data.enabled").value(false));
+
+        verify(alertService).toggleRule(eq("rule-1"), eq(false));
+    }
+
+    @Test
+    void toggleRuleShouldRejectMissingId() throws Exception {
+        mockMvc.perform(post("/api/alert-rules/toggle")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("enabled", true))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(alertService);
+    }
+
+    @Test
+    void toggleRuleShouldRejectMissingEnabled() throws Exception {
+        mockMvc.perform(post("/api/alert-rules/toggle")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", "rule-1"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("enabled is required"));
+
+        verifyNoInteractions(alertService);
+    }
+
+    @Test
+    void toggleRuleShouldRejectInvalidEnabledType() throws Exception {
+        mockMvc.perform(post("/api/alert-rules/toggle")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", "rule-1", "enabled", "invalid"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Invalid request body"));
+
+        verifyNoInteractions(alertService);
+    }
+
+    @Test
+    void deleteRuleShouldPassValidatedRequest() throws Exception {
+        mockMvc.perform(post("/api/alert-rules/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", "rule-1"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"));
+
+        verify(alertService).deleteRule("rule-1");
+    }
+
+    @Test
+    void deleteRuleShouldRejectBlankId() throws Exception {
+        mockMvc.perform(post("/api/alert-rules/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", " "))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(alertService);
+    }
+}


### PR DESCRIPTION
## Summary
- replace alert rule toggle/delete map parsing with typed request DTOs
- validate required rule ids and enabled state before invoking alert operations
- return structured 400 responses for missing ids, missing enabled values, and invalid enabled JSON types

## Scope
- RocketMQ Studio contest scope: Track 1 / METRICS-01 alert rule action hardening
- Does not introduce Namespace behavior

## Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test`
- `git diff --check`