### PR TITLE
[Studio] Validate ACL delete requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/acl/AclController.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/acl/AclController.java
@@ -17,6 +17,7 @@
 package com.rocketmq.studio.instance.acl;
 
 import com.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/acl")
@@ -53,8 +53,8 @@ public class AclController {
     }
 
     @PostMapping("/rules/delete")
-    public Result<Void> deleteRule(@RequestBody Map<String, String> request) {
-        aclService.deleteRule(request.get("id"));
+    public Result<Void> deleteRule(@Valid @RequestBody AclDeleteRequestDTO request) {
+        aclService.deleteRule(request.getId());
         return Result.ok();
     }
 
@@ -74,8 +74,8 @@ public class AclController {
     }
 
     @PostMapping("/users/delete")
-    public Result<Void> deleteUser(@RequestBody Map<String, String> request) {
-        aclService.deleteUser(request.get("id"));
+    public Result<Void> deleteUser(@Valid @RequestBody AclDeleteRequestDTO request) {
+        aclService.deleteUser(request.getId());
         return Result.ok();
     }
 }

--- a/server/src/main/java/com/rocketmq/studio/instance/acl/AclDeleteRequestDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/acl/AclDeleteRequestDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.instance.acl;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AclDeleteRequestDTO {
+    @NotBlank(message = "id is required")
+    private String id;
+}

--- a/server/src/test/java/com/rocketmq/studio/instance/acl/AclControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/acl/AclControllerTest.java
@@ -28,11 +28,13 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -138,6 +140,30 @@ class AclControllerTest {
     }
 
     @Test
+    void deleteRuleShouldPassValidatedRequest() throws Exception {
+        mockMvc.perform(post("/api/acl/rules/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", "rule-1"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"));
+
+        verify(aclService).deleteRule("rule-1");
+    }
+
+    @Test
+    void deleteRuleShouldRejectBlankId() throws Exception {
+        mockMvc.perform(post("/api/acl/rules/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", " "))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(aclService);
+    }
+
+    @Test
     void listUsersShouldReturnAllUsers() throws Exception {
         AclUserVO user = AclUserVO.builder()
                 .username("admin")
@@ -178,5 +204,29 @@ class AclControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.id").value("user-1"))
                 .andExpect(jsonPath("$.data.admin").value(false));
+    }
+
+    @Test
+    void deleteUserShouldPassValidatedRequest() throws Exception {
+        mockMvc.perform(post("/api/acl/users/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", "user-1"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"));
+
+        verify(aclService).deleteUser("user-1");
+    }
+
+    @Test
+    void deleteUserShouldRejectMissingId() throws Exception {
+        mockMvc.perform(post("/api/acl/users/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(aclService);
     }
 }


### PR DESCRIPTION
## Summary
- replace ACL rule/user delete map parsing with a typed request DTO
- validate required ids before invoking ACL delete operations
- return structured 400 responses for missing or blank ACL delete ids

## Scope
- RocketMQ Studio contest scope: Track 1 / AUTH-01 ACL management hardening
- Does not introduce Namespace behavior

## Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=AclControllerTest,AclServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test`
- `git diff --check`