### PR TITLE
[Studio] Validate system alert acknowledge requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/ops/alert/AcknowledgeSystemAlertDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/ops/alert/AcknowledgeSystemAlertDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.ops.alert;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AcknowledgeSystemAlertDTO {
+    @NotBlank(message = "id is required")
+    private String id;
+}

--- a/server/src/main/java/com/rocketmq/studio/ops/alert/SystemAlertController.java
+++ b/server/src/main/java/com/rocketmq/studio/ops/alert/SystemAlertController.java
@@ -17,6 +17,7 @@
 package com.rocketmq.studio.ops.alert;
 
 import com.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -42,8 +43,8 @@ public class SystemAlertController {
     }
 
     @PostMapping("/acknowledge")
-    public Result<SystemAlertVO> acknowledgeAlert(@RequestBody Map<String, String> request) {
-        return Result.ok(alertService.acknowledgeAlert(request.get("id")));
+    public Result<SystemAlertVO> acknowledgeAlert(@Valid @RequestBody AcknowledgeSystemAlertDTO request) {
+        return Result.ok(alertService.acknowledgeAlert(request.getId()));
     }
 
     @PostMapping("/clear-acknowledged")

--- a/server/src/test/java/com/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.ops.alert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rocketmq.studio.common.domain.enums.AlertLevel;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SystemAlertController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SystemAlertControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AlertService alertService;
+
+    @Test
+    void listAlertsShouldReturnSystemAlerts() throws Exception {
+        SystemAlertVO alert = SystemAlertVO.builder()
+                .id("alert-1")
+                .level(AlertLevel.error)
+                .title("Broker Down")
+                .acknowledged(false)
+                .build();
+        when(alertService.listAlerts("error")).thenReturn(List.of(alert));
+
+        mockMvc.perform(get("/api/system-alerts").param("level", "error"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data[0].id").value("alert-1"))
+                .andExpect(jsonPath("$.data[0].level").value("error"))
+                .andExpect(jsonPath("$.data[0].acknowledged").value(false));
+
+        verify(alertService).listAlerts("error");
+    }
+
+    @Test
+    void acknowledgeAlertShouldPassValidatedRequest() throws Exception {
+        SystemAlertVO acknowledged = SystemAlertVO.builder()
+                .id("alert-1")
+                .level(AlertLevel.warning)
+                .title("High Lag")
+                .acknowledged(true)
+                .build();
+        when(alertService.acknowledgeAlert("alert-1")).thenReturn(acknowledged);
+
+        mockMvc.perform(post("/api/system-alerts/acknowledge")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", "alert-1"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.id").value("alert-1"))
+                .andExpect(jsonPath("$.data.acknowledged").value(true));
+
+        verify(alertService).acknowledgeAlert("alert-1");
+    }
+
+    @Test
+    void acknowledgeAlertShouldRejectBlankId() throws Exception {
+        mockMvc.perform(post("/api/system-alerts/acknowledge")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", " "))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(alertService);
+    }
+
+    @Test
+    void acknowledgeAlertShouldRejectMissingId() throws Exception {
+        mockMvc.perform(post("/api/system-alerts/acknowledge")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(alertService);
+    }
+
+    @Test
+    void clearAcknowledgedShouldReturnClearedCount() throws Exception {
+        when(alertService.clearAcknowledged()).thenReturn(3);
+
+        mockMvc.perform(post("/api/system-alerts/clear-acknowledged"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.cleared").value(3));
+
+        verify(alertService).clearAcknowledged();
+    }
+}


### PR DESCRIPTION
## Summary
- replace system alert acknowledge map parsing with a typed request DTO
- validate required alert ids before invoking acknowledge operations
- add controller tests for list, acknowledge, reject invalid ids, and clear acknowledged alerts

## Scope
- RocketMQ Studio contest scope: Track 1 / METRICS-01 system alert action hardening
- Does not introduce Namespace behavior

## Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=SystemAlertControllerTest,AlertServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test`
- `git diff --check`