### PR TITLE
[Studio] Validate instance delete requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/InstanceController.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/InstanceController.java
@@ -19,6 +19,7 @@ package com.rocketmq.studio.instance;
 
 import com.rocketmq.studio.common.domain.Result;
 import com.rocketmq.studio.common.domain.enums.InstanceType;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,7 +29,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/instances")
@@ -55,8 +55,8 @@ public class InstanceController {
     }
 
     @PostMapping("/delete")
-    public Result<Void> deleteInstance(@RequestBody Map<String, String> body) {
-        instanceService.deleteInstance(body.get("id"));
+    public Result<Void> deleteInstance(@Valid @RequestBody InstanceDeleteRequestDTO request) {
+        instanceService.deleteInstance(request.getId());
         return Result.ok();
     }
 }

--- a/server/src/main/java/com/rocketmq/studio/instance/InstanceDeleteRequestDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/InstanceDeleteRequestDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.instance;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InstanceDeleteRequestDTO {
+    @NotBlank(message = "id is required")
+    private String id;
+}

--- a/server/src/test/java/com/rocketmq/studio/instance/InstanceControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/InstanceControllerTest.java
@@ -36,6 +36,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -173,6 +174,30 @@ class InstanceControllerTest {
                 .andExpect(jsonPath("$.message").value("success"));
 
         verify(instanceService).deleteInstance("inst-1");
+    }
+
+    @Test
+    void deleteInstanceShouldRejectBlankId() throws Exception {
+        mockMvc.perform(post("/api/instances/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", " "))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(instanceService);
+    }
+
+    @Test
+    void deleteInstanceShouldRejectMissingId() throws Exception {
+        mockMvc.perform(post("/api/instances/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(instanceService);
     }
 
     private InstanceVO buildInstance(String id, String name, InstanceType type, String endpoint) {


### PR DESCRIPTION
## Summary
- replace instance delete map parsing with a typed request DTO
- validate required instance ids before invoking delete operations
- add controller tests for blank and missing delete ids

## Scope
- RocketMQ Studio contest scope: Track 1 / ARCH-01 instance access management hardening
- Does not introduce Namespace behavior

## Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=InstanceControllerTest,InstanceServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test`
- `git diff --check`