### PR TITLE
[Studio] Validate proxy restart requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/cluster/proxy/ProxyController.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/proxy/ProxyController.java
@@ -18,6 +18,7 @@ package com.rocketmq.studio.cluster.proxy;
 
 import com.rocketmq.studio.cluster.broker.ClusterService;
 import com.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,7 +35,7 @@ public class ProxyController {
     private final ClusterService clusterService;
 
     @PostMapping("/restart")
-    public Result<Map<String, Boolean>> restartProxy(@RequestBody RestartProxyDTO command) {
+    public Result<Map<String, Boolean>> restartProxy(@Valid @RequestBody RestartProxyDTO command) {
         boolean success = clusterService.restartProxy(command);
         return Result.ok(Map.of("success", success));
     }

--- a/server/src/main/java/com/rocketmq/studio/cluster/proxy/RestartProxyDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/proxy/RestartProxyDTO.java
@@ -16,6 +16,7 @@
  */
 package com.rocketmq.studio.cluster.proxy;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,6 +27,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RestartProxyDTO {
+    @NotBlank(message = "clusterId is required")
     private String clusterId;
+
+    @NotBlank(message = "addr is required")
     private String addr;
 }

--- a/server/src/test/java/com/rocketmq/studio/cluster/proxy/ProxyControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/cluster/proxy/ProxyControllerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.proxy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rocketmq.studio.cluster.broker.ClusterService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProxyController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ProxyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ClusterService clusterService;
+
+    @Test
+    void restartProxyShouldPassValidatedRequest() throws Exception {
+        RestartProxyDTO request = RestartProxyDTO.builder()
+                .clusterId("cluster-1")
+                .addr("127.0.0.1:8081")
+                .build();
+        when(clusterService.restartProxy(any(RestartProxyDTO.class))).thenReturn(true);
+
+        mockMvc.perform(post("/api/proxies/restart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.success").value(true));
+
+        verify(clusterService).restartProxy(any(RestartProxyDTO.class));
+    }
+
+    @Test
+    void restartProxyShouldRejectMissingClusterId() throws Exception {
+        RestartProxyDTO request = RestartProxyDTO.builder()
+                .addr("127.0.0.1:8081")
+                .build();
+
+        mockMvc.perform(post("/api/proxies/restart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("clusterId is required"));
+
+        verifyNoInteractions(clusterService);
+    }
+
+    @Test
+    void restartProxyShouldRejectBlankAddr() throws Exception {
+        RestartProxyDTO request = RestartProxyDTO.builder()
+                .clusterId("cluster-1")
+                .addr(" ")
+                .build();
+
+        mockMvc.perform(post("/api/proxies/restart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("addr is required"));
+
+        verifyNoInteractions(clusterService);
+    }
+}


### PR DESCRIPTION
## Summary
- validate proxy restart clusterId and addr before invoking cluster operations
- enable controller-level request validation for proxy restarts
- add controller tests for valid restart requests and invalid inputs

## Scope
- RocketMQ Studio contest scope: Track 1 / ARCH-01 Proxy cluster management hardening
- Does not introduce Namespace behavior

## Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=ProxyControllerTest,ClusterServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test`
- `git diff --check`