### PR TITLE
[Studio] Validate cluster config update requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterController.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterController.java
@@ -19,6 +19,7 @@ package com.rocketmq.studio.cluster.broker;
 import com.rocketmq.studio.cluster.config.UpdateConfigDTO;
 
 import com.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -48,7 +49,7 @@ public class ClusterController {
     }
 
     @PostMapping("/config/update")
-    public Result<ClusterVO> updateClusterConfig(@RequestBody UpdateConfigDTO command) {
+    public Result<ClusterVO> updateClusterConfig(@Valid @RequestBody UpdateConfigDTO command) {
         return Result.ok(clusterService.updateClusterConfig(command));
     }
 

--- a/server/src/main/java/com/rocketmq/studio/cluster/config/UpdateConfigDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/config/UpdateConfigDTO.java
@@ -16,6 +16,7 @@
  */
 package com.rocketmq.studio.cluster.config;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,7 +27,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateConfigDTO {
+    @NotBlank(message = "id is required")
     private String id;
+
     private String flushDiskType;
     private Boolean autoCreateTopicEnable;
     private Boolean autoCreateSubscriptionGroup;

--- a/server/src/test/java/com/rocketmq/studio/cluster/broker/ClusterControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/cluster/broker/ClusterControllerTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -133,6 +134,40 @@ class ClusterControllerTest {
                 .andExpect(jsonPath("$.data.config.flushDiskType").value("SYNC_FLUSH"))
                 .andExpect(jsonPath("$.data.config.writeQueueNums").value(16))
                 .andExpect(jsonPath("$.data.config.readQueueNums").value(16));
+    }
+
+    @Test
+    void updateConfigShouldRejectMissingId() throws Exception {
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .flushDiskType("SYNC_FLUSH")
+                .writeQueueNums(16)
+                .build();
+
+        mockMvc.perform(post("/api/clusters/config/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(command)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(clusterService);
+    }
+
+    @Test
+    void updateConfigShouldRejectBlankId() throws Exception {
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id(" ")
+                .flushDiskType("SYNC_FLUSH")
+                .build();
+
+        mockMvc.perform(post("/api/clusters/config/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(command)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(clusterService);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- validate cluster config update ids before invoking cluster operations
- enable controller-level request validation for config updates
- add controller tests for missing and blank config update ids

## Scope
- RocketMQ Studio contest scope: Track 1 / ARCH-01 cluster config management hardening
- Does not introduce Namespace behavior

## Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=ClusterControllerTest,ClusterServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test`
- `git diff --check`