### PR TITLE
[Studio] Validate K8s certificate requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/cluster/k8s/CreateCertDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/k8s/CreateCertDTO.java
@@ -16,6 +16,8 @@
  */
 package com.rocketmq.studio.cluster.k8s;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,10 +30,16 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateCertDTO {
+    @NotBlank(message = "name is required")
     private String name;
+    @NotBlank(message = "namespace is required")
     private String namespace;
+    @NotBlank(message = "cluster is required")
     private String cluster;
+    @NotBlank(message = "type is required")
+    @Pattern(regexp = "TLS|mTLS|ServiceAccount", message = "type must be one of TLS, mTLS, ServiceAccount")
     private String type;
+    @NotBlank(message = "issuer is required")
     private String issuer;
     private List<String> san;
 }

--- a/server/src/main/java/com/rocketmq/studio/cluster/k8s/DeleteCertDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/k8s/DeleteCertDTO.java
@@ -16,6 +16,7 @@
  */
 package com.rocketmq.studio.cluster.k8s;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,5 +27,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DeleteCertDTO {
+    @NotBlank(message = "id is required")
     private String id;
 }

--- a/server/src/main/java/com/rocketmq/studio/cluster/k8s/K8sCertController.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/k8s/K8sCertController.java
@@ -17,6 +17,7 @@
 package com.rocketmq.studio.cluster.k8s;
 
 import com.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,22 +40,22 @@ public class K8sCertController {
     }
 
     @PostMapping("/create")
-    public Result<K8sCertVO> createCert(@RequestBody CreateCertDTO command) {
+    public Result<K8sCertVO> createCert(@Valid @RequestBody CreateCertDTO command) {
         return Result.ok(k8sCertService.createCert(command));
     }
 
     @PostMapping("/update")
-    public Result<K8sCertVO> updateCert(@RequestBody UpdateCertDTO command) {
+    public Result<K8sCertVO> updateCert(@Valid @RequestBody UpdateCertDTO command) {
         return Result.ok(k8sCertService.updateCert(command));
     }
 
     @PostMapping("/renew")
-    public Result<K8sCertVO> renewCert(@RequestBody RenewCertDTO command) {
+    public Result<K8sCertVO> renewCert(@Valid @RequestBody RenewCertDTO command) {
         return Result.ok(k8sCertService.renewCert(command));
     }
 
     @PostMapping("/delete")
-    public Result<Void> deleteCert(@RequestBody DeleteCertDTO command) {
+    public Result<Void> deleteCert(@Valid @RequestBody DeleteCertDTO command) {
         k8sCertService.deleteCert(command);
         return Result.ok();
     }

--- a/server/src/main/java/com/rocketmq/studio/cluster/k8s/RenewCertDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/k8s/RenewCertDTO.java
@@ -16,6 +16,7 @@
  */
 package com.rocketmq.studio.cluster.k8s;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,5 +27,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RenewCertDTO {
+    @NotBlank(message = "id is required")
     private String id;
 }

--- a/server/src/main/java/com/rocketmq/studio/cluster/k8s/UpdateCertDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/k8s/UpdateCertDTO.java
@@ -16,6 +16,8 @@
  */
 package com.rocketmq.studio.cluster.k8s;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,10 +30,12 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateCertDTO {
+    @NotBlank(message = "id is required")
     private String id;
     private String name;
     private String namespace;
     private String cluster;
+    @Pattern(regexp = "TLS|mTLS|ServiceAccount", message = "type must be one of TLS, mTLS, ServiceAccount")
     private String type;
     private String issuer;
     private List<String> san;

--- a/server/src/test/java/com/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -136,6 +137,89 @@ class K8sCertControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.id").value("cert-min"));
+    }
+
+    @Test
+    void createCertShouldRejectMissingName() throws Exception {
+        mockMvc.perform(post("/api/k8s-certs/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "namespace": "default",
+                                    "cluster": "test-cluster",
+                                    "type": "TLS",
+                                    "issuer": "vault"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("name is required"));
+
+        verifyNoInteractions(k8sCertService);
+    }
+
+    @Test
+    void createCertShouldRejectUnsupportedType() throws Exception {
+        mockMvc.perform(post("/api/k8s-certs/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "name": "new-cert",
+                                    "namespace": "default",
+                                    "cluster": "test-cluster",
+                                    "type": "PEM",
+                                    "issuer": "vault"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("type must be one of TLS, mTLS, ServiceAccount"));
+
+        verifyNoInteractions(k8sCertService);
+    }
+
+    @Test
+    void updateCertShouldRejectMissingId() throws Exception {
+        mockMvc.perform(post("/api/k8s-certs/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "name": "updated-cert"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(k8sCertService);
+    }
+
+    @Test
+    void renewCertShouldRejectBlankId() throws Exception {
+        mockMvc.perform(post("/api/k8s-certs/renew")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "id": " "
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(k8sCertService);
+    }
+
+    @Test
+    void deleteCertShouldRejectMissingId() throws Exception {
+        mockMvc.perform(post("/api/k8s-certs/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(k8sCertService);
     }
 
     private K8sCertVO buildCert(String id, String name, CertType type, CertStatus status) {


### PR DESCRIPTION
## Summary
- enable bean validation on K8s certificate create/update/renew/delete endpoints
- reject missing required certificate fields and unsupported certificate types before invoking service logic
- add controller tests for invalid certificate requests

## Scope
- RocketMQ Studio contest scope: Track 1 / BASE-01 HTTPS/SSL and ARCH-01 cluster operation hardening
- The `namespace` field is the existing Kubernetes certificate namespace field; this does not introduce RocketMQ Namespace behavior

## Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=K8sCertControllerTest,K8sCertServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test`
- `git diff --check`