### PR TITLE
[Studio] Validate data source requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/settings/DataSourceTestDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/settings/DataSourceTestDTO.java
@@ -16,6 +16,7 @@
  */
 package com.rocketmq.studio.settings;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,7 +27,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DataSourceTestDTO {
+    @NotBlank(message = "url is required")
     private String url;
+    @NotBlank(message = "type is required")
     private String type;
     private String auth;
 }

--- a/server/src/main/java/com/rocketmq/studio/settings/DataSourceVO.java
+++ b/server/src/main/java/com/rocketmq/studio/settings/DataSourceVO.java
@@ -16,6 +16,7 @@
  */
 package com.rocketmq.studio.settings;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,8 +28,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class DataSourceVO {
     private String key;
+    @NotBlank(message = "name is required")
     private String name;
+    @NotBlank(message = "type is required")
     private String type;
+    @NotBlank(message = "url is required")
     private String url;
     private String auth;
     private String status;

--- a/server/src/main/java/com/rocketmq/studio/settings/SettingsController.java
+++ b/server/src/main/java/com/rocketmq/studio/settings/SettingsController.java
@@ -52,12 +52,12 @@ public class SettingsController {
     }
 
     @PostMapping("/datasources/create")
-    public Result<DataSourceVO> createDataSource(@RequestBody DataSourceVO dataSource) {
+    public Result<DataSourceVO> createDataSource(@Valid @RequestBody DataSourceVO dataSource) {
         return Result.ok(settingsService.createDataSource(dataSource));
     }
 
     @PostMapping("/datasources/update")
-    public Result<DataSourceVO> updateDataSource(@RequestBody DataSourceVO dataSource) {
+    public Result<DataSourceVO> updateDataSource(@Valid @RequestBody DataSourceVO dataSource) {
         return Result.ok(settingsService.updateDataSource(dataSource));
     }
 
@@ -68,7 +68,7 @@ public class SettingsController {
     }
 
     @PostMapping("/datasources/test")
-    public Result<DataSourceTestResultVO> testDataSource(@RequestBody DataSourceTestDTO request) {
+    public Result<DataSourceTestResultVO> testDataSource(@Valid @RequestBody DataSourceTestDTO request) {
         return Result.ok(settingsService.testDataSource(request));
     }
 }

--- a/server/src/test/java/com/rocketmq/studio/settings/SettingsControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/settings/SettingsControllerTest.java
@@ -204,6 +204,23 @@ class SettingsControllerTest {
     }
 
     @Test
+    void createDataSourceShouldRejectMissingUrl() throws Exception {
+        mockMvc.perform(post("/api/settings/datasources/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "New DS",
+                                  "type": "prometheus"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", is(400)))
+                .andExpect(jsonPath("$.message", is("url is required")));
+
+        verifyNoInteractions(settingsService);
+    }
+
+    @Test
     void updateDataSourceShouldReturnUpdatedSource() throws Exception {
         DataSourceVO input = DataSourceVO.builder().key("ds-1").name("Updated DS").type("rocketmq")
                 .url("updated:9876").build();
@@ -216,6 +233,24 @@ class SettingsControllerTest {
                 .andExpect(jsonPath("$.code", is(200)))
                 .andExpect(jsonPath("$.data.key", is("ds-1")))
                 .andExpect(jsonPath("$.data.name", is("Updated DS")));
+    }
+
+    @Test
+    void updateDataSourceShouldRejectMissingName() throws Exception {
+        mockMvc.perform(post("/api/settings/datasources/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "key": "ds-1",
+                                  "type": "rocketmq",
+                                  "url": "updated:9876"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", is(400)))
+                .andExpect(jsonPath("$.message", is("name is required")));
+
+        verifyNoInteractions(settingsService);
     }
 
     @Test
@@ -249,5 +284,21 @@ class SettingsControllerTest {
                 .andExpect(jsonPath("$.code", is(200)))
                 .andExpect(jsonPath("$.data.success", is(true)))
                 .andExpect(jsonPath("$.data.message", is("Connection successful")));
+    }
+
+    @Test
+    void testDataSourceShouldRejectMissingType() throws Exception {
+        mockMvc.perform(post("/api/settings/datasources/test")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "url": "localhost:9876"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", is(400)))
+                .andExpect(jsonPath("$.message", is("type is required")));
+
+        verifyNoInteractions(settingsService);
     }
 }


### PR DESCRIPTION
## Summary
- enable bean validation on data source create/update/test endpoints
- require data source name, type, and url before invoking settings service logic
- add controller tests for invalid data source requests

## Scope
- RocketMQ Studio contest scope: Track 1 / METRICS-01 Prometheus and custom data source management hardening
- Keeps existing endpoint formats such as `host:port` valid; this does not add URL format restrictions

## Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=SettingsControllerTest,SettingsServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test`
- `git diff --check`