### PR TITLE
[Studio] Validate ops setting requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/ops/OpsController.java
+++ b/server/src/main/java/com/rocketmq/studio/ops/OpsController.java
@@ -18,6 +18,7 @@
 package com.rocketmq.studio.ops;
 
 import com.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,26 +39,26 @@ public class OpsController {
     }
 
     @PostMapping("/updateNameSvrAddr")
-    public Result<Void> updateNameSvrAddr(@RequestBody OpsNameServerDTO request) {
+    public Result<Void> updateNameSvrAddr(@Valid @RequestBody OpsNameServerDTO request) {
         opsService.updateNameServer(request.getNamesrvAddr());
         return Result.ok();
     }
 
     @PostMapping("/addNameSvrAddr")
-    public Result<Void> addNameSvrAddr(@RequestBody OpsNameServerDTO request) {
+    public Result<Void> addNameSvrAddr(@Valid @RequestBody OpsNameServerDTO request) {
         opsService.addNameServer(request.getNamesrvAddr());
         return Result.ok();
     }
 
     @PostMapping("/updateIsVIPChannel")
-    public Result<Void> updateIsVIPChannel(@RequestBody OpsVipChannelDTO request) {
-        opsService.updateVipChannel(request.isUseVIPChannel());
+    public Result<Void> updateIsVIPChannel(@Valid @RequestBody OpsVipChannelDTO request) {
+        opsService.updateVipChannel(request.getUseVIPChannel());
         return Result.ok();
     }
 
     @PostMapping("/updateUseTLS")
-    public Result<Void> updateUseTLS(@RequestBody OpsTlsDTO request) {
-        opsService.updateUseTLS(request.isUseTLS());
+    public Result<Void> updateUseTLS(@Valid @RequestBody OpsTlsDTO request) {
+        opsService.updateUseTLS(request.getUseTLS());
         return Result.ok();
     }
 }

--- a/server/src/main/java/com/rocketmq/studio/ops/OpsNameServerDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/ops/OpsNameServerDTO.java
@@ -17,9 +17,11 @@
 
 package com.rocketmq.studio.ops;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class OpsNameServerDTO {
+    @NotBlank(message = "namesrvAddr is required")
     private String namesrvAddr;
 }

--- a/server/src/main/java/com/rocketmq/studio/ops/OpsTlsDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/ops/OpsTlsDTO.java
@@ -17,9 +17,11 @@
 
 package com.rocketmq.studio.ops;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 public class OpsTlsDTO {
-    private boolean useTLS;
+    @NotNull(message = "useTLS is required")
+    private Boolean useTLS;
 }

--- a/server/src/main/java/com/rocketmq/studio/ops/OpsVipChannelDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/ops/OpsVipChannelDTO.java
@@ -17,9 +17,11 @@
 
 package com.rocketmq.studio.ops;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 public class OpsVipChannelDTO {
-    private boolean useVIPChannel;
+    @NotNull(message = "useVIPChannel is required")
+    private Boolean useVIPChannel;
 }

--- a/server/src/test/java/com/rocketmq/studio/ops/OpsControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/ops/OpsControllerTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -81,6 +82,18 @@ class OpsControllerTest {
     }
 
     @Test
+    void updateNameSvrAddrShouldRejectMissingAddress() throws Exception {
+        mockMvc.perform(post("/api/ops/updateNameSvrAddr")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("namesrvAddr is required"));
+
+        verifyNoInteractions(opsService);
+    }
+
+    @Test
     void addNameSvrAddrShouldDelegateToService() throws Exception {
         mockMvc.perform(post("/api/ops/addNameSvrAddr")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -88,6 +101,18 @@ class OpsControllerTest {
                 .andExpect(status().isOk());
 
         verify(opsService).addNameServer(eq("10.0.0.2:9876"));
+    }
+
+    @Test
+    void addNameSvrAddrShouldRejectBlankAddress() throws Exception {
+        mockMvc.perform(post("/api/ops/addNameSvrAddr")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("namesrvAddr", " "))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("namesrvAddr is required"));
+
+        verifyNoInteractions(opsService);
     }
 
     @Test
@@ -101,6 +126,18 @@ class OpsControllerTest {
     }
 
     @Test
+    void updateVipChannelShouldRejectMissingFlag() throws Exception {
+        mockMvc.perform(post("/api/ops/updateIsVIPChannel")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("useVIPChannel is required"));
+
+        verifyNoInteractions(opsService);
+    }
+
+    @Test
     void updateUseTlsShouldDelegateToService() throws Exception {
         mockMvc.perform(post("/api/ops/updateUseTLS")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -108,5 +145,17 @@ class OpsControllerTest {
                 .andExpect(status().isOk());
 
         verify(opsService).updateUseTLS(true);
+    }
+
+    @Test
+    void updateUseTlsShouldRejectMissingFlag() throws Exception {
+        mockMvc.perform(post("/api/ops/updateUseTLS")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("useTLS is required"));
+
+        verifyNoInteractions(opsService);
     }
 }


### PR DESCRIPTION
## Summary
- enable bean validation on NameServer, VIP channel, and TLS setting endpoints
- reject missing NameServer addresses and missing boolean flags before invoking ops service logic
- add controller tests for invalid ops setting requests

## Scope
- RocketMQ Studio contest scope: Track 1 / BASE-01 existing ops settings baseline
- Keeps existing valid request payloads and response contracts unchanged

## Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=OpsControllerTest,OpsServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test`
- `git diff --check`