### PR TITLE
[Studio] Validate LiteTopic TTL update requests

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/topic/LiteTopicController.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/topic/LiteTopicController.java
@@ -18,6 +18,7 @@
 package com.rocketmq.studio.instance.topic;
 
 import com.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -49,7 +50,7 @@ public class LiteTopicController {
     }
 
     @PostMapping("/extendTTL")
-    public Result<Void> extendTTL(@RequestBody LiteTopicTTLUpdateDTO request) {
+    public Result<Void> extendTTL(@Valid @RequestBody LiteTopicTTLUpdateDTO request) {
         liteTopicService.extendTTL(request.getTopicPattern(), request.getNewTTL());
         return Result.ok();
     }

--- a/server/src/main/java/com/rocketmq/studio/instance/topic/LiteTopicTTLUpdateDTO.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/topic/LiteTopicTTLUpdateDTO.java
@@ -17,10 +17,14 @@
 
 package com.rocketmq.studio.instance.topic;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.Data;
 
 @Data
 public class LiteTopicTTLUpdateDTO {
+    @NotBlank(message = "topicPattern is required")
     private String topicPattern;
+    @Positive(message = "newTTL must be positive")
     private Long newTTL;
 }

--- a/server/src/test/java/com/rocketmq/studio/instance/topic/LiteTopicControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/topic/LiteTopicControllerTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -123,5 +124,36 @@ class LiteTopicControllerTest {
                 .andExpect(jsonPath("$.code").value(200));
 
         verify(liteTopicService).extendTTL(eq("chat/{sessionId}"), eq(7_200_000L));
+    }
+
+    @Test
+    void extendTTLShouldRejectMissingTopicPattern() throws Exception {
+        LiteTopicTTLUpdateDTO request = new LiteTopicTTLUpdateDTO();
+        request.setNewTTL(7_200_000L);
+
+        mockMvc.perform(post("/api/liteTopic/extendTTL")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("topicPattern is required"));
+
+        verifyNoInteractions(liteTopicService);
+    }
+
+    @Test
+    void extendTTLShouldRejectNonPositiveTTL() throws Exception {
+        LiteTopicTTLUpdateDTO request = new LiteTopicTTLUpdateDTO();
+        request.setTopicPattern("chat/{sessionId}");
+        request.setNewTTL(0L);
+
+        mockMvc.perform(post("/api/liteTopic/extendTTL")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("newTTL must be positive"));
+
+        verifyNoInteractions(liteTopicService);
     }
 }


### PR DESCRIPTION
## Summary
- enable bean validation on LiteTopic TTL update requests
- require a topic pattern and positive TTL before invoking service logic
- add controller tests for missing topic pattern and non-positive TTL

## Scope
- RocketMQ Studio contest scope: Track 1 / META-01 LiteTopic management
- Does not introduce RocketMQ Namespace behavior

## Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=LiteTopicControllerTest,LiteTopicServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test`
- `git diff --check`