### PR TITLE
[Studio] Handle missing request parameters

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/rocketmq/studio/common/exception/GlobalExceptionHandler.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -62,6 +63,13 @@ public class GlobalExceptionHandler {
     public Result<?> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
         log.warn("Invalid request body");
         return Result.error(HttpStatus.BAD_REQUEST.value(), "Invalid request body");
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Result<?> handleMissingServletRequestParameterException(MissingServletRequestParameterException ex) {
+        String message = ex.getParameterName() + " is required";
+        return Result.error(HttpStatus.BAD_REQUEST.value(), message);
     }
 
     @ExceptionHandler(Exception.class)

--- a/server/src/test/java/com/rocketmq/studio/common/exception/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/common/exception/GlobalExceptionHandlerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -56,12 +57,25 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.message").value("failure-400"));
     }
 
+    @Test
+    void returnsBadRequestWhenRequiredRequestParamIsMissing() throws Exception {
+        mockMvc.perform(get("/test/required-param"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("key is required"));
+    }
+
     @RestController
     static class FailingController {
 
         @GetMapping("/test/business/{code}")
         Result<Void> fail(@PathVariable int code) {
             throw new BusinessException(code, "failure-" + code);
+        }
+
+        @GetMapping("/test/required-param")
+        Result<String> requiredParam(@RequestParam String key) {
+            return Result.ok(key);
         }
     }
 }


### PR DESCRIPTION
## Summary
- return structured 400 responses when required request parameters are missing
- cover the missing `@RequestParam` path in `GlobalExceptionHandlerTest`

## Validation
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=GlobalExceptionHandlerTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test` (292 tests, 0 failures, 0 errors)
- `git diff --check`