### PR TITLE
[Studio] Trim producer connection filters

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/cluster/client/ProducerConnectionService.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/client/ProducerConnectionService.java
@@ -32,8 +32,10 @@ public class ProducerConnectionService {
 
     public List<ProducerConnectionVO> listConnections(String topic, String producerGroup) {
         log.info("Listing producer connections, topic={}, producerGroup={}", topic, producerGroup);
+        String normalizedTopic = normalizeFilter(topic);
+        String normalizedProducerGroup = normalizeFilter(producerGroup);
         return clientService.listConnections(null, ClientType.Producer.name()).stream()
-                .filter(connection -> matchesFilter(connection, topic, producerGroup))
+                .filter(connection -> matchesFilter(connection, normalizedTopic, normalizedProducerGroup))
                 .map(this::toProducerConnection)
                 .toList();
     }
@@ -59,5 +61,9 @@ public class ProducerConnectionService {
 
     private boolean hasText(String value) {
         return value != null && !value.trim().isEmpty();
+    }
+
+    private String normalizeFilter(String value) {
+        return hasText(value) ? value.trim() : null;
     }
 }

--- a/server/src/test/java/com/rocketmq/studio/cluster/client/ProducerConnectionServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/cluster/client/ProducerConnectionServiceTest.java
@@ -92,6 +92,25 @@ class ProducerConnectionServiceTest {
     }
 
     @Test
+    void listConnectionsShouldTrimFilterValues() {
+        ClientConnectionVO producer = ClientConnectionVO.builder()
+                .clientId("producer-1")
+                .type(ClientType.Producer)
+                .groupOrTopic("order-topic")
+                .producerGroup("pg-order")
+                .address("10.0.0.1:38888")
+                .language(ClientLanguage.Java)
+                .version("5.1.0")
+                .build();
+        when(clientService.listConnections(null, ClientType.Producer.name())).thenReturn(List.of(producer));
+
+        List<ProducerConnectionVO> result = producerConnectionService.listConnections(" order-topic ", " pg-order ");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getClientId()).isEqualTo("producer-1");
+    }
+
+    @Test
     void listConnectionsShouldRequireProducerGroupWhenBothFiltersAreProvided() {
         ClientConnectionVO producer = ClientConnectionVO.builder()
                 .clientId("producer-1")


### PR DESCRIPTION
## Summary
- normalize producer connection topic/group filters before matching
- add a regression test for whitespace-padded filter values

## Validation
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=ProducerConnectionServiceTest,ProducerControllerTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test` (292 tests, 0 failures, 0 errors)
- `git diff --check`