### PR TITLE
[Studio] Validate Prometheus source queries

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/cluster/metrics/PrometheusMetricsSource.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/metrics/PrometheusMetricsSource.java
@@ -108,9 +108,21 @@ public class PrometheusMetricsSource implements MetricsSource {
         if (query == null) {
             throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query is required");
         }
+        if (!StringUtils.hasText(query.getMetric())) {
+            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query is required");
+        }
+        if (query.getStart() <= 0) {
+            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query start must be positive");
+        }
+        if (query.getEnd() <= 0) {
+            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query end must be positive");
+        }
         if (query.getEnd() < query.getStart()) {
             throw new PrometheusException(HttpStatus.BAD_REQUEST.value(),
                     "Metric query end must not be earlier than start");
+        }
+        if (!StringUtils.hasText(query.getStep())) {
+            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query step is required");
         }
     }
 

--- a/server/src/test/java/com/rocketmq/studio/cluster/metrics/PrometheusMetricsSourceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/cluster/metrics/PrometheusMetricsSourceTest.java
@@ -245,6 +245,70 @@ class PrometheusMetricsSourceTest {
     }
 
     @Test
+    void queryShouldRejectBlankMetric() {
+        MetricQueryDTO invalidQuery = MetricQueryDTO.builder()
+                .metric(" ")
+                .start(1L)
+                .end(2L)
+                .step("30s")
+                .build();
+
+        assertThatThrownBy(() -> source(Duration.ofSeconds(2)).query(invalidQuery))
+                .isInstanceOf(PrometheusException.class)
+                .satisfies(exception -> assertThat(((PrometheusException) exception).getStatusCode())
+                        .isEqualTo(HttpStatus.BAD_REQUEST.value()))
+                .hasMessage("Metric query is required");
+    }
+
+    @Test
+    void queryShouldRejectNonPositiveStart() {
+        MetricQueryDTO invalidQuery = MetricQueryDTO.builder()
+                .metric("up")
+                .start(0L)
+                .end(2L)
+                .step("30s")
+                .build();
+
+        assertThatThrownBy(() -> source(Duration.ofSeconds(2)).query(invalidQuery))
+                .isInstanceOf(PrometheusException.class)
+                .satisfies(exception -> assertThat(((PrometheusException) exception).getStatusCode())
+                        .isEqualTo(HttpStatus.BAD_REQUEST.value()))
+                .hasMessage("Metric query start must be positive");
+    }
+
+    @Test
+    void queryShouldRejectNonPositiveEnd() {
+        MetricQueryDTO invalidQuery = MetricQueryDTO.builder()
+                .metric("up")
+                .start(1L)
+                .end(0L)
+                .step("30s")
+                .build();
+
+        assertThatThrownBy(() -> source(Duration.ofSeconds(2)).query(invalidQuery))
+                .isInstanceOf(PrometheusException.class)
+                .satisfies(exception -> assertThat(((PrometheusException) exception).getStatusCode())
+                        .isEqualTo(HttpStatus.BAD_REQUEST.value()))
+                .hasMessage("Metric query end must be positive");
+    }
+
+    @Test
+    void queryShouldRejectBlankStep() {
+        MetricQueryDTO invalidQuery = MetricQueryDTO.builder()
+                .metric("up")
+                .start(1L)
+                .end(2L)
+                .step(" ")
+                .build();
+
+        assertThatThrownBy(() -> source(Duration.ofSeconds(2)).query(invalidQuery))
+                .isInstanceOf(PrometheusException.class)
+                .satisfies(exception -> assertThat(((PrometheusException) exception).getStatusCode())
+                        .isEqualTo(HttpStatus.BAD_REQUEST.value()))
+                .hasMessage("Metric query step is required");
+    }
+
+    @Test
     void queryShouldFailLoudWhenPrometheusIsNotConfigured() {
         PrometheusProperties properties = new PrometheusProperties();
         PrometheusMetricsSource source = new PrometheusMetricsSource(


### PR DESCRIPTION
## Summary
- reject blank PromQL and step values in the Prometheus metrics source
- reject non-positive query start/end values before calling Prometheus
- add source-level regression coverage for invalid metric query input

## Validation
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=PrometheusMetricsSourceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test` (295 tests, 0 failures, 0 errors)
- `git diff --check`