### PR TITLE
[Studio] Trim instance search filters

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/InstanceService.java
@@ -36,13 +36,14 @@ public class InstanceService {
 
     public List<InstanceVO> listInstances(InstanceType type, String search) {
         log.debug("Listing instances, type={}, search={}", type, search);
+        String normalizedSearch = search == null || search.isBlank() ? null : search.trim();
 
-        if (type != null && search != null && !search.isBlank()) {
-            return instanceRepository.findByTypeAndSearch(type, search);
+        if (type != null && normalizedSearch != null) {
+            return instanceRepository.findByTypeAndSearch(type, normalizedSearch);
         } else if (type != null) {
             return instanceRepository.findByType(type);
-        } else if (search != null && !search.isBlank()) {
-            return instanceRepository.search(search);
+        } else if (normalizedSearch != null) {
+            return instanceRepository.search(normalizedSearch);
         }
         return instanceRepository.findAll();
     }

--- a/server/src/test/java/com/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/InstanceServiceTest.java
@@ -84,6 +84,19 @@ class InstanceServiceTest {
     }
 
     @Test
+    void listInstancesShouldTrimSearchKeyword() {
+        List<InstanceVO> instances = List.of(
+                InstanceVO.builder().name("production").build()
+        );
+        when(instanceRepository.search("prod")).thenReturn(instances);
+
+        List<InstanceVO> result = instanceService.listInstances(null, " prod ");
+
+        assertThat(result).hasSize(1);
+        verify(instanceRepository).search("prod");
+    }
+
+    @Test
     void listInstancesShouldFilterByTypeAndSearch() {
         List<InstanceVO> instances = List.of(
                 InstanceVO.builder().name("production-proxy").type(InstanceType.PROXY).build()
@@ -91,6 +104,19 @@ class InstanceServiceTest {
         when(instanceRepository.findByTypeAndSearch(InstanceType.PROXY, "prod")).thenReturn(instances);
 
         List<InstanceVO> result = instanceService.listInstances(InstanceType.PROXY, "prod");
+
+        assertThat(result).hasSize(1);
+        verify(instanceRepository).findByTypeAndSearch(InstanceType.PROXY, "prod");
+    }
+
+    @Test
+    void listInstancesShouldTrimSearchKeywordWhenFilteringByType() {
+        List<InstanceVO> instances = List.of(
+                InstanceVO.builder().name("production-proxy").type(InstanceType.PROXY).build()
+        );
+        when(instanceRepository.findByTypeAndSearch(InstanceType.PROXY, "prod")).thenReturn(instances);
+
+        List<InstanceVO> result = instanceService.listInstances(InstanceType.PROXY, " prod ");
 
         assertThat(result).hasSize(1);
         verify(instanceRepository).findByTypeAndSearch(InstanceType.PROXY, "prod");


### PR DESCRIPTION
## Summary
- normalize instance search text before dispatching repository queries
- keep blank searches on the existing list-all path
- cover search-only and type+search filter trimming in service tests

## Validation
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=InstanceServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test` (293 tests, 0 failures, 0 errors)
- `git diff --check`