### PR TITLE
[Studio] Validate ACL create inputs

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/acl/AclService.java
@@ -41,6 +41,12 @@ public class AclService {
 
     public AclRuleVO createRule(AclRuleVO rule) {
         log.info("Creating ACL rule for principal={}", rule.getPrincipal());
+        if (isBlank(rule.getPrincipal())) {
+            throw new BusinessException(400, "ACL principal is required");
+        }
+        if (isBlank(rule.getResource())) {
+            throw new BusinessException(400, "ACL resource is required");
+        }
         rule.setId(UUID.randomUUID().toString());
         rule.setCreatedAt(LocalDateTime.now());
         return aclRepository.saveRule(rule);
@@ -71,6 +77,9 @@ public class AclService {
 
     public AclUserVO createUser(AclUserVO user) {
         log.info("Creating ACL user username={}", user.getUsername());
+        if (isBlank(user.getUsername())) {
+            throw new BusinessException(400, "ACL username is required");
+        }
         user.setId(UUID.randomUUID().toString());
         user.setAccessKey(UUID.randomUUID().toString().replace("-", ""));
         user.setSecretKey(UUID.randomUUID().toString().replace("-", ""));

--- a/server/src/test/java/com/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -17,6 +17,7 @@
 
 package com.rocketmq.studio.instance.acl;
 
+import com.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -28,6 +29,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -83,6 +85,34 @@ class AclServiceTest {
         assertThat(result.getPrincipal()).isEqualTo("user1");
         assertThat(result.getResource()).isEqualTo("topic-1");
         verify(aclRepository).saveRule(any(AclRuleVO.class));
+    }
+
+    @Test
+    void createRuleShouldRequirePrincipal() {
+        AclRuleVO input = AclRuleVO.builder()
+                .principal(" ")
+                .resource("topic-1")
+                .build();
+
+        assertThatThrownBy(() -> aclService.createRule(input))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400))
+                .hasMessage("ACL principal is required");
+        verify(aclRepository, never()).saveRule(any(AclRuleVO.class));
+    }
+
+    @Test
+    void createRuleShouldRequireResource() {
+        AclRuleVO input = AclRuleVO.builder()
+                .principal("user1")
+                .resource(" ")
+                .build();
+
+        assertThatThrownBy(() -> aclService.createRule(input))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400))
+                .hasMessage("ACL resource is required");
+        verify(aclRepository, never()).saveRule(any(AclRuleVO.class));
     }
 
     @Test
@@ -156,6 +186,20 @@ class AclServiceTest {
         assertThat(result.getCreatedAt()).isNotNull();
         assertThat(result.getUsername()).isEqualTo("newuser");
         verify(aclRepository).saveUser(any(AclUserVO.class));
+    }
+
+    @Test
+    void createUserShouldRequireUsername() {
+        AclUserVO input = AclUserVO.builder()
+                .username(" ")
+                .admin(false)
+                .build();
+
+        assertThatThrownBy(() -> aclService.createUser(input))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400))
+                .hasMessage("ACL username is required");
+        verify(aclRepository, never()).saveUser(any(AclUserVO.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- reject ACL rule creation when principal or resource is blank
- reject ACL user creation when username is blank
- cover invalid create inputs and verify they are not persisted

## Validation
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=AclServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test` (294 tests, 0 failures, 0 errors)
- `git diff --check`