### PR TITLE
[Studio] Normalize client connection filters

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/cluster/client/ClientService.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/client/ClientService.java
@@ -31,6 +31,10 @@ public class ClientService {
 
     public List<ClientConnectionVO> listConnections(String clusterId, String type) {
         log.info("Listing client connections, clusterId={}, type={}", clusterId, type);
-        return clientProvider.findConnections(clusterId, type);
+        return clientProvider.findConnections(normalizeFilter(clusterId), normalizeFilter(type));
+    }
+
+    private String normalizeFilter(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
     }
 }

--- a/server/src/test/java/com/rocketmq/studio/cluster/client/ClientServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/cluster/client/ClientServiceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.client;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClientServiceTest {
+
+    @Mock
+    private ClientProvider clientProvider;
+
+    @InjectMocks
+    private ClientService clientService;
+
+    @Test
+    void listConnectionsShouldTrimFiltersBeforeQueryingProvider() {
+        ClientConnectionVO connection = ClientConnectionVO.builder()
+                .clientId("client-1")
+                .clusterName("production-cluster")
+                .build();
+        when(clientProvider.findConnections("production-cluster", "Producer")).thenReturn(List.of(connection));
+
+        List<ClientConnectionVO> result = clientService.listConnections(" production-cluster ", " Producer ");
+
+        assertThat(result).containsExactly(connection);
+        verify(clientProvider).findConnections("production-cluster", "Producer");
+    }
+
+    @Test
+    void listConnectionsShouldTreatBlankFiltersAsUnspecified() {
+        when(clientProvider.findConnections(null, null)).thenReturn(List.of());
+
+        List<ClientConnectionVO> result = clientService.listConnections(" ", "\t");
+
+        assertThat(result).isEmpty();
+        verify(clientProvider).findConnections(null, null);
+    }
+}


### PR DESCRIPTION
## Summary
- trim client connection cluster/type filters before querying providers
- treat blank filters as unspecified so the client list is not accidentally filtered out
- add ClientService coverage without touching the controller contract PR

## Validation
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=ClientServiceTest,ClientControllerTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test` (293 tests, 0 failures, 0 errors)
- `git diff --check`