### PR TITLE
[Studio] Normalize consumer diagnostics inputs

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/group/ConsumerDiagnosticsService.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/group/ConsumerDiagnosticsService.java
@@ -30,12 +30,15 @@ public class ConsumerDiagnosticsService {
     private final ConsumerDiagnosticsProvider diagnosticsProvider;
 
     public ConsumerStackTraceVO getConsumerStack(String groupName, String clientId) {
-        if (!StringUtils.hasText(groupName)) {
-            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), "groupName is required");
+        String normalizedGroupName = normalizeRequired(groupName, "groupName");
+        String normalizedClientId = normalizeRequired(clientId, "clientId");
+        return diagnosticsProvider.getConsumerStack(normalizedGroupName, normalizedClientId);
+    }
+
+    private String normalizeRequired(String value, String fieldName) {
+        if (!StringUtils.hasText(value)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), fieldName + " is required");
         }
-        if (!StringUtils.hasText(clientId)) {
-            throw new BusinessException(HttpStatus.BAD_REQUEST.value(), "clientId is required");
-        }
-        return diagnosticsProvider.getConsumerStack(groupName, clientId);
+        return value.trim();
     }
 }

--- a/server/src/test/java/com/rocketmq/studio/instance/group/ConsumerDiagnosticsServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/group/ConsumerDiagnosticsServiceTest.java
@@ -61,6 +61,24 @@ class ConsumerDiagnosticsServiceTest {
     }
 
     @Test
+    void getConsumerStackShouldTrimInputsBeforeDelegatingToProvider() {
+        ConsumerStackTraceVO stackTrace = ConsumerStackTraceVO.builder()
+                .groupName("cg-orders")
+                .clientId("client-1")
+                .capturedAt(LocalDateTime.now())
+                .threadCount(0)
+                .threads(List.of())
+                .build();
+        when(diagnosticsProvider.getConsumerStack("cg-orders", "client-1")).thenReturn(stackTrace);
+
+        ConsumerStackTraceVO result = diagnosticsService.getConsumerStack(" cg-orders ", " client-1 ");
+
+        assertThat(result.getGroupName()).isEqualTo("cg-orders");
+        assertThat(result.getClientId()).isEqualTo("client-1");
+        verify(diagnosticsProvider).getConsumerStack("cg-orders", "client-1");
+    }
+
+    @Test
     void getConsumerStackShouldRejectBlankGroupName() {
         assertThatThrownBy(() -> diagnosticsService.getConsumerStack(" ", "client-1"))
                 .isInstanceOf(BusinessException.class)


### PR DESCRIPTION
## Summary
- trim consumer diagnostics group/client identifiers before querying the provider
- keep the existing required-field errors for blank inputs
- cover the normalized provider call in service tests

## Validation
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=ConsumerDiagnosticsServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test` (294 tests, 0 failures, 0 errors)
- `git diff --check`