### PR TITLE
[Studio] Normalize metadata list filters

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/topic/MetadataService.java
@@ -38,7 +38,10 @@ public class MetadataService {
 
 
     public List<TopicVO> listTopics(String clusterId, String type, String search) {
-        return metadataProvider.listTopics(clusterId, type, search);
+        return metadataProvider.listTopics(
+                normalizeFilter(clusterId),
+                normalizeFilter(type),
+                normalizeFilter(search));
     }
 
 
@@ -75,7 +78,7 @@ public class MetadataService {
 
 
     public List<ConsumerGroupVO> listConsumerGroups(String clusterId, String search) {
-        return metadataProvider.listConsumerGroups(clusterId, search);
+        return metadataProvider.listConsumerGroups(normalizeFilter(clusterId), normalizeFilter(search));
     }
 
 
@@ -113,5 +116,9 @@ public class MetadataService {
 
     public List<NamespaceVO> listNamespaces() {
         throw new UnsupportedOperationException("Not implemented");
+    }
+
+    private String normalizeFilter(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
     }
 }

--- a/server/src/test/java/com/rocketmq/studio/instance/topic/MetadataServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/topic/MetadataServiceTest.java
@@ -69,6 +69,28 @@ class MetadataServiceTest {
     }
 
     @Test
+    void listTopicsShouldNormalizeFiltersBeforeQueryingProvider() {
+        TopicVO topic = new TopicVO();
+        topic.setName("order-topic");
+        when(metadataProvider.listTopics("cluster-1", "FIFO", "order")).thenReturn(List.of(topic));
+
+        List<TopicVO> result = metadataService.listTopics(" cluster-1 ", " FIFO ", " order ");
+
+        assertThat(result).containsExactly(topic);
+        verify(metadataProvider).listTopics("cluster-1", "FIFO", "order");
+    }
+
+    @Test
+    void listTopicsShouldTreatBlankFiltersAsUnspecified() {
+        when(metadataProvider.listTopics(null, null, null)).thenReturn(List.of());
+
+        List<TopicVO> result = metadataService.listTopics(" ", "\t", "");
+
+        assertThat(result).isEmpty();
+        verify(metadataProvider).listTopics(null, null, null);
+    }
+
+    @Test
     void createTopicShouldDelegateToAdminClient() {
         TopicVO input = new TopicVO();
         input.setName("new-topic");
@@ -140,5 +162,17 @@ class MetadataServiceTest {
 
         assertThat(result).isEmpty();
         verify(metadataProvider).listConsumerGroups(null, "order");
+    }
+
+    @Test
+    void listConsumerGroupsShouldNormalizeFiltersBeforeQueryingProvider() {
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName("cg-order");
+        when(metadataProvider.listConsumerGroups("cluster-1", "order")).thenReturn(List.of(group));
+
+        List<ConsumerGroupVO> result = metadataService.listConsumerGroups(" cluster-1 ", " order ");
+
+        assertThat(result).containsExactly(group);
+        verify(metadataProvider).listConsumerGroups("cluster-1", "order");
     }
 }


### PR DESCRIPTION
## Summary
- trim Topic and ConsumerGroup list filters before querying the metadata provider
- treat blank filters as unspecified so list views are not accidentally filtered
- add MetadataService coverage for Topic and ConsumerGroup filter normalization

## Validation
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=MetadataServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q test` (296 tests, 0 failures, 0 errors)
- `git diff --check`