### PR TITLE
[Studio] fix: validate alert rule updates

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
@@ -24,6 +24,8 @@ public interface AlertRepository {
 
     AlertRuleVO saveRule(AlertRuleVO rule);
 
+    boolean replaceRule(AlertRuleVO rule);
+
     void deleteRule(String id);
 
     List<SystemAlertVO> findAlerts(String level);

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -72,8 +73,13 @@ public class AlertService {
 
 
     public AlertRuleVO updateRule(AlertRuleVO rule) {
-        log.info("Updating alert rule: {}", rule.getId());
-        return alertRepository.saveRule(rule);
+        String id = rule == null ? null : rule.getId();
+        log.info("Updating alert rule: {}", id);
+        validateRuleId(id);
+        if (!alertRepository.replaceRule(rule)) {
+            throw ruleNotFound(id);
+        }
+        return rule;
     }
 
 
@@ -244,5 +250,15 @@ public class AlertService {
 
     private record PrometheusAlertRule(String group, String alert, String expr, String duration,
                                        String severity, String team, String summary, String description) {
+    }
+
+    private void validateRuleId(String id) {
+        if (id == null || id.isBlank()) {
+            throw new BusinessException(400, "Alert rule ID is required");
+        }
+    }
+
+    private BusinessException ruleNotFound(String id) {
+        return new BusinessException(404, "Alert rule not found: " + id);
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/InMemoryAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/InMemoryAlertRepository.java
@@ -45,6 +45,13 @@ public class InMemoryAlertRepository implements AlertRepository {
     }
 
     @Override
+    public boolean replaceRule(AlertRuleVO rule) {
+        boolean replaced = rules.replace(rule.getId(), rule) != null;
+        log.debug("Replaced alert rule id={}, replaced={}", rule.getId(), replaced);
+        return replaced;
+    }
+
+    @Override
     public void deleteRule(String id) {
         rules.remove(id);
         log.debug("Deleted alert rule id={}", id);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -131,6 +132,53 @@ class AlertServiceTest {
         AlertRuleVO result2 = alertService.createRule(input2);
 
         assertThat(result1.getId()).isNotEqualTo(result2.getId());
+    }
+
+    @Test
+    void updateRuleShouldUpdateExistingRule() {
+        AlertRuleVO update = AlertRuleVO.builder().id("rule-1").name("CPU Alert").threshold(90.0).build();
+        when(alertRepository.replaceRule(update)).thenReturn(true);
+
+        AlertRuleVO result = alertService.updateRule(update);
+
+        assertThat(result.getId()).isEqualTo("rule-1");
+        assertThat(result.getThreshold()).isEqualTo(90.0);
+        verify(alertRepository).replaceRule(update);
+    }
+
+    @Test
+    void updateRuleShouldRejectNullId() {
+        AlertRuleVO update = AlertRuleVO.builder().name("CPU Alert").build();
+
+        assertThatThrownBy(() -> alertService.updateRule(update))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule ID is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        verify(alertRepository, never()).replaceRule(any());
+    }
+
+    @Test
+    void updateRuleShouldRejectBlankId() {
+        AlertRuleVO update = AlertRuleVO.builder().id("  ").name("CPU Alert").build();
+
+        assertThatThrownBy(() -> alertService.updateRule(update))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule ID is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        verify(alertRepository, never()).replaceRule(any());
+    }
+
+    @Test
+    void updateRuleShouldRejectUnknownId() {
+        AlertRuleVO update = AlertRuleVO.builder().id("missing").name("CPU Alert").build();
+        when(alertRepository.replaceRule(update)).thenReturn(false);
+
+        assertThatThrownBy(() -> alertService.updateRule(update))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule not found: missing")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
+        verify(alertRepository).replaceRule(update);
+        verify(alertRepository, never()).saveRule(any());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/InMemoryAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/InMemoryAlertRepositoryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryAlertRepositoryTest {
+
+    private final InMemoryAlertRepository repository = new InMemoryAlertRepository();
+
+    @Test
+    void replaceRuleShouldUpdateExistingRule() {
+        AlertRuleVO existing = AlertRuleVO.builder()
+                .id("rule-1")
+                .name("Original rule")
+                .build();
+        AlertRuleVO replacement = AlertRuleVO.builder()
+                .id("rule-1")
+                .name("Updated rule")
+                .build();
+        repository.saveRule(existing);
+
+        boolean replaced = repository.replaceRule(replacement);
+
+        assertThat(replaced).isTrue();
+        assertThat(repository.findAllRules()).containsExactly(replacement);
+    }
+
+    @Test
+    void replaceRuleShouldNotInsertUnknownRule() {
+        AlertRuleVO replacement = AlertRuleVO.builder()
+                .id("missing")
+                .name("Missing rule")
+                .build();
+
+        boolean replaced = repository.replaceRule(replacement);
+
+        assertThat(replaced).isFalse();
+        assertThat(repository.findAllRules()).isEmpty();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes #574 .

Prevent `/api/alert-rules/update` from returning an internal server error for missing IDs or creating new rules for blank and unknown IDs.

This complements #549, which validates alert rule toggle and delete request bodies; this change covers update semantics.

## Brief changelog

- Reject null and blank alert rule IDs with HTTP 400.
- Reject unknown alert rule IDs with HTTP 404.
- Atomically replace existing rules so update cannot create a missing rule.
- Add service and repository regression tests.