### PR TITLE
[Studio] fix: make K8s certificate updates atomic

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
@@ -69,49 +69,51 @@ public class K8sCertService {
 
     public K8sCertVO updateCert(UpdateCertDTO command) {
         log.info("Updating K8s certificate: {}", command.getId());
-        K8sCertVO cert = k8sCertRepository.findById(command.getId())
+        K8sCertVO existing = k8sCertRepository.findById(command.getId())
                 .orElseThrow(() -> new BusinessException(404, "Certificate not found: " + command.getId()));
 
+        K8sCertVO updated = copyOf(existing);
         if (command.getName() != null) {
-            cert.setName(command.getName());
+            updated.setName(command.getName());
         }
         if (command.getNamespace() != null) {
-            cert.setNamespace(command.getNamespace());
+            updated.setNamespace(command.getNamespace());
         }
         if (command.getCluster() != null) {
-            cert.setCluster(command.getCluster());
+            updated.setCluster(command.getCluster());
         }
         if (command.getType() != null) {
-            cert.setType(CertType.valueOf(command.getType()));
+            updated.setType(CertType.valueOf(command.getType()));
         }
         if (command.getIssuer() != null) {
-            cert.setIssuer(command.getIssuer());
+            updated.setIssuer(command.getIssuer());
         }
         if (command.getSan() != null) {
-            cert.setSan(command.getSan());
+            updated.setSan(command.getSan());
         }
-        cert.setUpdatedAt(LocalDateTime.now());
+        updated.setUpdatedAt(LocalDateTime.now());
 
-        K8sCertVO saved = k8sCertRepository.save(cert);
+        K8sCertVO saved = k8sCertRepository.save(updated);
         log.info("K8s certificate updated: {} (id={})", saved.getName(), saved.getId());
         return saved;
     }
 
     public K8sCertVO renewCert(RenewCertDTO command) {
         log.info("Renewing K8s certificate: {}", command.getId());
-        K8sCertVO cert = k8sCertRepository.findById(command.getId())
+        K8sCertVO existing = k8sCertRepository.findById(command.getId())
                 .orElseThrow(() -> new BusinessException(404, "Certificate not found: " + command.getId()));
 
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime notAfter = now.plusYears(1);
 
-        cert.setNotBefore(now);
-        cert.setNotAfter(notAfter);
-        cert.setStatus(CertStatus.valid);
-        cert.setDaysRemaining((int) ChronoUnit.DAYS.between(now, notAfter));
-        cert.setUpdatedAt(now);
+        K8sCertVO renewed = copyOf(existing);
+        renewed.setNotBefore(now);
+        renewed.setNotAfter(notAfter);
+        renewed.setStatus(CertStatus.valid);
+        renewed.setDaysRemaining((int) ChronoUnit.DAYS.between(now, notAfter));
+        renewed.setUpdatedAt(now);
 
-        K8sCertVO saved = k8sCertRepository.save(cert);
+        K8sCertVO saved = k8sCertRepository.save(renewed);
         log.info("K8s certificate renewed: {} (id={}), new expiry: {}", saved.getName(), saved.getId(), notAfter);
         return saved;
     }
@@ -122,5 +124,24 @@ public class K8sCertService {
                 .orElseThrow(() -> new BusinessException(404, "Certificate not found: " + command.getId()));
         k8sCertRepository.deleteById(command.getId());
         log.info("K8s certificate deleted: {}", command.getId());
+    }
+
+    private K8sCertVO copyOf(K8sCertVO cert) {
+        K8sCertVO copy = K8sCertVO.builder()
+                .name(cert.getName())
+                .namespace(cert.getNamespace())
+                .cluster(cert.getCluster())
+                .type(cert.getType())
+                .issuer(cert.getIssuer())
+                .notBefore(cert.getNotBefore())
+                .notAfter(cert.getNotAfter())
+                .status(cert.getStatus())
+                .daysRemaining(cert.getDaysRemaining())
+                .san(cert.getSan())
+                .build();
+        copy.setId(cert.getId());
+        copy.setCreatedAt(cert.getCreatedAt());
+        copy.setUpdatedAt(cert.getUpdatedAt());
+        return copy;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
@@ -65,6 +65,8 @@ class K8sCertServiceTest {
                 .san(Arrays.asList("rocketmq.example.com", "*.rocketmq.example.com"))
                 .build();
         sampleCert.setId("cert-1");
+        sampleCert.setCreatedAt(LocalDateTime.of(2024, 12, 1, 0, 0));
+        sampleCert.setUpdatedAt(LocalDateTime.of(2025, 1, 2, 0, 0));
     }
 
     @Test
@@ -175,7 +177,13 @@ class K8sCertServiceTest {
         assertThat(result.getType()).isEqualTo(CertType.mTLS);
         assertThat(result.getIssuer()).isEqualTo("new-issuer");
         assertThat(result.getSan()).containsExactly("new.example.com");
-        assertThat(result.getUpdatedAt()).isNotNull();
+        assertThat(result.getId()).isEqualTo("cert-1");
+        assertThat(result.getCreatedAt()).isEqualTo(LocalDateTime.of(2024, 12, 1, 0, 0));
+        assertThat(result.getUpdatedAt()).isAfter(sampleCert.getUpdatedAt());
+        assertThat(result).isNotSameAs(sampleCert);
+        assertThat(sampleCert.getName()).isEqualTo("rocketmq-tls");
+        assertThat(sampleCert.getType()).isEqualTo(CertType.TLS);
+        assertThat(sampleCert.getUpdatedAt()).isEqualTo(LocalDateTime.of(2025, 1, 2, 0, 0));
         verify(k8sCertRepository).save(any(K8sCertVO.class));
     }
 
@@ -214,9 +222,30 @@ class K8sCertServiceTest {
     }
 
     @Test
+    void updateCertShouldNotMutateStoredCertWhenSaveFails() {
+        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.save(any(K8sCertVO.class))).thenThrow(new IllegalStateException("save failed"));
+        UpdateCertDTO command = UpdateCertDTO.builder()
+                .id("cert-1")
+                .name("should-not-persist")
+                .type("mTLS")
+                .build();
+
+        assertThatThrownBy(() -> k8sCertService.updateCert(command))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("save failed");
+
+        assertThat(sampleCert.getName()).isEqualTo("rocketmq-tls");
+        assertThat(sampleCert.getType()).isEqualTo(CertType.TLS);
+        assertThat(sampleCert.getUpdatedAt()).isEqualTo(LocalDateTime.of(2025, 1, 2, 0, 0));
+    }
+
+    @Test
     void renewCertShouldRenewCertValidity() {
         sampleCert.setStatus(CertStatus.expired);
         sampleCert.setDaysRemaining(0);
+        LocalDateTime originalNotBefore = sampleCert.getNotBefore();
+        LocalDateTime originalNotAfter = sampleCert.getNotAfter();
 
         when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
         when(k8sCertRepository.save(any(K8sCertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -230,7 +259,37 @@ class K8sCertServiceTest {
         assertThat(result.getNotBefore()).isNotNull();
         assertThat(result.getNotAfter()).isAfter(result.getNotBefore());
         assertThat(result.getUpdatedAt()).isNotNull();
+        assertThat(result.getId()).isEqualTo("cert-1");
+        assertThat(result.getCreatedAt()).isEqualTo(sampleCert.getCreatedAt());
+        assertThat(result).isNotSameAs(sampleCert);
+        assertThat(sampleCert.getStatus()).isEqualTo(CertStatus.expired);
+        assertThat(sampleCert.getDaysRemaining()).isZero();
+        assertThat(sampleCert.getNotBefore()).isEqualTo(originalNotBefore);
+        assertThat(sampleCert.getNotAfter()).isEqualTo(originalNotAfter);
         verify(k8sCertRepository).save(any(K8sCertVO.class));
+    }
+
+    @Test
+    void renewCertShouldNotMutateStoredCertWhenSaveFails() {
+        sampleCert.setStatus(CertStatus.expired);
+        sampleCert.setDaysRemaining(0);
+        LocalDateTime originalNotBefore = sampleCert.getNotBefore();
+        LocalDateTime originalNotAfter = sampleCert.getNotAfter();
+
+        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.save(any(K8sCertVO.class))).thenThrow(new IllegalStateException("save failed"));
+
+        RenewCertDTO command = RenewCertDTO.builder().id("cert-1").build();
+
+        assertThatThrownBy(() -> k8sCertService.renewCert(command))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("save failed");
+
+        assertThat(sampleCert.getStatus()).isEqualTo(CertStatus.expired);
+        assertThat(sampleCert.getDaysRemaining()).isZero();
+        assertThat(sampleCert.getNotBefore()).isEqualTo(originalNotBefore);
+        assertThat(sampleCert.getNotAfter()).isEqualTo(originalNotAfter);
+        assertThat(sampleCert.getUpdatedAt()).isEqualTo(LocalDateTime.of(2025, 1, 2, 0, 0));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Fixes #578 .

K8s certificate update and renewal operations mutated the repository-held
object before calling `save`. This allowed readers to observe intermediate
state and allowed a failed save to leave changes from a failed request in
memory. This change uses copy-on-write so repository state is replaced only
when `save` succeeds.

This complements #556, which validates REST request DTOs; this change protects
service and repository state during valid update and renewal operations.

## Brief changelog

- Build update and renewal results from copies instead of mutating stored objects.
- Preserve certificate IDs, creation timestamps, omitted fields, and metadata.
- Publish the new state only through the repository `save` operation.
- Add regression tests for successful writes and repository save failures.