### PR TITLE
[Studio] Add DLQ provider stub data

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/instance/dlq/DLQProviderStub.java
+++ b/server/src/main/java/com/rocketmq/studio/instance/dlq/DLQProviderStub.java
@@ -18,22 +18,68 @@ package com.rocketmq.studio.instance.dlq;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
-import java.util.Collections;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Component
 @Slf4j
 public class DLQProviderStub implements DLQProvider {
 
+    private final List<StubDLQGroup> stubData = List.of(
+            new StubDLQGroup("rmq-cn-v5-prod-01", DLQGroupVO.builder()
+                    .groupName("cg-order-payment")
+                    .dlqTopic("%DLQ%cg-order-payment")
+                    .messageCount(128)
+                    .lastEnqueueTime(LocalDateTime.of(2026, 7, 24, 10, 15, 30))
+                    .retryCount(16)
+                    .status("ACTIVE")
+                    .build()),
+            new StubDLQGroup("rmq-cn-v5-prod-01", DLQGroupVO.builder()
+                    .groupName("cg-inventory-sync")
+                    .dlqTopic("%DLQ%cg-inventory-sync")
+                    .messageCount(24)
+                    .lastEnqueueTime(LocalDateTime.of(2026, 7, 24, 9, 40, 12))
+                    .retryCount(8)
+                    .status("ACTIVE")
+                    .build()),
+            new StubDLQGroup("rmq-cn-v4-prod-02", DLQGroupVO.builder()
+                    .groupName("legacy-order-consumer")
+                    .dlqTopic("%DLQ%legacy-order-consumer")
+                    .messageCount(6)
+                    .lastEnqueueTime(LocalDateTime.of(2026, 7, 23, 22, 5, 0))
+                    .retryCount(3)
+                    .status("ACKED")
+                    .build())
+    );
+
     @Override
     public List<DLQGroupVO> listDLQGroups(String clusterId) {
-        log.warn("DLQProviderStub.listDLQGroups called - returning empty list");
-        return Collections.emptyList();
+        log.info("DLQProviderStub.listDLQGroups called. clusterId={}", clusterId);
+        return stubData.stream()
+                .filter(item -> !StringUtils.hasText(clusterId) || item.clusterId().equals(clusterId))
+                .map(StubDLQGroup::group)
+                .map(DLQProviderStub::copyGroup)
+                .toList();
     }
 
     @Override
     public void resendMessages(String groupName, Long startTime, Long endTime, String targetTopic) {
         log.warn("DLQProviderStub.resendMessages called - no-op. group={}, targetTopic={}", groupName, targetTopic);
+    }
+
+    private static DLQGroupVO copyGroup(DLQGroupVO group) {
+        return DLQGroupVO.builder()
+                .groupName(group.getGroupName())
+                .dlqTopic(group.getDlqTopic())
+                .messageCount(group.getMessageCount())
+                .lastEnqueueTime(group.getLastEnqueueTime())
+                .retryCount(group.getRetryCount())
+                .status(group.getStatus())
+                .build();
+    }
+
+    private record StubDLQGroup(String clusterId, DLQGroupVO group) {
     }
 }

--- a/server/src/test/java/com/rocketmq/studio/instance/dlq/DLQProviderStubTest.java
+++ b/server/src/test/java/com/rocketmq/studio/instance/dlq/DLQProviderStubTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rocketmq.studio.instance.dlq;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DLQProviderStubTest {
+
+    private final DLQProviderStub provider = new DLQProviderStub();
+
+    @Test
+    void listDLQGroupsShouldReturnSampleGroupsForAllClusters() {
+        List<DLQGroupVO> groups = provider.listDLQGroups(null);
+
+        assertThat(groups)
+                .extracting(DLQGroupVO::getGroupName)
+                .containsExactly("cg-order-payment", "cg-inventory-sync", "legacy-order-consumer");
+        assertThat(groups)
+                .allSatisfy(group -> {
+                    assertThat(group.getDlqTopic()).startsWith("%DLQ%");
+                    assertThat(group.getMessageCount()).isPositive();
+                    assertThat(group.getLastEnqueueTime()).isNotNull();
+                    assertThat(group.getStatus()).isNotBlank();
+                });
+    }
+
+    @Test
+    void listDLQGroupsShouldFilterByClusterId() {
+        List<DLQGroupVO> groups = provider.listDLQGroups("rmq-cn-v5-prod-01");
+
+        assertThat(groups)
+                .extracting(DLQGroupVO::getGroupName)
+                .containsExactly("cg-order-payment", "cg-inventory-sync");
+    }
+
+    @Test
+    void listDLQGroupsShouldReturnEmptyForUnknownCluster() {
+        assertThat(provider.listDLQGroups("missing-cluster")).isEmpty();
+    }
+
+    @Test
+    void listDLQGroupsShouldReturnDefensiveCopies() {
+        List<DLQGroupVO> firstRead = provider.listDLQGroups("rmq-cn-v5-prod-01");
+        firstRead.get(0).setGroupName("mutated");
+
+        List<DLQGroupVO> secondRead = provider.listDLQGroups("rmq-cn-v5-prod-01");
+
+        assertThat(secondRead.get(0).getGroupName()).isEqualTo("cg-order-payment");
+    }
+}


### PR DESCRIPTION
## Summary
- return sample DLQ groups from the backend stub provider instead of an empty list
- support clusterId filtering in the stub data set
- add provider tests for sample data, filtering, unknown clusters, and defensive copies

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=DLQProviderStubTest,DLQServiceTest,DLQControllerTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn test`
- `git diff --check`