### PR TITLE
[Studio] Add proxy detail modal

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -502,6 +502,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'cluster.readQueues': { zh: '读队列数', en: 'Read Queues' },
   'cluster.brokerPermission': { zh: 'Broker 权限', en: 'Broker Permission' },
   'cluster.viewDetail': { zh: '查看详情: {addr}', en: 'View detail: {addr}' },
+  'cluster.proxyDetailTitle': { zh: 'Proxy 详情 - {addr}', en: 'Proxy Detail - {addr}' },
   'cluster.restartProxyConfirm': {
     zh: '确定要重启 Proxy "{addr}" 吗？',
     en: 'Are you sure to restart Proxy "{addr}"?',

--- a/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { App } from 'antd';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { LangProvider } from '../../../i18n/LangContext';
+import ClusterPage from '../index';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <App>
+      <LangProvider>{ui}</LangProvider>
+    </App>,
+  );
+
+describe('Cluster page', () => {
+  it('opens proxy detail dialog from the proxy table', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ClusterPage />);
+
+    await user.click(screen.getByRole('tab', { name: /Proxy 管理/ }));
+    const proxyRow = screen.getByRole('row', { name: /10\.101\.2\.21:8081/ });
+    await user.click(within(proxyRow).getByRole('button', { name: /详情/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: /Proxy 详情 - 10\.101\.2\.21:8081/ });
+    expect(within(dialog).getByText('rocketmq-prod')).toBeInTheDocument();
+    expect(within(dialog).getByText('ns-prod')).toBeInTheDocument();
+    expect(within(dialog).getAllByText('10.101.2.21:8081')).toHaveLength(1);
+    expect(within(dialog).getByText('1,842')).toBeInTheDocument();
+    expect(within(dialog).getByText('8081')).toBeInTheDocument();
+    expect(within(dialog).getByText('8080')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -29,6 +29,7 @@ import {
   Switch,
   InputNumber,
   Progress,
+  Descriptions,
   Flex,
   Space,
   Typography,
@@ -56,6 +57,8 @@ import clusters, {
 
 const { Text } = Typography;
 
+type ProxyDetail = ProxyInfo & { clusterName: string; nsClusterName: string };
+
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 const ClusterPage = () => {
@@ -69,6 +72,7 @@ const ClusterPage = () => {
   const [selectedCluster, setSelectedCluster] = useState<ClusterInfo | null>(null);
   const [nsModalOpen, setNsModalOpen] = useState(false);
   const [nsModalMode, setNsModalMode] = useState<'create' | 'edit'>('create');
+  const [selectedProxy, setSelectedProxy] = useState<ProxyDetail | null>(null);
   const [nsForm] = Form.useForm();
   const [configForm] = Form.useForm();
 
@@ -608,7 +612,7 @@ const ClusterPage = () => {
   // ─── Tab 3: Proxy 管理 (flat table) ────────────────────────────────────────
 
   function renderProxyTab() {
-    type ProxyRow = ProxyInfo & { clusterName: string; nsClusterName: string };
+    type ProxyRow = ProxyDetail;
 
     const allProxies: ProxyRow[] = clusters
       .filter((c) => c.proxies.length > 0)
@@ -704,7 +708,7 @@ const ClusterPage = () => {
               size="small"
               icon={<EyeOutlined />}
               style={{ borderColor: '#1677ff', color: '#1677ff' }}
-              onClick={() => message.info(t('cluster.viewDetail', { addr: record.addr }))}
+              onClick={() => setSelectedProxy(record)}
             >
               {t('common.detail')}
             </Button>
@@ -854,6 +858,54 @@ const ClusterPage = () => {
         </Form>
       </Modal>
       <Tabs items={tabItems} defaultActiveKey="broker" />
+      <Modal
+        title={t('cluster.proxyDetailTitle', { addr: selectedProxy?.addr ?? '' })}
+        open={Boolean(selectedProxy)}
+        onCancel={() => setSelectedProxy(null)}
+        footer={<Button onClick={() => setSelectedProxy(null)}>{t('common.close')}</Button>}
+        width={560}
+        destroyOnClose
+      >
+        {selectedProxy && (
+          <Descriptions column={1} bordered size="small">
+            <Descriptions.Item label={t('cluster.k8sName')}>
+              {selectedProxy.clusterName}
+            </Descriptions.Item>
+            <Descriptions.Item label={t('cluster.nsClusterName')}>
+              {selectedProxy.nsClusterName}
+            </Descriptions.Item>
+            <Descriptions.Item label={t('cluster.proxyAddr')}>
+              <Text copyable code>
+                {selectedProxy.addr}
+              </Text>
+            </Descriptions.Item>
+            <Descriptions.Item label={t('common.status')}>
+              <Tag
+                color={
+                  selectedProxy.status === 'healthy'
+                    ? 'green'
+                    : selectedProxy.status === 'warning'
+                      ? 'gold'
+                      : selectedProxy.status === 'error'
+                        ? 'red'
+                        : 'default'
+                }
+              >
+                {selectedProxy.status}
+              </Tag>
+            </Descriptions.Item>
+            <Descriptions.Item label={t('cluster.connections')}>
+              {selectedProxy.connections.toLocaleString()}
+            </Descriptions.Item>
+            <Descriptions.Item label={t('cluster.grpcPort')}>
+              {selectedProxy.grpcPort}
+            </Descriptions.Item>
+            <Descriptions.Item label={t('cluster.remotingPort')}>
+              {selectedProxy.remotingPort}
+            </Descriptions.Item>
+          </Descriptions>
+        )}
+      </Modal>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace the Proxy table detail toast with a real detail modal
- show cluster, NameServer cluster, address, status, connections, and gRPC/Remoting ports
- add a page regression test for opening the Proxy detail view

## Validation
- `npm test -- --run src/pages/cluster/__tests__/ClusterPage.test.tsx`
- `npm test`
- `npm run lint` (0 errors, 4 existing fast-refresh warnings)
- `npm run build`
- `git diff --check`