### PR TITLE
[Studio] Load alert rules after mount

### DIFF
--- a/web/src/pages/studio/AlertManagement.tsx
+++ b/web/src/pages/studio/AlertManagement.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   App,
   Badge,
@@ -145,6 +145,7 @@ const AlertManagementPage: React.FC = () => {
   const { t } = useLang();
   const { message } = App.useApp();
   const [form] = Form.useForm();
+  const fetchFailedMessage = t('alertMgmt.fetchFailed');
 
   const [alertRules, setAlertRules] = useState<AlertRule[]>([]);
   const [loading, setLoading] = useState(false);
@@ -162,32 +163,49 @@ const AlertManagementPage: React.FC = () => {
       return {};
     }
   });
+  const disabledRulesRef = useRef(disabledRules);
 
-  // One-time initialization (ESLint-compliant)
-  const initialized = useRef<boolean | null>(null);
-  if (initialized.current == null) {
-    initialized.current = true;
+  useEffect(() => {
+    disabledRulesRef.current = disabledRules;
+  }, [disabledRules]);
+
+  useEffect(() => {
+    let cancelled = false;
+
     const loadRules = async () => {
-      setLoading(true);
+      if (!cancelled) {
+        setLoading(true);
+      }
       try {
         const data = await queryAlertRules();
         const yamlStr = data.rules || '';
-        setAlertRules(parseYamlRules(yamlStr, disabledRules));
+        if (!cancelled) {
+          setAlertRules(parseYamlRules(yamlStr, disabledRulesRef.current));
+        }
       } catch {
-        message.error(t('alertMgmt.fetchFailed'));
+        if (!cancelled) {
+          message.error(fetchFailedMessage);
+        }
       } finally {
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     };
-    loadRules();
-  }
+
+    void loadRules();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchFailedMessage, message]);
 
   const fetchAlertRules = async () => {
     setLoading(true);
     try {
       const data = await queryAlertRules();
       const yamlStr = data.rules || '';
-      setAlertRules(parseYamlRules(yamlStr, disabledRules));
+      setAlertRules(parseYamlRules(yamlStr, disabledRulesRef.current));
     } catch {
       message.error(t('alertMgmt.fetchFailed'));
     } finally {

--- a/web/src/pages/studio/__tests__/AlertManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/AlertManagement.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactElement } from 'react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { App } from 'antd';
+import { LangProvider } from '../../../i18n/LangContext';
+import AlertManagementPage from '../AlertManagement';
+import { queryAlertRules } from '../../../api/alertManagement';
+
+vi.mock('../../../api/alertManagement', () => ({
+  queryAlertRules: vi.fn(),
+}));
+
+const rulesYaml = `
+groups:
+- name: rocketmq-broker.rules
+  rules:
+    # Rule 1:
+    - alert: BrokerDown
+      expr: up{job="rocketmq-broker"} == 0
+      for: 5m
+      labels:
+        severity: critical
+        team: broker
+      annotations:
+        summary: "Broker unavailable"
+        description: "Broker has been unavailable for five minutes"
+`;
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const renderWithProviders = (ui: ReactElement) => {
+  return render(
+    <App>
+      <LangProvider>{ui}</LangProvider>
+    </App>,
+  );
+};
+
+describe('AlertManagementPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.mocked(queryAlertRules).mockResolvedValue({ rules: rulesYaml });
+  });
+
+  it('loads alert rules after mount', async () => {
+    renderWithProviders(<AlertManagementPage />);
+
+    await waitFor(() => {
+      expect(queryAlertRules).toHaveBeenCalledTimes(1);
+    });
+
+    expect(await screen.findByText('BrokerDown')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- move AlertManagement rule loading out of render and into a mount effect
- guard async alert rule loading against state updates after unmount
- keep refresh parsing aligned with the latest disabled-rule map
- add page coverage for loading YAML-backed alert rules from the API

## Scope
- RocketMQ Studio contest track 1 / METRICS-01 adjacent observability and alert-rule management UX

## Tests
- npm test -- src/pages/studio/__tests__/AlertManagement.test.tsx
- npm run lint (passes with existing fast-refresh warnings outside this change)
- npm run build