### PR TITLE
[Studio] Preserve cluster id in provider stub

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterProviderStub.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterProviderStub.java
@@ -30,16 +30,16 @@ public class ClusterProviderStub implements ClusterProvider {
 
     @Override
     public List<ClusterVO> discoverClusters() {
-        return List.of(buildSampleCluster());
+        return List.of(buildSampleCluster("cluster-001"));
     }
 
     @Override
     public ClusterVO refreshClusterDetail(String clusterId) {
-        return buildSampleCluster();
+        return buildSampleCluster(clusterId);
     }
 
-    private ClusterVO buildSampleCluster() {
-        return ClusterVO.builder()
+    private ClusterVO buildSampleCluster(String clusterId) {
+        ClusterVO cluster = ClusterVO.builder()
                 .name("rmq-cluster-01")
                 .brokers(List.of(
                         BrokerVO.builder()
@@ -81,5 +81,7 @@ public class ClusterProviderStub implements ClusterProvider {
                                 .build()
                 ))
                 .build();
+        cluster.setId(clusterId);
+        return cluster;
     }
 }

--- a/server/src/test/java/com/rocketmq/studio/cluster/broker/ClusterProviderStubTest.java
+++ b/server/src/test/java/com/rocketmq/studio/cluster/broker/ClusterProviderStubTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.broker;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClusterProviderStubTest {
+
+    private final ClusterProviderStub provider = new ClusterProviderStub();
+
+    @Test
+    void discoverClustersShouldReturnStableClusterId() {
+        List<ClusterVO> clusters = provider.discoverClusters();
+
+        assertThat(clusters).hasSize(1);
+        assertThat(clusters.get(0).getId()).isEqualTo("cluster-001");
+        assertThat(clusters.get(0).getBrokers()).isNotEmpty();
+        assertThat(clusters.get(0).getProxies()).isNotEmpty();
+        assertThat(clusters.get(0).getNameServers()).isNotEmpty();
+    }
+
+    @Test
+    void refreshClusterDetailShouldPreserveRequestedClusterId() {
+        ClusterVO detail = provider.refreshClusterDetail("cluster-prod");
+
+        assertThat(detail.getId()).isEqualTo("cluster-prod");
+        assertThat(detail.getName()).isEqualTo("rmq-cluster-01");
+        assertThat(detail.getBrokers()).hasSize(2);
+    }
+}


### PR DESCRIPTION
## Summary
- keep a stable cluster id in the ClusterProvider stub discovery result
- preserve the requested cluster id when refreshing stub cluster details
- add unit coverage for the provider stub identity contract

## Scope
- RocketMQ Studio contest track 1 / ARCH-01 ClusterProvider abstraction baseline

## Tests
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=ClusterProviderStubTest test