### PR TITLE
[Studio] Return clusters in stable order

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,7 +46,11 @@ public class ClusterRepositoryImpl implements ClusterRepository {
 
     @Override
     public List<ClusterVO> findAll() {
-        return new ArrayList<>(store.values());
+        return store.values().stream()
+                .sorted(Comparator
+                        .comparing(ClusterVO::getName, Comparator.nullsLast(String::compareToIgnoreCase))
+                        .thenComparing(ClusterVO::getId, Comparator.nullsLast(String::compareTo)))
+                .toList();
     }
 
     @Override

--- a/server/src/test/java/com/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
+++ b/server/src/test/java/com/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.cluster.broker;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClusterRepositoryImplTest {
+
+    @Test
+    void findAllShouldReturnClustersInStableNameOrder() {
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl();
+
+        List<ClusterVO> clusters = repository.findAll();
+
+        assertThat(clusters).extracting(ClusterVO::getName)
+                .containsExactly("rmq-cluster-prod", "rmq-cluster-staging");
+    }
+}


### PR DESCRIPTION
## Summary
- return in-memory clusters in a deterministic name/id order
- add repository coverage so multi-cluster list ordering does not depend on ConcurrentHashMap iteration

## Scope
- RocketMQ Studio contest track 1 / ARCH-01 multi-cluster management baseline

## Tests
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=ClusterRepositoryImplTest test