### PR TITLE
[Studio] Make audit search null safe

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/ops/audit/InMemoryAuditRepository.java
+++ b/server/src/main/java/com/rocketmq/studio/ops/audit/InMemoryAuditRepository.java
@@ -35,11 +35,12 @@ public class InMemoryAuditRepository implements AuditRepository {
     public List<AuditRecordVO> findAll(String search, String operationType,
                                      LocalDateTime startDate, LocalDateTime endDate,
                                      String result) {
+        String normalizedSearch = normalize(search);
         return records.values().stream()
-                .filter(r -> search == null || search.isEmpty()
-                        || r.getDetail().toLowerCase().contains(search.toLowerCase())
-                        || r.getOperator().toLowerCase().contains(search.toLowerCase())
-                        || r.getTarget().toLowerCase().contains(search.toLowerCase()))
+                .filter(r -> normalizedSearch == null
+                        || containsIgnoreCase(r.getDetail(), normalizedSearch)
+                        || containsIgnoreCase(r.getOperator(), normalizedSearch)
+                        || containsIgnoreCase(r.getTarget(), normalizedSearch))
                 .filter(r -> operationType == null || operationType.isEmpty()
                         || operationType.equals(r.getOperationType()))
                 .filter(r -> startDate == null || r.getTimestamp() != null && !r.getTimestamp().isBefore(startDate))
@@ -52,6 +53,17 @@ public class InMemoryAuditRepository implements AuditRepository {
                     return b.getTimestamp().compareTo(a.getTimestamp());
                 })
                 .collect(Collectors.toList());
+    }
+
+    private String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.toLowerCase();
+    }
+
+    private boolean containsIgnoreCase(String value, String normalizedSearch) {
+        return value != null && value.toLowerCase().contains(normalizedSearch);
     }
 
     @Override

--- a/server/src/test/java/com/rocketmq/studio/ops/audit/InMemoryAuditRepositoryTest.java
+++ b/server/src/test/java/com/rocketmq/studio/ops/audit/InMemoryAuditRepositoryTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rocketmq.studio.ops.audit;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryAuditRepositoryTest {
+
+    private final InMemoryAuditRepository repository = new InMemoryAuditRepository();
+
+    @Test
+    void findAllShouldSearchAcrossNullableFields() {
+        AuditRecordVO missingTextFields = AuditRecordVO.builder()
+                .timestamp(LocalDateTime.now())
+                .operationType("CREATE")
+                .result("SUCCESS")
+                .build();
+        missingTextFields.setId("record-null-fields");
+        AuditRecordVO targetMatch = AuditRecordVO.builder()
+                .timestamp(LocalDateTime.now().minusMinutes(1))
+                .operator("admin")
+                .operationType("UPDATE")
+                .target("Topic-Order")
+                .detail(null)
+                .result("SUCCESS")
+                .build();
+        targetMatch.setId("record-target-match");
+
+        putRecords(missingTextFields, targetMatch);
+
+        assertThat(repository.findAll("order", null, null, null, null))
+                .extracting(AuditRecordVO::getId)
+                .containsExactly("record-target-match");
+    }
+
+    @Test
+    void findAllShouldTreatBlankSearchAsNoSearchFilter() {
+        AuditRecordVO record = AuditRecordVO.builder()
+                .timestamp(LocalDateTime.now())
+                .operationType("DELETE")
+                .result("FAILURE")
+                .build();
+        record.setId("record-blank-search");
+
+        putRecords(record);
+
+        assertThat(repository.findAll("   ", null, null, null, null))
+                .extracting(AuditRecordVO::getId)
+                .containsExactly("record-blank-search");
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("unchecked")
+    private final void putRecords(AuditRecordVO... records) {
+        Map<String, AuditRecordVO> store =
+                (Map<String, AuditRecordVO>) ReflectionTestUtils.getField(repository, "records");
+        assertThat(store).isNotNull();
+        store.clear();
+        for (AuditRecordVO record : records) {
+            store.put(record.getId(), record);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make in-memory audit search tolerate records with missing detail/operator/target fields
- treat blank search text as no search filter
- add repository coverage for nullable audit fields

## Scope
- RocketMQ Studio contest track 1 / BASE-01 audit log baseline

## Tests
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=InMemoryAuditRepositoryTest test