### PR TITLE
[Studio] Validate cluster flush disk type

### DIFF
--- a/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/com/rocketmq/studio/cluster/broker/ClusterService.java
@@ -65,7 +65,7 @@ public class ClusterService {
         }
 
         if (command.getFlushDiskType() != null) {
-            config.setFlushDiskType(FlushDiskType.valueOf(command.getFlushDiskType()));
+            config.setFlushDiskType(parseFlushDiskType(command.getFlushDiskType()));
         }
         if (command.getAutoCreateTopicEnable() != null) {
             config.setAutoCreateTopicEnable(command.getAutoCreateTopicEnable());
@@ -93,6 +93,14 @@ public class ClusterService {
         clusterRepository.updateConfig(command.getId(), config);
         log.info("Cluster config updated successfully for: {}", command.getId());
         return cluster;
+    }
+
+    private FlushDiskType parseFlushDiskType(String value) {
+        try {
+            return FlushDiskType.valueOf(value);
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException(400, "Invalid flushDiskType: " + value);
+        }
     }
 
     public boolean restartBroker(String clusterId, String brokerName) {

--- a/server/src/test/java/com/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/com/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -208,6 +209,22 @@ class ClusterServiceTest {
         assertThatThrownBy(() -> clusterService.updateClusterConfig(command))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Cluster not found: missing");
+    }
+
+    @Test
+    void updateConfigShouldRejectInvalidFlushDiskType() {
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .flushDiskType("INVALID_FLUSH")
+                .build();
+
+        assertThatThrownBy(() -> clusterService.updateClusterConfig(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Invalid flushDiskType: INVALID_FLUSH")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        verify(clusterRepository, never()).updateConfig(eq("cluster-1"), any(ClusterConfigVO.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- convert invalid flushDiskType values into a 400 BusinessException instead of an unchecked enum parsing failure
- keep invalid config updates from reaching repository persistence
- add ClusterService regression coverage

## Verification
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=ClusterServiceTest test