### PR TITLE
[Studio] Make group search case insensitive

### DIFF
--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -227,6 +227,11 @@ const GroupManagementPage = () => {
     setModalVisible(true);
   };
 
+  const normalizedSearchText = searchText.trim().toLowerCase();
+  const filteredGroupData = groupData.filter(
+    (record) => !normalizedSearchText || record.group.toLowerCase().includes(normalizedSearchText),
+  );
+
   const columns = [
     {
       title: t('groupMgmt.groupName'),
@@ -390,7 +395,7 @@ const GroupManagementPage = () => {
       <Card bordered={false} style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}>
         <Table
           columns={columns}
-          dataSource={groupData.filter((d) => !searchText || d.group.includes(searchText))}
+          dataSource={filteredGroupData}
           pagination={{
             pageSize: 10,
             showTotal: (total) => `${t('common.total')} ${total} Group`,

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -90,7 +90,7 @@ describe('GroupManagement Page', () => {
     const user = userEvent.setup();
     renderWithProviders(<GroupManagement />);
     const searchInput = screen.getByPlaceholderText('搜索消费组');
-    await user.type(searchInput, 'order');
+    await user.type(searchInput, 'ORDER');
     expect(screen.getByText('order-consumer-group')).toBeInTheDocument();
     expect(screen.queryByText('payment-consumer-group')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- normalize Consumer Group search text before filtering
- make group-name matching case-insensitive and ignore surrounding whitespace
- update page test coverage for uppercase search input

## Verification
- npm --prefix web test -- --run src/pages/studio/__tests__/GroupManagement.test.tsx
- (cd web && npm exec eslint -- src/pages/studio/GroupManagement.tsx src/pages/studio/__tests__/GroupManagement.test.tsx)
- npm --prefix web run build