### PR TITLE
[Studio] Normalize AI draft model

### DIFF
--- a/web/src/pages/ai/chatDraft.test.ts
+++ b/web/src/pages/ai/chatDraft.test.ts
@@ -20,7 +20,7 @@ import { getChatDraft } from './chatDraft';
 
 describe('AI chat draft navigation state', () => {
   it('normalizes a prompt and preserves a selected model', () => {
-    expect(getChatDraft({ prompt: '  检查集群状态  ', model: 'qwen3.7-max' })).toEqual({
+    expect(getChatDraft({ prompt: '  检查集群状态  ', model: '  qwen3.7-max  ' })).toEqual({
       prompt: '检查集群状态',
       model: 'qwen3.7-max',
     });
@@ -30,5 +30,11 @@ describe('AI chat draft navigation state', () => {
     expect(getChatDraft(null)).toBeNull();
     expect(getChatDraft({ prompt: '   ' })).toBeNull();
     expect(getChatDraft({ prompt: 42 })).toBeNull();
+  });
+
+  it('drops empty model values after normalization', () => {
+    expect(getChatDraft({ prompt: '检查集群状态', model: '   ' })).toEqual({
+      prompt: '检查集群状态',
+    });
   });
 });

--- a/web/src/pages/ai/chatDraft.ts
+++ b/web/src/pages/ai/chatDraft.ts
@@ -24,9 +24,10 @@ export function getChatDraft(state: unknown): ChatDraft | null {
   if (typeof state !== 'object' || state === null) return null;
   const candidate = state as Record<string, unknown>;
   if (typeof candidate.prompt !== 'string' || !candidate.prompt.trim()) return null;
+  const model = typeof candidate.model === 'string' ? candidate.model.trim() : '';
 
   return {
     prompt: candidate.prompt.trim(),
-    ...(typeof candidate.model === 'string' && candidate.model ? { model: candidate.model } : {}),
+    ...(model ? { model } : {}),
   };
 }


### PR DESCRIPTION
## Summary
- trim the AI chat draft model from navigation state before applying it
- drop empty model values after normalization so the chat page keeps its default selection
- add regression coverage for both cases

## Verification
- npm --prefix web test -- --run src/pages/ai/chatDraft.test.ts
- (cd web && npm exec eslint -- src/pages/ai/chatDraft.ts src/pages/ai/chatDraft.test.ts)
- npm --prefix web run build