### PR TITLE
[Studio] Trim mock Topic search

### DIFF
--- a/web/src/services/topicService.test.ts
+++ b/web/src/services/topicService.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config', () => ({ API_BASE_URL: '/api', USE_MOCK: true }));
+
+describe('topic service mock topic list', () => {
+  it('trims search text before filtering topic names', async () => {
+    const { listTopics } = await import('./topicService');
+
+    const topics = await listTopics({ search: '  ORDER-CREATE  ' });
+
+    expect(topics.map((topic) => topic.name)).toEqual(['order-create']);
+  });
+
+  it('ignores blank search text', async () => {
+    const { listTopics } = await import('./topicService');
+
+    const allTopics = await listTopics();
+    const blankSearchTopics = await listTopics({ search: '   ' });
+
+    expect(blankSearchTopics).toHaveLength(allTopics.length);
+  });
+});

--- a/web/src/services/topicService.ts
+++ b/web/src/services/topicService.ts
@@ -14,8 +14,8 @@ export async function listTopics(params?: TopicQuery): Promise<Topic[]> {
   if (USE_MOCK) {
     let result = [...mockTopics];
     if (params?.search) {
-      const kw = params.search.toLowerCase();
-      result = result.filter((t) => t.name.toLowerCase().includes(kw));
+      const keyword = params.search.trim().toLowerCase();
+      if (keyword) result = result.filter((topic) => topic.name.toLowerCase().includes(keyword));
     }
     if (params?.type) result = result.filter((t) => t.type === params.type);
     if (params?.clusterId) result = result.filter((t) => t.clusterId === params.clusterId);


### PR DESCRIPTION
## Summary
- trim mock Topic search text before filtering names
- treat blank search text as no filter
- add service-level regression coverage for both cases

## Verification
- npm --prefix web test -- --run src/services/topicService.test.ts
- (cd web && npm exec eslint -- src/services/topicService.ts src/services/topicService.test.ts)
- npm --prefix web run build