### PR TITLE
[Studio] fix: encode Topic and Consumer Group path segments

### DIFF
--- a/web/src/api/consumerGroups.test.ts
+++ b/web/src/api/consumerGroups.test.ts
@@ -18,7 +18,13 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { getConsumerGroup, listConsumerGroups, resetConsumerOffset } from './metadata';
+import {
+  getConsumerGroup,
+  getConsumerProgress,
+  getConsumerSubscriptions,
+  listConsumerGroups,
+  resetConsumerOffset,
+} from './metadata';
 
 const mock = new MockAdapter(client);
 const group = {
@@ -57,6 +63,17 @@ describe('consumer groups API contract', () => {
     });
 
     await expect(listConsumerGroups(params)).resolves.toEqual([group]);
+  });
+
+  it('encodes consumer group names used in path segments', async () => {
+    const groupName = '%RETRY%cg-order';
+    mock.onGet('/groups/%25RETRY%25cg-order').reply(200, { code: 200, data: group });
+    mock.onGet('/groups/%25RETRY%25cg-order/progress').reply(200, { code: 200, data: [] });
+    mock.onGet('/groups/%25RETRY%25cg-order/subscriptions').reply(200, { code: 200, data: [] });
+
+    await expect(getConsumerGroup(groupName)).resolves.toEqual(group);
+    await expect(getConsumerProgress(groupName)).resolves.toEqual([]);
+    await expect(getConsumerSubscriptions(groupName)).resolves.toEqual([]);
   });
 
   it('unwraps detail records and sends numeric reset timestamps', async () => {

--- a/web/src/api/metadata.test.ts
+++ b/web/src/api/metadata.test.ts
@@ -18,7 +18,14 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { createTopic, deleteTopic, listTopics, sendTopicMessage } from './metadata';
+import {
+  createTopic,
+  deleteTopic,
+  getTopicConsumers,
+  getTopicRoutes,
+  listTopics,
+  sendTopicMessage,
+} from './metadata';
 
 const mock = new MockAdapter(client);
 
@@ -41,6 +48,15 @@ describe('topic metadata API', () => {
     });
 
     await expect(listTopics(params)).resolves.toEqual([]);
+  });
+
+  it('encodes topic names used in path segments', async () => {
+    const topicName = '%DLQ%cg-order';
+    mock.onGet('/topics/%25DLQ%25cg-order/routes').reply(200, { code: 200, data: [] });
+    mock.onGet('/topics/%25DLQ%25cg-order/consumers').reply(200, { code: 200, data: [] });
+
+    await expect(getTopicRoutes(topicName)).resolves.toEqual([]);
+    await expect(getTopicConsumers(topicName)).resolves.toEqual([]);
   });
 
   it('persists topic creation, deletion, and sending through API endpoints', async () => {

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -124,12 +124,16 @@ export async function deleteTopic(name: string) {
 }
 
 export async function getTopicRoutes(name: string) {
-  const res = await client.get<{ data: BrokerRoute[] }>(`/topics/${name}/routes`);
+  const res = await client.get<{ data: BrokerRoute[] }>(
+    `/topics/${encodeURIComponent(name)}/routes`,
+  );
   return res.data.data;
 }
 
 export async function getTopicConsumers(name: string) {
-  const res = await client.get<{ data: ConsumerGroupInfo[] }>(`/topics/${name}/consumers`);
+  const res = await client.get<{ data: ConsumerGroupInfo[] }>(
+    `/topics/${encodeURIComponent(name)}/consumers`,
+  );
   return res.data.data;
 }
 
@@ -159,17 +163,23 @@ export async function listConsumerGroups(params?: ConsumerGroupQuery) {
 }
 
 export async function getConsumerGroup(name: string) {
-  const res = await client.get<{ data: ConsumerGroupDetail }>(`/groups/${name}`);
+  const res = await client.get<{ data: ConsumerGroupDetail }>(
+    `/groups/${encodeURIComponent(name)}`,
+  );
   return res.data.data;
 }
 
 export async function getConsumerProgress(name: string) {
-  const res = await client.get<{ data: QueueProgress[] }>(`/groups/${name}/progress`);
+  const res = await client.get<{ data: QueueProgress[] }>(
+    `/groups/${encodeURIComponent(name)}/progress`,
+  );
   return res.data.data;
 }
 
 export async function getConsumerSubscriptions(name: string) {
-  const res = await client.get<{ data: SubscriptionEntry[] }>(`/groups/${name}/subscriptions`);
+  const res = await client.get<{ data: SubscriptionEntry[] }>(
+    `/groups/${encodeURIComponent(name)}/subscriptions`,
+  );
   return res.data.data;
 }
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes #610 .

Encode Topic and Consumer Group names before inserting them into API URL path segments, preventing names containing `%` from producing malformed request paths.

## Brief changelog

- Encode Topic names for route and consumer queries.
- Encode Consumer Group names for detail, progress, and subscription queries.
- Add API regression tests for names containing `%`.