### PR TITLE
[Studio] Load clusters in cluster store

### DIFF
--- a/web/src/stores/clusterStore.test.ts
+++ b/web/src/stores/clusterStore.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ClusterInfo } from '../api/cluster';
+import { listClusters } from '../services/clusterService';
+import useClusterStore from './clusterStore';
+
+vi.mock('../services/clusterService', () => ({
+  listClusters: vi.fn(),
+}));
+
+const cluster: ClusterInfo = {
+  id: 'cluster-prod',
+  name: 'rocketmq-prod',
+  nsClusterName: 'ns-prod',
+  type: 'V5_PROXY_CLUSTER',
+  endpoint: '10.101.2.1:9876',
+  status: 'healthy',
+  version: '5.2.0',
+  brokers: [],
+  proxies: [],
+  nameServers: [],
+  config: {
+    flushDiskType: 'SYNC_FLUSH',
+    autoCreateTopicEnable: false,
+    autoCreateSubscriptionGroup: false,
+    maxMessageSize: 4194304,
+    msgTraceTopicName: 'RMQ_SYS_TRACE_TOPIC4',
+    fileReservedTime: 72,
+    writeQueueNums: 16,
+    readQueueNums: 16,
+    brokerPermission: 6,
+    deleteWhen: '04',
+  },
+  topicCount: 256,
+  groupCount: 128,
+  tpsHistory: [100, 120],
+};
+
+describe('clusterStore', () => {
+  afterEach(() => {
+    vi.mocked(listClusters).mockReset();
+    useClusterStore.setState({ clusters: [], loading: false });
+  });
+
+  it('loads clusters from the cluster service', async () => {
+    vi.mocked(listClusters).mockResolvedValue([cluster]);
+
+    await useClusterStore.getState().fetchClusters();
+
+    expect(listClusters).toHaveBeenCalledTimes(1);
+    expect(useClusterStore.getState()).toMatchObject({
+      clusters: [cluster],
+      loading: false,
+    });
+  });
+
+  it('resets loading when loading clusters fails', async () => {
+    const error = new Error('failed to load clusters');
+    vi.mocked(listClusters).mockRejectedValue(error);
+
+    await expect(useClusterStore.getState().fetchClusters()).rejects.toThrow(error);
+
+    expect(useClusterStore.getState()).toMatchObject({
+      clusters: [],
+      loading: false,
+    });
+  });
+});

--- a/web/src/stores/clusterStore.ts
+++ b/web/src/stores/clusterStore.ts
@@ -16,12 +16,11 @@
  */
 
 import { create } from 'zustand';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Cluster = any;
+import { listClusters } from '../services/clusterService';
+import type { ClusterInfo } from '../api/cluster';
 
 interface ClusterState {
-  clusters: Cluster[];
+  clusters: ClusterInfo[];
   loading: boolean;
   fetchClusters: () => Promise<void>;
 }
@@ -31,8 +30,12 @@ const useClusterStore = create<ClusterState>((set) => ({
   loading: false,
   fetchClusters: async () => {
     set({ loading: true });
-    // TODO: call API to fetch clusters
-    set({ clusters: [], loading: false });
+    try {
+      const clusters = await listClusters();
+      set({ clusters });
+    } finally {
+      set({ loading: false });
+    }
   },
 }));
 


### PR DESCRIPTION
## Summary
- wire clusterStore.fetchClusters to the existing cluster list service
- type the store with ClusterInfo instead of any
- keep loading state reset when cluster loading fails

## Tests
- npm --prefix web test -- --run src/stores/clusterStore.test.ts
- (cd web && npm exec eslint -- src/stores/clusterStore.ts src/stores/clusterStore.test.ts)
- npm --prefix web run build