### PR TITLE
[Studio] Encode cluster API path segments

### DIFF
--- a/web/src/api/cluster.test.ts
+++ b/web/src/api/cluster.test.ts
@@ -23,8 +23,10 @@ import {
   createNameServer,
   deleteK8sCert,
   deleteNameServer,
+  getCluster,
   listK8sCerts,
   renewK8sCert,
+  restartBroker,
   restartNameServer,
   restartProxy,
   updateK8sCert,
@@ -101,6 +103,33 @@ describe('K8s certificate API', () => {
     });
 
     await expect(deleteK8sCert(cert.id)).resolves.toBeUndefined();
+  });
+
+  it('encodes cluster path parameters', async () => {
+    const cluster = {
+      id: 'cloud/prod cluster:1',
+      name: 'prod',
+    };
+    mock.onGet('/clusters/cloud%2Fprod%20cluster%3A1').reply(200, {
+      code: 200,
+      data: cluster,
+    });
+
+    await expect(getCluster(cluster.id)).resolves.toEqual(cluster);
+  });
+
+  it('encodes broker restart path parameters', async () => {
+    mock
+      .onPost('/clusters/cloud%2Fprod%20cluster%3A1/brokers/broker%2Fmain%3A10911/restart')
+      .reply(200, {
+        code: 200,
+        data: { success: true, message: 'restarted' },
+      });
+
+    await expect(restartBroker('cloud/prod cluster:1', 'broker/main:10911')).resolves.toEqual({
+      success: true,
+      message: 'restarted',
+    });
   });
 
   it('sends NameServer operation payloads to their endpoints', async () => {

--- a/web/src/api/cluster.ts
+++ b/web/src/api/cluster.ts
@@ -17,6 +17,8 @@
 
 import client from './client';
 
+const pathSegment = (value: string): string => encodeURIComponent(value);
+
 // ─── Types ──────────────────────────────────────────────────────
 export interface ClusterInfo {
   id: string;
@@ -92,7 +94,7 @@ export async function listClusters() {
 }
 
 export async function getCluster(id: string) {
-  const res = await client.get<{ data: ClusterInfo }>(`/clusters/${id}`);
+  const res = await client.get<{ data: ClusterInfo }>(`/clusters/${pathSegment(id)}`);
   return res.data.data;
 }
 
@@ -102,7 +104,7 @@ export async function updateClusterConfig(data: { id: string } & Partial<Cluster
 
 export async function restartBroker(clusterId: string, brokerName: string) {
   const res = await client.post<{ data: { success: boolean; message: string } }>(
-    `/clusters/${clusterId}/brokers/${brokerName}/restart`,
+    `/clusters/${pathSegment(clusterId)}/brokers/${pathSegment(brokerName)}/restart`,
   );
   return res.data.data;
 }


### PR DESCRIPTION
## Summary
- encode cluster detail path ids before sending requests
- encode cluster and broker path segments for broker restart requests
- add regression coverage for ids/names containing slashes, spaces, and colons

## Tests
- npm --prefix web test -- --run src/api/cluster.test.ts src/api/clusterContract.test.ts
- (cd web && npm exec eslint -- src/api/cluster.ts src/api/cluster.test.ts)
- npm --prefix web run build