### PR TITLE
[Studio] fix: validate instance updates

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -74,6 +74,13 @@ public class InstanceService {
         InstanceVO existing = instanceRepository.findById(instance.getId())
                 .orElseThrow(() -> new BusinessException(404, "InstanceVO not found: " + instance.getId()));
 
+        if (instance.getName() != null && instance.getName().isBlank()) {
+            throw new BusinessException(400, "InstanceVO name is required");
+        }
+        if (instance.getEndpoint() != null && instance.getEndpoint().isBlank()) {
+            throw new BusinessException(400, "InstanceVO endpoint is required");
+        }
+
         if (instance.getName() != null) {
             existing.setName(instance.getName());
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -258,6 +259,50 @@ class InstanceServiceTest {
         assertThatThrownBy(() -> instanceService.updateInstance(input))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("InstanceVO not found: nonexistent");
+    }
+
+    @Test
+    void updateInstanceShouldRejectBlankName() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("existing-name")
+                .endpoint("10.0.1.1:8080")
+                .build();
+        existing.setId("inst-1");
+        InstanceVO update = InstanceVO.builder().name("   ").build();
+        update.setId("inst-1");
+
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> instanceService.updateInstance(update))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO name is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        assertThat(existing.getName()).isEqualTo("existing-name");
+        verify(instanceRepository, never()).save(any(InstanceVO.class));
+    }
+
+    @Test
+    void updateInstanceShouldRejectBlankEndpointWithoutMutatingExistingFields() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("existing-name")
+                .endpoint("10.0.1.1:8080")
+                .build();
+        existing.setId("inst-1");
+        InstanceVO update = InstanceVO.builder()
+                .name("new-name")
+                .endpoint("   ")
+                .build();
+        update.setId("inst-1");
+
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> instanceService.updateInstance(update))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO endpoint is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        assertThat(existing.getName()).isEqualTo("existing-name");
+        assertThat(existing.getEndpoint()).isEqualTo("10.0.1.1:8080");
+        verify(instanceRepository, never()).save(any(InstanceVO.class));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Fixes #613 .

Prevent `/api/instances/update` from accepting blank name or endpoint values and persisting invalid instance data.

## Brief changelog

- Reject non-null blank instance names and endpoints with HTTP 400.
- Validate all supplied required fields before modifying the existing instance.
- Preserve partial update semantics for omitted fields.
- Add regression tests for validation failures and mutation prevention.