### PR TITLE
[Studio] Encode message trace path segment

### DIFF
--- a/web/src/api/message.test.ts
+++ b/web/src/api/message.test.ts
@@ -109,4 +109,14 @@ describe('message API', () => {
 
     await expect(getMessageTrace('msg-1')).resolves.toEqual(trace);
   });
+
+  it('encodes message IDs before requesting trace records', async () => {
+    const trace = {
+      nodes: [],
+      consumerStatus: [],
+    };
+    mock.onGet('/messages/AC1E0A64%2F0000%202A9F%3A1/trace').reply(200, { code: 200, data: trace });
+
+    await expect(getMessageTrace('AC1E0A64/0000 2A9F:1')).resolves.toEqual(trace);
+  });
 });

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -69,7 +69,7 @@ export async function queryMessages(params: MessageQuery) {
 }
 
 export async function getMessageTrace(msgId: string) {
-  const res = await client.get<{ data: TraceRecord }>(`/messages/${msgId}/trace`);
+  const res = await client.get<{ data: TraceRecord }>(`/messages/${encodeURIComponent(msgId)}/trace`);
   return res.data.data;
 }
 


### PR DESCRIPTION
## Summary
- encode message IDs before building the trace API path
- add regression coverage for trace lookups with slash, space, and colon characters in the message ID

## Tests
- npm ci --ignore-scripts --no-audit --no-fund
- npm test -- --run src/api/message.test.ts
- npm run lint -- --max-warnings=999
- git diff --check