### PR TITLE
[Studio] Return ACL mock copies

### DIFF
--- a/web/src/services/aclService.test.ts
+++ b/web/src/services/aclService.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createAclRule,
+  createAclUser,
+  listAclRules,
+  listAclUsers,
+  updateAclRule,
+  updateAclUser,
+} from './aclService';
+
+vi.mock('../config', () => ({
+  API_BASE_URL: '/api',
+  USE_MOCK: true,
+}));
+
+describe('ACL service mock data', () => {
+  it('returns copied ACL rule rows', async () => {
+    const first = await listAclRules({ principal: 'user-admin' });
+    expect(first[0].principal).toBe('user-admin');
+
+    first[0].principal = 'mutated-principal';
+    first[0].actions.push('MUTATED');
+
+    const second = await listAclRules({ principal: 'user-admin' });
+    expect(second[0].principal).toBe('user-admin');
+    expect(second[0].actions).toEqual(['ALL']);
+    expect(second[0]).not.toBe(first[0]);
+  });
+
+  it('copies ACL rule arrays on create and update', async () => {
+    const actions = ['PUB'];
+    const created = await createAclRule({
+      principal: 'user-created-copy-test',
+      resource: 'created-topic',
+      actions,
+    });
+    actions.push('SUB');
+    created.actions.push('MUTATED');
+
+    const afterCreate = await listAclRules({ principal: 'user-created-copy-test' });
+    expect(afterCreate[0].actions).toEqual(['PUB']);
+
+    const updateActions = ['SUB'];
+    const updated = await updateAclRule({ id: created.id, actions: updateActions });
+    updateActions.push('PUB');
+    updated.actions.push('MUTATED');
+
+    const afterUpdate = await listAclRules({ principal: 'user-created-copy-test' });
+    expect(afterUpdate[0].actions).toEqual(['SUB']);
+  });
+
+  it('returns copied ACL user rows', async () => {
+    const first = await listAclUsers({ keyword: 'user-admin' });
+    expect(first[0].username).toBe('user-admin');
+
+    first[0].username = 'mutated-user';
+    first[0].clusters.push('mutated-cluster');
+
+    const second = await listAclUsers({ keyword: 'user-admin' });
+    expect(second[0].username).toBe('user-admin');
+    expect(second[0].clusters).not.toContain('mutated-cluster');
+    expect(second[0]).not.toBe(first[0]);
+  });
+
+  it('copies ACL user arrays on create and update', async () => {
+    const clusters = ['rmq-created'];
+    const created = await createAclUser({
+      username: 'user-created-copy-test',
+      clusters,
+    });
+    clusters.push('rmq-mutated');
+    created.clusters.push('rmq-mutated-return');
+
+    const afterCreate = await listAclUsers({ keyword: 'user-created-copy-test' });
+    expect(afterCreate[0].clusters).toEqual(['rmq-created']);
+
+    const updateClusters = ['rmq-updated'];
+    const updated = await updateAclUser({ id: created.id, clusters: updateClusters });
+    updateClusters.push('rmq-mutated');
+    updated.clusters.push('rmq-mutated-return');
+
+    const afterUpdate = await listAclUsers({ keyword: 'user-created-copy-test' });
+    expect(afterUpdate[0].clusters).toEqual(['rmq-updated']);
+  });
+});

--- a/web/src/services/aclService.ts
+++ b/web/src/services/aclService.ts
@@ -6,6 +6,20 @@ import { aclRules as mockRules, aclUsers as mockUsers } from '../mock/acl';
 const aclRulesState = mockRules as unknown as AclRule[];
 const aclUsersState = mockUsers as unknown as AclUser[];
 
+function copyAclRule(rule: AclRule): AclRule {
+  return {
+    ...rule,
+    actions: [...rule.actions],
+  };
+}
+
+function copyAclUser(user: AclUser): AclUser {
+  return {
+    ...user,
+    clusters: [...user.clusters],
+  };
+}
+
 export async function listAclRules(params?: AclRuleQuery): Promise<AclRule[]> {
   if (USE_MOCK) {
     let result = [...aclRulesState];
@@ -13,7 +27,7 @@ export async function listAclRules(params?: AclRuleQuery): Promise<AclRule[]> {
       const principal = params.principal.toLowerCase();
       result = result.filter((rule) => rule.principal.toLowerCase().includes(principal));
     }
-    return result;
+    return result.map(copyAclRule);
   }
   return aclApi.listAclRules(params);
 }
@@ -25,7 +39,7 @@ export async function listAclUsers(params?: { keyword?: string }): Promise<AclUs
       const kw = params.keyword.toLowerCase();
       result = result.filter((u) => u.username.toLowerCase().includes(kw));
     }
-    return result;
+    return result.map(copyAclUser);
   }
   return aclApi.listAclUsers(params);
 }
@@ -38,15 +52,15 @@ export async function createAclRule(data: Partial<AclRule>): Promise<AclRule> {
       resource: '',
       resourceType: '',
       resourcePattern: '',
-      actions: [],
       decision: '',
       scope: '',
       aclVersion: 2,
       createdAt: new Date().toISOString(),
       ...data,
+      actions: [...(data.actions ?? [])],
     };
     aclRulesState.push(rule);
-    return rule;
+    return copyAclRule(rule);
   }
   return aclApi.createAclRule(data);
 }
@@ -58,8 +72,9 @@ export async function updateAclRule(data: Partial<AclRule>): Promise<AclRule> {
     aclRulesState[idx] = {
       ...aclRulesState[idx],
       ...data,
+      actions: data.actions ? [...data.actions] : [...aclRulesState[idx].actions],
     };
-    return aclRulesState[idx];
+    return copyAclRule(aclRulesState[idx]);
   }
   return aclApi.updateAclRule(data);
 }
@@ -81,12 +96,12 @@ export async function createAclUser(data: Partial<AclUser>): Promise<AclUser> {
       accessKey: '',
       secretKey: '',
       admin: false,
-      clusters: [],
       createdAt: new Date().toISOString(),
       ...data,
+      clusters: [...(data.clusters ?? [])],
     };
     aclUsersState.push(user);
-    return user;
+    return copyAclUser(user);
   }
   return aclApi.createAclUser(data);
 }
@@ -98,8 +113,9 @@ export async function updateAclUser(data: Partial<AclUser>): Promise<AclUser> {
     aclUsersState[idx] = {
       ...aclUsersState[idx],
       ...data,
+      clusters: data.clusters ? [...data.clusters] : [...aclUsersState[idx].clusters],
     };
-    return aclUsersState[idx];
+    return copyAclUser(aclUsersState[idx]);
   }
   return aclApi.updateAclUser(data);
 }


### PR DESCRIPTION
## Summary
- return copied ACL rule and user mock rows
- copy actions and cluster arrays on create and update before exposing results
- add regression coverage for ACL mock mutation isolation

## Tests
- npm ci --ignore-scripts --no-audit --no-fund
- npm test -- --run src/services/aclService.test.ts
- npm run lint -- --max-warnings=999
- git diff --check