### PR TITLE
[Studio] fix: match navigation routes and preserve editing shortcuts

### DIFF
--- a/web/src/layouts/navigationSearch.test.ts
+++ b/web/src/layouts/navigationSearch.test.ts
@@ -29,6 +29,11 @@ describe('navigation search helpers', () => {
     expect(filterNavigationEntries(entries, '集群')).toEqual([entries[0]]);
   });
 
+  it('filters by route keys case-insensitively', () => {
+    expect(filterNavigationEntries(entries, 'CLUSTER')).toEqual([entries[0]]);
+    expect(filterNavigationEntries(entries, '/settings')).toEqual([entries[1]]);
+  });
+
   it('recognizes Control/Command-K but rejects alternative shortcuts', () => {
     expect(
       isNavigationSearchShortcut({ key: 'k', ctrlKey: true, metaKey: false, altKey: false }),
@@ -42,5 +47,27 @@ describe('navigation search helpers', () => {
     expect(
       isNavigationSearchShortcut({ key: 'k', ctrlKey: true, metaKey: false, altKey: true }),
     ).toBe(false);
+  });
+
+  it('does not capture the shortcut from editable elements', () => {
+    const input = document.createElement('input');
+    const textarea = document.createElement('textarea');
+    const select = document.createElement('select');
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+    const editableChild = document.createElement('span');
+    editable.appendChild(editableChild);
+
+    for (const target of [input, textarea, select, editable, editableChild]) {
+      expect(
+        isNavigationSearchShortcut({
+          key: 'k',
+          ctrlKey: true,
+          metaKey: false,
+          altKey: false,
+          target,
+        }),
+      ).toBe(false);
+    }
   });
 });

--- a/web/src/layouts/navigationSearch.ts
+++ b/web/src/layouts/navigationSearch.ts
@@ -29,7 +29,11 @@ export function filterNavigationEntries(
 ): NavigationSearchEntry[] {
   const normalizedQuery = query.trim().toLocaleLowerCase();
   if (!normalizedQuery) return entries;
-  return entries.filter((entry) => entry.label.toLocaleLowerCase().includes(normalizedQuery));
+  return entries.filter(
+    (entry) =>
+      entry.label.toLocaleLowerCase().includes(normalizedQuery) ||
+      entry.key.toLocaleLowerCase().includes(normalizedQuery),
+  );
 }
 
 export function isNavigationSearchShortcut(event: {
@@ -37,6 +41,18 @@ export function isNavigationSearchShortcut(event: {
   metaKey: boolean;
   ctrlKey: boolean;
   altKey: boolean;
+  target?: EventTarget | null;
 }): boolean {
-  return event.key.toLocaleLowerCase() === 'k' && (event.metaKey || event.ctrlKey) && !event.altKey;
+  const isEditableTarget =
+    event.target instanceof Element &&
+    event.target.closest(
+      'input, textarea, select, [contenteditable]:not([contenteditable="false"])',
+    ) !== null;
+
+  return (
+    event.key.toLocaleLowerCase() === 'k' &&
+    (event.metaKey || event.ctrlKey) &&
+    !event.altKey &&
+    !isEditableTarget
+  );
 }


### PR DESCRIPTION
## What is the purpose of the change

Fixes #624 .

Allow navigation entries to be found by either their localized labels or route keys, while preventing the global Control/Command-K shortcut from overriding editable elements.

## Brief changelog

- Match navigation entries by labels and route keys.
- Ignore Control/Command-K from input, textarea, select, and contenteditable elements.
- Add regression tests for route matching and shortcut handling.