### PR TITLE
[Studio] fix: localize status badge accessible names

### DIFF
--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -32,7 +32,7 @@ const StatusBadge = ({ status, text, showDot = true }: StatusBadgeProps) => {
   const config = STATUS_MAP[status] || STATUS_MAP.offline;
   const label = text || t(config.labelKey);
   return (
-    <Space size={4} role="status" aria-label={`状态：${label}`}>
+    <Space size={4} role="status" aria-label={label}>
       {showDot && <Badge color={config.dot} aria-hidden="true" />}
       <Text style={{ color: config.color, fontSize: 13 }}>{label}</Text>
     </Space>

--- a/web/src/components/__tests__/StatusBadge.test.tsx
+++ b/web/src/components/__tests__/StatusBadge.test.tsx
@@ -15,14 +15,19 @@
  * limitations under the License.
  */
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import StatusBadge from '../StatusBadge';
 import { LangProvider } from '../../i18n/LangContext';
+import { LANGUAGE_STORAGE_KEY } from '../../i18n/languagePreference';
 
 const renderWithLang = (ui: React.ReactElement) => render(<LangProvider>{ui}</LangProvider>);
 
 describe('StatusBadge', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
   it('renders the translated label for a known status in Chinese', () => {
     renderWithLang(<StatusBadge status="healthy" />);
     // theme.healthy in zh is '运行中'
@@ -73,5 +78,13 @@ describe('StatusBadge', () => {
     const { container } = renderWithLang(<StatusBadge status="healthy" />);
     const statusEl = container.querySelector('[role="status"]');
     expect(statusEl).toBeInTheDocument();
+  });
+
+  it('uses the translated status as its accessible name', () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en');
+
+    renderWithLang(<StatusBadge status="healthy" />);
+
+    expect(screen.getByRole('status')).toHaveAccessibleName('Healthy');
   });
 });


### PR DESCRIPTION
## What is the purpose of the change

Fixes #626 .

Ensure `StatusBadge` accessible names follow the selected language instead of including a hardcoded Chinese prefix.

## Brief changelog

- Use the translated status label directly as the `aria-label`.
- Preserve the existing status semantics and visible rendering.
- Add an English-mode accessibility regression test.