### PR TITLE
[Studio] fix: render zero throughput without visible bars

### DIFF
--- a/web/src/components/MiniBar.tsx
+++ b/web/src/components/MiniBar.tsx
@@ -52,7 +52,7 @@ const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: M
           key={i}
           style={{
             width: barWidth,
-            height: `${Math.max(4, (value / max) * height)}px`,
+            height: `${value === 0 ? 0 : Math.max(4, (value / max) * height)}px`,
             backgroundColor: color,
             borderRadius: 2,
             opacity: 0.3 + (i / data.length) * 0.7,

--- a/web/src/components/__tests__/MiniBar.test.tsx
+++ b/web/src/components/__tests__/MiniBar.test.tsx
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MiniBar from '../MiniBar';
+
+const getBarHeights = () =>
+  Array.from(screen.getByRole('img').children, (bar) => (bar as HTMLElement).style.height);
+
+describe('MiniBar', () => {
+  it('renders zero values without a visible bar', () => {
+    render(<MiniBar data={[0, 0, 0]} height={20} label="Throughput trend" />);
+
+    expect(getBarHeights()).toEqual(['0px', '0px', '0px']);
+  });
+
+  it('keeps positive values visible without turning zero into traffic', () => {
+    render(<MiniBar data={[0, 1, 10]} height={20} label="Throughput trend" />);
+
+    expect(getBarHeights()).toEqual(['0px', '4px', '20px']);
+  });
+});


### PR DESCRIPTION
## What is the purpose of the change

Fixes #628 .

Prevent `MiniBar` from rendering zero throughput values as visible 4px bars, which can make idle periods appear active.

## Brief changelog

- Render zero values with 0px height.
- Preserve the minimum 4px height for positive values.
- Add regression tests for all-zero and mixed throughput data.