### PR TITLE
[Studio] Validate cluster operation requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterController.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.broker;
 import org.apache.rocketmq.studio.cluster.config.UpdateConfigDTO;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -48,7 +49,7 @@ public class ClusterController {
     }
 
     @PostMapping("/config/update")
-    public Result<ClusterVO> updateClusterConfig(@RequestBody UpdateConfigDTO command) {
+    public Result<ClusterVO> updateClusterConfig(@Valid @RequestBody UpdateConfigDTO command) {
         return Result.ok(clusterService.updateClusterConfig(command));
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/config/UpdateConfigDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/config/UpdateConfigDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.cluster.config;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,7 +27,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateConfigDTO {
+    @NotBlank(message = "id is required")
     private String id;
+
     private String flushDiskType;
     private Boolean autoCreateTopicEnable;
     private Boolean autoCreateSubscriptionGroup;

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/CreateNameServerDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/CreateNameServerDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.cluster.nameserver;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,7 +27,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateNameServerDTO {
+    @NotBlank(message = "clusterId is required")
     private String clusterId;
+
+    @NotBlank(message = "addr is required")
     private String addr;
+
     private String version;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/DeleteNameServerDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/DeleteNameServerDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.cluster.nameserver;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,6 +27,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DeleteNameServerDTO {
+    @NotBlank(message = "clusterId is required")
     private String clusterId;
+
+    @NotBlank(message = "addr is required")
     private String addr;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerController.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.nameserver;
 import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,30 +36,30 @@ public class NameServerController {
     private final ClusterService clusterService;
 
     @PostMapping("/create")
-    public Result<NameServerVO> createNameServer(@RequestBody CreateNameServerDTO command) {
+    public Result<NameServerVO> createNameServer(@Valid @RequestBody CreateNameServerDTO command) {
         return Result.ok(clusterService.createNameServer(command));
     }
 
     @PostMapping("/update")
-    public Result<Void> updateNameServer(@RequestBody UpdateNameServerDTO command) {
+    public Result<Void> updateNameServer(@Valid @RequestBody UpdateNameServerDTO command) {
         clusterService.updateNameServer(command);
         return Result.ok();
     }
 
     @PostMapping("/restart")
-    public Result<Map<String, Boolean>> restartNameServer(@RequestBody RestartNameServerDTO command) {
+    public Result<Map<String, Boolean>> restartNameServer(@Valid @RequestBody RestartNameServerDTO command) {
         boolean success = clusterService.restartNameServer(command);
         return Result.ok(Map.of("success", success));
     }
 
     @PostMapping("/upgrade")
-    public Result<Map<String, Boolean>> upgradeNameServer(@RequestBody UpgradeNameServerDTO command) {
+    public Result<Map<String, Boolean>> upgradeNameServer(@Valid @RequestBody UpgradeNameServerDTO command) {
         boolean success = clusterService.upgradeNameServer(command);
         return Result.ok(Map.of("success", success));
     }
 
     @PostMapping("/delete")
-    public Result<Map<String, Boolean>> deleteNameServer(@RequestBody DeleteNameServerDTO command) {
+    public Result<Map<String, Boolean>> deleteNameServer(@Valid @RequestBody DeleteNameServerDTO command) {
         boolean success = clusterService.deleteNameServer(command);
         return Result.ok(Map.of("success", success));
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/RestartNameServerDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/RestartNameServerDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.cluster.nameserver;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,6 +27,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RestartNameServerDTO {
+    @NotBlank(message = "clusterId is required")
     private String clusterId;
+
+    @NotBlank(message = "addr is required")
     private String addr;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/UpdateNameServerDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/UpdateNameServerDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.cluster.nameserver;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,7 +27,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateNameServerDTO {
+    @NotBlank(message = "clusterId is required")
     private String clusterId;
+
+    @NotBlank(message = "addr is required")
     private String addr;
+
     private String version;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/UpgradeNameServerDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/UpgradeNameServerDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.cluster.nameserver;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,7 +27,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpgradeNameServerDTO {
+    @NotBlank(message = "clusterId is required")
     private String clusterId;
+
+    @NotBlank(message = "addr is required")
     private String addr;
+
+    @NotBlank(message = "targetVersion is required")
     private String targetVersion;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyController.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.proxy;
 
 import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 import org.apache.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,7 +35,7 @@ public class ProxyController {
     private final ClusterService clusterService;
 
     @PostMapping("/restart")
-    public Result<Map<String, Boolean>> restartProxy(@RequestBody RestartProxyDTO command) {
+    public Result<Map<String, Boolean>> restartProxy(@Valid @RequestBody RestartProxyDTO command) {
         boolean success = clusterService.restartProxy(command);
         return Result.ok(Map.of("success", success));
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/RestartProxyDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/RestartProxyDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.cluster.proxy;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,6 +27,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RestartProxyDTO {
+    @NotBlank(message = "clusterId is required")
     private String clusterId;
+
+    @NotBlank(message = "addr is required")
     private String addr;
 }

--- a/server/src/test/java/com/rocketmq/studio/cluster/nameserver/NameServerControllerTest.java
+++ b/server/src/test/java/com/rocketmq/studio/cluster/nameserver/NameServerControllerTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.nameserver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.cluster.broker.ClusterService;
+import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NameServerController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class NameServerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ClusterService clusterService;
+
+    @Test
+    void createNameServerShouldPassValidatedRequest() throws Exception {
+        CreateNameServerDTO request = CreateNameServerDTO.builder()
+                .clusterId("cluster-1")
+                .addr("127.0.0.1:9876")
+                .version("5.3.2")
+                .build();
+        NameServerVO created = NameServerVO.builder()
+                .addr("127.0.0.1:9876")
+                .status(ClusterStatus.healthy)
+                .build();
+        when(clusterService.createNameServer(any(CreateNameServerDTO.class))).thenReturn(created);
+
+        mockMvc.perform(post("/api/nameservers/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.addr").value("127.0.0.1:9876"));
+
+        verify(clusterService).createNameServer(any(CreateNameServerDTO.class));
+    }
+
+    @Test
+    void updateNameServerShouldRejectBlankAddr() throws Exception {
+        UpdateNameServerDTO request = UpdateNameServerDTO.builder()
+                .clusterId("cluster-1")
+                .addr(" ")
+                .build();
+
+        mockMvc.perform(post("/api/nameservers/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("addr is required"));
+
+        verifyNoInteractions(clusterService);
+    }
+
+    @Test
+    void restartNameServerShouldPassValidatedRequest() throws Exception {
+        RestartNameServerDTO request = RestartNameServerDTO.builder()
+                .clusterId("cluster-1")
+                .addr("127.0.0.1:9876")
+                .build();
+        when(clusterService.restartNameServer(any(RestartNameServerDTO.class))).thenReturn(true);
+
+        mockMvc.perform(post("/api/nameservers/restart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.success").value(true));
+
+        verify(clusterService).restartNameServer(any(RestartNameServerDTO.class));
+    }
+
+    @Test
+    void restartNameServerShouldRejectMissingClusterId() throws Exception {
+        RestartNameServerDTO request = RestartNameServerDTO.builder()
+                .addr("127.0.0.1:9876")
+                .build();
+
+        mockMvc.perform(post("/api/nameservers/restart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("clusterId is required"));
+
+        verifyNoInteractions(clusterService);
+    }
+
+    @Test
+    void upgradeNameServerShouldRejectMissingTargetVersion() throws Exception {
+        UpgradeNameServerDTO request = UpgradeNameServerDTO.builder()
+                .clusterId("cluster-1")
+                .addr("127.0.0.1:9876")
+                .build();
+
+        mockMvc.perform(post("/api/nameservers/upgrade")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("targetVersion is required"));
+
+        verifyNoInteractions(clusterService);
+    }
+
+    @Test
+    void deleteNameServerShouldPassValidatedRequest() throws Exception {
+        DeleteNameServerDTO request = DeleteNameServerDTO.builder()
+                .clusterId("cluster-1")
+                .addr("127.0.0.1:9876")
+                .build();
+        when(clusterService.deleteNameServer(any(DeleteNameServerDTO.class))).thenReturn(true);
+
+        mockMvc.perform(post("/api/nameservers/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.success").value(true));
+
+        verify(clusterService).deleteNameServer(any(DeleteNameServerDTO.class));
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterControllerTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -133,6 +134,40 @@ class ClusterControllerTest {
                 .andExpect(jsonPath("$.data.config.flushDiskType").value("SYNC_FLUSH"))
                 .andExpect(jsonPath("$.data.config.writeQueueNums").value(16))
                 .andExpect(jsonPath("$.data.config.readQueueNums").value(16));
+    }
+
+    @Test
+    void updateConfigShouldRejectMissingId() throws Exception {
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .flushDiskType("SYNC_FLUSH")
+                .writeQueueNums(16)
+                .build();
+
+        mockMvc.perform(post("/api/clusters/config/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(command)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(clusterService);
+    }
+
+    @Test
+    void updateConfigShouldRejectBlankId() throws Exception {
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id(" ")
+                .flushDiskType("SYNC_FLUSH")
+                .build();
+
+        mockMvc.perform(post("/api/clusters/config/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(command)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(clusterService);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyControllerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.proxy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.cluster.broker.ClusterService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProxyController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ProxyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ClusterService clusterService;
+
+    @Test
+    void restartProxyShouldPassValidatedRequest() throws Exception {
+        RestartProxyDTO request = RestartProxyDTO.builder()
+                .clusterId("cluster-1")
+                .addr("127.0.0.1:8081")
+                .build();
+        when(clusterService.restartProxy(any(RestartProxyDTO.class))).thenReturn(true);
+
+        mockMvc.perform(post("/api/proxies/restart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.success").value(true));
+
+        verify(clusterService).restartProxy(any(RestartProxyDTO.class));
+    }
+
+    @Test
+    void restartProxyShouldRejectMissingClusterId() throws Exception {
+        RestartProxyDTO request = RestartProxyDTO.builder()
+                .addr("127.0.0.1:8081")
+                .build();
+
+        mockMvc.perform(post("/api/proxies/restart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("clusterId is required"));
+
+        verifyNoInteractions(clusterService);
+    }
+
+    @Test
+    void restartProxyShouldRejectBlankAddr() throws Exception {
+        RestartProxyDTO request = RestartProxyDTO.builder()
+                .clusterId("cluster-1")
+                .addr(" ")
+                .build();
+
+        mockMvc.perform(post("/api/proxies/restart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("addr is required"));
+
+        verifyNoInteractions(clusterService);
+    }
+}


### PR DESCRIPTION
## Summary
- validate proxy restart request bodies with a dedicated DTO
- validate NameServer create/update/delete/restart/upgrade request bodies
- validate cluster config update request ids
- consolidate related cluster operation validation PRs into one review unit

## Supersedes
#553 #554 #555

## Tests
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=ProxyControllerTest,NameServerControllerTest,ClusterControllerTest test`
- `git diff --check`
