### PR TITLE
[Studio] Validate ACL request inputs

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.instance.acl;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/acl")
@@ -53,8 +53,8 @@ public class AclController {
     }
 
     @PostMapping("/rules/delete")
-    public Result<Void> deleteRule(@RequestBody Map<String, String> request) {
-        aclService.deleteRule(request.get("id"));
+    public Result<Void> deleteRule(@Valid @RequestBody AclDeleteRequestDTO request) {
+        aclService.deleteRule(request.getId());
         return Result.ok();
     }
 
@@ -74,8 +74,8 @@ public class AclController {
     }
 
     @PostMapping("/users/delete")
-    public Result<Void> deleteUser(@RequestBody Map<String, String> request) {
-        aclService.deleteUser(request.get("id"));
+    public Result<Void> deleteUser(@Valid @RequestBody AclDeleteRequestDTO request) {
+        aclService.deleteUser(request.getId());
         return Result.ok();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclDeleteRequestDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclDeleteRequestDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.acl;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AclDeleteRequestDTO {
+    @NotBlank(message = "id is required")
+    private String id;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -45,6 +45,12 @@ public class AclService {
 
     public AclRuleVO createRule(AclRuleVO rule) {
         log.info("Creating ACL rule for principal={}", rule.getPrincipal());
+        if (isBlank(rule.getPrincipal())) {
+            throw new BusinessException(400, "ACL principal is required");
+        }
+        if (isBlank(rule.getResource())) {
+            throw new BusinessException(400, "ACL resource is required");
+        }
         rule.setId(UUID.randomUUID().toString());
         rule.setCreatedAt(LocalDateTime.now());
         return aclRepository.saveRule(rule);
@@ -77,6 +83,9 @@ public class AclService {
 
     public AclUserVO createUser(AclUserVO user) {
         log.info("Creating ACL user username={}", user.getUsername());
+        if (isBlank(user.getUsername())) {
+            throw new BusinessException(400, "ACL username is required");
+        }
         user.setId(UUID.randomUUID().toString());
         user.setAccessKey(UUID.randomUUID().toString().replace("-", ""));
         user.setSecretKey(UUID.randomUUID().toString().replace("-", ""));

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
@@ -28,11 +28,13 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -138,6 +140,30 @@ class AclControllerTest {
     }
 
     @Test
+    void deleteRuleShouldPassValidatedRequest() throws Exception {
+        mockMvc.perform(post("/api/acl/rules/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", "rule-1"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"));
+
+        verify(aclService).deleteRule("rule-1");
+    }
+
+    @Test
+    void deleteRuleShouldRejectBlankId() throws Exception {
+        mockMvc.perform(post("/api/acl/rules/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", " "))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(aclService);
+    }
+
+    @Test
     void listUsersShouldReturnAllUsers() throws Exception {
         AclUserVO user = AclUserVO.builder()
                 .username("admin")
@@ -208,5 +234,29 @@ class AclControllerTest {
                 .andExpect(jsonPath("$.data.accessKey").value("acce****3456"))
                 .andExpect(jsonPath("$.data.secretKey").value("secr****7654"))
                 .andExpect(jsonPath("$.data.admin").value(false));
+    }
+
+    @Test
+    void deleteUserShouldPassValidatedRequest() throws Exception {
+        mockMvc.perform(post("/api/acl/users/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", "user-1"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"));
+
+        verify(aclService).deleteUser("user-1");
+    }
+
+    @Test
+    void deleteUserShouldRejectMissingId() throws Exception {
+        mockMvc.perform(post("/api/acl/users/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("id is required"));
+
+        verifyNoInteractions(aclService);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -299,6 +299,48 @@ class AclServiceTest {
     }
 
     @Test
+    void createRuleShouldRequirePrincipal() {
+        AclRuleVO input = AclRuleVO.builder()
+                .principal(" ")
+                .resource("topic-1")
+                .build();
+
+        assertThatThrownBy(() -> aclService.createRule(input))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400))
+                .hasMessage("ACL principal is required");
+        verify(aclRepository, never()).saveRule(any(AclRuleVO.class));
+    }
+
+    @Test
+    void createRuleShouldRequireResource() {
+        AclRuleVO input = AclRuleVO.builder()
+                .principal("user1")
+                .resource(" ")
+                .build();
+
+        assertThatThrownBy(() -> aclService.createRule(input))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400))
+                .hasMessage("ACL resource is required");
+        verify(aclRepository, never()).saveRule(any(AclRuleVO.class));
+    }
+
+    @Test
+    void createUserShouldRequireUsername() {
+        AclUserVO input = AclUserVO.builder()
+                .username(" ")
+                .admin(false)
+                .build();
+
+        assertThatThrownBy(() -> aclService.createUser(input))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400))
+                .hasMessage("ACL username is required");
+        verify(aclRepository, never()).saveUser(any(AclUserVO.class));
+    }
+
+    @Test
     void createListUpdateShouldPreserveStoredCredentials() {
         InMemoryAclRepository repository = new InMemoryAclRepository();
         AclService service = new AclService(repository);


### PR DESCRIPTION
## Summary
- validate ACL user/rule delete request bodies with a dedicated DTO
- validate ACL create inputs in the service layer
- consolidate related ACL request validation PRs into one review unit

## Supersedes
#550 #565

## Tests
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=AclControllerTest,AclServiceTest test`
- `git diff --check`
