### PR TITLE
[Studio] Encode API path segments

### DIFF
--- a/web/src/api/cluster.test.ts
+++ b/web/src/api/cluster.test.ts
@@ -23,8 +23,10 @@ import {
   createNameServer,
   deleteK8sCert,
   deleteNameServer,
+  getCluster,
   listK8sCerts,
   renewK8sCert,
+  restartBroker,
   restartNameServer,
   restartProxy,
   updateK8sCert,
@@ -101,6 +103,33 @@ describe('K8s certificate API', () => {
     });
 
     await expect(deleteK8sCert(cert.id)).resolves.toBeUndefined();
+  });
+
+  it('encodes cluster path parameters', async () => {
+    const cluster = {
+      id: 'cloud/prod cluster:1',
+      name: 'prod',
+    };
+    mock.onGet('/clusters/cloud%2Fprod%20cluster%3A1').reply(200, {
+      code: 200,
+      data: cluster,
+    });
+
+    await expect(getCluster(cluster.id)).resolves.toEqual(cluster);
+  });
+
+  it('encodes broker restart path parameters', async () => {
+    mock
+      .onPost('/clusters/cloud%2Fprod%20cluster%3A1/brokers/broker%2Fmain%3A10911/restart')
+      .reply(200, {
+        code: 200,
+        data: { success: true, message: 'restarted' },
+      });
+
+    await expect(restartBroker('cloud/prod cluster:1', 'broker/main:10911')).resolves.toEqual({
+      success: true,
+      message: 'restarted',
+    });
   });
 
   it('sends NameServer operation payloads to their endpoints', async () => {

--- a/web/src/api/cluster.ts
+++ b/web/src/api/cluster.ts
@@ -17,6 +17,8 @@
 
 import client from './client';
 
+const pathSegment = (value: string): string => encodeURIComponent(value);
+
 // ─── Types ──────────────────────────────────────────────────────
 export interface ClusterInfo {
   id: string;
@@ -92,7 +94,7 @@ export async function listClusters() {
 }
 
 export async function getCluster(id: string) {
-  const res = await client.get<{ data: ClusterInfo }>(`/clusters/${id}`);
+  const res = await client.get<{ data: ClusterInfo }>(`/clusters/${pathSegment(id)}`);
   return res.data.data;
 }
 
@@ -102,7 +104,7 @@ export async function updateClusterConfig(data: { id: string } & Partial<Cluster
 
 export async function restartBroker(clusterId: string, brokerName: string) {
   const res = await client.post<{ data: { success: boolean; message: string } }>(
-    `/clusters/${clusterId}/brokers/${brokerName}/restart`,
+    `/clusters/${pathSegment(clusterId)}/brokers/${pathSegment(brokerName)}/restart`,
   );
   return res.data.data;
 }

--- a/web/src/api/message.test.ts
+++ b/web/src/api/message.test.ts
@@ -110,4 +110,14 @@ describe('message API', () => {
 
     await expect(getMessageTrace('msg-1')).resolves.toEqual(trace);
   });
+
+  it('encodes message IDs before requesting trace records', async () => {
+    const trace = {
+      nodes: [],
+      consumerStatus: [],
+    };
+    mock.onGet('/messages/AC1E0A64%2F0000%202A9F%3A1/trace').reply(200, { code: 200, data: trace });
+
+    await expect(getMessageTrace('AC1E0A64/0000 2A9F:1')).resolves.toEqual(trace);
+  });
 });

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -70,7 +70,7 @@ export async function queryMessages(params: MessageQuery) {
 }
 
 export async function getMessageTrace(msgId: string) {
-  const res = await client.get<{ data: TraceRecord }>(`/messages/${msgId}/trace`);
+  const res = await client.get<{ data: TraceRecord }>(`/messages/${encodeURIComponent(msgId)}/trace`);
   return res.data.data;
 }
 


### PR DESCRIPTION
## Summary
- encode cluster API path segments before building dynamic URLs
- encode message trace path segments before building dynamic URLs
- consolidate related frontend API path encoding fixes into one review unit

## Supersedes
#614 #619

## Tests
- `npm ci --ignore-scripts --no-audit --no-fund && npm test -- --run src/api/cluster.test.ts src/api/message.test.ts`
- `git diff --check`
