### PR TITLE
[studio] feat: add common Result wrapper, BusinessException and Globa…

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusException.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import lombok.Getter;
+
+@Getter
+public class PrometheusException extends RuntimeException {
+    private final int statusCode;
+
+    public PrometheusException(int statusCode, String message) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    public PrometheusException(int statusCode, String message, Throwable cause) {
+        super(message, cause);
+        this.statusCode = statusCode;
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/common/domain/Result.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/domain/Result.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.domain;
+
+public class Result<T> {
+    private int status;
+    private T data;
+    private String errMsg;
+
+    private Result() {}
+
+    private Result(int status, String errMsg, T data) {
+        this.status = status;
+        this.errMsg = errMsg;
+        this.data = data;
+    }
+
+    public static <T> Result<T> ok(T data) {
+        return new Result<>(0, null, data);
+    }
+
+    public static <T> Result<T> ok() {
+        return new Result<>(0, null, null);
+    }
+
+    public static <T> Result<T> error(int status, String errMsg) {
+        return new Result<>(status, errMsg, null);
+    }
+
+    public int getStatus() { return status; }
+    public String getErrMsg() { return errMsg; }
+    public T getData() { return data; }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/common/exception/BusinessException.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/exception/BusinessException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final int code;
+
+    public BusinessException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.exception;
+
+import org.apache.rocketmq.studio.cluster.metrics.PrometheusException;
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(BusinessException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Result<?> handleBusinessException(BusinessException ex) {
+        log.warn("Business exception: {}", ex.getMessage());
+        return Result.error(ex.getCode(), ex.getMessage());
+    }
+
+    @ExceptionHandler(PrometheusException.class)
+    public ResponseEntity<Result<?>> handlePrometheusException(PrometheusException ex) {
+        log.warn("Prometheus exception: status={}, message={}", ex.getStatusCode(), ex.getMessage());
+        return ResponseEntity.status(ex.getStatusCode())
+                .body(Result.error(ex.getStatusCode(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Result<?> handleValidationException(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(error -> error.getDefaultMessage() == null ? "Invalid request" : error.getDefaultMessage())
+                .orElse("Invalid request");
+        return Result.error(HttpStatus.BAD_REQUEST.value(), message);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Result<?> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        log.warn("Invalid request body");
+        return Result.error(HttpStatus.BAD_REQUEST.value(), "Invalid request body");
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Result<?> handleException(Exception ex) {
+        log.error("Unexpected exception", ex);
+        return Result.error(500, "Internal Server Error");
+    }
+}


### PR DESCRIPTION
## Summary
- Add generic `Result<T>` API response wrapper with `ok()`/`error()` factory methods for standardized REST responses
- Add `BusinessException` with integer error code for domain-level error handling
- Add `GlobalExceptionHandler` (`@RestControllerAdvice`) to handle BusinessException, PrometheusException, validation errors (MethodArgumentNotValidException), and malformed requests (HttpMessageNotReadableException)
- Include `PrometheusException` as a dependency for the metrics module (PR-02)

## Test plan
- [ ] Verify `Result.ok()` and `Result.error()` return correct status/data/errMsg fields
- [ ] Verify GlobalExceptionHandler catches BusinessException and returns proper HTTP 400 response
- [ ] Verify GlobalExceptionHandler catches validation errors and returns proper response
- [ ] Verify PrometheusException carries HTTP status code correctly