### PR TITLE
[Studio] Add capability context for architecture-aware UI rendering

### DIFF
--- a/web/src/contexts/CapabilityContext.tsx
+++ b/web/src/contexts/CapabilityContext.tsx
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import client from '../api/client';
+import { USE_MOCK } from '../config';
+
+// ─── Types ──────────────────────────────────────────────────────
+// Mirrors org.apache.rocketmq.dashboard.model.ClusterCapability served by
+// GET /api/architecture/capabilities. Drives capability-based UI rendering
+// (menus / pages are shown or hidden depending on cluster features).
+export interface ClusterCapability {
+  namespaceSupported: boolean;
+  liteTopicSupported: boolean;
+  popConsumeSupported: boolean;
+  aclV2Supported: boolean;
+  grpcClientSupported: boolean;
+  architectureVersion: string;
+}
+
+export const DEFAULT_CAPABILITY: ClusterCapability = {
+  namespaceSupported: false,
+  liteTopicSupported: false,
+  popConsumeSupported: false,
+  aclV2Supported: false,
+  grpcClientSupported: false,
+  architectureVersion: 'unknown',
+};
+
+// Mock mode presents a full-featured 5.0 cluster so every page is reachable.
+const MOCK_CAPABILITY: ClusterCapability = {
+  namespaceSupported: true,
+  liteTopicSupported: true,
+  popConsumeSupported: true,
+  aclV2Supported: true,
+  grpcClientSupported: true,
+  architectureVersion: '5.0',
+};
+
+interface CapabilityContextValue {
+  capability: ClusterCapability;
+  loading: boolean;
+  refresh: () => Promise<void>;
+}
+
+const CapabilityContext = createContext<CapabilityContextValue>({
+  // In mock mode components may render without a provider (e.g. unit tests);
+  // fall back to the full-featured capability so pages stay reachable.
+  capability: USE_MOCK ? MOCK_CAPABILITY : DEFAULT_CAPABILITY,
+  loading: false,
+  refresh: async () => {},
+});
+
+/** Unwraps both raw and {status, data, errMsg} wrapped response bodies. */
+function unwrapCapability(body: unknown): ClusterCapability {
+  if (body && typeof body === 'object') {
+    const record = body as Record<string, unknown>;
+    const payload =
+      'data' in record && record.data && typeof record.data === 'object' ? record.data : record;
+    return { ...DEFAULT_CAPABILITY, ...(payload as Partial<ClusterCapability>) };
+  }
+  return DEFAULT_CAPABILITY;
+}
+
+export function CapabilityProvider({ children }: { children: ReactNode }) {
+  const [capability, setCapability] = useState<ClusterCapability>(
+    USE_MOCK ? MOCK_CAPABILITY : DEFAULT_CAPABILITY,
+  );
+  const [loading, setLoading] = useState(!USE_MOCK);
+
+  // All setState calls happen after the await, so the mount effect below
+  // never sets state synchronously (react-hooks/set-state-in-effect).
+  const refresh = useCallback(async () => {
+    if (USE_MOCK) return;
+    setLoading(true);
+    try {
+      const res = await client.get('/architecture/capabilities');
+      setCapability(unwrapCapability(res.data));
+    } catch {
+      // Keep the last known capability; pages degrade gracefully.
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Initial loading state already starts as true outside mock mode, so no
+    // synchronous setState is needed here; all updates occur after the await.
+    if (USE_MOCK) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await client.get('/architecture/capabilities');
+        if (!cancelled) setCapability(unwrapCapability(res.data));
+      } catch {
+        // Keep the last known capability; pages degrade gracefully.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <CapabilityContext.Provider value={{ capability, loading, refresh }}>
+      {children}
+    </CapabilityContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useCapability() {
+  return useContext(CapabilityContext);
+}

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -40,6 +40,7 @@ import {
 } from '@phosphor-icons/react';
 import { useLang } from '../i18n/LangContext';
 import { useTheme } from '../theme/ThemeContext';
+import { useCapability } from '../contexts/CapabilityContext';
 import { logout as requestLogout } from '../api/auth';
 import useAuthStore from '../stores/authStore';
 import {
@@ -56,6 +57,7 @@ const MainLayout = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { darkMode, toggleTheme } = useTheme();
+  const { capability } = useCapability();
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchText, setSearchText] = useState('');
   const { lang, setLang, t } = useLang();
@@ -270,6 +272,29 @@ const MainLayout = () => {
 
             {/* Right: Search + Lang + Theme + User */}
             <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+              {/* Architecture indicator */}
+              {capability.grpcClientSupported && (
+                <div
+                  onClick={() => navigate('/settings')}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 4,
+                    padding: '2px 8px',
+                    borderRadius: 4,
+                    fontSize: 11,
+                    fontWeight: 500,
+                    background: darkMode ? '#1a3a1a' : '#f0faf0',
+                    color: '#52c41a',
+                    border: '1px solid #52c41a33',
+                    cursor: 'pointer',
+                  }}
+                  title="V5 Proxy 架构 — 点击切换"
+                >
+                  <span style={{ fontSize: 10 }}>⚡</span> V5
+                </div>
+              )}
+
               {/* Search button */}
               <div
                 onClick={() => setSearchOpen(true)}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -23,6 +23,7 @@ import zhCN from 'antd/locale/zh_CN';
 import enUS from 'antd/locale/en_US';
 import { LangProvider, useLang } from './i18n/LangContext';
 import { ThemeProvider, useTheme } from './theme/ThemeContext';
+import { CapabilityProvider } from './contexts/CapabilityContext';
 import App from './App';
 import './index.css';
 
@@ -71,7 +72,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <LangProvider>
       <ThemeProvider>
-        <ThemedApp />
+        <CapabilityProvider>
+          <ThemedApp />
+        </CapabilityProvider>
       </ThemeProvider>
     </LangProvider>
   </React.StrictMode>,


### PR DESCRIPTION
## Summary

Introduce a capability-based UI rendering system that dynamically detects
cluster architecture features and conditionally shows/hides UI elements.

- Add `CapabilityContext` that queries `GET /architecture/capabilities` on
  mount to retrieve the cluster's feature matrix (namespace, liteTopic,
  popConsume, aclV2, grpcClient support)
- Support Mock mode (all features enabled for development/testing) and
  production mode (features fetched from backend)
- Wrap the application with `CapabilityProvider` in main.tsx
- Add a V5 architecture indicator badge in MainLayout's top bar that
  appears when `grpcClientSupported` is true, linking to settings page

## Test plan

- [ ] Verify app renders correctly with CapabilityProvider wrapping
- [ ] In mock mode (VITE_USE_MOCK=true), V5 indicator should appear
- [ ] When backend returns grpcClientSupported=false, indicator should hide
- [ ] Clicking the V5 badge should navigate to /settings