### PR TITLE
[Studio] Add CSRF token support for mutating HTTP requests

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -49,12 +49,52 @@ const client = axios.create({
   timeout: 30000,
 });
 
-// Request interceptor: attach Authorization header
+// ─── CSRF support ────────────────────────────────────────────────
+// The backend uses CookieCsrfTokenRepository (httpOnly=false), so the token
+// is available in the XSRF-TOKEN cookie. For mutating requests (POST/PUT/DELETE)
+// we must send it back as the X-XSRF-TOKEN header.
+function getXsrfTokenFromCookie(): string | null {
+  const match = document.cookie
+    .split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith('XSRF-TOKEN='));
+  return match ? decodeURIComponent(match.slice('XSRF-TOKEN='.length)) : null;
+}
+
+let xsrfFetchPromise: Promise<void> | null = null;
+
+async function ensureXsrfToken(): Promise<void> {
+  if (getXsrfTokenFromCookie()) return;
+  if (!xsrfFetchPromise) {
+    xsrfFetchPromise = fetch('/rocketmq-dashboard/csrf-token', {
+      method: 'GET',
+      credentials: 'same-origin',
+    })
+      .then(() => {
+        xsrfFetchPromise = null;
+      })
+      .catch(() => {
+        xsrfFetchPromise = null;
+      });
+  }
+  await xsrfFetchPromise;
+}
+
+// Request interceptor: attach Authorization + XSRF headers
 client.interceptors.request.use(
-  (config) => {
+  async (config) => {
     const token = localStorage.getItem(TOKEN_STORAGE_KEY);
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
+    }
+    // Attach XSRF token for mutating requests
+    const method = (config.method || '').toUpperCase();
+    if (['POST', 'PUT', 'DELETE', 'PATCH'].includes(method)) {
+      await ensureXsrfToken();
+      const xsrf = getXsrfTokenFromCookie();
+      if (xsrf) {
+        config.headers['X-XSRF-TOKEN'] = xsrf;
+      }
     }
     return config;
   },


### PR DESCRIPTION
## Summary

Add CSRF (Cross-Site Request Forgery) protection to the HTTP client to
complement the backend's CookieCsrfTokenRepository configuration.

- Read XSRF-TOKEN from cookies (set by backend with httpOnly=false)
- Request interceptor now attaches X-XSRF-TOKEN header for mutating
  methods: POST, PUT, DELETE, PATCH
- On first request, if XSRF cookie is not present, fetch
  `/rocketmq-dashboard/csrf-token` endpoint to trigger cookie creation
- Deduplicate concurrent CSRF fetch requests via shared promise
- Non-mutating requests (GET, HEAD, OPTIONS) are unaffected

## Test plan

- [ ] GET requests should NOT include X-XSRF-TOKEN header
- [ ] POST/PUT/DELETE requests should include X-XSRF-TOKEN from cookie
- [ ] First mutating request should trigger /csrf-token fetch if no cookie
- [ ] Existing Authorization header behavior unchanged
- [ ] 401 handling and auth session clearing still work correctly