### PR TITLE
[Studio] Improve StatusBadge accessibility with semantic aria-label

### DIFF
--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -32,7 +32,7 @@ const StatusBadge = ({ status, text, showDot = true }: StatusBadgeProps) => {
   const config = STATUS_MAP[status] || STATUS_MAP.offline;
   const label = text || t(config.labelKey);
   return (
-    <Space size={4} role="status" aria-label={label}>
+    <Space size={4} role="status" aria-label={`状态：${label}`}>
       {showDot && <Badge color={config.dot} aria-hidden="true" />}
       <Text style={{ color: config.color, fontSize: 13 }}>{label}</Text>
     </Space>


### PR DESCRIPTION
## Summary

Improve StatusBadge accessibility by adding a semantic prefix to the
aria-label attribute.

Before: `aria-label={label}` (e.g. "在线")
After: `aria-label={`状态：${label}`}` (e.g. "状态：在线")

This helps screen reader users understand the widget's purpose before
hearing the status value, aligning with WCAG 2.1 guidelines for
informative status indicators.

## Test plan

- [ ] Inspect StatusBadge element: aria-label should start with "状态："
- [ ] Screen reader should announce "状态：在线" instead of just "在线"