### PR TITLE
[Studio] fix: keep SSL settings state and actions consistent

### DIFF
--- a/web/src/pages/studio/SslSettings.tsx
+++ b/web/src/pages/studio/SslSettings.tsx
@@ -67,7 +67,6 @@ interface FormValues {
 const SslSettingsPage = () => {
   const [form] = Form.useForm<FormValues>();
   const [loading, setLoading] = useState(false);
-  const [sslEnabled, setSslEnabled] = useState(false);
   const [sslConfig, setSslConfig] = useState<SslConfig>({
     enabled: false,
     protocol: 'TLSv1.3',
@@ -81,6 +80,7 @@ const SslSettingsPage = () => {
     certificateExpiry: '2025-12-31',
     certificateIssuer: "Let's Encrypt",
   });
+  const sslEnabled = Form.useWatch('enabled', form) ?? sslConfig.enabled;
   const clientAuth = Form.useWatch('clientAuth', form) ?? sslConfig.clientAuth;
   const { t } = useLang();
   const { message } = App.useApp();
@@ -92,11 +92,6 @@ const SslSettingsPage = () => {
       message.success(t('ssl.saveSuccess'));
       setSslConfig({ ...sslConfig, ...values });
     }, 1000);
-  };
-
-  const handleToggleSsl = (checked: boolean) => {
-    setSslEnabled(checked);
-    form.setFieldsValue({ enabled: checked });
   };
 
   const uploadProps = {
@@ -144,8 +139,6 @@ const SslSettingsPage = () => {
         <Form form={form} layout="vertical" onFinish={handleSave} initialValues={sslConfig}>
           <Form.Item name="enabled" label={t('ssl.enabled')} valuePropName="checked">
             <Switch
-              checked={sslEnabled}
-              onChange={handleToggleSsl}
               checkedChildren={<CheckCircle size={12} />}
               unCheckedChildren={<XCircle size={12} />}
             />
@@ -276,19 +269,19 @@ const SslSettingsPage = () => {
                   </Form.Item>
                 </>
               )}
-
-              <Divider />
-
-              <Form.Item>
-                <Space>
-                  <Button type="primary" htmlType="submit" loading={loading}>
-                    {t('ssl.save')}
-                  </Button>
-                  <Button onClick={() => form.resetFields()}>{t('common.reset')}</Button>
-                </Space>
-              </Form.Item>
             </>
           )}
+
+          <Divider />
+
+          <Form.Item>
+            <Space>
+              <Button type="primary" htmlType="submit" loading={loading}>
+                {t('ssl.save')}
+              </Button>
+              <Button onClick={() => form.setFieldsValue(sslConfig)}>{t('common.reset')}</Button>
+            </Space>
+          </Form.Item>
         </Form>
       </Card>
 

--- a/web/src/pages/studio/__tests__/SslSettings.test.tsx
+++ b/web/src/pages/studio/__tests__/SslSettings.test.tsx
@@ -96,6 +96,34 @@ describe('SslSettings Page', () => {
     expect(screen.getByText('KeyStore 密码')).toBeInTheDocument();
   });
 
+  it('should restore the saved SSL state when resetting the form', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SslSettings />);
+    const switchEl = screen.getByRole('switch');
+
+    await user.click(switchEl);
+    expect(switchEl).toBeChecked();
+    expect(screen.getByText('KeyStore 配置')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /重\s*置/ }));
+
+    expect(switchEl).not.toBeChecked();
+    expect(screen.queryByText('KeyStore 配置')).not.toBeInTheDocument();
+  });
+
+  it('should keep form actions available after disabling SSL', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SslSettings />);
+    const switchEl = screen.getByRole('switch');
+
+    await user.click(switchEl);
+    await user.click(switchEl);
+
+    expect(switchEl).not.toBeChecked();
+    expect(screen.getByRole('button', { name: /保\s*存/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /重\s*置/ })).toBeInTheDocument();
+  });
+
   it('should show TrustStore fields when client authentication is required', async () => {
     const user = userEvent.setup();
     renderWithProviders(<SslSettings />);


### PR DESCRIPTION
## What is the purpose of the change

Resetting the SSL settings could leave the switch state inconsistent with the form value. Additionally, disabling SSL hid the save and reset buttons, preventing users from saving or reverting the disabled state.

## Brief changelog

- Use the form value as the single source of truth for the SSL enabled state
- Restore the latest saved configuration when resetting the form
- Keep save and reset actions available when SSL is disabled
- Add regression tests for reset behavior and disabled-state actions

## Verifying this change

- `npm test -- --maxWorkers=2 src/pages/studio/__tests__/SslSettings.test.tsx`
- `npm test -- --maxWorkers=2`
- `npm run lint`
- `npm run build`
- `prettier --check src/pages/studio/SslSettings.tsx src/pages/studio/__tests__/SslSettings.test.tsx`