### PR TITLE
[ISSUE #682] Stop showing simulated Proxy config

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -905,6 +905,11 @@ const translations: Record<string, Record<Lang, string>> = {
   'proxy.removeFailed': { zh: '移除代理失败', en: 'Failed to remove proxy' },
   'proxy.addrRequired': { zh: '请输入代理地址', en: 'Proxy address is required' },
   'proxy.noConfigData': { zh: '无配置数据', en: 'No config data' },
+  'proxy.configUnavailable': { zh: '配置接口未接入', en: 'Config API unavailable' },
+  'proxy.configUnavailableHint': {
+    zh: '当前版本尚未接入真实 Proxy 配置查询接口，已停止展示模拟配置。',
+    en: 'This version does not have a real Proxy config query API yet. Simulated config values are not shown.',
+  },
   'proxy.version': { zh: '版本', en: 'Version' },
   'proxy.status': { zh: '状态', en: 'Status' },
   'proxy.healthy': { zh: '健康', en: 'Healthy' },

--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -57,7 +57,6 @@ const ProxyPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [proxyNodes, setProxyNodes] = useState<ProxyNode[]>([]);
   const [selectedNode, setSelectedNode] = useState<ProxyNode | null>(null);
-  const [nodeConfig, setNodeConfig] = useState<Record<string, string>>({});
   const [configModalOpen, setConfigModalOpen] = useState(false);
   const [addNodeModalOpen, setAddNodeModalOpen] = useState(false);
   const [form] = Form.useForm();
@@ -119,19 +118,6 @@ const ProxyPage: React.FC = () => {
 
   const handleViewConfig = (node: ProxyNode) => {
     setSelectedNode(node);
-    // Simulated config data (API doesn't provide config endpoint)
-    setNodeConfig({
-      'proxy.name': `proxy-${node.address.split(':')[0]}`,
-      'proxy.listenPort': node.address.split(':')[1] || '8081',
-      'proxy.grpcPort': '8080',
-      'proxy.maxConnections': '10000',
-      'proxy.threadPoolSize': '64',
-      'proxy.messageMaxSize': '4194304',
-      'proxy.enableACL': 'true',
-      'proxy.tls.enabled': 'false',
-      'rocketmq.namesrv.addr': localStorage.getItem('namesrvAddr') || '127.0.0.1:9876',
-      'proxy.clusterName': 'DefaultCluster',
-    });
     setConfigModalOpen(true);
   };
 
@@ -288,6 +274,7 @@ const ProxyPage: React.FC = () => {
               type="link"
               size="small"
               icon={<GearSix size={14} />}
+              aria-label={t('proxy.viewConfig')}
               onClick={() => handleViewConfig(record)}
             />
           </Tooltip>
@@ -392,15 +379,9 @@ const ProxyPage: React.FC = () => {
         width={700}
       >
         <Descriptions bordered column={1} size="small">
-          {Object.entries(nodeConfig).length > 0 ? (
-            Object.entries(nodeConfig).map(([key, value]) => (
-              <Descriptions.Item key={key} label={key}>
-                {value}
-              </Descriptions.Item>
-            ))
-          ) : (
-            <Descriptions.Item label={t('proxy.noConfigData')}>-</Descriptions.Item>
-          )}
+          <Descriptions.Item label={t('proxy.configUnavailable')}>
+            {t('proxy.configUnavailableHint')}
+          </Descriptions.Item>
         </Descriptions>
       </Modal>
 

--- a/web/src/pages/studio/__tests__/Proxy.test.tsx
+++ b/web/src/pages/studio/__tests__/Proxy.test.tsx
@@ -89,4 +89,19 @@ describe('ProxyPage', () => {
     expect(screen.queryByText('刷新成功')).not.toBeInTheDocument();
     await waitFor(() => expect(queryProxyHomePage).toHaveBeenCalledTimes(2));
   });
+
+  it('does not render simulated proxy configuration values', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText('127.0.0.1:8081');
+
+    await user.click(screen.getByRole('button', { name: '查看配置' }));
+
+    expect(await screen.findByText('配置接口未接入')).toBeInTheDocument();
+    expect(
+      screen.getByText('当前版本尚未接入真实 Proxy 配置查询接口，已停止展示模拟配置。'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('proxy.maxConnections')).not.toBeInTheDocument();
+    expect(screen.queryByText('rocketmq.namesrv.addr')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- remove simulated Proxy runtime config values from the Studio Proxy config modal
- show an explicit unavailable state until a real Proxy config API exists
- add a regression test that verifies fake config keys are not rendered

Fixes https://github.com/apache/rocketmq-dashboard/issues/682

## Tests
- npm test -- Proxy.test.tsx