### PR TITLE
[ISSUE #686] Fail explicitly when DLQ provider is missing

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQProviderStub.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQProviderStub.java
@@ -16,70 +16,31 @@
  */
 package org.apache.rocketmq.studio.instance.dlq;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Component
 @Slf4j
 public class DLQProviderStub implements DLQProvider {
 
-    private final List<StubDLQGroup> stubData = List.of(
-            new StubDLQGroup("rmq-cn-v5-prod-01", DLQGroupVO.builder()
-                    .groupName("cg-order-payment")
-                    .dlqTopic("%DLQ%cg-order-payment")
-                    .messageCount(128)
-                    .lastEnqueueTime(LocalDateTime.of(2026, 7, 24, 10, 15, 30))
-                    .retryCount(16)
-                    .status("ACTIVE")
-                    .build()),
-            new StubDLQGroup("rmq-cn-v5-prod-01", DLQGroupVO.builder()
-                    .groupName("cg-inventory-sync")
-                    .dlqTopic("%DLQ%cg-inventory-sync")
-                    .messageCount(24)
-                    .lastEnqueueTime(LocalDateTime.of(2026, 7, 24, 9, 40, 12))
-                    .retryCount(8)
-                    .status("ACTIVE")
-                    .build()),
-            new StubDLQGroup("rmq-cn-v4-prod-02", DLQGroupVO.builder()
-                    .groupName("legacy-order-consumer")
-                    .dlqTopic("%DLQ%legacy-order-consumer")
-                    .messageCount(6)
-                    .lastEnqueueTime(LocalDateTime.of(2026, 7, 23, 22, 5, 0))
-                    .retryCount(3)
-                    .status("ACKED")
-                    .build())
-    );
-
     @Override
     public List<DLQGroupVO> listDLQGroups(String clusterId) {
-        log.info("DLQProviderStub.listDLQGroups called. clusterId={}", clusterId);
-        return stubData.stream()
-                .filter(item -> !StringUtils.hasText(clusterId) || item.clusterId().equals(clusterId))
-                .map(StubDLQGroup::group)
-                .map(DLQProviderStub::copyGroup)
-                .toList();
+        log.warn("DLQProviderStub.listDLQGroups called but no real DLQ provider is configured. clusterId={}",
+                clusterId);
+        throw unsupported();
     }
 
     @Override
     public void resendMessages(String groupName, Long startTime, Long endTime, String targetTopic) {
-        log.warn("DLQProviderStub.resendMessages called - no-op. group={}, targetTopic={}", groupName, targetTopic);
+        log.warn("DLQProviderStub.resendMessages called but no real DLQ provider is configured. group={}, targetTopic={}",
+                groupName, targetTopic);
+        throw unsupported();
     }
 
-    private static DLQGroupVO copyGroup(DLQGroupVO group) {
-        return DLQGroupVO.builder()
-                .groupName(group.getGroupName())
-                .dlqTopic(group.getDlqTopic())
-                .messageCount(group.getMessageCount())
-                .lastEnqueueTime(group.getLastEnqueueTime())
-                .retryCount(group.getRetryCount())
-                .status(group.getStatus())
-                .build();
-    }
-
-    private record StubDLQGroup(String clusterId, DLQGroupVO group) {
+    private BusinessException unsupported() {
+        return new BusinessException(501, "DLQ provider is not configured");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQProviderStubTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQProviderStubTest.java
@@ -17,53 +17,30 @@
 
 package org.apache.rocketmq.studio.instance.dlq;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DLQProviderStubTest {
 
     private final DLQProviderStub provider = new DLQProviderStub();
 
     @Test
-    void listDLQGroupsShouldReturnSampleGroupsForAllClusters() {
-        List<DLQGroupVO> groups = provider.listDLQGroups(null);
-
-        assertThat(groups)
-                .extracting(DLQGroupVO::getGroupName)
-                .containsExactly("cg-order-payment", "cg-inventory-sync", "legacy-order-consumer");
-        assertThat(groups)
-                .allSatisfy(group -> {
-                    assertThat(group.getDlqTopic()).startsWith("%DLQ%");
-                    assertThat(group.getMessageCount()).isPositive();
-                    assertThat(group.getLastEnqueueTime()).isNotNull();
-                    assertThat(group.getStatus()).isNotBlank();
-                });
+    void listDLQGroupsShouldFailExplicitlyWhenRealProviderIsMissing() {
+        assertThatThrownBy(() -> provider.listDLQGroups("cluster-1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("DLQ provider is not configured")
+                .extracting("code")
+                .isEqualTo(501);
     }
 
     @Test
-    void listDLQGroupsShouldFilterByClusterId() {
-        List<DLQGroupVO> groups = provider.listDLQGroups("rmq-cn-v5-prod-01");
-
-        assertThat(groups)
-                .extracting(DLQGroupVO::getGroupName)
-                .containsExactly("cg-order-payment", "cg-inventory-sync");
-    }
-
-    @Test
-    void listDLQGroupsShouldReturnEmptyForUnknownCluster() {
-        assertThat(provider.listDLQGroups("missing-cluster")).isEmpty();
-    }
-
-    @Test
-    void listDLQGroupsShouldReturnDefensiveCopies() {
-        List<DLQGroupVO> firstRead = provider.listDLQGroups("rmq-cn-v5-prod-01");
-        firstRead.get(0).setGroupName("mutated");
-
-        List<DLQGroupVO> secondRead = provider.listDLQGroups("rmq-cn-v5-prod-01");
-
-        assertThat(secondRead.get(0).getGroupName()).isEqualTo("cg-order-payment");
+    void resendMessagesShouldFailExplicitlyWhenRealProviderIsMissing() {
+        assertThatThrownBy(() -> provider.resendMessages("group-1", 1000L, 2000L, "target-topic"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("DLQ provider is not configured")
+                .extracting("code")
+                .isEqualTo(501);
     }
 }


### PR DESCRIPTION
## Summary
- stop returning sample DLQ groups from the production DLQProviderStub
- stop accepting DLQ resend as a no-op success
- return a structured 501 BusinessException when no real DLQ provider is configured
- update provider tests for the unsupported behavior

Fixes https://github.com/apache/rocketmq-dashboard/issues/686

## Tests
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=DLQProviderStubTest test