### PR TITLE
[Studio] Harden broker collection, message paging and user context

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/interceptor/AuthInterceptor.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/interceptor/AuthInterceptor.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.dashboard.interceptor;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.rocketmq.dashboard.service.LoginService;
+import org.apache.rocketmq.dashboard.util.UserInfoContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -40,6 +41,13 @@ public class AuthInterceptor implements HandlerInterceptor {
             return true;
         }
         return loginService.login(request, response);
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        // Clear the user info held in ThreadLocal, otherwise it will be leaked to the
+        // next request processed by the same thread (Tomcat worker threads are reused).
+        UserInfoContext.clear();
     }
 
 

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImpl.java
@@ -243,18 +243,22 @@ public class MessageServiceImpl implements MessageService {
                 query.getBegin(),
                 query.getEnd());
 
-        List<QueueOffsetInfo> queueOffsetInfos = CACHE.getIfPresent(query.getTaskId());
+        String taskId = query.getTaskId();
+        if (StringUtils.isBlank(taskId)) {
+            taskId = MessageClientIDSetter.createUniqID();
+            query.setTaskId(taskId);
+        }
+        List<QueueOffsetInfo> queueOffsetInfos = CACHE.getIfPresent(taskId);
 
         if (queueOffsetInfos == null) {
             query.setPageNum(1);
             MessagePageTask task = this.queryFirstMessagePage(queryByPage);
-            String taskId = MessageClientIDSetter.createUniqID();
             CACHE.put(taskId, task.getQueueOffsetInfos());
 
             return new MessagePage(task.getPage(), taskId);
         }
         Page<MessageView> messageViews = queryMessageByTaskPage(queryByPage, queueOffsetInfos);
-        return new MessagePage(messageViews, query.getTaskId());
+        return new MessagePage(messageViews, taskId);
 
     }
 

--- a/src/main/java/org/apache/rocketmq/dashboard/task/DashboardCollectTask.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/task/DashboardCollectTask.java
@@ -156,9 +156,7 @@ public class DashboardCollectTask {
                 Throwables.throwIfUnchecked(e1);
                 throw new RuntimeException(e1);
             }
-            fetchBrokerRuntimeStats(brokerAddr, retryTime - 1);
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
+            return fetchBrokerRuntimeStats(brokerAddr, retryTime - 1);
         }
     }
 


### PR DESCRIPTION
### Motivation

Fixed three real bugs found while reviewing the code:

1. **DashboardCollectTask: broker stats retry never actually retried**
   In `fetchBrokerRuntimeStats`, the recursive retry call's result was discarded and the original exception re-thrown, so a single failed fetch aborted the whole `collectBroker` scheduled task instead of retrying up to `retryTime` times. The caller already handles a `null` result by skipping the broker.

2. **MessageServiceImpl: NPE when `taskId` is blank in `queryMessageByPage`**
   `Cache.getIfPresent(query.getTaskId())` throws `NullPointerException` when the request body has no `taskId`. The API documents `taskId` as optional, so this endpoint 500s on valid input. A taskId is now generated when blank and reused consistently for the cache key and response.

3. **AuthInterceptor: user info in ThreadLocal is never cleared**
   `LoginServiceImpl` writes the logged-in user into `UserInfoContext` (a `ThreadLocal`) but nothing ever calls `UserInfoContext.clear()`. Since Tomcat reuses worker threads, the previous request's user info can leak into the next request handled by the same thread. Added `afterCompletion` to clear it.

### Verification

`mvn compiler:compile` passes (`BUILD SUCCESS`) after the changes.

### Diff

3 files changed, +16 / -6.