### PR TITLE
[ISSUE #696] Fail explicitly when client provider is missing

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientProviderStubTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientProviderStubTest.java
@@ -17,19 +17,23 @@
 package org.apache.rocketmq.studio.cluster.client;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-import java.util.List;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@Slf4j
-@Component
-public class ClientProviderStub implements ClientProvider {
+class ClientProviderStubTest {
 
-    @Override
-    public List<ClientConnectionVO> findConnections(String clusterId, String type) {
-        log.warn("ClientProviderStub.findConnections called without a real client provider. clusterId={}, type={}",
-                clusterId, type);
-        throw new BusinessException(501, "Client connection provider is not configured");
+    private final ClientProviderStub provider = new ClientProviderStub();
+
+    @Test
+    void findConnectionsShouldFailWhenRealProviderIsMissing() {
+        assertThatThrownBy(() -> provider.findConnections("production-cluster", "Producer"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Client connection provider is not configured")
+                .satisfies(ex -> assertThatBusinessExceptionCode(ex, 501));
+    }
+
+    private void assertThatBusinessExceptionCode(Throwable ex, int code) {
+        org.assertj.core.api.Assertions.assertThat(((BusinessException) ex).getCode()).isEqualTo(code);
     }
 }


### PR DESCRIPTION
## Summary

- remove hard-coded online client connection data from `ClientProviderStub`
- return a structured 501 `BusinessException` when no real client provider is configured
- add test coverage for the explicit unsupported-provider behavior

Fixes https://github.com/apache/rocketmq-dashboard/issues/696

## Tests

- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=ClientProviderStubTest test