### PR TITLE
[ISSUE #698] Fail explicitly when dashboard provider is missing

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardProviderStubTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardProviderStubTest.java
@@ -14,20 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.rocketmq.studio.ops.dashboard;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Slf4j
-@Component
-public class DashboardProviderStub implements DashboardProvider {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-    @Override
-    public DashboardDataVO getDashboardData() {
-        log.warn("DashboardProviderStub.getDashboardData called without a real dashboard provider");
-        throw new BusinessException(501, "Dashboard provider is not configured");
+class DashboardProviderStubTest {
+
+    private final DashboardProviderStub provider = new DashboardProviderStub();
+
+    @Test
+    void getDashboardDataShouldFailWhenRealProviderIsMissing() {
+        assertThatThrownBy(provider::getDashboardData)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Dashboard provider is not configured")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
     }
 }


### PR DESCRIPTION
## Summary

- remove hard-coded dashboard stats and cluster overview data from `DashboardProviderStub`
- return a structured 501 `BusinessException` when no real dashboard provider is configured
- add test coverage for the explicit unsupported-provider behavior

Fixes https://github.com/apache/rocketmq-dashboard/issues/698

## Tests

- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=DashboardProviderStubTest test