### PR TITLE
[ISSUE #700] Stop rendering mock infrastructure nodes

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -941,6 +941,10 @@ const translations: Record<string, Record<Lang, string>> = {
   'brokerCluster.restart': { zh: '重启', en: 'Restart' },
   'brokerCluster.manual': { zh: '手动', en: 'Manual' },
   'brokerCluster.createCluster': { zh: '创建集群', en: 'Create Cluster' },
+  'brokerCluster.providerUnavailable': {
+    zh: '当前版本尚未接入真实集群拓扑接口，已停止展示模拟 Broker / NameServer / Proxy 数据。',
+    en: 'The real cluster topology API is not connected yet, so mock Broker, NameServer, and Proxy data is no longer displayed.',
+  },
   'brokerCluster.nsName': { zh: 'NameServer 名称', en: 'NameServer Name' },
   'brokerCluster.nsManagement': { zh: 'NameServer 管理', en: 'NameServer Management' },
   'brokerCluster.brokerManagement': { zh: 'Broker 管理', en: 'Broker Management' },

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -62,128 +62,9 @@ interface ProxyRecord {
   connections: number;
 }
 
-// ─── Mock Data ──────────────────────────────────────────────────
-const brokerData: BrokerRecord[] = [
-  {
-    key: '1',
-    k8sCluster: 'prod-cn-east-1',
-    brokerName: 'broker-a',
-    status: 'running',
-    version: '5.3.0',
-    diskUsage: 62,
-    address: '10.0.1.10:10911',
-    tpsIn: '12,580',
-    tpsOut: '8,340',
-  },
-  {
-    key: '2',
-    k8sCluster: 'prod-cn-east-1',
-    brokerName: 'broker-b',
-    status: 'readonly',
-    version: '5.3.0',
-    diskUsage: 89,
-    address: '10.0.1.11:10911',
-    tpsIn: '0',
-    tpsOut: '3,120',
-  },
-  {
-    key: '3',
-    k8sCluster: 'prod-cn-east-1',
-    brokerName: 'broker-c',
-    status: 'running',
-    version: '5.2.0',
-    diskUsage: 45,
-    address: '10.0.1.12:10911',
-    tpsIn: '9,750',
-    tpsOut: '6,280',
-  },
-  {
-    key: '4',
-    k8sCluster: 'prod-cn-south-1',
-    brokerName: 'broker-d',
-    status: 'maintenance',
-    version: '5.3.0',
-    diskUsage: 33,
-    address: '10.0.2.10:10911',
-    tpsIn: '0',
-    tpsOut: '0',
-  },
-  {
-    key: '5',
-    k8sCluster: 'prod-cn-south-1',
-    brokerName: 'broker-e',
-    status: 'running',
-    version: '5.3.0',
-    diskUsage: 51,
-    address: '10.0.2.11:10911',
-    tpsIn: '7,890',
-    tpsOut: '5,430',
-  },
-  {
-    key: '6',
-    k8sCluster: 'staging-cn-east-1',
-    brokerName: 'broker-staging-a',
-    status: 'running',
-    version: '5.3.1',
-    diskUsage: 28,
-    address: '10.0.10.10:10911',
-    tpsIn: '1,230',
-    tpsOut: '980',
-  },
-];
-
-const nameServerData: NameServerRecord[] = [
-  {
-    key: '1',
-    k8sCluster: 'prod-cn-east-1',
-    name: 'nameserver-a',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.1.20:9876',
-    connections: 156,
-  },
-  {
-    key: '2',
-    k8sCluster: 'prod-cn-east-1',
-    name: 'nameserver-b',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.1.21:9876',
-    connections: 148,
-  },
-  {
-    key: '3',
-    k8sCluster: 'prod-cn-south-1',
-    name: 'nameserver-c',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.2.20:9876',
-    connections: 92,
-  },
-];
-
-const proxyData: ProxyRecord[] = [
-  {
-    key: '1',
-    k8sCluster: 'prod-cn-east-1',
-    name: 'proxy-a',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.1.30:8080',
-    grpcPort: '10.0.1.30:8081',
-    connections: 2340,
-  },
-  {
-    key: '2',
-    k8sCluster: 'prod-cn-south-1',
-    name: 'proxy-b',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.2.30:8080',
-    grpcPort: '10.0.2.30:8081',
-    connections: 1560,
-  },
-];
+const brokerData: BrokerRecord[] = [];
+const nameServerData: NameServerRecord[] = [];
+const proxyData: ProxyRecord[] = [];
 
 // ─── Component ──────────────────────────────────────────────────
 const BrokerClusterPage = () => {
@@ -499,6 +380,7 @@ const BrokerClusterPage = () => {
                 <Table
                   columns={nsColumns}
                   dataSource={nameServerData}
+                  locale={{ emptyText: t('brokerCluster.providerUnavailable') }}
                   pagination={false}
                   size="middle"
                 />
@@ -516,6 +398,7 @@ const BrokerClusterPage = () => {
                 <Table
                   columns={brokerColumns}
                   dataSource={brokerData}
+                  locale={{ emptyText: t('brokerCluster.providerUnavailable') }}
                   pagination={{
                     pageSize: 10,
                     showTotal: (total) => `${t('common.total')} ${total} Broker`,
@@ -536,6 +419,7 @@ const BrokerClusterPage = () => {
                 <Table
                   columns={proxyColumns}
                   dataSource={proxyData}
+                  locale={{ emptyText: t('brokerCluster.providerUnavailable') }}
                   pagination={false}
                   size="middle"
                 />

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -69,19 +69,17 @@ describe('BrokerCluster Page', () => {
     expect(screen.getByText('重置')).toBeInTheDocument();
   });
 
-  it('should display broker tab with mock data', () => {
+  it('should show an explicit unavailable state instead of mock broker data', () => {
     renderWithProviders(<BrokerCluster />);
-    // Default tab is broker - check for mock broker data
-    expect(screen.getByText('broker-a')).toBeInTheDocument();
-    expect(screen.getByText('broker-b')).toBeInTheDocument();
+    expect(screen.getByText('当前版本尚未接入真实集群拓扑接口，已停止展示模拟 Broker / NameServer / Proxy 数据。')).toBeInTheDocument();
+    expect(screen.queryByText('broker-a')).not.toBeInTheDocument();
+    expect(screen.queryByText('broker-b')).not.toBeInTheDocument();
   });
 
-  it('should display broker status tags', () => {
+  it('should not render row status tags without real broker data', () => {
     renderWithProviders(<BrokerCluster />);
-    const runningTags = screen.getAllByText('运行中');
-    expect(runningTags.length).toBeGreaterThan(0);
-    const readonlyTags = screen.getAllByText('只读');
-    expect(readonlyTags.length).toBeGreaterThan(0);
+    expect(screen.queryByText('运行中')).not.toBeInTheDocument();
+    expect(screen.queryByText('只读')).not.toBeInTheDocument();
   });
 
   it('should switch to NameServer tab on click', async () => {
@@ -89,8 +87,10 @@ describe('BrokerCluster Page', () => {
     renderWithProviders(<BrokerCluster />);
     const nsTab = screen.getByText('NameServer 管理');
     await user.click(nsTab);
-    // After clicking, NameServer data should be visible
-    expect(screen.getByText('nameserver-a')).toBeInTheDocument();
+    expect(
+      screen.getAllByText('当前版本尚未接入真实集群拓扑接口，已停止展示模拟 Broker / NameServer / Proxy 数据。').length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText('nameserver-a')).not.toBeInTheDocument();
   });
 
   it('should switch to Proxy tab on click', async () => {
@@ -98,15 +98,15 @@ describe('BrokerCluster Page', () => {
     renderWithProviders(<BrokerCluster />);
     const proxyTab = screen.getByText('Proxy 管理');
     await user.click(proxyTab);
-    // After clicking, Proxy data should be visible
-    expect(screen.getByText('proxy-a')).toBeInTheDocument();
+    expect(
+      screen.getAllByText('当前版本尚未接入真实集群拓扑接口，已停止展示模拟 Broker / NameServer / Proxy 数据。').length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText('proxy-a')).not.toBeInTheDocument();
   });
 
-  it('should render config and restart action buttons', () => {
+  it('should not render row action buttons without real infrastructure data', () => {
     renderWithProviders(<BrokerCluster />);
-    const configButtons = screen.getAllByText('配置');
-    expect(configButtons.length).toBeGreaterThan(0);
-    const restartButtons = screen.getAllByText('重启');
-    expect(restartButtons.length).toBeGreaterThan(0);
+    expect(screen.queryByText('配置')).not.toBeInTheDocument();
+    expect(screen.queryByText('重启')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- remove hard-coded Broker, NameServer, and Proxy node data from the BrokerCluster page
- show an explicit unavailable state until a real cluster topology provider is connected
- update page tests so mock infrastructure names are no longer expected

Fixes https://github.com/apache/rocketmq-dashboard/issues/700

## Tests

- npm test -- BrokerCluster.test.tsx
- npx eslint src/pages/studio/BrokerCluster.tsx src/pages/studio/__tests__/BrokerCluster.test.tsx src/i18n/translations.ts