### PR TITLE
[ISSUE #702] Fail explicitly when diagnostics provider is missing

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerDiagnosticsProviderStubTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerDiagnosticsProviderStubTest.java
@@ -14,21 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.rocketmq.studio.instance.group;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Slf4j
-@Component
-public class ConsumerDiagnosticsProviderStub implements ConsumerDiagnosticsProvider {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-    @Override
-    public ConsumerStackTraceVO getConsumerStack(String groupName, String clientId) {
-        log.warn("ConsumerDiagnosticsProviderStub.getConsumerStack called without a real diagnostics provider. "
-                + "groupName={}, clientId={}", groupName, clientId);
-        throw new BusinessException(501, "Consumer diagnostics provider is not configured");
+class ConsumerDiagnosticsProviderStubTest {
+
+    private final ConsumerDiagnosticsProviderStub provider = new ConsumerDiagnosticsProviderStub();
+
+    @Test
+    void getConsumerStackShouldFailWhenRealProviderIsMissing() {
+        assertThatThrownBy(() -> provider.getConsumerStack("cg-orders", "client-1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Consumer diagnostics provider is not configured")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
     }
 }


### PR DESCRIPTION
## Summary

- stop returning successful empty consumer stack traces from `ConsumerDiagnosticsProviderStub`
- return a structured 501 `BusinessException` when no real diagnostics provider is configured
- add test coverage for the explicit unsupported-provider behavior

Fixes https://github.com/apache/rocketmq-dashboard/issues/702

## Tests

- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=ConsumerDiagnosticsProviderStubTest test