### PR TITLE
[ISSUE #704] Start K8s cert repository empty

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/InMemoryK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/InMemoryK8sCertRepository.java
@@ -16,12 +16,9 @@
  */
 package org.apache.rocketmq.studio.cluster.k8s;
 
-import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
-import org.apache.rocketmq.studio.common.domain.enums.CertType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -33,10 +30,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public class InMemoryK8sCertRepository implements K8sCertRepository {
 
     private final Map<String, K8sCertVO> store = new ConcurrentHashMap<>();
-
-    public InMemoryK8sCertRepository() {
-        initStubData();
-    }
 
     @Override
     public List<K8sCertVO> findAll() {
@@ -59,61 +52,5 @@ public class InMemoryK8sCertRepository implements K8sCertRepository {
     public void deleteById(String id) {
         store.remove(id);
         log.info("Deleted certificate: {}", id);
-    }
-
-    private void initStubData() {
-        LocalDateTime now = LocalDateTime.now();
-
-        K8sCertVO cert1 = K8sCertVO.builder()
-                .name("rmq-proxy-tls")
-                .namespace("rocketmq")
-                .cluster("rmq-cluster-prod")
-                .type(CertType.TLS)
-                .issuer("letsencrypt-prod")
-                .notBefore(now.minusDays(30))
-                .notAfter(now.plusDays(60))
-                .status(CertStatus.valid)
-                .daysRemaining(60)
-                .san(List.of("proxy.rmq.local", "*.proxy.rmq.local"))
-                .build();
-        cert1.setId("cert-001");
-        cert1.setCreatedAt(now.minusDays(30));
-        cert1.setUpdatedAt(now.minusDays(30));
-
-        K8sCertVO cert2 = K8sCertVO.builder()
-                .name("rmq-broker-mtls")
-                .namespace("rocketmq")
-                .cluster("rmq-cluster-prod")
-                .type(CertType.mTLS)
-                .issuer("internal-ca")
-                .notBefore(now.minusDays(350))
-                .notAfter(now.plusDays(15))
-                .status(CertStatus.expiring)
-                .daysRemaining(15)
-                .san(List.of("broker-a.rmq.local", "broker-b.rmq.local"))
-                .build();
-        cert2.setId("cert-002");
-        cert2.setCreatedAt(now.minusDays(350));
-        cert2.setUpdatedAt(now.minusDays(350));
-
-        K8sCertVO cert3 = K8sCertVO.builder()
-                .name("rmq-staging-sa")
-                .namespace("rocketmq-staging")
-                .cluster("rmq-cluster-staging")
-                .type(CertType.ServiceAccount)
-                .issuer("k8s-self-signed")
-                .notBefore(now.minusDays(400))
-                .notAfter(now.minusDays(35))
-                .status(CertStatus.expired)
-                .daysRemaining(-35)
-                .san(List.of("sa.rmq-staging.local"))
-                .build();
-        cert3.setId("cert-003");
-        cert3.setCreatedAt(now.minusDays(400));
-        cert3.setUpdatedAt(now.minusDays(400));
-
-        store.put(cert1.getId(), cert1);
-        store.put(cert2.getId(), cert2);
-        store.put(cert3.getId(), cert3);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/InMemoryK8sCertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/InMemoryK8sCertRepositoryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.k8s;
+
+import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
+import org.apache.rocketmq.studio.common.domain.enums.CertType;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryK8sCertRepositoryTest {
+
+    @Test
+    void repositoryShouldStartEmpty() {
+        InMemoryK8sCertRepository repository = new InMemoryK8sCertRepository();
+
+        assertThat(repository.findAll()).isEmpty();
+    }
+
+    @Test
+    void saveFindAndDeleteShouldManageExplicitRecordsOnly() {
+        InMemoryK8sCertRepository repository = new InMemoryK8sCertRepository();
+        K8sCertVO cert = K8sCertVO.builder()
+                .name("rocketmq-tls")
+                .namespace("rocketmq")
+                .cluster("prod")
+                .type(CertType.TLS)
+                .issuer("issuer")
+                .notBefore(LocalDateTime.now().minusDays(1))
+                .notAfter(LocalDateTime.now().plusDays(30))
+                .status(CertStatus.valid)
+                .daysRemaining(30)
+                .san(List.of("broker.example.com"))
+                .build();
+        cert.setId("cert-explicit");
+
+        repository.save(cert);
+
+        assertThat(repository.findAll()).containsExactly(cert);
+        assertThat(repository.findById("cert-explicit")).contains(cert);
+
+        repository.deleteById("cert-explicit");
+
+        assertThat(repository.findAll()).isEmpty();
+        assertThat(repository.findById("cert-explicit")).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- remove startup-seeded fake certificate records from InMemoryK8sCertRepository
- keep the in-memory repository empty until records are explicitly saved
- add repository tests for empty startup and save/find/delete behavior

Fixes https://github.com/apache/rocketmq-dashboard/issues/704

## Tests
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=InMemoryK8sCertRepositoryTest test