### PR TITLE
[ISSUE #669] Show UNSPECIFIED topics in topic list

### DIFF
--- a/frontend-new/src/pages/Topic/topic.jsx
+++ b/frontend-new/src/pages/Topic/topic.jsx
@@ -209,8 +209,9 @@ const DeployHistoryList = () => {
         if (filterDLQ && type.includes("DLQ")) return true;
         if (filterSystem && type.includes("SYSTEM")) return true;
         if (rmqVersion && filterUnspecified && type.includes("UNSPECIFIED")) return true;
-        if (filterNormal && type.includes("NORMAL")) return true;
-        if (!rmqVersion && filterNormal && type.includes("UNSPECIFIED")) return true;
+        // Topics without a message type attribute (e.g. 4.x clusters) report UNSPECIFIED,
+        // which semantically is a normal topic and should be shown when NORMAL is selected.
+        if (filterNormal && (type.includes("NORMAL") || type.includes("UNSPECIFIED"))) return true;
         if (rmqVersion && filterDelay && type.includes("DELAY")) return true;
         if (rmqVersion && filterFifo && type.includes("FIFO")) return true;
         if (rmqVersion && filterTransaction && type.includes("TRANSACTION")) return true;


### PR DESCRIPTION
Fixes #669

### Problem

On 4.x clusters (or 5.x clusters where topics were created without a message type attribute), every topic reports `messageType = UNSPECIFIED`. The topic page's default filter only selects `NORMAL`, and the `UNSPECIFIED` fallback branch was guarded by `rmqVersion` which is hardcoded to `true` and never updated, so all these topics were filtered out and the topic table appeared empty even though the backend returned full data.

### Fix

In `frontend-new/src/pages/Topic/topic.jsx`, treat `UNSPECIFIED` as a normal topic in `filterByType`:

```diff
-        if (filterNormal && type.includes("NORMAL")) return true;
-        if (!rmqVersion && filterNormal && type.includes("UNSPECIFIED")) return true;
+        if (filterNormal && (type.includes("NORMAL") || type.includes("UNSPECIFIED"))) return true;
```

### Verification

`npm run build` passes on the fixed source (react-scripts build, which also runs ESLint), and the built bundle contains the updated filter logic.

### Diff

1 file changed, +3 / -2.