### PR TITLE
[Studio] Synchronize consumer group cache and handle empty brokers

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
@@ -70,6 +70,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -101,7 +102,9 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
 
     private final List<GroupConsumeInfo> cacheConsumeInfoList = Collections.synchronizedList(new ArrayList<>());
 
-    private final HashMap<String, List<String>> consumerGroupMap = Maps.newHashMap();
+    // Shared across request threads (queryGroupList/makeGroupListCache) and refreshAllGroup,
+    // so it must be thread-safe; a plain HashMap would risk ConcurrentModificationException.
+    private final Map<String, List<String>> consumerGroupMap = new ConcurrentHashMap<>();
 
     @Override
     public void afterPropertiesSet() {
@@ -194,7 +197,7 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
             throw new RuntimeException(err);
         }
 
-        if (subscriptionGroupWrapper != null && subscriptionGroupWrapper.getSubscriptionGroupTable().isEmpty()) {
+        if (subscriptionGroupWrapper == null || subscriptionGroupWrapper.getSubscriptionGroupTable().isEmpty()) {
             logger.warn("No subscription group information available");
             isCacheBeingBuilt = false;
             return;


### PR DESCRIPTION
### Motivation

Two robustness fixes in `ConsumerServiceImpl`:

1. **`consumerGroupMap` is not thread-safe**
   The map is a plain `HashMap` but is read/written concurrently: `queryGroupList`/`makeGroupListCache` mutate it (on request threads), while `refreshAllGroup` calls `consumerGroupMap.clear()` without holding the same lock and `refreshGroup` reads it directly. This can trigger `ConcurrentModificationException` or lost updates. Changed it to a `ConcurrentHashMap`.

2. **NPE when the cluster has no brokers**
   In `makeGroupListCache`, `subscriptionGroupWrapper` starts as `null` and is only assigned inside the per-broker loop. When the broker table is empty the wrapper stays `null`, so `subscriptionGroupWrapper.getSubscriptionGroupTable()` throws a `NullPointerException`. The empty/`null` check is now `subscriptionGroupWrapper == null || ...isEmpty()` and returns early instead.

### Verification

`mvn compiler:compile` passes (`BUILD SUCCESS`).

### Diff

1 file changed, +5 / -2.