### PR TITLE
[Studio] Guard runtime edge cases

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/DashboardCollectServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/DashboardCollectServiceImpl.java
@@ -115,7 +115,12 @@ public class DashboardCollectServiceImpl implements DashboardCollectService {
         for (String string : strings) {
             sb.append(string);
         }
-        JSONObject json = (JSONObject) JSONObject.parse(sb.toString());
+        Object parsed = JSONObject.parse(sb.toString());
+        if (parsed == null) {
+            log.warn("No valid dashboard data in file: {}", file.getAbsolutePath());
+            return Maps.newHashMap();
+        }
+        JSONObject json = (JSONObject) parsed;
         Set<Map.Entry<String, Object>> entries = json.entrySet();
         Map<String, List<String>> map = Maps.newHashMap();
         for (Map.Entry<String, Object> entry : entries) {

--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/TopicServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/TopicServiceImpl.java
@@ -38,6 +38,7 @@ import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.topic.TopicValidator;
 import org.apache.rocketmq.dashboard.config.RMQConfigure;
+import org.apache.rocketmq.dashboard.exception.ServiceException;
 import org.apache.rocketmq.dashboard.model.request.SendTopicMessageRequest;
 import org.apache.rocketmq.dashboard.model.request.TopicConfigInfo;
 import org.apache.rocketmq.dashboard.model.request.TopicTypeList;
@@ -380,6 +381,9 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
     @Override
     public SendResult sendTopicMessageRequest(SendTopicMessageRequest sendTopicMessageRequest) {
         List<TopicConfigInfo> topicConfigInfos = examineTopicConfig(sendTopicMessageRequest.getTopic());
+        if (topicConfigInfos.isEmpty()) {
+            throw new ServiceException(-1, String.format("Topic [%s] has no broker route, cannot send message", sendTopicMessageRequest.getTopic()));
+        }
         String messageType = topicConfigInfos.get(0).getMessageType();
         AclClientRPCHook rpcHook = null;
         if (configure.isACLEnabled()) {

--- a/src/main/java/org/apache/rocketmq/dashboard/service/strategy/FileUserStrategy.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/strategy/FileUserStrategy.java
@@ -94,7 +94,12 @@ public class FileUserStrategy implements UserStrategy, InitializingBean {
                 } else if (arrs.length == 1) {
                     role = 0;
                 } else {
-                    role = Integer.parseInt(arrs[1].trim());
+                    try {
+                        role = Integer.parseInt(arrs[1].trim());
+                    } catch (NumberFormatException e) {
+                        log.error("Invalid role '{}' for user '{}', defaulting to normal user", arrs[1].trim(), key);
+                        role = 0;
+                    }
                 }
 
                 loadUserMap.put(key, new User(key, arrs[0].trim(), role));

--- a/src/main/java/org/apache/rocketmq/dashboard/task/DashboardCollectTask.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/task/DashboardCollectTask.java
@@ -127,7 +127,11 @@ public class DashboardCollectTask {
                 if (kvTable == null) {
                     continue;
                 }
-                String[] tpsArray = kvTable.getTable().get("getTotalTps").split(" ");
+                String totalTpsStr = kvTable.getTable().get("getTotalTps");
+                if (totalTpsStr == null || totalTpsStr.trim().isEmpty()) {
+                    continue;
+                }
+                String[] tpsArray = totalTpsStr.trim().split(" ");
                 BigDecimal totalTps = new BigDecimal(0);
                 for (String tps : tpsArray) {
                     totalTps = totalTps.add(new BigDecimal(tps));


### PR DESCRIPTION
### Motivation

Four defensive fixes for runtime crashes found by code review:

1. **TopicServiceImpl.sendTopicMessageRequest** — when a topic has no broker route, `topicConfigInfos.get(0)` threw `IndexOutOfBoundsException`. Now a clear `ServiceException` is thrown instead.

2. **DashboardCollectTask.collectBroker** — `kvTable.getTable().get("getTotalTps")` could be `null` or blank, causing a `NullPointerException` or a divide-by-zero when the blank value splits into an empty array. The broker is now skipped when there is no TPS data.

3. **DashboardCollectServiceImpl.jsonDataFile2map** — an empty or corrupt dashboard data file makes `JSONObject.parse` return `null`, so `json.entrySet()` threw `NullPointerException`. An empty map is returned instead.

4. **FileUserStrategy.FileBasedUserInfoStore.load** — a non-numeric role in `users.properties` threw `NumberFormatException` outside of any `try/catch`, aborting application startup. It is now treated as a normal user (role 0) with a warning logged.

### Verification

`mvn compiler:compile` passes (`BUILD SUCCESS`).

### Diff

4 files changed, +21 / -3.