### PR TITLE
[studio] Preserve sessions for public authentication failures

### DIFF
--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -119,4 +119,33 @@ describe('API client response contract', () => {
 
     await client.get('/clusters');
   });
+
+  it.each(['/auth/login', '/auth/status'])(
+    'does not clear the current session when public auth request %s returns 401',
+    async (path) => {
+      localStorage.setItem('token', 'current-token');
+      localStorage.setItem('rocketmq-studio-user', 'admin');
+      localStorage.setItem('rocketmq-studio-user-admin', 'true');
+      mock.onAny(path).reply(401, { code: 401, message: 'Unauthorized', data: null });
+
+      await expect(client.get(path)).rejects.toMatchObject({ response: { status: 401 } });
+
+      expect(localStorage.getItem('token')).toBe('current-token');
+      expect(localStorage.getItem('rocketmq-studio-user')).toBe('admin');
+      expect(localStorage.getItem('rocketmq-studio-user-admin')).toBe('true');
+    },
+  );
+
+  it('clears the current session when a protected API request returns 401', async () => {
+    localStorage.setItem('token', 'expired-token');
+    localStorage.setItem('rocketmq-studio-user', 'admin');
+    localStorage.setItem('rocketmq-studio-user-admin', 'true');
+    mock.onGet('/clusters').reply(401, { code: 401, message: 'Unauthorized', data: null });
+
+    await expect(client.get('/clusters')).rejects.toMatchObject({ response: { status: 401 } });
+
+    expect(localStorage.getItem('token')).toBeNull();
+    expect(localStorage.getItem('rocketmq-studio-user')).toBeNull();
+    expect(localStorage.getItem('rocketmq-studio-user-admin')).toBeNull();
+  });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -21,6 +21,7 @@ import { clearAuthSession, TOKEN_STORAGE_KEY } from '../stores/authStorage';
 import { API_BASE_URL } from '../config';
 
 const SUCCESS_BUSINESS_CODES = new Set([0, 200]);
+const PUBLIC_AUTH_PATHS = new Set(['/auth/login', '/auth/status']);
 
 interface BusinessResponse {
   code?: unknown;
@@ -42,6 +43,16 @@ function getBusinessError(data: unknown): string | null {
     return null;
   }
   return typeof data.message === 'string' && data.message.trim() ? data.message : '请求失败';
+}
+
+function isPublicAuthRequest(url?: string): boolean {
+  if (!url) return false;
+  const requestPath = new URL(url, window.location.origin).pathname;
+  const apiBasePath = new URL(API_BASE_URL, window.location.origin).pathname;
+  const relativePath = requestPath.startsWith(`${apiBasePath}/`)
+    ? requestPath.slice(apiBasePath.length)
+    : requestPath;
+  return PUBLIC_AUTH_PATHS.has(relativePath);
 }
 
 const client = axios.create({
@@ -72,7 +83,7 @@ client.interceptors.response.use(
     return response;
   },
   (error) => {
-    if (error.response?.status === 401) {
+    if (error.response?.status === 401 && !isPublicAuthRequest(error.config?.url)) {
       clearAuthSession();
       window.location.href = '/';
     }


### PR DESCRIPTION
Fixes #716

## Summary

- exempt only `/auth/login` and `/auth/status` from the global protected-session 401 recovery path
- keep session clearing and redirect behavior unchanged for business API 401 responses
- add regression coverage for both public endpoints and a protected API

## Root cause

The shared Axios interceptor interpreted every HTTP 401 as an expired protected session. Expected authentication failures such as invalid login credentials therefore cleared local state and navigated away before the public auth caller could handle the error.

## Validation

- deterministic baseline reproduction: failed 5/5 before the fix
- focused public/protected 401 regression: passed 20/20 after the fix
- full Node 20 frontend suite: 63 files / 268 tests
- `npm run lint`: 0 errors (4 existing Fast Refresh warnings)
- `npm run build`: passed
- `git diff --check`: passed
