### PR TITLE
[studio] Allow CORS preflight before authentication

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @RequiredArgsConstructor
@@ -34,7 +35,8 @@ public class AuthInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
                              Object handler) throws Exception {
-        if (!authProperties.isLoginRequired() || isPublicPath(requestPath(request))) {
+        if (!authProperties.isLoginRequired() || CorsUtils.isPreFlightRequest(request)
+                || isPublicPath(requestPath(request))) {
             return true;
         }
         if (authService.isAuthenticated(request.getHeader(HttpHeaders.AUTHORIZATION))) {

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCorsIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCorsIntegrationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.studio.auth;
+
+import org.apache.rocketmq.studio.common.config.CorsConfig;
+import org.apache.rocketmq.studio.instance.InstanceController;
+import org.apache.rocketmq.studio.instance.InstanceService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = InstanceController.class, properties = "studio.auth.login-required=true")
+@AutoConfigureMockMvc(addFilters = false)
+@Import({AuthWebConfig.class, CorsConfig.class})
+class AuthCorsIntegrationTest {
+
+    private static final String FRONTEND_ORIGIN = "https://studio.example.com";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private InstanceService instanceService;
+
+    @MockBean
+    private AuthProperties authProperties;
+
+    @MockBean
+    private AuthService authService;
+
+    @BeforeEach
+    void enableLoginProtection() {
+        when(authProperties.isLoginRequired()).thenReturn(true);
+    }
+
+    @Test
+    void shouldAllowCorsPreflightWithoutAuthentication() throws Exception {
+        mockMvc.perform(options("/api/instances")
+                        .header(HttpHeaders.ORIGIN, FRONTEND_ORIGIN)
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*"));
+
+        verifyNoMoreInteractions(authService);
+    }
+
+    @Test
+    void shouldStillRejectAnonymousProtectedRequests() throws Exception {
+        mockMvc.perform(get("/api/instances")
+                        .header(HttpHeaders.ORIGIN, FRONTEND_ORIGIN))
+                .andExpect(status().isUnauthorized());
+
+        verify(authService).isAuthenticated(null);
+    }
+}


### PR DESCRIPTION
Fixes #719

## Summary

- allow valid Spring CORS preflight requests to reach the configured CORS handler before bearer authentication
- keep ordinary anonymous protected requests returning 401
- add a MockMvc integration regression covering the real interceptor and CORS configuration

## Root cause

`AuthInterceptor` applied bearer authentication to every `/api/**` request. Browser preflight requests do not carry the business request's Authorization header, so the interceptor returned 401 before Spring could emit CORS response headers.

## Validation

- deterministic baseline reproduction: failed 5/5 before the fix
- focused preflight and anonymous-request regression: passed 20/20 after the fix
- complete Java 21 server suite: 488 tests, 0 failures/errors
- Maven package: passed
- Checkstyle: 0 violations
- `git diff --check`: passed
