### PR TITLE
[Studio] fix: handle partial topic batch deletion failures

### DIFF
--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -89,6 +89,7 @@ const getTableBody = () => {
 describe('TopicPage', () => {
   beforeEach(() => {
     topicServiceMocks.listTopics.mockResolvedValue(buildTopics(25));
+    topicServiceMocks.batchDeleteTopics.mockResolvedValue({ deleted: [], failed: [] });
     topicServiceMocks.getTopicRoutes.mockResolvedValue([]);
     topicServiceMocks.getTopicConsumers.mockResolvedValue([]);
   });
@@ -119,5 +120,28 @@ describe('TopicPage', () => {
 
     expect(within(getTableBody()).getByText('topic-21')).toBeInTheDocument();
     expect(within(getTableBody()).queryByText('topic-01')).not.toBeInTheDocument();
+  });
+
+  it('keeps failed topics selected after a partially successful batch deletion', async () => {
+    const user = userEvent.setup();
+    topicServiceMocks.listTopics.mockResolvedValue(buildTopics(3));
+    topicServiceMocks.batchDeleteTopics.mockResolvedValue({
+      deleted: ['topic-01', 'topic-03'],
+      failed: ['topic-02'],
+    });
+    renderWithProviders();
+
+    expect(await screen.findByText('topic-01')).toBeInTheDocument();
+    await user.click(screen.getAllByRole('checkbox')[0]);
+    await user.click(screen.getByRole('button', { name: /删除 \(3\)$/ }));
+
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: /删\s*除/ }));
+
+    await waitFor(() => expect(screen.queryByText('topic-01')).not.toBeInTheDocument());
+    expect(screen.getByText('topic-02')).toBeInTheDocument();
+    expect(screen.queryByText('topic-03')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /删除 \(1\)$/ })).toBeInTheDocument();
+    expect(screen.getByText('已删除 2 个 Topic，1 个删除失败')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -685,12 +685,24 @@ const TopicPage = () => {
                   onOk: async () => {
                     try {
                       const names = selectedRowKeys.map(String);
-                      await batchDeleteTopics(names);
-                      setTopics((previous) =>
-                        previous.filter((topic) => !names.includes(topic.name)),
-                      );
-                      message.success(`已删除 ${names.length} 个 Topic`);
-                      setSelectedRowKeys([]);
+                      const { deleted, failed } = await batchDeleteTopics(names);
+                      if (deleted.length > 0) {
+                        const deletedNames = new Set(deleted);
+                        setTopics((previous) =>
+                          previous.filter((topic) => !deletedNames.has(topic.name)),
+                        );
+                      }
+                      setSelectedRowKeys(failed);
+
+                      if (failed.length === 0) {
+                        message.success(`已删除 ${deleted.length} 个 Topic`);
+                      } else if (deleted.length > 0) {
+                        message.warning(
+                          `已删除 ${deleted.length} 个 Topic，${failed.length} 个删除失败`,
+                        );
+                      } else {
+                        message.error(`${failed.length} 个 Topic 删除失败，请稍后重试`);
+                      }
                     } catch {
                       message.error('批量删除 Topic 失败，请稍后重试');
                     }

--- a/web/src/services/topicService.batchDelete.test.ts
+++ b/web/src/services/topicService.batchDelete.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const metadataApiMocks = vi.hoisted(() => ({
+  deleteTopic: vi.fn(),
+}));
+
+vi.mock('../config', () => ({
+  API_BASE_URL: '/api',
+  USE_MOCK: false,
+}));
+
+vi.mock('../api/metadata', () => metadataApiMocks);
+
+import { batchDeleteTopics } from './topicService';
+
+describe('topic service batch deletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('continues deleting after a failure and reports each outcome', async () => {
+    metadataApiMocks.deleteTopic.mockImplementation((name: string) =>
+      name === 'topic-02' ? Promise.reject(new Error('delete failed')) : Promise.resolve(),
+    );
+
+    await expect(batchDeleteTopics(['topic-01', 'topic-02', 'topic-03'])).resolves.toEqual({
+      deleted: ['topic-01', 'topic-03'],
+      failed: ['topic-02'],
+    });
+    expect(metadataApiMocks.deleteTopic.mock.calls.map(([name]) => name)).toEqual([
+      'topic-01',
+      'topic-02',
+      'topic-03',
+    ]);
+  });
+});

--- a/web/src/services/topicService.ts
+++ b/web/src/services/topicService.ts
@@ -64,11 +64,23 @@ export async function deleteTopic(name: string): Promise<void> {
   return metadataApi.deleteTopic(name);
 }
 
-// Batch delete: loop through single delete calls
-export async function batchDeleteTopics(names: string[]): Promise<void> {
+export interface BatchDeleteTopicsResult {
+  deleted: string[];
+  failed: string[];
+}
+
+// Batch delete: attempt every selected topic and report partial failures.
+export async function batchDeleteTopics(names: string[]): Promise<BatchDeleteTopicsResult> {
+  const result: BatchDeleteTopicsResult = { deleted: [], failed: [] };
   for (const name of names) {
-    await deleteTopic(name);
+    try {
+      await deleteTopic(name);
+      result.deleted.push(name);
+    } catch {
+      result.failed.push(name);
+    }
   }
+  return result;
 }
 
 export async function getTopicRoutes(name: string): Promise<BrokerRoute[]> {
@@ -77,7 +89,8 @@ export async function getTopicRoutes(name: string): Promise<BrokerRoute[]> {
 }
 
 export async function getTopicConsumers(name: string): Promise<ConsumerGroupInfo[]> {
-  if (USE_MOCK) return cloneConsumers((topicConsumers[name] as unknown as ConsumerGroupInfo[]) ?? []);
+  if (USE_MOCK)
+    return cloneConsumers((topicConsumers[name] as unknown as ConsumerGroupInfo[]) ?? []);
   return metadataApi.getTopicConsumers(name);
 }
 


### PR DESCRIPTION
## What is the purpose of the change

Topic batch deletion stopped at the first failed request. Topics deleted before the failure remained visible, while later selected topics were not attempted, leaving the page inconsistent with the backend state.

## Brief changelog

- Continue processing the remaining topics when an individual deletion fails.
- Return successfully deleted and failed topic names separately.
- Remove only successfully deleted topics from the page.
- Keep failed topics selected for retry and show partial failure feedback.

## Verifying this change

- Added service coverage for continuing after an individual deletion failure.
- Added page coverage for partial success, retained selection, and user feedback.
- Ran `npm test`.
- Ran `npm run lint`.
- Ran `npm run build`.
- Ran Prettier checks and `git diff --check`.