### PR TITLE
[studio][ISSUE #726] Keep active LLM config unchanged when persistence fails

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
@@ -80,9 +80,8 @@ public class LlmConfigService {
         if (validation.getStatus() != 0) {
             throw new LlmGatewayException(400, validation.getCode(), validation.getErrMsg(), validation.getHint());
         }
-        overrides = copy(normalized);
         GeneralSettingsVO current = settingsService.getGeneralSettings();
-        settingsService.saveGeneralSettings(GeneralSettingsVO.builder()
+        GeneralSettingsVO updated = GeneralSettingsVO.builder()
                 .theme(current.getTheme())
                 .compact(current.isCompact())
                 .desktopNotify(current.isDesktopNotify())
@@ -93,7 +92,10 @@ public class LlmConfigService {
                 .apiKey(normalized.getApiKey())
                 .model(normalized.getModel())
                 .baseUrl(normalized.getApiBase())
-                .build());
+                .build();
+        LlmConfigVO nextOverrides = copy(normalized);
+        settingsService.saveGeneralSettings(updated);
+        overrides = nextOverrides;
     }
 
     public LlmOperationResultVO testConfig(LlmConfigVO config) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -151,6 +153,27 @@ class LlmConfigServiceTest {
         assertThat(saved.getModel()).isEqualTo("deepseek-chat");
         assertThat(saved.getBaseUrl()).isEqualTo("https://api.deepseek.com/v1");
         assertThat(llmConfigService.getConfig().getProvider()).isEqualTo("deepseek");
+    }
+
+    @Test
+    void saveConfigShouldKeepCurrentConfigWhenPersistenceFails() {
+        doThrow(new IllegalStateException("persistence failed"))
+                .when(settingsService).saveGeneralSettings(any(GeneralSettingsVO.class));
+
+        assertThatThrownBy(() -> llmConfigService.saveConfig(LlmConfigVO.builder()
+                .provider("deepseek")
+                .apiKey("sk-deepseek")
+                .apiBase("https://api.deepseek.com/v1")
+                .model("deepseek-chat")
+                .maxTokens(8192)
+                .temperature(0.2)
+                .enabled(true)
+                .build()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("persistence failed");
+
+        assertThat(llmConfigService.getConfig().getProvider()).isEqualTo("openai");
+        assertThat(llmConfigService.getConfig().getModel()).isEqualTo("gpt-4o");
     }
 
     @Test


### PR DESCRIPTION
Fixes #726

## What changed

`LlmConfigService.saveConfig` now builds the next settings and runtime override without publishing either value early. It persists the settings first and replaces the in-memory override only after that call succeeds.

This keeps the previously active provider and model unchanged when persistence fails, while preserving the existing synchronized update and public API.

## Validation

- Failure-path regression test: 20/20 consecutive runs on Java 21
- Complete `LlmConfigServiceTest`: 20/20 tests passed
- Complete server test suite: 487/487 tests passed
- `mvn package`: passed
- Maven Checkstyle: passed
- `git diff --check`: passed

The project does not configure SpotBugs/FindBugs in its POM.
