### PR TITLE
[Studio] Skip malformed message trace lines

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/util/MsgTraceDecodeUtil.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/util/MsgTraceDecodeUtil.java
@@ -50,113 +50,119 @@ public class MsgTraceDecodeUtil {
         }
         String[] contextList = traceData.split(String.valueOf(TraceConstants.FIELD_SPLITOR));
         for (String context : contextList) {
-            String[] line = context.split(String.valueOf(TraceConstants.CONTENT_SPLITOR));
-            if (line[0].equals(Pub.name())) {
-                TraceContext pubContext = initTraceContext();
-                pubContext.setTraceType(Pub);
-                pubContext.setTimeStamp(Long.parseLong(line[1]));
-                pubContext.setRegionId(line[2]);
-                pubContext.setGroupName(line[3]);
-                TraceBean bean = new TraceBean();
-                bean.setTopic(line[4]);
-                bean.setMsgId(line[5]);
-                bean.setTags(line[6]);
-                bean.setKeys(line[7]);
-                bean.setStoreHost(line[8]);
-                bean.setBodyLength(Integer.parseInt(line[9]));
-                pubContext.setCostTime(Integer.parseInt(line[10]));
-                bean.setMsgType(MessageType.values()[Integer.parseInt(line[11])]);
-                // compatible with different version
-                switch (line.length) {
-                    case TRACE_MSG_PUB_V1_LEN:
-                        break;
-                    case TRACE_MSG_PUB_V2_LEN:
-                        pubContext.setSuccess(Boolean.parseBoolean(line[12]));
-                        break;
-                    case TRACE_MSG_PUB_V3_LEN:
-                        bean.setOffsetMsgId(line[12]);
-                        pubContext.setSuccess(Boolean.parseBoolean(line[13]));
-                        break;
-                    case TRACE_MSG_PUB_V4_LEN:
-                        bean.setOffsetMsgId(line[12]);
-                        pubContext.setSuccess(Boolean.parseBoolean(line[13]));
-                        bean.setClientHost(line[14]);
-                        break;
-                    default:
-                        bean.setOffsetMsgId(line[12]);
-                        pubContext.setSuccess(Boolean.parseBoolean(line[13]));
-                        bean.setClientHost(line[14]);
-                        log.warn("Detect new version trace msg of {} type", Pub.name());
-                        break;
-                }
+            // A single malformed trace line (wrong field count or non-numeric value) must not
+            // abort the decoding of the remaining lines, so decode each context in isolation.
+            try {
+                String[] line = context.split(String.valueOf(TraceConstants.CONTENT_SPLITOR));
+                if (line[0].equals(Pub.name())) {
+                    TraceContext pubContext = initTraceContext();
+                    pubContext.setTraceType(Pub);
+                    pubContext.setTimeStamp(Long.parseLong(line[1]));
+                    pubContext.setRegionId(line[2]);
+                    pubContext.setGroupName(line[3]);
+                    TraceBean bean = new TraceBean();
+                    bean.setTopic(line[4]);
+                    bean.setMsgId(line[5]);
+                    bean.setTags(line[6]);
+                    bean.setKeys(line[7]);
+                    bean.setStoreHost(line[8]);
+                    bean.setBodyLength(Integer.parseInt(line[9]));
+                    pubContext.setCostTime(Integer.parseInt(line[10]));
+                    bean.setMsgType(MessageType.values()[Integer.parseInt(line[11])]);
+                    // compatible with different version
+                    switch (line.length) {
+                        case TRACE_MSG_PUB_V1_LEN:
+                            break;
+                        case TRACE_MSG_PUB_V2_LEN:
+                            pubContext.setSuccess(Boolean.parseBoolean(line[12]));
+                            break;
+                        case TRACE_MSG_PUB_V3_LEN:
+                            bean.setOffsetMsgId(line[12]);
+                            pubContext.setSuccess(Boolean.parseBoolean(line[13]));
+                            break;
+                        case TRACE_MSG_PUB_V4_LEN:
+                            bean.setOffsetMsgId(line[12]);
+                            pubContext.setSuccess(Boolean.parseBoolean(line[13]));
+                            bean.setClientHost(line[14]);
+                            break;
+                        default:
+                            bean.setOffsetMsgId(line[12]);
+                            pubContext.setSuccess(Boolean.parseBoolean(line[13]));
+                            bean.setClientHost(line[14]);
+                            log.warn("Detect new version trace msg of {} type", Pub.name());
+                            break;
+                    }
 
-                pubContext.setTraceBeans(new ArrayList<TraceBean>(1));
-                pubContext.getTraceBeans().add(bean);
-                resList.add(pubContext);
-            } else if (line[0].equals(TraceType.SubBefore.name())) {
-                TraceContext subBeforeContext = initTraceContext();
-                subBeforeContext.setTraceType(TraceType.SubBefore);
-                subBeforeContext.setTimeStamp(Long.parseLong(line[1]));
-                subBeforeContext.setRegionId(line[2]);
-                subBeforeContext.setGroupName(line[3]);
-                subBeforeContext.setRequestId(line[4]);
-                TraceBean bean = new TraceBean();
-                bean.setMsgId(line[5]);
-                bean.setRetryTimes(Integer.parseInt(line[6]));
-                bean.setKeys(line[7]);
-                subBeforeContext.setTraceBeans(new ArrayList<TraceBean>(1));
-                subBeforeContext.getTraceBeans().add(bean);
-                resList.add(subBeforeContext);
-            } else if (line[0].equals(TraceType.SubAfter.name())) {
-                TraceContext subAfterContext = initTraceContext();
-                subAfterContext.setTraceType(TraceType.SubAfter);
-                subAfterContext.setRequestId(line[1]);
-                TraceBean bean = new TraceBean();
-                bean.setMsgId(line[2]);
-                bean.setKeys(line[5]);
-                subAfterContext.setTraceBeans(new ArrayList<TraceBean>(1));
-                subAfterContext.getTraceBeans().add(bean);
-                subAfterContext.setCostTime(Integer.parseInt(line[3]));
-                subAfterContext.setSuccess(Boolean.parseBoolean(line[4]));
-                // compatible with different version
-                switch (line.length) {
-                    case TRACE_MSG_SUBAFTER_V1_LEN:
-                        break;
-                    case TRACE_MSG_SUBAFTER_V2_LEN:
-                        subAfterContext.setContextCode(Integer.parseInt(line[6]));
-                        break;
-                    case TRACE_MSG_SUBAFTER_V3_LEN:
-                        subAfterContext.setContextCode(Integer.parseInt(line[6]));
-                        subAfterContext.setTimeStamp(Long.parseLong(line[7]));
-                        subAfterContext.setGroupName(line[8]);
-                        break;
-                    default:
-                        subAfterContext.setContextCode(Integer.parseInt(line[6]));
-                        subAfterContext.setTimeStamp(Long.parseLong(line[7]));
-                        subAfterContext.setGroupName(line[8]);
-                        log.warn("Detect new version trace msg of {} type", TraceType.SubAfter.name());
-                        break;
+                    pubContext.setTraceBeans(new ArrayList<TraceBean>(1));
+                    pubContext.getTraceBeans().add(bean);
+                    resList.add(pubContext);
+                } else if (line[0].equals(TraceType.SubBefore.name())) {
+                    TraceContext subBeforeContext = initTraceContext();
+                    subBeforeContext.setTraceType(TraceType.SubBefore);
+                    subBeforeContext.setTimeStamp(Long.parseLong(line[1]));
+                    subBeforeContext.setRegionId(line[2]);
+                    subBeforeContext.setGroupName(line[3]);
+                    subBeforeContext.setRequestId(line[4]);
+                    TraceBean bean = new TraceBean();
+                    bean.setMsgId(line[5]);
+                    bean.setRetryTimes(Integer.parseInt(line[6]));
+                    bean.setKeys(line[7]);
+                    subBeforeContext.setTraceBeans(new ArrayList<TraceBean>(1));
+                    subBeforeContext.getTraceBeans().add(bean);
+                    resList.add(subBeforeContext);
+                } else if (line[0].equals(TraceType.SubAfter.name())) {
+                    TraceContext subAfterContext = initTraceContext();
+                    subAfterContext.setTraceType(TraceType.SubAfter);
+                    subAfterContext.setRequestId(line[1]);
+                    TraceBean bean = new TraceBean();
+                    bean.setMsgId(line[2]);
+                    bean.setKeys(line[5]);
+                    subAfterContext.setTraceBeans(new ArrayList<TraceBean>(1));
+                    subAfterContext.getTraceBeans().add(bean);
+                    subAfterContext.setCostTime(Integer.parseInt(line[3]));
+                    subAfterContext.setSuccess(Boolean.parseBoolean(line[4]));
+                    // compatible with different version
+                    switch (line.length) {
+                        case TRACE_MSG_SUBAFTER_V1_LEN:
+                            break;
+                        case TRACE_MSG_SUBAFTER_V2_LEN:
+                            subAfterContext.setContextCode(Integer.parseInt(line[6]));
+                            break;
+                        case TRACE_MSG_SUBAFTER_V3_LEN:
+                            subAfterContext.setContextCode(Integer.parseInt(line[6]));
+                            subAfterContext.setTimeStamp(Long.parseLong(line[7]));
+                            subAfterContext.setGroupName(line[8]);
+                            break;
+                        default:
+                            subAfterContext.setContextCode(Integer.parseInt(line[6]));
+                            subAfterContext.setTimeStamp(Long.parseLong(line[7]));
+                            subAfterContext.setGroupName(line[8]);
+                            log.warn("Detect new version trace msg of {} type", TraceType.SubAfter.name());
+                            break;
+                    }
+                    resList.add(subAfterContext);
+                } else if (line[0].equals(TraceType.EndTransaction.name())) {
+                    TraceContext endTransactionContext = initTraceContext();
+                    endTransactionContext.setTraceType(TraceType.EndTransaction);
+                    endTransactionContext.setTimeStamp(Long.parseLong(line[1]));
+                    endTransactionContext.setRegionId(line[2]);
+                    endTransactionContext.setGroupName(line[3]);
+                    TraceBean bean = new TraceBean();
+                    bean.setTopic(line[4]);
+                    bean.setMsgId(line[5]);
+                    bean.setTags(line[6]);
+                    bean.setKeys(line[7]);
+                    bean.setStoreHost(line[8]);
+                    bean.setMsgType(MessageType.values()[Integer.parseInt(line[9])]);
+                    bean.setTransactionId(line[10]);
+                    bean.setTransactionState(LocalTransactionState.valueOf(line[11]));
+                    bean.setFromTransactionCheck(Boolean.parseBoolean(line[12]));
+                    endTransactionContext.setTraceBeans(new ArrayList<TraceBean>(1));
+                    endTransactionContext.getTraceBeans().add(bean);
+                    resList.add(endTransactionContext);
                 }
-                resList.add(subAfterContext);
-            } else if (line[0].equals(TraceType.EndTransaction.name())) {
-                TraceContext endTransactionContext = initTraceContext();
-                endTransactionContext.setTraceType(TraceType.EndTransaction);
-                endTransactionContext.setTimeStamp(Long.parseLong(line[1]));
-                endTransactionContext.setRegionId(line[2]);
-                endTransactionContext.setGroupName(line[3]);
-                TraceBean bean = new TraceBean();
-                bean.setTopic(line[4]);
-                bean.setMsgId(line[5]);
-                bean.setTags(line[6]);
-                bean.setKeys(line[7]);
-                bean.setStoreHost(line[8]);
-                bean.setMsgType(MessageType.values()[Integer.parseInt(line[9])]);
-                bean.setTransactionId(line[10]);
-                bean.setTransactionState(LocalTransactionState.valueOf(line[11]));
-                bean.setFromTransactionCheck(Boolean.parseBoolean(line[12]));
-                endTransactionContext.setTraceBeans(new ArrayList<TraceBean>(1));
-                endTransactionContext.getTraceBeans().add(bean);
-                resList.add(endTransactionContext);
+            } catch (Exception e) {
+                log.warn("Decode trace context failed, skip this context: {}", context, e);
             }
         }
         return resList;


### PR DESCRIPTION
### Problem

`MsgTraceDecodeUtil.decoderFromTraceDataString` parses each trace line by accessing `line[1..N]` and calling `Integer.parseInt` / `Long.parseLong` / `MessageType.values()[i]` **without validating the field count or the values**.

A single malformed trace line — too few fields, or a non-numeric value — throws `ArrayIndexOutOfBoundsException` / `NumberFormatException`. That exception propagates out of the decoding loop, so `MessageTraceView.decodeFromTraceTransData` (which has no try/catch) fails, and the whole message-trace query returns an error — even though all the other trace lines were perfectly valid.

Since trace data comes from message bodies (potentially produced by mixed client versions or corrupted), a malformed line is plausible and should not break the entire result.

### Fix

Decode each trace context in isolation: wrap the per-line parsing in a `try/catch` and skip (with a warning log) any line that fails to parse, so one bad line no longer aborts the rest.

### Verification

`mvn compiler:compile` passes (`BUILD SUCCESS`).

### Diff

1 file changed (the change is mostly re-indentation from wrapping the loop body in a try/catch).