### PR TITLE
[Studio] Isolate broker failures in cluster list

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/ClusterServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/ClusterServiceImpl.java
@@ -52,8 +52,13 @@ public class ClusterServiceImpl implements ClusterService {
             for (BrokerData brokerData : clusterInfo.getBrokerAddrTable().values()) {
                 Map<Long, Object> brokerMasterSlaveMap = Maps.newHashMap();
                 for (Map.Entry<Long/* brokerId */, String/* broker address */> brokerAddr : brokerData.getBrokerAddrs().entrySet()) {
-                    KVTable kvTable = mqAdminExt.fetchBrokerRuntimeStats(brokerAddr.getValue());
-                    brokerMasterSlaveMap.put(brokerAddr.getKey(), kvTable.getTable());
+                    try {
+                        KVTable kvTable = mqAdminExt.fetchBrokerRuntimeStats(brokerAddr.getValue());
+                        brokerMasterSlaveMap.put(brokerAddr.getKey(), kvTable.getTable());
+                    } catch (Exception e) {
+                        // A single unreachable broker must not fail the whole cluster view.
+                        logger.warn("Failed to fetch runtime stats for broker: {}", brokerAddr.getValue(), e);
+                    }
                 }
                 brokerServer.put(brokerData.getBrokerName(), brokerMasterSlaveMap);
             }


### PR DESCRIPTION
### Problem

`ClusterServiceImpl.list()` fetched every broker's runtime stats inside one big `try` block:

```java
for (Map.Entry<Long, String> brokerAddr : brokerData.getBrokerAddrs().entrySet()) {
    KVTable kvTable = mqAdminExt.fetchBrokerRuntimeStats(brokerAddr.getValue());
    brokerMasterSlaveMap.put(brokerAddr.getKey(), kvTable.getTable());
}
```

If **any one** broker is temporarily unreachable, `fetchBrokerRuntimeStats` throws, the exception propagates to the outer catch, and the entire Cluster page fails — even though all the other brokers are healthy and their data is available.

### Fix

Fetch each broker's runtime stats in its own `try/catch` and skip the brokers that fail (logging a warning). This is consistent with how `DashboardCollectTask.collectBroker` already handles per-broker failures (it skips brokers whose stats cannot be fetched).

### Verification

`mvn compiler:compile` passes (`BUILD SUCCESS`).

### Diff

1 file changed, +7 / -2.