### PR TITLE
[Studio] feat: support Grafana Mimir data sources

### DIFF
--- a/web/src/pages/settings/__tests__/DataSourceTab.test.tsx
+++ b/web/src/pages/settings/__tests__/DataSourceTab.test.tsx
@@ -163,6 +163,55 @@ describe('DataSourceTab', () => {
     });
   });
 
+  it('creates and tests a Grafana Mimir data source', async () => {
+    vi.mocked(testDataSource).mockResolvedValue({ success: true, message: 'ok' });
+    vi.mocked(createDataSource).mockResolvedValue({
+      key: 'mimir-prod',
+      name: 'Mimir prod',
+      type: 'Mimir',
+      url: 'http://mimir:9009',
+      auth: 'None',
+      status: 'healthy',
+    });
+
+    const user = userEvent.setup();
+    render(
+      <App>
+        <DataSourceTab />
+      </App>,
+    );
+
+    await screen.findByText('Prometheus prod');
+    await user.click(screen.getByRole('button', { name: /添加数据源/ }));
+    await user.type(screen.getByLabelText('名称'), 'Mimir prod');
+    await selectAntdOption(user, '类型', 'Grafana Mimir');
+    await user.type(screen.getByLabelText('URL'), 'http://mimir:9009');
+
+    const testButtons = screen.getAllByRole('button', { name: /测试连接/ });
+    await user.click(testButtons[testButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(testDataSource).toHaveBeenCalledWith({
+        type: 'Mimir',
+        url: 'http://mimir:9009',
+        auth: 'None',
+      });
+    });
+
+    await user.click(screen.getByRole('button', { name: 'OK' }));
+
+    await waitFor(() => {
+      expect(createDataSource).toHaveBeenCalledWith({
+        name: 'Mimir prod',
+        type: 'Mimir',
+        url: 'http://mimir:9009',
+        auth: 'None',
+      });
+    });
+    expect(await screen.findByText('Mimir prod')).toBeInTheDocument();
+    expect(screen.getByText('Mimir')).toHaveClass('ant-tag-cyan');
+  });
+
   it('does not persist modal-only credentials when creating a data source', async () => {
     vi.mocked(createDataSource).mockResolvedValue({
       key: 'prom-secure',
@@ -202,7 +251,11 @@ describe('DataSourceTab', () => {
   });
 });
 
-async function selectAntdOption(user: ReturnType<typeof userEvent.setup>, label: string, option: string) {
+async function selectAntdOption(
+  user: ReturnType<typeof userEvent.setup>,
+  label: string,
+  option: string,
+) {
   await user.click(screen.getByLabelText(label));
   const popupId = label === '类型' ? 'type_list' : 'auth_list';
   const popup = await waitFor(() => {

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -68,6 +68,7 @@ const typeTagColor: Record<string, string> = {
   Prometheus: 'orange',
   VictoriaMetrics: 'blue',
   Thanos: 'purple',
+  Mimir: 'cyan',
 };
 
 type DataSourceFormValues = Partial<DataSource>;
@@ -377,7 +378,9 @@ export const DataSourceTab = () => {
             icon={<ApiOutlined />}
             loading={testingKey === record.key}
             disabled={authNeedsSecret(record.auth)}
-            title={authNeedsSecret(record.auth) ? '认证数据源请编辑后输入凭据再测试连接' : undefined}
+            title={
+              authNeedsSecret(record.auth) ? '认证数据源请编辑后输入凭据再测试连接' : undefined
+            }
             onClick={() => void handleTestConnection(record, record.key)}
           >
             测试连接
@@ -454,6 +457,7 @@ export const DataSourceTab = () => {
                 { value: 'Prometheus', label: 'Prometheus' },
                 { value: 'VictoriaMetrics', label: 'VictoriaMetrics' },
                 { value: 'Thanos', label: 'Thanos' },
+                { value: 'Mimir', label: 'Grafana Mimir' },
               ]}
             />
           </Form.Item>
@@ -470,7 +474,11 @@ export const DataSourceTab = () => {
             <Select
               virtual={false}
               onChange={() => {
-                dsForm.setFieldsValue({ username: undefined, password: undefined, bearerToken: undefined });
+                dsForm.setFieldsValue({
+                  username: undefined,
+                  password: undefined,
+                  bearerToken: undefined,
+                });
               }}
               options={[
                 { value: 'None', label: 'None' },


### PR DESCRIPTION
## What is the purpose of the change

Allow users to configure and test Grafana Mimir as a Prometheus-compatible data source.

## Brief changelog

- Add Grafana Mimir to the available data source types.
- Display Mimir data sources with a dedicated tag.
- Add regression coverage for testing, creating, and displaying Mimir data sources.

## Verifying this change

- `npm test -- DataSourceTab`
- `npm test`
- `npm run lint`
- `npm run build`
- `mvn -B -ntp -Dtest=SettingsServiceTest test`
- `mvn -B -ntp test`
- Manually verified Mimir connection testing and creation through the Settings page.