### PR TITLE
[Studio] Skip topics without collected data

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/DashboardServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/DashboardServiceImpl.java
@@ -68,6 +68,10 @@ public class DashboardServiceImpl implements DashboardService {
         List<String> result = Lists.newArrayList();
         for (Map.Entry<String, List<String>> entry : topicCache.entrySet()) {
             List<String> value = entry.getValue();
+            // A topic may have no collected data points yet; skip it instead of calling get(-1).
+            if (value == null || value.isEmpty()) {
+                continue;
+            }
             result.add(entry.getKey() + "," + value.get(value.size() - 1).split(",")[4]);
         }
         return result;


### PR DESCRIPTION
### Problem

`DashboardServiceImpl.queryTopicCurrentData` iterated the topic cache and, for every entry, called:

```java
result.add(entry.getKey() + "," + value.get(value.size() - 1).split(",")[4]);
```

A topic that has **no collected data points yet** maps to an empty list, so `value.size() - 1` is `-1` and `value.get(-1)` throws `IndexOutOfBoundsException`. Because there is no try/catch, the entire `queryTopicCurrentData` endpoint fails as soon as one topic has an empty data list.

### Fix

Skip entries whose value list is `null` or empty before indexing the last element.

### Verification

`mvn compiler:compile` passes (`BUILD SUCCESS`).

### Diff

1 file changed, +4.