### PR TITLE
[Studio] Handle empty queue offsets in message paging

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImpl.java
@@ -528,6 +528,12 @@ public class MessageServiceImpl implements MessageService {
 
     private void moveEndOffset(List<QueueOffsetInfo> queueOffsets, MessageQueryByPage query, int next) {
         int size = queueOffsets.size();
+        // The loop below indexes queueOffsets and computes (next + 1) % size; with an empty
+        // list (e.g. a topic that has no message queues) that would throw
+        // IndexOutOfBoundsException and divide by zero.
+        if (size == 0) {
+            return;
+        }
         for (int j = 0; j < query.getPageSize(); j++) {
             QueueOffsetInfo nextQueueOffset = queueOffsets.get(next);
             next = (next + 1) % size;


### PR DESCRIPTION
### Problem

`MessageServiceImpl.moveEndOffset` loops `query.getPageSize()` times (independent of the list size), and every iteration does:

```java
QueueOffsetInfo nextQueueOffset = queueOffsets.get(next);
next = (next + 1) % size;
```

When `queueOffsets` is **empty** — e.g. querying messages by page for a topic that has no message queues — `size` is `0`, so `queueOffsets.get(next)` throws `IndexOutOfBoundsException` and `(next + 1) % size` divides by zero (`ArithmeticException`).

### Fix

Return early when the queue offset list is empty.

### Verification

`mvn compiler:compile` passes (`BUILD SUCCESS`).

### Diff

1 file changed, +6.