### PR TITLE
[ISSUE #686] Fail explicitly when DLQ provider is missing

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQProviderStub.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQProviderStub.java
@@ -16,70 +16,31 @@
  */
 package org.apache.rocketmq.studio.instance.dlq;
 
-import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * Placeholder {@link DLQProvider} used until a real DLQ provider is connected.
+ *
+ * <p>Rather than returning sample DLQ groups (which could mislead operators into believing real
+ * DLQ data exists) or silently accepting resend requests as a no-op, both operations fail
+ * explicitly with a structured "not implemented" response.
+ */
 @Component
-@Slf4j
 public class DLQProviderStub implements DLQProvider {
-
-    private final List<StubDLQGroup> stubData = List.of(
-            new StubDLQGroup("rmq-cn-v5-prod-01", DLQGroupVO.builder()
-                    .groupName("cg-order-payment")
-                    .dlqTopic("%DLQ%cg-order-payment")
-                    .messageCount(128)
-                    .lastEnqueueTime(LocalDateTime.of(2026, 7, 24, 10, 15, 30))
-                    .retryCount(16)
-                    .status("ACTIVE")
-                    .build()),
-            new StubDLQGroup("rmq-cn-v5-prod-01", DLQGroupVO.builder()
-                    .groupName("cg-inventory-sync")
-                    .dlqTopic("%DLQ%cg-inventory-sync")
-                    .messageCount(24)
-                    .lastEnqueueTime(LocalDateTime.of(2026, 7, 24, 9, 40, 12))
-                    .retryCount(8)
-                    .status("ACTIVE")
-                    .build()),
-            new StubDLQGroup("rmq-cn-v4-prod-02", DLQGroupVO.builder()
-                    .groupName("legacy-order-consumer")
-                    .dlqTopic("%DLQ%legacy-order-consumer")
-                    .messageCount(6)
-                    .lastEnqueueTime(LocalDateTime.of(2026, 7, 23, 22, 5, 0))
-                    .retryCount(3)
-                    .status("ACKED")
-                    .build())
-    );
 
     @Override
     public List<DLQGroupVO> listDLQGroups(String clusterId) {
-        log.info("DLQProviderStub.listDLQGroups called. clusterId={}", clusterId);
-        return stubData.stream()
-                .filter(item -> !StringUtils.hasText(clusterId) || item.clusterId().equals(clusterId))
-                .map(StubDLQGroup::group)
-                .map(DLQProviderStub::copyGroup)
-                .toList();
+        throw new BusinessException(HttpStatus.NOT_IMPLEMENTED.value(),
+                "DLQ listing is not yet implemented: no DLQ provider is connected");
     }
 
     @Override
     public void resendMessages(String groupName, Long startTime, Long endTime, String targetTopic) {
-        log.warn("DLQProviderStub.resendMessages called - no-op. group={}, targetTopic={}", groupName, targetTopic);
-    }
-
-    private static DLQGroupVO copyGroup(DLQGroupVO group) {
-        return DLQGroupVO.builder()
-                .groupName(group.getGroupName())
-                .dlqTopic(group.getDlqTopic())
-                .messageCount(group.getMessageCount())
-                .lastEnqueueTime(group.getLastEnqueueTime())
-                .retryCount(group.getRetryCount())
-                .status(group.getStatus())
-                .build();
-    }
-
-    private record StubDLQGroup(String clusterId, DLQGroupVO group) {
+        throw new BusinessException(HttpStatus.NOT_IMPLEMENTED.value(),
+                "DLQ message resend is not yet implemented: no DLQ provider is connected");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQProviderStubTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQProviderStubTest.java
@@ -17,53 +17,35 @@
 
 package org.apache.rocketmq.studio.instance.dlq;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
+import org.springframework.http.HttpStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DLQProviderStubTest {
 
     private final DLQProviderStub provider = new DLQProviderStub();
 
     @Test
-    void listDLQGroupsShouldReturnSampleGroupsForAllClusters() {
-        List<DLQGroupVO> groups = provider.listDLQGroups(null);
-
-        assertThat(groups)
-                .extracting(DLQGroupVO::getGroupName)
-                .containsExactly("cg-order-payment", "cg-inventory-sync", "legacy-order-consumer");
-        assertThat(groups)
-                .allSatisfy(group -> {
-                    assertThat(group.getDlqTopic()).startsWith("%DLQ%");
-                    assertThat(group.getMessageCount()).isPositive();
-                    assertThat(group.getLastEnqueueTime()).isNotNull();
-                    assertThat(group.getStatus()).isNotBlank();
-                });
+    void listDLQGroupsShouldFailAsNotImplemented() {
+        assertThatThrownBy(() -> provider.listDLQGroups(null))
+                .isInstanceOfSatisfying(BusinessException.class, ex ->
+                        assertThat(ex.getCode()).isEqualTo(HttpStatus.NOT_IMPLEMENTED.value()));
     }
 
     @Test
-    void listDLQGroupsShouldFilterByClusterId() {
-        List<DLQGroupVO> groups = provider.listDLQGroups("rmq-cn-v5-prod-01");
-
-        assertThat(groups)
-                .extracting(DLQGroupVO::getGroupName)
-                .containsExactly("cg-order-payment", "cg-inventory-sync");
+    void listDLQGroupsShouldFailAsNotImplementedForAnyCluster() {
+        assertThatThrownBy(() -> provider.listDLQGroups("rmq-cn-v5-prod-01"))
+                .isInstanceOfSatisfying(BusinessException.class, ex ->
+                        assertThat(ex.getCode()).isEqualTo(HttpStatus.NOT_IMPLEMENTED.value()));
     }
 
     @Test
-    void listDLQGroupsShouldReturnEmptyForUnknownCluster() {
-        assertThat(provider.listDLQGroups("missing-cluster")).isEmpty();
-    }
-
-    @Test
-    void listDLQGroupsShouldReturnDefensiveCopies() {
-        List<DLQGroupVO> firstRead = provider.listDLQGroups("rmq-cn-v5-prod-01");
-        firstRead.get(0).setGroupName("mutated");
-
-        List<DLQGroupVO> secondRead = provider.listDLQGroups("rmq-cn-v5-prod-01");
-
-        assertThat(secondRead.get(0).getGroupName()).isEqualTo("cg-order-payment");
+    void resendMessagesShouldFailAsNotImplemented() {
+        assertThatThrownBy(() -> provider.resendMessages("cg-order-payment", null, null, "target-topic"))
+                .isInstanceOfSatisfying(BusinessException.class, ex ->
+                        assertThat(ex.getCode()).isEqualTo(HttpStatus.NOT_IMPLEMENTED.value()));
     }
 }


### PR DESCRIPTION
Fixes #686

### Problem

`DLQProviderStub` is wired as the production `DLQProvider`, but it:
- returns **hard-coded sample DLQ groups** from `listDLQGroups`, and
- treats `resendMessages` as a **no-op** (only logs, never resends).

Returning sample data and successful no-op responses can mislead operators into believing real DLQ groups exist and that resend requests actually succeeded.

### Fix

Until a real DLQ provider is connected, both operations now **fail explicitly** with a structured `501 Not Implemented` `BusinessException` (which `GlobalExceptionHandler` maps to a clean `Result.error(501, ...)` response), as the issue's "Expected" section calls for. The hard-coded stub data and its helper methods are removed.

`DLQProviderStubTest` is updated to assert the new not-implemented behavior.

### Verification

`mvn test -Dtest=DLQProviderStubTest` passes on JDK 21: `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`.

### Diff

2 files changed, +28 / -85.