### PR TITLE
[ISSUE #684] Fail explicitly when message provider is missing

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProviderStub.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProviderStub.java
@@ -16,29 +16,31 @@
  */
 package org.apache.rocketmq.studio.instance.message;
 
-import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
 import java.util.List;
 
+/**
+ * Placeholder {@link MessageProvider} used until a real message query provider is connected.
+ *
+ * <p>Rather than returning empty results (which could mislead operators into thinking no message
+ * or trace exists), both operations fail explicitly with a structured "not implemented" response.
+ */
 @Component
-@Slf4j
 public class MessageProviderStub implements MessageProvider {
 
     @Override
     public List<MessageRecordVO> queryMessages(String topic, String msgId, String tag, String key, Long startTime,
                                                Long endTime) {
-        log.warn("MessageProviderStub.queryMessages called - returning empty list");
-        return Collections.emptyList();
+        throw new BusinessException(HttpStatus.NOT_IMPLEMENTED.value(),
+                "Message query is not yet implemented: no message provider is connected");
     }
 
     @Override
     public TraceRecordVO getMessageTrace(String msgId) {
-        log.warn("MessageProviderStub.getMessageTrace called - returning empty trace");
-        return TraceRecordVO.builder()
-                .nodes(Collections.emptyList())
-                .consumerStatus(Collections.emptyList())
-                .build();
+        throw new BusinessException(HttpStatus.NOT_IMPLEMENTED.value(),
+                "Message trace is not yet implemented: no message provider is connected");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageProviderStubTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageProviderStubTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.studio.instance.message;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MessageProviderStubTest {
+
+    private final MessageProviderStub provider = new MessageProviderStub();
+
+    @Test
+    void queryMessagesShouldFailAsNotImplemented() {
+        assertThatThrownBy(() -> provider.queryMessages("orders", null, null, null, null, null))
+                .isInstanceOfSatisfying(BusinessException.class, ex ->
+                        assertThat(ex.getCode()).isEqualTo(HttpStatus.NOT_IMPLEMENTED.value()));
+    }
+
+    @Test
+    void getMessageTraceShouldFailAsNotImplemented() {
+        assertThatThrownBy(() -> provider.getMessageTrace("msg-001"))
+                .isInstanceOfSatisfying(BusinessException.class, ex ->
+                        assertThat(ex.getCode()).isEqualTo(HttpStatus.NOT_IMPLEMENTED.value()));
+    }
+}


### PR DESCRIPTION
Fixes #684

### Problem

`MessageProviderStub` is wired as the production `MessageProvider`, but `queryMessages` returns an empty list and `getMessageTrace` returns an empty trace. A successful empty response can mislead operators into thinking no message or trace exists, when in fact no real provider is connected.

### Fix

Until a real message provider is connected, both operations now fail explicitly with a structured `501 Not Implemented` `BusinessException` (mapped by `GlobalExceptionHandler` to a clean `Result.error(501, ...)`), matching the issue's expected behavior. Added `MessageProviderStubTest`.

### Verification

`mvn test -Dtest=MessageProviderStubTest` on JDK 21: `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`.

### Diff

2 files changed, +56 / -10.