### PR TITLE
[ISSUE #696] Fail explicitly when client provider is missing

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientProviderStubTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientProviderStubTest.java
@@ -14,27 +14,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.rocketmq.studio.cluster.client;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
 
-import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/**
- * Placeholder {@link ClientProvider} used until a real Remoting/gRPC client provider is connected.
- *
- * <p>Rather than returning hard-coded sample connections (which could mislead operators into
- * believing real clients are online), the operation fails explicitly with a structured
- * "not implemented" response.
- */
-@Component
-public class ClientProviderStub implements ClientProvider {
+class ClientProviderStubTest {
 
-    @Override
-    public List<ClientConnectionVO> findConnections(String clusterId, String type) {
-        throw new BusinessException(HttpStatus.NOT_IMPLEMENTED.value(),
-                "Client connection listing is not yet implemented: no client provider is connected");
+    private final ClientProviderStub provider = new ClientProviderStub();
+
+    @Test
+    void findConnectionsShouldFailAsNotImplemented() {
+        assertThatThrownBy(() -> provider.findConnections(null, null))
+                .isInstanceOfSatisfying(BusinessException.class, ex ->
+                        assertThat(ex.getCode()).isEqualTo(HttpStatus.NOT_IMPLEMENTED.value()));
+    }
+
+    @Test
+    void findConnectionsShouldFailAsNotImplementedForAnyFilter() {
+        assertThatThrownBy(() -> provider.findConnections("production-cluster", "Producer"))
+                .isInstanceOfSatisfying(BusinessException.class, ex ->
+                        assertThat(ex.getCode()).isEqualTo(HttpStatus.NOT_IMPLEMENTED.value()));
     }
 }


### PR DESCRIPTION
Fixes #696

### Problem

`ClientProviderStub` is wired as the production `ClientProvider` but returns hard-coded sample connections (`producer-001`, `consumer-001`, `consumer-002`). The client connection page should not show production-looking fake clients when no real client provider is configured — it can mislead operators during validation.

### Fix

Until a real Remoting/gRPC client provider is connected, `findConnections` now fails explicitly with a structured `501 Not Implemented` `BusinessException` (mapped by `GlobalExceptionHandler` to `Result.error(501, ...)`), matching the issue's expected behavior. Added `ClientProviderStubTest`.

### Verification

`mvn test -Dtest=ClientProviderStubTest` on JDK 21: `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`.

### Diff

2 files changed.