### PR TITLE
[studio] fix: scope LLM operations to the current form

### DIFF
--- a/web/src/pages/studio/LlmSettings.tsx
+++ b/web/src/pages/studio/LlmSettings.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
   Button,
@@ -80,6 +80,29 @@ const LlmSettingsPage: React.FC = () => {
   const [apiKeyConfigured, setApiKeyConfigured] = useState(false);
   const [modelOptions, setModelOptions] = useState<{ value: string; label: string }[]>([]);
   const [testResult, setTestResult] = useState<TestState | null>(null);
+  const mountedRef = useRef(false);
+  const lifecycleGeneration = useRef(0);
+  const operationGeneration = useRef(0);
+  const testRequestGeneration = useRef(0);
+  const saveRequestGeneration = useRef(0);
+
+  const beginOperation = () => {
+    const lifecycle = lifecycleGeneration.current;
+    const operation = ++operationGeneration.current;
+    return () =>
+      mountedRef.current &&
+      lifecycleGeneration.current === lifecycle &&
+      operationGeneration.current === operation;
+  };
+
+  const invalidateOperation = useCallback(() => {
+    operationGeneration.current += 1;
+    testRequestGeneration.current += 1;
+    if (mountedRef.current) {
+      setTesting(false);
+      setTestResult(null);
+    }
+  }, []);
 
   const buildModelOptions = (
     nextProvider: string,
@@ -112,6 +135,8 @@ const LlmSettingsPage: React.FC = () => {
   };
 
   useEffect(() => {
+    const lifecycle = ++lifecycleGeneration.current;
+    mountedRef.current = true;
     let cancelled = false;
     Promise.all([getLlmConfig(), getLlmModels().catch(() => null)])
       .then(([config, models]) => {
@@ -126,11 +151,19 @@ const LlmSettingsPage: React.FC = () => {
       });
     return () => {
       cancelled = true;
+      if (lifecycleGeneration.current === lifecycle) {
+        mountedRef.current = false;
+        lifecycleGeneration.current += 1;
+        operationGeneration.current += 1;
+        testRequestGeneration.current += 1;
+        saveRequestGeneration.current += 1;
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleProviderChange = (nextProvider: string) => {
+    invalidateOperation();
     setModelOptions(fallbackModelOptions(nextProvider));
     const fallbackModel = fallbackModelOptions(nextProvider)[0]?.value;
     form.setFieldsValue({
@@ -138,7 +171,6 @@ const LlmSettingsPage: React.FC = () => {
       model: fallbackModel,
       apiBase: DEFAULT_BASE_URL[nextProvider] || form.getFieldValue('apiBase'),
     });
-    setTestResult(null);
   };
 
   const buildPayload = async (): Promise<LlmConfig | null> => {
@@ -175,25 +207,38 @@ const LlmSettingsPage: React.FC = () => {
   };
 
   const handleTest = async () => {
+    const ownsOperation = beginOperation();
     const payload = await buildPayload();
-    if (!payload) return;
+    if (!payload || !ownsOperation()) return;
+    const request = ++testRequestGeneration.current;
     setTesting(true);
     setTestResult(null);
     try {
-      applyTestResult(await testLlmConnection(payload));
+      const result = await testLlmConnection(payload);
+      if (ownsOperation()) applyTestResult(result);
     } catch {
-      setTestResult({ success: false, msg: '连接测试请求失败，请稍后重试' });
+      if (ownsOperation()) {
+        setTestResult({ success: false, msg: '连接测试请求失败，请稍后重试' });
+      }
     } finally {
-      setTesting(false);
+      if (mountedRef.current && testRequestGeneration.current === request) {
+        setTesting(false);
+      }
     }
   };
 
   const handleSave = async () => {
+    const ownsOperation = beginOperation();
+    testRequestGeneration.current += 1;
+    setTesting(false);
+    setTestResult(null);
     const payload = await buildPayload();
-    if (!payload) return;
+    if (!payload || !ownsOperation()) return;
+    const request = ++saveRequestGeneration.current;
     setSaving(true);
     try {
       const result = await saveLlmConfig(payload);
+      if (!ownsOperation()) return;
       if (result.status === 0) {
         message.success('保存成功');
         if (payload.apiKey) {
@@ -204,9 +249,11 @@ const LlmSettingsPage: React.FC = () => {
         message.error(result.errMsg || '保存失败');
       }
     } catch {
-      message.error('保存请求失败，请稍后重试');
+      if (ownsOperation()) message.error('保存请求失败，请稍后重试');
     } finally {
-      setSaving(false);
+      if (mountedRef.current && saveRequestGeneration.current === request) {
+        setSaving(false);
+      }
     }
   };
 
@@ -219,6 +266,7 @@ const LlmSettingsPage: React.FC = () => {
           form={form}
           layout="vertical"
           initialValues={{ provider: 'tongyi', engine: 'claude-code' }}
+          onValuesChange={invalidateOperation}
         >
           <Form.Item
             label="执行引擎"
@@ -302,7 +350,7 @@ const LlmSettingsPage: React.FC = () => {
               <Button type="primary" loading={saving} onClick={() => void handleSave()}>
                 保存
               </Button>
-              <Button loading={testing} onClick={() => void handleTest()}>
+              <Button disabled={saving} loading={testing} onClick={() => void handleTest()}>
                 测试连接
               </Button>
             </Space>

--- a/web/src/pages/studio/__tests__/LlmSettingsOperationOwnership.test.tsx
+++ b/web/src/pages/studio/__tests__/LlmSettingsOperationOwnership.test.tsx
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StrictMode } from 'react';
+import { App } from 'antd';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LangProvider } from '../../../i18n/LangContext';
+import type { LlmTestResult } from '../../../api/llm';
+import LlmSettingsPage from '../LlmSettings';
+
+const llmApiMocks = vi.hoisted(() => ({
+  getLlmConfig: vi.fn(),
+  saveLlmConfig: vi.fn(),
+  testLlmConnection: vi.fn(),
+  getLlmModels: vi.fn(),
+}));
+
+vi.mock('../../../api/llm', () => llmApiMocks);
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+const deferred = <T,>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const OPENAI_CONFIG = {
+  provider: 'openai',
+  engine: 'http',
+  apiBase: 'https://api.openai.com/v1',
+  model: 'gpt-4o',
+  maxTokens: 4096,
+  temperature: 0.7,
+  enabled: true,
+  apiKeyConfigured: false,
+};
+
+const renderPage = async () => {
+  render(
+    <StrictMode>
+      <App>
+        <LangProvider>
+          <LlmSettingsPage />
+        </LangProvider>
+      </App>
+    </StrictMode>,
+  );
+  await screen.findByDisplayValue(OPENAI_CONFIG.apiBase);
+};
+
+const testButton = () => screen.getByRole('button', { name: /测\s*试\s*连\s*接/ });
+const saveButton = () => screen.getByRole('button', { name: /保\s*存/ });
+
+describe('LlmSettingsPage operation ownership', () => {
+  beforeEach(() => {
+    Object.values(llmApiMocks).forEach((mock) => mock.mockReset());
+    llmApiMocks.getLlmConfig.mockResolvedValue(OPENAI_CONFIG);
+    llmApiMocks.getLlmModels.mockResolvedValue({
+      status: 0,
+      data: [{ id: 'gpt-4o' }, { id: 'gpt-4.1' }],
+    });
+    llmApiMocks.saveLlmConfig.mockResolvedValue({ status: 0 });
+    llmApiMocks.testLlmConnection.mockResolvedValue({ status: 0, msg: 'current result' });
+  });
+
+  it('ignores a test result after the provider changes', async () => {
+    const user = userEvent.setup();
+    const request = deferred<LlmTestResult>();
+    llmApiMocks.testLlmConnection.mockReturnValueOnce(request.promise);
+    await renderPage();
+
+    await user.click(testButton());
+    await waitFor(() => expect(llmApiMocks.testLlmConnection).toHaveBeenCalledTimes(1));
+    expect(testButton()).toHaveClass('ant-btn-loading');
+
+    await user.click(screen.getByRole('combobox', { name: '模型服务商' }));
+    await user.click(
+      await screen.findByText('DeepSeek', { selector: '.ant-select-item-option-content' }),
+    );
+    expect(screen.getByRole('textbox', { name: 'API Base URL' })).toHaveValue(
+      'https://api.deepseek.com/v1',
+    );
+
+    await act(async () => {
+      request.resolve({ status: 0, msg: 'stale provider result' });
+      await request.promise;
+    });
+
+    expect(screen.queryByText('stale provider result')).not.toBeInTheDocument();
+    expect(llmApiMocks.saveLlmConfig).not.toHaveBeenCalled();
+  });
+
+  it('ignores a test result after the execution engine changes', async () => {
+    const user = userEvent.setup();
+    const request = deferred<LlmTestResult>();
+    llmApiMocks.testLlmConnection.mockReturnValueOnce(request.promise);
+    await renderPage();
+
+    await user.click(testButton());
+    await waitFor(() => expect(llmApiMocks.testLlmConnection).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole('combobox', { name: '执行引擎' }));
+    await user.click(
+      await screen.findByText('Qoder CLI', { selector: '.ant-select-item-option-content' }),
+    );
+
+    await act(async () => {
+      request.resolve({ status: 0, msg: 'stale engine result' });
+      await request.promise;
+    });
+
+    expect(screen.queryByText('stale engine result')).not.toBeInTheDocument();
+  });
+
+  it('does not let an older test clear the loading state of a newer test', async () => {
+    const user = userEvent.setup();
+    const firstRequest = deferred<LlmTestResult>();
+    const secondRequest = deferred<LlmTestResult>();
+    llmApiMocks.testLlmConnection
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise);
+    await renderPage();
+
+    await user.click(testButton());
+    await waitFor(() => expect(llmApiMocks.testLlmConnection).toHaveBeenCalledTimes(1));
+    const apiKeyInput = screen.getByLabelText(/^API Key$/);
+    await user.type(apiKeyInput, 'replacement-key');
+    expect(testButton()).not.toHaveClass('ant-btn-loading');
+
+    await user.click(testButton());
+    await waitFor(() => expect(llmApiMocks.testLlmConnection).toHaveBeenCalledTimes(2));
+    expect(testButton()).toHaveClass('ant-btn-loading');
+
+    await act(async () => {
+      firstRequest.resolve({ status: 0, msg: 'older result' });
+      await firstRequest.promise;
+    });
+    expect(testButton()).toHaveClass('ant-btn-loading');
+    expect(screen.queryByText('older result')).not.toBeInTheDocument();
+
+    await act(async () => {
+      secondRequest.resolve({ status: 0, msg: 'newer result' });
+      await secondRequest.promise;
+    });
+    expect(await screen.findByText('newer result')).toBeInTheDocument();
+    expect(testButton()).not.toHaveClass('ant-btn-loading');
+  });
+
+  it('lets an explicit save supersede a pending connection test', async () => {
+    const user = userEvent.setup();
+    const request = deferred<LlmTestResult>();
+    llmApiMocks.testLlmConnection.mockReturnValueOnce(request.promise);
+    await renderPage();
+
+    await user.click(testButton());
+    await waitFor(() => expect(llmApiMocks.testLlmConnection).toHaveBeenCalledTimes(1));
+    await user.click(saveButton());
+    await waitFor(() => expect(llmApiMocks.saveLlmConfig).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      request.resolve({ status: 0, msg: 'stale test after save' });
+      await request.promise;
+    });
+
+    expect(screen.queryByText('stale test after save')).not.toBeInTheDocument();
+    expect(llmApiMocks.saveLlmConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a stale save clear a newly edited API key', async () => {
+    const user = userEvent.setup();
+    const request = deferred<LlmTestResult>();
+    llmApiMocks.saveLlmConfig.mockReturnValueOnce(request.promise);
+    await renderPage();
+
+    const apiKeyInput = screen.getByLabelText(/^API Key$/);
+    await user.type(apiKeyInput, 'submitted-key');
+    await user.click(saveButton());
+    await waitFor(() => expect(llmApiMocks.saveLlmConfig).toHaveBeenCalledTimes(1));
+    expect(testButton()).toBeDisabled();
+
+    await user.clear(apiKeyInput);
+    await user.type(apiKeyInput, 'replacement-key');
+    await act(async () => {
+      request.resolve({ status: 0 });
+      await request.promise;
+    });
+
+    expect(apiKeyInput).toHaveValue('replacement-key');
+    expect(screen.queryByText('密钥已配置')).not.toBeInTheDocument();
+    expect(screen.queryByText('保存成功')).not.toBeInTheDocument();
+    expect(saveButton()).not.toHaveClass('ant-btn-loading');
+    expect(testButton()).not.toBeDisabled();
+  });
+
+  it('ignores a test error after the form changes', async () => {
+    const user = userEvent.setup();
+    const request = deferred<LlmTestResult>();
+    llmApiMocks.testLlmConnection.mockReturnValueOnce(request.promise);
+    await renderPage();
+
+    await user.click(testButton());
+    await waitFor(() => expect(llmApiMocks.testLlmConnection).toHaveBeenCalledTimes(1));
+    const apiBaseInput = screen.getByRole('textbox', { name: 'API Base URL' });
+    await user.clear(apiBaseInput);
+    await user.type(apiBaseInput, 'https://replacement.example/v1');
+
+    await act(async () => {
+      request.reject(new Error('stale request failure'));
+      await expect(request.promise).rejects.toThrow('stale request failure');
+    });
+
+    expect(apiBaseInput).toHaveValue('https://replacement.example/v1');
+    expect(screen.queryByText('连接测试请求失败，请稍后重试')).not.toBeInTheDocument();
+  });
+
+  it('shows a current test result without saving or clearing the API key', async () => {
+    const user = userEvent.setup();
+    await renderPage();
+
+    const apiKeyInput = screen.getByLabelText(/^API Key$/);
+    await user.type(apiKeyInput, 'test-only-key');
+    await user.click(testButton());
+
+    expect(await screen.findByText('current result')).toBeInTheDocument();
+    expect(apiKeyInput).toHaveValue('test-only-key');
+    expect(llmApiMocks.saveLlmConfig).not.toHaveBeenCalled();
+  });
+
+  it('keeps the current explicit-save behavior', async () => {
+    const user = userEvent.setup();
+    await renderPage();
+
+    const apiKeyInput = screen.getByLabelText(/^API Key$/);
+    await user.type(apiKeyInput, 'saved-key');
+    await user.click(saveButton());
+
+    expect(await screen.findByText('密钥已配置')).toBeInTheDocument();
+    expect(await screen.findByText('保存成功')).toBeInTheDocument();
+    expect(apiKeyInput).toHaveValue('');
+    expect(llmApiMocks.saveLlmConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'openai',
+        engine: 'http',
+        apiKey: 'saved-key',
+        enabled: true,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- rebase the fix onto the latest `rocketmq-studio` branch and adapt it to the redesigned LLM settings flow from #954
- bind connection-test and explicit-save callbacks to the current component lifecycle, form generation, and operation generation
- ignore late success, error, and loading callbacks after provider/engine/form changes, a newer operation, or unmount
- prevent a stale save from clearing a replacement API key or publishing a success notification for an obsolete form
- keep the current no-auto-save connection-test contract and temporarily disable connection tests while an explicit save is in flight

Fixes #738.

This remains separate from the initial configuration/model request ownership fixed by #737.

## Root cause

`handleTest` and `handleSave` allowed every Promise callback to update the current form and shared loading/result state. A request started for an older form could therefore publish its result after the user changed provider, engine, or fields. An older explicit save could also clear a newly entered API key when its response arrived late.

The fix uses a shared operation generation for result ownership and per-request generations for loading ownership. Form changes invalidate connection tests immediately, while an already-sent save keeps its loading guard until it settles so another mutation cannot be started accidentally.

## Compatibility

- no public API, payload, configuration, or persistence-format changes
- preserves `provider`, `engine`, `enabled: true`, empty-key retention, and the no-auto-save test behavior introduced by #954
- an explicit save still submits exactly once; only stale UI callbacks are suppressed

## Verification

- latest base: `228ad5298dbbeaa769f1c1de242117c6cfbe4216`
- unmodified rebased baseline: 6 deterministic ownership regressions failed in the targeted suite
- targeted operation-ownership suite: 20 isolated processes, 8/8 each (160/160)
- clean Node 20.20.2 container: 81 test files / 396 tests passed
- ESLint: 0 errors (4 pre-existing Fast Refresh warnings)
- TypeScript/Vite production build: passed, 7,997 modules transformed
- Prettier check and `git diff --check`: passed
