### PR TITLE
[Studio] feat: support exporting selected alert rules as YAML

### DIFF
--- a/web/src/pages/studio/AlertManagement.tsx
+++ b/web/src/pages/studio/AlertManagement.tsx
@@ -155,6 +155,7 @@ const AlertManagementPage: React.FC = () => {
   const [filterGroup, setFilterGroup] = useState('all');
   const [filterSeverity, setFilterSeverity] = useState('all');
   const [filterStatus, setFilterStatus] = useState('all');
+  const [selectedRuleKeys, setSelectedRuleKeys] = useState<React.Key[]>([]);
   const [disabledRules, setDisabledRules] = useState<Record<string, boolean>>(() => {
     try {
       const saved = localStorage.getItem('alertDisabledRules');
@@ -180,7 +181,14 @@ const AlertManagementPage: React.FC = () => {
         const data = await queryAlertRules();
         const yamlStr = data.rules || '';
         if (!cancelled) {
-          setAlertRules(parseYamlRules(yamlStr, disabledRulesRef.current));
+          const loadedRules = parseYamlRules(yamlStr, disabledRulesRef.current);
+          const enabledRuleKeys = new Set<React.Key>(
+            loadedRules.filter((rule) => rule.enabled).map((rule) => rule.key),
+          );
+          setAlertRules(loadedRules);
+          setSelectedRuleKeys((currentKeys) =>
+            currentKeys.filter((key) => enabledRuleKeys.has(key)),
+          );
         }
       } catch {
         if (!cancelled) {
@@ -205,7 +213,12 @@ const AlertManagementPage: React.FC = () => {
     try {
       const data = await queryAlertRules();
       const yamlStr = data.rules || '';
-      setAlertRules(parseYamlRules(yamlStr, disabledRulesRef.current));
+      const loadedRules = parseYamlRules(yamlStr, disabledRulesRef.current);
+      const enabledRuleKeys = new Set<React.Key>(
+        loadedRules.filter((rule) => rule.enabled).map((rule) => rule.key),
+      );
+      setAlertRules(loadedRules);
+      setSelectedRuleKeys((currentKeys) => currentKeys.filter((key) => enabledRuleKeys.has(key)));
     } catch {
       message.error(t('alertMgmt.fetchFailed'));
     } finally {
@@ -220,6 +233,7 @@ const AlertManagementPage: React.FC = () => {
     setAlertRules((prev) =>
       prev.map((rule) => (rule.key === ruleKey ? { ...rule, enabled: !rule.enabled } : rule)),
     );
+    setSelectedRuleKeys((currentKeys) => currentKeys.filter((key) => key !== ruleKey));
   };
 
   const handleAddRule = () => {
@@ -247,6 +261,7 @@ const AlertManagementPage: React.FC = () => {
 
   const handleDeleteRule = (ruleKey: string) => {
     setAlertRules((prev) => prev.filter((rule) => rule.key !== ruleKey));
+    setSelectedRuleKeys((currentKeys) => currentKeys.filter((key) => key !== ruleKey));
     const updated = { ...disabledRules };
     delete updated[ruleKey];
     setDisabledRules(updated);
@@ -258,6 +273,11 @@ const AlertManagementPage: React.FC = () => {
     try {
       const values = await form.validateFields();
       if (editingRule) {
+        if (values.alert !== editingRule.key || values.enabled === false) {
+          setSelectedRuleKeys((currentKeys) =>
+            currentKeys.filter((key) => key !== editingRule.key),
+          );
+        }
         setAlertRules((prev) =>
           prev.map((rule) =>
             rule.key === editingRule.key
@@ -301,8 +321,14 @@ const AlertManagementPage: React.FC = () => {
     }
   };
 
+  const selectedRules = useMemo(
+    () => alertRules.filter((rule) => rule.enabled && selectedRuleKeys.includes(rule.key)),
+    [alertRules, selectedRuleKeys],
+  );
+
   const handleExportYaml = () => {
-    const enabledRules = alertRules.filter((r) => r.enabled);
+    const enabledRules =
+      selectedRules.length > 0 ? selectedRules : alertRules.filter((rule) => rule.enabled);
     const groups: Record<string, AlertRule[]> = {};
     for (const rule of enabledRules) {
       if (!groups[rule.group]) groups[rule.group] = [];
@@ -533,6 +559,7 @@ const AlertManagementPage: React.FC = () => {
             </Button>
             <Button icon={<DownloadSimple size={16} />} onClick={handleExportYaml} size="small">
               {t('alertMgmt.exportYaml')}
+              {selectedRules.length > 0 ? ` (${selectedRules.length})` : ''}
             </Button>
           </Space>
         }
@@ -587,6 +614,12 @@ const AlertManagementPage: React.FC = () => {
           dataSource={filteredRules}
           loading={loading}
           rowKey="key"
+          rowSelection={{
+            selectedRowKeys: selectedRules.map((rule) => rule.key),
+            onChange: setSelectedRuleKeys,
+            preserveSelectedRowKeys: true,
+            getCheckboxProps: (record) => ({ disabled: !record.enabled }),
+          }}
           size="small"
           pagination={{
             pageSize: 10,

--- a/web/src/pages/studio/__tests__/AlertManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/AlertManagement.test.tsx
@@ -16,8 +16,9 @@
  */
 
 import type { ReactElement } from 'react';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
 import AlertManagementPage from '../AlertManagement';
@@ -41,6 +42,16 @@ groups:
       annotations:
         summary: "Broker unavailable"
         description: "Broker has been unavailable for five minutes"
+    # Rule 2:
+    - alert: ConsumerLagHigh
+      expr: rocketmq_consumer_lag_messages > 100000
+      for: 10m
+      labels:
+        severity: warning
+        team: consumer
+      annotations:
+        summary: "Consumer lag is high"
+        description: "Consumer lag has exceeded the threshold"
 `;
 
 beforeAll(() => {
@@ -68,10 +79,29 @@ const renderWithProviders = (ui: ReactElement) => {
 };
 
 describe('AlertManagementPage', () => {
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+  let clickSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    createObjectURL = vi.fn().mockReturnValue('blob:alert-rules');
+    revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
     vi.mocked(queryAlertRules).mockResolvedValue({ rules: rulesYaml });
+  });
+
+  afterEach(() => {
+    clickSpy.mockRestore();
   });
 
   it('loads alert rules after mount', async () => {
@@ -82,5 +112,79 @@ describe('AlertManagementPage', () => {
     });
 
     expect(await screen.findByText('BrokerDown')).toBeInTheDocument();
+  });
+
+  it('exports only the selected enabled alert rules when rows are selected', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AlertManagementPage />);
+
+    const brokerRule = await screen.findByText('BrokerDown');
+    expect(screen.getByText('ConsumerLagHigh')).toBeInTheDocument();
+
+    const brokerRow = brokerRule.closest('tr');
+    expect(brokerRow).not.toBeNull();
+    await user.click(within(brokerRow!).getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: '导出 YAML (1)' }));
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    const yaml = await blob.text();
+    expect(yaml).toContain('alert: BrokerDown');
+    expect(yaml).not.toContain('alert: ConsumerLagHigh');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:alert-rules');
+  });
+
+  it('exports all enabled alert rules when no rows are selected', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AlertManagementPage />);
+
+    await screen.findByText('BrokerDown');
+    await user.click(screen.getByRole('button', { name: '导出 YAML' }));
+
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    const yaml = await blob.text();
+    expect(yaml).toContain('alert: BrokerDown');
+    expect(yaml).toContain('alert: ConsumerLagHigh');
+  });
+
+  it('removes a selected rule when it is disabled', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AlertManagementPage />);
+
+    const brokerRule = await screen.findByText('BrokerDown');
+    const brokerRow = brokerRule.closest('tr');
+    expect(brokerRow).not.toBeNull();
+
+    await user.click(within(brokerRow!).getByRole('checkbox'));
+    expect(screen.getByRole('button', { name: '导出 YAML (1)' })).toBeInTheDocument();
+
+    await user.click(within(brokerRow!).getByRole('switch'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '导出 YAML' })).toBeInTheDocument();
+    });
+    expect(within(brokerRow!).getByRole('checkbox')).toBeDisabled();
+  });
+
+  it('preserves selected rules while filtering the table', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AlertManagementPage />);
+
+    const brokerRule = await screen.findByText('BrokerDown');
+    const brokerRow = brokerRule.closest('tr');
+    expect(brokerRow).not.toBeNull();
+    await user.click(within(brokerRow!).getByRole('checkbox'));
+
+    await user.type(screen.getByRole('textbox'), 'ConsumerLagHigh');
+
+    expect(screen.queryByText('BrokerDown')).not.toBeInTheDocument();
+    expect(screen.getByText('ConsumerLagHigh')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: '导出 YAML (1)' }));
+
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    const yaml = await blob.text();
+    expect(yaml).toContain('alert: BrokerDown');
+    expect(yaml).not.toContain('alert: ConsumerLagHigh');
   });
 });


### PR DESCRIPTION
## What is the purpose of the change

The alert management page only supports exporting all enabled rules, making it difficult to export a specific subset. This change allows users to select enabled alert rules and export only the selected rules while preserving the existing behavior when no rules are selected.

## Brief changelog

- Add row selection for enabled alert rules.
- Display the selected rule count in the YAML export button.
- Export selected enabled rules when available, otherwise export all enabled rules.
- Preserve selections while filtering and clear invalid selections when rules are disabled, deleted, edited, or refreshed.

## Verifying this change

Added tests covering selected rule export, default export behavior, disabled rule selection cleanup, and selection preservation while filtering. Ran the focused tests, full frontend test suite, ESLint, production build, Prettier check, and browser interaction verification.