### PR TITLE
[Studio] feat: support multi-term navigation search

### DIFF
--- a/web/src/layouts/navigationSearch.test.ts
+++ b/web/src/layouts/navigationSearch.test.ts
@@ -22,6 +22,7 @@ describe('navigation search helpers', () => {
   const entries = [
     { key: '/cluster', label: 'RocketMQ 集群' },
     { key: '/settings', label: 'Settings' },
+    { key: '/ops/system-alerts', label: 'Alert Events' },
   ];
 
   it('filters labels case-insensitively and ignores query whitespace', () => {
@@ -32,6 +33,27 @@ describe('navigation search helpers', () => {
   it('filters by route keys case-insensitively', () => {
     expect(filterNavigationEntries(entries, 'CLUSTER')).toEqual([entries[0]]);
     expect(filterNavigationEntries(entries, '/settings')).toEqual([entries[1]]);
+  });
+
+  it('matches multiple terms across labels and normalized route segments', () => {
+    expect(filterNavigationEntries(entries, 'system alerts')).toEqual([entries[2]]);
+    expect(filterNavigationEntries(entries, 'OPS / SYSTEM')).toEqual([entries[2]]);
+    expect(filterNavigationEntries(entries, 'rocketmq cluster')).toEqual([entries[0]]);
+    expect(filterNavigationEntries(entries, 'system cluster')).toEqual([]);
+  });
+
+  it('ranks exact and prefix matches before broader matches', () => {
+    const rankedEntries = [
+      { key: '/settings/data-sources', label: 'Data Source Settings' },
+      { key: '/settings', label: 'Settings' },
+      { key: '/settings/general', label: 'Settings - General' },
+    ];
+
+    expect(filterNavigationEntries(rankedEntries, 'settings')).toEqual([
+      rankedEntries[1],
+      rankedEntries[2],
+      rankedEntries[0],
+    ]);
   });
 
   it('recognizes Control/Command-K but rejects alternative shortcuts', () => {

--- a/web/src/layouts/navigationSearch.ts
+++ b/web/src/layouts/navigationSearch.ts
@@ -23,17 +23,45 @@ export interface NavigationSearchEntry {
   icon?: ReactNode;
 }
 
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFKC')
+    .toLocaleLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim();
+}
+
+function matchScore(entry: NavigationSearchEntry, query: string, terms: string[]): number | null {
+  const label = normalizeSearchText(entry.label);
+  const key = normalizeSearchText(entry.key);
+  const searchableText = `${label} ${key}`;
+
+  if (!terms.every((term) => searchableText.includes(term))) return null;
+  if (label === query) return 0;
+  if (key === query) return 1;
+  if (label.startsWith(query)) return 2;
+  if (key.startsWith(query)) return 3;
+  if (label.includes(query)) return 4;
+  if (key.includes(query)) return 5;
+  return 6;
+}
+
 export function filterNavigationEntries(
   entries: NavigationSearchEntry[],
   query: string,
 ): NavigationSearchEntry[] {
-  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const normalizedQuery = normalizeSearchText(query);
   if (!normalizedQuery) return entries;
-  return entries.filter(
-    (entry) =>
-      entry.label.toLocaleLowerCase().includes(normalizedQuery) ||
-      entry.key.toLocaleLowerCase().includes(normalizedQuery),
-  );
+  const terms = normalizedQuery.split(' ');
+
+  return entries
+    .map((entry, index) => ({ entry, index, score: matchScore(entry, normalizedQuery, terms) }))
+    .filter(
+      (match): match is { entry: NavigationSearchEntry; index: number; score: number } =>
+        match.score !== null,
+    )
+    .sort((left, right) => left.score - right.score || left.index - right.index)
+    .map(({ entry }) => entry);
 }
 
 export function isNavigationSearchShortcut(event: {


### PR DESCRIPTION
## What is the purpose of the change

Improve the global navigation search so users can find pages with multi-term queries such as `system alerts` and `ops alerts`. Previously, navigation search required a contiguous match within either the page label or route key.

## Brief changelog

- Normalize navigation labels, route keys, and queries across case, whitespace, and separators.
- Match all query terms across both page labels and route segments.
- Rank exact and prefix matches ahead of broader matches while preserving stable ordering.
- Add regression tests for multi-term matching and relevance ranking.

## Verifying this change

- Added tests covering multi-term queries, route separator normalization, unmatched terms, and relevance ranking.
- Ran the focused navigation search tests.
- Ran the full frontend test suite with 63 test files and 267 tests.
- Ran frontend lint, production build, Prettier checks, and `git diff --check`.
- Manually verified the `Ctrl/Cmd+K` search behavior in the browser.