### PR TITLE
[ISSUE #773] Surface unavailable client provider errors

### DIFF
--- a/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
@@ -187,6 +187,18 @@ describe('Clients page', () => {
     ).toBeInTheDocument();
   });
 
+  it('surfaces unavailable provider errors from the client API', async () => {
+    vi.mocked(connectionsService.listConnections).mockRejectedValue(
+      new Error('Client connection provider is not configured'),
+    );
+    renderWithProviders(<ClientsPage />);
+
+    expect(
+      await screen.findByText('Client connection provider is not configured'),
+    ).toBeInTheDocument();
+    expect(within(screen.getByTestId('connection-total')).getByText('0')).toBeInTheDocument();
+  });
+
   it('opens a client detail dialog from the connection table', async () => {
     const user = userEvent.setup();
     renderWithProviders(<ClientsPage />);

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -17,6 +17,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import {
+  Alert,
   Button,
   Card,
   Descriptions,
@@ -29,7 +30,6 @@ import {
   Table,
   Tag,
   Typography,
-  message,
   theme,
 } from 'antd';
 import { Eye, MagnifyingGlass } from '@phosphor-icons/react';
@@ -41,6 +41,7 @@ import type { ClientConnection } from '../../api/connections';
 import { listConnections } from '../../services/connectionsService';
 
 const { Text } = Typography;
+const DEFAULT_LOAD_ERROR = '客户端连接加载失败，请稍后重试';
 
 /* ─── Helpers ─── */
 
@@ -75,6 +76,27 @@ const countBy = (values: string[]) =>
     .map(([label, count]) => ({ label, count }))
     .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
 
+type ApiErrorLike = {
+  message?: unknown;
+  response?: {
+    data?: {
+      message?: unknown;
+    };
+  };
+};
+
+function getLoadErrorMessage(error: unknown): string {
+  const apiError = error as ApiErrorLike;
+  const responseMessage = apiError.response?.data?.message;
+  if (typeof responseMessage === 'string' && responseMessage.trim()) {
+    return responseMessage;
+  }
+  if (typeof apiError.message === 'string' && apiError.message.trim()) {
+    return apiError.message;
+  }
+  return DEFAULT_LOAD_ERROR;
+}
+
 /* ═══════════════════════════════════════════
    ClientsPage
    ═══════════════════════════════════════════ */
@@ -86,16 +108,22 @@ const ClientsPage = () => {
   const [search, setSearch] = useState('');
   const [clusterFilter, setClusterFilter] = useState<string>('ALL');
   const [selectedConnection, setSelectedConnection] = useState<ClientConnection | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
     void listConnections()
       .then((nextConnections) => {
-        if (!cancelled) setConnections(nextConnections);
+        if (!cancelled) {
+          setConnections(nextConnections);
+          setLoadError(null);
+        }
       })
-      .catch(() => {
-        if (!cancelled) message.error('客户端连接加载失败，请稍后重试');
+      .catch((error) => {
+        if (!cancelled) {
+          setLoadError(getLoadErrorMessage(error));
+        }
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -296,6 +324,10 @@ const ClientsPage = () => {
         title={t('clients.title')}
         subtitle={`${t('clients.title')} — ${filtered.length} connections`}
       />
+
+      {loadError && (
+        <Alert showIcon type="warning" message={loadError} style={{ marginBottom: 16 }} />
+      )}
 
       {/* ─── Filter Bar ─── */}
       <Flex justify="space-between" align="center" style={{ marginBottom: 16 }}>


### PR DESCRIPTION
Fixes #773.

### What changed
- Surface backend client-provider errors as a visible warning on the client connections page.
- Preserve an empty statistics/table state instead of hiding the actionable error behind a generic retry toast.
- Add regression coverage for the current `Client connection provider is not configured` path.

### Validation
- `npm --prefix web test -- ClientsPage.test.tsx`
- `npm --prefix web exec -- eslint web/src/pages/cluster/clients.tsx web/src/pages/cluster/__tests__/ClientsPage.test.tsx`
- `cd web && npx tsc -b --noEmit`