### PR TITLE
[ISSUE #775] Gate demo cluster seed data

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
 import org.apache.rocketmq.studio.common.domain.enums.FlushDiskType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -40,8 +41,11 @@ public class ClusterRepositoryImpl implements ClusterRepository {
 
     private final Map<String, ClusterVO> store = new ConcurrentHashMap<>();
 
-    public ClusterRepositoryImpl() {
-        initStubData();
+    public ClusterRepositoryImpl(@Value("${studio.cluster.seed-demo-data:false}") boolean seedDemoData) {
+        if (seedDemoData) {
+            initStubData();
+            log.info("Initialized demo cluster data for Studio cluster repository");
+        }
     }
 
     @Override

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -20,6 +20,8 @@ studio:
       - username: ${STUDIO_AUTH_ADMIN_USERNAME:}
         password: ${STUDIO_AUTH_ADMIN_PASSWORD:}
         admin: true
+  cluster:
+    seed-demo-data: ${STUDIO_CLUSTER_SEED_DEMO_DATA:false}
   metrics:
     prometheus:
       base-url: ${STUDIO_METRICS_PROMETHEUS_BASE_URL:}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
@@ -26,11 +26,18 @@ class ClusterRepositoryImplTest {
 
     @Test
     void findAllShouldReturnClustersInStableNameOrder() {
-        ClusterRepositoryImpl repository = new ClusterRepositoryImpl();
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(true);
 
         List<ClusterVO> clusters = repository.findAll();
 
         assertThat(clusters).extracting(ClusterVO::getName)
                 .containsExactly("rmq-cluster-prod", "rmq-cluster-staging");
+    }
+
+    @Test
+    void findAllShouldBeEmptyWhenDemoDataIsDisabled() {
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(false);
+
+        assertThat(repository.findAll()).isEmpty();
     }
 }


### PR DESCRIPTION
Fixes #775.

### What changed
- Add `studio.cluster.seed-demo-data`, defaulting to `false`.
- Only seed the in-memory cluster repository when the flag is explicitly enabled.
- Update repository tests to cover both explicit demo seeding and the default empty state.

### Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=ClusterRepositoryImplTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=StudioApplicationTest test`
- `git diff --check`