### PR TITLE
[ISSUE #778] Surface unavailable message provider errors

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -121,6 +121,37 @@ describe('MessagePage async request ownership', () => {
     expect(screen.queryByText('late-after-reset')).not.toBeInTheDocument();
   });
 
+  it('surfaces unavailable message provider errors from query requests', async () => {
+    serviceMocks.queryMessages.mockRejectedValue(
+      new Error('Message query provider is not configured'),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+
+    expect(await screen.findByText('Message query provider is not configured')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
+  });
+
+  it('surfaces unavailable message provider errors from trace requests', async () => {
+    serviceMocks.queryMessages.mockResolvedValue([createMessage('message-a')]);
+    serviceMocks.getMessageTrace.mockRejectedValue(
+      new Error('Message query provider is not configured'),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+    const row = await screen.findByRole('row', { name: /message-a/ });
+    await user.click(within(row).getByRole('button', { name: /轨迹/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: '消息详情' });
+    expect(
+      await within(dialog).findByText('Message query provider is not configured'),
+    ).toBeInTheDocument();
+  });
+
   it('keeps the latest query loading and ignores an earlier query result', async () => {
     const firstQuery = createDeferred<MessageRecord[]>();
     const secondQuery = createDeferred<MessageRecord[]>();

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -17,6 +17,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import {
+  Alert,
   Card,
   Table,
   Tag,
@@ -57,6 +58,8 @@ import { getMessageTrace, queryMessages } from '../../services/messageService';
 
 const { Paragraph, Text } = Typography;
 const { RangePicker } = DatePicker;
+const DEFAULT_QUERY_ERROR = '消息查询失败，请稍后重试';
+const DEFAULT_TRACE_ERROR = '消息轨迹加载失败，请稍后重试';
 
 /* ─── Constants ─── */
 
@@ -65,6 +68,15 @@ type QueryMode = 'topic' | 'key' | 'msgid';
 type RecentQuery = {
   mode: QueryMode;
   params: MessageQuery;
+};
+
+type ApiErrorLike = {
+  message?: unknown;
+  response?: {
+    data?: {
+      message?: unknown;
+    };
+  };
 };
 
 const QUERY_HISTORY_STORAGE_KEY = 'rocketmq-studio-message-query-history';
@@ -175,6 +187,18 @@ const queryLabel = ({ mode, params }: RecentQuery): string => {
   return `Topic: ${params.topic || '全部'}${params.tag ? ` · Tag: ${params.tag}` : ''}`;
 };
 
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  const apiError = error as ApiErrorLike;
+  const responseMessage = apiError.response?.data?.message;
+  if (typeof responseMessage === 'string' && responseMessage.trim()) {
+    return responseMessage;
+  }
+  if (typeof apiError.message === 'string' && apiError.message.trim()) {
+    return apiError.message;
+  }
+  return fallback;
+};
+
 /* ═══════════════════════════════════════════
    MessagePage
    ═══════════════════════════════════════════ */
@@ -193,6 +217,8 @@ const MessagePage = () => {
   const [selectedMsg, setSelectedMsg] = useState<MessageRecord | null>(null);
   const [traceData, setTraceData] = useState<TraceRecord | null>(null);
   const [traceLoading, setTraceLoading] = useState(false);
+  const [queryError, setQueryError] = useState<string | null>(null);
+  const [traceError, setTraceError] = useState<string | null>(null);
   const [recentQueries, setRecentQueries] = useState<RecentQuery[]>(loadRecentQueries);
   const queryGenerationRef = useRef(0);
   const traceGenerationRef = useRef(0);
@@ -214,6 +240,7 @@ const MessagePage = () => {
     setMsgIdInput('');
     setDateRange(getDefaultRange());
     setMessages([]);
+    setQueryError(null);
     setQueryLoading(false);
   };
 
@@ -238,15 +265,17 @@ const MessagePage = () => {
     const requestGeneration = queryGenerationRef.current + 1;
     queryGenerationRef.current = requestGeneration;
     setQueryLoading(true);
+    setQueryError(null);
     try {
       const result = await queryMessages(params);
       if (queryGenerationRef.current !== requestGeneration) return;
       setMessages(result);
+      setQueryError(null);
       saveRecentQuery(mode, params);
       message.success(`查询完成，共 ${result.length} 条`);
-    } catch {
+    } catch (error) {
       if (queryGenerationRef.current === requestGeneration) {
-        message.error('消息查询失败，请稍后重试');
+        setQueryError(getErrorMessage(error, DEFAULT_QUERY_ERROR));
       }
     } finally {
       if (queryGenerationRef.current === requestGeneration) {
@@ -339,13 +368,15 @@ const MessagePage = () => {
     setModalOpen(true);
     setTraceData(null);
     setTraceLoading(true);
+    setTraceError(null);
     try {
       const result = await getMessageTrace(record.msgId);
       if (traceGenerationRef.current !== requestGeneration) return;
       setTraceData(result);
-    } catch {
+      setTraceError(null);
+    } catch (error) {
       if (traceGenerationRef.current === requestGeneration) {
-        message.error('消息轨迹加载失败，请稍后重试');
+        setTraceError(getErrorMessage(error, DEFAULT_TRACE_ERROR));
       }
     } finally {
       if (traceGenerationRef.current === requestGeneration) {
@@ -358,6 +389,7 @@ const MessagePage = () => {
     traceGenerationRef.current += 1;
     setModalOpen(false);
     setTraceLoading(false);
+    setTraceError(null);
   };
 
   const handleDownload = (record: MessageRecord) => {
@@ -584,6 +616,8 @@ const MessagePage = () => {
       label: '消息轨迹',
       children: traceLoading ? (
         <Typography.Text type="secondary">正在加载轨迹数据…</Typography.Text>
+      ) : traceError ? (
+        <Alert showIcon type="warning" message={traceError} />
       ) : traceData?.nodes?.length ? (
         <Steps
           direction="vertical"
@@ -728,6 +762,10 @@ const MessagePage = () => {
           </Space>
         </Space>
       </Card>
+
+      {queryError && (
+        <Alert showIcon type="warning" message={queryError} style={{ marginBottom: 16 }} />
+      )}
 
       {/* ── Results Table ── */}
       <Card bodyStyle={{ padding: 0 }}>


### PR DESCRIPTION
Fixes #778.

### What changed
- Surface backend message-provider errors as visible warnings on the message query page.
- Surface trace loading provider errors inside the message detail dialog.
- Keep query history unchanged for failed provider calls.
- Add regression coverage for query and trace unavailable-provider paths.

### Validation
- `npm --prefix web test -- MessagePageAsyncState.test.tsx`
- `npm --prefix web exec -- eslint web/src/pages/instance/message.tsx web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx`
- `cd web && npx tsc -b --noEmit`