### PR TITLE
[ISSUE #780] Surface unavailable DLQ provider errors

### DIFF
--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -104,6 +104,15 @@ describe('DLQ page', () => {
     expect(messageService.listDLQGroups).toHaveBeenCalledTimes(1);
   });
 
+  it('surfaces unavailable DLQ provider errors when loading groups', async () => {
+    vi.mocked(messageService.listDLQGroups).mockRejectedValue(
+      new Error('DLQ provider is not configured'),
+    );
+    renderWithProviders(<DLQPage />);
+
+    expect(await screen.findByText('DLQ provider is not configured')).toBeInTheDocument();
+  });
+
   it('opens a detail dialog with the selected group metadata', async () => {
     const user = userEvent.setup();
     renderWithProviders(<DLQPage />);
@@ -174,5 +183,22 @@ describe('DLQ page', () => {
     await waitFor(() => expect(messageService.listDLQGroups).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(within(orderRow).getByRole('checkbox')).toBeDisabled());
     expect(screen.getByRole('button', { name: /批量导出/ })).toBeDisabled();
+  });
+
+  it('surfaces unavailable DLQ provider errors when retry submission fails', async () => {
+    vi.mocked(messageService.resendDLQ).mockRejectedValue(
+      new Error('DLQ provider is not configured'),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<DLQPage />);
+
+    const orderRow = (await screen.findByText('cg-order')).closest('tr');
+    if (!orderRow) throw new Error('DLQ group row not found');
+
+    await user.click(within(orderRow).getByRole('button', { name: '重投消息' }));
+    await user.type(screen.getByPlaceholderText('输入目标 Topic 名称'), 'orders-retry');
+    await user.click(screen.getByRole('button', { name: '确认重投' }));
+
+    expect(await screen.findByText('DLQ provider is not configured')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -17,6 +17,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import {
+  Alert,
   Card,
   Table,
   Button,
@@ -39,8 +40,31 @@ import { listDLQGroups, resendDLQ } from '../../services/messageService';
 
 const { Text } = Typography;
 const { RangePicker } = DatePicker;
+const DEFAULT_LOAD_ERROR = '死信队列加载失败，请稍后重试';
+const DEFAULT_RETRY_ERROR = '提交重投任务失败，请稍后重试';
 
 /* ─── Helpers ─── */
+
+type ApiErrorLike = {
+  message?: unknown;
+  response?: {
+    data?: {
+      message?: unknown;
+    };
+  };
+};
+
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  const apiError = error as ApiErrorLike;
+  const responseMessage = apiError.response?.data?.message;
+  if (typeof responseMessage === 'string' && responseMessage.trim()) {
+    return responseMessage;
+  }
+  if (typeof apiError.message === 'string' && apiError.message.trim()) {
+    return apiError.message;
+  }
+  return fallback;
+};
 
 const formatDateTime = (iso: string): string => {
   const d = new Date(iso);
@@ -94,6 +118,8 @@ const DLQPage = () => {
   const [retrySubmitting, setRetrySubmitting] = useState(false);
   const [detailGroup, setDetailGroup] = useState<DLQGroup | null>(null);
   const [selectedGroupNames, setSelectedGroupNames] = useState<string[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [retryError, setRetryError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -102,6 +128,7 @@ const DLQPage = () => {
       .then((nextGroups) => {
         if (!cancelled) {
           setGroups(nextGroups);
+          setLoadError(null);
           const availableGroups = new Set(
             nextGroups.filter((group) => group.messageCount > 0).map((group) => group.groupName),
           );
@@ -110,8 +137,8 @@ const DLQPage = () => {
           );
         }
       })
-      .catch(() => {
-        if (!cancelled) message.error('死信队列加载失败，请稍后重试');
+      .catch((error) => {
+        if (!cancelled) setLoadError(getErrorMessage(error, DEFAULT_LOAD_ERROR));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -141,6 +168,7 @@ const DLQPage = () => {
     setRetryGroup(group);
     setRetryRange([dayjs().subtract(1, 'day'), dayjs()]);
     setRetryTargetTopic('');
+    setRetryError(null);
     setRetryModalOpen(true);
   };
 
@@ -152,6 +180,7 @@ const DLQPage = () => {
     if (!retryGroup) return;
 
     setRetrySubmitting(true);
+    setRetryError(null);
     try {
       await resendDLQ({
         groupName: retryGroup.groupName,
@@ -163,8 +192,9 @@ const DLQPage = () => {
       message.success(`已提交重投任务：${retryGroup.groupName} → ${retryTargetTopic}`);
       setRetryModalOpen(false);
       setRetryGroup(null);
-    } catch {
-      message.error('提交重投任务失败，请稍后重试');
+      setRetryError(null);
+    } catch (error) {
+      setRetryError(getErrorMessage(error, DEFAULT_RETRY_ERROR));
     } finally {
       setRetrySubmitting(false);
     }
@@ -299,6 +329,10 @@ const DLQPage = () => {
         </Button>
       </Flex>
 
+      {loadError && (
+        <Alert showIcon type="warning" message={loadError} style={{ marginBottom: 16 }} />
+      )}
+
       {/* ── Table ── */}
       <Card bodyStyle={{ padding: 0 }}>
         <Table
@@ -335,6 +369,7 @@ const DLQPage = () => {
         onCancel={() => {
           setRetryModalOpen(false);
           setRetryGroup(null);
+          setRetryError(null);
         }}
         onOk={handleRetry}
         confirmLoading={retrySubmitting}
@@ -345,6 +380,10 @@ const DLQPage = () => {
       >
         {retryGroup && (
           <div style={{ marginTop: 16 }}>
+            {retryError && (
+              <Alert showIcon type="warning" message={retryError} style={{ marginBottom: 16 }} />
+            )}
+
             <div
               style={{
                 marginBottom: 16,


### PR DESCRIPTION
Fixes #780.

### What changed
- Surface backend DLQ provider errors as visible warnings when the DLQ list fails to load.
- Surface resend provider errors inside the retry modal.
- Add regression coverage for list and resend unavailable-provider paths.

### Validation
- `npm --prefix web test -- DLQPage.test.tsx`
- `npm --prefix web exec -- eslint web/src/pages/instance/dlq.tsx web/src/pages/instance/__tests__/DLQPage.test.tsx`
- `cd web && npx tsc -b --noEmit`