### PR TITLE
[ISSUE #782] Disable simulated message resend action

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -121,6 +121,21 @@ describe('MessagePage async request ownership', () => {
     expect(screen.queryByText('late-after-reset')).not.toBeInTheDocument();
   });
 
+  it('keeps normal message resend disabled until a real API is wired', async () => {
+    serviceMocks.queryMessages.mockResolvedValue([createMessage('message-a')]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+    const row = await screen.findByRole('row', { name: /message-a/ });
+    await user.click(within(row).getByRole('button', { name: /详情/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: '消息详情' });
+    const resendButton = within(dialog).getByRole('button', { name: /重新发送/ });
+    expect(resendButton).toBeDisabled();
+    expect(resendButton).toHaveAttribute('title', '当前版本尚未接入普通消息重新发送接口');
+  });
+
   it('keeps the latest query loading and ignores an earlier query result', async () => {
     const firstQuery = createDeferred<MessageRecord[]>();
     const secondQuery = createDeferred<MessageRecord[]>();

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -69,6 +69,7 @@ type RecentQuery = {
 
 const QUERY_HISTORY_STORAGE_KEY = 'rocketmq-studio-message-query-history';
 const MAX_QUERY_HISTORY = 5;
+const RESEND_UNAVAILABLE_MESSAGE = '当前版本尚未接入普通消息重新发送接口';
 
 const QUERY_OPTIONS = [
   { value: 'topic' as const, label: '按 Topic 查询' },
@@ -325,10 +326,6 @@ const MessagePage = () => {
     }
     const recentQuery = recentQueries[Number(key)];
     if (recentQuery) replayRecentQuery(recentQuery);
-  };
-
-  const handleResend = () => {
-    message.success('消息重新发送成功（模拟）');
   };
 
   const openDetail = async (record: MessageRecord, tab = 'content') => {
@@ -755,7 +752,12 @@ const MessagePage = () => {
         footer={
           <Flex justify="flex-end" gap={8}>
             <Button onClick={closeDetail}>关闭</Button>
-            <Button type="primary" icon={<SendOutlined />} onClick={handleResend}>
+            <Button
+              type="primary"
+              icon={<SendOutlined />}
+              disabled
+              title={RESEND_UNAVAILABLE_MESSAGE}
+            >
               重新发送
             </Button>
           </Flex>


### PR DESCRIPTION
Fixes #782.

### What changed
- Remove the simulated success handler from the normal message resend action.
- Disable the resend button until a real normal-message resend API is wired.
- Add regression coverage that the message detail resend action is not executable.

### Validation
- `npm --prefix web test -- MessagePageAsyncState.test.tsx`
- `npm --prefix web exec -- eslint web/src/pages/instance/message.tsx web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx`
- `cd web && npx tsc -b --noEmit`