### PR TITLE
[ISSUE #784] Return unavailable for unimplemented cluster operations

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -26,7 +26,6 @@ import org.apache.rocketmq.studio.cluster.nameserver.UpdateNameServerDTO;
 import org.apache.rocketmq.studio.cluster.nameserver.UpgradeNameServerDTO;
 import org.apache.rocketmq.studio.cluster.proxy.RestartProxyDTO;
 
-import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.studio.common.domain.enums.FlushDiskType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -126,20 +125,14 @@ public class ClusterService {
                 .noneMatch(broker -> brokerName.equals(broker.getName()))) {
             throw new BusinessException(404, "Broker not found: " + brokerName);
         }
-        log.info("Broker restart initiated for: {} in cluster: {}", brokerName, clusterId);
-        return true;
+        throw unsupportedOperation("Broker restart");
     }
 
     public NameServerVO createNameServer(CreateNameServerDTO command) {
         log.info("Creating NameServer for cluster: {}", command.getClusterId());
         clusterRepository.findById(command.getClusterId())
                 .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
-        NameServerVO ns = NameServerVO.builder()
-                .addr(command.getAddr())
-                .status(ClusterStatus.healthy)
-                .build();
-        log.info("NameServer created: {}", command.getAddr());
-        return ns;
+        throw unsupportedOperation("NameServer create");
     }
 
     public void updateNameServer(UpdateNameServerDTO command) {
@@ -147,7 +140,7 @@ public class ClusterService {
         ClusterVO cluster = clusterRepository.findById(command.getClusterId())
                 .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
         requireNameServer(cluster, command.getAddr());
-        log.info("NameServer updated: {}", command.getAddr());
+        throw unsupportedOperation("NameServer update");
     }
 
     public boolean restartNameServer(RestartNameServerDTO command) {
@@ -155,8 +148,7 @@ public class ClusterService {
         ClusterVO cluster = clusterRepository.findById(command.getClusterId())
                 .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
         requireNameServer(cluster, command.getAddr());
-        log.info("NameServer restart initiated: {}", command.getAddr());
-        return true;
+        throw unsupportedOperation("NameServer restart");
     }
 
     public boolean upgradeNameServer(UpgradeNameServerDTO command) {
@@ -165,8 +157,7 @@ public class ClusterService {
         ClusterVO cluster = clusterRepository.findById(command.getClusterId())
                 .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
         requireNameServer(cluster, command.getAddr());
-        log.info("NameServer upgrade initiated: {}", command.getAddr());
-        return true;
+        throw unsupportedOperation("NameServer upgrade");
     }
 
     public boolean deleteNameServer(DeleteNameServerDTO command) {
@@ -174,8 +165,7 @@ public class ClusterService {
         ClusterVO cluster = clusterRepository.findById(command.getClusterId())
                 .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
         requireNameServer(cluster, command.getAddr());
-        log.info("NameServer deleted: {}", command.getAddr());
-        return true;
+        throw unsupportedOperation("NameServer delete");
     }
 
     public boolean restartProxy(RestartProxyDTO command) {
@@ -183,8 +173,7 @@ public class ClusterService {
         ClusterVO cluster = clusterRepository.findById(command.getClusterId())
                 .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
         requireProxy(cluster, command.getAddr());
-        log.info("Proxy restart initiated: {}", command.getAddr());
-        return true;
+        throw unsupportedOperation("Proxy restart");
     }
 
     private void requireNameServer(ClusterVO cluster, String addr) {
@@ -199,5 +188,9 @@ public class ClusterService {
                 .noneMatch(proxy -> addr.equals(proxy.getAddr()))) {
             throw new BusinessException(404, "Proxy not found: " + addr);
         }
+    }
+
+    private BusinessException unsupportedOperation(String operation) {
+        return new BusinessException(501, operation + " is not implemented by the current cluster provider");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.broker;
 
 import org.apache.rocketmq.studio.cluster.config.ClusterConfigVO;
 import org.apache.rocketmq.studio.cluster.config.UpdateConfigDTO;
+import org.apache.rocketmq.studio.cluster.nameserver.CreateNameServerDTO;
 import org.apache.rocketmq.studio.cluster.nameserver.DeleteNameServerDTO;
 import org.apache.rocketmq.studio.cluster.nameserver.NameServerVO;
 import org.apache.rocketmq.studio.cluster.nameserver.RestartNameServerDTO;
@@ -41,9 +42,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.assertj.core.api.ThrowableAssert;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -320,12 +321,11 @@ class ClusterServiceTest {
     }
 
     @Test
-    void restartBrokerShouldReturnTrue() {
+    void restartBrokerShouldThrowUnsupportedWhenBrokerExists() {
         when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
 
-        boolean result = clusterService.restartBroker("cluster-1", "broker-0");
-
-        assertThat(result).isTrue();
+        assertUnsupportedOperation(() -> clusterService.restartBroker("cluster-1", "broker-0"),
+                "Broker restart is not implemented");
     }
 
     @Test
@@ -348,7 +348,19 @@ class ClusterServiceTest {
     }
 
     @Test
-    void nameServerOperationsShouldAcceptExistingNameServer() {
+    void createNameServerShouldThrowUnsupportedWhenClusterExists() {
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+        CreateNameServerDTO command = CreateNameServerDTO.builder()
+                .clusterId("cluster-1")
+                .addr("10.0.0.21:9876")
+                .build();
+
+        assertUnsupportedOperation(() -> clusterService.createNameServer(command),
+                "NameServer create is not implemented");
+    }
+
+    @Test
+    void nameServerOperationsShouldThrowUnsupportedWhenNameServerExists() {
         when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
         UpdateNameServerDTO update = UpdateNameServerDTO.builder()
                 .clusterId("cluster-1")
@@ -368,21 +380,26 @@ class ClusterServiceTest {
                 .addr("10.0.0.20:9876")
                 .build();
 
-        assertThatCode(() -> clusterService.updateNameServer(update)).doesNotThrowAnyException();
-        assertThat(clusterService.restartNameServer(restart)).isTrue();
-        assertThat(clusterService.upgradeNameServer(upgrade)).isTrue();
-        assertThat(clusterService.deleteNameServer(delete)).isTrue();
+        assertUnsupportedOperation(() -> clusterService.updateNameServer(update),
+                "NameServer update is not implemented");
+        assertUnsupportedOperation(() -> clusterService.restartNameServer(restart),
+                "NameServer restart is not implemented");
+        assertUnsupportedOperation(() -> clusterService.upgradeNameServer(upgrade),
+                "NameServer upgrade is not implemented");
+        assertUnsupportedOperation(() -> clusterService.deleteNameServer(delete),
+                "NameServer delete is not implemented");
     }
 
     @Test
-    void restartProxyShouldReturnTrueWhenProxyExists() {
+    void restartProxyShouldThrowUnsupportedWhenProxyExists() {
         when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
         RestartProxyDTO command = RestartProxyDTO.builder()
                 .clusterId("cluster-1")
                 .addr("10.0.0.10:8081")
                 .build();
 
-        assertThat(clusterService.restartProxy(command)).isTrue();
+        assertUnsupportedOperation(() -> clusterService.restartProxy(command),
+                "Proxy restart is not implemented");
     }
 
     @Test
@@ -454,5 +471,12 @@ class ClusterServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Proxy not found: missing:8081")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
+    }
+
+    private void assertUnsupportedOperation(ThrowableAssert.ThrowingCallable callable, String message) {
+        assertThatThrownBy(callable)
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(message)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
     }
 }


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #784

### Brief Description

This PR stops Studio cluster runtime operations from reporting fake success before a real execution provider is wired.

The affected service methods still validate cluster/node existence first, preserving existing 404 behavior. When the target exists, broker restart, NameServer create/update/restart/upgrade/delete, and proxy restart now return a `BusinessException(501, ...)` instead of logging a no-op and returning success.

### How Did You Test This Change?

- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=ClusterServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=ClusterControllerTest,NameServerControllerTest,ProxyControllerTest test`
