### PR TITLE
[ISSUE #786] Return unavailable for consumer group providers

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/CloudMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/CloudMetadataProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.instance.topic;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
 import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
@@ -37,7 +38,7 @@ public class CloudMetadataProvider implements MetadataProvider {
 
     @Override
     public List<ConsumerGroupVO> listConsumerGroups(String clusterId, String search) {
-        throw new UnsupportedOperationException("Not implemented");
+        throw consumerGroupProviderUnavailable();
     }
 
     @Override
@@ -52,11 +53,15 @@ public class CloudMetadataProvider implements MetadataProvider {
 
     @Override
     public List<QueueProgressVO> getGroupProgress(String name) {
-        throw new UnsupportedOperationException("Not implemented");
+        throw consumerGroupProviderUnavailable();
     }
 
     @Override
     public List<SubscriptionEntryVO> getGroupSubscriptions(String name) {
-        throw new UnsupportedOperationException("Not implemented");
+        throw consumerGroupProviderUnavailable();
+    }
+
+    private BusinessException consumerGroupProviderUnavailable() {
+        return new BusinessException(501, "Consumer group metadata provider is not configured");
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/NameSrvAdminClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/NameSrvAdminClient.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.instance.topic;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +34,7 @@ public class NameSrvAdminClient implements AdminClient {
 
     @Override
     public ConsumerGroupVO getConsumerGroup(String name) {
-        throw new UnsupportedOperationException("Not implemented");
+        throw consumerGroupAdminUnavailable();
     }
 
     @Override
@@ -58,16 +59,20 @@ public class NameSrvAdminClient implements AdminClient {
 
     @Override
     public ConsumerGroupVO createConsumerGroup(ConsumerGroupVO group) {
-        throw new UnsupportedOperationException("Not implemented");
+        throw consumerGroupAdminUnavailable();
     }
 
     @Override
     public void deleteConsumerGroup(String name) {
-        throw new UnsupportedOperationException("Not implemented");
+        throw consumerGroupAdminUnavailable();
     }
 
     @Override
     public void resetOffset(String name, long timestamp, String topic) {
-        throw new UnsupportedOperationException("Not implemented");
+        throw consumerGroupAdminUnavailable();
+    }
+
+    private BusinessException consumerGroupAdminUnavailable() {
+        return new BusinessException(501, "Consumer group admin client is not configured");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/CloudMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/CloudMetadataProviderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.topic;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CloudMetadataProviderTest {
+
+    private final CloudMetadataProvider provider = new CloudMetadataProvider();
+
+    @Test
+    void consumerGroupQueriesShouldReturnProviderUnavailable() {
+        assertUnavailable(() -> provider.listConsumerGroups("cluster-1", "order"));
+        assertUnavailable(() -> provider.getGroupProgress("cg-order"));
+        assertUnavailable(() -> provider.getGroupSubscriptions("cg-order"));
+    }
+
+    private void assertUnavailable(ThrowableAssert.ThrowingCallable callable) {
+        assertThatThrownBy(callable)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Consumer group metadata provider is not configured")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/NameSrvAdminClientTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/NameSrvAdminClientTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.topic;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NameSrvAdminClientTest {
+
+    private final NameSrvAdminClient adminClient = new NameSrvAdminClient();
+
+    @Test
+    void consumerGroupOperationsShouldReturnAdminUnavailable() {
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName("cg-order");
+
+        assertUnavailable(() -> adminClient.getConsumerGroup("cg-order"));
+        assertUnavailable(() -> adminClient.createConsumerGroup(group));
+        assertUnavailable(() -> adminClient.deleteConsumerGroup("cg-order"));
+        assertUnavailable(() -> adminClient.resetOffset("cg-order", 1784246400000L, "order-topic"));
+    }
+
+    private void assertUnavailable(ThrowableAssert.ThrowingCallable callable) {
+        assertThatThrownBy(callable)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Consumer group admin client is not configured")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
+    }
+}


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #786

### Brief Description

The default Consumer Group metadata/admin implementations now return explicit `BusinessException(501, ...)` responses when the backing provider is not configured, instead of throwing plain `UnsupportedOperationException` and surfacing as generic 500 errors.

This keeps the current Topic paths untouched and only changes Consumer Group operations used by `/api/groups`.

### How Did You Test This Change?

- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=CloudMetadataProviderTest,NameSrvAdminClientTest,MetadataServiceTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=ConsumerGroupControllerTest test`
