### PR TITLE
[ISSUE #788] Return unavailable for Ops setting writes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/OpsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/OpsService.java
@@ -30,6 +30,9 @@ import java.util.Set;
 @Service
 public class OpsService {
 
+    private static final String OPS_SETTINGS_UNAVAILABLE =
+            "Ops settings are not connected to the cluster admin configuration";
+
     private final Set<String> namesrvAddrs = new LinkedHashSet<>(List.of("127.0.0.1:9876"));
     private String currentNamesrv = "127.0.0.1:9876";
     private boolean useVIPChannel = true;
@@ -45,41 +48,26 @@ public class OpsService {
     }
 
     public synchronized void updateNameServer(String namesrvAddr) {
-        String normalized = normalizeNameServer(namesrvAddr);
-        namesrvAddrs.add(normalized);
-        currentNamesrv = normalized;
-        log.info("Updated current NameServer address to {}", normalized);
+        normalizeNameServer(namesrvAddr);
+        throw settingsUnavailable();
     }
 
     public synchronized void addNameServer(String namesrvAddr) {
-        String normalized = normalizeNameServer(namesrvAddr);
-        namesrvAddrs.add(normalized);
-        log.info("Added NameServer address {}", normalized);
+        normalizeNameServer(namesrvAddr);
+        throw settingsUnavailable();
     }
 
     public synchronized void deleteNameServer(String namesrvAddr) {
-        String normalized = normalizeNameServer(namesrvAddr);
-        if (!namesrvAddrs.contains(normalized)) {
-            throw new BusinessException(404, "NameServer address not found: " + normalized);
-        }
-        if (namesrvAddrs.size() == 1) {
-            throw new BusinessException(409, "Cannot delete the last NameServer address");
-        }
-        if (normalized.equals(currentNamesrv)) {
-            throw new BusinessException(409, "Cannot delete the current NameServer address");
-        }
-        namesrvAddrs.remove(normalized);
-        log.info("Deleted NameServer address {}", normalized);
+        normalizeNameServer(namesrvAddr);
+        throw settingsUnavailable();
     }
 
     public synchronized void updateVipChannel(boolean enabled) {
-        useVIPChannel = enabled;
-        log.info("Updated VIP channel setting to {}", enabled);
+        throw settingsUnavailable();
     }
 
     public synchronized void updateUseTLS(boolean enabled) {
-        useTLS = enabled;
-        log.info("Updated TLS setting to {}", enabled);
+        throw settingsUnavailable();
     }
 
     private String normalizeNameServer(String namesrvAddr) {
@@ -87,5 +75,10 @@ public class OpsService {
             throw new BusinessException(400, "namesrvAddr is required");
         }
         return namesrvAddr.trim();
+    }
+
+    private BusinessException settingsUnavailable() {
+        log.warn(OPS_SETTINGS_UNAVAILABLE);
+        return new BusinessException(501, OPS_SETTINGS_UNAVAILABLE);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/OpsControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/OpsControllerTest.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.studio.ops;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -77,6 +79,22 @@ class OpsControllerTest {
                         .content(objectMapper.writeValueAsString(Map.of("namesrvAddr", "10.0.0.1:9876"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200));
+
+        verify(opsService).updateNameServer(eq("10.0.0.1:9876"));
+    }
+
+    @Test
+    void updateNameSvrAddrShouldReturnUnavailableWhenServiceRejects() throws Exception {
+        doThrow(new BusinessException(501, "Ops settings are not connected to the cluster admin configuration"))
+                .when(opsService).updateNameServer("10.0.0.1:9876");
+
+        mockMvc.perform(post("/api/ops/updateNameSvrAddr")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("namesrvAddr", "10.0.0.1:9876"))))
+                .andExpect(status().isNotImplemented())
+                .andExpect(jsonPath("$.code").value(501))
+                .andExpect(jsonPath("$.message").value(
+                        "Ops settings are not connected to the cluster admin configuration"));
 
         verify(opsService).updateNameServer(eq("10.0.0.1:9876"));
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/OpsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/OpsServiceTest.java
@@ -38,22 +38,19 @@ class OpsServiceTest {
     }
 
     @Test
-    void addAndUpdateNameServerShouldMaintainUniqueAddressList() {
-        opsService.addNameServer(" 10.0.0.1:9876 ");
-        opsService.addNameServer("10.0.0.1:9876");
-        opsService.updateNameServer("10.0.0.2:9876");
-
-        OpsHomeVO home = opsService.getHomePage();
-        assertThat(home.getNamesvrAddrList())
-                .containsExactly("127.0.0.1:9876", "10.0.0.1:9876", "10.0.0.2:9876");
-        assertThat(home.getCurrentNamesrv()).isEqualTo("10.0.0.2:9876");
-    }
-
-    @Test
-    void deleteNameServerShouldRemoveNonCurrentAddress() {
-        opsService.addNameServer("10.0.0.1:9876");
-
-        opsService.deleteNameServer(" 10.0.0.1:9876 ");
+    void nameServerWritesShouldReturnUnavailable() {
+        assertThatThrownBy(() -> opsService.addNameServer(" 10.0.0.1:9876 "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Ops settings are not connected to the cluster admin configuration")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
+        assertThatThrownBy(() -> opsService.updateNameServer("10.0.0.2:9876"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Ops settings are not connected to the cluster admin configuration")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
+        assertThatThrownBy(() -> opsService.deleteNameServer("127.0.0.1:9876"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Ops settings are not connected to the cluster admin configuration")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
 
         OpsHomeVO home = opsService.getHomePage();
         assertThat(home.getNamesvrAddrList()).containsExactly("127.0.0.1:9876");
@@ -61,33 +58,19 @@ class OpsServiceTest {
     }
 
     @Test
-    void deleteNameServerShouldRejectUnknownCurrentAndLastAddress() {
-        assertThatThrownBy(() -> opsService.deleteNameServer("10.0.0.1:9876"))
+    void togglesShouldReturnUnavailable() {
+        assertThatThrownBy(() -> opsService.updateVipChannel(false))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("NameServer address not found: 10.0.0.1:9876")
-                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
-
-        assertThatThrownBy(() -> opsService.deleteNameServer("127.0.0.1:9876"))
+                .hasMessage("Ops settings are not connected to the cluster admin configuration")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
+        assertThatThrownBy(() -> opsService.updateUseTLS(true))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("Cannot delete the last NameServer address")
-                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(409));
-
-        opsService.addNameServer("10.0.0.1:9876");
-        opsService.updateNameServer("10.0.0.1:9876");
-        assertThatThrownBy(() -> opsService.deleteNameServer("10.0.0.1:9876"))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("Cannot delete the current NameServer address")
-                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(409));
-    }
-
-    @Test
-    void togglesShouldUpdateHomePageSettings() {
-        opsService.updateVipChannel(false);
-        opsService.updateUseTLS(true);
+                .hasMessage("Ops settings are not connected to the cluster admin configuration")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
 
         OpsHomeVO home = opsService.getHomePage();
-        assertThat(home.isUseVIPChannel()).isFalse();
-        assertThat(home.isUseTLS()).isTrue();
+        assertThat(home.isUseVIPChannel()).isTrue();
+        assertThat(home.isUseTLS()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #788

### Brief Description

The Ops page exposes NameServer, VIP channel, and TLS write operations, but the current service only updates process-local fields and does not apply those settings to the real RocketMQ AdminClient/configuration path.

This PR keeps the read-only Ops home data available, but changes write operations to fail explicitly with HTTP 501 until they are wired to the real cluster admin configuration flow. This avoids showing users a successful applied change when no runtime MQAdmin setting was changed.

Covered write operations:

- update current NameServer
- add NameServer
- delete NameServer
- update VIP channel
- update TLS

### How Did You Test This Change?

- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=OpsServiceTest,OpsControllerTest test`