### PR TITLE
[ISSUE #790] Gate demo instance seed data

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InMemoryInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InMemoryInstanceRepository.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.studio.instance;
 
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -34,8 +35,10 @@ public class InMemoryInstanceRepository implements InstanceRepository {
 
     private final Map<String, InstanceVO> store = new ConcurrentHashMap<>();
 
-    public InMemoryInstanceRepository() {
-        initData();
+    public InMemoryInstanceRepository(@Value("${studio.instance.seed-demo-data:false}") boolean seedDemoData) {
+        if (seedDemoData) {
+            initData();
+        }
     }
 
     private void initData() {

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -20,6 +20,8 @@ studio:
       - username: ${STUDIO_AUTH_ADMIN_USERNAME:}
         password: ${STUDIO_AUTH_ADMIN_PASSWORD:}
         admin: true
+  instance:
+    seed-demo-data: ${STUDIO_INSTANCE_SEED_DEMO_DATA:false}
   metrics:
     prometheus:
       base-url: ${STUDIO_METRICS_PROMETHEUS_BASE_URL:}

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InMemoryInstanceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InMemoryInstanceRepositoryTest.java
@@ -23,7 +23,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class InMemoryInstanceRepositoryTest {
 
-    private final InMemoryInstanceRepository repository = new InMemoryInstanceRepository();
+    private final InMemoryInstanceRepository repository = new InMemoryInstanceRepository(true);
+
+    @Test
+    void findAllShouldBeEmptyWhenDemoDataIsDisabled() {
+        InMemoryInstanceRepository emptyRepository = new InMemoryInstanceRepository(false);
+
+        assertThat(emptyRepository.findAll()).isEmpty();
+    }
 
     @Test
     void searchShouldMatchInstanceEndpoints() {


### PR DESCRIPTION
### Which Issue(s) This PR Fixes

Fixes #790

### Brief Description

`InMemoryInstanceRepository` currently seeds demo production/staging/dev instances as soon as the backend starts. This PR makes demo instance data opt-in so a fresh Studio backend does not fabricate instance resources by default.

Changes:

- Add `studio.instance.seed-demo-data`, defaulting to `false`.
- Seed `InMemoryInstanceRepository` only when that flag is enabled.
- Update repository tests to cover both default empty state and explicit demo seeding.

### How Did You Test This Change?

- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=InMemoryInstanceRepositoryTest,StudioApplicationTest test`