### PR TITLE
[Studio] test(web): stop the suite from failing under parallel load

### DIFF
--- a/web/src/pages/settings/__tests__/DataSourceTab.test.tsx
+++ b/web/src/pages/settings/__tests__/DataSourceTab.test.tsx
@@ -82,7 +82,7 @@ describe('DataSourceTab', () => {
       }),
     );
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
       <App>
         <DataSourceTab />
@@ -104,7 +104,7 @@ describe('DataSourceTab', () => {
   it('submits basic auth credentials when testing from the modal', async () => {
     vi.mocked(testDataSource).mockResolvedValue({ success: true, message: 'ok' });
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
       <App>
         <DataSourceTab />
@@ -136,7 +136,7 @@ describe('DataSourceTab', () => {
   it('submits bearer token when testing from the modal', async () => {
     vi.mocked(testDataSource).mockResolvedValue({ success: true, message: 'ok' });
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
       <App>
         <DataSourceTab />
@@ -174,7 +174,7 @@ describe('DataSourceTab', () => {
       status: 'healthy',
     });
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
       <App>
         <DataSourceTab />
@@ -222,7 +222,7 @@ describe('DataSourceTab', () => {
       status: 'healthy',
     });
 
-    const user = userEvent.setup();
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
       <App>
         <DataSourceTab />
@@ -251,6 +251,8 @@ describe('DataSourceTab', () => {
   });
 });
 
+// antd's Select dropdown keeps `pointer-events: none` while its open animation runs,
+// so userEvent refuses to click the option; the interaction itself is valid.
 async function selectAntdOption(
   user: ReturnType<typeof userEvent.setup>,
   label: string,

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,5 +1,10 @@
 /// <reference types="vitest/globals" />
 import '@testing-library/jest-dom/vitest';
+import { configure } from '@testing-library/react';
+
+// findBy*/waitFor default to 1s, which antd's async rendering exceeds once the whole
+// suite runs in parallel.
+configure({ asyncUtilTimeout: 5000 });
 
 // Clean up localStorage between tests
 beforeEach(() => {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,6 +20,10 @@ export default defineConfig(({ mode }) => {
       environment: 'jsdom',
       setupFiles: './src/test/setup.ts',
       css: true,
+      // antd interactions driven through userEvent are slow in jsdom, and the default
+      // 5s budget is exceeded once the whole suite runs in parallel.
+      testTimeout: 20000,
+      hookTimeout: 20000,
     },
   };
 });


### PR DESCRIPTION
Five tests failed randomly on full runs while passing in isolation, and the
failing set drifted between runs.

- vitest's default 5s per-test budget is not enough for userEvent-driven antd
  modal and table interactions once 74 files run in parallel; raise
  testTimeout/hookTimeout to 20s and findBy*/waitFor to 5s
- antd keeps `pointer-events: none` on a Select dropdown while its open
  animation runs, so clicking an option was rejected; skip that check where
  the dropdown is driven