### PR TITLE
[ISSUE #795] Fail closed on LiteTopic capability errors

### DIFF
--- a/web/src/pages/studio/LiteTopic.tsx
+++ b/web/src/pages/studio/LiteTopic.tsx
@@ -204,7 +204,12 @@ const LiteTopicPage: React.FC = () => {
         }
       } catch {
         if (!bootstrapIsActive()) return;
-        // Assume supported when capability detection is unavailable.
+        ++displayCounter.current;
+        setCapabilitySupported(false);
+        setTopicList([]);
+        setQuota(null);
+        setLoading(false);
+        return;
       }
 
       if (displayCounter.current === initialDisplayRequestId) {

--- a/web/src/pages/studio/__tests__/LiteTopic.test.tsx
+++ b/web/src/pages/studio/__tests__/LiteTopic.test.tsx
@@ -328,6 +328,18 @@ describe('LiteTopic Page', () => {
     expect(screen.queryByText('late-result-*')).not.toBeInTheDocument();
   });
 
+  it('fails closed when capability detection is unavailable', async () => {
+    apiMocks.queryLiteTopicCapability.mockRejectedValue(new Error('capability unavailable'));
+
+    renderPage();
+
+    expect(
+      await screen.findByText('当前集群不支持 LiteTopic，请升级到 RocketMQ 5.x'),
+    ).toBeInTheDocument();
+    expect(apiMocks.queryLiteTopicList).not.toHaveBeenCalled();
+    expect(apiMocks.queryLiteTopicQuota).not.toHaveBeenCalled();
+  });
+
   it('ignores stale list and quota responses when namespaces change quickly', async () => {
     const alphaList = createDeferred<LiteTopicItem[]>();
     const betaList = createDeferred<LiteTopicItem[]>();


### PR DESCRIPTION
### What changed

This PR makes the LiteTopic page fail closed when capability detection is unavailable.

Previously, if `/api/liteTopic/capability` failed, the page assumed LiteTopic support and continued to load list/quota data. Now it clears current data, stops loading, and renders the unavailable state instead.

### Why

The UI should not expose LiteTopic management when Studio cannot confirm that the backend/provider path supports it. This avoids misleading users with an enabled management surface during backend/provider failures.

Fixes #795.

### Verification

```bash
npm test -- --run src/pages/studio/__tests__/LiteTopic.test.tsx
```

Result: 1 test file passed, 9 tests passed.
