### PR TITLE
[ISSUE #802] Disable mock mode for production builds

### DIFF
--- a/web/.env.production
+++ b/web/.env.production
@@ -1,3 +1,3 @@
-# Backend not ready yet - use mock data
-# Set to "false" when real API is available
-VITE_USE_MOCK=true
+# Production builds should call real backend APIs by default.
+# Set to "true" only for explicit demo/mock deployments.
+VITE_USE_MOCK=false


### PR DESCRIPTION
### What changed

This PR changes `web/.env.production` so production builds use real backend APIs by default:

```env
VITE_USE_MOCK=false
```

Local development mock mode remains available through `web/.env` or explicit deployment overrides.

### Why

Production-like builds should not default to mock data. Keeping mock mode enabled in production can show simulated resources and successful control-plane actions without backend interaction.

Fixes #802.

### Verification

```bash
npm run build
```

Result: build completed successfully. Vite reported only the existing large chunk warning.
