### PR TITLE
[ISSUE #804] Load BrokerCluster data from service

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -66,129 +66,6 @@ interface ProxyRecord {
   connections: number;
 }
 
-// ─── Mock Data (fallback when the API is unavailable) ───────────
-const mockBrokerData: BrokerRecord[] = [
-  {
-    key: '1',
-    k8sCluster: 'prod-cn-east-1',
-    brokerName: 'broker-a',
-    status: 'running',
-    version: '5.3.0',
-    diskUsage: 62,
-    address: '10.0.1.10:10911',
-    tpsIn: 12580,
-    tpsOut: 8340,
-  },
-  {
-    key: '2',
-    k8sCluster: 'prod-cn-east-1',
-    brokerName: 'broker-b',
-    status: 'readonly',
-    version: '5.3.0',
-    diskUsage: 89,
-    address: '10.0.1.11:10911',
-    tpsIn: 0,
-    tpsOut: 3120,
-  },
-  {
-    key: '3',
-    k8sCluster: 'prod-cn-east-1',
-    brokerName: 'broker-c',
-    status: 'running',
-    version: '5.2.0',
-    diskUsage: 45,
-    address: '10.0.1.12:10911',
-    tpsIn: 9750,
-    tpsOut: 6280,
-  },
-  {
-    key: '4',
-    k8sCluster: 'prod-cn-south-1',
-    brokerName: 'broker-d',
-    status: 'maintenance',
-    version: '5.3.0',
-    diskUsage: 33,
-    address: '10.0.2.10:10911',
-    tpsIn: 0,
-    tpsOut: 0,
-  },
-  {
-    key: '5',
-    k8sCluster: 'prod-cn-south-1',
-    brokerName: 'broker-e',
-    status: 'running',
-    version: '5.3.0',
-    diskUsage: 51,
-    address: '10.0.2.11:10911',
-    tpsIn: 7890,
-    tpsOut: 5430,
-  },
-  {
-    key: '6',
-    k8sCluster: 'staging-cn-east-1',
-    brokerName: 'broker-staging-a',
-    status: 'running',
-    version: '5.3.1',
-    diskUsage: 28,
-    address: '10.0.10.10:10911',
-    tpsIn: 1230,
-    tpsOut: 980,
-  },
-];
-
-const mockNameServerData: NameServerRecord[] = [
-  {
-    key: '1',
-    k8sCluster: 'prod-cn-east-1',
-    name: 'nameserver-a',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.1.20:9876',
-    connections: 156,
-  },
-  {
-    key: '2',
-    k8sCluster: 'prod-cn-east-1',
-    name: 'nameserver-b',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.1.21:9876',
-    connections: 148,
-  },
-  {
-    key: '3',
-    k8sCluster: 'prod-cn-south-1',
-    name: 'nameserver-c',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.2.20:9876',
-    connections: 92,
-  },
-];
-
-const mockProxyData: ProxyRecord[] = [
-  {
-    key: '1',
-    k8sCluster: 'prod-cn-east-1',
-    name: 'proxy-a',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.1.30:8080',
-    grpcPort: '10.0.1.30:8081',
-    connections: 2340,
-  },
-  {
-    key: '2',
-    k8sCluster: 'prod-cn-south-1',
-    name: 'proxy-b',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.2.30:8080',
-    grpcPort: '10.0.2.30:8081',
-    connections: 1560,
-  },
-];
-
 // ─── Helpers ────────────────────────────────────────────────────
 const normalizeStatus = (status: string): NodeStatus => {
   const value = (status || '').toLowerCase();
@@ -260,9 +137,9 @@ const BrokerClusterPage = () => {
   const [autoRefresh, setAutoRefresh] = useState(false);
   const [activeTab, setActiveTab] = useState('broker');
   const [loading, setLoading] = useState(false);
-  const [brokerData, setBrokerData] = useState<BrokerRecord[]>(mockBrokerData);
-  const [nameServerData, setNameServerData] = useState<NameServerRecord[]>(mockNameServerData);
-  const [proxyData, setProxyData] = useState<ProxyRecord[]>(mockProxyData);
+  const [brokerData, setBrokerData] = useState<BrokerRecord[]>([]);
+  const [nameServerData, setNameServerData] = useState<NameServerRecord[]>([]);
+  const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
   const { t } = useLang();
   const { message } = App.useApp();
 

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -62,7 +62,7 @@ const clusterFixture: ClusterInfo[] = [
     version: '5.3.0',
     brokers: [
       {
-        name: 'broker-a',
+        name: 'broker-api-a',
         addr: '10.0.1.10:10911',
         version: '5.3.0',
         status: 'running',
@@ -71,7 +71,7 @@ const clusterFixture: ClusterInfo[] = [
         tpsOut: 8340,
       },
       {
-        name: 'broker-b',
+        name: 'broker-api-b',
         addr: '10.0.1.11:10911',
         version: '5.3.0',
         status: 'readonly',
@@ -89,7 +89,7 @@ const clusterFixture: ClusterInfo[] = [
         remotingPort: 8080,
       },
     ],
-    nameServers: [{ addr: 'nameserver-a', status: 'healthy' }],
+    nameServers: [{ addr: 'nameserver-api-a', status: 'healthy' }],
     config: {
       flushDiskType: 'SYNC_FLUSH',
       autoCreateTopicEnable: false,
@@ -140,14 +140,15 @@ describe('BrokerCluster Page', () => {
   it('should display broker tab with data from the API', async () => {
     renderWithProviders(<BrokerCluster />);
     // Default tab is broker - data is loaded asynchronously from the service
-    const brokerA = await screen.findAllByText('broker-a');
+    const brokerA = await screen.findAllByText('broker-api-a');
     expect(brokerA.length).toBeGreaterThan(0);
-    expect(screen.getAllByText('broker-b').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('broker-api-b').length).toBeGreaterThan(0);
+    expect(screen.queryByText('broker-a')).not.toBeInTheDocument();
   });
 
   it('should display broker status tags', async () => {
     renderWithProviders(<BrokerCluster />);
-    await screen.findAllByText('broker-a');
+    await screen.findAllByText('broker-api-a');
     const runningTags = screen.getAllByText('运行中');
     expect(runningTags.length).toBeGreaterThan(0);
     const readonlyTags = screen.getAllByText('只读');
@@ -157,17 +158,18 @@ describe('BrokerCluster Page', () => {
   it('should switch to NameServer tab on click', async () => {
     const user = userEvent.setup();
     renderWithProviders(<BrokerCluster />);
-    await screen.findByText('broker-a');
+    await screen.findByText('broker-api-a');
     const nsTab = screen.getByText('NameServer 管理');
     await user.click(nsTab);
     // After clicking, NameServer data should be visible (name equals address, so it appears twice)
-    expect(screen.getAllByText('nameserver-a').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('nameserver-api-a').length).toBeGreaterThan(0);
+    expect(screen.queryByText('nameserver-a')).not.toBeInTheDocument();
   });
 
   it('should switch to Proxy tab on click', async () => {
     const user = userEvent.setup();
     renderWithProviders(<BrokerCluster />);
-    await screen.findByText('broker-a');
+    await screen.findByText('broker-api-a');
     const proxyTab = screen.getByText('Proxy 管理');
     await user.click(proxyTab);
     // After clicking, Proxy data should be visible (proxy name equals its address, so it appears twice)
@@ -176,19 +178,21 @@ describe('BrokerCluster Page', () => {
 
   it('should render config and restart action buttons', async () => {
     renderWithProviders(<BrokerCluster />);
-    await screen.findByText('broker-a');
+    await screen.findByText('broker-api-a');
     const configButtons = screen.getAllByText('配置');
     expect(configButtons.length).toBeGreaterThan(0);
     const restartButtons = screen.getAllByText('重启');
     expect(restartButtons.length).toBeGreaterThan(0);
   });
 
-  it('should fall back to mock data when the API fails', async () => {
+  it('should keep topology tables empty when the API fails', async () => {
     vi.mocked(listClusters).mockRejectedValueOnce(new Error('network error'));
     renderWithProviders(<BrokerCluster />);
-    // Initial state holds the mock fallback rows
     await waitFor(() => {
-      expect(screen.getByText('broker-a')).toBeInTheDocument();
+      expect(listClusters).toHaveBeenCalledTimes(1);
     });
+    expect(screen.queryByText('broker-a')).not.toBeInTheDocument();
+    expect(screen.queryByText('nameserver-a')).not.toBeInTheDocument();
+    expect(screen.queryByText('proxy-a')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### What changed

- Removed BrokerCluster page-local fallback topology records.
- Keep Broker/NameServer/Proxy tables empty until `listClusters()` returns real data.
- Updated page tests to verify API-provided topology is rendered and stale demo nodes are not shown after API failure.

Fixes #804.

### Verification

`npm test -- --run src/pages/studio/__tests__/BrokerCluster.test.tsx`

Result: 1 test file passed, 9 tests passed.
