### PR TITLE
[ISSUE #806] Align Tongyi LLM provider key

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
@@ -240,6 +240,9 @@ public class LlmConfigService {
 
     private String normalizeProvider(String provider) {
         String normalized = defaultString(provider, OPENAI).toLowerCase(Locale.ROOT);
+        if ("qwen".equals(normalized)) {
+            return "tongyi";
+        }
         return PROVIDER_MODELS.containsKey(normalized) ? normalized : OPENAI;
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
@@ -71,6 +71,28 @@ class LlmConfigServiceTest {
     }
 
     @Test
+    void getConfigShouldNormalizeLegacyQwenProviderToTongyi() {
+        when(settingsService.getGeneralSettings()).thenReturn(GeneralSettingsVO.builder()
+                .theme("dark")
+                .compact(true)
+                .desktopNotify(true)
+                .notifySound(false)
+                .sessionTimeout(45)
+                .requireLogin(true)
+                .llmProvider("qwen")
+                .apiKey("dashscope-key")
+                .model("qwen-plus")
+                .baseUrl("")
+                .build());
+
+        LlmConfigVO config = llmConfigService.getConfig();
+
+        assertThat(config.getProvider()).isEqualTo("tongyi");
+        assertThat(config.getApiBase()).isEqualTo("https://dashscope.aliyuncs.com/compatible-mode/v1");
+        assertThat(config.getModel()).isEqualTo("qwen-plus");
+    }
+
+    @Test
     void configToStringShouldNotExposeApiKey() {
         LlmConfigVO config = LlmConfigVO.builder()
                 .provider("openai")
@@ -153,6 +175,27 @@ class LlmConfigServiceTest {
         assertThat(saved.getModel()).isEqualTo("deepseek-chat");
         assertThat(saved.getBaseUrl()).isEqualTo("https://api.deepseek.com/v1");
         assertThat(llmConfigService.getConfig().getProvider()).isEqualTo("deepseek");
+    }
+
+    @Test
+    void saveConfigShouldNormalizeLegacyQwenProviderToTongyi() {
+        LlmConfigVO config = LlmConfigVO.builder()
+                .provider("qwen")
+                .apiKey("dashscope-key")
+                .model("qwen-plus")
+                .maxTokens(8192)
+                .temperature(0.2)
+                .enabled(true)
+                .build();
+
+        llmConfigService.saveConfig(config);
+
+        ArgumentCaptor<GeneralSettingsVO> captor = ArgumentCaptor.forClass(GeneralSettingsVO.class);
+        verify(settingsService).saveGeneralSettings(captor.capture());
+        GeneralSettingsVO saved = captor.getValue();
+        assertThat(saved.getLlmProvider()).isEqualTo("tongyi");
+        assertThat(saved.getBaseUrl()).isEqualTo("https://dashscope.aliyuncs.com/compatible-mode/v1");
+        assertThat(llmConfigService.getConfig().getProvider()).isEqualTo("tongyi");
     }
 
     @Test

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -212,7 +212,7 @@ const GeneralSettingsTab = () => {
             { value: 'openai', label: 'OpenAI' },
             { value: 'azure', label: 'Azure OpenAI' },
             { value: 'ollama', label: 'Ollama' },
-            { value: 'qwen', label: '通义千问' },
+            { value: 'tongyi', label: '通义千问' },
           ]}
         />
       </Form.Item>


### PR DESCRIPTION
## Track

Track 3 / AI Native - LLM integration

### What is changed

- Align the legacy settings page Tongyi provider value with the backend-supported `tongyi` key.
- Keep `qwen` as a backend compatibility alias so existing saved configs do not silently fall back to OpenAI.
- Add regression coverage for loading and saving the legacy `qwen` provider value.

### Why

The old Settings page used `qwen`, while the Studio LLM settings and backend provider registry use `tongyi`. Saving from the old page could make the backend normalize the provider to `openai`, which breaks model/base URL defaults.

Fixes #806

### Verification

- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=LlmConfigServiceTest test`
- `npm run build`