### PR TITLE
[ISSUE #811] Use configured API base URL for AI chat stream

### DIFF
--- a/web/src/api/ai.test.ts
+++ b/web/src/api/ai.test.ts
@@ -28,6 +28,8 @@ import {
   type McpTool,
 } from './ai';
 
+vi.mock('../config', () => ({ API_BASE_URL: '/studio-api' }));
+
 const mock = new MockAdapter(client);
 const encoder = new TextEncoder();
 
@@ -58,23 +60,25 @@ describe('AI API', () => {
 
   describe('chatStream (SSE)', () => {
     it('reassembles an event split across network chunks', async () => {
-      vi.stubGlobal(
-        'fetch',
-        vi
-          .fn()
-          .mockResolvedValue(
-            streamResponse([
-              'event: message\r\ndata: {"text":"hel',
-              'lo"}\r\n\r\nevent: done\r\ndata: [DONE]\r\n\r\n',
-            ]),
-          ),
-      );
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(
+          streamResponse([
+            'event: message\r\ndata: {"text":"hel',
+            'lo"}\r\n\r\nevent: done\r\ndata: [DONE]\r\n\r\n',
+          ]),
+        );
+      vi.stubGlobal('fetch', fetchMock);
       const chunks: string[] = [];
 
       await chatStream({ message: 'hello', mode: 'chat', model: 'stub' }, (text) =>
         chunks.push(text),
       );
 
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/studio-api/ai/chat',
+        expect.objectContaining({ method: 'POST' }),
+      );
       expect(chunks).toEqual(['hello']);
     });
 

--- a/web/src/api/ai.ts
+++ b/web/src/api/ai.ts
@@ -16,6 +16,7 @@
  */
 
 import client from './client';
+import { API_BASE_URL } from '../config';
 
 // ─── Types ──────────────────────────────────────────────────────
 export interface McpTool {
@@ -135,7 +136,7 @@ export async function chatStream(
   onChunk: (text: string) => void,
   signal?: AbortSignal,
 ) {
-  const response = await fetch('/api/ai/chat', {
+  const response = await fetch(`${API_BASE_URL}/ai/chat`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Track

Track 3 / AI Native - LLM integration

### What is changed
- Build the AI chat SSE endpoint from the shared `API_BASE_URL` config instead of hard-coding `/api/ai/chat`.
- Extend the SSE API test to verify streaming chat respects a configured API base path.

Fixes #811

### Verification
- npm test -- --run src/api/ai.test.ts
- npm run build