### PR TITLE
[ISSUE #813] Preserve LLM configuration across general updates

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
@@ -77,12 +77,8 @@ public class LlmConfigService {
     private final OpenAiCompatibleLlmClient llmClient;
     private final AgentProviderRegistry agentProviders;
     private final LlmProperties llmProperties;
-    private LlmConfigVO overrides;
-
     public synchronized LlmConfigVO getConfig() {
-        LlmConfigVO config = overrides != null
-                ? copy(overrides)
-                : fromGeneralSettings(settingsService.getGeneralSettings());
+        LlmConfigVO config = fromGeneralSettings(settingsService.getGeneralSettings());
         String token = envToken();
         if (!!StringUtils.hasText(token)) {
             config.setApiKey(token.trim());
@@ -120,9 +116,7 @@ public class LlmConfigService {
                 .maxTokens(normalized.getMaxTokens())
                 .temperature(normalized.getTemperature())
                 .build();
-        LlmConfigVO nextOverrides = copy(normalized);
         settingsService.saveGeneralSettings(updated);
-        overrides = nextOverrides;
     }
 
     public LlmOperationResultVO testConfig(LlmConfigVO config) {
@@ -270,10 +264,6 @@ public class LlmConfigService {
                 .apiVersion(defaultString(config == null ? null : config.getApiVersion(), "2024-02-15-preview"))
                 .awsRegion(defaultString(config == null ? null : config.getAwsRegion(), "us-east-1"))
                 .build();
-    }
-
-    private LlmConfigVO copy(LlmConfigVO config) {
-        return normalize(config);
     }
 
     private LlmConfigVO normalizeWithStoredApiKey(LlmConfigVO config) {

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -112,6 +112,9 @@ public class SettingsService {
             settings.setApiKey(currentSettings.getApiKey());
         }
         if (currentSettings != null) {
+            if (!StringUtils.hasText(settings.getLlmEngine())) {
+                settings.setLlmEngine(currentSettings.getLlmEngine());
+            }
             if (!StringUtils.hasText(settings.getDeploymentName())) {
                 settings.setDeploymentName(currentSettings.getDeploymentName());
             }
@@ -120,6 +123,12 @@ public class SettingsService {
             }
             if (!StringUtils.hasText(settings.getAwsRegion())) {
                 settings.setAwsRegion(currentSettings.getAwsRegion());
+            }
+            if (settings.getMaxTokens() == null) {
+                settings.setMaxTokens(currentSettings.getMaxTokens());
+            }
+            if (settings.getTemperature() == null) {
+                settings.setTemperature(currentSettings.getTemperature());
             }
         }
         settings.setClearApiKey(false);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
@@ -29,11 +29,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -187,6 +189,7 @@ class LlmConfigServiceTest {
         assertThat(saved.getBaseUrl()).isEqualTo("https://api.deepseek.com/v1");
         assertThat(saved.getMaxTokens()).isEqualTo(8192);
         assertThat(saved.getTemperature()).isEqualTo(0.2);
+        when(settingsService.getGeneralSettings()).thenReturn(saved);
         assertThat(llmConfigService.getConfig().getProvider()).isEqualTo("deepseek");
         assertThat(llmConfigService.getConfig().getMaxTokens()).isEqualTo(8192);
         assertThat(llmConfigService.getConfig().getTemperature()).isEqualTo(0.2);
@@ -240,6 +243,36 @@ class LlmConfigServiceTest {
 
         assertThat(llmConfigService.getConfig().getProvider()).isEqualTo("openai");
         assertThat(llmConfigService.getConfig().getModel()).isEqualTo("gpt-4o");
+    }
+
+    @Test
+    void getConfigShouldReflectGeneralSettingsSavedAfterLlmConfiguration() {
+        llmConfigService.saveConfig(LlmConfigVO.builder()
+                .provider("deepseek")
+                .apiKey("sk-deepseek")
+                .apiBase("https://api.deepseek.com/v1")
+                .model("deepseek-chat")
+                .maxTokens(8192)
+                .temperature(0.2)
+                .enabled(true)
+                .build());
+        when(settingsService.getGeneralSettings()).thenReturn(GeneralSettingsVO.builder()
+                .llmProvider("ollama")
+                .llmEngine("http")
+                .apiKey("")
+                .model("llama3")
+                .baseUrl("http://localhost:11434/v1")
+                .maxTokens(4096)
+                .temperature(0.7)
+                .build());
+
+        LlmConfigVO config = llmConfigService.getConfig();
+
+        assertThat(config.getProvider()).isEqualTo("ollama");
+        assertThat(config.getEngine()).isEqualTo("http");
+        assertThat(config.getModel()).isEqualTo("llama3");
+        assertThat(config.getMaxTokens()).isEqualTo(4096);
+        assertThat(config.getTemperature()).isEqualTo(0.7);
     }
 
     @Test
@@ -503,6 +536,13 @@ class LlmConfigServiceTest {
 
     @Test
     void listModelsShouldUseSavedProvider() {
+        AtomicReference<GeneralSettingsVO> persisted = new AtomicReference<>(settingsService.getGeneralSettings());
+        when(settingsService.getGeneralSettings()).thenAnswer(invocation -> persisted.get());
+        doAnswer(invocation -> {
+            persisted.set(invocation.getArgument(0));
+            return null;
+        }).when(settingsService).saveGeneralSettings(any(GeneralSettingsVO.class));
+
         llmConfigService.saveConfig(LlmConfigVO.builder()
                 .provider("tongyi")
                 .apiKey("dashscope-key")
@@ -552,6 +592,13 @@ class LlmConfigServiceTest {
 
     @Test
     void listModelsShouldNotBlockConcurrentConfigReadsOrWrites() throws Exception {
+        AtomicReference<GeneralSettingsVO> persisted = new AtomicReference<>(settingsService.getGeneralSettings());
+        when(settingsService.getGeneralSettings()).thenAnswer(invocation -> persisted.get());
+        doAnswer(invocation -> {
+            persisted.set(invocation.getArgument(0));
+            return null;
+        }).when(settingsService).saveGeneralSettings(any(GeneralSettingsVO.class));
+
         CountDownLatch listingStarted = new CountDownLatch(1);
         CountDownLatch releaseListing = new CountDownLatch(1);
         when(llmClient.supports(any())).thenReturn(true);

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -136,11 +136,14 @@ class SettingsServiceTest {
     }
 
     @Test
-    void saveGeneralSettingsShouldPreserveProviderSpecificLlmFieldsWhenOmitted() {
+    void saveGeneralSettingsShouldPreserveLlmFieldsWhenOmitted() {
         GeneralSettingsVO existing = GeneralSettingsVO.builder()
+                .llmEngine("qoder")
                 .deploymentName("production-gpt")
                 .apiVersion("2024-06-01")
                 .awsRegion("eu-west-1")
+                .maxTokens(8192)
+                .temperature(0.2)
                 .build();
         GeneralSettingsVO update = GeneralSettingsVO.builder()
                 .theme("light")
@@ -149,9 +152,12 @@ class SettingsServiceTest {
 
         settingsService.saveGeneralSettings(update);
 
+        assertThat(update.getLlmEngine()).isEqualTo("qoder");
         assertThat(update.getDeploymentName()).isEqualTo("production-gpt");
         assertThat(update.getApiVersion()).isEqualTo("2024-06-01");
         assertThat(update.getAwsRegion()).isEqualTo("eu-west-1");
+        assertThat(update.getMaxTokens()).isEqualTo(8192);
+        assertThat(update.getTemperature()).isEqualTo(0.2);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #813.

- Preserve omitted llmEngine, maxTokens, and temperature when General Settings saves a legacy or reduced client payload.
- Remove the in-memory LLM override so reads, model discovery, and AI requests use only successfully persisted settings.
- Add regression coverage for retained advanced fields and runtime synchronization after a General Settings update.

## Why

The previous implementation persisted advanced LLM fields, but a subsequent General Settings save could drop them because that UI payload does not include those fields. The temporary runtime override then masked the loss until restart.

## Verification

- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=LlmConfigServiceTest,SettingsServiceTest,SettingsControllerTest test
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -DskipTests package
- git diff --check