### PR TITLE
[ISSUE #815] Keep AI chat conversation context

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmChatMessage.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmChatMessage.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+public record LlmChatMessage(String role, String content) {
+
+    public static LlmChatMessage user(String content) {
+        return new LlmChatMessage("user", content);
+    }
+
+    public static LlmChatMessage assistant(String content) {
+        return new LlmChatMessage("assistant", content);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConversationMemory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConversationMemory.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class LlmConversationMemory {
+
+    private static final int MAX_CONVERSATIONS = 200;
+    private static final int MAX_MESSAGES_PER_CONVERSATION = 12;
+    private static final int MAX_MESSAGE_CHARS = 8_000;
+
+    private final Map<String, Deque<LlmChatMessage>> conversations =
+            new LinkedHashMap<>(16, 0.75f, true);
+
+    public synchronized List<LlmChatMessage> appendUserAndSnapshot(String conversationId, String message) {
+        LlmChatMessage userMessage = LlmChatMessage.user(normalizeContent(message));
+        String id = normalizeConversationId(conversationId);
+        if (!StringUtils.hasText(id)) {
+            return List.of(userMessage);
+        }
+        Deque<LlmChatMessage> messages = conversations.computeIfAbsent(id, ignored -> new ArrayDeque<>());
+        messages.addLast(userMessage);
+        trim(messages);
+        evictOldestConversationIfNeeded();
+        return new ArrayList<>(messages);
+    }
+
+    public synchronized void appendAssistant(String conversationId, String message) {
+        String id = normalizeConversationId(conversationId);
+        if (!StringUtils.hasText(id) || !StringUtils.hasText(message)) {
+            return;
+        }
+        Deque<LlmChatMessage> messages = conversations.computeIfAbsent(id, ignored -> new ArrayDeque<>());
+        messages.addLast(LlmChatMessage.assistant(normalizeContent(message)));
+        trim(messages);
+        evictOldestConversationIfNeeded();
+    }
+
+    private void trim(Deque<LlmChatMessage> messages) {
+        while (messages.size() > MAX_MESSAGES_PER_CONVERSATION) {
+            messages.removeFirst();
+        }
+    }
+
+    private void evictOldestConversationIfNeeded() {
+        while (conversations.size() > MAX_CONVERSATIONS) {
+            String oldestKey = conversations.keySet().iterator().next();
+            conversations.remove(oldestKey);
+        }
+    }
+
+    private String normalizeConversationId(String conversationId) {
+        if (!StringUtils.hasText(conversationId)) {
+            return "";
+        }
+        String id = conversationId.trim();
+        return id.length() <= 128 ? id : id.substring(0, 128);
+    }
+
+    private String normalizeContent(String content) {
+        if (!StringUtils.hasText(content)) {
+            return "";
+        }
+        String normalized = content.trim();
+        return normalized.length() <= MAX_MESSAGE_CHARS ? normalized : normalized.substring(0, MAX_MESSAGE_CHARS);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -70,8 +70,12 @@ public class OpenAiCompatibleLlmClient {
     }
 
     public String complete(LlmConfigVO config, String prompt, String modelOverride) {
+        return complete(config, List.of(LlmChatMessage.user(normalizeMessage(prompt))), modelOverride);
+    }
+
+    public String complete(LlmConfigVO config, List<LlmChatMessage> messages, String modelOverride) {
         validate(config);
-        Map<String, Object> requestBody = requestBody(config, prompt, modelOverride, false);
+        Map<String, Object> requestBody = requestBody(config, messages, modelOverride, false);
         HttpRequest request = request(config, "application/json", requestBody);
         try {
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
@@ -119,8 +123,13 @@ public class OpenAiCompatibleLlmClient {
     }
 
     public void stream(LlmConfigVO config, String prompt, String modelOverride, Consumer<String> tokenConsumer) {
+        stream(config, List.of(LlmChatMessage.user(normalizeMessage(prompt))), modelOverride, tokenConsumer);
+    }
+
+    public void stream(LlmConfigVO config, List<LlmChatMessage> messages, String modelOverride,
+                       Consumer<String> tokenConsumer) {
         validate(config);
-        Map<String, Object> requestBody = requestBody(config, prompt, modelOverride, true);
+        Map<String, Object> requestBody = requestBody(config, messages, modelOverride, true);
         HttpRequest request = request(config, "text/event-stream", requestBody);
         try {
             HttpResponse<java.io.InputStream> response = httpClient.send(
@@ -208,17 +217,38 @@ public class OpenAiCompatibleLlmClient {
         return builder.build();
     }
 
-    private Map<String, Object> requestBody(LlmConfigVO config, String prompt, String modelOverride,
+    private Map<String, Object> requestBody(LlmConfigVO config, List<LlmChatMessage> messages, String modelOverride,
                                             boolean stream) {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", StringUtils.hasText(modelOverride) ? modelOverride.trim() : config.getModel().trim());
-        body.put("messages", List.of(Map.of(
-                "role", "user",
-                "content", StringUtils.hasText(prompt) ? prompt.trim() : "")));
+        body.put("messages", normalizeMessages(messages));
         body.put("temperature", config.getTemperature());
         body.put("max_tokens", config.getMaxTokens());
         body.put("stream", stream);
         return body;
+    }
+
+    private List<Map<String, String>> normalizeMessages(List<LlmChatMessage> messages) {
+        List<LlmChatMessage> normalizedMessages = messages == null || messages.isEmpty()
+                ? List.of(LlmChatMessage.user(""))
+                : messages;
+        return normalizedMessages.stream()
+                .map(message -> Map.of(
+                        "role", normalizeRole(message),
+                        "content", normalizeMessage(message == null ? null : message.content())))
+                .toList();
+    }
+
+    private String normalizeRole(LlmChatMessage message) {
+        if (message == null || !StringUtils.hasText(message.role())) {
+            return "user";
+        }
+        String role = message.role().trim();
+        return "assistant".equals(role) ? "assistant" : "user";
+    }
+
+    private String normalizeMessage(String message) {
+        return StringUtils.hasText(message) ? message.trim() : "";
     }
 
     private URI chatCompletionsUri(LlmConfigVO config) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
@@ -27,6 +27,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -40,6 +41,7 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
     private final LlmConfigService configService;
     private final OpenAiCompatibleLlmClient llmClient;
     private final ObjectMapper objectMapper;
+    private final LlmConversationMemory conversationMemory;
     private final ExecutorService executor = Executors.newCachedThreadPool();
 
     @Override
@@ -52,8 +54,11 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
             return errorEmitter(unsupportedProviderException());
         }
 
+        String conversationId = request == null ? null : request.getConversationId();
+        String message = request == null ? null : request.getMessage();
+        List<LlmChatMessage> messages = conversationMemory.appendUserAndSnapshot(conversationId, message);
         SseEmitter emitter = new SseEmitter(60_000L);
-        executor.execute(() -> streamChat(request, config, emitter));
+        executor.execute(() -> streamChat(request, config, emitter, messages));
         return emitter;
     }
 
@@ -72,11 +77,17 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
         executor.shutdownNow();
     }
 
-    private void streamChat(ChatDTO request, LlmConfigVO config, SseEmitter emitter) {
+    private void streamChat(ChatDTO request, LlmConfigVO config, SseEmitter emitter, List<LlmChatMessage> messages) {
+        String conversationId = request == null ? null : request.getConversationId();
+        StringBuilder assistantMessage = new StringBuilder();
         try {
-            llmClient.stream(config, request == null ? null : request.getMessage(),
+            llmClient.stream(config, messages,
                     request == null ? null : request.getModel(),
-                    token -> sendMessage(emitter, token));
+                    token -> {
+                        assistantMessage.append(token);
+                        sendMessage(emitter, token);
+                    });
+            conversationMemory.appendAssistant(conversationId, assistantMessage.toString());
             emitter.send(SseEmitter.event().name("done").data("[DONE]"));
             emitter.complete();
         } catch (LlmGatewayException exception) {
@@ -85,7 +96,8 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
         } catch (Exception exception) {
             log.error("Failed to stream LLM chat response", exception);
             sendError(emitter, new LlmGatewayException(502, "llm.gateway_error",
-                    "Failed to stream LLM chat response", "Check the LLM provider configuration and retry.", exception));
+                    "Failed to stream LLM chat response",
+                    "Check the LLM provider configuration and retry.", exception));
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConversationMemoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConversationMemoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmConversationMemoryTest {
+
+    @Test
+    void appendUserAndSnapshotShouldIncludePreviousTurnsForConversation() {
+        LlmConversationMemory memory = new LlmConversationMemory();
+
+        List<LlmChatMessage> first = memory.appendUserAndSnapshot(" conv-1 ", " first question ");
+        memory.appendAssistant("conv-1", " first answer ");
+        List<LlmChatMessage> second = memory.appendUserAndSnapshot("conv-1", "follow up");
+
+        assertThat(first).extracting(LlmChatMessage::role).containsExactly("user");
+        assertThat(first).extracting(LlmChatMessage::content).containsExactly("first question");
+        assertThat(second).extracting(LlmChatMessage::role)
+                .containsExactly("user", "assistant", "user");
+        assertThat(second).extracting(LlmChatMessage::content)
+                .containsExactly("first question", "first answer", "follow up");
+    }
+
+    @Test
+    void blankConversationIdShouldRemainSingleTurn() {
+        LlmConversationMemory memory = new LlmConversationMemory();
+
+        List<LlmChatMessage> first = memory.appendUserAndSnapshot("", "first");
+        memory.appendAssistant("", "answer");
+        List<LlmChatMessage> second = memory.appendUserAndSnapshot("", "second");
+
+        assertThat(first).extracting(LlmChatMessage::content).containsExactly("first");
+        assertThat(second).extracting(LlmChatMessage::content).containsExactly("second");
+    }
+
+    @Test
+    void conversationHistoryShouldBeBounded() {
+        LlmConversationMemory memory = new LlmConversationMemory();
+
+        for (int i = 0; i < 10; i++) {
+            memory.appendUserAndSnapshot("conv-1", "question-" + i);
+            memory.appendAssistant("conv-1", "answer-" + i);
+        }
+        List<LlmChatMessage> snapshot = memory.appendUserAndSnapshot("conv-1", "latest");
+
+        assertThat(snapshot).hasSize(12);
+        assertThat(snapshot.get(0).content()).isEqualTo("answer-4");
+        assertThat(snapshot.get(11).content()).isEqualTo("latest");
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
@@ -137,6 +137,36 @@ class OpenAiCompatibleLlmClientTest {
     }
 
     @Test
+    void streamShouldSendConversationMessages() {
+        AtomicReference<JsonNode> requestBody = new AtomicReference<>();
+        server.createContext("/v1/chat/completions", exchange -> {
+            requestBody.set(objectMapper.readTree(exchange.getRequestBody()));
+            respond(exchange, 200, """
+                    data: {"choices":[{"delta":{"content":"ok"}}]}
+
+                    data: [DONE]
+
+                    """, "text/event-stream");
+        });
+
+        List<String> tokens = new ArrayList<>();
+        client.stream(config("openai", "sk-test"), List.of(
+                LlmChatMessage.user("first question"),
+                LlmChatMessage.assistant("first answer"),
+                LlmChatMessage.user("follow up")), null, tokens::add);
+
+        JsonNode messages = requestBody.get().path("messages");
+        assertThat(tokens).containsExactly("ok");
+        assertThat(messages).hasSize(3);
+        assertThat(messages.path(0).path("role").asText()).isEqualTo("user");
+        assertThat(messages.path(0).path("content").asText()).isEqualTo("first question");
+        assertThat(messages.path(1).path("role").asText()).isEqualTo("assistant");
+        assertThat(messages.path(1).path("content").asText()).isEqualTo("first answer");
+        assertThat(messages.path(2).path("role").asText()).isEqualTo("user");
+        assertThat(messages.path(2).path("content").asText()).isEqualTo("follow up");
+    }
+
+    @Test
     void ollamaShouldAllowMissingApiKeyAndOmitAuthorizationHeader() {
         AtomicReference<String> authorization = new AtomicReference<>();
         server.createContext("/v1/chat/completions", exchange -> {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGatewayTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGatewayTest.java
@@ -37,7 +37,7 @@ class OpenAiCompatibleLlmGatewayTest {
     private final LlmConfigService configService = mock(LlmConfigService.class);
     private final OpenAiCompatibleLlmClient llmClient = mock(OpenAiCompatibleLlmClient.class);
     private final OpenAiCompatibleLlmGateway gateway = new OpenAiCompatibleLlmGateway(
-            configService, llmClient, new ObjectMapper());
+            configService, llmClient, new ObjectMapper(), new LlmConversationMemory());
 
     @Test
     void chatShouldRejectIncompleteConfigWithoutCallingProvider() {


### PR DESCRIPTION
## Track

Track 3 / AI Native - LLM integration

## What changed
- Add bounded in-memory conversation memory keyed by `conversationId`.
- Send recent user/assistant turns to the OpenAI-compatible chat completions payload.
- Keep blank `conversationId` behavior as single-turn chat.
- Add tests for memory behavior and multi-message provider payloads.

## Why
The frontend and backend already expose `conversationId`, but the gateway ignored it and sent only the current user message. Follow-up questions in the same visible AI chat lost context.

Fixes #815

## Verification
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=OpenAiCompatibleLlmClientTest,OpenAiCompatibleLlmGatewayTest,LlmConversationMemoryTest test