### PR TITLE
[ISSUE #817] Preserve home AI mode in chat

### DIFF
--- a/web/src/pages/ai/chatDraft.test.ts
+++ b/web/src/pages/ai/chatDraft.test.ts
@@ -19,10 +19,13 @@ import { describe, expect, it } from 'vitest';
 import { getChatDraft } from './chatDraft';
 
 describe('AI chat draft navigation state', () => {
-  it('normalizes a prompt and preserves a selected model', () => {
-    expect(getChatDraft({ prompt: '  检查集群状态  ', model: '  qwen3.7-max  ' })).toEqual({
+  it('normalizes a prompt and preserves selected model and mode', () => {
+    expect(
+      getChatDraft({ prompt: '  检查集群状态  ', model: '  qwen3.7-max  ', mode: ' diagnose ' }),
+    ).toEqual({
       prompt: '检查集群状态',
       model: 'qwen3.7-max',
+      mode: 'diagnose',
     });
   });
 
@@ -34,6 +37,12 @@ describe('AI chat draft navigation state', () => {
 
   it('drops empty model values after normalization', () => {
     expect(getChatDraft({ prompt: '检查集群状态', model: '   ' })).toEqual({
+      prompt: '检查集群状态',
+    });
+  });
+
+  it('drops unsupported mode values after normalization', () => {
+    expect(getChatDraft({ prompt: '检查集群状态', mode: 'unknown' })).toEqual({
       prompt: '检查集群状态',
     });
   });

--- a/web/src/pages/ai/chatDraft.ts
+++ b/web/src/pages/ai/chatDraft.ts
@@ -18,16 +18,21 @@
 export interface ChatDraft {
   prompt: string;
   model?: string;
+  mode?: string;
 }
+
+const SUPPORTED_MODES = new Set(['query', 'diagnose', 'manage', 'chat']);
 
 export function getChatDraft(state: unknown): ChatDraft | null {
   if (typeof state !== 'object' || state === null) return null;
   const candidate = state as Record<string, unknown>;
   if (typeof candidate.prompt !== 'string' || !candidate.prompt.trim()) return null;
   const model = typeof candidate.model === 'string' ? candidate.model.trim() : '';
+  const mode = typeof candidate.mode === 'string' ? candidate.mode.trim() : '';
 
   return {
     prompt: candidate.prompt.trim(),
     ...(model ? { model } : {}),
+    ...(SUPPORTED_MODES.has(mode) ? { mode } : {}),
   };
 }

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -314,6 +314,7 @@ const AiPage = () => {
   const [modelOptions, setModelOptions] = useState<{ value: string; label: string }[]>([]);
   const [modelsLoading, setModelsLoading] = useState(false);
   const [selectedModel, setSelectedModel] = useState('');
+  const [chatMode, setChatMode] = useState('chat');
   const [toolModalOpen, setToolModalOpen] = useState(false);
   const [tools, setTools] = useState<McpTool[]>([]);
   const [toolsLoading, setToolsLoading] = useState(false);
@@ -385,6 +386,9 @@ const AiPage = () => {
             : [{ value: draftModel, label: draftModel }, ...options],
         );
       }
+      if (draft.mode) {
+        setChatMode(draft.mode);
+      }
       navigate('/ai', { replace: true, state: null });
       textareaRef.current?.focus();
     });
@@ -440,7 +444,7 @@ const AiPage = () => {
       await chatStream(
         {
           message: text,
-          mode: 'chat',
+          mode: chatMode,
           model: selectedModel,
           conversationId: conversationIdRef.current,
         },
@@ -473,7 +477,7 @@ const AiPage = () => {
       if (abortControllerRef.current === controller) abortControllerRef.current = null;
       setLoading(false);
     }
-  }, [inputValue, llmReady, loading, selectedModel]);
+  }, [chatMode, inputValue, llmReady, loading, selectedModel]);
 
   const handleStop = useCallback(() => {
     abortControllerRef.current?.abort();

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -83,19 +83,23 @@ const HomePage = () => {
       if (cancelled) return;
 
       const configuredModel = config?.model?.trim() ?? '';
-      const providerModels = modelsResult?.status === 0 && modelsResult.data
-        ? modelsResult.data.map((item) => item.id || item.name || '').filter(Boolean)
-        : [];
-      const values = Array.from(new Set([
-        ...(configuredModel ? [configuredModel] : []),
-        ...providerModels,
-      ]));
+      const providerModels =
+        modelsResult?.status === 0 && modelsResult.data
+          ? modelsResult.data.map((item) => item.id || item.name || '').filter(Boolean)
+          : [];
+      const values = Array.from(
+        new Set([...(configuredModel ? [configuredModel] : []), ...providerModels]),
+      );
 
-      setModelOptions(values.map((value, index) => ({
-        value,
-        recommended: configuredModel ? value === configuredModel : index === 0,
-      })));
-      setSelectedModel((current) => (current && values.includes(current) ? current : values[0] || ''));
+      setModelOptions(
+        values.map((value, index) => ({
+          value,
+          recommended: configuredModel ? value === configuredModel : index === 0,
+        })),
+      );
+      setSelectedModel((current) =>
+        current && values.includes(current) ? current : values[0] || '',
+      );
     };
 
     void loadModels();
@@ -156,7 +160,11 @@ const HomePage = () => {
 
   const handlePromptSubmit = () => {
     const prompt = inputValue.trim();
-    navigate('/ai', { state: prompt ? { prompt, ...(selectedModel ? { model: selectedModel } : {}) } : null });
+    navigate('/ai', {
+      state: prompt
+        ? { prompt, mode: activeMode, ...(selectedModel ? { model: selectedModel } : {}) }
+        : null,
+    });
   };
 
   return (


### PR DESCRIPTION
## Track

Track 3 / AI Native - LLM integration

## What changed
- Pass the selected home AI mode through `/ai` navigation state.
- Normalize supported draft modes in `getChatDraft`.
- Send the preserved mode in `chatStream` instead of hard-coding `chat`.
- Add draft parser tests for valid and unsupported modes.

## Why
The home page exposes query/diagnose/manage/chat modes, but the selected mode was only UI state. Prompts opened from the home page always reached the backend as `mode: chat`.

Fixes #817

## Verification
- npm ci
- npm test -- --run src/pages/ai/chatDraft.test.ts
- npm run build