### PR TITLE
[ISSUE #819] Redact user password in toString

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/User.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/User.java
@@ -76,7 +76,7 @@ public class User {
         return "User{" +
                 "id=" + id +
                 ", name='" + name + '\'' +
-                ", password='" + password + '\'' +
+                ", password='******'" +
                 ", type=" + type +
                 '}';
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/model/UserTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/UserTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    @Test
+    void toStringShouldNotExposePassword() {
+        User user = new User("admin", "plain-secret", User.SUPER);
+
+        String value = user.toString();
+
+        assertThat(value).contains("name='admin'");
+        assertThat(value).contains("password='******'");
+        assertThat(value).doesNotContain("plain-secret");
+    }
+}


### PR DESCRIPTION
## What is changed
- Redact the password field in User.toString() so logs/debug output cannot expose plaintext credentials.
- Add a regression test to keep the toString output from leaking the original password.

## Why
- Fixes #819.

## Verification
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=UserTest test