### PR TITLE
[ISSUE #823] Redact login password in toString

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/LoginDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/LoginDTOTest.java
@@ -14,15 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.rocketmq.studio.auth;
 
-import lombok.Data;
-import lombok.ToString;
+import org.junit.jupiter.api.Test;
 
-@Data
-public class LoginDTO {
-    private String username;
-    @ToString.Exclude
-    private String password;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoginDTOTest {
+
+    @Test
+    void toStringShouldNotExposePassword() {
+        LoginDTO request = new LoginDTO();
+        request.setUsername("admin");
+        request.setPassword("plain-secret");
+
+        String value = request.toString();
+
+        assertThat(value).contains("username=admin");
+        assertThat(value).doesNotContain("plain-secret");
+    }
 }


### PR DESCRIPTION
## What is changed
- Exclude the login password field from Lombok-generated toString output.
- Add a regression test that verifies the plaintext login password is not present in DTO diagnostics.

## Why
- Fixes #823.

## Verification
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=LoginDTOTest test