### PR TITLE
[ISSUE #825] Redact login token in toString

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/LoginVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/LoginVOTest.java
@@ -14,31 +14,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.rocketmq.studio.auth;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import org.junit.jupiter.api.Test;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class LoginVO {
-    @ToString.Exclude
-    private String token;
-    private int expiresIn;
-    private UserInfo user;
+import static org.assertj.core.api.Assertions.assertThat;
 
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class UserInfo {
-        private String username;
-        private boolean admin;
+class LoginVOTest {
+
+    @Test
+    void toStringShouldNotExposeToken() {
+        LoginVO response = LoginVO.builder()
+            .token("studio-jwt-secret")
+            .expiresIn(3600)
+            .user(LoginVO.UserInfo.builder()
+                .username("admin")
+                .admin(true)
+                .build())
+            .build();
+
+        String value = response.toString();
+
+        assertThat(value).contains("expiresIn=3600");
+        assertThat(value).contains("username=admin");
+        assertThat(value).doesNotContain("studio-jwt-secret");
     }
 }


### PR DESCRIPTION
## What is changed
- Exclude the issued login token from Lombok-generated toString output.
- Add a regression test that verifies the token is not present while non-sensitive fields remain available.

## Why
- Fixes #825.

## Verification
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=LoginVOTest test