### PR TITLE
[ISSUE #831] Validate proxy address format

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
@@ -25,10 +25,17 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service
 public class ProxyAddressService {
+
+    private static final Pattern PROXY_ADDR_PATTERN =
+            Pattern.compile("^(\\[[0-9a-fA-F:.]+]|[A-Za-z0-9._-]+):(\\d{1,5})$");
+    private static final int MIN_PORT = 1;
+    private static final int MAX_PORT = 65535;
 
     private final Set<String> proxyAddrs = new LinkedHashSet<>(List.of("127.0.0.1:8081"));
     private String currentProxyAddr = "127.0.0.1:8081";
@@ -64,6 +71,15 @@ public class ProxyAddressService {
         if (proxyAddr == null || proxyAddr.trim().isEmpty()) {
             throw new BusinessException(400, fieldName + " is required");
         }
-        return proxyAddr.trim();
+        String normalized = proxyAddr.trim();
+        Matcher matcher = PROXY_ADDR_PATTERN.matcher(normalized);
+        if (!matcher.matches()) {
+            throw new BusinessException(400, fieldName + " must be in host:port or [ipv6]:port format");
+        }
+        int port = Integer.parseInt(matcher.group(2));
+        if (port < MIN_PORT || port > MAX_PORT) {
+            throw new BusinessException(400, fieldName + " port must be between 1 and 65535");
+        }
+        return normalized;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
@@ -20,6 +20,8 @@ package org.apache.rocketmq.studio.cluster.proxy;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -51,6 +53,33 @@ class ProxyAddressServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("newProxyAddr is required")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+    }
+
+    @Test
+    void addProxyAddrShouldAcceptBracketedIpv6Address() {
+        proxyAddressService.addProxyAddr(" [::1]:8081 ");
+
+        ProxyHomeVO home = proxyAddressService.getHomePage();
+        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081", "[::1]:8081");
+    }
+
+    @Test
+    void addProxyAddrShouldRejectInvalidAddressFormats() {
+        List<String> invalidProxyAddrs = List.of(
+                "10.0.0.1",
+                "10.0.0.1:abc",
+                "10.0.0.1:0",
+                "10.0.0.1:65536",
+                "http://10.0.0.1:8081",
+                "10.0.0.1:8081/path"
+        );
+
+        for (String invalidProxyAddr : invalidProxyAddrs) {
+            assertThatThrownBy(() -> proxyAddressService.addProxyAddr(invalidProxyAddr))
+                    .as("invalid proxy address %s", invalidProxyAddr)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        }
     }
 
     @Test


### PR DESCRIPTION
### Summary
- Validate Proxy addresses on the backend before storing them
- Accept host:port and bracketed IPv6 address formats
- Reject missing ports, non-numeric ports, out-of-range ports, schemes, and paths

### Tests
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=ProxyAddressServiceTest test

Closes #831