### PR TITLE
[ISSUE #833] Validate AI request bodies

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.ai;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -41,12 +42,18 @@ public class AiController {
     private final AiService aiService;
 
     @PostMapping(value = "/chat", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter chat(@RequestBody ChatDTO request) {
+    public SseEmitter chat(@RequestBody(required = false) ChatDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "chat request is required");
+        }
         return aiService.chat(request);
     }
 
     @PostMapping("/execute")
-    public Result<AiExecuteResultVO> execute(@RequestBody AiCommandDTO command) {
+    public Result<AiExecuteResultVO> execute(@RequestBody(required = false) AiCommandDTO command) {
+        if (command == null) {
+            throw new BusinessException(400, "AI command request is required");
+        }
         return Result.ok(aiService.execute(command));
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiService.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.ops.ai;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -34,12 +35,18 @@ public class AiService {
 
 
     public SseEmitter chat(ChatDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "chat request is required");
+        }
         log.info("Chat request received: mode={}, conversationId={}", request.getMode(), request.getConversationId());
         return llmGateway.chat(request);
     }
 
 
     public AiExecuteResultVO execute(AiCommandDTO command) {
+        if (command == null) {
+            throw new BusinessException(400, "AI command request is required");
+        }
         log.info("Executing AI command: {}", command.getCommand());
         try {
             String result = llmGateway.execute(command);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiControllerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import org.apache.rocketmq.studio.common.exception.GlobalExceptionHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -26,7 +27,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -45,7 +48,9 @@ class AiControllerTest {
     @BeforeEach
     void setUp() {
         aiService = mock(AiService.class);
-        mockMvc = MockMvcBuilders.standaloneSetup(new AiController(aiService)).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(new AiController(aiService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
 
         when(aiService.catalogVersion()).thenReturn("1.0.0");
         when(aiService.catalogDigest()).thenReturn(DIGEST);
@@ -124,5 +129,27 @@ class AiControllerTest {
                 .andExpect(jsonPath("$.data").isArray());
 
         verify(aiService).executeTool("rmq.cluster.list", Collections.emptyMap());
+    }
+
+    @Test
+    void chatShouldRejectMissingRequestBody() throws Exception {
+        mockMvc.perform(post("/api/ai/chat")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("chat request is required"));
+
+        verify(aiService, never()).chat(any());
+    }
+
+    @Test
+    void executeShouldRejectMissingRequestBody() throws Exception {
+        mockMvc.perform(post("/api/ai/execute")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("AI command request is required"));
+
+        verify(aiService, never()).execute(any());
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -30,7 +31,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -78,6 +81,16 @@ class AiServiceTest {
     }
 
     @Test
+    void chatShouldRejectNullRequest() {
+        assertThatThrownBy(() -> aiService.chat(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("chat request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(llmGateway, never()).chat(any());
+    }
+
+    @Test
     void executeShouldReturnSuccessResult() {
         AiCommandDTO command = AiCommandDTO.builder()
                 .command("list_topics")
@@ -107,6 +120,16 @@ class AiServiceTest {
 
         assertThat(result.isSuccess()).isFalse();
         assertThat(result.getResult()).contains("Error: Permission denied");
+    }
+
+    @Test
+    void executeShouldRejectNullRequest() {
+        assertThatThrownBy(() -> aiService.execute(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("AI command request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(llmGateway, never()).execute(any());
     }
 
     @Test


### PR DESCRIPTION
## Track

Track 3 / AI Native - LLM integration

### Summary
- Reject missing AI chat and execute request bodies with explicit 400 responses
- Add service-level guards so internal calls cannot reach the LLM gateway with null requests
- Keep AI tool execution behavior unchanged for absent bodies

### Tests
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=AiServiceTest,AiControllerTest test

Closes #833