### PR TITLE
[ISSUE #835] Make audit ordering null-safe

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/InMemoryAuditRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/InMemoryAuditRepository.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -46,12 +47,11 @@ public class InMemoryAuditRepository implements AuditRepository {
                 .filter(r -> startDate == null || r.getTimestamp() != null && !r.getTimestamp().isBefore(startDate))
                 .filter(r -> endDate == null || r.getTimestamp() != null && !r.getTimestamp().isAfter(endDate))
                 .filter(r -> result == null || result.isEmpty() || result.equals(r.getResult()))
-                .sorted((a, b) -> {
-                    if (a.getTimestamp() == null || b.getTimestamp() == null) {
-                        return 0;
-                    }
-                    return b.getTimestamp().compareTo(a.getTimestamp());
-                })
+                .sorted(Comparator
+                        .comparing(AuditRecordVO::getTimestamp,
+                                Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(AuditRecordVO::getId,
+                                Comparator.nullsLast(Comparator.naturalOrder())))
                 .collect(Collectors.toList());
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/InMemoryAuditRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/InMemoryAuditRepositoryTest.java
@@ -69,6 +69,33 @@ class InMemoryAuditRepositoryTest {
                 .containsExactly("record-blank-search");
     }
 
+    @Test
+    void findAllShouldOrderTimestampedRecordsBeforeMissingTimestamps() {
+        AuditRecordVO noTimestamp = AuditRecordVO.builder()
+                .operationType("CREATE")
+                .result("SUCCESS")
+                .build();
+        noTimestamp.setId("record-no-timestamp");
+        AuditRecordVO newest = AuditRecordVO.builder()
+                .timestamp(LocalDateTime.of(2026, 8, 1, 10, 0))
+                .operationType("UPDATE")
+                .result("SUCCESS")
+                .build();
+        newest.setId("record-newest");
+        AuditRecordVO older = AuditRecordVO.builder()
+                .timestamp(LocalDateTime.of(2026, 8, 1, 9, 0))
+                .operationType("DELETE")
+                .result("SUCCESS")
+                .build();
+        older.setId("record-older");
+
+        putRecords(noTimestamp, older, newest);
+
+        assertThat(repository.findAll(null, null, null, null, null))
+                .extracting(AuditRecordVO::getId)
+                .containsExactly("record-newest", "record-older", "record-no-timestamp");
+    }
+
     @SafeVarargs
     @SuppressWarnings("unchecked")
     private final void putRecords(AuditRecordVO... records) {


### PR DESCRIPTION
### Summary
- Sort audit records by timestamp descending with null timestamps last
- Add an id tie-breaker so in-memory ordering is deterministic
- Add repository coverage for mixed timestamp and missing timestamp records

### Tests
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=InMemoryAuditRepositoryTest test

Closes #835