### PR TITLE
[ISSUE #844] Validate null datasource requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.settings;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -52,13 +53,13 @@ public class SettingsController {
     }
 
     @PostMapping("/datasources/create")
-    public Result<DataSourceVO> createDataSource(@Valid @RequestBody DataSourceVO dataSource) {
-        return Result.ok(settingsService.createDataSource(dataSource));
+    public Result<DataSourceVO> createDataSource(@Valid @RequestBody(required = false) DataSourceVO dataSource) {
+        return Result.ok(settingsService.createDataSource(requireDataSource(dataSource)));
     }
 
     @PostMapping("/datasources/update")
-    public Result<DataSourceVO> updateDataSource(@Valid @RequestBody DataSourceVO dataSource) {
-        return Result.ok(settingsService.updateDataSource(dataSource));
+    public Result<DataSourceVO> updateDataSource(@Valid @RequestBody(required = false) DataSourceVO dataSource) {
+        return Result.ok(settingsService.updateDataSource(requireDataSource(dataSource)));
     }
 
     @PostMapping("/datasources/delete")
@@ -70,5 +71,12 @@ public class SettingsController {
     @PostMapping("/datasources/test")
     public Result<DataSourceTestResultVO> testDataSource(@Valid @RequestBody DataSourceTestDTO request) {
         return Result.ok(settingsService.testDataSource(request));
+    }
+
+    private DataSourceVO requireDataSource(DataSourceVO dataSource) {
+        if (dataSource == null) {
+            throw new BusinessException(400, "Data source request is required");
+        }
+        return dataSource;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -99,6 +99,9 @@ public class SettingsService {
 
 
     public DataSourceVO createDataSource(DataSourceVO dataSource) {
+        if (dataSource == null) {
+            throw new BusinessException(400, "Data source request is required");
+        }
         log.info("Creating data source: {}", dataSource.getName());
         dataSource.setKey(UUID.randomUUID().toString());
         return settingsRepository.saveDataSource(dataSource);
@@ -106,6 +109,9 @@ public class SettingsService {
 
 
     public DataSourceVO updateDataSource(DataSourceVO dataSource) {
+        if (dataSource == null) {
+            throw new BusinessException(400, "Data source request is required");
+        }
         String key = normalizeDataSourceKey(dataSource.getKey());
         dataSource.setKey(key);
         log.info("Updating data source: {}", key);

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
@@ -223,6 +223,18 @@ class SettingsControllerTest {
     }
 
     @Test
+    void createDataSourceShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/settings/datasources/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", is(400)))
+                .andExpect(jsonPath("$.message", is("Data source request is required")));
+
+        verifyNoInteractions(settingsService);
+    }
+
+    @Test
     void updateDataSourceShouldReturnUpdatedSource() throws Exception {
         DataSourceVO input = DataSourceVO.builder().key("ds-1").name("Updated DS").type("rocketmq")
                 .url("updated:9876").build();
@@ -251,6 +263,18 @@ class SettingsControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code", is(400)))
                 .andExpect(jsonPath("$.message", is("name is required")));
+
+        verifyNoInteractions(settingsService);
+    }
+
+    @Test
+    void updateDataSourceShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/settings/datasources/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", is(400)))
+                .andExpect(jsonPath("$.message", is("Data source request is required")));
 
         verifyNoInteractions(settingsService);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -42,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -215,6 +216,17 @@ class SettingsServiceTest {
     }
 
     @Test
+    void createDataSourceShouldRejectNullRequest() {
+        assertThatThrownBy(() -> settingsService.createDataSource(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Data source request is required")
+                .extracting("code")
+                .isEqualTo(400);
+
+        verifyNoInteractions(settingsRepository);
+    }
+
+    @Test
     void updateDataSourceShouldDelegateToRepository() {
         DataSourceVO input = DataSourceVO.builder().key("ds-1").name("Updated DS").type("rocketmq")
                 .url("updated-host:9876").build();
@@ -225,6 +237,17 @@ class SettingsServiceTest {
         assertThat(result.getKey()).isEqualTo("ds-1");
         assertThat(result.getName()).isEqualTo("Updated DS");
         verify(settingsRepository).replaceDataSource(input);
+    }
+
+    @Test
+    void updateDataSourceShouldRejectNullRequest() {
+        assertThatThrownBy(() -> settingsService.updateDataSource(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Data source request is required")
+                .extracting("code")
+                .isEqualTo(400);
+
+        verifyNoInteractions(settingsRepository);
     }
 
     @Test


### PR DESCRIPTION
### Summary
- Reject null data source create/update request bodies before invoking the service
- Add service-level null guards to avoid internal NPEs on direct calls
- Cover controller and service null-request paths with tests

### Tests
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=SettingsControllerTest,SettingsServiceTest test

Closes #844