### PR TITLE
[ISSUE #846] Validate null alert rule requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,13 +41,13 @@ public class AlertRuleController {
     }
 
     @PostMapping("/create")
-    public Result<AlertRuleVO> createRule(@RequestBody AlertRuleVO rule) {
-        return Result.ok(alertService.createRule(rule));
+    public Result<AlertRuleVO> createRule(@RequestBody(required = false) AlertRuleVO rule) {
+        return Result.ok(alertService.createRule(requireAlertRule(rule)));
     }
 
     @PostMapping("/update")
-    public Result<AlertRuleVO> updateRule(@RequestBody AlertRuleVO rule) {
-        return Result.ok(alertService.updateRule(rule));
+    public Result<AlertRuleVO> updateRule(@RequestBody(required = false) AlertRuleVO rule) {
+        return Result.ok(alertService.updateRule(requireAlertRule(rule)));
     }
 
     @PostMapping("/toggle")
@@ -58,5 +59,12 @@ public class AlertRuleController {
     public Result<Void> deleteRule(@Valid @RequestBody DeleteAlertRuleDTO request) {
         alertService.deleteRule(request.getId());
         return Result.ok();
+    }
+
+    private AlertRuleVO requireAlertRule(AlertRuleVO rule) {
+        if (rule == null) {
+            throw new BusinessException(400, "Alert rule request is required");
+        }
+        return rule;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -67,6 +67,9 @@ public class AlertService {
 
 
     public AlertRuleVO createRule(AlertRuleVO rule) {
+        if (rule == null) {
+            throw new BusinessException(400, "Alert rule request is required");
+        }
         log.info("Creating alert rule: {}", rule.getName());
         rule.setId(UUID.randomUUID().toString());
         return alertRepository.saveRule(rule);
@@ -74,7 +77,10 @@ public class AlertService {
 
 
     public AlertRuleVO updateRule(AlertRuleVO rule) {
-        String id = rule == null ? null : rule.getId();
+        if (rule == null) {
+            throw new BusinessException(400, "Alert rule request is required");
+        }
+        String id = rule.getId();
         log.info("Updating alert rule: {}", id);
         validateRuleId(id);
         if (!alertRepository.replaceRule(rule)) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleControllerTest.java
@@ -92,6 +92,30 @@ class AlertRuleControllerTest {
     }
 
     @Test
+    void createRuleShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/alert-rules/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Alert rule request is required"));
+
+        verifyNoInteractions(alertService);
+    }
+
+    @Test
+    void updateRuleShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/alert-rules/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Alert rule request is required"));
+
+        verifyNoInteractions(alertService);
+    }
+
+    @Test
     void toggleRuleShouldPassValidatedRequest() throws Exception {
         AlertRuleVO toggled = AlertRuleVO.builder()
                 .id("rule-1")

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -248,6 +248,16 @@ class AlertServiceTest {
     }
 
     @Test
+    void createRuleShouldRejectNullRequest() {
+        assertThatThrownBy(() -> alertService.createRule(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(alertRepository, never()).saveRule(any());
+    }
+
+    @Test
     void updateRuleShouldUpdateExistingRule() {
         AlertRuleVO update = AlertRuleVO.builder().id("rule-1").name("CPU Alert").threshold(90.0).build();
         when(alertRepository.replaceRule(update)).thenReturn(true);
@@ -257,6 +267,16 @@ class AlertServiceTest {
         assertThat(result.getId()).isEqualTo("rule-1");
         assertThat(result.getThreshold()).isEqualTo(90.0);
         verify(alertRepository).replaceRule(update);
+    }
+
+    @Test
+    void updateRuleShouldRejectNullRequest() {
+        assertThatThrownBy(() -> alertService.updateRule(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(alertRepository, never()).replaceRule(any());
     }
 
     @Test


### PR DESCRIPTION
### Summary
- Reject null alert rule create/update request bodies before invoking the service
- Add service-level null guards to avoid internal NPEs on direct calls
- Cover controller and service null-request paths with tests

### Tests
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=AlertRuleControllerTest,AlertServiceTest test

Closes #846