### PR TITLE
[ISSUE #848] Validate null instance requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.instance;
 
 import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,12 +46,14 @@ public class InstanceController {
     }
 
     @PostMapping("/create")
-    public Result<InstanceVO> createInstance(@RequestBody InstanceVO instance) {
+    public Result<InstanceVO> createInstance(@RequestBody(required = false) InstanceVO instance) {
+        requireInstance(instance);
         return Result.ok(instanceService.createInstance(instance));
     }
 
     @PostMapping("/update")
-    public Result<InstanceVO> updateInstance(@RequestBody InstanceVO instance) {
+    public Result<InstanceVO> updateInstance(@RequestBody(required = false) InstanceVO instance) {
+        requireInstance(instance);
         return Result.ok(instanceService.updateInstance(instance));
     }
 
@@ -58,5 +61,11 @@ public class InstanceController {
     public Result<Void> deleteInstance(@Valid @RequestBody InstanceDeleteRequestDTO request) {
         instanceService.deleteInstance(request.getId());
         return Result.ok();
+    }
+
+    private void requireInstance(InstanceVO instance) {
+        if (instance == null) {
+            throw new BusinessException(400, "Instance request is required");
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -49,6 +49,7 @@ public class InstanceService {
     }
 
     public InstanceVO createInstance(InstanceVO instance) {
+        requireInstance(instance);
         log.info("Creating instance: {}", instance.getName());
 
         if (instance.getName() == null || instance.getName().isBlank()) {
@@ -65,6 +66,7 @@ public class InstanceService {
     }
 
     public InstanceVO updateInstance(InstanceVO instance) {
+        requireInstance(instance);
         log.info("Updating instance: {}", instance.getId());
 
         if (instance.getId() == null || instance.getId().isBlank()) {
@@ -109,6 +111,12 @@ public class InstanceService {
         instanceRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(404, "InstanceVO not found: " + id));
         instanceRepository.deleteById(id);
+    }
+
+    private void requireInstance(InstanceVO instance) {
+        if (instance == null) {
+            throw new BusinessException(400, "Instance request is required");
+        }
     }
 
     private InstanceVO copyOf(InstanceVO instance) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
@@ -134,6 +134,18 @@ class InstanceControllerTest {
     }
 
     @Test
+    void createInstanceShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/instances/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Instance request is required"));
+
+        verifyNoInteractions(instanceService);
+    }
+
+    @Test
     void updateInstanceShouldReturnUpdatedInstance() throws Exception {
         InstanceVO update = InstanceVO.builder()
                 .name("updated-name")
@@ -158,6 +170,18 @@ class InstanceControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.id").value("inst-1"))
                 .andExpect(jsonPath("$.data.name").value("updated-name"));
+    }
+
+    @Test
+    void updateInstanceShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/instances/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Instance request is required"));
+
+        verifyNoInteractions(instanceService);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -133,6 +134,16 @@ class InstanceServiceTest {
 
         assertThat(result).hasSize(1);
         verify(instanceRepository).findAll();
+    }
+
+    @Test
+    void createInstanceShouldThrowWhenRequestIsNull() {
+        assertThatThrownBy(() -> instanceService.createInstance(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Instance request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verifyNoInteractions(instanceRepository);
     }
 
     @Test
@@ -285,6 +296,16 @@ class InstanceServiceTest {
         assertThat(stored.getId()).isEqualTo("inst-1");
         assertThat(stored.getCreatedAt()).isEqualTo(originalCreatedAt);
         assertThat(stored.getUpdatedAt()).isEqualTo(originalUpdatedAt);
+    }
+
+    @Test
+    void updateInstanceShouldThrowWhenRequestIsNull() {
+        assertThatThrownBy(() -> instanceService.updateInstance(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Instance request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verifyNoInteractions(instanceRepository);
     }
 
     @Test


### PR DESCRIPTION
### Summary
- Reject null instance create/update request bodies before invoking the service
- Add service-level null guards to avoid internal NPEs on direct calls
- Cover controller and service null-request paths with tests

### Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=InstanceControllerTest,InstanceServiceTest test`

Closes #848
