### PR TITLE
[ISSUE #850] Validate null nameserver requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -207,6 +207,7 @@ public class ClusterService {
     }
 
     public NameServerVO createNameServer(CreateNameServerDTO command) {
+        requireNameServerCommand(command);
         log.info("Creating NameServer for cluster: {}", command.getClusterId());
         clusterRepository.findById(command.getClusterId())
                 .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
@@ -219,6 +220,7 @@ public class ClusterService {
     }
 
     public void updateNameServer(UpdateNameServerDTO command) {
+        requireNameServerCommand(command);
         log.info("Updating NameServer: {} in cluster: {}", command.getAddr(), command.getClusterId());
         ClusterVO cluster = clusterRepository.findById(command.getClusterId())
                 .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
@@ -227,6 +229,7 @@ public class ClusterService {
     }
 
     public boolean restartNameServer(RestartNameServerDTO command) {
+        requireNameServerCommand(command);
         log.info("Restarting NameServer: {} in cluster: {}", command.getAddr(), command.getClusterId());
         ClusterVO cluster = clusterRepository.findById(command.getClusterId())
                 .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
@@ -236,6 +239,7 @@ public class ClusterService {
     }
 
     public boolean upgradeNameServer(UpgradeNameServerDTO command) {
+        requireNameServerCommand(command);
         log.info("Upgrading NameServer: {} to version: {} in cluster: {}",
                 command.getAddr(), command.getTargetVersion(), command.getClusterId());
         ClusterVO cluster = clusterRepository.findById(command.getClusterId())
@@ -246,6 +250,7 @@ public class ClusterService {
     }
 
     public boolean deleteNameServer(DeleteNameServerDTO command) {
+        requireNameServerCommand(command);
         log.info("Deleting NameServer: {} from cluster: {}", command.getAddr(), command.getClusterId());
         ClusterVO cluster = clusterRepository.findById(command.getClusterId())
                 .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getClusterId()));
@@ -261,6 +266,12 @@ public class ClusterService {
         requireProxy(cluster, command.getAddr());
         log.info("Proxy restart initiated: {}", command.getAddr());
         return true;
+    }
+
+    private void requireNameServerCommand(Object command) {
+        if (command == null) {
+            throw new BusinessException(400, "NameServer request is required");
+        }
     }
 
     private void requireNameServer(ClusterVO cluster, String addr) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerController.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.nameserver;
 import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,31 +37,45 @@ public class NameServerController {
     private final ClusterService clusterService;
 
     @PostMapping("/create")
-    public Result<NameServerVO> createNameServer(@Valid @RequestBody CreateNameServerDTO command) {
+    public Result<NameServerVO> createNameServer(@Valid @RequestBody(required = false) CreateNameServerDTO command) {
+        requireCommand(command);
         return Result.ok(clusterService.createNameServer(command));
     }
 
     @PostMapping("/update")
-    public Result<Void> updateNameServer(@Valid @RequestBody UpdateNameServerDTO command) {
+    public Result<Void> updateNameServer(@Valid @RequestBody(required = false) UpdateNameServerDTO command) {
+        requireCommand(command);
         clusterService.updateNameServer(command);
         return Result.ok();
     }
 
     @PostMapping("/restart")
-    public Result<Map<String, Boolean>> restartNameServer(@Valid @RequestBody RestartNameServerDTO command) {
+    public Result<Map<String, Boolean>> restartNameServer(
+            @Valid @RequestBody(required = false) RestartNameServerDTO command) {
+        requireCommand(command);
         boolean success = clusterService.restartNameServer(command);
         return Result.ok(Map.of("success", success));
     }
 
     @PostMapping("/upgrade")
-    public Result<Map<String, Boolean>> upgradeNameServer(@Valid @RequestBody UpgradeNameServerDTO command) {
+    public Result<Map<String, Boolean>> upgradeNameServer(
+            @Valid @RequestBody(required = false) UpgradeNameServerDTO command) {
+        requireCommand(command);
         boolean success = clusterService.upgradeNameServer(command);
         return Result.ok(Map.of("success", success));
     }
 
     @PostMapping("/delete")
-    public Result<Map<String, Boolean>> deleteNameServer(@Valid @RequestBody DeleteNameServerDTO command) {
+    public Result<Map<String, Boolean>> deleteNameServer(
+            @Valid @RequestBody(required = false) DeleteNameServerDTO command) {
+        requireCommand(command);
         boolean success = clusterService.deleteNameServer(command);
         return Result.ok(Map.of("success", success));
+    }
+
+    private void requireCommand(Object command) {
+        if (command == null) {
+            throw new BusinessException(400, "NameServer request is required");
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.broker;
 
 import org.apache.rocketmq.studio.cluster.config.ClusterConfigVO;
 import org.apache.rocketmq.studio.cluster.config.UpdateConfigDTO;
+import org.apache.rocketmq.studio.cluster.nameserver.CreateNameServerDTO;
 import org.apache.rocketmq.studio.cluster.nameserver.DeleteNameServerDTO;
 import org.apache.rocketmq.studio.cluster.nameserver.NameServerVO;
 import org.apache.rocketmq.studio.cluster.nameserver.RestartNameServerDTO;
@@ -50,6 +51,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -372,6 +374,32 @@ class ClusterServiceTest {
         assertThat(clusterService.restartNameServer(restart)).isTrue();
         assertThat(clusterService.upgradeNameServer(upgrade)).isTrue();
         assertThat(clusterService.deleteNameServer(delete)).isTrue();
+    }
+
+    @Test
+    void nameServerOperationsShouldRejectNullCommand() {
+        assertThatThrownBy(() -> clusterService.createNameServer((CreateNameServerDTO) null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("NameServer request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        assertThatThrownBy(() -> clusterService.updateNameServer(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("NameServer request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        assertThatThrownBy(() -> clusterService.restartNameServer(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("NameServer request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        assertThatThrownBy(() -> clusterService.upgradeNameServer(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("NameServer request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        assertThatThrownBy(() -> clusterService.deleteNameServer(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("NameServer request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verifyNoInteractions(clusterRepository);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerControllerTest.java
@@ -72,6 +72,28 @@ class NameServerControllerTest {
     }
 
     @Test
+    void nameServerWriteEndpointsShouldRejectNullRequestBody() throws Exception {
+        String[] paths = {
+            "/api/nameservers/create",
+            "/api/nameservers/update",
+            "/api/nameservers/restart",
+            "/api/nameservers/upgrade",
+            "/api/nameservers/delete"
+        };
+
+        for (String path : paths) {
+            mockMvc.perform(post(path)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("null"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(400))
+                    .andExpect(jsonPath("$.message").value("NameServer request is required"));
+        }
+
+        verifyNoInteractions(clusterService);
+    }
+
+    @Test
     void updateNameServerShouldRejectBlankAddr() throws Exception {
         UpdateNameServerDTO request = UpdateNameServerDTO.builder()
                 .clusterId("cluster-1")


### PR DESCRIPTION
### Summary
- Reject null NameServer write request bodies at the controller boundary
- Add service-level null guards before reading command fields
- Cover all NameServer write endpoints and direct service null-command calls

### Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=NameServerControllerTest,ClusterServiceTest test`

Closes #850
