### PR TITLE
[ISSUE #852] Validate null K8s certificate requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.cluster.k8s;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,23 +41,33 @@ public class K8sCertController {
     }
 
     @PostMapping("/create")
-    public Result<K8sCertVO> createCert(@Valid @RequestBody CreateCertDTO command) {
+    public Result<K8sCertVO> createCert(@Valid @RequestBody(required = false) CreateCertDTO command) {
+        requireCommand(command);
         return Result.ok(k8sCertService.createCert(command));
     }
 
     @PostMapping("/update")
-    public Result<K8sCertVO> updateCert(@Valid @RequestBody UpdateCertDTO command) {
+    public Result<K8sCertVO> updateCert(@Valid @RequestBody(required = false) UpdateCertDTO command) {
+        requireCommand(command);
         return Result.ok(k8sCertService.updateCert(command));
     }
 
     @PostMapping("/renew")
-    public Result<K8sCertVO> renewCert(@Valid @RequestBody RenewCertDTO command) {
+    public Result<K8sCertVO> renewCert(@Valid @RequestBody(required = false) RenewCertDTO command) {
+        requireCommand(command);
         return Result.ok(k8sCertService.renewCert(command));
     }
 
     @PostMapping("/delete")
-    public Result<Void> deleteCert(@Valid @RequestBody DeleteCertDTO command) {
+    public Result<Void> deleteCert(@Valid @RequestBody(required = false) DeleteCertDTO command) {
+        requireCommand(command);
         k8sCertService.deleteCert(command);
         return Result.ok();
+    }
+
+    private void requireCommand(Object command) {
+        if (command == null) {
+            throw new BusinessException(400, "K8s certificate request is required");
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
@@ -59,6 +59,7 @@ public class K8sCertService {
     }
 
     public K8sCertVO createCert(CreateCertDTO command) {
+        requireCommand(command);
         log.info("Creating K8s certificate: {}", command.getName());
 
         LocalDateTime now = LocalDateTime.now(clock);
@@ -86,6 +87,7 @@ public class K8sCertService {
     }
 
     public K8sCertVO updateCert(UpdateCertDTO command) {
+        requireCommand(command);
         log.info("Updating K8s certificate: {}", command.getId());
         K8sCertVO existing = k8sCertRepository.findById(command.getId())
                 .orElseThrow(() -> new BusinessException(404, "Certificate not found: " + command.getId()));
@@ -118,6 +120,7 @@ public class K8sCertService {
     }
 
     public K8sCertVO renewCert(RenewCertDTO command) {
+        requireCommand(command);
         log.info("Renewing K8s certificate: {}", command.getId());
         K8sCertVO existing = k8sCertRepository.findById(command.getId())
                 .orElseThrow(() -> new BusinessException(404, "Certificate not found: " + command.getId()));
@@ -138,11 +141,18 @@ public class K8sCertService {
     }
 
     public void deleteCert(DeleteCertDTO command) {
+        requireCommand(command);
         log.info("Deleting K8s certificate: {}", command.getId());
         k8sCertRepository.findById(command.getId())
                 .orElseThrow(() -> new BusinessException(404, "Certificate not found: " + command.getId()));
         k8sCertRepository.deleteById(command.getId());
         log.info("K8s certificate deleted: {}", command.getId());
+    }
+
+    private void requireCommand(Object command) {
+        if (command == null) {
+            throw new BusinessException(400, "K8s certificate request is required");
+        }
     }
 
     private K8sCertVO refreshExpirationState(K8sCertVO cert, LocalDateTime now) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
@@ -140,6 +140,27 @@ class K8sCertControllerTest {
     }
 
     @Test
+    void certWriteEndpointsShouldRejectNullRequestBody() throws Exception {
+        String[] paths = {
+            "/api/k8s-certs/create",
+            "/api/k8s-certs/update",
+            "/api/k8s-certs/renew",
+            "/api/k8s-certs/delete"
+        };
+
+        for (String path : paths) {
+            mockMvc.perform(post(path)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("null"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(400))
+                    .andExpect(jsonPath("$.message").value("K8s certificate request is required"));
+        }
+
+        verifyNoInteractions(k8sCertService);
+    }
+
+    @Test
     void createCertShouldRejectMissingName() throws Exception {
         mockMvc.perform(post("/api/k8s-certs/create")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -168,6 +169,28 @@ class K8sCertServiceTest {
         assertThat(result.getCreatedAt()).isEqualTo(now);
         assertThat(result.getUpdatedAt()).isEqualTo(now);
         verify(k8sCertRepository).save(any(K8sCertVO.class));
+    }
+
+    @Test
+    void certWriteOperationsShouldRejectNullCommand() {
+        assertThatThrownBy(() -> k8sCertService.createCert(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("K8s certificate request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        assertThatThrownBy(() -> k8sCertService.updateCert(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("K8s certificate request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        assertThatThrownBy(() -> k8sCertService.renewCert(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("K8s certificate request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        assertThatThrownBy(() -> k8sCertService.deleteCert(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("K8s certificate request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verifyNoInteractions(k8sCertRepository);
     }
 
     @Test


### PR DESCRIPTION
### Summary
- Reject null K8s certificate write request bodies at the controller boundary
- Add service-level null guards before reading command fields
- Cover all K8s certificate write endpoints and direct service null-command calls

### Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=K8sCertControllerTest,K8sCertServiceTest test`

Closes #852
