### PR TITLE
[ISSUE #854] Validate null DLQ resend requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.instance.dlq;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,9 +42,16 @@ public class DLQController {
     }
 
     @PostMapping("/resend")
-    public Result<Void> resendMessages(@Valid @RequestBody DLQResendRequestDTO request) {
+    public Result<Void> resendMessages(@Valid @RequestBody(required = false) DLQResendRequestDTO request) {
+        requireRequest(request);
         dlqService.resendMessages(
                 request.getGroupName(), request.getStartTime(), request.getEndTime(), request.getTargetTopic());
         return Result.ok();
+    }
+
+    private void requireRequest(DLQResendRequestDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "DLQ resend request is required");
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQControllerTest.java
@@ -125,6 +125,18 @@ class DLQControllerTest {
     }
 
     @Test
+    void resendMessagesShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/dlq/resend")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("DLQ resend request is required"));
+
+        verifyNoInteractions(dlqService);
+    }
+
+    @Test
     void resendMessagesShouldRejectMissingGroupName() throws Exception {
         Map<String, Object> body = Map.of(
                 "startTime", 1000,


### PR DESCRIPTION
### Summary
- Reject null DLQ resend request bodies before dereferencing request fields
- Keep malformed and missing-field validation behavior unchanged
- Cover the null request path with a controller test

### Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=DLQControllerTest test`

Closes #854
