### PR TITLE
[ISSUE #856] Validate null system alert acknowledge requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,7 +44,9 @@ public class SystemAlertController {
     }
 
     @PostMapping("/acknowledge")
-    public Result<SystemAlertVO> acknowledgeAlert(@Valid @RequestBody AcknowledgeSystemAlertDTO request) {
+    public Result<SystemAlertVO> acknowledgeAlert(
+            @Valid @RequestBody(required = false) AcknowledgeSystemAlertDTO request) {
+        requireAcknowledgeRequest(request);
         return Result.ok(alertService.acknowledgeAlert(request.getId()));
     }
 
@@ -51,5 +54,11 @@ public class SystemAlertController {
     public Result<Map<String, Integer>> clearAcknowledged() {
         int cleared = alertService.clearAcknowledged();
         return Result.ok(Map.of("cleared", cleared));
+    }
+
+    private void requireAcknowledgeRequest(AcknowledgeSystemAlertDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "System alert acknowledge request is required");
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
@@ -92,6 +92,18 @@ class SystemAlertControllerTest {
     }
 
     @Test
+    void acknowledgeAlertShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/system-alerts/acknowledge")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("System alert acknowledge request is required"));
+
+        verifyNoInteractions(alertService);
+    }
+
+    @Test
     void acknowledgeAlertShouldRejectBlankId() throws Exception {
         mockMvc.perform(post("/api/system-alerts/acknowledge")
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
### Summary
- Reject null system alert acknowledge request bodies before dereferencing request fields
- Keep existing id validation behavior unchanged
- Cover the null request path with a controller test

### Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=SystemAlertControllerTest test`

Closes #856
