### PR TITLE
[ISSUE #858] Validate null topic requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.instance.topic;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
 import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
@@ -46,11 +47,13 @@ public class MetadataService {
 
 
     public TopicVO createTopic(TopicVO topic) {
+        requireTopic(topic);
         return adminClient.createTopic(topic);
     }
 
 
     public TopicVO updateTopic(TopicVO topic) {
+        requireTopic(topic);
         return adminClient.updateTopic(topic);
     }
 
@@ -71,6 +74,7 @@ public class MetadataService {
 
 
     public SendMessageVO sendMessage(SendMessageDTO request) {
+        requireSendMessageRequest(request);
         return adminClient.sendMessage(request);
     }
 
@@ -120,5 +124,17 @@ public class MetadataService {
 
     private String normalizeFilter(String value) {
         return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private void requireTopic(TopicVO topic) {
+        if (topic == null) {
+            throw new BusinessException(400, "Topic request is required");
+        }
+    }
+
+    private void requireSendMessageRequest(SendMessageDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "Topic send message request is required");
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/TopicController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/TopicController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.instance.topic;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,17 +46,20 @@ public class TopicController {
     }
 
     @PostMapping("/create")
-    public Result<TopicVO> createTopic(@RequestBody TopicVO topic) {
+    public Result<TopicVO> createTopic(@RequestBody(required = false) TopicVO topic) {
+        requireTopicRequest(topic);
         return Result.ok(metadataService.createTopic(topic));
     }
 
     @PostMapping("/update")
-    public Result<TopicVO> updateTopic(@RequestBody TopicVO topic) {
+    public Result<TopicVO> updateTopic(@RequestBody(required = false) TopicVO topic) {
+        requireTopicRequest(topic);
         return Result.ok(metadataService.updateTopic(topic));
     }
 
     @PostMapping("/delete")
-    public Result<Void> deleteTopic(@Valid @RequestBody DeleteTopicDTO request) {
+    public Result<Void> deleteTopic(@Valid @RequestBody(required = false) DeleteTopicDTO request) {
+        requireDeleteTopicRequest(request);
         metadataService.deleteTopic(request.getName());
         return Result.ok();
     }
@@ -71,7 +75,26 @@ public class TopicController {
     }
 
     @PostMapping("/send")
-    public Result<SendMessageVO> sendMessage(@RequestBody SendMessageDTO request) {
+    public Result<SendMessageVO> sendMessage(@RequestBody(required = false) SendMessageDTO request) {
+        requireSendMessageRequest(request);
         return Result.ok(metadataService.sendMessage(request));
+    }
+
+    private void requireTopicRequest(TopicVO topic) {
+        if (topic == null) {
+            throw new BusinessException(400, "Topic request is required");
+        }
+    }
+
+    private void requireDeleteTopicRequest(DeleteTopicDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "Topic delete request is required");
+        }
+    }
+
+    private void requireSendMessageRequest(SendMessageDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "Topic send message request is required");
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.studio.instance.topic;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,8 +28,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -88,6 +91,24 @@ class MetadataServiceTest {
 
         assertThat(result).isEmpty();
         verify(metadataProvider).listTopics(null, null, null);
+    }
+
+    @Test
+    void topicWriteOperationsShouldRejectNullRequest() {
+        assertThatThrownBy(() -> metadataService.createTopic(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Topic request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        assertThatThrownBy(() -> metadataService.updateTopic(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Topic request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        assertThatThrownBy(() -> metadataService.sendMessage(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Topic send message request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verifyNoInteractions(adminClient);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/TopicControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/TopicControllerTest.java
@@ -109,6 +109,39 @@ class TopicControllerTest {
     }
 
     @Test
+    void topicWriteEndpointsShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/topics/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Topic request is required"));
+
+        mockMvc.perform(post("/api/topics/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Topic request is required"));
+
+        mockMvc.perform(post("/api/topics/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Topic delete request is required"));
+
+        mockMvc.perform(post("/api/topics/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Topic send message request is required"));
+
+        verifyNoInteractions(metadataService);
+    }
+
+    @Test
     void sendMessageShouldReturnResult() throws Exception {
         SendMessageDTO request = SendMessageDTO.builder()
                 .topic("test-topic")


### PR DESCRIPTION
### Summary
- Reject null topic create/update/delete/send request bodies at the controller boundary
- Add metadata service null guards before forwarding topic create/update/send commands to the admin client
- Cover controller and service null-request paths with tests

### Tests
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=TopicControllerTest,MetadataServiceTest test`

Closes #858
