### PR TITLE
[ISSUE #860] Validate null cluster config requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterController.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.broker;
 import org.apache.rocketmq.studio.cluster.config.UpdateConfigDTO;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,7 +56,8 @@ public class ClusterController {
     }
 
     @PostMapping("/config/update")
-    public Result<ClusterVO> updateClusterConfig(@Valid @RequestBody UpdateConfigDTO command) {
+    public Result<ClusterVO> updateClusterConfig(@Valid @RequestBody(required = false) UpdateConfigDTO command) {
+        requireUpdateConfigCommand(command);
         return Result.ok(clusterService.updateClusterConfig(command));
     }
 
@@ -67,5 +69,11 @@ public class ClusterController {
                 "success", success,
                 "message", "Broker restart initiated for " + name
         ));
+    }
+
+    private void requireUpdateConfigCommand(UpdateConfigDTO command) {
+        if (command == null) {
+            throw new BusinessException(400, "Cluster config update request is required");
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterControllerTest.java
@@ -188,6 +188,18 @@ class ClusterControllerTest {
     }
 
     @Test
+    void updateConfigShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/clusters/config/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Cluster config update request is required"));
+
+        verifyNoInteractions(clusterService);
+    }
+
+    @Test
     void updateConfigShouldRejectMissingId() throws Exception {
         UpdateConfigDTO command = UpdateConfigDTO.builder()
                 .flushDiskType("SYNC_FLUSH")


### PR DESCRIPTION
### Summary

- reject JSON `null` bodies for the cluster config update API at the controller boundary
- keep existing field validation behavior unchanged
- add WebMvc coverage to ensure null requests return 400 without invoking the service layer

### Tests

- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=ClusterControllerTest test`

Closes #860