### PR TITLE
fix(web): keep LLM connection test read-only

### DIFF
--- a/web/src/pages/studio/LlmSettings.tsx
+++ b/web/src/pages/studio/LlmSettings.tsx
@@ -387,31 +387,17 @@ const LlmSettingsPage: React.FC = () => {
   };
 
   const handleTestConnection = () => {
-    const requestProviderGeneration = providerInteractionGeneration.current;
     setTestLoading(true);
     setTestResult(null);
     form
       .validateFields()
       .then((values) => {
-        const testConfig = buildConfig(values, true);
+        const testConfig = buildConfig(values, enabled);
         testLlmConnection(testConfig)
           .then((result) => {
             if (result && result.status === 0) {
               setTestResult({ success: true, msg: result.msg || t('llm.testSuccessMsg') });
               message.success(t('llm.testSuccess'));
-              // Auto-save after successful test
-              saveLlmConfig(testConfig)
-                .then(() => {
-                  if (testConfig.apiKey) {
-                    setSavedApiKey(MASKED_API_KEY);
-                    form.setFieldsValue({ apiKey: MASKED_API_KEY });
-                    setApiKeyMasked(true);
-                  }
-                  fetchModels(testConfig.provider, testConfig.model, requestProviderGeneration);
-                })
-                .catch(() => {
-                  // auto-save failure is non-critical
-                });
             } else {
               setTestResult(buildLlmFailureResult(result, t('llm.testFailedMsg')));
               message.error(t('llm.testFailed'));

--- a/web/src/pages/studio/__tests__/LlmSettingsAsyncState.test.tsx
+++ b/web/src/pages/studio/__tests__/LlmSettingsAsyncState.test.tsx
@@ -174,7 +174,7 @@ describe('LlmSettingsPage async request ownership', () => {
     await act(async () => {
       oldProviderTest.resolve({ status: 0 });
     });
-    await waitFor(() => expect(apiMocks.saveLlmConfig).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(apiMocks.testLlmConnection).toHaveBeenCalledTimes(1));
 
     await user.click(screen.getByRole('combobox'));
     expect(
@@ -188,6 +188,25 @@ describe('LlmSettingsPage async request ownership', () => {
       }),
     ).toBeInTheDocument();
     expect(apiMocks.getLlmModels).toHaveBeenCalledTimes(1);
+    expect(apiMocks.saveLlmConfig).not.toHaveBeenCalled();
+  });
+
+  it('tests the current LLM config without saving it or forcing it enabled', async () => {
+    apiMocks.getLlmConfig.mockResolvedValue({
+      ...OPENAI_CONFIG,
+      enabled: false,
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(apiMocks.getLlmConfig).toHaveBeenCalled());
+    await user.click(screen.getByRole('button', { name: '连接测试' }));
+
+    await waitFor(() => expect(apiMocks.testLlmConnection).toHaveBeenCalledTimes(1));
+    expect(apiMocks.testLlmConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+    expect(apiMocks.saveLlmConfig).not.toHaveBeenCalled();
   });
 
   it('ignores configuration from the discarded StrictMode lifecycle', async () => {


### PR DESCRIPTION
## Track

Track 3 / AI Native - LLM integration

### Summary

- keep the LLM connection test as a read-only probe
- stop auto-saving the tested config after a successful test
- preserve the current enabled state instead of forcing test payloads enabled
- add regression coverage for disabled configs and stale provider requests

### Related Issue

Fixes #863

### Tests

- `npm test -- --run src/pages/studio/__tests__/LlmSettingsAsyncState.test.tsx`
- `npm run lint -- src/pages/studio/LlmSettings.tsx src/pages/studio/__tests__/LlmSettingsAsyncState.test.tsx` (passes with existing fast-refresh warnings)