### PR TITLE
fix(web): show topic test message send failures

### DIFF
--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -18,7 +18,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { App } from 'antd';
+import { App, message } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
 import type { Topic } from '../../../api/metadata';
 import TopicPage from '../topic';
@@ -143,5 +143,29 @@ describe('TopicPage', () => {
     expect(screen.queryByText('topic-03')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /删除 \(1\)$/ })).toBeInTheDocument();
     expect(screen.getByText('已删除 2 个 Topic，1 个删除失败')).toBeInTheDocument();
+  });
+
+  it('shows an error when sending a test message fails', async () => {
+    const user = userEvent.setup();
+    const errorSpy = vi.spyOn(message, 'error').mockImplementation(vi.fn());
+    topicServiceMocks.listTopics.mockResolvedValue(buildTopics(1));
+    topicServiceMocks.sendTopicMessage.mockRejectedValue(new Error('send failed'));
+
+    renderWithProviders();
+
+    expect(await screen.findByText('topic-01')).toBeInTheDocument();
+    const row = within(getTableBody()).getByText('topic-01').closest('tr');
+    expect(row).not.toBeNull();
+    await user.click(within(row as HTMLElement).getByRole('button', { name: /发送/ }));
+    const dialogTitle = await screen.findByText('发送消息到 topic-01');
+    const dialog = dialogTitle.closest('[role="dialog"]') as HTMLElement;
+    expect(dialog).not.toBeNull();
+    await user.type(within(dialog).getByLabelText('消息体 Body'), 'test message');
+    await user.click(within(dialog).getByRole('button', { name: /^发\s*送$/ }));
+
+    await waitFor(() => expect(topicServiceMocks.sendTopicMessage).toHaveBeenCalledTimes(1));
+    expect(errorSpy).toHaveBeenCalledWith('发送测试消息失败，请稍后重试');
+    expect(dialogTitle).toBeInTheDocument();
+    errorSpy.mockRestore();
   });
 });

--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -148,6 +148,7 @@ describe('TopicPage', () => {
   it('shows an error when sending a test message fails', async () => {
     const user = userEvent.setup();
     const errorSpy = vi.spyOn(message, 'error').mockImplementation(vi.fn());
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
     topicServiceMocks.listTopics.mockResolvedValue(buildTopics(1));
     topicServiceMocks.sendTopicMessage.mockRejectedValue(new Error('send failed'));
 
@@ -165,7 +166,12 @@ describe('TopicPage', () => {
 
     await waitFor(() => expect(topicServiceMocks.sendTopicMessage).toHaveBeenCalledTimes(1));
     expect(errorSpy).toHaveBeenCalledWith('发送测试消息失败，请稍后重试');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Test message send failed', {
+      topic: 'topic-01',
+      error: 'send failed',
+    });
     expect(dialogTitle).toBeInTheDocument();
     errorSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -211,6 +211,14 @@ const formatDateTime = (iso: string): string => {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 };
 
+type SendMessageFormValues = {
+  topic: string;
+  tag?: string;
+  key?: string;
+  body: string;
+  properties?: Array<{ key?: string; value?: string }>;
+};
+
 // ═══════════════════════════════════════════════════════════════════
 const TopicPage = () => {
   const { t } = useLang();
@@ -612,16 +620,19 @@ const TopicPage = () => {
 
   // ─── Send message modal submit ────────────────────────────────
   const handleSend = async () => {
+    let values: SendMessageFormValues;
     try {
-      const values = await sendForm.validateFields();
-      setSending(true);
-      // Build properties from the list
+      values = await sendForm.validateFields();
+    } catch {
+      return;
+    }
+
+    setSending(true);
+    try {
       const props: Record<string, string> = {};
-      if (values.properties && Array.isArray(values.properties)) {
-        values.properties.forEach((p: { key?: string; value?: string }) => {
-          if (p.key) props[p.key] = p.value || '';
-        });
-      }
+      values.properties?.forEach((p: { key?: string; value?: string }) => {
+        if (p.key) props[p.key] = p.value || '';
+      });
       const result = await sendTopicMessage({
         topic: values.topic,
         tag: values.tag || undefined,
@@ -633,7 +644,7 @@ const TopicPage = () => {
       setSendModalOpen(false);
       sendForm.resetFields();
     } catch {
-      // validation error, do nothing
+      message.error('发送测试消息失败，请稍后重试');
     } finally {
       setSending(false);
     }

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -643,7 +643,11 @@ const TopicPage = () => {
       message.success(`消息发送成功！MsgId: ${result.msgId}`);
       setSendModalOpen(false);
       sendForm.resetFields();
-    } catch {
+    } catch (error) {
+      console.error('Test message send failed', {
+        topic: values.topic,
+        error: error instanceof Error ? error.message : String(error),
+      });
       message.error('发送测试消息失败，请稍后重试');
     } finally {
       setSending(false);


### PR DESCRIPTION
### Summary

- separate Topic send-message form validation from the send API call
- keep validation failures local to the form
- show an explicit error when `sendTopicMessage(...)` rejects
- add regression coverage for failed test-message sends

### Related Issue

Fixes #865

### Tests

- `npm test -- --run src/pages/instance/__tests__/TopicPage.test.tsx`
- `npm run lint -- src/pages/instance/topic.tsx src/pages/instance/__tests__/TopicPage.test.tsx` (passes with existing fast-refresh warnings)