### PR TITLE
fix(server): validate consumer group create requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupController.java
@@ -70,8 +70,8 @@ public class ConsumerGroupController {
     }
 
     @PostMapping("/create")
-    public Result<ConsumerGroupVO> createConsumerGroup(@RequestBody ConsumerGroupVO group) {
-        return Result.ok(metadataService.createConsumerGroup(group));
+    public Result<ConsumerGroupVO> createConsumerGroup(@Valid @RequestBody CreateConsumerGroupDTO group) {
+        return Result.ok(metadataService.createConsumerGroup(group.toConsumerGroupVO()));
     }
 
     @PostMapping("/delete")

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/CreateConsumerGroupDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/CreateConsumerGroupDTO.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Data;
+import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
+import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
+
+@Data
+public class CreateConsumerGroupDTO {
+    @NotBlank(message = "name is required")
+    private String name;
+    private String namespace;
+    private String clusterId;
+    private SubscriptionMode subscriptionMode;
+    private ConsumeType consumeType;
+    private String subscriptionDataType;
+    private String deliveryOrderType;
+    @PositiveOrZero(message = "retryMaxTimes must be zero or positive")
+    private Integer retryMaxTimes;
+    @PositiveOrZero(message = "delaySeconds must be zero or positive")
+    private Integer delaySeconds;
+
+    public ConsumerGroupVO toConsumerGroupVO() {
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName(name);
+        group.setNamespace(namespace);
+        group.setClusterId(clusterId);
+        group.setSubscriptionMode(subscriptionMode);
+        group.setConsumeType(consumeType);
+        group.setSubscriptionDataType(subscriptionDataType);
+        group.setDeliveryOrderType(deliveryOrderType);
+        if (retryMaxTimes != null) {
+            group.setRetryMaxTimes(retryMaxTimes);
+        }
+        if (delaySeconds != null) {
+            group.setDelaySeconds(delaySeconds);
+        }
+        return group;
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupControllerTest.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.studio.instance.group;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.instance.topic.MetadataService;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -31,6 +32,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -55,6 +58,70 @@ class ConsumerGroupControllerTest {
 
     @MockBean
     private ConsumerDiagnosticsService consumerDiagnosticsService;
+
+    @Test
+    void createConsumerGroupShouldPassValidatedRequest() throws Exception {
+        Map<String, Object> body = Map.of(
+                "name", "cg-orders",
+                "clusterId", "cluster-a",
+                "retryMaxTimes", 8,
+                "delaySeconds", 0
+        );
+        ConsumerGroupVO created = new ConsumerGroupVO();
+        created.setName("cg-orders");
+        created.setClusterId("cluster-a");
+        created.setRetryMaxTimes(8);
+
+        when(metadataService.createConsumerGroup(any(ConsumerGroupVO.class))).thenReturn(created);
+
+        mockMvc.perform(post("/api/groups/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.name").value("cg-orders"))
+                .andExpect(jsonPath("$.data.retryMaxTimes").value(8));
+
+        ArgumentCaptor<ConsumerGroupVO> captor = ArgumentCaptor.forClass(ConsumerGroupVO.class);
+        verify(metadataService).createConsumerGroup(captor.capture());
+        assertThat(captor.getValue().getName()).isEqualTo("cg-orders");
+        assertThat(captor.getValue().getClusterId()).isEqualTo("cluster-a");
+        assertThat(captor.getValue().getRetryMaxTimes()).isEqualTo(8);
+    }
+
+    @Test
+    void createConsumerGroupShouldRejectMissingName() throws Exception {
+        Map<String, Object> body = Map.of(
+                "clusterId", "cluster-a",
+                "retryMaxTimes", 8
+        );
+
+        mockMvc.perform(post("/api/groups/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("name is required"));
+
+        verifyNoInteractions(metadataService);
+    }
+
+    @Test
+    void createConsumerGroupShouldRejectNegativeRetryMaxTimes() throws Exception {
+        Map<String, Object> body = Map.of(
+                "name", "cg-orders",
+                "retryMaxTimes", -1
+        );
+
+        mockMvc.perform(post("/api/groups/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("retryMaxTimes must be zero or positive"));
+
+        verifyNoInteractions(metadataService);
+    }
 
     @Test
     void getConsumerStackShouldReturnStackTrace() throws Exception {


### PR DESCRIPTION
### Summary

- add a create-specific ConsumerGroup DTO with request validation
- reject blank group names and negative retry/delay values at the controller boundary
- keep the existing ConsumerGroupVO response model optional for list/detail responses
- add MockMvc regression coverage for valid and invalid create requests

### Related Issue

Fixes #867

### Tests

- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=ConsumerGroupControllerTest test`