### PR TITLE
fix(server): validate topic create requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/CreateTopicDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/CreateTopicDTO.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.topic;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Data;
+import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
+import org.apache.rocketmq.studio.common.domain.enums.TopicType;
+
+@Data
+public class CreateTopicDTO {
+    @NotBlank(message = "name is required")
+    private String name;
+    private String namespace;
+    private String clusterId;
+    private TopicType type;
+    @PositiveOrZero(message = "writeQueues must be zero or positive")
+    private Integer writeQueues;
+    @PositiveOrZero(message = "readQueues must be zero or positive")
+    private Integer readQueues;
+    private TopicPerm perm;
+    private String remark;
+
+    public TopicVO toTopicVO() {
+        TopicVO topic = new TopicVO();
+        topic.setName(name);
+        topic.setNamespace(namespace);
+        topic.setClusterId(clusterId);
+        topic.setType(type);
+        if (writeQueues != null) {
+            topic.setWriteQueues(writeQueues);
+        }
+        if (readQueues != null) {
+            topic.setReadQueues(readQueues);
+        }
+        topic.setPerm(perm);
+        topic.setRemark(remark);
+        return topic;
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/TopicController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/TopicController.java
@@ -45,8 +45,8 @@ public class TopicController {
     }
 
     @PostMapping("/create")
-    public Result<TopicVO> createTopic(@RequestBody TopicVO topic) {
-        return Result.ok(metadataService.createTopic(topic));
+    public Result<TopicVO> createTopic(@Valid @RequestBody CreateTopicDTO topic) {
+        return Result.ok(metadataService.createTopic(topic.toTopicVO()));
     }
 
     @PostMapping("/update")

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/TopicControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/TopicControllerTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.instance.topic;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -29,6 +30,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -106,6 +108,47 @@ class TopicControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.name").value("new-topic"))
                 .andExpect(jsonPath("$.data.writeQueues").value(16));
+
+        ArgumentCaptor<TopicVO> captor = ArgumentCaptor.forClass(TopicVO.class);
+        verify(metadataService).createTopic(captor.capture());
+        assertThat(captor.getValue().getName()).isEqualTo("new-topic");
+        assertThat(captor.getValue().getWriteQueues()).isEqualTo(16);
+        assertThat(captor.getValue().getReadQueues()).isEqualTo(16);
+    }
+
+    @Test
+    void createTopicShouldRejectMissingName() throws Exception {
+        mockMvc.perform(post("/api/topics/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "writeQueues": 8,
+                                  "readQueues": 8
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("name is required"));
+
+        verifyNoInteractions(metadataService);
+    }
+
+    @Test
+    void createTopicShouldRejectNegativeQueueCount() throws Exception {
+        mockMvc.perform(post("/api/topics/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "new-topic",
+                                  "writeQueues": -1,
+                                  "readQueues": 8
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("writeQueues must be zero or positive"));
+
+        verifyNoInteractions(metadataService);
     }
 
     @Test


### PR DESCRIPTION
### Summary

- add a create-specific Topic DTO with request validation
- reject blank topic names and negative queue counts before calling MetadataService
- keep TopicVO as the response/list model without forcing response-only fields
- add MockMvc regression coverage for valid and invalid create payloads

### Related Issue

Fixes #872

### Tests

- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=TopicControllerTest test`