### PR TITLE
fix(server): validate acl user create requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclController.java
@@ -64,8 +64,8 @@ public class AclController {
     }
 
     @PostMapping("/users/create")
-    public Result<AclUserVO> createUser(@RequestBody AclUserVO user) {
-        return Result.ok(aclService.createUser(user));
+    public Result<AclUserVO> createUser(@Valid @RequestBody CreateAclUserDTO user) {
+        return Result.ok(aclService.createUser(user.toAclUserVO()));
     }
 
     @PostMapping("/users/update")

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/CreateAclUserDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/CreateAclUserDTO.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.acl;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CreateAclUserDTO {
+    @NotBlank(message = "username is required")
+    private String username;
+    private boolean admin;
+    private List<String> clusters;
+
+    public AclUserVO toAclUserVO() {
+        AclUserVO user = new AclUserVO();
+        user.setUsername(username);
+        user.setAdmin(admin);
+        user.setClusters(clusters);
+        return user;
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.studio.instance.acl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -31,6 +32,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -221,11 +223,39 @@ class AclControllerTest {
 
         mockMvc.perform(post("/api/acl/users/create")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"username\":\"new-user\"}"))
+                        .content("""
+                                {
+                                  "username": "new-user",
+                                  "admin": true,
+                                  "clusters": ["cluster-a"]
+                                }
+                                """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.accessKey").value("access-key-123456"))
                 .andExpect(jsonPath("$.data.secretKey").value("secret-key-987654"));
+
+        ArgumentCaptor<AclUserVO> captor = ArgumentCaptor.forClass(AclUserVO.class);
+        verify(aclService).createUser(captor.capture());
+        assertThat(captor.getValue().getUsername()).isEqualTo("new-user");
+        assertThat(captor.getValue().isAdmin()).isTrue();
+        assertThat(captor.getValue().getClusters()).containsExactly("cluster-a");
+    }
+
+    @Test
+    void createUserShouldRejectMissingUsername() throws Exception {
+        mockMvc.perform(post("/api/acl/users/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "admin": false
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("username is required"));
+
+        verifyNoInteractions(aclService);
     }
 
     @Test


### PR DESCRIPTION
### Summary

- add a create-specific ACL user DTO with username validation
- reject missing/blank usernames before calling AclService
- keep AclUserVO as the response model for generated/masked credentials
- add MockMvc regression coverage for valid and invalid create-user payloads

### Related Issue

Fixes #874

### Tests

- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=AclControllerTest test`