### PR TITLE
fix(web): stop simulating SSL settings saves

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1057,6 +1057,10 @@ const translations: Record<string, Record<Lang, string>> = {
   'ssl.expiryDate': { zh: '过期日期', en: 'Expiry Date' },
   'ssl.active': { zh: '有效', en: 'Active' },
   'ssl.saveSuccess': { zh: 'SSL 配置保存成功', en: 'SSL configuration saved successfully' },
+  'ssl.saveUnavailable': {
+    zh: 'SSL 配置保存功能尚未接入真实后端接口',
+    en: 'SSL configuration persistence is not wired to a backend API yet',
+  },
   'ssl.invalidCertFormat': { zh: '仅允许证书文件！', en: 'Only certificate files are allowed!' },
   'ssl.certRemoved': { zh: '证书文件已移除', en: 'Certificate file removed' },
 

--- a/web/src/pages/studio/SslSettings.tsx
+++ b/web/src/pages/studio/SslSettings.tsx
@@ -66,8 +66,7 @@ interface FormValues {
 // ─── Component ──────────────────────────────────────────────────
 const SslSettingsPage = () => {
   const [form] = Form.useForm<FormValues>();
-  const [loading, setLoading] = useState(false);
-  const [sslConfig, setSslConfig] = useState<SslConfig>({
+  const [sslConfig] = useState<SslConfig>({
     enabled: false,
     protocol: 'TLSv1.3',
     keyStoreType: 'JKS',
@@ -85,13 +84,8 @@ const SslSettingsPage = () => {
   const { t } = useLang();
   const { message } = App.useApp();
 
-  const handleSave = (values: FormValues) => {
-    setLoading(true);
-    setTimeout(() => {
-      setLoading(false);
-      message.success(t('ssl.saveSuccess'));
-      setSslConfig({ ...sslConfig, ...values });
-    }, 1000);
+  const handleSave = () => {
+    message.error(t('ssl.saveUnavailable'));
   };
 
   const uploadProps = {
@@ -276,7 +270,7 @@ const SslSettingsPage = () => {
 
           <Form.Item>
             <Space>
-              <Button type="primary" htmlType="submit" loading={loading}>
+              <Button type="primary" htmlType="submit">
                 {t('ssl.save')}
               </Button>
               <Button onClick={() => form.setFieldsValue(sslConfig)}>{t('common.reset')}</Button>

--- a/web/src/pages/studio/__tests__/SslSettings.test.tsx
+++ b/web/src/pages/studio/__tests__/SslSettings.test.tsx
@@ -124,6 +124,26 @@ describe('SslSettings Page', () => {
     expect(screen.getByRole('button', { name: /重\s*置/ })).toBeInTheDocument();
   });
 
+  it('does not persist SSL changes when the backend API is unavailable', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SslSettings />);
+
+    const switchEl = screen.getByRole('switch');
+    await user.click(switchEl);
+    await user.type(screen.getByLabelText('KeyStore 路径'), '/etc/rocketmq/keystore.jks');
+    await user.type(screen.getByLabelText('KeyStore 密码'), 'changeit');
+
+    await user.click(screen.getByRole('button', { name: /保\s*存/ }));
+
+    expect(await screen.findByText('SSL 配置保存功能尚未接入真实后端接口')).toBeInTheDocument();
+    expect(screen.queryByText('SSL 配置保存成功')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /重\s*置/ }));
+
+    expect(switchEl).not.toBeChecked();
+    expect(screen.queryByText('KeyStore 配置')).not.toBeInTheDocument();
+  });
+
   it('should show TrustStore fields when client authentication is required', async () => {
     const user = userEvent.setup();
     renderWithProviders(<SslSettings />);


### PR DESCRIPTION
## Summary
- remove the fake setTimeout-based SSL settings save success path
- show an explicit unavailable message until a real backend SSL configuration API exists
- add a regression test that verifies SSL edits are not persisted locally after a failed save

Fixes #876

## Tests
- npm test -- --run src/pages/studio/__tests__/SslSettings.test.tsx
- npm run lint -- src/pages/studio/SslSettings.tsx src/pages/studio/__tests__/SslSettings.test.tsx src/i18n/translations.ts
- git diff --check

Note: lint reports only the existing react-refresh warnings in LangContext.tsx, main.tsx, and ThemeContext.tsx.