### PR TITLE
fix(server): normalize auth public paths

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
@@ -50,11 +50,25 @@ public class AuthInterceptor implements HandlerInterceptor {
     }
 
     private boolean isPublicPath(String path) {
+        path = normalizePath(path);
         return path.equals("/api/auth/login")
                 || path.equals("/api/auth/status")
                 || path.startsWith("/api-docs")
                 || path.startsWith("/swagger-ui")
                 || path.startsWith("/actuator/health");
+    }
+
+    private String normalizePath(String path) {
+        if (path == null || path.isBlank()) {
+            return "";
+        }
+        if (path.equals("/")) {
+            return path;
+        }
+        while (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path;
     }
 
     private String requestPath(HttpServletRequest request) {

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -90,11 +90,35 @@ class AuthInterceptorTest {
     }
 
     @Test
+    void shouldAllowLoginEndpointWithTrailingSlashWhenLoginIsEnabled() throws Exception {
+        AuthProperties properties = new AuthProperties();
+        properties.setLoginRequired(true);
+        AuthInterceptor interceptor = new AuthInterceptor(properties, new AuthService(properties));
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/auth/login/");
+
+        boolean allowed = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+        assertThat(allowed).isTrue();
+    }
+
+    @Test
     void shouldAllowAuthStatusEndpointWhenLoginIsEnabled() throws Exception {
         AuthProperties properties = new AuthProperties();
         properties.setLoginRequired(true);
         AuthInterceptor interceptor = new AuthInterceptor(properties, new AuthService(properties));
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/auth/status");
+
+        boolean allowed = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+        assertThat(allowed).isTrue();
+    }
+
+    @Test
+    void shouldAllowAuthStatusEndpointWithTrailingSlashWhenLoginIsEnabled() throws Exception {
+        AuthProperties properties = new AuthProperties();
+        properties.setLoginRequired(true);
+        AuthInterceptor interceptor = new AuthInterceptor(properties, new AuthService(properties));
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/auth/status/");
 
         boolean allowed = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
 


### PR DESCRIPTION
## Summary
- normalize trailing slashes before matching auth public endpoints
- keep the allow-list strict while allowing `/api/auth/login/` and `/api/auth/status/`
- add regression coverage for both trailing-slash public endpoints

Fixes #878

## Tests
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -Dtest=AuthInterceptorTest test
- git diff --check