### PR TITLE
[ISSUE #880] Stop fake consume verification success on message page

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -33,6 +33,19 @@ vi.mock('../../../services/messageService', () => messageServiceMocks);
 
 import MessagePage from '../message';
 
+const createMessage = (msgId: string) => ({
+  msgId,
+  topic: `topic-${msgId}`,
+  tag: 'tag',
+  key: `key-${msgId}`,
+  body: '{}',
+  storeTime: '2026-07-31T00:00:00Z',
+  bornHost: '127.0.0.1:1000',
+  storeHost: '127.0.0.1:10911',
+  properties: {},
+  size: 2,
+});
+
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -212,5 +225,23 @@ describe('Message page query history', () => {
     expect(await screen.findByText('Message ID: MID-VALID')).toBeInTheDocument();
     expect(screen.queryByText(/invalid/)).not.toBeInTheDocument();
     expect(screen.queryByText(/order-create/)).not.toBeInTheDocument();
+  });
+
+  it('does not report consume verification success without a backend API', async () => {
+    const user = userEvent.setup();
+    messageServiceMocks.queryMessages.mockResolvedValue([createMessage('MID-CONSUME-VERIFY-001')]);
+    renderWithProviders(<MessagePage />);
+
+    await user.click(screen.getByText('按 Message ID'));
+    await user.type(screen.getByPlaceholderText('输入 Message ID'), 'MID-CONSUME-VERIFY-001');
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+
+    expect(await screen.findByText('MID-CONSUME-VERIFY-001')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /验证/ }));
+
+    expect(
+      await screen.findByText('消费验证接口尚未接入，无法确认该消息的真实消费状态'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/消费验证成功/)).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -331,6 +331,10 @@ const MessagePage = () => {
     message.success('消息重新发送成功（模拟）');
   };
 
+  const handleVerifyConsume = () => {
+    message.warning('消费验证接口尚未接入，无法确认该消息的真实消费状态');
+  };
+
   const openDetail = async (record: MessageRecord, tab = 'content') => {
     const requestGeneration = traceGenerationRef.current + 1;
     traceGenerationRef.current = requestGeneration;
@@ -459,7 +463,7 @@ const MessagePage = () => {
             size="small"
             icon={<CheckCircleOutlined />}
             style={{ borderColor: '#52c41a', color: '#52c41a' }}
-            onClick={() => message.success(`消息 ${record.msgId.slice(0, 16)}... 消费验证成功`)}
+            onClick={handleVerifyConsume}
           >
             验证
           </Button>


### PR DESCRIPTION
## Summary

- replace the message list consume verification fake success toast with a clear unavailable warning
- add a regression test that clicks the Verify action and ensures no consume verification success is reported without a backend API

## Tests

- npm test -- --run src/pages/instance/__tests__/MessagePage.test.tsx
- npm run lint -- src/pages/instance/message.tsx src/pages/instance/__tests__/MessagePage.test.tsx
- git diff --check

Closes #880
