### PR TITLE
[ISSUE #882][ISSUE #884] Disable unavailable AI toolbar actions

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -154,6 +154,14 @@ body {
 .tool-btn:hover {
   background: #f3f4f6;
 }
+.tool-btn:disabled {
+  color: #9ca3af;
+  cursor: not-allowed;
+  opacity: 0.72;
+}
+.tool-btn:disabled:hover {
+  background: #f9fafb;
+}
 
 /* === Mode Toggle === */
 .mode-btn {

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -136,6 +136,12 @@ describe('AiPage tool runner', () => {
     expect(within(dialog).getByTestId('tool-result')).toHaveTextContent('"GRPC"');
   });
 
+  it('marks prompt enhancement unavailable until the feature is wired', () => {
+    renderPage();
+
+    expect(screen.getByRole('button', { name: /Prompt 增强/ })).toBeDisabled();
+  });
+
   it('reloads the available tools and template when the cluster changes', async () => {
     const user = userEvent.setup();
     vi.mocked(listTools).mockImplementation(async (cluster) => [

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -781,7 +781,7 @@ const AiPage = () => {
                       <SlidersHorizontal size={17} />
                       <span>工具</span>
                     </button>
-                    <button className="tool-btn">
+                    <button className="tool-btn" disabled title="Prompt 增强暂未接入">
                       <Sparkle size={17} />
                       <span>Prompt 增强</span>
                     </button>

--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -85,6 +85,12 @@ describe('HomePage LLM models', () => {
     expect(screen.queryByText('qwen3.7-max')).not.toBeInTheDocument();
   });
 
+  it('marks prompt enhancement unavailable until the feature is wired', () => {
+    renderHome();
+
+    expect(screen.getByRole('button', { name: /Prompt 增强/ })).toBeDisabled();
+  });
+
   it('submits the configured provider model to the AI page', async () => {
     const user = userEvent.setup();
     renderHome();

--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -85,10 +85,12 @@ describe('HomePage LLM models', () => {
     expect(screen.queryByText('qwen3.7-max')).not.toBeInTheDocument();
   });
 
-  it('marks prompt enhancement unavailable until the feature is wired', () => {
+  it('marks unavailable toolbar actions disabled until the features are wired', () => {
     renderHome();
 
+    expect(screen.getByRole('button', { name: '工具' })).toBeDisabled();
     expect(screen.getByRole('button', { name: /Prompt 增强/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '语音输入' })).toBeDisabled();
   });
 
   it('submits the configured provider model to the AI page', async () => {

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -387,7 +387,7 @@ const HomePage = () => {
                             <SlidersHorizontal size={17} />
                             <span>工具</span>
                           </button>
-                          <button className="tool-btn">
+                          <button className="tool-btn" disabled title="Prompt 增强暂未接入">
                             <Sparkle size={17} />
                             <span>Prompt 增强</span>
                           </button>

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -383,7 +383,7 @@ const HomePage = () => {
                     <div className="flex items-center gap-2 w-full">
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 overflow-x-auto scrollbar-hide max-w-full py-2">
-                          <button className="tool-btn">
+                          <button className="tool-btn" disabled title="工具面板暂未在首页接入">
                             <SlidersHorizontal size={17} />
                             <span>工具</span>
                           </button>
@@ -393,6 +393,9 @@ const HomePage = () => {
                           </button>
                           <button
                             className="tool-btn"
+                            disabled
+                            aria-label="语音输入"
+                            title="语音输入暂未接入"
                             style={{ minHeight: 30, minWidth: 32, padding: 6 }}
                           >
                             <Microphone size={17} />


### PR DESCRIPTION
## Track

Track 3 / AI Native - LLM integration

## Summary

- mark Prompt 增强 controls as disabled on the AI assistant and home assistant inputs
- mark unavailable home toolbar controls (Tool and voice input) as disabled until wired
- add disabled styling for toolbar buttons
- cover AI and home assistant toolbars with regression tests

## Tests

- npm test -- --run src/pages/ai/__tests__/AiPage.test.tsx src/pages/home/__tests__/HomePage.test.tsx
- npm run lint -- src/pages/ai/index.tsx src/pages/ai/__tests__/AiPage.test.tsx src/pages/home/index.tsx src/pages/home/__tests__/HomePage.test.tsx src/index.css
- git diff --check

Closes #882
Closes #884