### PR TITLE
[ISSUE #886] Export filtered topics as CSV

### DIFF
--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -49,6 +49,14 @@ beforeAll(() => {
       dispatchEvent: vi.fn(),
     })),
   });
+  Object.defineProperty(URL, 'createObjectURL', {
+    writable: true,
+    value: vi.fn(() => 'blob:topic-export'),
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    writable: true,
+    value: vi.fn(),
+  });
 });
 
 const buildTopics = (count: number): Topic[] =>
@@ -96,6 +104,49 @@ describe('TopicPage', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('downloads the currently filtered topics when exporting', async () => {
+    const user = userEvent.setup();
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(vi.fn());
+    let exportedBlob: Blob | undefined;
+    vi.mocked(URL.createObjectURL).mockImplementation((blob) => {
+      exportedBlob = blob as Blob;
+      return 'blob:topic-export';
+    });
+    topicServiceMocks.listTopics.mockResolvedValue([
+      {
+        ...buildTopics(1)[0],
+        name: 'orders-topic',
+        namespace: 'trade',
+        remark: 'orders, "critical"',
+      },
+      {
+        ...buildTopics(1)[0],
+        name: 'users-topic',
+        namespace: 'user',
+        remark: '=formula-risk',
+      },
+    ]);
+    renderWithProviders();
+
+    expect(await screen.findByText('orders-topic')).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('搜索 Topic 名称'), 'orders');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(screen.queryByText('users-topic')).not.toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /导出/ }));
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:topic-export');
+    expect(document.querySelector('a[download^="rocketmq-topics-"]')).not.toBeInTheDocument();
+
+    expect(exportedBlob).toBeDefined();
+    const csv = await exportedBlob!.text();
+    expect(csv).toContain('"orders-topic"');
+    expect(csv).toContain('"orders, ""critical"""');
+    expect(csv).not.toContain('users-topic');
+    clickSpy.mockRestore();
   });
 
   it('keeps the current table page after opening and closing topic details', async () => {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -96,6 +96,49 @@ const TYPE_OPTIONS = [
 // ─── Perm label ───────────────────────────────────────────────────
 const PERM_LABEL: Record<string, string> = { RW: '读写', RO: '只读', WO: '只写' };
 
+const TOPIC_EXPORT_COLUMNS: Array<{ header: string; value: (topic: Topic) => unknown }> = [
+  { header: 'Name', value: (topic) => topic.name },
+  { header: 'Namespace', value: (topic) => topic.namespace },
+  { header: 'Type', value: (topic) => topic.type },
+  { header: 'Cluster ID', value: (topic) => topic.clusterId },
+  { header: 'Write Queues', value: (topic) => topic.writeQueues },
+  { header: 'Read Queues', value: (topic) => topic.readQueues },
+  { header: 'Permission', value: (topic) => topic.perm },
+  { header: 'Message Count', value: (topic) => topic.messageCount },
+  { header: 'TPS', value: (topic) => topic.tps },
+  { header: 'Consumer Groups', value: (topic) => topic.consumerGroupCount },
+  { header: 'Remark', value: (topic) => topic.remark },
+  { header: 'Created At', value: (topic) => topic.createdAt },
+  { header: 'Updated At', value: (topic) => topic.updatedAt },
+];
+
+const escapeCsvCell = (value: unknown) => {
+  const text = value == null ? '' : String(value);
+  const formulaSafeText = /^[=+\-@]/.test(text) ? `'${text}` : text;
+  return `"${formulaSafeText.replace(/"/g, '""')}"`;
+};
+
+const buildTopicCsv = (topics: Topic[]) =>
+  [
+    TOPIC_EXPORT_COLUMNS.map((column) => escapeCsvCell(column.header)).join(','),
+    ...topics.map((topic) =>
+      TOPIC_EXPORT_COLUMNS.map((column) => escapeCsvCell(column.value(topic))).join(','),
+    ),
+  ].join('\n');
+
+const downloadCsv = (filename: string, csv: string) => {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};
+
 // ─── Random message body generators ──────────────────────────────
 const randomOrderBody = () =>
   JSON.stringify(
@@ -748,7 +791,13 @@ const TopicPage = () => {
           </Button>
           <Button
             icon={<ExportOutlined />}
-            onClick={() => message.success(`已导出 ${filteredTopics.length} 个 Topic`)}
+            onClick={() => {
+              downloadCsv(
+                `rocketmq-topics-${new Date().toISOString().slice(0, 10)}.csv`,
+                buildTopicCsv(filteredTopics),
+              );
+              message.success(`已导出 ${filteredTopics.length} 个 Topic`);
+            }}
           >
             导出
           </Button>


### PR DESCRIPTION
## Summary
- replace the Topic export success-only toast with a real CSV download
- export the currently filtered Topic list with CSV escaping and formula-prefix protection
- add regression coverage for filtered export behavior

## Tests
- npm test -- --run src/pages/instance/__tests__/TopicPage.test.tsx
- npm run lint -- src/pages/instance/topic.tsx src/pages/instance/__tests__/TopicPage.test.tsx
- git diff --check

Closes #886