### PR TITLE
[ISSUE #888] Export filtered consumer groups as CSV

### DIFF
--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -50,6 +50,14 @@ beforeAll(() => {
       dispatchEvent: vi.fn(),
     })),
   });
+  Object.defineProperty(URL, 'createObjectURL', {
+    writable: true,
+    value: vi.fn(() => 'blob:consumer-group-export'),
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    writable: true,
+    value: vi.fn(),
+  });
 });
 
 const group: ConsumerGroup = {
@@ -106,6 +114,48 @@ describe('Consumer page', () => {
     expect(await screen.findByText('remote-cg')).toBeInTheDocument();
     expect(screen.getByText('Push')).toBeInTheDocument();
     expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it('downloads the currently filtered consumer groups when exporting', async () => {
+    const user = userEvent.setup();
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(vi.fn());
+    let exportedBlob: Blob | undefined;
+    vi.mocked(URL.createObjectURL).mockImplementation((blob) => {
+      exportedBlob = blob as Blob;
+      return 'blob:consumer-group-export';
+    });
+    vi.mocked(consumerService.listConsumerGroups).mockResolvedValue([
+      {
+        ...group,
+        name: 'orders-cg',
+        namespace: 'trade',
+        subscribedTopics: ['orders-topic', 'payments,topic'],
+      },
+      {
+        ...group,
+        name: 'users-cg',
+        namespace: '=formula-risk',
+        subscribedTopics: ['users-topic'],
+      },
+    ]);
+    renderWithProviders(<ConsumerPage />);
+
+    expect(await screen.findByText('orders-cg')).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('搜索 Group 名称、命名空间或 Topic'), 'orders');
+    await waitFor(() => expect(screen.queryByText('users-cg')).not.toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: /导出/ }));
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:consumer-group-export');
+    expect(document.querySelector('a[download^="rocketmq-consumer-groups-"]')).not.toBeInTheDocument();
+
+    expect(exportedBlob).toBeDefined();
+    const csv = await exportedBlob!.text();
+    expect(csv).toContain('"orders-cg"');
+    expect(csv).toContain('"orders-topic;payments,topic"');
+    expect(csv).not.toContain('users-cg');
+    clickSpy.mockRestore();
   });
 
   it('loads subscriptions and progress when opening a group', async () => {

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -112,6 +112,50 @@ const formatDelay = (totalSeconds: number): string => {
   return parts.length > 0 ? parts.join('') : '0秒';
 };
 
+const GROUP_EXPORT_COLUMNS: Array<{ header: string; value: (group: ConsumerGroup) => unknown }> = [
+  { header: 'Name', value: (group) => group.name },
+  { header: 'Namespace', value: (group) => group.namespace },
+  { header: 'Cluster ID', value: (group) => group.clusterId },
+  { header: 'Subscription Mode', value: (group) => group.subscriptionMode },
+  { header: 'Consume Type', value: (group) => group.consumeType },
+  { header: 'Online Instances', value: (group) => group.onlineInstances },
+  { header: 'Total Lag', value: (group) => group.totalLag },
+  { header: 'Delay Seconds', value: (group) => group.delaySeconds },
+  { header: 'Subscription Data Type', value: (group) => group.subscriptionDataType },
+  { header: 'Delivery Order Type', value: (group) => group.deliveryOrderType },
+  { header: 'Retry Max Times', value: (group) => group.retryMaxTimes },
+  { header: 'Subscribed Topics', value: (group) => group.subscribedTopics.join(';') },
+  { header: 'Created At', value: (group) => group.createdAt },
+  { header: 'Updated At', value: (group) => group.updatedAt },
+];
+
+const escapeCsvCell = (value: unknown) => {
+  const text = value == null ? '' : String(value);
+  const formulaSafeText = /^[=+\-@]/.test(text) ? `'${text}` : text;
+  return `"${formulaSafeText.replace(/"/g, '""')}"`;
+};
+
+const buildConsumerGroupCsv = (groups: ConsumerGroup[]) =>
+  [
+    GROUP_EXPORT_COLUMNS.map((column) => escapeCsvCell(column.header)).join(','),
+    ...groups.map((group) =>
+      GROUP_EXPORT_COLUMNS.map((column) => escapeCsvCell(column.value(group))).join(','),
+    ),
+  ].join('\n');
+
+const downloadCsv = (filename: string, csv: string) => {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};
+
 const normalizedConsistency = (value?: string | null): string => value?.trim().toLowerCase() ?? '';
 
 const isConsistentValue = (value?: string | null): boolean =>
@@ -648,7 +692,13 @@ const ConsumerPage = () => {
           </Button>
           <Button
             icon={<ExportOutlined />}
-            onClick={() => message.success(`已导出 ${filtered.length} 个 Group`)}
+            onClick={() => {
+              downloadCsv(
+                `rocketmq-consumer-groups-${new Date().toISOString().slice(0, 10)}.csv`,
+                buildConsumerGroupCsv(filtered),
+              );
+              message.success(`已导出 ${filtered.length} 个 Group`);
+            }}
           >
             导出
           </Button>


### PR DESCRIPTION
## Summary
- replace the Consumer Group export success-only toast with a real CSV download
- export the currently filtered group list with CSV escaping and formula-prefix protection
- add regression coverage for filtered export behavior

## Tests
- npm test -- --run src/pages/instance/__tests__/ConsumerPage.test.tsx
- npm run lint -- src/pages/instance/consumer.tsx src/pages/instance/__tests__/ConsumerPage.test.tsx
- git diff --check

Closes #888