### PR TITLE
[ISSUE #890] Use attached anchors for downloads

### DIFF
--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -36,6 +36,7 @@ import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
 import type { DLQGroup } from '../../api/message';
 import { listDLQGroups, resendDLQ } from '../../services/messageService';
+import { downloadBlob } from '../../utils/download';
 
 const { Text } = Typography;
 const { RangePicker } = DatePicker;
@@ -67,12 +68,7 @@ const exportDLQGroups = (groups: DLQGroup[], filename: string) => {
   ];
   const csv = rows.map((row) => row.map(escapeCSVValue).join(',')).join('\n');
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = filename;
-  anchor.click();
-  URL.revokeObjectURL(url);
+  downloadBlob(blob, filename);
 };
 
 /* ═══════════════════════════════════════════

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -54,6 +54,7 @@ import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
 import type { MessageQuery, MessageRecord, TraceRecord } from '../../api/message';
 import { getMessageTrace, queryMessages } from '../../services/messageService';
+import { downloadBlob } from '../../utils/download';
 
 const { Paragraph, Text } = Typography;
 const { RangePicker } = DatePicker;
@@ -362,12 +363,7 @@ const MessagePage = () => {
 
   const handleDownload = (record: MessageRecord) => {
     const blob = new Blob([formatBody(record.body)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${record.msgId}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, `${record.msgId}.json`);
     message.success('消息下载成功');
   };
 

--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -40,6 +40,7 @@ import { useLang } from '../../i18n/LangContext';
 import type { AuditFilter } from '../../api/audit';
 import type { AuditRecord } from '../../api/ops';
 import { cleanupAuditLogs, exportAuditLogs, listAuditRecords } from '../../services/opsService';
+import { downloadBlob } from '../../utils/download';
 
 const operationTypeColors: Record<string, string> = {
   创建Topic: 'blue',
@@ -136,12 +137,7 @@ const AuditPage: React.FC = () => {
         buildAuditFilter(searchText, selectedType, dateRange, resultFilter),
       );
       const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
-      const url = URL.createObjectURL(blob);
-      const anchor = document.createElement('a');
-      anchor.href = url;
-      anchor.download = `rocketmq-audit-logs-${dayjs().format('YYYY-MM-DD')}.csv`;
-      anchor.click();
-      URL.revokeObjectURL(url);
+      downloadBlob(blob, `rocketmq-audit-logs-${dayjs().format('YYYY-MM-DD')}.csv`);
     } catch {
       message.error('导出审计日志失败，请稍后重试');
     } finally {

--- a/web/src/pages/studio/AlertManagement.tsx
+++ b/web/src/pages/studio/AlertManagement.tsx
@@ -47,6 +47,7 @@ import {
 } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
 import { queryAlertRules } from '../../api/alertManagement';
+import { downloadBlob } from '../../utils/download';
 
 const { TextArea } = Input;
 
@@ -361,12 +362,7 @@ const AlertManagementPage: React.FC = () => {
     }
 
     const blob = new Blob([yaml], { type: 'text/yaml' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'rocketmq-alert-rules.yaml';
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, 'rocketmq-alert-rules.yaml');
     message.success(t('alertMgmt.exportSuccess'));
   };
 

--- a/web/src/utils/download.test.ts
+++ b/web/src/utils/download.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { downloadBlob } from './download';
+
+describe('downloadBlob', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('clicks an attached temporary anchor and removes it after download', () => {
+    const createObjectURL = vi.fn(() => 'blob:download');
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      writable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      writable: true,
+      value: revokeObjectURL,
+    });
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      expect(document.body.contains(this)).toBe(true);
+      expect(this.download).toBe('export.csv');
+      expect(this.href).toBe('blob:download');
+    });
+
+    const blob = new Blob(['content'], { type: 'text/csv' });
+
+    downloadBlob(blob, 'export.csv');
+
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('a[download="export.csv"]')).not.toBeInTheDocument();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:download');
+  });
+});

--- a/web/src/utils/download.ts
+++ b/web/src/utils/download.ts
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const downloadBlob = (blob: Blob, filename: string) => {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
## Summary
- add a shared `downloadBlob` helper that appends a hidden temporary anchor before clicking it
- reuse the helper for DLQ export, audit log export, alert rule export, and message body download
- add unit coverage for anchor attachment, cleanup, and object URL revocation

## Tests
- npm test -- --run src/utils/download.test.ts src/pages/instance/__tests__/DLQPage.test.tsx src/pages/ops/__tests__/AuditPage.test.tsx src/pages/studio/__tests__/AlertManagement.test.tsx src/pages/instance/__tests__/MessagePage.test.tsx
- npm run lint -- src/utils/download.ts src/utils/download.test.ts src/pages/instance/dlq.tsx src/pages/ops/audit.tsx src/pages/studio/AlertManagement.tsx src/pages/instance/message.tsx
- git diff --check

Closes #890