### PR TITLE
[ISSUE #892] Navigate from instance rows

### DIFF
--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -16,9 +16,11 @@
  */
 
 import { App } from 'antd';
+import { useEffect } from 'react';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import type { Instance } from '../../../api/instance';
 import { LangProvider } from '../../../i18n/LangContext';
 import * as instanceService from '../../../services/instanceService';
@@ -59,18 +61,37 @@ const instance = (id: string, name: string, type: Instance['type'] = 'PROXY'): I
   updatedAt: '2026-01-01T00:00:00Z',
 });
 
+let currentLocation = '';
+
+const LocationProbe = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    currentLocation = `${location.pathname}${location.search}`;
+  }, [location.pathname, location.search]);
+
+  return null;
+};
+
 const renderPage = () =>
   render(
-    <App>
-      <LangProvider>
-        <InstancePage />
-      </LangProvider>
-    </App>,
+    <MemoryRouter initialEntries={['/instance']}>
+      <App>
+        <LangProvider>
+          <LocationProbe />
+          <Routes>
+            <Route path="/instance" element={<InstancePage />} />
+            <Route path="/instance/topic" element={<div>Topic route</div>} />
+          </Routes>
+        </LangProvider>
+      </App>
+    </MemoryRouter>,
   );
 
 describe('InstancePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    currentLocation = '';
     vi.mocked(instanceService.listInstances).mockResolvedValue([
       instance('proxy-1', 'production-proxy'),
       instance('direct-1', 'development-direct', 'DIRECT'),
@@ -184,5 +205,27 @@ describe('InstancePage', () => {
       }),
     );
     expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' });
+  });
+
+  it('navigates to the topic view with the selected instance id when a row is clicked', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByText('production-proxy'));
+
+    expect(await screen.findByText('Topic route')).toBeInTheDocument();
+    expect(currentLocation).toBe('/instance/topic?instanceId=proxy-1');
+  });
+
+  it('does not navigate when clicking row action buttons', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(await screen.findByText('production-proxy')).toBeInTheDocument();
+    await user.click(screen.getAllByRole('button', { name: /编辑/ })[0]);
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(currentLocation).toBe('/instance');
+    expect(screen.queryByText('Topic route')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -16,7 +16,6 @@
  */
 
 import { App } from 'antd';
-import { useEffect } from 'react';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -61,16 +60,10 @@ const instance = (id: string, name: string, type: Instance['type'] = 'PROXY'): I
   updatedAt: '2026-01-01T00:00:00Z',
 });
 
-let currentLocation = '';
-
 const LocationProbe = () => {
   const location = useLocation();
 
-  useEffect(() => {
-    currentLocation = `${location.pathname}${location.search}`;
-  }, [location.pathname, location.search]);
-
-  return null;
+  return <span data-testid="location-probe">{`${location.pathname}${location.search}`}</span>;
 };
 
 const renderPage = () =>
@@ -91,7 +84,6 @@ const renderPage = () =>
 describe('InstancePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    currentLocation = '';
     vi.mocked(instanceService.listInstances).mockResolvedValue([
       instance('proxy-1', 'production-proxy'),
       instance('direct-1', 'development-direct', 'DIRECT'),
@@ -214,7 +206,9 @@ describe('InstancePage', () => {
     await user.click(await screen.findByText('production-proxy'));
 
     expect(await screen.findByText('Topic route')).toBeInTheDocument();
-    expect(currentLocation).toBe('/instance/topic?instanceId=proxy-1');
+    expect(await screen.findByTestId('location-probe')).toHaveTextContent(
+      '/instance/topic?instanceId=proxy-1',
+    );
   });
 
   it('does not navigate when clicking row action buttons', async () => {
@@ -225,7 +219,7 @@ describe('InstancePage', () => {
     await user.click(screen.getAllByRole('button', { name: /编辑/ })[0]);
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
-    expect(currentLocation).toBe('/instance');
+    expect(screen.getByTestId('location-probe')).toHaveTextContent('/instance');
     expect(screen.queryByText('Topic route')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -19,6 +19,7 @@ import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vite
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
+import { MemoryRouter } from 'react-router-dom';
 import { LangProvider } from '../../../i18n/LangContext';
 import type { Topic } from '../../../api/metadata';
 import TopicPage from '../topic';
@@ -71,13 +72,15 @@ const buildTopics = (count: number): Topic[] =>
     };
   });
 
-const renderWithProviders = () =>
+const renderWithProviders = (initialEntry = '/instance/topic') =>
   render(
-    <App>
-      <LangProvider>
-        <TopicPage />
-      </LangProvider>
-    </App>,
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <App>
+        <LangProvider>
+          <TopicPage />
+        </LangProvider>
+      </App>
+    </MemoryRouter>,
   );
 
 const getTableBody = () => {
@@ -120,6 +123,14 @@ describe('TopicPage', () => {
 
     expect(within(getTableBody()).getByText('topic-21')).toBeInTheDocument();
     expect(within(getTableBody()).queryByText('topic-01')).not.toBeInTheDocument();
+  });
+
+  it('loads topics for the instance selected in the URL', async () => {
+    renderWithProviders('/instance/topic?instanceId=proxy-1');
+
+    await waitFor(() =>
+      expect(topicServiceMocks.listTopics).toHaveBeenCalledWith({ clusterId: 'proxy-1' }),
+    );
   });
 
   it('keeps failed topics selected after a partially successful batch deletion', async () => {

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -16,6 +16,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Table,
   Card,
@@ -58,6 +59,7 @@ type InstanceTypeFilter = 'ALL' | Instance['type'];
    ═══════════════════════════════════════════ */
 const InstancePage = () => {
   const { t } = useLang();
+  const navigate = useNavigate();
   const [instances, setInstances] = useState<Instance[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
@@ -240,7 +242,8 @@ const InstancePage = () => {
             size="small"
             icon={<EditOutlined />}
             style={{ borderColor: '#1677ff', color: '#1677ff' }}
-            onClick={() => {
+            onClick={(event) => {
+              event.stopPropagation();
               setEditingInstance(record);
               editForm.setFieldsValue({ remark: record.remark });
               setEditModalOpen(true);
@@ -252,15 +255,16 @@ const InstancePage = () => {
             size="small"
             icon={<DeleteOutlined />}
             style={{ borderColor: '#ff4d4f', color: '#ff4d4f' }}
-            onClick={() =>
+            onClick={(event) => {
+              event.stopPropagation();
               Modal.confirm({
                 title: `确认删除 "${record.name}"？`,
                 content: '此操作不可恢复。',
                 okText: '删除',
                 okButtonProps: { danger: true },
                 onOk: () => handleDelete(record),
-              })
-            }
+              });
+            }}
           >
             删除
           </Button>
@@ -327,7 +331,7 @@ const InstancePage = () => {
           size="small"
           onRow={(record) => ({
             style: { cursor: 'pointer' },
-            onClick: () => message.info(`进入 ${record.name}`),
+            onClick: () => navigate(`/instance/topic?instanceId=${encodeURIComponent(record.id)}`),
           })}
         />
       </Card>

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -16,6 +16,7 @@
  */
 
 import { useEffect, useState, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   Alert,
   Table,
@@ -214,6 +215,8 @@ const formatDateTime = (iso: string): string => {
 // ═══════════════════════════════════════════════════════════════════
 const TopicPage = () => {
   const { t } = useLang();
+  const [searchParams] = useSearchParams();
+  const instanceId = searchParams.get('instanceId')?.trim() || undefined;
 
   // ─── State ─────────────────────────────────────────────────────
   const [topics, setTopics] = useState<Topic[]>([]);
@@ -241,7 +244,7 @@ const TopicPage = () => {
 
   useEffect(() => {
     let cancelled = false;
-    void listTopics()
+    void listTopics(instanceId ? { clusterId: instanceId } : undefined)
       .then((nextTopics) => {
         if (!cancelled) setTopics(nextTopics);
       })
@@ -255,7 +258,7 @@ const TopicPage = () => {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [instanceId]);
 
   // ─── Filtered data ─────────────────────────────────────────────
   const filteredTopics = useMemo(


### PR DESCRIPTION
## Summary
- replace the Instance table row toast-only action with navigation to the Topic view scoped by instanceId
- stop Edit/Delete row action clicks from bubbling into the row navigation handler
- add routing regression coverage for row navigation and action-button propagation

## Tests
- npm test -- --run src/pages/instance/__tests__/InstancePage.test.tsx
- npm run lint -- src/pages/instance/index.tsx src/pages/instance/__tests__/InstancePage.test.tsx
- git diff --check

Closes #892