### PR TITLE
[ISSUE #897] Report dashboard broker version

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProvider.java
@@ -164,8 +164,11 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                                     clusterTpsIn += (int) parseTps(rt.getTable().get("putTps"));
                                     clusterTpsOut += (int) parseTps(rt.getTable().get("getTransferedTps"));
                                     String v = rt.getTable().get("brokerVersionDesc");
-                                    if (v != null && !"unknown".equals(version)) {
-                                        version = v;
+                                    if (v != null && "unknown".equals(version)) {
+                                        String brokerVersion = v.trim();
+                                        if (!brokerVersion.isEmpty()) {
+                                            version = brokerVersion;
+                                        }
                                     }
                                 }
                             } catch (Exception ignored) {

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProviderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.rocketmq;
+
+import java.util.HashMap;
+import java.util.Set;
+
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.KVTable;
+import org.apache.rocketmq.remoting.protocol.body.TopicList;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RocketMQDashboardProviderTest {
+
+    @Test
+    void dashboardClusterOverviewShouldUseBrokerVersionDesc() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        RocketMQDashboardProvider provider = new RocketMQDashboardProvider(adminExt);
+
+        DashboardDataVO dashboard = provider.getDashboardData();
+
+        assertThat(dashboard.getClusters()).hasSize(1);
+        assertThat(dashboard.getClusters().get(0).getVersion()).isEqualTo("V5_3_3");
+    }
+
+    private ClusterInfo clusterInfo() {
+        ClusterInfo info = new ClusterInfo();
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "10.0.0.11:10911");
+
+        HashMap<String, BrokerData> brokerAddrTable = new HashMap<>();
+        brokerAddrTable.put("broker-a", new BrokerData("DefaultCluster", "broker-a", new HashMap<>(addrs)));
+        info.setBrokerAddrTable(brokerAddrTable);
+
+        HashMap<String, Set<String>> clusterAddrTable = new HashMap<>();
+        clusterAddrTable.put("DefaultCluster", Set.of("broker-a"));
+        info.setClusterAddrTable(clusterAddrTable);
+        return info;
+    }
+
+    private TopicList topicList() {
+        TopicList topicList = new TopicList();
+        topicList.setTopicList(Set.of("order-topic"));
+        return topicList;
+    }
+
+    private KVTable runtimeStats() {
+        HashMap<String, String> table = new HashMap<>();
+        table.put("brokerVersionDesc", "  V5_3_3  ");
+        table.put("putTps", "1.0 2.0 3.0");
+        table.put("getTransferedTps", "4.0 5.0 6.0");
+        table.put("msgPutTotalTodayMorning", "42");
+
+        KVTable kvTable = new KVTable();
+        kvTable.setTable(table);
+        return kvTable;
+    }
+}


### PR DESCRIPTION
### What
- Fix `RocketMQDashboardProvider` so cluster overview uses the first non-blank `brokerVersionDesc` from broker runtime stats.
- Add provider coverage proving the dashboard cluster version is populated instead of staying `unknown`.

### Why
The previous condition only assigned the broker version when the current value was already not `unknown`, so the initial `unknown` value was never replaced.

### Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=RocketMQDashboardProviderTest test`
- `git diff --check`

Closes #897
