### PR TITLE
[ISSUE #903] Guard null DLQ queue lists

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProvider.java
@@ -184,6 +184,9 @@ public class RocketMQDLQProvider implements DLQProvider {
         try {
             consumer.start();
             Set<MessageQueue> queues = consumer.fetchSubscribeMessageQueues(dlqTopic);
+            if (queues == null || queues.isEmpty()) {
+                return result;
+            }
             outer:
             for (MessageQueue queue : queues) {
                 long minOffset = consumer.searchOffset(queue, begin);

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProviderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.rocketmq;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.studio.ops.audit.AuditService;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RocketMQDLQProviderTest {
+
+    @Mock
+    private ObjectProvider<DefaultMQAdminExt> adminExtProvider;
+
+    @Mock
+    private DefaultMQAdminExt adminExt;
+
+    @Mock
+    private AuditService auditService;
+
+    private RocketMQDLQProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        when(adminExtProvider.getIfAvailable()).thenReturn(adminExt);
+        provider = new RocketMQDLQProvider(adminExtProvider, auditService, new RocketMQProperties());
+    }
+
+    @Test
+    void resendMessagesDoesNotPullWhenDlqQueueSetIsNull() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(null);
+                         doNothing().when(consumer).shutdown();
+                     });
+             MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class)) {
+            provider.resendMessages("group-a", 100L, 200L, "target-topic");
+
+            assertThat(mockedConsumers.constructed()).hasSize(1);
+            DefaultMQPullConsumer consumer = mockedConsumers.constructed().get(0);
+            verify(consumer).start();
+            verify(consumer).fetchSubscribeMessageQueues(dlqTopic);
+            verify(consumer, never()).pull(any(MessageQueue.class), anyString(), anyLong(), anyInt());
+            verify(consumer).shutdown();
+            assertThat(mockedProducers.constructed()).isEmpty();
+        }
+        verify(auditService).record(
+                eq("RESEND_DLQ"),
+                eq("group-a"),
+                contains("matched=0, resent=0, failed=0"),
+                eq("SUCCESS"));
+    }
+}


### PR DESCRIPTION
### Summary

- guard DLQ resend collection when `fetchSubscribeMessageQueues` returns null or empty
- add a provider unit test that verifies the null queue-set path does not attempt pulls or create a resend producer

### Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=RocketMQDLQProviderTest test`
- `git diff --check`

Closes #903