### PR TITLE
[ISSUE #909] Guard stale cluster store refreshes

### DIFF
--- a/web/src/stores/clusterStore.test.ts
+++ b/web/src/stores/clusterStore.test.ts
@@ -52,6 +52,23 @@ const cluster: ClusterInfo = {
   tpsHistory: [100, 120],
 };
 
+const newerCluster: ClusterInfo = {
+  ...cluster,
+  id: 'cluster-staging',
+  name: 'rocketmq-staging',
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
 describe('clusterStore', () => {
   afterEach(() => {
     vi.mocked(listClusters).mockReset();
@@ -66,6 +83,33 @@ describe('clusterStore', () => {
     expect(listClusters).toHaveBeenCalledTimes(1);
     expect(useClusterStore.getState()).toMatchObject({
       clusters: [cluster],
+      loading: false,
+    });
+  });
+
+  it('keeps the newest cluster list when overlapping loads finish out of order', async () => {
+    const firstLoad = deferred<ClusterInfo[]>();
+    const secondLoad = deferred<ClusterInfo[]>();
+    vi.mocked(listClusters)
+      .mockReturnValueOnce(firstLoad.promise)
+      .mockReturnValueOnce(secondLoad.promise);
+
+    const firstFetch = useClusterStore.getState().fetchClusters();
+    const secondFetch = useClusterStore.getState().fetchClusters();
+
+    secondLoad.resolve([newerCluster]);
+    await secondFetch;
+
+    expect(useClusterStore.getState()).toMatchObject({
+      clusters: [newerCluster],
+      loading: false,
+    });
+
+    firstLoad.resolve([cluster]);
+    await firstFetch;
+
+    expect(useClusterStore.getState()).toMatchObject({
+      clusters: [newerCluster],
       loading: false,
     });
   });

--- a/web/src/stores/clusterStore.ts
+++ b/web/src/stores/clusterStore.ts
@@ -25,16 +25,23 @@ interface ClusterState {
   fetchClusters: () => Promise<void>;
 }
 
+let latestFetchRequestId = 0;
+
 const useClusterStore = create<ClusterState>((set) => ({
   clusters: [],
   loading: false,
   fetchClusters: async () => {
+    const requestId = ++latestFetchRequestId;
     set({ loading: true });
     try {
       const clusters = await listClusters();
-      set({ clusters });
+      if (requestId === latestFetchRequestId) {
+        set({ clusters });
+      }
     } finally {
-      set({ loading: false });
+      if (requestId === latestFetchRequestId) {
+        set({ loading: false });
+      }
     }
   },
 }));


### PR DESCRIPTION
### Summary

- ignore stale `fetchClusters` responses when overlapping cluster refreshes finish out of order
- keep `loading` controlled by the latest in-flight refresh
- add a regression test for out-of-order cluster refresh completion

### Tests

- `npm test -- --run src/stores/clusterStore.test.ts`
- `npm run lint -- src/stores/clusterStore.ts src/stores/clusterStore.test.ts` (passes with existing fast-refresh warnings in unrelated files)
- `git diff --check`

Closes #909