### PR TITLE
[ISSUE #911] Trim consumer group search text

### DIFF
--- a/web/src/services/consumerService.test.ts
+++ b/web/src/services/consumerService.test.ts
@@ -55,6 +55,19 @@ describe('consumer service mock data', () => {
     expect(second.instances[0]).not.toBe(first.instances[0]);
   });
 
+  it('trims search text before filtering consumer group names', async () => {
+    const groups = await listConsumerGroups({ search: '  CG-ORDER-NOTIFY  ' });
+
+    expect(groups.map((group) => group.name)).toEqual(['cg-order-notify']);
+  });
+
+  it('ignores blank search text', async () => {
+    const allGroups = await listConsumerGroups();
+    const blankSearchGroups = await listConsumerGroups({ search: '   ' });
+
+    expect(blankSearchGroups).toHaveLength(allGroups.length);
+  });
+
   it('returns copied progress and subscription rows', async () => {
     const firstProgress = await getConsumerProgress('cg-order-notify');
     const firstSubscriptions = await getConsumerSubscriptions('cg-order-notify');

--- a/web/src/services/consumerService.ts
+++ b/web/src/services/consumerService.ts
@@ -43,8 +43,8 @@ export async function listConsumerGroups(params?: ConsumerGroupQuery): Promise<C
     let result = [...consumerGroupsState];
     if (params?.clusterId) result = result.filter((group) => group.clusterId === params.clusterId);
     if (params?.search) {
-      const kw = params.search.toLowerCase();
-      result = result.filter((g) => g.name.toLowerCase().includes(kw));
+      const kw = params.search.trim().toLowerCase();
+      if (kw) result = result.filter((g) => g.name.toLowerCase().includes(kw));
     }
     return result.map(copyConsumerGroup);
   }


### PR DESCRIPTION
### Summary

- trim consumer group search text before filtering mock rows
- ignore blank consumer search text instead of returning an empty list
- align consumer group search behavior with topic search

### Tests

- `npm test -- --run src/services/consumerService.test.ts`
- `npm run lint -- src/services/consumerService.ts src/services/consumerService.test.ts` (passes with existing fast-refresh warnings in unrelated files)
- `git diff --check`

Closes #911