### PR TITLE
[ISSUE #913] Reject missing alert rule updates

### DIFF
--- a/web/src/services/opsService.test.ts
+++ b/web/src/services/opsService.test.ts
@@ -82,6 +82,23 @@ describe('ops service mock data', () => {
     expect(afterUpdate?.channels).toEqual(['webhook']);
   });
 
+  it('rejects updates for unknown alert rule IDs', async () => {
+    const before = await listAlertRules();
+    const missingRule = {
+      ...before[0],
+      id: 'missing-alert-rule',
+      name: 'missing rule',
+    };
+
+    await expect(updateAlertRule(missingRule)).rejects.toThrow(
+      'Alert rule not found: missing-alert-rule',
+    );
+
+    const after = await listAlertRules();
+    expect(after.map((rule) => rule.id)).toEqual(before.map((rule) => rule.id));
+    expect(after.find((rule) => rule.id === 'missing-alert-rule')).toBeUndefined();
+  });
+
   it('returns copied system alert rows', async () => {
     const first = await listSystemAlerts();
     const originalTitle = first[0].title;

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -101,8 +101,9 @@ export async function createAlertRule(data: Partial<AlertRule>): Promise<AlertRu
 export async function updateAlertRule(data: AlertRule): Promise<AlertRule> {
   if (isMockMode()) {
     const index = alertRulesState.findIndex((rule) => rule.id === data.id);
+    if (index < 0) throw new Error(`Alert rule not found: ${data.id}`);
     const rule = copyAlertRule(data);
-    if (index >= 0) alertRulesState[index] = rule;
+    alertRulesState[index] = rule;
     return copyAlertRule(rule);
   }
   return opsApi.updateAlertRule(data);


### PR DESCRIPTION
### Summary

- fail mock alert rule updates when the target ID does not exist
- avoid returning a fake successful update for stale alert rule IDs
- add a regression test that verifies the alert rule list remains unchanged

### Tests

- `npm test -- --run src/services/opsService.test.ts`
- `npm run lint -- src/services/opsService.ts src/services/opsService.test.ts` (passes with existing fast-refresh warnings in unrelated files)
- `git diff --check`

Closes #913