### PR TITLE
[ISSUE #915][ISSUE #917] Harden cluster mock service writes

### DIFF
--- a/web/src/services/clusterService.test.ts
+++ b/web/src/services/clusterService.test.ts
@@ -22,7 +22,15 @@ vi.mock('../config', () => ({
   API_BASE_URL: '/api',
 }));
 
-import { getCluster, listClusters, updateClusterConfig } from './clusterService';
+import {
+  createK8sCert,
+  deleteK8sCert,
+  getCluster,
+  listClusters,
+  listK8sCerts,
+  updateClusterConfig,
+  updateK8sCert,
+} from './clusterService';
 
 describe('clusterService mock clusters', () => {
   it('returns defensive copies from cluster detail reads', async () => {
@@ -83,6 +91,35 @@ describe('clusterService mock clusters', () => {
         id: before.id,
         ...originalConfig,
       });
+    }
+  });
+
+  it('copies certificate SAN arrays before writing them into the mock store', async () => {
+    const san = ['proxy.example.com'];
+    const created = await createK8sCert({
+      name: 'cert-copy-test',
+      namespace: 'rocketmq',
+      cluster: 'cluster-prod',
+      san,
+    });
+
+    try {
+      san.push('mutated-create.example.com');
+
+      let stored = (await listK8sCerts()).find((cert) => cert.id === created.id);
+      expect(stored?.san).toEqual(['proxy.example.com']);
+
+      const nextSan = ['proxy-next.example.com'];
+      await updateK8sCert({
+        id: created.id,
+        san: nextSan,
+      });
+      nextSan.push('mutated-update.example.com');
+
+      stored = (await listK8sCerts()).find((cert) => cert.id === created.id);
+      expect(stored?.san).toEqual(['proxy-next.example.com']);
+    } finally {
+      await deleteK8sCert(created.id);
     }
   });
 });

--- a/web/src/services/clusterService.test.ts
+++ b/web/src/services/clusterService.test.ts
@@ -30,6 +30,7 @@ import {
   listK8sCerts,
   updateClusterConfig,
   updateK8sCert,
+  updateNameServer,
 } from './clusterService';
 
 describe('clusterService mock clusters', () => {
@@ -91,6 +92,36 @@ describe('clusterService mock clusters', () => {
         id: before.id,
         ...originalConfig,
       });
+    }
+  });
+
+  it('rejects NameServer edits that would duplicate an address in the same cluster', async () => {
+    const clusterId = 'cluster-prod';
+    const original = await getCluster(clusterId);
+    const [first, second] = original.nameServers;
+
+    try {
+      await expect(
+        updateNameServer({
+          clusterId,
+          addr: first.addr,
+          newAddr: second.addr,
+        }),
+      ).rejects.toThrow(`NameServer already exists: ${second.addr}`);
+
+      const fresh = await getCluster(clusterId);
+      expect(fresh.nameServers.map((item) => item.addr)).toEqual(
+        original.nameServers.map((item) => item.addr),
+      );
+    } finally {
+      const current = await getCluster(clusterId);
+      for (let index = 0; index < original.nameServers.length; index += 1) {
+        const currentAddr = current.nameServers[index]?.addr;
+        const originalAddr = original.nameServers[index].addr;
+        if (currentAddr && currentAddr !== originalAddr) {
+          await updateNameServer({ clusterId, addr: currentAddr, newAddr: originalAddr });
+        }
+      }
     }
   });
 

--- a/web/src/services/clusterService.ts
+++ b/web/src/services/clusterService.ts
@@ -82,7 +82,7 @@ export async function createK8sCert(data: Partial<K8sCertInfo>): Promise<K8sCert
       notAfter: notAfter.toISOString(),
       status: 'valid',
       daysRemaining: 365,
-      san: data.san ?? [],
+      san: [...(data.san ?? [])],
     };
     mockCertStore.push(cert);
     return { ...cert, san: [...cert.san] };
@@ -94,7 +94,7 @@ export async function updateK8sCert(data: Partial<K8sCertInfo>): Promise<K8sCert
   if (isMockMode()) {
     const existing = mockCertStore.find((cert) => cert.id === data.id);
     if (!existing) throw new Error(`Certificate not found: ${data.id}`);
-    Object.assign(existing, data, { san: data.san ?? existing.san });
+    Object.assign(existing, data, { san: data.san ? [...data.san] : existing.san });
     return { ...existing, san: [...existing.san] };
   }
   return clusterApi.updateK8sCert(data);

--- a/web/src/services/clusterService.ts
+++ b/web/src/services/clusterService.ts
@@ -204,10 +204,13 @@ export async function updateNameServer(data: {
   newAddr?: string;
 }): Promise<void> {
   if (isMockMode()) {
-    const nameServer = getMockCluster(data.clusterId).nameServers.find(
-      (item) => item.addr === data.addr,
-    );
+    const nameServers = getMockCluster(data.clusterId).nameServers;
+    const nameServer = nameServers.find((item) => item.addr === data.addr);
     if (!nameServer) throw new Error(`NameServer not found: ${data.addr}`);
+    if (data.newAddr && data.newAddr !== data.addr) {
+      const duplicate = nameServers.some((item) => item !== nameServer && item.addr === data.newAddr);
+      if (duplicate) throw new Error(`NameServer already exists: ${data.newAddr}`);
+    }
     if (data.newAddr) nameServer.addr = data.newAddr;
     return;
   }


### PR DESCRIPTION
### What is changed

This PR fixes #915 and fixes #917 by tightening the web mock cluster service write paths.

### Why

Two mock-mode write paths could mutate state in ways that do not match the intended control-plane contract:

- `createK8sCert()` and `updateK8sCert()` returned defensive SAN copies, but stored the caller-provided `san` array reference. Mutating the original request array after the call could change stored certificate state.
- `updateNameServer()` could rename a NameServer to an address already used by another NameServer in the same cluster, even though `createNameServer()` already rejects duplicates.

### How it is fixed

- Copy `data.san` before writing K8s certificate records into the mock store.
- Reject NameServer edits that would duplicate another address in the same cluster.
- Add regression tests for both write paths.

### Verification

- `npm test -- --run src/services/clusterService.test.ts`
- `git diff --check`
- `npm run lint -- src/services/clusterService.ts src/services/clusterService.test.ts` (passes with existing fast-refresh warnings in unrelated files)