### PR TITLE
[ISSUE #918] Reject duplicate mock topic creates

### DIFF
--- a/web/src/services/topicService.test.ts
+++ b/web/src/services/topicService.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { getTopicConsumers, getTopicRoutes, listTopics } from './topicService';
+import { createTopic, getTopicConsumers, getTopicRoutes, listTopics } from './topicService';
 
 vi.mock('./dataMode', () => ({ isMockMode: () => true }));
 vi.mock('../config', () => ({
@@ -67,5 +67,25 @@ describe('topic service mock data', () => {
     const blankSearchTopics = await listTopics({ search: '   ' });
 
     expect(blankSearchTopics).toHaveLength(allTopics.length);
+  });
+
+  it('rejects duplicate topic creates in the same cluster', async () => {
+    const existing = (await listTopics({ search: 'order-create' }))[0];
+    const before = await listTopics({ clusterId: existing.clusterId });
+
+    await expect(
+      createTopic({
+        name: existing.name,
+        clusterId: existing.clusterId,
+        namespace: existing.namespace,
+        type: existing.type,
+        writeQueues: existing.writeQueues,
+        readQueues: existing.readQueues,
+        perm: existing.perm,
+      }),
+    ).rejects.toThrow(`Topic already exists: ${existing.name}`);
+
+    const after = await listTopics({ clusterId: existing.clusterId });
+    expect(after).toEqual(before);
   });
 });

--- a/web/src/services/topicService.ts
+++ b/web/src/services/topicService.ts
@@ -31,6 +31,11 @@ export async function listTopics(params?: TopicQuery): Promise<Topic[]> {
 
 export async function createTopic(data: Partial<Topic>): Promise<Topic> {
   if (isMockMode()) {
+    const duplicate = mockTopics.some(
+      (topic) => topic.name === data.name && topic.clusterId === data.clusterId,
+    );
+    if (duplicate) throw new Error(`Topic already exists: ${data.name}`);
+
     const topic = {
       ...data,
       createdAt: new Date().toISOString(),


### PR DESCRIPTION
### What is changed

This PR fixes #918 by rejecting duplicate mock topic creates within the same cluster.

### Why

`createTopic()` previously inserted a new mock row without checking for an existing topic with the same `name` and `clusterId`. Since follow-up mock update/delete actions identify topics by name, allowing duplicate names in one cluster can make later actions ambiguous.

This is intentionally scoped to same-cluster duplicate creation. The broader cross-cluster identity problem remains tracked by #739.

### How it is fixed

- Check for an existing topic with the same `name` and `clusterId` before inserting a mock topic.
- Add a regression test that verifies the duplicate create is rejected and the existing cluster topic list remains unchanged.

### Verification

- `npm test -- --run src/services/topicService.test.ts`
- `git diff --check`
- `npm run lint -- src/services/topicService.ts src/services/topicService.test.ts` (passes with existing fast-refresh warnings in unrelated files)
