### PR TITLE
[ISSUE #920] Reject missing mock instance deletes

### DIFF
--- a/web/src/services/instanceService.test.ts
+++ b/web/src/services/instanceService.test.ts
@@ -22,7 +22,7 @@ vi.mock('../config', () => ({
   API_BASE_URL: '/api',
 }));
 
-import { createInstance, listInstances, updateInstance } from './instanceService';
+import { createInstance, deleteInstance, listInstances, updateInstance } from './instanceService';
 
 describe('instanceService mock instances', () => {
   it('returns defensive copies from list reads', async () => {
@@ -78,5 +78,15 @@ describe('instanceService mock instances', () => {
     const afterUpdate = await listInstances();
     const storedUpdated = afterUpdate.find((instance) => instance.id === created.id);
     expect(storedUpdated?.remark).toBe('updated');
+  });
+
+  it('rejects deleting missing mock instances', async () => {
+    const before = await listInstances();
+
+    await expect(deleteInstance('missing-instance')).rejects.toThrow(
+      'Instance not found: missing-instance',
+    );
+
+    await expect(listInstances()).resolves.toEqual(before);
   });
 });

--- a/web/src/services/instanceService.ts
+++ b/web/src/services/instanceService.ts
@@ -65,7 +65,8 @@ export async function updateInstance(data: UpdateInstanceRequest): Promise<Insta
 export async function deleteInstance(id: string): Promise<void> {
   if (isMockMode()) {
     const idx = mockInstances.findIndex((i) => i.id === id);
-    if (idx >= 0) mockInstances.splice(idx, 1);
+    if (idx < 0) throw new Error(`Instance not found: ${id}`);
+    mockInstances.splice(idx, 1);
     return;
   }
   return instanceApi.deleteInstance(id);


### PR DESCRIPTION
### What is changed

This PR fixes #920 by making mock instance deletion reject missing ids.

### Why

The API-backed instance service rejects missing instance ids, but the web mock service silently returned success when no record matched. That can make the Instance page show a successful delete for a stale or invalid row.

### How it is fixed

- Throw `Instance not found: <id>` when mock deletion cannot find the requested id.
- Add regression coverage that a failed delete leaves the stored mock instance list unchanged.

### Verification

- `npm test -- --run src/services/instanceService.test.ts`
- `git diff --check`
- `npm run lint -- src/services/instanceService.ts src/services/instanceService.test.ts` (passes with existing fast-refresh warnings in unrelated files)
