### PR TITLE
[ISSUE #922] Filter mock messages by time range

### DIFF
--- a/web/src/services/messageService.test.ts
+++ b/web/src/services/messageService.test.ts
@@ -39,6 +39,18 @@ describe('message service mock data', () => {
     expect(second[0].properties).not.toBe(first[0].properties);
   });
 
+  it('filters mock topic queries by the selected store-time range', async () => {
+    const messages = await queryMessages({
+      topic: 'order-create',
+      startTime: Date.parse('2026-07-01T10:24:00.000Z'),
+      endTime: Date.parse('2026-07-01T10:26:00.000Z'),
+    });
+
+    expect(messages.map((message) => message.msgId)).toEqual([
+      'AC1E0A6400002A9F0000000001A3F7C2',
+    ]);
+  });
+
   it('returns copied message trace rows', async () => {
     const first = await getMessageTrace('AC1E0A6400002A9F0000000001A3F2B1');
     expect(first?.nodes[0].title).toBe('Producer 发送');

--- a/web/src/services/messageService.ts
+++ b/web/src/services/messageService.ts
@@ -17,6 +17,13 @@ const cloneTrace = (trace: TraceRecord): TraceRecord => ({
 
 const cloneDLQGroup = (group: DLQGroup): DLQGroup => ({ ...group });
 
+const toStoreTimestamp = (storeTime: MessageRecord['storeTime']): number => {
+  if (typeof storeTime === 'number') return storeTime;
+
+  const parsed = Date.parse(storeTime);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
 export async function queryMessages(params: MessageQuery): Promise<MessageRecord[]> {
   if (isMockMode()) {
     let result = [...mockMessages];
@@ -24,6 +31,12 @@ export async function queryMessages(params: MessageQuery): Promise<MessageRecord
     if (params.tag) result = result.filter((m) => m.tag === params.tag);
     if (params.key) result = result.filter((m) => m.key.includes(params.key!));
     if (params.msgId) result = result.filter((m) => m.msgId === params.msgId);
+    if (params.startTime !== undefined) {
+      result = result.filter((m) => toStoreTimestamp(m.storeTime) >= params.startTime!);
+    }
+    if (params.endTime !== undefined) {
+      result = result.filter((m) => toStoreTimestamp(m.storeTime) <= params.endTime!);
+    }
     return sortMessagesByStoreTimeDesc((result as unknown as MessageRecord[]).map(cloneMessage));
   }
   return messageApi.queryMessages(params);


### PR DESCRIPTION
### What is changed

This PR fixes #922 by applying the selected time range to mock message queries.

### Why

The Message page sends `startTime` and `endTime` for topic-based queries, but the mock service ignored both fields and returned every topic/tag match. That made mock mode diverge from the real query contract and could show messages outside the selected window.

### How it is fixed

- Parse each mock message `storeTime` into a timestamp.
- Apply inclusive `startTime` / `endTime` filters before sorting results.
- Add regression coverage for a narrow topic time window.

### Verification

- `npm test -- --run src/services/messageService.test.ts`
- `git diff --check`
- `npm run lint -- src/services/messageService.ts src/services/messageService.test.ts` (passes with existing fast-refresh warnings in unrelated files)
