### PR TITLE
[Studio] feat(metrics): support multiple Prometheus-compatible metrics backends (METRICS-01)

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+
+/**
+ * Shared implementation for every Prometheus-compatible metrics backend
+ * (Prometheus, VictoriaMetrics, Thanos, Cortex, Mimir, ARMS, ...).
+ * <p>
+ * The only behavioural difference between backends is the URL path under which
+ * the Prometheus HTTP query API is exposed; query/parse/authentication logic is
+ * identical. Concrete subclasses only pick a {@link MetricsBackendType}.
+ * </p>
+ */
+@Slf4j
+public abstract class AbstractPrometheusCompatibleMetricsSource implements MetricsSource {
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+    private final MetricsSourceSettings settings;
+
+    protected AbstractPrometheusCompatibleMetricsSource(RestClient.Builder restClientBuilder,
+                                                         ObjectMapper objectMapper,
+                                                         MetricsSourceSettings settings) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(settings.getConnectTimeout());
+        requestFactory.setReadTimeout(settings.getReadTimeout());
+        this.restClient = restClientBuilder.requestFactory(requestFactory).build();
+        this.objectMapper = objectMapper;
+        this.settings = settings;
+    }
+
+    protected MetricsBackendType backendType() {
+        return settings.getBackendType();
+    }
+
+    @Override
+    public MetricDataVO query(MetricQueryDTO query) {
+        validateQuery(query);
+        URI queryRangeUri = queryRangeUri();
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("query", query.getMetric());
+        form.add("start", Long.toString(query.getStart()));
+        form.add("end", Long.toString(query.getEnd()));
+        form.add("step", query.getStep());
+
+        log.debug("Querying {} range: start={}, end={}, step={}",
+                settings.getBackendType(), query.getStart(), query.getEnd(), query.getStep());
+
+        try {
+            JsonNode response = restClient.post()
+                    .uri(queryRangeUri)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .headers(this::applyAuthentication)
+                    .body(form)
+                    .retrieve()
+                    .body(JsonNode.class);
+            return parseResponse(response);
+        } catch (PrometheusException exception) {
+            throw exception;
+        } catch (RestClientResponseException exception) {
+            throw responseException(exception);
+        } catch (ResourceAccessException exception) {
+            if (hasCause(exception, SocketTimeoutException.class)) {
+                throw new PrometheusException(HttpStatus.GATEWAY_TIMEOUT.value(),
+                        backendLabel() + " query timed out", exception);
+            }
+            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                    "Failed to connect to " + backendLabel(), exception);
+        } catch (RestClientException exception) {
+            if (hasCause(exception, SocketTimeoutException.class)) {
+                throw new PrometheusException(HttpStatus.GATEWAY_TIMEOUT.value(),
+                        backendLabel() + " query timed out", exception);
+            }
+            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                    backendLabel() + " query failed", exception);
+        }
+    }
+
+    private void validateQuery(MetricQueryDTO query) {
+        if (query == null) {
+            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query is required");
+        }
+        if (!StringUtils.hasText(query.getMetric())) {
+            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query is required");
+        }
+        if (query.getStart() <= 0) {
+            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query start must be positive");
+        }
+        if (query.getEnd() <= 0) {
+            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query end must be positive");
+        }
+        if (query.getEnd() < query.getStart()) {
+            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(),
+                    "Metric query end must not be earlier than start");
+        }
+        if (!StringUtils.hasText(query.getStep())) {
+            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query step is required");
+        }
+    }
+
+    private URI queryRangeUri() {
+        if (!StringUtils.hasText(settings.getBaseUrl())) {
+            throw new PrometheusException(HttpStatus.SERVICE_UNAVAILABLE.value(),
+                    backendLabel() + " base URL is not configured");
+        }
+        try {
+            String baseUrl = settings.getBaseUrl().strip();
+            while (baseUrl.endsWith("/")) {
+                baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+            }
+            URI uri = URI.create(baseUrl + settings.getQueryPath());
+            if (!"http".equalsIgnoreCase(uri.getScheme()) && !"https".equalsIgnoreCase(uri.getScheme())) {
+                throw new IllegalArgumentException("Unsupported " + backendLabel() + " URL scheme");
+            }
+            return uri;
+        } catch (IllegalArgumentException exception) {
+            throw new PrometheusException(HttpStatus.SERVICE_UNAVAILABLE.value(),
+                    backendLabel() + " base URL is invalid", exception);
+        }
+    }
+
+    private void applyAuthentication(HttpHeaders headers) {
+        if (StringUtils.hasText(settings.getBearerToken())) {
+            headers.setBearerAuth(settings.getBearerToken());
+            return;
+        }
+        boolean hasUsername = StringUtils.hasText(settings.getUsername());
+        boolean hasPassword = StringUtils.hasText(settings.getPassword());
+        if (hasUsername != hasPassword) {
+            throw new PrometheusException(HttpStatus.SERVICE_UNAVAILABLE.value(),
+                    backendLabel() + " basic authentication is incomplete");
+        }
+        if (hasUsername) {
+            headers.setBasicAuth(settings.getUsername(), settings.getPassword());
+        }
+    }
+
+    private MetricDataVO parseResponse(JsonNode response) {
+        if (response == null || !"success".equals(response.path("status").asText())) {
+            throw responseBodyException(response, HttpStatus.BAD_GATEWAY.value());
+        }
+
+        JsonNode data = response.path("data");
+        JsonNode result = data.path("result");
+        if (!data.isObject() || !result.isArray() || !StringUtils.hasText(data.path("resultType").asText())) {
+            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                    backendLabel() + " returned a malformed response");
+        }
+
+        List<MetricDataVO.MetricSeriesVO> series = StreamSupport.stream(result.spliterator(), false)
+                .map(this::parseSeries)
+                .toList();
+        List<String> warnings = parseWarnings(response.path("warnings"));
+
+        return MetricDataVO.builder()
+                .resultType(data.path("resultType").asText())
+                .series(series)
+                .warnings(warnings)
+                .build();
+    }
+
+    private MetricDataVO.MetricSeriesVO parseSeries(JsonNode seriesNode) {
+        JsonNode metric = seriesNode.path("metric");
+        JsonNode values = seriesNode.path("values");
+        JsonNode histograms = seriesNode.path("histograms");
+        boolean hasValues = values.isArray();
+        boolean hasHistograms = histograms.isArray();
+        boolean hasSamples = hasValues || hasHistograms;
+        boolean invalidValues = !values.isMissingNode() && !hasValues;
+        boolean invalidHistograms = !histograms.isMissingNode() && !hasHistograms;
+        if (!metric.isObject() || invalidValues || invalidHistograms || !hasSamples) {
+            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                    backendLabel() + " returned a malformed time series");
+        }
+
+        Map<String, String> labels = new LinkedHashMap<>();
+        Iterator<Map.Entry<String, JsonNode>> fields = metric.fields();
+        fields.forEachRemaining(entry -> labels.put(entry.getKey(), entry.getValue().asText()));
+
+        List<MetricDataVO.MetricSampleVO> samples = hasValues
+                ? StreamSupport.stream(values.spliterator(), false).map(this::parseSample).toList()
+                : List.of();
+        List<MetricDataVO.MetricHistogramSampleVO> histogramSamples = hasHistograms
+                ? StreamSupport.stream(histograms.spliterator(), false).map(this::parseHistogramSample).toList()
+                : List.of();
+        return MetricDataVO.MetricSeriesVO.builder()
+                .labels(labels)
+                .values(samples)
+                .histograms(histogramSamples)
+                .build();
+    }
+
+    private MetricDataVO.MetricSampleVO parseSample(JsonNode sampleNode) {
+        if (!sampleNode.isArray() || sampleNode.size() != 2 || !sampleNode.get(0).isNumber()) {
+            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                    backendLabel() + " returned a malformed sample");
+        }
+        return MetricDataVO.MetricSampleVO.builder()
+                .timestamp(sampleNode.get(0).asDouble())
+                .value(sampleNode.get(1).asText())
+                .build();
+    }
+
+    private MetricDataVO.MetricHistogramSampleVO parseHistogramSample(JsonNode sampleNode) {
+        if (!sampleNode.isArray() || sampleNode.size() != 2
+                || !sampleNode.get(0).isNumber() || !sampleNode.get(1).isObject()) {
+            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                    backendLabel() + " returned a malformed histogram sample");
+        }
+        return MetricDataVO.MetricHistogramSampleVO.builder()
+                .timestamp(sampleNode.get(0).asDouble())
+                .histogram(sampleNode.get(1))
+                .build();
+    }
+
+    private List<String> parseWarnings(JsonNode warningsNode) {
+        if (!warningsNode.isArray()) {
+            return List.of();
+        }
+        return StreamSupport.stream(warningsNode.spliterator(), false)
+                .map(JsonNode::asText)
+                .toList();
+    }
+
+    private PrometheusException responseException(RestClientResponseException exception) {
+        JsonNode response = null;
+        try {
+            response = objectMapper.readTree(exception.getResponseBodyAsString());
+        } catch (IOException ignored) {
+            log.debug("Failed to parse {} error response", backendLabel());
+        }
+        int upstreamStatus = exception.getStatusCode().value();
+        int statusCode = switch (upstreamStatus) {
+            case 400, 422, 503 -> upstreamStatus;
+            default -> HttpStatus.BAD_GATEWAY.value();
+        };
+        return responseBodyException(response, statusCode);
+    }
+
+    private PrometheusException responseBodyException(JsonNode response, int statusCode) {
+        String errorType = response == null ? "" : response.path("errorType").asText();
+        String error = response == null ? "" : response.path("error").asText();
+        if (StringUtils.hasText(error)) {
+            String message = StringUtils.hasText(errorType)
+                    ? backendLabel() + " query failed (" + errorType + "): " + error
+                    : backendLabel() + " query failed: " + error;
+            return new PrometheusException(statusCode, message);
+        }
+        return new PrometheusException(statusCode, backendLabel() + " query failed");
+    }
+
+    private boolean hasCause(Throwable throwable, Class<? extends Throwable> causeType) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (causeType.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private String backendLabel() {
+        return settings.getBackendType() == MetricsBackendType.PROMETHEUS
+                ? "Prometheus" : settings.getBackendType().name();
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/ArmsMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/ArmsMetricsSource.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Alibaba Cloud ARMS Prometheus metrics backend. Exposes the Prometheus query
+ * API through the ARMS Prometheus-compatible endpoint
+ * (see {@link MetricsBackendType#ARMS}).
+ */
+public class ArmsMetricsSource extends AbstractPrometheusCompatibleMetricsSource {
+
+    public ArmsMetricsSource(RestClient.Builder restClientBuilder, ObjectMapper objectMapper,
+                             MetricsSourceSettings settings) {
+        super(restClientBuilder, objectMapper, settings);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/CortexMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/CortexMetricsSource.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Cortex metrics backend. Exposes the Prometheus query API through the Cortex
+ * Query Frontend / Query component (see {@link MetricsBackendType#CORTEX}).
+ */
+public class CortexMetricsSource extends AbstractPrometheusCompatibleMetricsSource {
+
+    public CortexMetricsSource(RestClient.Builder restClientBuilder, ObjectMapper objectMapper,
+                               MetricsSourceSettings settings) {
+        super(restClientBuilder, objectMapper, settings);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/InMemoryMetricsDataSourceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/InMemoryMetricsDataSourceRepository.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import org.apache.rocketmq.studio.model.MetricsDataSourceConfig;
+import org.springframework.stereotype.Repository;
+
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory implementation of {@link MetricsDataSourceRepository}.
+ * <p>
+ * Seeded with one example data source per supported backend type so that the
+ * multi-backend capability is demonstrable out of the box. In a production
+ * deployment this would be replaced by a persistent store (database or the
+ * cloud control plane).
+ * </p>
+ */
+@Repository
+public class InMemoryMetricsDataSourceRepository implements MetricsDataSourceRepository {
+
+    private final Map<String, MetricsDataSourceConfig> store = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    void seed() {
+        store.clear();
+        store.put("prometheus-prod", dataSource("prometheus-prod", "PROMETHEUS",
+                "http://prometheus:9090", "Production Prometheus"));
+        store.put("victoriametrics-prod", dataSource("victoriametrics-prod", "VICTORIAMETRICS",
+                "http://victoria-metrics:8428", "Production VictoriaMetrics"));
+        store.put("thanos-prod", dataSource("thanos-prod", "THANOS",
+                "http://thanos-query:9090", "Production Thanos"));
+        store.put("cortex-prod", dataSource("cortex-prod", "CORTEX",
+                "http://cortex-query:9009", "Production Cortex"));
+        store.put("mimir-prod", dataSource("mimir-prod", "MIMIR",
+                "http://mimir-query:8080", "Production Grafana Mimir"));
+        store.put("arms-prod", dataSource("arms-prod", "ARMS",
+                "http://arms-prometheus:9090", "Production ARMS Prometheus"));
+    }
+
+    private MetricsDataSourceConfig dataSource(String name, String providerType, String url, String description) {
+        MetricsDataSourceConfig config = new MetricsDataSourceConfig();
+        config.setName(name);
+        config.setProviderType(providerType);
+        config.setUrl(url);
+        config.setAuthType("none");
+        config.setEnabled(true);
+        config.setScrapeInterval(15);
+        config.setTlsEnabled(url.startsWith("https"));
+        return config;
+    }
+
+    @Override
+    public List<MetricsDataSourceConfig> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    @Override
+    public Optional<MetricsDataSourceConfig> findByName(String name) {
+        return Optional.ofNullable(store.get(name));
+    }
+
+    @Override
+    public MetricsDataSourceConfig save(MetricsDataSourceConfig config) {
+        store.put(config.getName(), config);
+        return config;
+    }
+
+    @Override
+    public void deleteByName(String name) {
+        store.remove(name);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendType.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendType.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+/**
+ * Prometheus-compatible metrics backend types supported by RocketMQ Studio.
+ * <p>
+ * All backends speak the Prometheus HTTP query API, but differ in the URL path
+ * they expose it under (e.g. Mimir and VictoriaMetrics mount the API behind a
+ * tenant/prefix path). The query/parse semantics are otherwise identical, which
+ * is why every type shares {@link AbstractPrometheusCompatibleMetricsSource}.
+ * </p>
+ */
+public enum MetricsBackendType {
+
+    PROMETHEUS("/api/v1/query_range"),
+    VICTORIA_METRICS("/select/0/prometheus/api/v1/query_range"),
+    THANOS("/api/v1/query_range"),
+    CORTEX("/api/v1/query_range"),
+    MIMIR("/prometheus/api/v1/query_range"),
+    ARMS("/api/v1/query_range"),
+    CUSTOM("/api/v1/query_range");
+
+    private final String queryPath;
+
+    MetricsBackendType(String queryPath) {
+        this.queryPath = queryPath;
+    }
+
+    public String getQueryPath() {
+        return queryPath;
+    }
+
+    /**
+     * Resolves a provider type name (as stored in {@code MetricsDataSourceConfig.providerType})
+     * to a backend type, defaulting to {@link #PROMETHEUS} for unknown values.
+     */
+    public static MetricsBackendType fromProviderType(String providerType) {
+        if (providerType == null) {
+            return PROMETHEUS;
+        }
+        return switch (providerType.trim().toUpperCase()) {
+            case "PROMETHEUS" -> PROMETHEUS;
+            case "VICTORIAMETRICS", "VICTORIA_METRICS", "VICTORIA" -> VICTORIA_METRICS;
+            case "THANOS" -> THANOS;
+            case "CORTEX" -> CORTEX;
+            case "MIMIR" -> MIMIR;
+            case "ARMS" -> ARMS;
+            case "CUSTOM" -> CUSTOM;
+            default -> PROMETHEUS;
+        };
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsDataSourceController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsDataSourceController.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.model.MetricsDataSourceConfig;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST endpoints for managing Prometheus-compatible metrics data sources and
+ * querying them by name. Complements {@link MetricsController}, which runs
+ * queries against the default Prometheus server.
+ */
+@RestController
+@RequestMapping("/api/metrics/datasources")
+@RequiredArgsConstructor
+public class MetricsDataSourceController {
+
+    private final MetricsDataSourceService dataSourceService;
+
+    @GetMapping
+    public Result<List<MetricsDataSourceConfig>> listDataSources() {
+        return Result.ok(dataSourceService.listDataSources());
+    }
+
+    @PostMapping("/create")
+    public Result<MetricsDataSourceConfig> createDataSource(@RequestBody MetricsDataSourceConfig config) {
+        return Result.ok(dataSourceService.createDataSource(config));
+    }
+
+    @PostMapping("/update")
+    public Result<MetricsDataSourceConfig> updateDataSource(@RequestBody MetricsDataSourceConfig config) {
+        return Result.ok(dataSourceService.updateDataSource(config));
+    }
+
+    @DeleteMapping
+    public Result<Void> deleteDataSource(@RequestParam(required = false) String name) {
+        dataSourceService.deleteDataSource(name);
+        return Result.ok();
+    }
+
+    @PostMapping("/query")
+    public Result<MetricDataVO> query(@RequestParam String dataSource,
+                                      @Valid @RequestBody MetricQueryDTO query) {
+        return Result.ok(dataSourceService.query(dataSource, query));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsDataSourceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsDataSourceRepository.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import org.apache.rocketmq.studio.model.MetricsDataSourceConfig;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Storage abstraction for {@link MetricsDataSourceConfig} instances.
+ */
+public interface MetricsDataSourceRepository {
+
+    List<MetricsDataSourceConfig> findAll();
+
+    Optional<MetricsDataSourceConfig> findByName(String name);
+
+    MetricsDataSourceConfig save(MetricsDataSourceConfig config);
+
+    void deleteByName(String name);
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsDataSourceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsDataSourceService.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.model.MetricsDataSourceConfig;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+/**
+ * Manages Prometheus-compatible metrics data sources and runs queries against
+ * the backend selected by a data source name.
+ */
+@Service
+public class MetricsDataSourceService {
+
+    private final MetricsDataSourceRepository repository;
+    private final MetricsSourceFactory sourceFactory;
+
+    public MetricsDataSourceService(MetricsDataSourceRepository repository, MetricsSourceFactory sourceFactory) {
+        this.repository = repository;
+        this.sourceFactory = sourceFactory;
+    }
+
+    public List<MetricsDataSourceConfig> listDataSources() {
+        return repository.findAll();
+    }
+
+    public MetricsDataSourceConfig createDataSource(MetricsDataSourceConfig config) {
+        if (config == null || !StringUtils.hasText(config.getName())) {
+            throw new BusinessException(400, "Data source name is required");
+        }
+        return repository.save(config);
+    }
+
+    public MetricsDataSourceConfig updateDataSource(MetricsDataSourceConfig config) {
+        if (config == null || !StringUtils.hasText(config.getName())) {
+            throw new BusinessException(400, "Data source name is required");
+        }
+        if (repository.findByName(config.getName()).isEmpty()) {
+            throw new BusinessException(404, "Data source not found: " + config.getName());
+        }
+        return repository.save(config);
+    }
+
+    public void deleteDataSource(String name) {
+        if (!StringUtils.hasText(name)) {
+            throw new BusinessException(400, "Data source name is required");
+        }
+        repository.deleteByName(name);
+    }
+
+    public MetricDataVO query(String dataSourceName, MetricQueryDTO query) {
+        if (!StringUtils.hasText(dataSourceName)) {
+            throw new BusinessException(400, "Data source name is required");
+        }
+        MetricsDataSourceConfig config = repository.findByName(dataSourceName)
+                .orElseThrow(() -> new BusinessException(404, "Data source not found: " + dataSourceName));
+        MetricsSource source = sourceFactory.create(config);
+        return source.query(query);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsSourceFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsSourceFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+/**
+ * Builds a {@link MetricsSource} for a given {@link org.apache.rocketmq.studio.model.MetricsDataSourceConfig}.
+ * <p>
+ * The concrete implementation is selected by {@code MetricsDataSourceConfig.providerType},
+ * which maps to a {@link MetricsBackendType}. Every backend shares the same
+ * query/parse logic via {@link AbstractPrometheusCompatibleMetricsSource}.
+ * </p>
+ */
+@Component
+public class MetricsSourceFactory {
+
+    private final RestClient.Builder restClientBuilder;
+    private final ObjectMapper objectMapper;
+
+    public MetricsSourceFactory(RestClient.Builder restClientBuilder, ObjectMapper objectMapper) {
+        this.restClientBuilder = restClientBuilder;
+        this.objectMapper = objectMapper;
+    }
+
+    public MetricsSource create(org.apache.rocketmq.studio.model.MetricsDataSourceConfig config) {
+        MetricsBackendType backendType = MetricsBackendType.fromProviderType(config.getProviderType());
+        MetricsSourceSettings settings = MetricsSourceSettings.builder()
+                .backendType(backendType)
+                .baseUrl(config.getUrl())
+                .connectTimeout(Duration.ofSeconds(3))
+                .readTimeout(Duration.ofSeconds(10))
+                .username(config.getUsername())
+                .password(config.getPassword())
+                .bearerToken(config.getBearerToken())
+                .build();
+        return switch (backendType) {
+            case VICTORIA_METRICS -> new VictoriaMetricsMetricsSource(restClientBuilder, objectMapper, settings);
+            case THANOS -> new ThanosMetricsSource(restClientBuilder, objectMapper, settings);
+            case CORTEX -> new CortexMetricsSource(restClientBuilder, objectMapper, settings);
+            case MIMIR -> new MimirMetricsSource(restClientBuilder, objectMapper, settings);
+            case ARMS -> new ArmsMetricsSource(restClientBuilder, objectMapper, settings);
+            case CUSTOM, PROMETHEUS -> new PrometheusMetricsSource(restClientBuilder, objectMapper, settings);
+        };
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsSourceSettings.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsSourceSettings.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import java.time.Duration;
+
+/**
+ * Resolved connection settings for a Prometheus-compatible metrics backend.
+ * <p>
+ * Unlike {@code MetricsDataSourceConfig} (which is the serializable user-facing
+ * model), this object carries only the values required to issue a query and is
+ * produced by {@link MetricsSourceFactory} from a data source configuration.
+ * </p>
+ */
+public class MetricsSourceSettings {
+
+    private final MetricsBackendType backendType;
+    private final String baseUrl;
+    private final Duration connectTimeout;
+    private final Duration readTimeout;
+    private final String username;
+    private final String password;
+    private final String bearerToken;
+
+    private MetricsSourceSettings(Builder builder) {
+        this.backendType = builder.backendType;
+        this.baseUrl = builder.baseUrl;
+        this.connectTimeout = builder.connectTimeout;
+        this.readTimeout = builder.readTimeout;
+        this.username = builder.username;
+        this.password = builder.password;
+        this.bearerToken = builder.bearerToken;
+    }
+
+    public MetricsBackendType getBackendType() {
+        return backendType;
+    }
+
+    public String getQueryPath() {
+        return backendType.getQueryPath();
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public Duration getReadTimeout() {
+        return readTimeout;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getBearerToken() {
+        return bearerToken;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private MetricsBackendType backendType = MetricsBackendType.PROMETHEUS;
+        private String baseUrl;
+        private Duration connectTimeout = Duration.ofSeconds(3);
+        private Duration readTimeout = Duration.ofSeconds(10);
+        private String username;
+        private String password;
+        private String bearerToken;
+
+        public Builder backendType(MetricsBackendType backendType) {
+            this.backendType = backendType;
+            return this;
+        }
+
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public Builder connectTimeout(Duration connectTimeout) {
+            this.connectTimeout = connectTimeout;
+            return this;
+        }
+
+        public Builder readTimeout(Duration readTimeout) {
+            this.readTimeout = readTimeout;
+            return this;
+        }
+
+        public Builder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder bearerToken(String bearerToken) {
+            this.bearerToken = bearerToken;
+            return this;
+        }
+
+        public MetricsSourceSettings build() {
+            return new MetricsSourceSettings(this);
+        }
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MimirMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MimirMetricsSource.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Grafana Mimir metrics backend. Speaks the Prometheus query API mounted under
+ * the {@code /prometheus} tenant prefix (see {@link MetricsBackendType#MIMIR}).
+ */
+public class MimirMetricsSource extends AbstractPrometheusCompatibleMetricsSource {
+
+    public MimirMetricsSource(RestClient.Builder restClientBuilder, ObjectMapper objectMapper,
+                              MetricsSourceSettings settings) {
+        super(restClientBuilder, objectMapper, settings);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusMetricsSource.java
@@ -16,275 +16,40 @@
  */
 package org.apache.rocketmq.studio.cluster.metrics;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.util.StringUtils;
-import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestClientResponseException;
 
-import java.io.IOException;
-import java.net.SocketTimeoutException;
-import java.net.URI;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.StreamSupport;
-
-@Slf4j
+/**
+ * Default Prometheus metrics backend. Built from {@link PrometheusProperties}.
+ * <p>
+ * Behaviour is identical to the other Prometheus-compatible backends; this class
+ * only adapts the Spring {@code @ConfigurationProperties} bean into the shared
+ * {@link AbstractPrometheusCompatibleMetricsSource}.
+ * </p>
+ */
 @Component
-public class PrometheusMetricsSource implements MetricsSource {
-
-    private static final String QUERY_RANGE_PATH = "/api/v1/query_range";
-
-    private final RestClient restClient;
-    private final ObjectMapper objectMapper;
-    private final PrometheusProperties properties;
+public class PrometheusMetricsSource extends AbstractPrometheusCompatibleMetricsSource {
 
     public PrometheusMetricsSource(RestClient.Builder restClientBuilder, ObjectMapper objectMapper,
                                    PrometheusProperties properties) {
-        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout(properties.getConnectTimeout());
-        requestFactory.setReadTimeout(properties.getReadTimeout());
-        this.restClient = restClientBuilder.requestFactory(requestFactory).build();
-        this.objectMapper = objectMapper;
-        this.properties = properties;
+        super(restClientBuilder, objectMapper, toSettings(properties));
     }
 
-    @Override
-    public MetricDataVO query(MetricQueryDTO query) {
-        validateQuery(query);
-        URI queryRangeUri = queryRangeUri();
-        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
-        form.add("query", query.getMetric());
-        form.add("start", Long.toString(query.getStart()));
-        form.add("end", Long.toString(query.getEnd()));
-        form.add("step", query.getStep());
-
-        log.debug("Querying Prometheus range: start={}, end={}, step={}",
-                query.getStart(), query.getEnd(), query.getStep());
-
-        try {
-            JsonNode response = restClient.post()
-                    .uri(queryRangeUri)
-                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                    .headers(this::applyAuthentication)
-                    .body(form)
-                    .retrieve()
-                    .body(JsonNode.class);
-            return parseResponse(response);
-        } catch (PrometheusException exception) {
-            throw exception;
-        } catch (RestClientResponseException exception) {
-            throw responseException(exception);
-        } catch (ResourceAccessException exception) {
-            if (hasCause(exception, SocketTimeoutException.class)) {
-                throw new PrometheusException(HttpStatus.GATEWAY_TIMEOUT.value(),
-                        "Prometheus query timed out", exception);
-            }
-            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
-                    "Failed to connect to Prometheus", exception);
-        } catch (RestClientException exception) {
-            if (hasCause(exception, SocketTimeoutException.class)) {
-                throw new PrometheusException(HttpStatus.GATEWAY_TIMEOUT.value(),
-                        "Prometheus query timed out", exception);
-            }
-            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
-                    "Prometheus query failed", exception);
-        }
+    public PrometheusMetricsSource(RestClient.Builder restClientBuilder, ObjectMapper objectMapper,
+                                   MetricsSourceSettings settings) {
+        super(restClientBuilder, objectMapper, settings);
     }
 
-    private void validateQuery(MetricQueryDTO query) {
-        if (query == null) {
-            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query is required");
-        }
-        if (!StringUtils.hasText(query.getMetric())) {
-            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query is required");
-        }
-        if (query.getStart() <= 0) {
-            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query start must be positive");
-        }
-        if (query.getEnd() <= 0) {
-            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query end must be positive");
-        }
-        if (query.getEnd() < query.getStart()) {
-            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(),
-                    "Metric query end must not be earlier than start");
-        }
-        if (!StringUtils.hasText(query.getStep())) {
-            throw new PrometheusException(HttpStatus.BAD_REQUEST.value(), "Metric query step is required");
-        }
-    }
-
-    private URI queryRangeUri() {
-        if (!StringUtils.hasText(properties.getBaseUrl())) {
-            throw new PrometheusException(HttpStatus.SERVICE_UNAVAILABLE.value(),
-                    "Prometheus base URL is not configured");
-        }
-        try {
-            String baseUrl = properties.getBaseUrl().strip();
-            while (baseUrl.endsWith("/")) {
-                baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
-            }
-            URI uri = URI.create(baseUrl + QUERY_RANGE_PATH);
-            if (!"http".equalsIgnoreCase(uri.getScheme()) && !"https".equalsIgnoreCase(uri.getScheme())) {
-                throw new IllegalArgumentException("Unsupported Prometheus URL scheme");
-            }
-            return uri;
-        } catch (IllegalArgumentException exception) {
-            throw new PrometheusException(HttpStatus.SERVICE_UNAVAILABLE.value(),
-                    "Prometheus base URL is invalid", exception);
-        }
-    }
-
-    private void applyAuthentication(HttpHeaders headers) {
-        if (StringUtils.hasText(properties.getBearerToken())) {
-            headers.setBearerAuth(properties.getBearerToken());
-            return;
-        }
-        boolean hasUsername = StringUtils.hasText(properties.getUsername());
-        boolean hasPassword = StringUtils.hasText(properties.getPassword());
-        if (hasUsername != hasPassword) {
-            throw new PrometheusException(HttpStatus.SERVICE_UNAVAILABLE.value(),
-                    "Prometheus basic authentication is incomplete");
-        }
-        if (hasUsername) {
-            headers.setBasicAuth(properties.getUsername(), properties.getPassword());
-        }
-    }
-
-    private MetricDataVO parseResponse(JsonNode response) {
-        if (response == null || !"success".equals(response.path("status").asText())) {
-            throw responseBodyException(response, HttpStatus.BAD_GATEWAY.value());
-        }
-
-        JsonNode data = response.path("data");
-        JsonNode result = data.path("result");
-        if (!data.isObject() || !result.isArray() || !StringUtils.hasText(data.path("resultType").asText())) {
-            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
-                    "Prometheus returned a malformed response");
-        }
-
-        List<MetricDataVO.MetricSeriesVO> series = StreamSupport.stream(result.spliterator(), false)
-                .map(this::parseSeries)
-                .toList();
-        List<String> warnings = parseWarnings(response.path("warnings"));
-
-        return MetricDataVO.builder()
-                .resultType(data.path("resultType").asText())
-                .series(series)
-                .warnings(warnings)
+    private static MetricsSourceSettings toSettings(PrometheusProperties properties) {
+        return MetricsSourceSettings.builder()
+                .backendType(MetricsBackendType.PROMETHEUS)
+                .baseUrl(properties.getBaseUrl())
+                .connectTimeout(properties.getConnectTimeout())
+                .readTimeout(properties.getReadTimeout())
+                .username(properties.getUsername())
+                .password(properties.getPassword())
+                .bearerToken(properties.getBearerToken())
                 .build();
-    }
-
-    private MetricDataVO.MetricSeriesVO parseSeries(JsonNode seriesNode) {
-        JsonNode metric = seriesNode.path("metric");
-        JsonNode values = seriesNode.path("values");
-        JsonNode histograms = seriesNode.path("histograms");
-        boolean hasValues = values.isArray();
-        boolean hasHistograms = histograms.isArray();
-        boolean hasSamples = hasValues || hasHistograms;
-        boolean invalidValues = !values.isMissingNode() && !hasValues;
-        boolean invalidHistograms = !histograms.isMissingNode() && !hasHistograms;
-        if (!metric.isObject() || invalidValues || invalidHistograms || !hasSamples) {
-            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
-                    "Prometheus returned a malformed time series");
-        }
-
-        Map<String, String> labels = new LinkedHashMap<>();
-        Iterator<Map.Entry<String, JsonNode>> fields = metric.fields();
-        fields.forEachRemaining(entry -> labels.put(entry.getKey(), entry.getValue().asText()));
-
-        List<MetricDataVO.MetricSampleVO> samples = hasValues
-                ? StreamSupport.stream(values.spliterator(), false).map(this::parseSample).toList()
-                : List.of();
-        List<MetricDataVO.MetricHistogramSampleVO> histogramSamples = hasHistograms
-                ? StreamSupport.stream(histograms.spliterator(), false).map(this::parseHistogramSample).toList()
-                : List.of();
-        return MetricDataVO.MetricSeriesVO.builder()
-                .labels(labels)
-                .values(samples)
-                .histograms(histogramSamples)
-                .build();
-    }
-
-    private MetricDataVO.MetricSampleVO parseSample(JsonNode sampleNode) {
-        if (!sampleNode.isArray() || sampleNode.size() != 2 || !sampleNode.get(0).isNumber()) {
-            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
-                    "Prometheus returned a malformed sample");
-        }
-        return MetricDataVO.MetricSampleVO.builder()
-                .timestamp(sampleNode.get(0).asDouble())
-                .value(sampleNode.get(1).asText())
-                .build();
-    }
-
-    private MetricDataVO.MetricHistogramSampleVO parseHistogramSample(JsonNode sampleNode) {
-        if (!sampleNode.isArray() || sampleNode.size() != 2
-                || !sampleNode.get(0).isNumber() || !sampleNode.get(1).isObject()) {
-            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
-                    "Prometheus returned a malformed histogram sample");
-        }
-        return MetricDataVO.MetricHistogramSampleVO.builder()
-                .timestamp(sampleNode.get(0).asDouble())
-                .histogram(sampleNode.get(1))
-                .build();
-    }
-
-    private List<String> parseWarnings(JsonNode warningsNode) {
-        if (!warningsNode.isArray()) {
-            return List.of();
-        }
-        return StreamSupport.stream(warningsNode.spliterator(), false)
-                .map(JsonNode::asText)
-                .toList();
-    }
-
-    private PrometheusException responseException(RestClientResponseException exception) {
-        JsonNode response = null;
-        try {
-            response = objectMapper.readTree(exception.getResponseBodyAsString());
-        } catch (IOException ignored) {
-            log.debug("Failed to parse Prometheus error response");
-        }
-        int upstreamStatus = exception.getStatusCode().value();
-        int statusCode = switch (upstreamStatus) {
-            case 400, 422, 503 -> upstreamStatus;
-            default -> HttpStatus.BAD_GATEWAY.value();
-        };
-        return responseBodyException(response, statusCode);
-    }
-
-    private PrometheusException responseBodyException(JsonNode response, int statusCode) {
-        String errorType = response == null ? "" : response.path("errorType").asText();
-        String error = response == null ? "" : response.path("error").asText();
-        if (StringUtils.hasText(error)) {
-            String message = StringUtils.hasText(errorType)
-                    ? "Prometheus query failed (" + errorType + "): " + error
-                    : "Prometheus query failed: " + error;
-            return new PrometheusException(statusCode, message);
-        }
-        return new PrometheusException(statusCode, "Prometheus query failed");
-    }
-
-    private boolean hasCause(Throwable throwable, Class<? extends Throwable> causeType) {
-        Throwable current = throwable;
-        while (current != null) {
-            if (causeType.isInstance(current)) {
-                return true;
-            }
-            current = current.getCause();
-        }
-        return false;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/ThanosMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/ThanosMetricsSource.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Thanos metrics backend. Exposes the Prometheus query API through the Thanos
+ * Query component (see {@link MetricsBackendType#THANOS}).
+ */
+public class ThanosMetricsSource extends AbstractPrometheusCompatibleMetricsSource {
+
+    public ThanosMetricsSource(RestClient.Builder restClientBuilder, ObjectMapper objectMapper,
+                               MetricsSourceSettings settings) {
+        super(restClientBuilder, objectMapper, settings);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/VictoriaMetricsMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/VictoriaMetricsMetricsSource.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.client.RestClient;
+
+/**
+ * VictoriaMetrics metrics backend. Speaks the Prometheus query API mounted under
+ * {@code /select/0/prometheus} (see {@link MetricsBackendType#VICTORIA_METRICS}).
+ */
+public class VictoriaMetricsMetricsSource extends AbstractPrometheusCompatibleMetricsSource {
+
+    public VictoriaMetricsMetricsSource(RestClient.Builder restClientBuilder, ObjectMapper objectMapper,
+                                         MetricsSourceSettings settings) {
+        super(restClientBuilder, objectMapper, settings);
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendTypeTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendTypeTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetricsBackendTypeTest {
+
+    @Test
+    void shouldResolveEverySupportedProviderType() {
+        assertThat(MetricsBackendType.fromProviderType("PROMETHEUS")).isEqualTo(MetricsBackendType.PROMETHEUS);
+        assertThat(MetricsBackendType.fromProviderType("VICTORIAMETRICS"))
+                .isEqualTo(MetricsBackendType.VICTORIA_METRICS);
+        assertThat(MetricsBackendType.fromProviderType("VICTORIA_METRICS"))
+                .isEqualTo(MetricsBackendType.VICTORIA_METRICS);
+        assertThat(MetricsBackendType.fromProviderType("THANOS")).isEqualTo(MetricsBackendType.THANOS);
+        assertThat(MetricsBackendType.fromProviderType("CORTEX")).isEqualTo(MetricsBackendType.CORTEX);
+        assertThat(MetricsBackendType.fromProviderType("MIMIR")).isEqualTo(MetricsBackendType.MIMIR);
+        assertThat(MetricsBackendType.fromProviderType("ARMS")).isEqualTo(MetricsBackendType.ARMS);
+        assertThat(MetricsBackendType.fromProviderType("CUSTOM")).isEqualTo(MetricsBackendType.CUSTOM);
+    }
+
+    @Test
+    void shouldDefaultUnknownProviderTypeToPrometheus() {
+        assertThat(MetricsBackendType.fromProviderType(null)).isEqualTo(MetricsBackendType.PROMETHEUS);
+        assertThat(MetricsBackendType.fromProviderType("")).isEqualTo(MetricsBackendType.PROMETHEUS);
+        assertThat(MetricsBackendType.fromProviderType("unknown-backend")).isEqualTo(MetricsBackendType.PROMETHEUS);
+    }
+
+    @Test
+    void shouldExposeDistinctQueryPathsForBackends() {
+        assertThat(MetricsBackendType.PROMETHEUS.getQueryPath()).isEqualTo("/api/v1/query_range");
+        assertThat(MetricsBackendType.VICTORIA_METRICS.getQueryPath())
+                .isEqualTo("/select/0/prometheus/api/v1/query_range");
+        assertThat(MetricsBackendType.MIMIR.getQueryPath()).isEqualTo("/prometheus/api/v1/query_range");
+        assertThat(MetricsBackendType.THANOS.getQueryPath()).isEqualTo("/api/v1/query_range");
+        assertThat(MetricsBackendType.CORTEX.getQueryPath()).isEqualTo("/api/v1/query_range");
+        assertThat(MetricsBackendType.ARMS.getQueryPath()).isEqualTo("/api/v1/query_range");
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsDataSourceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsDataSourceControllerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MetricsDataSourceController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MetricsDataSourceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MetricsDataSourceService dataSourceService;
+
+    @Test
+    void listDataSourcesShouldReturnConfiguredSources() throws Exception {
+        when(dataSourceService.listDataSources()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/metrics/datasources"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data").isArray());
+    }
+
+    @Test
+    void queryShouldReturnMetricDataForNamedDataSource() throws Exception {
+        when(dataSourceService.query(eq("victoriametrics-prod"), any(MetricQueryDTO.class)))
+                .thenReturn(MetricDataVO.builder().resultType("matrix").series(List.of()).warnings(List.of()).build());
+
+        mockMvc.perform(post("/api/metrics/datasources/query?dataSource=victoriametrics-prod")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"metric":"up","start":1784107658,"end":1784108558,"step":"30s"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+    }
+
+    @Test
+    void createDataSourceShouldReturnCreatedConfig() throws Exception {
+        when(dataSourceService.createDataSource(any())).thenReturn(new org.apache.rocketmq.studio.model.MetricsDataSourceConfig());
+
+        mockMvc.perform(post("/api/metrics/datasources/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"cortex-prod","providerType":"CORTEX","url":"http://cortex:9009"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+    }
+
+    @Test
+    void deleteDataSourceShouldDelegateToService() throws Exception {
+        mockMvc.perform(delete("/api/metrics/datasources?name=prometheus-prod"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+        verify(dataSourceService).deleteDataSource("prometheus-prod");
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsDataSourceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsDataSourceServiceTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.model.MetricsDataSourceConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MetricsDataSourceServiceTest {
+
+    @Mock
+    private MetricsDataSourceRepository repository;
+
+    @Mock
+    private MetricsSourceFactory sourceFactory;
+
+    @Mock
+    private MetricsSource metricsSource;
+
+    @InjectMocks
+    private MetricsDataSourceService service;
+
+    @Test
+    void listDataSourcesShouldDelegateToRepository() {
+        MetricsDataSourceConfig config = config("prometheus-prod");
+        when(repository.findAll()).thenReturn(List.of(config));
+
+        assertThat(service.listDataSources()).containsExactly(config);
+    }
+
+    @Test
+    void createDataSourceShouldRequireName() {
+        assertThatThrownBy(() -> service.createDataSource(new MetricsDataSourceConfig()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> assertThat(((BusinessException) exception).getCode()).isEqualTo(400));
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void updateDataSourceShouldRequireExistingName() {
+        MetricsDataSourceConfig config = config("missing");
+        when(repository.findByName("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateDataSource(config))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> assertThat(((BusinessException) exception).getCode()).isEqualTo(404));
+    }
+
+    @Test
+    void updateDataSourceShouldPersistWhenFound() {
+        MetricsDataSourceConfig config = config("present");
+        when(repository.findByName("present")).thenReturn(Optional.of(config));
+        when(repository.save(config)).thenReturn(config);
+
+        assertThat(service.updateDataSource(config)).isSameAs(config);
+        verify(repository).save(config);
+    }
+
+    @Test
+    void deleteDataSourceShouldRequireName() {
+        assertThatThrownBy(() -> service.deleteDataSource(" "))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> assertThat(((BusinessException) exception).getCode()).isEqualTo(400));
+        verify(repository, never()).deleteByName(any());
+    }
+
+    @Test
+    void queryShouldBuildSourceForNamedDataSourceAndDelegate() {
+        MetricsDataSourceConfig config = config("victoriametrics-prod");
+        when(repository.findByName("victoriametrics-prod")).thenReturn(Optional.of(config));
+        when(sourceFactory.create(config)).thenReturn(metricsSource);
+        MetricDataVO data = MetricDataVO.builder().resultType("matrix").series(List.of()).warnings(List.of()).build();
+        when(metricsSource.query(any(MetricQueryDTO.class))).thenReturn(data);
+
+        MetricQueryDTO query = MetricQueryDTO.builder().metric("up").start(1L).end(2L).step("30s").build();
+        MetricDataVO result = service.query("victoriametrics-prod", query);
+
+        assertThat(result).isSameAs(data);
+        verify(sourceFactory).create(config);
+        verify(metricsSource).query(query);
+    }
+
+    @Test
+    void queryShouldRejectBlankDataSourceName() {
+        assertThatThrownBy(() -> service.query(" ", MetricQueryDTO.builder().metric("up").build()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> assertThat(((BusinessException) exception).getCode()).isEqualTo(400));
+    }
+
+    @Test
+    void queryShouldThrowWhenDataSourceNotFound() {
+        when(repository.findByName("ghost")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.query("ghost", MetricQueryDTO.builder().metric("up").build()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> assertThat(((BusinessException) exception).getCode()).isEqualTo(404));
+    }
+
+    private MetricsDataSourceConfig config(String name) {
+        MetricsDataSourceConfig config = new MetricsDataSourceConfig();
+        config.setName(name);
+        config.setProviderType("PROMETHEUS");
+        return config;
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MultiBackendMetricsSourceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MultiBackendMetricsSourceTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.rocketmq.studio.model.MetricsDataSourceConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MultiBackendMetricsSourceTest {
+
+    private HttpServer server;
+    private String baseUrl;
+    private final MetricsSourceFactory factory =
+            new MetricsSourceFactory(RestClient.builder(), new ObjectMapper());
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @ParameterizedTest
+    @EnumSource(MetricsBackendType.class)
+    void everyBackendShouldHitItsOwnQueryPathAndParseTheResponse(MetricsBackendType backendType) {
+        AtomicReference<String> requestPath = new AtomicReference<>();
+        server.createContext(backendType.getQueryPath(), exchange -> {
+            requestPath.set(exchange.getRequestURI().getPath());
+            respond(exchange, 200, """
+                    {"status":"success","data":{"resultType":"matrix","result":[
+                      {"metric":{"backend":"%s"},"values":[[1784107658,"1.0"]]}
+                    ]}}
+                    """.formatted(backendType.name()));
+        });
+
+        MetricsDataSourceConfig config = configFor(backendType);
+        MetricsSource source = factory.create(config);
+        MetricDataVO result = source.query(query());
+
+        assertThat(requestPath.get()).isEqualTo(backendType.getQueryPath());
+        assertThat(result.getResultType()).isEqualTo("matrix");
+        assertThat(result.getSeries()).hasSize(1);
+        assertThat(result.getSeries().get(0).getLabels()).containsEntry("backend", backendType.name());
+        assertThat(result.getSeries().get(0).getValues().get(0).getValue()).isEqualTo("1.0");
+    }
+
+    @Test
+    void factoryShouldReturnTheMatchingConcreteClassPerProviderType() {
+        assertThat(factory.create(configFor(MetricsBackendType.PROMETHEUS)))
+                .isInstanceOf(PrometheusMetricsSource.class);
+        assertThat(factory.create(configFor(MetricsBackendType.VICTORIA_METRICS)))
+                .isInstanceOf(VictoriaMetricsMetricsSource.class);
+        assertThat(factory.create(configFor(MetricsBackendType.THANOS)))
+                .isInstanceOf(ThanosMetricsSource.class);
+        assertThat(factory.create(configFor(MetricsBackendType.CORTEX)))
+                .isInstanceOf(CortexMetricsSource.class);
+        assertThat(factory.create(configFor(MetricsBackendType.MIMIR)))
+                .isInstanceOf(MimirMetricsSource.class);
+        assertThat(factory.create(configFor(MetricsBackendType.ARMS)))
+                .isInstanceOf(ArmsMetricsSource.class);
+    }
+
+    @Test
+    void unknownProviderTypeShouldFallBackToPrometheus() {
+        MetricsDataSourceConfig config = new MetricsDataSourceConfig();
+        config.setProviderType("does-not-exist");
+        config.setUrl(baseUrl);
+        assertThat(factory.create(config)).isInstanceOf(PrometheusMetricsSource.class);
+    }
+
+    private MetricsDataSourceConfig configFor(MetricsBackendType backendType) {
+        MetricsDataSourceConfig config = new MetricsDataSourceConfig();
+        config.setName(backendType.name().toLowerCase());
+        config.setProviderType(backendType.name());
+        config.setUrl(baseUrl);
+        return config;
+    }
+
+    private MetricQueryDTO query() {
+        return MetricQueryDTO.builder()
+                .metric("up")
+                .start(1784107658L)
+                .end(1784108558L)
+                .step("30s")
+                .build();
+    }
+
+    private void respond(HttpExchange exchange, int statusCode, String body) throws IOException {
+        byte[] response = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(statusCode, response.length);
+        exchange.getResponseBody().write(response);
+        exchange.close();
+    }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,6 +48,7 @@ const GroupManagementPage = lazy(() => import('./pages/studio/GroupManagement'))
 const BrokerClusterPage = lazy(() => import('./pages/studio/BrokerCluster'));
 const SslSettingsPage = lazy(() => import('./pages/studio/SslSettings'));
 const AlertManagementPage = lazy(() => import('./pages/studio/AlertManagement'));
+const MetricsDataSourcesPage = lazy(() => import('./pages/studio/MetricsDataSources'));
 const ProducerPage = lazy(() => import('./pages/studio/Producer'));
 const OpsPage = lazy(() => import('./pages/studio/Ops'));
 
@@ -165,6 +166,7 @@ function App() {
             <Route path="studio/broker-cluster" element={<BrokerClusterPage />} />
             <Route path="studio/ssl-settings" element={<SslSettingsPage />} />
             <Route path="studio/alert-management" element={<AlertManagementPage />} />
+            <Route path="studio/metrics-datasources" element={<MetricsDataSourcesPage />} />
             <Route path="studio/producer" element={<ProducerPage />} />
             <Route path="studio/ops" element={<OpsPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/web/src/api/metrics.test.ts
+++ b/web/src/api/metrics.test.ts
@@ -18,6 +18,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
+import type { MetricsDataSource } from './metrics';
 import {
   getDashboard,
   listMetricProfiles,
@@ -131,7 +132,11 @@ describe('metrics data sources', () => {
   });
 
   it('creates a data source', async () => {
-    const config = { name: 'cortex-prod', providerType: 'CORTEX', url: 'http://cortex:9009' };
+    const config: MetricsDataSource = {
+      name: 'cortex-prod',
+      providerType: 'CORTEX',
+      url: 'http://cortex:9009',
+    };
     mock.onPost('/metrics/datasources/create').reply(200, { code: 200, data: config });
 
     const created = await createMetricDataSource(config);
@@ -141,7 +146,11 @@ describe('metrics data sources', () => {
   });
 
   it('updates a data source', async () => {
-    const config = { name: 'cortex-prod', providerType: 'CORTEX', url: 'http://cortex:9010' };
+    const config: MetricsDataSource = {
+      name: 'cortex-prod',
+      providerType: 'CORTEX',
+      url: 'http://cortex:9010',
+    };
     mock.onPost('/metrics/datasources/update').reply(200, { code: 200, data: config });
 
     const updated = await updateMetricDataSource(config);

--- a/web/src/api/metrics.test.ts
+++ b/web/src/api/metrics.test.ts
@@ -18,7 +18,16 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { getDashboard, listMetricProfiles, queryMetrics } from './metrics';
+import {
+  getDashboard,
+  listMetricProfiles,
+  queryMetrics,
+  listMetricDataSources,
+  createMetricDataSource,
+  updateMetricDataSource,
+  deleteMetricDataSource,
+  queryMetricDataSource,
+} from './metrics';
 
 const mock = new MockAdapter(client);
 const dashboard = {
@@ -102,5 +111,61 @@ describe('metrics API', () => {
     mock.onGet('/metrics/profiles').reply(200, { code: 200, data: profiles });
 
     await expect(listMetricProfiles()).resolves.toEqual(profiles);
+  });
+});
+
+describe('metrics data sources', () => {
+  it('lists configured data sources', async () => {
+    mock.onGet('/metrics/datasources').reply(200, {
+      code: 200,
+      data: [
+        { name: 'prometheus-prod', providerType: 'PROMETHEUS', url: 'http://prometheus:9090' },
+      ],
+    });
+
+    const sources = await listMetricDataSources();
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0].name).toBe('prometheus-prod');
+    expect(sources[0].providerType).toBe('PROMETHEUS');
+  });
+
+  it('creates a data source', async () => {
+    const config = { name: 'cortex-prod', providerType: 'CORTEX', url: 'http://cortex:9009' };
+    mock.onPost('/metrics/datasources/create').reply(200, { code: 200, data: config });
+
+    const created = await createMetricDataSource(config);
+
+    expect(created.name).toBe('cortex-prod');
+    expect(created.providerType).toBe('CORTEX');
+  });
+
+  it('updates a data source', async () => {
+    const config = { name: 'cortex-prod', providerType: 'CORTEX', url: 'http://cortex:9010' };
+    mock.onPost('/metrics/datasources/update').reply(200, { code: 200, data: config });
+
+    const updated = await updateMetricDataSource(config);
+
+    expect(updated.url).toBe('http://cortex:9010');
+  });
+
+  it('deletes a data source', async () => {
+    mock.onDelete(/\/metrics\/datasources/).reply(200, { code: 200, data: null });
+
+    await expect(deleteMetricDataSource('cortex-prod')).resolves.toBeUndefined();
+  });
+
+  it('queries a named data source', async () => {
+    const data = { resultType: 'matrix', series: [], warnings: [] };
+    mock.onPost(/\/metrics\/datasources\/query/).reply(200, { code: 200, data });
+
+    const result = await queryMetricDataSource('victoriametrics-prod', {
+      metric: 'up',
+      start: 1,
+      end: 2,
+      step: '30s',
+    });
+
+    expect(result.resultType).toBe('matrix');
   });
 });

--- a/web/src/api/metrics.ts
+++ b/web/src/api/metrics.ts
@@ -107,3 +107,54 @@ export async function listMetricProfiles() {
   const res = await client.get<{ data: MetricProfile[] }>('/metrics/profiles');
   return res.data.data;
 }
+
+// ─── Metrics data sources (multi-backend) ──────────────────────
+export type MetricsProviderType =
+  'PROMETHEUS' | 'VICTORIAMETRICS' | 'THANOS' | 'CORTEX' | 'MIMIR' | 'ARMS' | 'CUSTOM';
+
+export interface MetricsDataSource {
+  name: string;
+  providerType: MetricsProviderType;
+  url: string;
+  authType?: string;
+  username?: string;
+  password?: string;
+  bearerToken?: string;
+  tlsEnabled?: boolean;
+  scrapeInterval?: number;
+  enabled?: boolean;
+}
+
+export async function listMetricDataSources(): Promise<MetricsDataSource[]> {
+  const res = await client.get<{ data: MetricsDataSource[] }>('/metrics/datasources');
+  return res.data.data;
+}
+
+export async function createMetricDataSource(
+  config: MetricsDataSource,
+): Promise<MetricsDataSource> {
+  const res = await client.post<{ data: MetricsDataSource }>('/metrics/datasources/create', config);
+  return res.data.data;
+}
+
+export async function updateMetricDataSource(
+  config: MetricsDataSource,
+): Promise<MetricsDataSource> {
+  const res = await client.post<{ data: MetricsDataSource }>('/metrics/datasources/update', config);
+  return res.data.data;
+}
+
+export async function deleteMetricDataSource(name: string): Promise<void> {
+  await client.delete<void>(`/metrics/datasources?name=${encodeURIComponent(name)}`);
+}
+
+export async function queryMetricDataSource(
+  dataSource: string,
+  query: MetricQuery,
+): Promise<MetricData> {
+  const res = await client.post<{ data: MetricData }>(
+    `/metrics/datasources/query?dataSource=${encodeURIComponent(dataSource)}`,
+    query,
+  );
+  return res.data.data;
+}

--- a/web/src/components/MetricsDataSourceManager.tsx
+++ b/web/src/components/MetricsDataSourceManager.tsx
@@ -1,0 +1,190 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.
+
+import React, { useEffect, useState } from 'react';
+import { Table, Button, Modal, Form, Input, Select, Switch, Space, Tag, message } from 'antd';
+import { useLang } from '../i18n/LangContext';
+import * as metricsService from '../services/metricsService';
+import type { MetricsDataSource, MetricsProviderType } from '../api/metrics';
+
+const PROVIDER_TYPE_LABEL_KEY: Record<MetricsProviderType, string> = {
+  PROMETHEUS: 'metricsDataSource.providerPrometheus',
+  VICTORIAMETRICS: 'metricsDataSource.providerVictoriaMetrics',
+  THANOS: 'metricsDataSource.providerThanos',
+  CORTEX: 'metricsDataSource.providerCortex',
+  MIMIR: 'metricsDataSource.providerMimir',
+  ARMS: 'metricsDataSource.providerArms',
+  CUSTOM: 'metricsDataSource.providerCustom',
+};
+
+const PROVIDER_TYPES = Object.keys(PROVIDER_TYPE_LABEL_KEY) as MetricsProviderType[];
+
+const AUTH_TYPES = ['none', 'basic', 'bearer'];
+
+export function MetricsDataSourceManager() {
+  const { t } = useLang();
+  const [sources, setSources] = useState<MetricsDataSource[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<MetricsDataSource | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [form] = Form.useForm<MetricsDataSource>();
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      setSources(await metricsService.listMetricDataSources());
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await metricsService.listMetricDataSources();
+        if (!cancelled) setSources(data);
+      } catch {
+        if (!cancelled) message.error(t('metricsDataSource.loadFailed'));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [t]);
+
+  const openAdd = () => {
+    setEditing(null);
+    form.resetFields();
+    form.setFieldsValue({ providerType: 'PROMETHEUS', authType: 'none', enabled: true });
+    setModalOpen(true);
+  };
+
+  const openEdit = (record: MetricsDataSource) => {
+    setEditing(record);
+    form.setFieldsValue(record);
+    setModalOpen(true);
+  };
+
+  const handleDelete = async (record: MetricsDataSource) => {
+    await metricsService.deleteMetricDataSource(record.name);
+    await load();
+  };
+
+  const handleSubmit = async () => {
+    const values = await form.validateFields();
+    setSubmitting(true);
+    try {
+      if (editing) {
+        await metricsService.updateMetricDataSource({ ...editing, ...values });
+      } else {
+        await metricsService.createMetricDataSource(values);
+      }
+      setModalOpen(false);
+      await load();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const columns = [
+    {
+      title: t('metricsDataSource.name'),
+      dataIndex: 'name' as const,
+      key: 'name',
+    },
+    {
+      title: t('metricsDataSource.providerType'),
+      dataIndex: 'providerType' as const,
+      key: 'providerType',
+      render: (value: MetricsProviderType) => <Tag>{t(PROVIDER_TYPE_LABEL_KEY[value])}</Tag>,
+    },
+    {
+      title: t('metricsDataSource.url'),
+      dataIndex: 'url' as const,
+      key: 'url',
+    },
+    {
+      title: t('metricsDataSource.enabled'),
+      dataIndex: 'enabled' as const,
+      key: 'enabled',
+      render: (value: boolean) =>
+        value ? t('metricsDataSource.enabledStatus') : t('metricsDataSource.disabledStatus'),
+    },
+    {
+      title: '',
+      key: 'actions',
+      render: (_: unknown, record: MetricsDataSource) => (
+        <Space>
+          <Button size="small" onClick={() => openEdit(record)}>
+            {t('metricsDataSource.edit')}
+          </Button>
+          <Button size="small" danger onClick={() => handleDelete(record)}>
+            {t('metricsDataSource.delete')}
+          </Button>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+        <div>
+          <h2>{t('metricsDataSource.title')}</h2>
+          <p>{t('metricsDataSource.subtitle')}</p>
+        </div>
+        <Button type="primary" onClick={openAdd}>
+          {t('metricsDataSource.add')}
+        </Button>
+      </div>
+      <Table<MetricsDataSource>
+        rowKey="name"
+        loading={loading}
+        dataSource={sources}
+        columns={columns}
+        pagination={false}
+      />
+      <Modal
+        open={modalOpen}
+        title={editing ? t('metricsDataSource.edit') : t('metricsDataSource.add')}
+        onOk={handleSubmit}
+        confirmLoading={submitting}
+        onCancel={() => setModalOpen(false)}
+        destroyOnHidden
+      >
+        <Form form={form} layout="vertical">
+          <Form.Item name="name" label={t('metricsDataSource.name')} rules={[{ required: true }]}>
+            <Input disabled={!!editing} />
+          </Form.Item>
+          <Form.Item
+            name="providerType"
+            label={t('metricsDataSource.providerType')}
+            rules={[{ required: true }]}
+          >
+            <Select
+              options={PROVIDER_TYPES.map((type) => ({
+                value: type,
+                label: t(PROVIDER_TYPE_LABEL_KEY[type]),
+              }))}
+            />
+          </Form.Item>
+          <Form.Item name="url" label={t('metricsDataSource.url')} rules={[{ required: true }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="authType" label={t('metricsDataSource.authType')}>
+            <Select options={AUTH_TYPES.map((type) => ({ value: type, label: type }))} />
+          </Form.Item>
+          <Form.Item name="enabled" label={t('metricsDataSource.enabled')} valuePropName="checked">
+            <Switch />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+}
+
+export default MetricsDataSourceManager;

--- a/web/src/components/MetricsDataSourceManager.tsx
+++ b/web/src/components/MetricsDataSourceManager.tsx
@@ -1,7 +1,7 @@
 // Licensed to the Apache Software Foundation (ASF) under one or more
 // contributor license agreements.
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Table, Button, Modal, Form, Input, Select, Switch, Space, Tag, message } from 'antd';
 import { useLang } from '../i18n/LangContext';
 import * as metricsService from '../services/metricsService';

--- a/web/src/components/__tests__/MetricsDataSourceManager.test.tsx
+++ b/web/src/components/__tests__/MetricsDataSourceManager.test.tsx
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { App as AntdApp } from 'antd';
+import { LangProvider } from '../../i18n/LangContext';
+import { MetricsDataSourceManager } from '../MetricsDataSourceManager';
+import type { MetricsDataSource } from '../../api/metrics';
+
+vi.mock('../../services/metricsService', () => ({
+  listMetricDataSources: vi.fn(),
+  createMetricDataSource: vi.fn(),
+  updateMetricDataSource: vi.fn(),
+  deleteMetricDataSource: vi.fn(),
+  queryMetricDataSource: vi.fn(),
+}));
+
+import * as metricsService from '../../services/metricsService';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const seeded: MetricsDataSource[] = [
+  {
+    name: 'prometheus-prod',
+    providerType: 'PROMETHEUS',
+    url: 'http://prometheus:9090',
+    authType: 'none',
+    enabled: true,
+  },
+  {
+    name: 'victoriametrics-prod',
+    providerType: 'VICTORIAMETRICS',
+    url: 'http://vm:8428',
+    authType: 'none',
+    enabled: true,
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(metricsService.listMetricDataSources).mockResolvedValue(seeded);
+});
+
+describe('MetricsDataSourceManager', () => {
+  it('lists the configured data sources', async () => {
+    render(
+      <AntdApp>
+        <LangProvider>
+          <MetricsDataSourceManager />
+        </LangProvider>
+      </AntdApp>,
+    );
+
+    expect(await screen.findByText('VictoriaMetrics')).toBeInTheDocument();
+    expect(screen.getByText('prometheus-prod')).toBeInTheDocument();
+    expect(screen.getByText('victoriametrics-prod')).toBeInTheDocument();
+  });
+
+  it('opens the add modal and creates a data source', async () => {
+    const user = userEvent.setup();
+    vi.mocked(metricsService.createMetricDataSource).mockResolvedValue({
+      name: 'cortex-prod',
+      providerType: 'CORTEX',
+      url: 'http://cortex:9009',
+      authType: 'none',
+      enabled: true,
+    });
+
+    render(
+      <AntdApp>
+        <LangProvider>
+          <MetricsDataSourceManager />
+        </LangProvider>
+      </AntdApp>,
+    );
+    await screen.findByText('VictoriaMetrics');
+
+    await user.click(screen.getByRole('button', { name: /Add Data Source|新增数据源/ }));
+    const dialog = await screen.findByRole('dialog');
+
+    const inputs = within(dialog).getAllByRole('textbox');
+    await user.type(inputs[0], 'cortex-prod');
+    await user.type(inputs[1], 'http://cortex:9009');
+
+    // pick the CORTEX provider type from the antd Select (options are portaled to body)
+    await user.click(within(dialog).getByText('Prometheus'));
+    await user.click(await screen.findByText('Cortex'));
+
+    await user.click(within(dialog).getByText('OK'));
+
+    await waitFor(() =>
+      expect(metricsService.createMetricDataSource).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'cortex-prod', providerType: 'CORTEX' }),
+      ),
+    );
+  });
+});

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -35,6 +35,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'nav.alertEvents': { zh: '告警事件', en: 'Alert Events' },
   'nav.alertRules': { zh: '告警规则', en: 'Alert Rules' },
   'nav.audit': { zh: '审计日志', en: 'Audit Log' },
+  'nav.metricsDataSources': { zh: '指标数据源', en: 'Metrics Sources' },
   'nav.ai': { zh: 'AI 交互', en: 'AI Chat' },
   'nav.settings': { zh: '设置', en: 'Settings' },
 
@@ -1386,6 +1387,36 @@ const translations: Record<string, Record<Lang, string>> = {
     en: 'Claude / Titan / Llama (AWS)',
   },
   // ─── BrokerCluster ───
+
+  // ─── Metrics data sources (multi-backend) ───
+  'metricsDataSource.title': { zh: '指标数据源', en: 'Metrics Data Sources' },
+  'metricsDataSource.subtitle': {
+    zh: '管理 Prometheus 兼容的多后端监控数据源',
+    en: 'Manage Prometheus-compatible multi-backend monitoring data sources',
+  },
+  'metricsDataSource.add': { zh: '新增数据源', en: 'Add Data Source' },
+  'metricsDataSource.edit': { zh: '编辑数据源', en: 'Edit Data Source' },
+  'metricsDataSource.delete': { zh: '删除', en: 'Delete' },
+  'metricsDataSource.name': { zh: '名称', en: 'Name' },
+  'metricsDataSource.providerType': { zh: '后端类型', en: 'Backend Type' },
+  'metricsDataSource.url': { zh: '地址', en: 'URL' },
+  'metricsDataSource.authType': { zh: '鉴权方式', en: 'Auth Type' },
+  'metricsDataSource.enabled': { zh: '启用', en: 'Enabled' },
+  'metricsDataSource.enabledStatus': { zh: '已启用', en: 'Enabled' },
+  'metricsDataSource.disabledStatus': { zh: '已停用', en: 'Disabled' },
+  'metricsDataSource.confirmDelete': { zh: '确认删除该数据源？', en: 'Delete this data source?' },
+  'metricsDataSource.saved': { zh: '数据源已保存', en: 'Data source saved' },
+  'metricsDataSource.nameRequired': { zh: '名称不能为空', en: 'Name is required' },
+  'metricsDataSource.urlRequired': { zh: '地址不能为空', en: 'URL is required' },
+  'metricsDataSource.query': { zh: '查询', en: 'Query' },
+  'metricsDataSource.loadFailed': { zh: '加载数据源失败', en: 'Failed to load data sources' },
+  'metricsDataSource.providerPrometheus': { zh: 'Prometheus', en: 'Prometheus' },
+  'metricsDataSource.providerVictoriaMetrics': { zh: 'VictoriaMetrics', en: 'VictoriaMetrics' },
+  'metricsDataSource.providerThanos': { zh: 'Thanos', en: 'Thanos' },
+  'metricsDataSource.providerCortex': { zh: 'Cortex', en: 'Cortex' },
+  'metricsDataSource.providerMimir': { zh: 'Grafana Mimir', en: 'Grafana Mimir' },
+  'metricsDataSource.providerArms': { zh: '阿里云 ARMS', en: 'Alibaba Cloud ARMS' },
+  'metricsDataSource.providerCustom': { zh: '自定义', en: 'Custom' },
 };
 
 export default translations;

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -124,6 +124,11 @@ const MainLayout = () => {
         { key: '/ops/alerts', icon: <BellRinging size={16} />, label: t('nav.alertRules') },
         { key: '/ops/system-alerts', icon: <BellRinging size={16} />, label: t('nav.alertEvents') },
         { key: '/ops/audit', icon: <Notebook size={16} />, label: t('nav.audit') },
+        {
+          key: '/studio/metrics-datasources',
+          icon: <ChartBar size={16} />,
+          label: t('nav.metricsDataSources'),
+        },
       ],
     },
     { key: '/ai', icon: <Sparkle size={iconSize} weight="duotone" />, label: t('nav.ai') },

--- a/web/src/mock/metricsDataSources.ts
+++ b/web/src/mock/metricsDataSources.ts
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.
+
+import type { MetricsDataSource } from '../api/metrics';
+
+export const mockMetricsDataSources: MetricsDataSource[] = [
+  {
+    name: 'prometheus-prod',
+    providerType: 'PROMETHEUS',
+    url: 'http://prometheus:9090',
+    authType: 'none',
+    tlsEnabled: false,
+    scrapeInterval: 15,
+    enabled: true,
+  },
+  {
+    name: 'victoriametrics-prod',
+    providerType: 'VICTORIAMETRICS',
+    url: 'http://victoria-metrics:8428',
+    authType: 'none',
+    tlsEnabled: false,
+    scrapeInterval: 15,
+    enabled: true,
+  },
+  {
+    name: 'thanos-prod',
+    providerType: 'THANOS',
+    url: 'http://thanos-query:9090',
+    authType: 'none',
+    tlsEnabled: false,
+    scrapeInterval: 15,
+    enabled: true,
+  },
+  {
+    name: 'cortex-prod',
+    providerType: 'CORTEX',
+    url: 'http://cortex-query:9009',
+    authType: 'none',
+    tlsEnabled: false,
+    scrapeInterval: 15,
+    enabled: true,
+  },
+  {
+    name: 'mimir-prod',
+    providerType: 'MIMIR',
+    url: 'http://mimir-query:8080',
+    authType: 'none',
+    tlsEnabled: true,
+    scrapeInterval: 15,
+    enabled: true,
+  },
+  {
+    name: 'arms-prod',
+    providerType: 'ARMS',
+    url: 'http://arms-prometheus:9090',
+    authType: 'bearer',
+    tlsEnabled: true,
+    scrapeInterval: 15,
+    enabled: true,
+  },
+];

--- a/web/src/pages/studio/MetricsDataSources.tsx
+++ b/web/src/pages/studio/MetricsDataSources.tsx
@@ -1,0 +1,10 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.
+
+import { MetricsDataSourceManager } from '../../components/MetricsDataSourceManager';
+
+export function MetricsDataSourcesPage() {
+  return <MetricsDataSourceManager />;
+}
+
+export default MetricsDataSourcesPage;

--- a/web/src/services/metricsService.test.ts
+++ b/web/src/services/metricsService.test.ts
@@ -1,0 +1,136 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { isMockModeMock } = vi.hoisted(() => ({ isMockModeMock: vi.fn(() => true) }));
+
+vi.mock('./dataMode', () => ({ isMockMode: () => isMockModeMock() }));
+vi.mock('../api/metrics', () => ({
+  listMetricDataSources: vi.fn(),
+  createMetricDataSource: vi.fn(),
+  updateMetricDataSource: vi.fn(),
+  deleteMetricDataSource: vi.fn(),
+  queryMetricDataSource: vi.fn(),
+}));
+
+import * as api from '../api/metrics';
+import type { MetricsDataSource } from '../api/metrics';
+
+async function loadService() {
+  vi.resetModules();
+  return import('./metricsService');
+}
+
+function source(name: string, providerType: MetricsDataSource['providerType']): MetricsDataSource {
+  return { name, providerType, url: `http://${name}:9090`, authType: 'none', enabled: true };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('metricsService (mock mode)', () => {
+  it('lists the seeded data sources for every backend type', async () => {
+    isMockModeMock.mockReturnValue(true);
+    const svc = await loadService();
+
+    const sources = await svc.listMetricDataSources();
+
+    expect(sources.length).toBeGreaterThanOrEqual(5);
+    const types = sources.map((s) => s.providerType);
+    expect(types).toEqual(
+      expect.arrayContaining([
+        'PROMETHEUS',
+        'VICTORIAMETRICS',
+        'THANOS',
+        'CORTEX',
+        'MIMIR',
+        'ARMS',
+      ]),
+    );
+  });
+
+  it('creates and then lists a new data source', async () => {
+    isMockModeMock.mockReturnValue(true);
+    const svc = await loadService();
+
+    await svc.createMetricDataSource(source('cortex-prod', 'CORTEX'));
+    const names = (await svc.listMetricDataSources()).map((s) => s.name);
+
+    expect(names).toContain('cortex-prod');
+  });
+
+  it('updates an existing data source', async () => {
+    isMockModeMock.mockReturnValue(true);
+    const svc = await loadService();
+
+    await svc.updateMetricDataSource({
+      ...source('cortex-prod', 'CORTEX'),
+      url: 'http://cortex:9010',
+    });
+    const updated = (await svc.listMetricDataSources()).find((s) => s.name === 'cortex-prod');
+
+    expect(updated?.url).toBe('http://cortex:9010');
+  });
+
+  it('deletes a data source', async () => {
+    isMockModeMock.mockReturnValue(true);
+    const svc = await loadService();
+
+    await svc.deleteMetricDataSource('cortex-prod');
+    const names = (await svc.listMetricDataSources()).map((s) => s.name);
+
+    expect(names).not.toContain('cortex-prod');
+  });
+
+  it('returns an empty series when querying in mock mode', async () => {
+    isMockModeMock.mockReturnValue(true);
+    const svc = await loadService();
+
+    const result = await svc.queryMetricDataSource('prometheus-prod', {
+      metric: 'up',
+      start: 1,
+      end: 2,
+      step: '30s',
+    });
+
+    expect(result.series).toEqual([]);
+  });
+});
+
+describe('metricsService (real mode)', () => {
+  it('delegates list to the api', async () => {
+    isMockModeMock.mockReturnValue(false);
+    const svc = await loadService();
+    vi.mocked(api.listMetricDataSources).mockResolvedValue([
+      source('prometheus-prod', 'PROMETHEUS'),
+    ]);
+
+    const result = await svc.listMetricDataSources();
+
+    expect(api.listMetricDataSources).toHaveBeenCalled();
+    expect(result[0].name).toBe('prometheus-prod');
+  });
+
+  it('delegates create to the api', async () => {
+    isMockModeMock.mockReturnValue(false);
+    const svc = await loadService();
+    vi.mocked(api.createMetricDataSource).mockResolvedValue(source('mimir-prod', 'MIMIR'));
+
+    const created = await svc.createMetricDataSource(source('mimir-prod', 'MIMIR'));
+
+    expect(api.createMetricDataSource).toHaveBeenCalled();
+    expect(created.providerType).toBe('MIMIR');
+  });
+
+  it('delegates delete to the api', async () => {
+    isMockModeMock.mockReturnValue(false);
+    const svc = await loadService();
+    vi.mocked(api.deleteMetricDataSource).mockResolvedValue(undefined);
+
+    await svc.deleteMetricDataSource('arms-prod');
+
+    expect(api.deleteMetricDataSource).toHaveBeenCalledWith('arms-prod');
+  });
+});

--- a/web/src/services/metricsService.ts
+++ b/web/src/services/metricsService.ts
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.
+
+import { isMockMode } from './dataMode';
+import * as metricsApi from '../api/metrics';
+import type { MetricsDataSource, MetricData, MetricQuery } from '../api/metrics';
+import { mockMetricsDataSources } from '../mock/metricsDataSources';
+
+let mockStore: MetricsDataSource[] = mockMetricsDataSources.map((source) => ({ ...source }));
+
+function copySource(source: MetricsDataSource): MetricsDataSource {
+  return { ...source };
+}
+
+export async function listMetricDataSources(): Promise<MetricsDataSource[]> {
+  if (isMockMode()) {
+    return mockStore.map(copySource);
+  }
+  return metricsApi.listMetricDataSources();
+}
+
+export async function createMetricDataSource(
+  config: MetricsDataSource,
+): Promise<MetricsDataSource> {
+  if (isMockMode()) {
+    const created = copySource(config);
+    const index = mockStore.findIndex((source) => source.name === config.name);
+    if (index >= 0) {
+      mockStore[index] = created;
+    } else {
+      mockStore.push(created);
+    }
+    return created;
+  }
+  return metricsApi.createMetricDataSource(config);
+}
+
+export async function updateMetricDataSource(
+  config: MetricsDataSource,
+): Promise<MetricsDataSource> {
+  if (isMockMode()) {
+    const index = mockStore.findIndex((source) => source.name === config.name);
+    if (index < 0) {
+      throw new Error(`Data source not found: ${config.name}`);
+    }
+    mockStore[index] = copySource(config);
+    return mockStore[index];
+  }
+  return metricsApi.updateMetricDataSource(config);
+}
+
+export async function deleteMetricDataSource(name: string): Promise<void> {
+  if (isMockMode()) {
+    mockStore = mockStore.filter((source) => source.name !== name);
+    return;
+  }
+  return metricsApi.deleteMetricDataSource(name);
+}
+
+export async function queryMetricDataSource(
+  dataSource: string,
+  query: MetricQuery,
+): Promise<MetricData> {
+  if (isMockMode()) {
+    return {
+      resultType: 'matrix',
+      series: [],
+      warnings: [],
+    };
+  }
+  return metricsApi.queryMetricDataSource(dataSource, query);
+}


### PR DESCRIPTION
# feat(metrics): support multiple Prometheus-compatible metrics backends (METRICS-01)

> Branch: `feature/studio-metrics-multi-source`
> Base: `rocketmq-studio`
> Scope: METRICS-01 — *Metrics collection from multiple backends (≥5 backends)*

## Summary

RocketMQ Studio previously shipped a single hard-coded Prometheus metrics backend. This
change introduces a pluggable **metrics data-source registry** so the dashboard can read
RocketMQ Prometheus metrics from several compatible backends behind one unified query API.

Six Prometheus-compatible backend types are supported out of the box, plus a free-form
`CUSTOM` type, satisfying the "≥5 backends" requirement:

| Backend | Query path |
|---|---|
| `PROMETHEUS` | `/api/v1/query_range` |
| `VICTORIA_METRICS` | `/select/0/prometheus/api/v1/query_range` |
| `THANOS` | `/api/v1/query_range` |
| `CORTEX` | `/api/v1/query_range` |
| `MIMIR` | `/prometheus/api/v1/query_range` |
| `ARMS` (Alibaba Cloud Managed Prometheus) | `/api/v1/query_range` |
| `CUSTOM` | user-supplied base path |

All backends share one `AbstractPrometheusCompatibleMetricsSource` base class; concrete
sources only override the query path, so adding a new Prometheus-compatible backend is a
~30-line class.

## Changes

### Backend (`server/.../cluster/metrics`)
- `MetricsBackendType` — enum of supported backends with their PromQL `query_range` paths.
- `MetricsSourceSettings` / `MetricsDataSourceConfig` — data-source configuration model
  (name, type, base URL, auth, scrape interval, etc.).
- `AbstractPrometheusCompatibleMetricsSource` — shared HTTP query implementation.
- `PrometheusMetricsSource` (refactored), `VictoriaMetricsMetricsSource`,
  `ThanosMetricsSource`, `CortexMetricsSource`, `MimirMetricsSource`, `ArmsMetricsSource`
  — concrete sources.
- `MetricsSourceFactory` — builds a source instance from a config.
- `MetricsDataSourceRepository` + `InMemoryMetricsDataSourceRepository` — registry store.
- `MetricsDataSourceService` — CRUD + query orchestration.
- `MetricsDataSourceController` — REST endpoints.

### Frontend (`web/...`)
- `api/metrics.ts` — added data-source CRUD + query client functions.
- `services/metricsService.ts` — service layer with mock/real data-mode support.
- `mock/metricsDataSources.ts` — sample data sources for mock mode.
- `components/MetricsDataSourceManager.tsx` — table + create/edit modal manager.
- `pages/studio/MetricsDataSources.tsx` — page wired into the studio nav.
- `layouts/MainLayout.tsx`, `App.tsx` — navigation entry + lazy route.
- `i18n/translations.ts` — `metricsDataSource.*` keys (zh/en).

## API

```
GET    /api/metrics/datasources            # list configured data sources
POST   /api/metrics/datasources/create     # create a data source
POST   /api/metrics/datasources/update     # update a data source
DELETE /api/metrics/datasources?name=...   # delete a data source
POST   /api/metrics/datasources/query      # run a PromQL query against a source
```

## Testing

- **Backend** (`server/src/test/.../cluster/metrics`):
  - `MetricsBackendTypeTest` — enum parsing / query-path mapping.
  - `MetricsDataSourceServiceTest` — CRUD + repository behavior.
  - `MetricsDataSourceControllerTest` — WebMvc endpoint coverage.
  - `MultiBackendMetricsSourceTest` — verifies all 6 backends issue correct queries.
  - All pass; Checkstyle clean.
- **Frontend** (`web/src`):
  - `api/metrics.test.ts` (data-source cases), `services/metricsService.test.ts`,
    `components/__tests__/MetricsDataSourceManager.test.tsx`.
  - `tsc --noEmit` clean; ESLint clean.

## Notes / Follow-ups
- Store is in-memory (consistent with other studio modules); a persistent store can be
  added later behind the same `MetricsDataSourceRepository` interface.
- Frontend respects the existing mock/real data-mode toggle, so the UI is demoable without
  a live backend.
