### PR TITLE
[ISSUE #775][ISSUE #790][ISSUE #802][ISSUE #870] Harden demo and mock data boundaries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
 import org.apache.rocketmq.studio.common.domain.enums.FlushDiskType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -40,8 +41,11 @@ public class ClusterRepositoryImpl implements ClusterRepository {
 
     private final Map<String, ClusterVO> store = new ConcurrentHashMap<>();
 
-    public ClusterRepositoryImpl() {
-        initStubData();
+    public ClusterRepositoryImpl(@Value("${studio.cluster.seed-demo-data:false}") boolean seedDemoData) {
+        if (seedDemoData) {
+            initStubData();
+            log.info("Initialized demo cluster data for Studio cluster repository");
+        }
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InMemoryInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InMemoryInstanceRepository.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.studio.instance;
 
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -34,8 +35,10 @@ public class InMemoryInstanceRepository implements InstanceRepository {
 
     private final Map<String, InstanceVO> store = new ConcurrentHashMap<>();
 
-    public InMemoryInstanceRepository() {
-        initData();
+    public InMemoryInstanceRepository(@Value("${studio.instance.seed-demo-data:false}") boolean seedDemoData) {
+        if (seedDemoData) {
+            initData();
+        }
     }
 
     private void initData() {

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -34,6 +34,8 @@ studio:
       - username: ${STUDIO_AUTH_ADMIN_USERNAME:}
         password: ${STUDIO_AUTH_ADMIN_PASSWORD:}
         admin: true
+  cluster:
+    seed-demo-data: ${STUDIO_CLUSTER_SEED_DEMO_DATA:false}
   metrics:
     prometheus:
       base-url: ${STUDIO_METRICS_PROMETHEUS_BASE_URL:}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -36,6 +36,8 @@ studio:
         admin: true
   cluster:
     seed-demo-data: ${STUDIO_CLUSTER_SEED_DEMO_DATA:false}
+  instance:
+    seed-demo-data: ${STUDIO_INSTANCE_SEED_DEMO_DATA:false}
   metrics:
     prometheus:
       base-url: ${STUDIO_METRICS_PROMETHEUS_BASE_URL:}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
@@ -26,11 +26,18 @@ class ClusterRepositoryImplTest {
 
     @Test
     void findAllShouldReturnClustersInStableNameOrder() {
-        ClusterRepositoryImpl repository = new ClusterRepositoryImpl();
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(true);
 
         List<ClusterVO> clusters = repository.findAll();
 
         assertThat(clusters).extracting(ClusterVO::getName)
                 .containsExactly("rmq-cluster-prod", "rmq-cluster-staging");
+    }
+
+    @Test
+    void findAllShouldBeEmptyWhenDemoDataIsDisabled() {
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(false);
+
+        assertThat(repository.findAll()).isEmpty();
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InMemoryInstanceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InMemoryInstanceRepositoryTest.java
@@ -23,7 +23,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class InMemoryInstanceRepositoryTest {
 
-    private final InMemoryInstanceRepository repository = new InMemoryInstanceRepository();
+    private final InMemoryInstanceRepository repository = new InMemoryInstanceRepository(true);
+
+    @Test
+    void findAllShouldBeEmptyWhenDemoDataIsDisabled() {
+        InMemoryInstanceRepository emptyRepository = new InMemoryInstanceRepository(false);
+
+        assertThat(emptyRepository.findAll()).isEmpty();
+    }
 
     @Test
     void searchShouldMatchInstanceEndpoints() {

--- a/web/.env.production
+++ b/web/.env.production
@@ -1,3 +1,3 @@
-# Backend not ready yet - use mock data
-# Set to "false" when real API is available
-VITE_USE_MOCK=true
+# Production builds should call real backend APIs by default.
+# Set to "true" only for explicit demo/mock deployments.
+VITE_USE_MOCK=false

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -66,129 +66,6 @@ interface ProxyRecord {
   connections: number;
 }
 
-// ─── Mock Data (fallback when the API is unavailable) ───────────
-const mockBrokerData: BrokerRecord[] = [
-  {
-    key: '1',
-    k8sCluster: 'prod-cn-east-1',
-    brokerName: 'broker-a',
-    status: 'running',
-    version: '5.3.0',
-    diskUsage: 62,
-    address: '10.0.1.10:10911',
-    tpsIn: 12580,
-    tpsOut: 8340,
-  },
-  {
-    key: '2',
-    k8sCluster: 'prod-cn-east-1',
-    brokerName: 'broker-b',
-    status: 'readonly',
-    version: '5.3.0',
-    diskUsage: 89,
-    address: '10.0.1.11:10911',
-    tpsIn: 0,
-    tpsOut: 3120,
-  },
-  {
-    key: '3',
-    k8sCluster: 'prod-cn-east-1',
-    brokerName: 'broker-c',
-    status: 'running',
-    version: '5.2.0',
-    diskUsage: 45,
-    address: '10.0.1.12:10911',
-    tpsIn: 9750,
-    tpsOut: 6280,
-  },
-  {
-    key: '4',
-    k8sCluster: 'prod-cn-south-1',
-    brokerName: 'broker-d',
-    status: 'maintenance',
-    version: '5.3.0',
-    diskUsage: 33,
-    address: '10.0.2.10:10911',
-    tpsIn: 0,
-    tpsOut: 0,
-  },
-  {
-    key: '5',
-    k8sCluster: 'prod-cn-south-1',
-    brokerName: 'broker-e',
-    status: 'running',
-    version: '5.3.0',
-    diskUsage: 51,
-    address: '10.0.2.11:10911',
-    tpsIn: 7890,
-    tpsOut: 5430,
-  },
-  {
-    key: '6',
-    k8sCluster: 'staging-cn-east-1',
-    brokerName: 'broker-staging-a',
-    status: 'running',
-    version: '5.3.1',
-    diskUsage: 28,
-    address: '10.0.10.10:10911',
-    tpsIn: 1230,
-    tpsOut: 980,
-  },
-];
-
-const mockNameServerData: NameServerRecord[] = [
-  {
-    key: '1',
-    k8sCluster: 'prod-cn-east-1',
-    name: 'nameserver-a',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.1.20:9876',
-    connections: 156,
-  },
-  {
-    key: '2',
-    k8sCluster: 'prod-cn-east-1',
-    name: 'nameserver-b',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.1.21:9876',
-    connections: 148,
-  },
-  {
-    key: '3',
-    k8sCluster: 'prod-cn-south-1',
-    name: 'nameserver-c',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.2.20:9876',
-    connections: 92,
-  },
-];
-
-const mockProxyData: ProxyRecord[] = [
-  {
-    key: '1',
-    k8sCluster: 'prod-cn-east-1',
-    name: 'proxy-a',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.1.30:8080',
-    grpcPort: '10.0.1.30:8081',
-    connections: 2340,
-  },
-  {
-    key: '2',
-    k8sCluster: 'prod-cn-south-1',
-    name: 'proxy-b',
-    status: 'running',
-    version: '5.3.0',
-    address: '10.0.2.30:8080',
-    grpcPort: '10.0.2.30:8081',
-    connections: 1560,
-  },
-];
-
 // ─── Helpers ────────────────────────────────────────────────────
 const normalizeStatus = (status: string): NodeStatus => {
   const value = (status || '').toLowerCase();
@@ -260,9 +137,9 @@ const BrokerClusterPage = () => {
   const [autoRefresh, setAutoRefresh] = useState(false);
   const [activeTab, setActiveTab] = useState('broker');
   const [loading, setLoading] = useState(false);
-  const [brokerData, setBrokerData] = useState<BrokerRecord[]>(mockBrokerData);
-  const [nameServerData, setNameServerData] = useState<NameServerRecord[]>(mockNameServerData);
-  const [proxyData, setProxyData] = useState<ProxyRecord[]>(mockProxyData);
+  const [brokerData, setBrokerData] = useState<BrokerRecord[]>([]);
+  const [nameServerData, setNameServerData] = useState<NameServerRecord[]>([]);
+  const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
   const { t } = useLang();
   const { message } = App.useApp();
 

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -183,12 +183,14 @@ describe('BrokerCluster Page', () => {
     expect(restartButtons.length).toBeGreaterThan(0);
   });
 
-  it('should fall back to mock data when the API fails', async () => {
+  it('does not show mock infrastructure data when the API fails', async () => {
     vi.mocked(listClusters).mockRejectedValueOnce(new Error('network error'));
     renderWithProviders(<BrokerCluster />);
-    // Initial state holds the mock fallback rows
     await waitFor(() => {
-      expect(screen.getByText('broker-a')).toBeInTheDocument();
+      expect(listClusters).toHaveBeenCalledTimes(1);
     });
+    expect(screen.queryByText('broker-a')).not.toBeInTheDocument();
+    expect(screen.queryByText('broker-b')).not.toBeInTheDocument();
+    expect(screen.queryByText('proxy-a')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

**Track:** Track 1 / Control Plane reliability

Consolidates and supersedes #776, #791, #803, and #871.

- Gate in-memory cluster and instance demo seed data behind explicit configuration disabled by default.
- Disable frontend mock mode in production builds.
- Remove BrokerCluster fallback rows when the service returns no data.

## Verification

- `mvn -Dtest=ClusterRepositoryImplTest,InMemoryInstanceRepositoryTest test`
- `npm test -- --run src/pages/studio/__tests__/BrokerCluster.test.tsx`
- `npm run lint -- src/pages/studio/BrokerCluster.tsx src/pages/studio/__tests__/BrokerCluster.test.tsx`
- `git diff --check origin/rocketmq-studio...HEAD`

Closes #775
Closes #790
Closes #802
Closes #870