### PR TITLE
[ISSUE #778][ISSUE #780] Surface unavailable message and DLQ providers

### DIFF
--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -104,6 +104,15 @@ describe('DLQ page', () => {
     expect(messageService.listDLQGroups).toHaveBeenCalledTimes(1);
   });
 
+  it('surfaces unavailable DLQ provider errors when loading groups', async () => {
+    vi.mocked(messageService.listDLQGroups).mockRejectedValue(
+      new Error('DLQ provider is not configured'),
+    );
+    renderWithProviders(<DLQPage />);
+
+    expect(await screen.findByText('DLQ provider is not configured')).toBeInTheDocument();
+  });
+
   it('opens a detail dialog with the selected group metadata', async () => {
     const user = userEvent.setup();
     renderWithProviders(<DLQPage />);
@@ -174,5 +183,22 @@ describe('DLQ page', () => {
     await waitFor(() => expect(messageService.listDLQGroups).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(within(orderRow).getByRole('checkbox')).toBeDisabled());
     expect(screen.getByRole('button', { name: /批量导出/ })).toBeDisabled();
+  });
+
+  it('surfaces unavailable DLQ provider errors when retry submission fails', async () => {
+    vi.mocked(messageService.resendDLQ).mockRejectedValue(
+      new Error('DLQ provider is not configured'),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<DLQPage />);
+
+    const orderRow = (await screen.findByText('cg-order')).closest('tr');
+    if (!orderRow) throw new Error('DLQ group row not found');
+
+    await user.click(within(orderRow).getByRole('button', { name: '重投消息' }));
+    await user.type(screen.getByPlaceholderText('输入目标 Topic 名称'), 'orders-retry');
+    await user.click(screen.getByRole('button', { name: '确认重投' }));
+
+    expect(await screen.findByText('DLQ provider is not configured')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -121,6 +121,37 @@ describe('MessagePage async request ownership', () => {
     expect(screen.queryByText('late-after-reset')).not.toBeInTheDocument();
   });
 
+  it('surfaces unavailable message provider errors from query requests', async () => {
+    serviceMocks.queryMessages.mockRejectedValue(
+      new Error('Message query provider is not configured'),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+
+    expect(await screen.findByText('Message query provider is not configured')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
+  });
+
+  it('surfaces unavailable message provider errors from trace requests', async () => {
+    serviceMocks.queryMessages.mockResolvedValue([createMessage('message-a')]);
+    serviceMocks.getMessageTrace.mockRejectedValue(
+      new Error('Message query provider is not configured'),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+    const row = await screen.findByRole('row', { name: /message-a/ });
+    await user.click(within(row).getByRole('button', { name: /轨迹/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: '消息详情' });
+    expect(
+      await within(dialog).findByText('Message query provider is not configured'),
+    ).toBeInTheDocument();
+  });
+
   it('keeps the latest query loading and ignores an earlier query result', async () => {
     const firstQuery = createDeferred<MessageRecord[]>();
     const secondQuery = createDeferred<MessageRecord[]>();

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -17,6 +17,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import {
+  Alert,
   Card,
   Table,
   Button,
@@ -39,8 +40,31 @@ import { listDLQGroups, resendDLQ } from '../../services/messageService';
 
 const { Text } = Typography;
 const { RangePicker } = DatePicker;
+const DEFAULT_LOAD_ERROR = '死信队列加载失败，请稍后重试';
+const DEFAULT_RETRY_ERROR = '提交重投任务失败，请稍后重试';
 
 /* ─── Helpers ─── */
+
+type ApiErrorLike = {
+  message?: unknown;
+  response?: {
+    data?: {
+      message?: unknown;
+    };
+  };
+};
+
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  const apiError = error as ApiErrorLike;
+  const responseMessage = apiError.response?.data?.message;
+  if (typeof responseMessage === 'string' && responseMessage.trim()) {
+    return responseMessage;
+  }
+  if (typeof apiError.message === 'string' && apiError.message.trim()) {
+    return apiError.message;
+  }
+  return fallback;
+};
 
 const formatDateTime = (iso: string): string => {
   const d = new Date(iso);
@@ -94,6 +118,8 @@ const DLQPage = () => {
   const [retrySubmitting, setRetrySubmitting] = useState(false);
   const [detailGroup, setDetailGroup] = useState<DLQGroup | null>(null);
   const [selectedGroupNames, setSelectedGroupNames] = useState<string[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [retryError, setRetryError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -102,6 +128,7 @@ const DLQPage = () => {
       .then((nextGroups) => {
         if (!cancelled) {
           setGroups(nextGroups);
+          setLoadError(null);
           const availableGroups = new Set(
             nextGroups.filter((group) => group.messageCount > 0).map((group) => group.groupName),
           );
@@ -110,8 +137,8 @@ const DLQPage = () => {
           );
         }
       })
-      .catch(() => {
-        if (!cancelled) message.error('死信队列加载失败，请稍后重试');
+      .catch((error) => {
+        if (!cancelled) setLoadError(getErrorMessage(error, DEFAULT_LOAD_ERROR));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -141,6 +168,7 @@ const DLQPage = () => {
     setRetryGroup(group);
     setRetryRange([dayjs().subtract(1, 'day'), dayjs()]);
     setRetryTargetTopic('');
+    setRetryError(null);
     setRetryModalOpen(true);
   };
 
@@ -152,6 +180,7 @@ const DLQPage = () => {
     if (!retryGroup) return;
 
     setRetrySubmitting(true);
+    setRetryError(null);
     try {
       await resendDLQ({
         groupName: retryGroup.groupName,
@@ -163,8 +192,9 @@ const DLQPage = () => {
       message.success(`已提交重投任务：${retryGroup.groupName} → ${retryTargetTopic}`);
       setRetryModalOpen(false);
       setRetryGroup(null);
-    } catch {
-      message.error('提交重投任务失败，请稍后重试');
+      setRetryError(null);
+    } catch (error) {
+      setRetryError(getErrorMessage(error, DEFAULT_RETRY_ERROR));
     } finally {
       setRetrySubmitting(false);
     }
@@ -299,6 +329,10 @@ const DLQPage = () => {
         </Button>
       </Flex>
 
+      {loadError && (
+        <Alert showIcon type="warning" message={loadError} style={{ marginBottom: 16 }} />
+      )}
+
       {/* ── Table ── */}
       <Card bodyStyle={{ padding: 0 }}>
         <Table
@@ -335,6 +369,7 @@ const DLQPage = () => {
         onCancel={() => {
           setRetryModalOpen(false);
           setRetryGroup(null);
+          setRetryError(null);
         }}
         onOk={handleRetry}
         confirmLoading={retrySubmitting}
@@ -345,6 +380,10 @@ const DLQPage = () => {
       >
         {retryGroup && (
           <div style={{ marginTop: 16 }}>
+            {retryError && (
+              <Alert showIcon type="warning" message={retryError} style={{ marginBottom: 16 }} />
+            )}
+
             <div
               style={{
                 marginBottom: 16,

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -17,6 +17,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import {
+  Alert,
   Card,
   Table,
   Tag,
@@ -57,6 +58,8 @@ import { getMessageTrace, queryMessages } from '../../services/messageService';
 
 const { Paragraph, Text } = Typography;
 const { RangePicker } = DatePicker;
+const DEFAULT_QUERY_ERROR = '消息查询失败，请稍后重试';
+const DEFAULT_TRACE_ERROR = '消息轨迹加载失败，请稍后重试';
 
 /* ─── Constants ─── */
 
@@ -65,6 +68,15 @@ type QueryMode = 'topic' | 'key' | 'msgid';
 type RecentQuery = {
   mode: QueryMode;
   params: MessageQuery;
+};
+
+type ApiErrorLike = {
+  message?: unknown;
+  response?: {
+    data?: {
+      message?: unknown;
+    };
+  };
 };
 
 const QUERY_HISTORY_STORAGE_KEY = 'rocketmq-studio-message-query-history';
@@ -175,6 +187,18 @@ const queryLabel = ({ mode, params }: RecentQuery): string => {
   return `Topic: ${params.topic || '全部'}${params.tag ? ` · Tag: ${params.tag}` : ''}`;
 };
 
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  const apiError = error as ApiErrorLike;
+  const responseMessage = apiError.response?.data?.message;
+  if (typeof responseMessage === 'string' && responseMessage.trim()) {
+    return responseMessage;
+  }
+  if (typeof apiError.message === 'string' && apiError.message.trim()) {
+    return apiError.message;
+  }
+  return fallback;
+};
+
 /* ═══════════════════════════════════════════
    MessagePage
    ═══════════════════════════════════════════ */
@@ -193,6 +217,8 @@ const MessagePage = () => {
   const [selectedMsg, setSelectedMsg] = useState<MessageRecord | null>(null);
   const [traceData, setTraceData] = useState<TraceRecord | null>(null);
   const [traceLoading, setTraceLoading] = useState(false);
+  const [queryError, setQueryError] = useState<string | null>(null);
+  const [traceError, setTraceError] = useState<string | null>(null);
   const [recentQueries, setRecentQueries] = useState<RecentQuery[]>(loadRecentQueries);
   const queryGenerationRef = useRef(0);
   const traceGenerationRef = useRef(0);
@@ -214,6 +240,7 @@ const MessagePage = () => {
     setMsgIdInput('');
     setDateRange(getDefaultRange());
     setMessages([]);
+    setQueryError(null);
     setQueryLoading(false);
   };
 
@@ -238,15 +265,17 @@ const MessagePage = () => {
     const requestGeneration = queryGenerationRef.current + 1;
     queryGenerationRef.current = requestGeneration;
     setQueryLoading(true);
+    setQueryError(null);
     try {
       const result = await queryMessages(params);
       if (queryGenerationRef.current !== requestGeneration) return;
       setMessages(result);
+      setQueryError(null);
       saveRecentQuery(mode, params);
       message.success(`查询完成，共 ${result.length} 条`);
-    } catch {
+    } catch (error) {
       if (queryGenerationRef.current === requestGeneration) {
-        message.error('消息查询失败，请稍后重试');
+        setQueryError(getErrorMessage(error, DEFAULT_QUERY_ERROR));
       }
     } finally {
       if (queryGenerationRef.current === requestGeneration) {
@@ -339,13 +368,15 @@ const MessagePage = () => {
     setModalOpen(true);
     setTraceData(null);
     setTraceLoading(true);
+    setTraceError(null);
     try {
       const result = await getMessageTrace(record.msgId);
       if (traceGenerationRef.current !== requestGeneration) return;
       setTraceData(result);
-    } catch {
+      setTraceError(null);
+    } catch (error) {
       if (traceGenerationRef.current === requestGeneration) {
-        message.error('消息轨迹加载失败，请稍后重试');
+        setTraceError(getErrorMessage(error, DEFAULT_TRACE_ERROR));
       }
     } finally {
       if (traceGenerationRef.current === requestGeneration) {
@@ -358,6 +389,7 @@ const MessagePage = () => {
     traceGenerationRef.current += 1;
     setModalOpen(false);
     setTraceLoading(false);
+    setTraceError(null);
   };
 
   const handleDownload = (record: MessageRecord) => {
@@ -584,6 +616,8 @@ const MessagePage = () => {
       label: '消息轨迹',
       children: traceLoading ? (
         <Typography.Text type="secondary">正在加载轨迹数据…</Typography.Text>
+      ) : traceError ? (
+        <Alert showIcon type="warning" message={traceError} />
       ) : traceData?.nodes?.length ? (
         <Steps
           direction="vertical"
@@ -728,6 +762,10 @@ const MessagePage = () => {
           </Space>
         </Space>
       </Card>
+
+      {queryError && (
+        <Alert showIcon type="warning" message={queryError} style={{ marginBottom: 16 }} />
+      )}
 
       {/* ── Results Table ── */}
       <Card bodyStyle={{ padding: 0 }}>


### PR DESCRIPTION
## Summary

**Track:** Track 1 / Control Plane reliability

Consolidates and supersedes #779 and #781.

Message and DLQ pages now present a clear unavailable state when their provider is not configured, rather than showing an indistinguishable empty result.

## Verification

- `npm test -- --run src/pages/instance/__tests__/MessagePageAsyncState.test.tsx src/pages/instance/__tests__/DLQPage.test.tsx` (15 passed)
- `npm run lint -- src/pages/instance/message.tsx src/pages/instance/dlq.tsx src/pages/instance/__tests__/MessagePageAsyncState.test.tsx src/pages/instance/__tests__/DLQPage.test.tsx` (0 errors; existing Fast Refresh warnings)
- `git diff --check origin/rocketmq-studio...HEAD`

Closes #778
Closes #780