### PR TITLE
[ISSUE #831][ISSUE #844][ISSUE #846][ISSUE #854][ISSUE #856] Validate operational API requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
@@ -25,10 +25,17 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service
 public class ProxyAddressService {
+
+    private static final Pattern PROXY_ADDR_PATTERN =
+            Pattern.compile("^(\\[[0-9a-fA-F:.]+]|[A-Za-z0-9._-]+):(\\d{1,5})$");
+    private static final int MIN_PORT = 1;
+    private static final int MAX_PORT = 65535;
 
     private final Set<String> proxyAddrs = new LinkedHashSet<>(List.of("127.0.0.1:8081"));
     private String currentProxyAddr = "127.0.0.1:8081";
@@ -64,6 +71,15 @@ public class ProxyAddressService {
         if (proxyAddr == null || proxyAddr.trim().isEmpty()) {
             throw new BusinessException(400, fieldName + " is required");
         }
-        return proxyAddr.trim();
+        String normalized = proxyAddr.trim();
+        Matcher matcher = PROXY_ADDR_PATTERN.matcher(normalized);
+        if (!matcher.matches()) {
+            throw new BusinessException(400, fieldName + " must be in host:port or [ipv6]:port format");
+        }
+        int port = Integer.parseInt(matcher.group(2));
+        if (port < MIN_PORT || port > MAX_PORT) {
+            throw new BusinessException(400, fieldName + " port must be between 1 and 65535");
+        }
+        return normalized;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.instance.dlq;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,9 +42,16 @@ public class DLQController {
     }
 
     @PostMapping("/resend")
-    public Result<Void> resendMessages(@Valid @RequestBody DLQResendRequestDTO request) {
+    public Result<Void> resendMessages(@Valid @RequestBody(required = false) DLQResendRequestDTO request) {
+        requireRequest(request);
         dlqService.resendMessages(
                 request.getGroupName(), request.getStartTime(), request.getEndTime(), request.getTargetTopic());
         return Result.ok();
+    }
+
+    private void requireRequest(DLQResendRequestDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "DLQ resend request is required");
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,13 +41,13 @@ public class AlertRuleController {
     }
 
     @PostMapping("/create")
-    public Result<AlertRuleVO> createRule(@RequestBody AlertRuleVO rule) {
-        return Result.ok(alertService.createRule(rule));
+    public Result<AlertRuleVO> createRule(@RequestBody(required = false) AlertRuleVO rule) {
+        return Result.ok(alertService.createRule(requireAlertRule(rule)));
     }
 
     @PostMapping("/update")
-    public Result<AlertRuleVO> updateRule(@RequestBody AlertRuleVO rule) {
-        return Result.ok(alertService.updateRule(rule));
+    public Result<AlertRuleVO> updateRule(@RequestBody(required = false) AlertRuleVO rule) {
+        return Result.ok(alertService.updateRule(requireAlertRule(rule)));
     }
 
     @PostMapping("/toggle")
@@ -58,5 +59,12 @@ public class AlertRuleController {
     public Result<Void> deleteRule(@Valid @RequestBody DeleteAlertRuleDTO request) {
         alertService.deleteRule(request.getId());
         return Result.ok();
+    }
+
+    private AlertRuleVO requireAlertRule(AlertRuleVO rule) {
+        if (rule == null) {
+            throw new BusinessException(400, "Alert rule request is required");
+        }
+        return rule;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -67,6 +67,9 @@ public class AlertService {
 
 
     public AlertRuleVO createRule(AlertRuleVO rule) {
+        if (rule == null) {
+            throw new BusinessException(400, "Alert rule request is required");
+        }
         log.info("Creating alert rule: {}", rule.getName());
         rule.setId(UUID.randomUUID().toString());
         return alertRepository.saveRule(rule);
@@ -74,7 +77,10 @@ public class AlertService {
 
 
     public AlertRuleVO updateRule(AlertRuleVO rule) {
-        String id = rule == null ? null : rule.getId();
+        if (rule == null) {
+            throw new BusinessException(400, "Alert rule request is required");
+        }
+        String id = rule.getId();
         log.info("Updating alert rule: {}", id);
         validateRuleId(id);
         if (!alertRepository.replaceRule(rule)) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,7 +44,9 @@ public class SystemAlertController {
     }
 
     @PostMapping("/acknowledge")
-    public Result<SystemAlertVO> acknowledgeAlert(@Valid @RequestBody AcknowledgeSystemAlertDTO request) {
+    public Result<SystemAlertVO> acknowledgeAlert(
+            @Valid @RequestBody(required = false) AcknowledgeSystemAlertDTO request) {
+        requireAcknowledgeRequest(request);
         return Result.ok(alertService.acknowledgeAlert(request.getId()));
     }
 
@@ -51,5 +54,11 @@ public class SystemAlertController {
     public Result<Map<String, Integer>> clearAcknowledged() {
         int cleared = alertService.clearAcknowledged();
         return Result.ok(Map.of("cleared", cleared));
+    }
+
+    private void requireAcknowledgeRequest(AcknowledgeSystemAlertDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "System alert acknowledge request is required");
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.settings;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -52,13 +53,13 @@ public class SettingsController {
     }
 
     @PostMapping("/datasources/create")
-    public Result<DataSourceVO> createDataSource(@Valid @RequestBody DataSourceVO dataSource) {
-        return Result.ok(settingsService.createDataSource(dataSource));
+    public Result<DataSourceVO> createDataSource(@Valid @RequestBody(required = false) DataSourceVO dataSource) {
+        return Result.ok(settingsService.createDataSource(requireDataSource(dataSource)));
     }
 
     @PostMapping("/datasources/update")
-    public Result<DataSourceVO> updateDataSource(@Valid @RequestBody DataSourceVO dataSource) {
-        return Result.ok(settingsService.updateDataSource(dataSource));
+    public Result<DataSourceVO> updateDataSource(@Valid @RequestBody(required = false) DataSourceVO dataSource) {
+        return Result.ok(settingsService.updateDataSource(requireDataSource(dataSource)));
     }
 
     @PostMapping("/datasources/delete")
@@ -70,5 +71,12 @@ public class SettingsController {
     @PostMapping("/datasources/test")
     public Result<DataSourceTestResultVO> testDataSource(@Valid @RequestBody DataSourceTestDTO request) {
         return Result.ok(settingsService.testDataSource(request));
+    }
+
+    private DataSourceVO requireDataSource(DataSourceVO dataSource) {
+        if (dataSource == null) {
+            throw new BusinessException(400, "Data source request is required");
+        }
+        return dataSource;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -99,6 +99,9 @@ public class SettingsService {
 
 
     public DataSourceVO createDataSource(DataSourceVO dataSource) {
+        if (dataSource == null) {
+            throw new BusinessException(400, "Data source request is required");
+        }
         log.info("Creating data source: {}", dataSource.getName());
         dataSource.setKey(UUID.randomUUID().toString());
         return settingsRepository.saveDataSource(dataSource);
@@ -106,6 +109,9 @@ public class SettingsService {
 
 
     public DataSourceVO updateDataSource(DataSourceVO dataSource) {
+        if (dataSource == null) {
+            throw new BusinessException(400, "Data source request is required");
+        }
         String key = normalizeDataSourceKey(dataSource.getKey());
         dataSource.setKey(key);
         log.info("Updating data source: {}", key);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
@@ -20,6 +20,8 @@ package org.apache.rocketmq.studio.cluster.proxy;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -51,6 +53,33 @@ class ProxyAddressServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("newProxyAddr is required")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+    }
+
+    @Test
+    void addProxyAddrShouldAcceptBracketedIpv6Address() {
+        proxyAddressService.addProxyAddr(" [::1]:8081 ");
+
+        ProxyHomeVO home = proxyAddressService.getHomePage();
+        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081", "[::1]:8081");
+    }
+
+    @Test
+    void addProxyAddrShouldRejectInvalidAddressFormats() {
+        List<String> invalidProxyAddrs = List.of(
+                "10.0.0.1",
+                "10.0.0.1:abc",
+                "10.0.0.1:0",
+                "10.0.0.1:65536",
+                "http://10.0.0.1:8081",
+                "10.0.0.1:8081/path"
+        );
+
+        for (String invalidProxyAddr : invalidProxyAddrs) {
+            assertThatThrownBy(() -> proxyAddressService.addProxyAddr(invalidProxyAddr))
+                    .as("invalid proxy address %s", invalidProxyAddr)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        }
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQControllerTest.java
@@ -125,6 +125,18 @@ class DLQControllerTest {
     }
 
     @Test
+    void resendMessagesShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/dlq/resend")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("DLQ resend request is required"));
+
+        verifyNoInteractions(dlqService);
+    }
+
+    @Test
     void resendMessagesShouldRejectMissingGroupName() throws Exception {
         Map<String, Object> body = Map.of(
                 "startTime", 1000,

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleControllerTest.java
@@ -92,6 +92,30 @@ class AlertRuleControllerTest {
     }
 
     @Test
+    void createRuleShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/alert-rules/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Alert rule request is required"));
+
+        verifyNoInteractions(alertService);
+    }
+
+    @Test
+    void updateRuleShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/alert-rules/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Alert rule request is required"));
+
+        verifyNoInteractions(alertService);
+    }
+
+    @Test
     void toggleRuleShouldPassValidatedRequest() throws Exception {
         AlertRuleVO toggled = AlertRuleVO.builder()
                 .id("rule-1")

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -251,6 +251,16 @@ class AlertServiceTest {
     }
 
     @Test
+    void createRuleShouldRejectNullRequest() {
+        assertThatThrownBy(() -> alertService.createRule(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(alertRepository, never()).saveRule(any());
+    }
+
+    @Test
     void updateRuleShouldUpdateExistingRule() {
         AlertRuleVO update = AlertRuleVO.builder().id("rule-1").name("CPU Alert").threshold(90.0).build();
         when(alertRepository.replaceRule(update)).thenReturn(true);
@@ -260,6 +270,16 @@ class AlertServiceTest {
         assertThat(result.getId()).isEqualTo("rule-1");
         assertThat(result.getThreshold()).isEqualTo(90.0);
         verify(alertRepository).replaceRule(update);
+    }
+
+    @Test
+    void updateRuleShouldRejectNullRequest() {
+        assertThatThrownBy(() -> alertService.updateRule(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(alertRepository, never()).replaceRule(any());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
@@ -92,6 +92,18 @@ class SystemAlertControllerTest {
     }
 
     @Test
+    void acknowledgeAlertShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/system-alerts/acknowledge")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("System alert acknowledge request is required"));
+
+        verifyNoInteractions(alertService);
+    }
+
+    @Test
     void acknowledgeAlertShouldRejectBlankId() throws Exception {
         mockMvc.perform(post("/api/system-alerts/acknowledge")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
@@ -223,6 +223,18 @@ class SettingsControllerTest {
     }
 
     @Test
+    void createDataSourceShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/settings/datasources/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", is(400)))
+                .andExpect(jsonPath("$.message", is("Data source request is required")));
+
+        verifyNoInteractions(settingsService);
+    }
+
+    @Test
     void updateDataSourceShouldReturnUpdatedSource() throws Exception {
         DataSourceVO input = DataSourceVO.builder().key("ds-1").name("Updated DS").type("rocketmq")
                 .url("updated:9876").build();
@@ -251,6 +263,18 @@ class SettingsControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code", is(400)))
                 .andExpect(jsonPath("$.message", is("name is required")));
+
+        verifyNoInteractions(settingsService);
+    }
+
+    @Test
+    void updateDataSourceShouldRejectNullRequestBody() throws Exception {
+        mockMvc.perform(post("/api/settings/datasources/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("null"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", is(400)))
+                .andExpect(jsonPath("$.message", is("Data source request is required")));
 
         verifyNoInteractions(settingsService);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -42,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -215,6 +216,17 @@ class SettingsServiceTest {
     }
 
     @Test
+    void createDataSourceShouldRejectNullRequest() {
+        assertThatThrownBy(() -> settingsService.createDataSource(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Data source request is required")
+                .extracting("code")
+                .isEqualTo(400);
+
+        verifyNoInteractions(settingsRepository);
+    }
+
+    @Test
     void updateDataSourceShouldDelegateToRepository() {
         DataSourceVO input = DataSourceVO.builder().key("ds-1").name("Updated DS").type("rocketmq")
                 .url("updated-host:9876").build();
@@ -225,6 +237,17 @@ class SettingsServiceTest {
         assertThat(result.getKey()).isEqualTo("ds-1");
         assertThat(result.getName()).isEqualTo("Updated DS");
         verify(settingsRepository).replaceDataSource(input);
+    }
+
+    @Test
+    void updateDataSourceShouldRejectNullRequest() {
+        assertThatThrownBy(() -> settingsService.updateDataSource(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Data source request is required")
+                .extracting("code")
+                .isEqualTo(400);
+
+        verifyNoInteractions(settingsRepository);
     }
 
     @Test


### PR DESCRIPTION
## Summary

**Track:** Track 1 / Control Plane reliability

Consolidates and supersedes #832, #845, #847, #855, and #857.

- Validate proxy address syntax before configuration is persisted.
- Reject absent request bodies for datasource, alert-rule, DLQ resend, and system-alert acknowledgement APIs.
- Add service and controller regression coverage for these operational request boundaries.

## Verification

- `mvn -Dtest=ProxyAddressServiceTest,SettingsControllerTest,SettingsServiceTest,AlertRuleControllerTest,AlertServiceTest,DLQControllerTest,SystemAlertControllerTest test` (101 passed)
- `git diff --check origin/rocketmq-studio...HEAD`

Closes #831
Closes #844
Closes #846
Closes #854
Closes #856