### PR TITLE
[Track 3] feat(ai): harden LLM provider configuration and CLI persistence

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
@@ -110,6 +110,8 @@ public class LlmConfigService {
                 .apiKey(persistedApiKey)
                 .model(normalized.getModel())
                 .baseUrl(normalized.getApiBase())
+                .maxTokens(normalized.getMaxTokens())
+                .temperature(normalized.getTemperature())
                 .build();
         LlmConfigVO nextOverrides = copy(normalized);
         settingsService.saveGeneralSettings(updated);
@@ -213,8 +215,8 @@ public class LlmConfigService {
                 .apiKey(apiKey)
                 .apiBase(apiBase)
                 .model(model)
-                .maxTokens(DEFAULT_MAX_TOKENS)
-                .temperature(DEFAULT_TEMPERATURE)
+                .maxTokens(resolveMaxTokens(settings.getMaxTokens()))
+                .temperature(resolveTemperature(settings.getTemperature()))
                 .enabled(!requiresApiKey(provider) || !isBlank(apiKey))
                 .apiVersion("2024-02-15-preview")
                 .awsRegion("us-east-1")
@@ -289,6 +291,20 @@ public class LlmConfigService {
             case LlmConfigVO.ENGINE_HTTP, LlmConfigVO.ENGINE_CLAUDE_CODE, LlmConfigVO.ENGINE_QODER -> normalized;
             default -> LlmConfigVO.ENGINE_HTTP;
         };
+    }
+
+    private int resolveMaxTokens(Integer maxTokens) {
+        if (maxTokens == null || maxTokens <= 0 || maxTokens > MAX_TOKENS_LIMIT) {
+            return DEFAULT_MAX_TOKENS;
+        }
+        return maxTokens;
+    }
+
+    private double resolveTemperature(Double temperature) {
+        if (temperature == null || !Double.isFinite(temperature) || temperature < 0 || temperature > 2) {
+            return DEFAULT_TEMPERATURE;
+        }
+        return temperature;
     }
 
     private String defaultModel(String provider) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
@@ -277,6 +277,9 @@ public class LlmConfigService {
 
     private String normalizeProvider(String provider) {
         String normalized = defaultString(provider, DEFAULT_PROVIDER).toLowerCase(Locale.ROOT);
+        if ("qwen".equals(normalized)) {
+            return "tongyi";
+        }
         return PROVIDER_MODELS.containsKey(normalized) ? normalized : DEFAULT_PROVIDER;
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
@@ -205,19 +205,20 @@ public class LlmConfigService {
 
     private LlmConfigVO fromGeneralSettings(GeneralSettingsVO settings) {
         String provider = normalizeProvider(settings.getLlmProvider());
+        String engine = normalizeEngine(settings.getLlmEngine());
         // Token injected via RMQ_LLM_TOKEN takes precedence over the key saved in settings.
         String apiKey = defaultString(envToken(), defaultString(settings.getApiKey(), ""));
         String apiBase = normalizeApiBase(defaultString(settings.getBaseUrl(), defaultApiBase(provider)));
         String model = defaultString(settings.getModel(), defaultModel(provider));
         return LlmConfigVO.builder()
                 .provider(provider)
-                .engine(normalizeEngine(settings.getLlmEngine()))
+                .engine(engine)
                 .apiKey(apiKey)
                 .apiBase(apiBase)
                 .model(model)
                 .maxTokens(resolveMaxTokens(settings.getMaxTokens()))
                 .temperature(resolveTemperature(settings.getTemperature()))
-                .enabled(!requiresApiKey(provider) || !isBlank(apiKey))
+                .enabled(!requiresApiKey(provider, engine) || !isBlank(apiKey))
                 .apiVersion("2024-02-15-preview")
                 .awsRegion("us-east-1")
                 .build();
@@ -251,7 +252,7 @@ public class LlmConfigService {
 
     private LlmConfigVO normalizeWithStoredApiKey(LlmConfigVO config) {
         LlmConfigVO normalized = normalize(config);
-        if (!requiresApiKey(normalized.getProvider())) {
+        if (!requiresApiKey(normalized.getProvider(), normalized.getEngine())) {
             normalized.setApiKey("");
             return normalized;
         }
@@ -273,8 +274,8 @@ public class LlmConfigService {
                 exception.getMessage(), exception.getCode(), exception.getHint());
     }
 
-    private boolean requiresApiKey(String provider) {
-        return !"ollama".equals(provider);
+    private boolean requiresApiKey(String provider, String engine) {
+        return LlmConfigVO.ENGINE_HTTP.equalsIgnoreCase(engine) && !"ollama".equals(provider);
     }
 
     private String normalizeProvider(String provider) {
@@ -286,7 +287,7 @@ public class LlmConfigService {
     }
 
     private String normalizeEngine(String engine) {
-        String normalized = defaultString(engine, LlmConfigVO.ENGINE_CLAUDE_CODE).toLowerCase(Locale.ROOT);
+        String normalized = defaultString(engine, LlmConfigVO.ENGINE_HTTP).toLowerCase(Locale.ROOT);
         return switch (normalized) {
             case LlmConfigVO.ENGINE_HTTP, LlmConfigVO.ENGINE_CLAUDE_CODE, LlmConfigVO.ENGINE_QODER -> normalized;
             default -> LlmConfigVO.ENGINE_HTTP;

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -66,6 +66,8 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
                     .apiKey("")
                     .model("gpt-4")
                     .baseUrl("")
+                    .maxTokens(4096)
+                    .temperature(0.7)
                     .build();
         }
         try {
@@ -83,6 +85,8 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
                     .apiKey("")
                     .model("gpt-4")
                     .baseUrl("")
+                    .maxTokens(4096)
+                    .temperature(0.7)
                     .build();
         }
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.persistence;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.persistence.entity.RmqDataSource;
 import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
@@ -94,7 +95,7 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
     @Override
     public void saveGeneralSettings(GeneralSettingsVO settings) {
         try {
-            String json = objectMapper.writeValueAsString(settings);
+            String json = serializeGeneralSettings(settings);
             RmqSettings entity = settingsMapper.selectById(SETTINGS_ID);
             if (entity == null) {
                 entity = new RmqSettings();
@@ -111,6 +112,15 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
             log.error("Failed to serialize general settings", e);
             throw new RuntimeException("Failed to save settings", e);
         }
+    }
+
+    /**
+     * API serialization must not expose the LLM API key, while persistence needs to retain it.
+     */
+    private String serializeGeneralSettings(GeneralSettingsVO settings) throws JsonProcessingException {
+        ObjectNode json = objectMapper.valueToTree(settings);
+        json.put("apiKey", settings.getApiKey());
+        return objectMapper.writeValueAsString(json);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/GeneralSettingsUpdateDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/GeneralSettingsUpdateDTO.java
@@ -16,6 +16,8 @@
  */
 package org.apache.rocketmq.studio.settings;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -55,6 +57,12 @@ public class GeneralSettingsUpdateDTO {
     private String model;
     @NotNull
     private String baseUrl;
+    @Min(1)
+    @Max(200000)
+    private Integer maxTokens;
+    @DecimalMin("0.0")
+    @DecimalMax("2.0")
+    private Double temperature;
 
     public GeneralSettingsVO toSettings() {
         return GeneralSettingsVO.builder()
@@ -70,6 +78,8 @@ public class GeneralSettingsUpdateDTO {
                 .clearApiKey(clearApiKey)
                 .model(model)
                 .baseUrl(baseUrl)
+                .maxTokens(maxTokens)
+                .temperature(temperature)
                 .build();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/GeneralSettingsVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/GeneralSettingsVO.java
@@ -44,6 +44,8 @@ public class GeneralSettingsVO {
     private boolean clearApiKey;
     private String model;
     private String baseUrl;
+    private Integer maxTokens;
+    private Double temperature;
 
     @JsonProperty(value = "apiKeyConfigured", access = JsonProperty.Access.READ_ONLY)
     public boolean isApiKeyConfigured() {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
@@ -94,6 +94,28 @@ class LlmConfigServiceTest {
     }
 
     @Test
+    void getConfigShouldNormalizeLegacyQwenProviderToTongyi() {
+        when(settingsService.getGeneralSettings()).thenReturn(GeneralSettingsVO.builder()
+                .theme("dark")
+                .compact(true)
+                .desktopNotify(true)
+                .notifySound(false)
+                .sessionTimeout(45)
+                .requireLogin(true)
+                .llmProvider("qwen")
+                .apiKey("dashscope-key")
+                .model("qwen-plus")
+                .baseUrl("")
+                .build());
+
+        LlmConfigVO config = llmConfigService.getConfig();
+
+        assertThat(config.getProvider()).isEqualTo("tongyi");
+        assertThat(config.getApiBase()).isEqualTo("https://dashscope.aliyuncs.com/compatible-mode/v1");
+        assertThat(config.getModel()).isEqualTo("qwen-plus");
+    }
+
+    @Test
     void configToStringShouldNotExposeApiKey() {
         LlmConfigVO config = LlmConfigVO.builder()
                 .provider("openai")
@@ -176,6 +198,27 @@ class LlmConfigServiceTest {
         assertThat(saved.getModel()).isEqualTo("deepseek-chat");
         assertThat(saved.getBaseUrl()).isEqualTo("https://api.deepseek.com/v1");
         assertThat(llmConfigService.getConfig().getProvider()).isEqualTo("deepseek");
+    }
+
+    @Test
+    void saveConfigShouldNormalizeLegacyQwenProviderToTongyi() {
+        LlmConfigVO config = LlmConfigVO.builder()
+                .provider("qwen")
+                .apiKey("dashscope-key")
+                .model("qwen-plus")
+                .maxTokens(8192)
+                .temperature(0.2)
+                .enabled(true)
+                .build();
+
+        llmConfigService.saveConfig(config);
+
+        ArgumentCaptor<GeneralSettingsVO> captor = ArgumentCaptor.forClass(GeneralSettingsVO.class);
+        verify(settingsService).saveGeneralSettings(captor.capture());
+        GeneralSettingsVO saved = captor.getValue();
+        assertThat(saved.getLlmProvider()).isEqualTo("tongyi");
+        assertThat(saved.getBaseUrl()).isEqualTo("https://dashscope.aliyuncs.com/compatible-mode/v1");
+        assertThat(llmConfigService.getConfig().getProvider()).isEqualTo("tongyi");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
@@ -53,6 +53,8 @@ class LlmConfigServiceTest {
                 .apiKey("sk-test")
                 .model("gpt-4o")
                 .baseUrl("https://api.openai.com/v1")
+                .maxTokens(8192)
+                .temperature(0.2)
                 .build());
         llmClient = mock(OpenAiCompatibleLlmClient.class);
         llmConfigService = new LlmConfigService(settingsService, llmClient, new LlmProperties());
@@ -66,6 +68,8 @@ class LlmConfigServiceTest {
         assertThat(config.getApiKey()).isEqualTo("sk-test");
         assertThat(config.getApiBase()).isEqualTo("https://api.openai.com/v1");
         assertThat(config.getModel()).isEqualTo("gpt-4o");
+        assertThat(config.getMaxTokens()).isEqualTo(8192);
+        assertThat(config.getTemperature()).isEqualTo(0.2);
         assertThat(config.isEnabled()).isTrue();
         assertThat(config.isReady()).isTrue();
     }
@@ -91,6 +95,27 @@ class LlmConfigServiceTest {
         assertThat(captor.getValue().getApiKey()).isEqualTo("sk-test");
 
         assertThat(service.getConfig().getApiKey()).isEqualTo("env-token");
+    }
+
+    @Test
+    void getConfigShouldUseDefaultsWhenAdvancedSettingsAreMissing() {
+        when(settingsService.getGeneralSettings()).thenReturn(GeneralSettingsVO.builder()
+                .theme("dark")
+                .compact(true)
+                .desktopNotify(true)
+                .notifySound(false)
+                .sessionTimeout(45)
+                .requireLogin(true)
+                .llmProvider("openai")
+                .apiKey("sk-test")
+                .model("gpt-4o")
+                .baseUrl("https://api.openai.com/v1")
+                .build());
+
+        LlmConfigVO config = llmConfigService.getConfig();
+
+        assertThat(config.getMaxTokens()).isEqualTo(4096);
+        assertThat(config.getTemperature()).isEqualTo(0.7);
     }
 
     @Test
@@ -197,7 +222,11 @@ class LlmConfigServiceTest {
         assertThat(saved.getApiKey()).isEqualTo("sk-deepseek");
         assertThat(saved.getModel()).isEqualTo("deepseek-chat");
         assertThat(saved.getBaseUrl()).isEqualTo("https://api.deepseek.com/v1");
+        assertThat(saved.getMaxTokens()).isEqualTo(8192);
+        assertThat(saved.getTemperature()).isEqualTo(0.2);
         assertThat(llmConfigService.getConfig().getProvider()).isEqualTo("deepseek");
+        assertThat(llmConfigService.getConfig().getMaxTokens()).isEqualTo(8192);
+        assertThat(llmConfigService.getConfig().getTemperature()).isEqualTo(0.2);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
@@ -200,6 +200,51 @@ class LlmConfigServiceTest {
     }
 
     @Test
+    void getConfigShouldKeepSavedCliEngineEnabledWithoutApiKeyAfterRestart() {
+        when(settingsService.getGeneralSettings()).thenReturn(GeneralSettingsVO.builder()
+                .theme("dark")
+                .compact(true)
+                .desktopNotify(true)
+                .notifySound(false)
+                .sessionTimeout(45)
+                .requireLogin(true)
+                .llmProvider("openai")
+                .llmEngine(LlmConfigVO.ENGINE_CLAUDE_CODE)
+                .apiKey("")
+                .model("gpt-4o")
+                .baseUrl("https://api.openai.com/v1")
+                .build());
+
+        LlmConfigVO config = llmConfigService.getConfig();
+
+        assertThat(config.getEngine()).isEqualTo(LlmConfigVO.ENGINE_CLAUDE_CODE);
+        assertThat(config.isEnabled()).isTrue();
+        assertThat(config.isReady()).isTrue();
+    }
+
+    @Test
+    void getConfigShouldKeepSavedHttpEngineDisabledWithoutApiKeyAfterRestart() {
+        when(settingsService.getGeneralSettings()).thenReturn(GeneralSettingsVO.builder()
+                .theme("dark")
+                .compact(true)
+                .desktopNotify(true)
+                .notifySound(false)
+                .sessionTimeout(45)
+                .requireLogin(true)
+                .llmProvider("openai")
+                .llmEngine(LlmConfigVO.ENGINE_HTTP)
+                .apiKey("")
+                .model("gpt-4o")
+                .baseUrl("https://api.openai.com/v1")
+                .build());
+
+        LlmConfigVO config = llmConfigService.getConfig();
+
+        assertThat(config.isEnabled()).isFalse();
+        assertThat(config.isReady()).isFalse();
+    }
+
+    @Test
     void saveConfigShouldPreserveGeneralSettingsAndStoreLlmFields() {
         LlmConfigVO config = LlmConfigVO.builder()
                 .provider("deepseek")

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.studio.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
+import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqSettingsMapper;
+import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MybatisPlusSettingsRepositoryTest {
+
+    @Mock
+    private RmqSettingsMapper settingsMapper;
+
+    @Mock
+    private RmqDataSourceMapper dataSourceMapper;
+
+    @InjectMocks
+    private MybatisPlusSettingsRepository repository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void saveAndLoadShouldRetainApiKeyWithoutExposingItThroughDefaultSerialization() throws Exception {
+        repository = new MybatisPlusSettingsRepository(settingsMapper, dataSourceMapper, objectMapper);
+        GeneralSettingsVO settings = GeneralSettingsVO.builder()
+                .theme("system")
+                .llmProvider("openai")
+                .apiKey("sk-persisted")
+                .model("gpt-4o")
+                .baseUrl("https://api.openai.com/v1")
+                .build();
+        when(settingsMapper.selectById("singleton")).thenReturn(null);
+
+        repository.saveGeneralSettings(settings);
+
+        ArgumentCaptor<RmqSettings> captor = ArgumentCaptor.forClass(RmqSettings.class);
+        verify(settingsMapper).insert(captor.capture());
+        RmqSettings stored = captor.getValue();
+        assertThat(stored.getJson()).contains("apiKey").contains("sk-persisted");
+        assertThat(objectMapper.writeValueAsString(settings)).doesNotContain("sk-persisted");
+
+        when(settingsMapper.selectById("singleton")).thenReturn(stored);
+
+        assertThat(repository.loadGeneralSettings().getApiKey()).isEqualTo("sk-persisted");
+    }
+}

--- a/web/src/api/ai.test.ts
+++ b/web/src/api/ai.test.ts
@@ -28,6 +28,8 @@ import {
   type McpTool,
 } from './ai';
 
+vi.mock('../config', () => ({ API_BASE_URL: '/studio-api' }));
+
 const mock = new MockAdapter(client);
 const encoder = new TextEncoder();
 
@@ -58,23 +60,25 @@ describe('AI API', () => {
 
   describe('chatStream (SSE)', () => {
     it('reassembles an event split across network chunks', async () => {
-      vi.stubGlobal(
-        'fetch',
-        vi
-          .fn()
-          .mockResolvedValue(
-            streamResponse([
-              'event: message\r\ndata: {"text":"hel',
-              'lo"}\r\n\r\nevent: done\r\ndata: [DONE]\r\n\r\n',
-            ]),
-          ),
-      );
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(
+          streamResponse([
+            'event: message\r\ndata: {"text":"hel',
+            'lo"}\r\n\r\nevent: done\r\ndata: [DONE]\r\n\r\n',
+          ]),
+        );
+      vi.stubGlobal('fetch', fetchMock);
       const chunks: string[] = [];
 
       await chatStream({ message: 'hello', mode: 'chat', model: 'stub' }, (text) =>
         chunks.push(text),
       );
 
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/studio-api/ai/chat',
+        expect.objectContaining({ method: 'POST' }),
+      );
       expect(chunks).toEqual(['hello']);
     });
 

--- a/web/src/api/ai.ts
+++ b/web/src/api/ai.ts
@@ -16,6 +16,7 @@
  */
 
 import client from './client';
+import { API_BASE_URL } from '../config';
 
 // ─── Types ──────────────────────────────────────────────────────
 export interface McpTool {
@@ -158,7 +159,7 @@ export async function chatStream(
   signal?: AbortSignal,
   onEnhance?: (prompt: string) => void,
 ) {
-  const response = await fetch('/api/ai/chat', {
+  const response = await fetch(`${API_BASE_URL}/ai/chat`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -212,7 +212,7 @@ const GeneralSettingsTab = () => {
             { value: 'openai', label: 'OpenAI' },
             { value: 'azure', label: 'Azure OpenAI' },
             { value: 'ollama', label: 'Ollama' },
-            { value: 'qwen', label: '通义千问' },
+            { value: 'tongyi', label: '通义千问' },
           ]}
         />
       </Form.Item>

--- a/web/src/pages/studio/LlmSettings.tsx
+++ b/web/src/pages/studio/LlmSettings.tsx
@@ -44,10 +44,8 @@ import { fallbackModelOptions } from './llmModelOptions';
 const PROVIDER_OPTIONS = [
   { value: 'tongyi', label: '通义千问（DashScope）' },
   { value: 'openai', label: 'OpenAI' },
-  { value: 'azure', label: 'Azure OpenAI' },
   { value: 'deepseek', label: 'DeepSeek' },
   { value: 'ollama', label: 'Ollama（本地）' },
-  { value: 'bedrock', label: 'AWS Bedrock' },
 ];
 
 const ENGINE_OPTIONS = [


### PR DESCRIPTION
## Summary

**Track:** Track 3 / AI Native

Consolidates #807, #810, #812, #814, #864, and #977.

- Normalize legacy Tongyi provider keys and expose only providers supported by the OpenAI-compatible client.
- Persist advanced model settings and preserve configured API keys through settings updates.
- Use the configured API base URL for AI chat streaming.
- Keep connection tests read-only.
- Preserve explicit Claude Code and Qoder CLI engine selections after restart without requiring an HTTP API key.

## Verification

- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=LlmConfigServiceTest test
- npm test -- --run src/api/ai.test.ts src/pages/studio/__tests__/LlmSettingsPage.test.tsx (14 passed)
- git diff --check origin/rocketmq-studio...HEAD

Closes #806
Closes #809
Closes #811
Closes #813
Closes #863
Closes #975