### PR TITLE
[Track 3] fix(ai): harden chat gateway request and execution safety

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.ai;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -41,12 +42,18 @@ public class AiController {
     private final AiService aiService;
 
     @PostMapping(value = "/chat", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter chat(@RequestBody ChatDTO request) {
+    public SseEmitter chat(@RequestBody(required = false) ChatDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "chat request is required");
+        }
         return aiService.chat(request);
     }
 
     @PostMapping("/execute")
-    public Result<AiExecuteResultVO> execute(@RequestBody AiCommandDTO command) {
+    public Result<AiExecuteResultVO> execute(@RequestBody(required = false) AiCommandDTO command) {
+        if (command == null) {
+            throw new BusinessException(400, "AI command request is required");
+        }
         return Result.ok(aiService.execute(command));
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiService.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.ops.ai;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -34,12 +35,18 @@ public class AiService {
 
 
     public SseEmitter chat(ChatDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "chat request is required");
+        }
         log.info("Chat request received: mode={}, conversationId={}", request.getMode(), request.getConversationId());
         return llmGateway.chat(request);
     }
 
 
     public AiExecuteResultVO execute(AiCommandDTO command) {
+        if (command == null) {
+            throw new BusinessException(400, "AI command request is required");
+        }
         log.info("Executing AI command: {}", command.getCommand());
         try {
             String result = llmGateway.execute(command);

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProvider.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -96,22 +97,31 @@ public class ClaudeCodeAgentProvider extends CliAgentProvider {
             Process process = builder.start();
             AtomicBoolean emitted = new AtomicBoolean(false);
             StringBuilder resultText = new StringBuilder();
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    parseStreamLine(line, tokenConsumer, emitted, resultText);
+            CompletableFuture<Void> stdoutFuture = new CompletableFuture<>();
+            Thread.ofVirtual().start(() -> {
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        parseStreamLine(line, tokenConsumer, emitted, resultText);
+                    }
+                    stdoutFuture.complete(null);
+                } catch (Exception exception) {
+                    stdoutFuture.completeExceptionally(exception);
                 }
-            }
+            });
+            CompletableFuture<String> stderrFuture = readAsync(process.getErrorStream());
             boolean finished = process.waitFor(STREAM_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
+                process.waitFor();
                 throw new LlmGatewayException(504, "llm.provider.timeout",
                         binaryName() + " CLI stream timed out after " + STREAM_TIMEOUT_SECONDS + "s",
                         "Retry with a shorter prompt or check the gateway latency.");
             }
+            await(stdoutFuture);
+            String stderr = await(stderrFuture);
             if (process.exitValue() != 0 && !emitted.get()) {
-                String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
                 throw new LlmGatewayException(502, "llm.provider.cli_error",
                         binaryName() + " CLI failed: " + (StringUtils.hasText(stderr) ? stderr.trim() : "unknown error"),
                         "Check the provider credentials, base URL and model name.");

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/CliAgentProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/CliAgentProvider.java
@@ -20,9 +20,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -71,15 +74,19 @@ public abstract class CliAgentProvider implements AgentProvider {
         builder.redirectErrorStream(false);
         try {
             Process process = builder.start();
-            String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
-            boolean finished = process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            CompletableFuture<String> stdoutFuture = readAsync(process.getInputStream());
+            CompletableFuture<String> stderrFuture = readAsync(process.getErrorStream());
+            long timeoutSeconds = timeoutSeconds();
+            boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
+                process.waitFor();
                 throw new LlmGatewayException(504, "llm.provider.timeout",
-                        binaryName() + " CLI timed out after " + TIMEOUT_SECONDS + "s",
+                        binaryName() + " CLI timed out after " + timeoutSeconds + "s",
                         "Retry with a shorter prompt or check the gateway latency.");
             }
+            String stdout = await(stdoutFuture);
+            String stderr = await(stderrFuture);
             if (process.exitValue() != 0) {
                 log.warn("{} CLI failed rc={}, stderr={}", binaryName(), process.exitValue(), abbreviate(stderr));
                 throw new LlmGatewayException(502, "llm.provider.cli_error",
@@ -102,6 +109,37 @@ public abstract class CliAgentProvider implements AgentProvider {
             Thread.currentThread().interrupt();
             throw new LlmGatewayException(502, "llm.provider.interrupted",
                     binaryName() + " CLI execution was interrupted", "Retry the request.", exception);
+        }
+    }
+
+    protected CompletableFuture<String> readAsync(InputStream stream) {
+        CompletableFuture<String> result = new CompletableFuture<>();
+        Thread.ofVirtual().start(() -> {
+            try (stream) {
+                result.complete(new String(stream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (Exception exception) {
+                result.completeExceptionally(exception);
+            }
+        });
+        return result;
+    }
+
+    protected long timeoutSeconds() {
+        return TIMEOUT_SECONDS;
+    }
+
+    protected <T> T await(CompletableFuture<T> future) throws IOException {
+        try {
+            return future.join();
+        } catch (CompletionException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof IOException ioException) {
+                throw ioException;
+            }
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new IOException("Failed to read CLI process output", cause);
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmChatMessage.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmChatMessage.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+public record LlmChatMessage(String role, String content) {
+
+    public static LlmChatMessage user(String content) {
+        return new LlmChatMessage("user", content);
+    }
+
+    public static LlmChatMessage assistant(String content) {
+        return new LlmChatMessage("assistant", content);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConversationMemory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConversationMemory.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class LlmConversationMemory {
+
+    private static final int MAX_CONVERSATIONS = 200;
+    private static final int MAX_MESSAGES_PER_CONVERSATION = 12;
+    private static final int MAX_MESSAGE_CHARS = 8_000;
+
+    private final Map<String, Deque<LlmChatMessage>> conversations =
+            new LinkedHashMap<>(16, 0.75f, true);
+
+    public synchronized List<LlmChatMessage> appendUserAndSnapshot(String conversationId, String message) {
+        LlmChatMessage userMessage = LlmChatMessage.user(normalizeContent(message));
+        String id = normalizeConversationId(conversationId);
+        if (!StringUtils.hasText(id)) {
+            return List.of(userMessage);
+        }
+        Deque<LlmChatMessage> messages = conversations.computeIfAbsent(id, ignored -> new ArrayDeque<>());
+        messages.addLast(userMessage);
+        trim(messages);
+        evictOldestConversationIfNeeded();
+        return new ArrayList<>(messages);
+    }
+
+    public synchronized void appendAssistant(String conversationId, String message) {
+        String id = normalizeConversationId(conversationId);
+        if (!StringUtils.hasText(id) || !StringUtils.hasText(message)) {
+            return;
+        }
+        Deque<LlmChatMessage> messages = conversations.computeIfAbsent(id, ignored -> new ArrayDeque<>());
+        messages.addLast(LlmChatMessage.assistant(normalizeContent(message)));
+        trim(messages);
+        evictOldestConversationIfNeeded();
+    }
+
+    private void trim(Deque<LlmChatMessage> messages) {
+        while (messages.size() > MAX_MESSAGES_PER_CONVERSATION) {
+            messages.removeFirst();
+        }
+    }
+
+    private void evictOldestConversationIfNeeded() {
+        while (conversations.size() > MAX_CONVERSATIONS) {
+            String oldestKey = conversations.keySet().iterator().next();
+            conversations.remove(oldestKey);
+        }
+    }
+
+    private String normalizeConversationId(String conversationId) {
+        if (!StringUtils.hasText(conversationId)) {
+            return "";
+        }
+        String id = conversationId.trim();
+        return id.length() <= 128 ? id : id.substring(0, 128);
+    }
+
+    private String normalizeContent(String content) {
+        if (!StringUtils.hasText(content)) {
+            return "";
+        }
+        String normalized = content.trim();
+        return normalized.length() <= MAX_MESSAGE_CHARS ? normalized : normalized.substring(0, MAX_MESSAGE_CHARS);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -23,9 +23,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -47,6 +49,10 @@ public class OpenAiCompatibleLlmClient {
     private static final String CHAT_COMPLETIONS_PATH = "/chat/completions";
     private static final String MODELS_PATH = "/models";
     private static final Set<String> SUPPORTED_PROVIDERS = Set.of("openai", "deepseek", "tongyi", "ollama");
+    // Bound materialized provider payloads while leaving normal LLM responses unaffected.
+    private static final int MAX_RESPONSE_BYTES = 1024 * 1024;
+    private static final int MAX_SSE_EVENT_CHARS = 64 * 1024;
+    private static final int MAX_SSE_STREAM_CHARS = 1024 * 1024;
 
     private final ObjectMapper objectMapper;
     private final HttpClient httpClient;
@@ -78,11 +84,14 @@ public class OpenAiCompatibleLlmClient {
         Map<String, Object> requestBody = requestBody(config, messages, modelOverride, false);
         HttpRequest request = request(config, "application/json", requestBody);
         try {
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() >= 400) {
-                throw upstreamException(response.statusCode(), response.body());
+            HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            try (InputStream body = response.body()) {
+                String responseBody = readLimitedBody(body);
+                if (response.statusCode() >= 400) {
+                    throw upstreamException(response.statusCode(), responseBody);
+                }
+                return parseCompletion(responseBody);
             }
-            return parseCompletion(response.body());
         } catch (HttpTimeoutException exception) {
             throw new LlmGatewayException(504, "llm.provider.timeout",
                     "LLM provider request timed out",
@@ -102,11 +111,14 @@ public class OpenAiCompatibleLlmClient {
         validateModelListing(config);
         HttpRequest request = getRequest(config, modelsUri(config));
         try {
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() >= 400) {
-                throw upstreamException(response.statusCode(), response.body());
+            HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            try (InputStream body = response.body()) {
+                String responseBody = readLimitedBody(body);
+                if (response.statusCode() >= 400) {
+                    throw upstreamException(response.statusCode(), responseBody);
+                }
+                return parseModels(responseBody);
             }
-            return parseModels(response.body());
         } catch (HttpTimeoutException exception) {
             throw new LlmGatewayException(504, "llm.provider.timeout",
                     "LLM provider model request timed out",
@@ -132,13 +144,14 @@ public class OpenAiCompatibleLlmClient {
         Map<String, Object> requestBody = requestBody(config, messages, modelOverride, true);
         HttpRequest request = request(config, "text/event-stream", requestBody);
         try {
-            HttpResponse<java.io.InputStream> response = httpClient.send(
+            HttpResponse<InputStream> response = httpClient.send(
                     request, HttpResponse.BodyHandlers.ofInputStream());
-            if (response.statusCode() >= 400) {
-                throw upstreamException(response.statusCode(),
-                        new String(response.body().readAllBytes(), StandardCharsets.UTF_8));
+            try (InputStream body = response.body()) {
+                if (response.statusCode() >= 400) {
+                    throw upstreamException(response.statusCode(), readLimitedBody(body));
+                }
+                parseStream(body, tokenConsumer);
             }
-            parseStream(response, tokenConsumer);
         } catch (HttpTimeoutException exception) {
             throw new LlmGatewayException(504, "llm.provider.timeout",
                     "LLM provider stream timed out",
@@ -154,27 +167,74 @@ public class OpenAiCompatibleLlmClient {
         }
     }
 
-    private void parseStream(HttpResponse<java.io.InputStream> response, Consumer<String> tokenConsumer)
-            throws IOException {
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(response.body(), StandardCharsets.UTF_8))) {
+    private void parseStream(InputStream body, Consumer<String> tokenConsumer) throws IOException {
+        try (Reader reader = new InputStreamReader(body, StandardCharsets.UTF_8)) {
             List<String> dataLines = new ArrayList<>();
             String line;
-            while ((line = reader.readLine()) != null) {
+            int eventChars = 0;
+            int streamChars = 0;
+            while ((line = readSseLine(reader)) != null) {
                 if (line.isEmpty()) {
                     if (emitStreamEvent(dataLines, tokenConsumer)) {
                         return;
                     }
                     dataLines.clear();
+                    eventChars = 0;
                     continue;
                 }
                 if (line.startsWith("data:")) {
                     String value = line.substring(5);
-                    dataLines.add(value.startsWith(" ") ? value.substring(1) : value);
+                    value = value.startsWith(" ") ? value.substring(1) : value;
+                    eventChars = checkedAdd(eventChars, value.length(), MAX_SSE_EVENT_CHARS);
+                    streamChars = checkedAdd(streamChars, value.length(), MAX_SSE_STREAM_CHARS);
+                    dataLines.add(value);
                 }
             }
             emitStreamEvent(dataLines, tokenConsumer);
         }
+    }
+
+    private String readLimitedBody(InputStream body) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        int total = 0;
+        int read;
+        while ((read = body.read(buffer)) != -1) {
+            total = checkedAdd(total, read, MAX_RESPONSE_BYTES);
+            output.write(buffer, 0, read);
+        }
+        return output.toString(StandardCharsets.UTF_8);
+    }
+
+    private String readSseLine(Reader reader) throws IOException {
+        StringBuilder line = new StringBuilder();
+        int character;
+        while ((character = reader.read()) != -1) {
+            if (character == '\n') {
+                if (!line.isEmpty() && line.charAt(line.length() - 1) == '\r') {
+                    line.setLength(line.length() - 1);
+                }
+                return line.toString();
+            }
+            if (line.length() >= MAX_SSE_EVENT_CHARS) {
+                throw responseTooLarge();
+            }
+            line.append((char) character);
+        }
+        return line.isEmpty() ? null : line.toString();
+    }
+
+    private int checkedAdd(int current, int increment, int limit) {
+        if (increment > limit - current) {
+            throw responseTooLarge();
+        }
+        return current + increment;
+    }
+
+    private LlmGatewayException responseTooLarge() {
+        return new LlmGatewayException(502, "llm.provider.response_too_large",
+                "LLM provider response exceeds the configured safety limit",
+                "Reduce the provider response size or configure a model with a smaller output.");
     }
 
     private boolean emitStreamEvent(List<String> dataLines, Consumer<String> tokenConsumer) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -70,8 +70,12 @@ public class OpenAiCompatibleLlmClient {
     }
 
     public String complete(LlmConfigVO config, String prompt, String modelOverride) {
+        return complete(config, List.of(LlmChatMessage.user(normalizeMessage(prompt))), modelOverride);
+    }
+
+    public String complete(LlmConfigVO config, List<LlmChatMessage> messages, String modelOverride) {
         validate(config);
-        Map<String, Object> requestBody = requestBody(config, prompt, modelOverride, false);
+        Map<String, Object> requestBody = requestBody(config, messages, modelOverride, false);
         HttpRequest request = request(config, "application/json", requestBody);
         try {
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
@@ -119,8 +123,13 @@ public class OpenAiCompatibleLlmClient {
     }
 
     public void stream(LlmConfigVO config, String prompt, String modelOverride, Consumer<String> tokenConsumer) {
+        stream(config, List.of(LlmChatMessage.user(normalizeMessage(prompt))), modelOverride, tokenConsumer);
+    }
+
+    public void stream(LlmConfigVO config, List<LlmChatMessage> messages, String modelOverride,
+                       Consumer<String> tokenConsumer) {
         validate(config);
-        Map<String, Object> requestBody = requestBody(config, prompt, modelOverride, true);
+        Map<String, Object> requestBody = requestBody(config, messages, modelOverride, true);
         HttpRequest request = request(config, "text/event-stream", requestBody);
         try {
             HttpResponse<java.io.InputStream> response = httpClient.send(
@@ -208,17 +217,38 @@ public class OpenAiCompatibleLlmClient {
         return builder.build();
     }
 
-    private Map<String, Object> requestBody(LlmConfigVO config, String prompt, String modelOverride,
+    private Map<String, Object> requestBody(LlmConfigVO config, List<LlmChatMessage> messages, String modelOverride,
                                             boolean stream) {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", StringUtils.hasText(modelOverride) ? modelOverride.trim() : config.getModel().trim());
-        body.put("messages", List.of(Map.of(
-                "role", "user",
-                "content", StringUtils.hasText(prompt) ? prompt.trim() : "")));
+        body.put("messages", normalizeMessages(messages));
         body.put("temperature", config.getTemperature());
         body.put("max_tokens", config.getMaxTokens());
         body.put("stream", stream);
         return body;
+    }
+
+    private List<Map<String, String>> normalizeMessages(List<LlmChatMessage> messages) {
+        List<LlmChatMessage> normalizedMessages = messages == null || messages.isEmpty()
+                ? List.of(LlmChatMessage.user(""))
+                : messages;
+        return normalizedMessages.stream()
+                .map(message -> Map.of(
+                        "role", normalizeRole(message),
+                        "content", normalizeMessage(message == null ? null : message.content())))
+                .toList();
+    }
+
+    private String normalizeRole(LlmChatMessage message) {
+        if (message == null || !StringUtils.hasText(message.role())) {
+            return "user";
+        }
+        String role = message.role().trim();
+        return "assistant".equals(role) ? "assistant" : "user";
+    }
+
+    private String normalizeMessage(String message) {
+        return StringUtils.hasText(message) ? message.trim() : "";
     }
 
     private URI chatCompletionsUri(LlmConfigVO config) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
@@ -31,9 +31,12 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Primary
@@ -41,12 +44,17 @@ import java.util.concurrent.Executors;
 @RequiredArgsConstructor
 public class OpenAiCompatibleLlmGateway implements LlmGateway {
 
+    private static final int MAX_STREAMING_TASKS = 16;
+    private static final int MAX_QUEUED_TASKS = 32;
+
     private final LlmConfigService configService;
     private final OpenAiCompatibleLlmClient llmClient;
     private final AgentProviderRegistry agentProviders;
     private final ObjectMapper objectMapper;
     private final LlmConversationMemory conversationMemory;
-    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final ExecutorService executor = new ThreadPoolExecutor(
+            MAX_STREAMING_TASKS, MAX_STREAMING_TASKS, 0L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(MAX_QUEUED_TASKS), new ThreadPoolExecutor.AbortPolicy());
 
     @Override
     public SseEmitter chat(ChatDTO request) {
@@ -56,20 +64,18 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
         }
         String engine = resolveEngine(request == null ? null : request.getEngine(), config);
         if (isCliEngine(engine)) {
-            SseEmitter emitter = new SseEmitter(300_000L);
-            executor.execute(() -> runCliChat(request, config, engine, emitter));
-            return emitter;
+            return submitChat(300_000L, emitter -> runCliChat(request, config, engine, emitter));
         }
         if (!llmClient.supports(config)) {
             return errorEmitter(unsupportedProviderException());
         }
 
-        String conversationId = request == null ? null : request.getConversationId();
-        String message = request == null ? null : request.getMessage();
-        List<LlmChatMessage> messages = conversationMemory.appendUserAndSnapshot(conversationId, message);
-        SseEmitter emitter = new SseEmitter(60_000L);
-        executor.execute(() -> streamChat(request, config, emitter, messages));
-        return emitter;
+        return submitChat(60_000L, emitter -> {
+            String conversationId = request == null ? null : request.getConversationId();
+            String message = request == null ? null : request.getMessage();
+            List<LlmChatMessage> messages = conversationMemory.appendUserAndSnapshot(conversationId, message);
+            streamChat(request, config, emitter, messages);
+        });
     }
 
     @Override
@@ -237,7 +243,17 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
 
     private SseEmitter errorEmitter(LlmGatewayException exception) {
         SseEmitter emitter = new SseEmitter(60_000L);
-        executor.execute(() -> sendError(emitter, exception));
+        Thread.ofVirtual().start(() -> sendError(emitter, exception));
+        return emitter;
+    }
+
+    private SseEmitter submitChat(long timeoutMillis, java.util.function.Consumer<SseEmitter> task) {
+        SseEmitter emitter = new SseEmitter(timeoutMillis);
+        try {
+            executor.execute(() -> task.accept(emitter));
+        } catch (RejectedExecutionException exception) {
+            Thread.ofVirtual().start(() -> sendError(emitter, gatewayBusyException()));
+        }
         return emitter;
     }
 
@@ -271,6 +287,12 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
         return new LlmGatewayException(400, "llm.config.incomplete",
                 "LLM provider is not configured or enabled",
                 "Configure and enable an LLM provider in Studio LLM Settings before using AI chat.");
+    }
+
+    private LlmGatewayException gatewayBusyException() {
+        return new LlmGatewayException(503, "llm.gateway.busy",
+                "LLM gateway is busy processing other requests",
+                "Retry shortly or reduce concurrent AI chat requests.");
     }
 
     private LlmGatewayException unsupportedProviderException() {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
@@ -29,6 +29,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -43,6 +45,7 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
     private final OpenAiCompatibleLlmClient llmClient;
     private final AgentProviderRegistry agentProviders;
     private final ObjectMapper objectMapper;
+    private final LlmConversationMemory conversationMemory;
     private final ExecutorService executor = Executors.newCachedThreadPool();
 
     @Override
@@ -61,8 +64,11 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
             return errorEmitter(unsupportedProviderException());
         }
 
+        String conversationId = request == null ? null : request.getConversationId();
+        String message = request == null ? null : request.getMessage();
+        List<LlmChatMessage> messages = conversationMemory.appendUserAndSnapshot(conversationId, message);
         SseEmitter emitter = new SseEmitter(60_000L);
-        executor.execute(() -> streamChat(request, config, emitter));
+        executor.execute(() -> streamChat(request, config, emitter, messages));
         return emitter;
     }
 
@@ -187,15 +193,24 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
         executor.shutdownNow();
     }
 
-    private void streamChat(ChatDTO request, LlmConfigVO config, SseEmitter emitter) {
+    private void streamChat(ChatDTO request, LlmConfigVO config, SseEmitter emitter, List<LlmChatMessage> messages) {
+        String conversationId = request == null ? null : request.getConversationId();
+        StringBuilder assistantMessage = new StringBuilder();
         try {
+            List<LlmChatMessage> requestMessages = messages;
             String prompt = request == null ? null : request.getMessage();
             if (request != null && request.isEnhance() && StringUtils.hasText(prompt)) {
                 prompt = enhanceAndEmitHttp(config, prompt, emitter);
+                requestMessages = new ArrayList<>(messages);
+                requestMessages.set(requestMessages.size() - 1, LlmChatMessage.user(prompt));
             }
-            llmClient.stream(config, prompt,
+            llmClient.stream(config, requestMessages,
                     request == null ? null : request.getModel(),
-                    token -> sendMessage(emitter, token));
+                    token -> {
+                        assistantMessage.append(token);
+                        sendMessage(emitter, token);
+                    });
+            conversationMemory.appendAssistant(conversationId, assistantMessage.toString());
             emitter.send(SseEmitter.event().name("done").data("[DONE]"));
             emitter.complete();
         } catch (LlmGatewayException exception) {
@@ -204,7 +219,8 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
         } catch (Exception exception) {
             log.error("Failed to stream LLM chat response", exception);
             sendError(emitter, new LlmGatewayException(502, "llm.gateway_error",
-                    "Failed to stream LLM chat response", "Check the LLM provider configuration and retry.", exception));
+                    "Failed to stream LLM chat response",
+                    "Check the LLM provider configuration and retry.", exception));
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiControllerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import org.apache.rocketmq.studio.common.exception.GlobalExceptionHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -26,7 +27,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -45,7 +48,9 @@ class AiControllerTest {
     @BeforeEach
     void setUp() {
         aiService = mock(AiService.class);
-        mockMvc = MockMvcBuilders.standaloneSetup(new AiController(aiService)).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(new AiController(aiService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
 
         when(aiService.catalogVersion()).thenReturn("1.0.0");
         when(aiService.catalogDigest()).thenReturn(DIGEST);
@@ -124,5 +129,27 @@ class AiControllerTest {
                 .andExpect(jsonPath("$.data").isArray());
 
         verify(aiService).executeTool("rmq.cluster.list", Collections.emptyMap());
+    }
+
+    @Test
+    void chatShouldRejectMissingRequestBody() throws Exception {
+        mockMvc.perform(post("/api/ai/chat")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("chat request is required"));
+
+        verify(aiService, never()).chat(any());
+    }
+
+    @Test
+    void executeShouldRejectMissingRequestBody() throws Exception {
+        mockMvc.perform(post("/api/ai/execute")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("AI command request is required"));
+
+        verify(aiService, never()).execute(any());
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -30,7 +31,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -78,6 +81,16 @@ class AiServiceTest {
     }
 
     @Test
+    void chatShouldRejectNullRequest() {
+        assertThatThrownBy(() -> aiService.chat(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("chat request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(llmGateway, never()).chat(any());
+    }
+
+    @Test
     void executeShouldReturnSuccessResult() {
         AiCommandDTO command = AiCommandDTO.builder()
                 .command("list_topics")
@@ -107,6 +120,16 @@ class AiServiceTest {
 
         assertThat(result.isSuccess()).isFalse();
         assertThat(result.getResult()).contains("Error: Permission denied");
+    }
+
+    @Test
+    void executeShouldRejectNullRequest() {
+        assertThatThrownBy(() -> aiService.execute(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("AI command request is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(llmGateway, never()).execute(any());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/CliAgentProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/CliAgentProviderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CliAgentProviderTest {
+
+    @Test
+    void completeShouldDrainStderrWhileProcessIsRunning() {
+        CliAgentProvider provider = new TestCliAgentProvider(
+                List.of("sh", "-c", "yes error | head -c 131072 >&2; printf done"), 5);
+
+        assertThat(provider.complete(LlmConfigVO.builder().build(), "", null)).isEqualTo("done");
+    }
+
+    @Test
+    void completeShouldTimeOutBeforeWaitingForOutputReaders() {
+        CliAgentProvider provider = new TestCliAgentProvider(List.of("sh", "-c", "sleep 2"), 1);
+
+        assertThatThrownBy(() -> provider.complete(LlmConfigVO.builder().build(), "", null))
+                .isInstanceOf(LlmGatewayException.class)
+                .satisfies(exception -> assertThat(((LlmGatewayException) exception).getStatusCode()).isEqualTo(504));
+    }
+
+    private static class TestCliAgentProvider extends CliAgentProvider {
+
+        private final List<String> command;
+        private final long timeoutSeconds;
+
+        private TestCliAgentProvider(List<String> command, long timeoutSeconds) {
+            this.command = command;
+            this.timeoutSeconds = timeoutSeconds;
+        }
+
+        @Override
+        public String engine() {
+            return "test";
+        }
+
+        @Override
+        public boolean available() {
+            return true;
+        }
+
+        @Override
+        protected List<String> buildCommand(LlmConfigVO config, String prompt, String modelOverride) {
+            return command;
+        }
+
+        @Override
+        protected Map<String, String> childEnv(LlmConfigVO config) {
+            return Map.of();
+        }
+
+        @Override
+        protected String binaryName() {
+            return "test";
+        }
+
+        @Override
+        protected long timeoutSeconds() {
+            return timeoutSeconds;
+        }
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConversationMemoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConversationMemoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmConversationMemoryTest {
+
+    @Test
+    void appendUserAndSnapshotShouldIncludePreviousTurnsForConversation() {
+        LlmConversationMemory memory = new LlmConversationMemory();
+
+        List<LlmChatMessage> first = memory.appendUserAndSnapshot(" conv-1 ", " first question ");
+        memory.appendAssistant("conv-1", " first answer ");
+        List<LlmChatMessage> second = memory.appendUserAndSnapshot("conv-1", "follow up");
+
+        assertThat(first).extracting(LlmChatMessage::role).containsExactly("user");
+        assertThat(first).extracting(LlmChatMessage::content).containsExactly("first question");
+        assertThat(second).extracting(LlmChatMessage::role)
+                .containsExactly("user", "assistant", "user");
+        assertThat(second).extracting(LlmChatMessage::content)
+                .containsExactly("first question", "first answer", "follow up");
+    }
+
+    @Test
+    void blankConversationIdShouldRemainSingleTurn() {
+        LlmConversationMemory memory = new LlmConversationMemory();
+
+        List<LlmChatMessage> first = memory.appendUserAndSnapshot("", "first");
+        memory.appendAssistant("", "answer");
+        List<LlmChatMessage> second = memory.appendUserAndSnapshot("", "second");
+
+        assertThat(first).extracting(LlmChatMessage::content).containsExactly("first");
+        assertThat(second).extracting(LlmChatMessage::content).containsExactly("second");
+    }
+
+    @Test
+    void conversationHistoryShouldBeBounded() {
+        LlmConversationMemory memory = new LlmConversationMemory();
+
+        for (int i = 0; i < 10; i++) {
+            memory.appendUserAndSnapshot("conv-1", "question-" + i);
+            memory.appendAssistant("conv-1", "answer-" + i);
+        }
+        List<LlmChatMessage> snapshot = memory.appendUserAndSnapshot("conv-1", "latest");
+
+        assertThat(snapshot).hasSize(12);
+        assertThat(snapshot.get(0).content()).isEqualTo("answer-4");
+        assertThat(snapshot.get(11).content()).isEqualTo("latest");
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
@@ -234,6 +234,45 @@ class OpenAiCompatibleLlmClientTest {
     }
 
     @Test
+    void completeShouldRejectOversizedProviderResponse() {
+        server.createContext("/v1/chat/completions", exchange -> respond(exchange, 200,
+                "x".repeat(2 * 1024 * 1024), "application/json"));
+
+        assertResponseTooLarge(() -> client.complete(config("openai", "sk-test"), "hello", null));
+    }
+
+    @Test
+    void streamShouldRejectOversizedErrorBody() {
+        server.createContext("/v1/chat/completions", exchange -> respond(exchange, 500,
+                "x".repeat(2 * 1024 * 1024), "application/json"));
+
+        assertResponseTooLarge(() -> client.stream(config("openai", "sk-test"), "hello", null, ignored -> {
+        }));
+    }
+
+    @Test
+    void streamShouldRejectOversizedEventPayload() {
+        String oversizedEvent = "data: " + "x".repeat(128 * 1024) + "\n\n";
+        server.createContext("/v1/chat/completions", exchange -> respond(exchange, 200,
+                oversizedEvent, "text/event-stream"));
+
+        assertResponseTooLarge(() -> client.stream(config("openai", "sk-test"), "hello", null, ignored -> {
+        }));
+    }
+
+    @Test
+    void streamShouldRejectOversizedCumulativePayload() {
+        String event = "data: {\"choices\":[{\"delta\":{\"content\":\""
+                + "x".repeat(16 * 1024) + "\"}}]}\n\n";
+        String payload = event.repeat(65);
+        server.createContext("/v1/chat/completions", exchange -> respond(exchange, 200,
+                payload, "text/event-stream"));
+
+        assertResponseTooLarge(() -> client.stream(config("openai", "sk-test"), "hello", null, ignored -> {
+        }));
+    }
+
+    @Test
     void unsupportedProviderShouldFailBeforeCallingUpstream() {
         assertThatThrownBy(() -> client.complete(config("bedrock", "key"), "hello", null))
                 .isInstanceOf(LlmGatewayException.class)
@@ -302,6 +341,18 @@ class OpenAiCompatibleLlmClientTest {
                     assertThat(gatewayException.getStatusCode()).isEqualTo(504);
                     assertThat(gatewayException.getCode()).isEqualTo("llm.provider.timeout");
                     assertThat(gatewayException.getHint()).contains("network connectivity");
+                });
+    }
+
+    private void assertResponseTooLarge(org.assertj.core.api.ThrowableAssert.ThrowingCallable action) {
+        assertThatThrownBy(action)
+                .isInstanceOf(LlmGatewayException.class)
+                .hasMessage("LLM provider response exceeds the configured safety limit")
+                .satisfies(exception -> {
+                    LlmGatewayException gatewayException = (LlmGatewayException) exception;
+                    assertThat(gatewayException.getStatusCode()).isEqualTo(502);
+                    assertThat(gatewayException.getCode()).isEqualTo("llm.provider.response_too_large");
+                    assertThat(gatewayException.getHint()).contains("smaller output");
                 });
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
@@ -137,6 +137,36 @@ class OpenAiCompatibleLlmClientTest {
     }
 
     @Test
+    void streamShouldSendConversationMessages() {
+        AtomicReference<JsonNode> requestBody = new AtomicReference<>();
+        server.createContext("/v1/chat/completions", exchange -> {
+            requestBody.set(objectMapper.readTree(exchange.getRequestBody()));
+            respond(exchange, 200, """
+                    data: {"choices":[{"delta":{"content":"ok"}}]}
+
+                    data: [DONE]
+
+                    """, "text/event-stream");
+        });
+
+        List<String> tokens = new ArrayList<>();
+        client.stream(config("openai", "sk-test"), List.of(
+                LlmChatMessage.user("first question"),
+                LlmChatMessage.assistant("first answer"),
+                LlmChatMessage.user("follow up")), null, tokens::add);
+
+        JsonNode messages = requestBody.get().path("messages");
+        assertThat(tokens).containsExactly("ok");
+        assertThat(messages).hasSize(3);
+        assertThat(messages.path(0).path("role").asText()).isEqualTo("user");
+        assertThat(messages.path(0).path("content").asText()).isEqualTo("first question");
+        assertThat(messages.path(1).path("role").asText()).isEqualTo("assistant");
+        assertThat(messages.path(1).path("content").asText()).isEqualTo("first answer");
+        assertThat(messages.path(2).path("role").asText()).isEqualTo("user");
+        assertThat(messages.path(2).path("content").asText()).isEqualTo("follow up");
+    }
+
+    @Test
     void ollamaShouldAllowMissingApiKeyAndOmitAuthorizationHeader() {
         AtomicReference<String> authorization = new AtomicReference<>();
         server.createContext("/v1/chat/completions", exchange -> {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGatewayTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGatewayTest.java
@@ -37,7 +37,8 @@ class OpenAiCompatibleLlmGatewayTest {
     private final LlmConfigService configService = mock(LlmConfigService.class);
     private final OpenAiCompatibleLlmClient llmClient = mock(OpenAiCompatibleLlmClient.class);
     private final OpenAiCompatibleLlmGateway gateway = new OpenAiCompatibleLlmGateway(
-            configService, llmClient, new AgentProviderRegistry(java.util.List.of()), new ObjectMapper());
+            configService, llmClient, new AgentProviderRegistry(java.util.List.of()), new ObjectMapper(),
+            new LlmConversationMemory());
 
     @Test
     void chatShouldRejectIncompleteConfigWithoutCallingProvider() {


### PR DESCRIPTION
## Summary

**Track:** Track 3 / AI Native

Consolidates #816, #834, #961, and #1008.

- Preserve bounded conversation context for OpenAI-compatible chat requests.
- Validate chat and command request bodies at the controller and service boundaries.
- Drain CLI stdout and stderr concurrently, and apply execution timeouts before waiting for output readers.
- Bound concurrent and queued SSE chat tasks, returning structured `llm.gateway.busy` errors when saturated.
- Bound provider completion, model-listing, and streaming-error response bodies to 1 MiB; bound individual SSE events to 64 KiB and cumulative SSE data to 1 MiB.

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=AiControllerTest,AiServiceTest,LlmConversationMemoryTest,OpenAiCompatibleLlmClientTest,OpenAiCompatibleLlmGatewayTest,CliAgentProviderTest test`
- `git diff --check origin/rocketmq-studio...HEAD`

Closes #815
Closes #833
Closes #959
Closes #1008