### PR TITLE
[ISSUE #895][ISSUE #897][ISSUE #901][ISSUE #903][ISSUE #905][ISSUE #907][ISSUE #908] Harden RocketMQ provider data handling

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProvider.java
@@ -111,6 +111,9 @@ public class RocketMQClientProvider implements ClientProvider {
                     continue;
                 }
                 for (Connection connection : producerConnection.getConnectionSet()) {
+                    if (connection == null) {
+                        continue;
+                    }
                     result.add(toConnectionVO(connection, ClientType.Producer, topic, topic, clusterId));
                 }
             } catch (Exception e) {
@@ -133,6 +136,9 @@ public class RocketMQClientProvider implements ClientProvider {
                     continue;
                 }
                 for (Connection connection : consumerConnection.getConnectionSet()) {
+                    if (connection == null) {
+                        continue;
+                    }
                     result.add(toConnectionVO(connection, ClientType.Consumer, group, null, clusterId));
                 }
             } catch (Exception e) {

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProvider.java
@@ -161,6 +161,9 @@ public class RocketMQClientProvider implements ClientProvider {
             return groups;
         }
         for (BrokerData brokerData : clusterInfo.getBrokerAddrTable().values()) {
+            if (brokerData == null) {
+                continue;
+            }
             String brokerAddr = brokerData.selectBrokerAddr();
             if (brokerAddr == null) {
                 continue;

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQClusterProvider.java
@@ -218,7 +218,7 @@ public class RocketMQClusterProvider implements ClusterProvider {
      */
     private int parseFirstTpsValue(String tpsStr) {
         try {
-            String[] parts = tpsStr.split(" ");
+            String[] parts = tpsStr.trim().split("\\s+");
             if (parts.length > 0) {
                 return (int) Double.parseDouble(parts[0]);
             }

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProvider.java
@@ -184,6 +184,9 @@ public class RocketMQDLQProvider implements DLQProvider {
         try {
             consumer.start();
             Set<MessageQueue> queues = consumer.fetchSubscribeMessageQueues(dlqTopic);
+            if (queues == null || queues.isEmpty()) {
+                return result;
+            }
             outer:
             for (MessageQueue queue : queues) {
                 long minOffset = consumer.searchOffset(queue, begin);

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProvider.java
@@ -164,8 +164,11 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                                     clusterTpsIn += (int) parseTps(rt.getTable().get("putTps"));
                                     clusterTpsOut += (int) parseTps(rt.getTable().get("getTransferedTps"));
                                     String v = rt.getTable().get("brokerVersionDesc");
-                                    if (v != null && !"unknown".equals(version)) {
-                                        version = v;
+                                    if (v != null && "unknown".equals(version)) {
+                                        String brokerVersion = v.trim();
+                                        if (!brokerVersion.isEmpty()) {
+                                            version = brokerVersion;
+                                        }
                                     }
                                 }
                             } catch (Exception ignored) {

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProvider.java
@@ -184,6 +184,9 @@ public class RocketMQMessageProvider implements MessageProvider {
         try {
             consumer.start();
             Set<MessageQueue> queues = consumer.fetchSubscribeMessageQueues(topic);
+            if (queues == null || queues.isEmpty()) {
+                return result;
+            }
             outer:
             for (MessageQueue queue : queues) {
                 long minOffset = consumer.searchOffset(queue, begin);

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProviderTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.rocketmq;
+
+import org.apache.rocketmq.remoting.protocol.LanguageCode;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.Connection;
+import org.apache.rocketmq.remoting.protocol.body.ConsumerConnection;
+import org.apache.rocketmq.remoting.protocol.body.ProducerConnection;
+import org.apache.rocketmq.remoting.protocol.body.SubscriptionGroupWrapper;
+import org.apache.rocketmq.remoting.protocol.body.TopicList;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
+import org.apache.rocketmq.studio.cluster.client.ClientConnectionVO;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RocketMQClientProviderTest {
+
+    @Mock
+    private ObjectProvider<DefaultMQAdminExt> adminExtProvider;
+
+    @Mock
+    private DefaultMQAdminExt adminExt;
+
+    private RocketMQClientProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        when(adminExtProvider.getIfAvailable()).thenReturn(adminExt);
+        provider = new RocketMQClientProvider(adminExtProvider);
+    }
+
+    @Test
+    void producerScanTreatsNullTopicSetAsEmpty() throws Exception {
+        when(adminExt.fetchAllTopicList()).thenReturn(new TopicList());
+
+        List<ClientConnectionVO> connections = provider.findConnections("cluster-a", "Producer");
+
+        assertThat(connections).isEmpty();
+        verify(adminExt).fetchAllTopicList();
+        verify(adminExt, never()).examineProducerConnectionInfo(anyString(), anyString());
+    }
+
+    @Test
+    void producerScanSkipsNullConnectionEntries() throws Exception {
+        TopicList topicList = new TopicList();
+        topicList.setTopicList(new HashSet<>(List.of("TopicA")));
+        ProducerConnection producerConnection = new ProducerConnection();
+        HashSet<Connection> connectionSet = new HashSet<>();
+        connectionSet.add(null);
+        connectionSet.add(connection("producer-client", "10.0.0.1:1000"));
+        producerConnection.setConnectionSet(connectionSet);
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList);
+        when(adminExt.examineProducerConnectionInfo(null, "TopicA")).thenReturn(producerConnection);
+
+        List<ClientConnectionVO> connections = provider.findConnections("cluster-a", "Producer");
+
+        assertThat(connections).hasSize(1);
+        assertThat(connections.get(0).getClientId()).isEqualTo("producer-client");
+    }
+
+    @Test
+    void consumerScanSkipsNullBrokerMetadata() throws Exception {
+        ClusterInfo clusterInfo = new ClusterInfo();
+        Map<String, BrokerData> brokerAddrTable = new HashMap<>();
+        brokerAddrTable.put("broken-broker", null);
+        brokerAddrTable.put("broker-a", new BrokerData("cluster-a", "broker-a",
+                new HashMap<>(Map.of(0L, "127.0.0.1:10911"))));
+        clusterInfo.setBrokerAddrTable(brokerAddrTable);
+        SubscriptionGroupWrapper wrapper = new SubscriptionGroupWrapper();
+        wrapper.setSubscriptionGroupTable(new ConcurrentHashMap<>());
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo);
+        when(adminExt.getAllSubscriptionGroup("127.0.0.1:10911", 5000L)).thenReturn(wrapper);
+
+        List<ClientConnectionVO> connections = provider.findConnections("cluster-a", "Consumer");
+
+        assertThat(connections).isEmpty();
+        verify(adminExt).examineBrokerClusterInfo();
+        verify(adminExt).getAllSubscriptionGroup("127.0.0.1:10911", 5000L);
+    }
+
+    @Test
+    void consumerScanSkipsNullConnectionEntries() throws Exception {
+        ClusterInfo clusterInfo = new ClusterInfo();
+        clusterInfo.setBrokerAddrTable(Map.of("broker-a", new BrokerData("cluster-a", "broker-a",
+                new HashMap<>(Map.of(0L, "127.0.0.1:10911")))));
+        SubscriptionGroupWrapper wrapper = new SubscriptionGroupWrapper();
+        ConcurrentHashMap<String, SubscriptionGroupConfig> groups = new ConcurrentHashMap<>();
+        groups.put("group-a", new SubscriptionGroupConfig());
+        wrapper.setSubscriptionGroupTable(groups);
+        ConsumerConnection consumerConnection = new ConsumerConnection();
+        HashSet<Connection> connectionSet = new HashSet<>();
+        connectionSet.add(null);
+        connectionSet.add(connection("consumer-client", "10.0.0.2:1000"));
+        consumerConnection.setConnectionSet(connectionSet);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo);
+        when(adminExt.getAllSubscriptionGroup("127.0.0.1:10911", 5000L)).thenReturn(wrapper);
+        when(adminExt.examineConsumerConnectionInfo("group-a")).thenReturn(consumerConnection);
+
+        List<ClientConnectionVO> connections = provider.findConnections("cluster-a", "Consumer");
+
+        assertThat(connections).hasSize(1);
+        assertThat(connections.get(0).getClientId()).isEqualTo("consumer-client");
+    }
+
+    private static Connection connection(String clientId, String clientAddr) {
+        Connection connection = new Connection();
+        connection.setClientId(clientId);
+        connection.setClientAddr(clientAddr);
+        connection.setLanguage(LanguageCode.JAVA);
+        connection.setVersion(500);
+        return connection;
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQClusterProviderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.rocketmq;
+
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.KVTable;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.cluster.broker.ClusterVO;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RocketMQClusterProviderTest {
+
+    @Test
+    void discoverClustersShouldParseRuntimeTpsWithExtraWhitespace() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RocketMQProperties properties = new RocketMQProperties();
+        properties.setNamesrvAddr("10.0.0.1:9876");
+        RocketMQClusterProvider provider = new RocketMQClusterProvider(adminExt, properties);
+
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        List<ClusterVO> clusters = provider.discoverClusters();
+
+        assertThat(clusters).hasSize(1);
+        assertThat(clusters.get(0).getBrokers()).hasSize(1);
+        assertThat(clusters.get(0).getBrokers().get(0).getTpsIn()).isEqualTo(12);
+        assertThat(clusters.get(0).getBrokers().get(0).getTpsOut()).isEqualTo(34);
+    }
+
+    private ClusterInfo clusterInfo() {
+        ClusterInfo clusterInfo = new ClusterInfo();
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "10.0.0.11:10911");
+        HashMap<String, BrokerData> brokerAddrTable = new HashMap<>();
+        brokerAddrTable.put("broker-a", new BrokerData("DefaultCluster", "broker-a", addrs));
+        clusterInfo.setBrokerAddrTable(brokerAddrTable);
+
+        HashMap<String, Set<String>> clusterAddrTable = new HashMap<>();
+        clusterAddrTable.put("DefaultCluster", Set.of("broker-a"));
+        clusterInfo.setClusterAddrTable(clusterAddrTable);
+        return clusterInfo;
+    }
+
+    private KVTable runtimeStats() {
+        KVTable table = new KVTable();
+        HashMap<String, String> stats = new HashMap<>();
+        stats.put("putTps", "  12.7   10.0  9.0");
+        stats.put("getTransferedTps", "\t34.2  30.0  29.0");
+        table.setTable(stats);
+        return table;
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProviderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.rocketmq;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.studio.ops.audit.AuditService;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RocketMQDLQProviderTest {
+
+    @Mock
+    private ObjectProvider<DefaultMQAdminExt> adminExtProvider;
+
+    @Mock
+    private DefaultMQAdminExt adminExt;
+
+    @Mock
+    private AuditService auditService;
+
+    private RocketMQDLQProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        when(adminExtProvider.getIfAvailable()).thenReturn(adminExt);
+        provider = new RocketMQDLQProvider(adminExtProvider, auditService, new RocketMQProperties());
+    }
+
+    @Test
+    void resendMessagesDoesNotPullWhenDlqQueueSetIsNull() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(null);
+                         doNothing().when(consumer).shutdown();
+                     });
+             MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class)) {
+            provider.resendMessages("group-a", 100L, 200L, "target-topic");
+
+            assertThat(mockedConsumers.constructed()).hasSize(1);
+            DefaultMQPullConsumer consumer = mockedConsumers.constructed().get(0);
+            verify(consumer).start();
+            verify(consumer).fetchSubscribeMessageQueues(dlqTopic);
+            verify(consumer, never()).pull(any(MessageQueue.class), anyString(), anyLong(), anyInt());
+            verify(consumer).shutdown();
+            assertThat(mockedProducers.constructed()).isEmpty();
+        }
+        verify(auditService).record(
+                eq("RESEND_DLQ"),
+                eq("group-a"),
+                contains("matched=0, resent=0, failed=0"),
+                eq("SUCCESS"));
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProviderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.rocketmq;
+
+import java.util.HashMap;
+import java.util.Set;
+
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.KVTable;
+import org.apache.rocketmq.remoting.protocol.body.TopicList;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RocketMQDashboardProviderTest {
+
+    @Test
+    void dashboardClusterOverviewShouldUseBrokerVersionDesc() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        RocketMQDashboardProvider provider = new RocketMQDashboardProvider(adminExt);
+
+        DashboardDataVO dashboard = provider.getDashboardData();
+
+        assertThat(dashboard.getClusters()).hasSize(1);
+        assertThat(dashboard.getClusters().get(0).getVersion()).isEqualTo("V5_3_3");
+    }
+
+    private ClusterInfo clusterInfo() {
+        ClusterInfo info = new ClusterInfo();
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "10.0.0.11:10911");
+
+        HashMap<String, BrokerData> brokerAddrTable = new HashMap<>();
+        brokerAddrTable.put("broker-a", new BrokerData("DefaultCluster", "broker-a", new HashMap<>(addrs)));
+        info.setBrokerAddrTable(brokerAddrTable);
+
+        HashMap<String, Set<String>> clusterAddrTable = new HashMap<>();
+        clusterAddrTable.put("DefaultCluster", Set.of("broker-a"));
+        info.setClusterAddrTable(clusterAddrTable);
+        return info;
+    }
+
+    private TopicList topicList() {
+        TopicList topicList = new TopicList();
+        topicList.setTopicList(Set.of("order-topic"));
+        return topicList;
+    }
+
+    private KVTable runtimeStats() {
+        HashMap<String, String> table = new HashMap<>();
+        table.put("brokerVersionDesc", "  V5_3_3  ");
+        table.put("putTps", "1.0 2.0 3.0");
+        table.put("getTransferedTps", "4.0 5.0 6.0");
+        table.put("msgPutTotalTodayMorning", "42");
+
+        KVTable kvTable = new KVTable();
+        kvTable.setTable(table);
+        return kvTable;
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProviderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.rocketmq;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
+import org.apache.rocketmq.studio.queryhistory.QueryHistoryService;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RocketMQMessageProviderTest {
+
+    @Mock
+    private ObjectProvider<DefaultMQAdminExt> adminExtProvider;
+
+    @Mock
+    private DefaultMQAdminExt adminExt;
+
+    @Mock
+    private QueryHistoryService queryHistoryService;
+
+    private RocketMQMessageProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        when(adminExtProvider.getIfAvailable()).thenReturn(adminExt);
+        provider = new RocketMQMessageProvider(adminExtProvider, queryHistoryService, new RocketMQProperties());
+    }
+
+    @Test
+    void queryByTopicReturnsEmptyListWhenQueueSetIsNull() throws Exception {
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues("TopicA")).thenReturn(null);
+                         doNothing().when(consumer).shutdown();
+                     })) {
+            List<MessageRecordVO> messages = provider.queryMessages("TopicA", null, null, null, 100L, 200L);
+
+            assertThat(messages).isEmpty();
+            assertThat(mockedConsumers.constructed()).hasSize(1);
+            DefaultMQPullConsumer consumer = mockedConsumers.constructed().get(0);
+            verify(consumer).start();
+            verify(consumer).fetchSubscribeMessageQueues("TopicA");
+            verify(consumer, never()).pull(any(MessageQueue.class), anyString(), anyLong(), anyInt());
+            verify(consumer).shutdown();
+        }
+        verify(queryHistoryService).recordMessageQuery("TOPIC", "TopicA", null, null, null, 100L, 200L, 0);
+    }
+}


### PR DESCRIPTION
## Summary

**Track:** Track 1 / Control Plane reliability

Consolidates and supersedes #935 and #948.

- Guard message, DLQ, and client scans against missing broker metadata.
- Parse broker TPS output with flexible whitespace.
- Include the broker version in dashboard data.
- Cover all affected RocketMQ provider adapters with focused tests.

## Verification

- `mvn -Dtest=RocketMQClientProviderTest,RocketMQClusterProviderTest,RocketMQDashboardProviderTest,RocketMQDLQProviderTest,RocketMQMessageProviderTest test`
- `git diff --check origin/rocketmq-studio...HEAD`

Closes #895
Closes #897
Closes #901
Closes #903
Closes #905
Closes #907
Closes #908