### PR TITLE
fix: keep nginx proxying to the backend across container IP changes

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -57,6 +57,12 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8888/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
 
   rocketmq-web:
     build:
@@ -68,7 +74,8 @@ services:
     ports:
       - "6789:80"
     depends_on:
-      - rocketmq-server
+      rocketmq-server:
+        condition: service_healthy
     networks:
       - studio-net
 

--- a/web/15-resolver.envsh
+++ b/web/15-resolver.envsh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Sourced by docker-entrypoint.sh (*.envsh), so RESOLVER is visible to the
+# later 20-envsubst-on-templates.sh step. Uses the podman network gateway
+# (the container DNS server) only — the host resolv.conf may leak public DNS
+# servers that cannot resolve container names and cause random 502s.
+RESOLVER="$(ip route | awk '/default/ {print $3; exit}')"
+if [ -z "$RESOLVER" ]; then
+    RESOLVER="127.0.0.11"
+fi
+export RESOLVER
+echo "15-resolver.envsh: resolver=$RESOLVER"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,8 +8,9 @@ RUN npm run build
 
 # Stage 2: Serve
 FROM nginx:alpine
-ENV NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1 \
-    NGINX_ENVSUBST_FILTER=^NGINX_LOCAL_RESOLVERS$
+ENV NGINX_ENVSUBST_FILTER=^RESOLVER$
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/templates/default.conf.template
+COPY 15-resolver.envsh /docker-entrypoint.d/15-resolver.envsh
+RUN chmod +x /docker-entrypoint.d/15-resolver.envsh
 EXPOSE 80

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -2,6 +2,12 @@ server {
     listen 80;
     server_name _;
 
+    # RESOLVER is injected by 15-resolver.sh (podman network gateway only).
+    # Variable proxy_pass re-resolves on every request, so a recreated
+    # rocketmq-server container with a new IP is picked up without restarting
+    # nginx.
+    resolver ${RESOLVER} valid=10s;
+
     location / {
         root /usr/share/nginx/html;
         index index.html;
@@ -9,7 +15,8 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://rocketmq-server:8888;
+        set $backend http://rocketmq-server:8888;
+        proxy_pass $backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -17,7 +24,8 @@ server {
     }
 
     location /actuator/ {
-        proxy_pass http://rocketmq-server:8888;
+        set $backend_actuator http://rocketmq-server:8888;
+        proxy_pass $backend_actuator;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary

- Switch the nginx template to variable `proxy_pass` with a resolver pinned to the podman network gateway (injected by `15-resolver.envsh` before the envsubst step), so a recreated `rocketmq-server` container with a new IP is picked up per request instead of returning 502 until the web container restarts.
- Add a curl healthcheck to `rocketmq-server` and make `rocketmq-web` wait for `service_healthy`, so nginx never boots before the backend is resolvable and serving.

## Test plan

- [x] Deployed: `/api/auth/status` stays 200 across `docker restart rocketmq-server`