### PR TITLE
feat(server): add PostgreSQL persistence profile

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -32,6 +32,22 @@ cd deploy && docker compose up -d --build
 
 默认访问地址为 `http://127.0.0.1:6789`。
 
+## PostgreSQL 持久化
+
+Studio 默认 Docker Compose 部署继续使用 MySQL。使用已有 PostgreSQL 16+ 实例时，启用
+`postgres` profile，并提供数据库连接信息：
+
+```env
+SPRING_PROFILES_ACTIVE=postgres
+SPRING_DATASOURCE_URL=jdbc:postgresql://postgres.example:5432/rocketmq_studio
+SPRING_DATASOURCE_USERNAME=rocketmq_studio
+SPRING_DATASOURCE_PASSWORD=change-me
+```
+
+首次启动会执行 `server/src/main/resources/db/schema-postgresql.sql` 创建 Studio 自身的
+配置、审计和管理记录表。该 schema 不保存 RocketMQ 消息、消费位点或 Broker 运行态数据；
+这些数据仍通过 RocketMQ 管理接口读取。
+
 ## 开启登录保护
 
 `studio.auth.login-required` 默认为 `false`，便于本地开发和演示环境直接访问。共享环境建议在

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -66,7 +66,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
-        <!-- MyBatis-Plus + MySQL -->
+        <!-- MyBatis-Plus persistence backends -->
         <dependency>
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
@@ -78,9 +78,24 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
         </dependency>
         <!-- RocketMQ Admin Tools (kept from trunk #694) -->
         <dependency>

--- a/server/src/main/resources/application-postgres.yml
+++ b/server/src/main/resources/application-postgres.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/rocketmq_studio}
+    username: ${SPRING_DATASOURCE_USERNAME:rocketmq_studio}
+    password: ${SPRING_DATASOURCE_PASSWORD:rocketmq_studio}
+    driver-class-name: org.postgresql.Driver
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:db/schema-postgresql.sql

--- a/server/src/main/resources/db/schema-postgresql.sql
+++ b/server/src/main/resources/db/schema-postgresql.sql
@@ -1,0 +1,189 @@
+-- RocketMQ Studio schema for PostgreSQL 16+.
+-- This mirrors db/schema.sql without MySQL-only clauses or sample data.
+
+CREATE TABLE IF NOT EXISTS rmq_nameserver (
+  id VARCHAR(64) PRIMARY KEY,
+  name VARCHAR(128) NOT NULL,
+  namesrv_addr VARCHAR(512) NOT NULL,
+  cluster_type VARCHAR(32) DEFAULT 'V5_PROXY_CLUSTER',
+  status VARCHAR(32) DEFAULT 'healthy',
+  description TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS rmq_instance (
+  id VARCHAR(64) PRIMARY KEY,
+  name VARCHAR(128) NOT NULL,
+  remark VARCHAR(255),
+  type VARCHAR(32) NOT NULL,
+  endpoint VARCHAR(512) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS rmq_topic (
+  id BIGSERIAL PRIMARY KEY,
+  cluster_id VARCHAR(64) NOT NULL,
+  instance_id VARCHAR(64),
+  name VARCHAR(255) NOT NULL,
+  topic_type VARCHAR(32) DEFAULT 'NORMAL',
+  read_queue_nums INTEGER DEFAULT 8,
+  write_queue_nums INTEGER DEFAULT 8,
+  perm INTEGER DEFAULT 6,
+  remark VARCHAR(255),
+  status VARCHAR(32) DEFAULT 'ACTIVE',
+  created_by VARCHAR(64),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT uk_cluster_topic UNIQUE (cluster_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_topic_instance ON rmq_topic (instance_id);
+
+CREATE TABLE IF NOT EXISTS rmq_group (
+  id BIGSERIAL PRIMARY KEY,
+  cluster_id VARCHAR(64) NOT NULL,
+  instance_id VARCHAR(64),
+  name VARCHAR(255) NOT NULL,
+  consume_type VARCHAR(32) DEFAULT 'CONCURRENTLY',
+  message_model VARCHAR(32) DEFAULT 'CLUSTERING',
+  max_retry INTEGER DEFAULT 16,
+  status VARCHAR(32) DEFAULT 'ACTIVE',
+  created_by VARCHAR(64),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT uk_cluster_group UNIQUE (cluster_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_group_instance ON rmq_group (instance_id);
+
+CREATE TABLE IF NOT EXISTS rmq_k8s_certificate (
+  id VARCHAR(64) PRIMARY KEY,
+  name VARCHAR(128) NOT NULL,
+  namespace VARCHAR(128),
+  cluster VARCHAR(128),
+  cert_type VARCHAR(32) DEFAULT 'TLS',
+  issuer VARCHAR(256),
+  not_before TIMESTAMP,
+  not_after TIMESTAMP,
+  status VARCHAR(32) DEFAULT 'valid',
+  days_remaining INTEGER,
+  san TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS rmq_message_query (
+  id BIGSERIAL PRIMARY KEY,
+  query_type VARCHAR(32) NOT NULL,
+  topic VARCHAR(255),
+  msg_id VARCHAR(128),
+  tag VARCHAR(128),
+  message_key VARCHAR(255),
+  start_time BIGINT,
+  end_time BIGINT,
+  result_count INTEGER DEFAULT 0,
+  queried_by VARCHAR(64),
+  queried_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_message_query_queried_at ON rmq_message_query (queried_at);
+CREATE INDEX IF NOT EXISTS idx_message_query_topic ON rmq_message_query (topic);
+
+CREATE TABLE IF NOT EXISTS rmq_trace_query (
+  id BIGSERIAL PRIMARY KEY,
+  msg_id VARCHAR(128) NOT NULL,
+  topic VARCHAR(255),
+  node_count INTEGER DEFAULT 0,
+  consumer_count INTEGER DEFAULT 0,
+  queried_by VARCHAR(64),
+  queried_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_trace_query_msg_id ON rmq_trace_query (msg_id);
+CREATE INDEX IF NOT EXISTS idx_trace_query_queried_at ON rmq_trace_query (queried_at);
+
+CREATE TABLE IF NOT EXISTS rmq_operation_audit (
+  id BIGSERIAL PRIMARY KEY,
+  operation VARCHAR(64) NOT NULL,
+  resource_type VARCHAR(64) NOT NULL,
+  resource_name VARCHAR(255),
+  cluster_id VARCHAR(64),
+  detail TEXT,
+  result VARCHAR(16) DEFAULT 'SUCCESS',
+  error_message TEXT,
+  operator VARCHAR(64),
+  operated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_operation_audit_operated_at ON rmq_operation_audit (operated_at);
+CREATE INDEX IF NOT EXISTS idx_operation_audit_resource ON rmq_operation_audit (resource_type, resource_name);
+CREATE INDEX IF NOT EXISTS idx_operation_audit_operation ON rmq_operation_audit (operation);
+
+CREATE TABLE IF NOT EXISTS rmq_settings (
+  id VARCHAR(16) PRIMARY KEY DEFAULT 'singleton',
+  json TEXT NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS rmq_data_source (
+  ds_key VARCHAR(64) PRIMARY KEY,
+  json TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS rmq_acl_rule (
+  id VARCHAR(64) PRIMARY KEY,
+  principal VARCHAR(128) NOT NULL,
+  resource VARCHAR(255) NOT NULL,
+  resource_type VARCHAR(32),
+  resource_pattern VARCHAR(32),
+  actions VARCHAR(128),
+  decision VARCHAR(16),
+  scope VARCHAR(64),
+  acl_version VARCHAR(16),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_acl_rule_principal ON rmq_acl_rule (principal);
+
+CREATE TABLE IF NOT EXISTS rmq_acl_user (
+  id VARCHAR(64) PRIMARY KEY,
+  username VARCHAR(128) NOT NULL,
+  access_key VARCHAR(255) NOT NULL,
+  secret_key VARCHAR(512) NOT NULL,
+  admin BOOLEAN DEFAULT FALSE,
+  clusters VARCHAR(1024),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT uk_acl_user_username UNIQUE (username)
+);
+
+CREATE TABLE IF NOT EXISTS rmq_alert_rule (
+  id VARCHAR(64) PRIMARY KEY,
+  name VARCHAR(128) NOT NULL,
+  metric VARCHAR(128),
+  operator VARCHAR(16),
+  threshold DOUBLE PRECISION,
+  threshold_unit VARCHAR(32),
+  duration VARCHAR(32),
+  channels VARCHAR(512),
+  enabled BOOLEAN DEFAULT TRUE,
+  last_triggered VARCHAR(64),
+  description VARCHAR(512),
+  broker_name VARCHAR(128),
+  cluster_name VARCHAR(128),
+  severity VARCHAR(32),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS rmq_system_alert (
+  id VARCHAR(64) PRIMARY KEY,
+  level VARCHAR(32),
+  title VARCHAR(255),
+  description TEXT,
+  time TIMESTAMP,
+  acknowledged BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_system_alert_level ON rmq_system_alert (level);
+CREATE INDEX IF NOT EXISTS idx_system_alert_acknowledged ON rmq_system_alert (acknowledged);

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/PostgreSqlSettingsRepositoryIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/PostgreSqlSettingsRepositoryIntegrationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.persistence;
+
+import org.apache.rocketmq.studio.settings.DataSourceVO;
+import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
+import org.apache.rocketmq.studio.settings.SettingsRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers(disabledWithoutDocker = true)
+@ActiveProfiles("postgres")
+@SpringBootTest
+class PostgreSqlSettingsRepositoryIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("rocketmq_studio")
+            .withUsername("rocketmq_studio")
+            .withPassword("rocketmq_studio");
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+
+    @Autowired
+    private SettingsRepository settingsRepository;
+
+    @Test
+    void persistsGeneralSettingsAndDataSources() {
+        GeneralSettingsVO settings = GeneralSettingsVO.builder()
+                .theme("dark")
+                .compact(true)
+                .desktopNotify(false)
+                .notifySound(false)
+                .sessionTimeout(15)
+                .requireLogin(true)
+                .llmProvider("openai")
+                .apiKey("test-key")
+                .model("gpt-4")
+                .baseUrl("https://example.test/v1")
+                .build();
+        settingsRepository.saveGeneralSettings(settings);
+
+        DataSourceVO dataSource = DataSourceVO.builder()
+                .key("postgres-prometheus")
+                .name("PostgreSQL integration test")
+                .type("prometheus")
+                .url("https://prometheus.example.test")
+                .auth("none")
+                .status("healthy")
+                .build();
+        settingsRepository.saveDataSource(dataSource);
+
+        assertThat(settingsRepository.loadGeneralSettings())
+                .usingRecursiveComparison()
+                .ignoringFields("apiKey", "clearApiKey")
+                .isEqualTo(settings);
+        assertThat(settingsRepository.findDataSourceByKey(dataSource.getKey()))
+                .contains(dataSource);
+        assertThat(settingsRepository.findAllDataSources()).contains(dataSource);
+
+        dataSource.setName("Updated PostgreSQL integration test");
+        assertThat(settingsRepository.replaceDataSource(dataSource)).isTrue();
+        assertThat(settingsRepository.findDataSourceByKey(dataSource.getKey()))
+                .contains(dataSource);
+        assertThat(settingsRepository.deleteDataSource(dataSource.getKey())).isTrue();
+        assertThat(settingsRepository.findDataSourceByKey(dataSource.getKey())).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Adds PostgreSQL 16+ support for the existing Studio MyBatis-Plus persistence layer.

- adds the PostgreSQL JDBC runtime driver and Testcontainers test dependencies
- adds a postgres Spring profile that initializes the PostgreSQL schema
- adds a PostgreSQL DDL equivalent for all current Studio persistence entities
- adds a PostgreSQL integration test for general settings and data-source CRUD
- documents external PostgreSQL deployment configuration

## Validation

- mvn -Dtest=PostgreSqlSettingsRepositoryIntegrationTest test
  - compiles successfully; the Testcontainers test is skipped locally because this machine's Docker Java client reports API 1.32 while the Docker daemon requires 1.40
- manual PostgreSQL 16 validation through Docker CLI:
  - started Studio with the postgres profile
  - created a data source through the settings API
  - restarted Studio and confirmed the data source was still returned
  - confirmed one persisted rmq_data_source row in PostgreSQL

Closes #956