### PR TITLE
fix(settings): persist configured LLM API key

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.persistence;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.persistence.entity.RmqDataSource;
 import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
@@ -90,7 +91,7 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
     @Override
     public void saveGeneralSettings(GeneralSettingsVO settings) {
         try {
-            String json = objectMapper.writeValueAsString(settings);
+            String json = serializeGeneralSettings(settings);
             RmqSettings entity = settingsMapper.selectById(SETTINGS_ID);
             if (entity == null) {
                 entity = new RmqSettings();
@@ -107,6 +108,15 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
             log.error("Failed to serialize general settings", e);
             throw new RuntimeException("Failed to save settings", e);
         }
+    }
+
+    /**
+     * API serialization must not expose the LLM API key, while persistence needs to retain it.
+     */
+    private String serializeGeneralSettings(GeneralSettingsVO settings) throws JsonProcessingException {
+        ObjectNode json = objectMapper.valueToTree(settings);
+        json.put("apiKey", settings.getApiKey());
+        return objectMapper.writeValueAsString(json);
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.studio.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
+import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqSettingsMapper;
+import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MybatisPlusSettingsRepositoryTest {
+
+    @Mock
+    private RmqSettingsMapper settingsMapper;
+
+    @Mock
+    private RmqDataSourceMapper dataSourceMapper;
+
+    @InjectMocks
+    private MybatisPlusSettingsRepository repository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void saveAndLoadShouldRetainApiKeyWithoutExposingItThroughDefaultSerialization() throws Exception {
+        repository = new MybatisPlusSettingsRepository(settingsMapper, dataSourceMapper, objectMapper);
+        GeneralSettingsVO settings = GeneralSettingsVO.builder()
+                .theme("system")
+                .llmProvider("openai")
+                .apiKey("sk-persisted")
+                .model("gpt-4o")
+                .baseUrl("https://api.openai.com/v1")
+                .build();
+        when(settingsMapper.selectById("singleton")).thenReturn(null);
+
+        repository.saveGeneralSettings(settings);
+
+        ArgumentCaptor<RmqSettings> captor = ArgumentCaptor.forClass(RmqSettings.class);
+        verify(settingsMapper).insert(captor.capture());
+        RmqSettings stored = captor.getValue();
+        assertThat(stored.getJson()).contains("apiKey").contains("sk-persisted");
+        assertThat(objectMapper.writeValueAsString(settings)).doesNotContain("sk-persisted");
+
+        when(settingsMapper.selectById("singleton")).thenReturn(stored);
+
+        assertThat(repository.loadGeneralSettings().getApiKey()).isEqualTo("sk-persisted");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #958. The API key remains `WRITE_ONLY` for REST serialization, while the settings repository now explicitly retains it in the persisted JSON document.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=MybatisPlusSettingsRepositoryTest test`
- The new regression test verifies repository save/load retains the key while normal Jackson serialization does not expose it.