### PR TITLE
fix(ai): bound CLI execution and drain process output

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProvider.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -96,22 +97,31 @@ public class ClaudeCodeAgentProvider extends CliAgentProvider {
             Process process = builder.start();
             AtomicBoolean emitted = new AtomicBoolean(false);
             StringBuilder resultText = new StringBuilder();
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    parseStreamLine(line, tokenConsumer, emitted, resultText);
+            CompletableFuture<Void> stdoutFuture = new CompletableFuture<>();
+            Thread.ofVirtual().start(() -> {
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        parseStreamLine(line, tokenConsumer, emitted, resultText);
+                    }
+                    stdoutFuture.complete(null);
+                } catch (Exception exception) {
+                    stdoutFuture.completeExceptionally(exception);
                 }
-            }
+            });
+            CompletableFuture<String> stderrFuture = readAsync(process.getErrorStream());
             boolean finished = process.waitFor(STREAM_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
+                process.waitFor();
                 throw new LlmGatewayException(504, "llm.provider.timeout",
                         binaryName() + " CLI stream timed out after " + STREAM_TIMEOUT_SECONDS + "s",
                         "Retry with a shorter prompt or check the gateway latency.");
             }
+            await(stdoutFuture);
+            String stderr = await(stderrFuture);
             if (process.exitValue() != 0 && !emitted.get()) {
-                String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
                 throw new LlmGatewayException(502, "llm.provider.cli_error",
                         binaryName() + " CLI failed: " + (StringUtils.hasText(stderr) ? stderr.trim() : "unknown error"),
                         "Check the provider credentials, base URL and model name.");

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/CliAgentProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/CliAgentProvider.java
@@ -20,9 +20,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -71,15 +74,19 @@ public abstract class CliAgentProvider implements AgentProvider {
         builder.redirectErrorStream(false);
         try {
             Process process = builder.start();
-            String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
-            boolean finished = process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            CompletableFuture<String> stdoutFuture = readAsync(process.getInputStream());
+            CompletableFuture<String> stderrFuture = readAsync(process.getErrorStream());
+            long timeoutSeconds = timeoutSeconds();
+            boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
+                process.waitFor();
                 throw new LlmGatewayException(504, "llm.provider.timeout",
-                        binaryName() + " CLI timed out after " + TIMEOUT_SECONDS + "s",
+                        binaryName() + " CLI timed out after " + timeoutSeconds + "s",
                         "Retry with a shorter prompt or check the gateway latency.");
             }
+            String stdout = await(stdoutFuture);
+            String stderr = await(stderrFuture);
             if (process.exitValue() != 0) {
                 log.warn("{} CLI failed rc={}, stderr={}", binaryName(), process.exitValue(), abbreviate(stderr));
                 throw new LlmGatewayException(502, "llm.provider.cli_error",
@@ -102,6 +109,37 @@ public abstract class CliAgentProvider implements AgentProvider {
             Thread.currentThread().interrupt();
             throw new LlmGatewayException(502, "llm.provider.interrupted",
                     binaryName() + " CLI execution was interrupted", "Retry the request.", exception);
+        }
+    }
+
+    protected CompletableFuture<String> readAsync(InputStream stream) {
+        CompletableFuture<String> result = new CompletableFuture<>();
+        Thread.ofVirtual().start(() -> {
+            try (stream) {
+                result.complete(new String(stream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (Exception exception) {
+                result.completeExceptionally(exception);
+            }
+        });
+        return result;
+    }
+
+    protected long timeoutSeconds() {
+        return TIMEOUT_SECONDS;
+    }
+
+    protected <T> T await(CompletableFuture<T> future) throws IOException {
+        try {
+            return future.join();
+        } catch (CompletionException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof IOException ioException) {
+                throw ioException;
+            }
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new IOException("Failed to read CLI process output", cause);
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
@@ -29,9 +29,12 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Primary
@@ -39,11 +42,16 @@ import java.util.concurrent.Executors;
 @RequiredArgsConstructor
 public class OpenAiCompatibleLlmGateway implements LlmGateway {
 
+    private static final int MAX_STREAMING_TASKS = 16;
+    private static final int MAX_QUEUED_TASKS = 32;
+
     private final LlmConfigService configService;
     private final OpenAiCompatibleLlmClient llmClient;
     private final AgentProviderRegistry agentProviders;
     private final ObjectMapper objectMapper;
-    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final ExecutorService executor = new ThreadPoolExecutor(
+            MAX_STREAMING_TASKS, MAX_STREAMING_TASKS, 0L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(MAX_QUEUED_TASKS), new ThreadPoolExecutor.AbortPolicy());
 
     @Override
     public SseEmitter chat(ChatDTO request) {
@@ -53,17 +61,13 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
         }
         String engine = resolveEngine(request == null ? null : request.getEngine(), config);
         if (isCliEngine(engine)) {
-            SseEmitter emitter = new SseEmitter(300_000L);
-            executor.execute(() -> runCliChat(request, config, engine, emitter));
-            return emitter;
+            return submitChat(300_000L, emitter -> runCliChat(request, config, engine, emitter));
         }
         if (!llmClient.supports(config)) {
             return errorEmitter(unsupportedProviderException());
         }
 
-        SseEmitter emitter = new SseEmitter(60_000L);
-        executor.execute(() -> streamChat(request, config, emitter));
-        return emitter;
+        return submitChat(60_000L, emitter -> streamChat(request, config, emitter));
     }
 
     @Override
@@ -221,7 +225,17 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
 
     private SseEmitter errorEmitter(LlmGatewayException exception) {
         SseEmitter emitter = new SseEmitter(60_000L);
-        executor.execute(() -> sendError(emitter, exception));
+        Thread.ofVirtual().start(() -> sendError(emitter, exception));
+        return emitter;
+    }
+
+    private SseEmitter submitChat(long timeoutMillis, java.util.function.Consumer<SseEmitter> task) {
+        SseEmitter emitter = new SseEmitter(timeoutMillis);
+        try {
+            executor.execute(() -> task.accept(emitter));
+        } catch (RejectedExecutionException exception) {
+            Thread.ofVirtual().start(() -> sendError(emitter, gatewayBusyException()));
+        }
         return emitter;
     }
 
@@ -255,6 +269,12 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
         return new LlmGatewayException(400, "llm.config.incomplete",
                 "LLM provider is not configured or enabled",
                 "Configure and enable an LLM provider in Studio LLM Settings before using AI chat.");
+    }
+
+    private LlmGatewayException gatewayBusyException() {
+        return new LlmGatewayException(503, "llm.gateway.busy",
+                "LLM gateway is busy processing other requests",
+                "Retry shortly or reduce concurrent AI chat requests.");
     }
 
     private LlmGatewayException unsupportedProviderException() {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/CliAgentProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/CliAgentProviderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CliAgentProviderTest {
+
+    @Test
+    void completeShouldDrainStderrWhileProcessIsRunning() {
+        CliAgentProvider provider = new TestCliAgentProvider(
+                List.of("sh", "-c", "yes error | head -c 131072 >&2; printf done"), 5);
+
+        assertThat(provider.complete(LlmConfigVO.builder().build(), "", null)).isEqualTo("done");
+    }
+
+    @Test
+    void completeShouldTimeOutBeforeWaitingForOutputReaders() {
+        CliAgentProvider provider = new TestCliAgentProvider(List.of("sh", "-c", "sleep 2"), 1);
+
+        assertThatThrownBy(() -> provider.complete(LlmConfigVO.builder().build(), "", null))
+                .isInstanceOf(LlmGatewayException.class)
+                .satisfies(exception -> assertThat(((LlmGatewayException) exception).getStatusCode()).isEqualTo(504));
+    }
+
+    private static class TestCliAgentProvider extends CliAgentProvider {
+
+        private final List<String> command;
+        private final long timeoutSeconds;
+
+        private TestCliAgentProvider(List<String> command, long timeoutSeconds) {
+            this.command = command;
+            this.timeoutSeconds = timeoutSeconds;
+        }
+
+        @Override
+        public String engine() {
+            return "test";
+        }
+
+        @Override
+        public boolean available() {
+            return true;
+        }
+
+        @Override
+        protected List<String> buildCommand(LlmConfigVO config, String prompt, String modelOverride) {
+            return command;
+        }
+
+        @Override
+        protected Map<String, String> childEnv(LlmConfigVO config) {
+            return Map.of();
+        }
+
+        @Override
+        protected String binaryName() {
+            return "test";
+        }
+
+        @Override
+        protected long timeoutSeconds() {
+            return timeoutSeconds;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #959.

- Drain CLI stdout and stderr concurrently so either pipe cannot block the child process.
- Apply the execution timeout before waiting on output readers.
- Bound asynchronous SSE chat work to 16 active tasks and 32 queued tasks, returning structured `llm.gateway.busy` errors when saturated.

## Validation

`JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=CliAgentProviderTest,OpenAiCompatibleLlmGatewayTest test`

The new test covers large stderr output and timeout behavior.