### PR TITLE
fix(cluster): avoid mock fallback when discovery is unavailable

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -53,7 +53,7 @@ public class ClusterService {
             discovered.forEach(this::enrichWithLiveConfig);
             return discovered;
         }
-        return clusterRepository.findAll();
+        return List.of();
     }
 
     public ClusterVO getCluster(String id) {
@@ -63,8 +63,7 @@ public class ClusterService {
             enrichWithLiveConfig(live);
             return live;
         }
-        return clusterRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + id));
+        throw new BusinessException(503, "Cluster details are unavailable: " + id);
     }
 
     /**

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -110,19 +110,19 @@ class ClusterServiceTest {
                 .build();
         secondCluster.setId("cluster-2");
 
-        when(clusterRepository.findAll()).thenReturn(Arrays.asList(sampleCluster, secondCluster));
+        when(clusterProvider.discoverClusters()).thenReturn(Arrays.asList(sampleCluster, secondCluster));
 
         List<ClusterVO> result = clusterService.listClusters();
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getName()).isEqualTo("test-cluster");
         assertThat(result.get(1).getName()).isEqualTo("second-cluster");
-        verify(clusterRepository).findAll();
+        verify(clusterRepository, never()).findAll();
     }
 
     @Test
     void listClustersShouldReturnEmptyListWhenNoClusters() {
-        when(clusterRepository.findAll()).thenReturn(Collections.emptyList());
+        when(clusterProvider.discoverClusters()).thenReturn(Collections.emptyList());
 
         List<ClusterVO> result = clusterService.listClusters();
 
@@ -131,7 +131,7 @@ class ClusterServiceTest {
 
     @Test
     void getClusterShouldReturnClusterWhenFound() {
-        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+        when(clusterProvider.refreshClusterDetail("cluster-1")).thenReturn(sampleCluster);
 
         ClusterVO result = clusterService.getCluster("cluster-1");
 
@@ -144,12 +144,12 @@ class ClusterServiceTest {
 
     @Test
     void getClusterShouldThrowWhenNotFound() {
-        when(clusterRepository.findById("nonexistent")).thenReturn(Optional.empty());
+        when(clusterProvider.refreshClusterDetail("nonexistent")).thenReturn(null);
 
         assertThatThrownBy(() -> clusterService.getCluster("nonexistent"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("Cluster not found: nonexistent")
-                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
+                .hasMessageContaining("Cluster details are unavailable: nonexistent")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(503));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #870.

The server no longer falls back to `ClusterRepositoryImpl` sample clusters when live discovery is empty. It returns an empty list for discovery and a controlled 503 for unavailable cluster details. This also prevents MCP `rmq.cluster.list` from returning fabricated clusters.

## Validation

`JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=ClusterServiceTest,ToolGatewayServiceTest test`