### PR TITLE
[Studio] Surface consumer group Admin failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
@@ -16,11 +16,13 @@
  */
 package org.apache.rocketmq.studio.rocketmq;
 
+import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.client.producer.SendResult;
 import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -122,8 +124,14 @@ public class RocketMQAdminClientImpl implements AdminClient {
                     vo.setSubscribedTopics(new ArrayList<>(conn.getSubscriptionTable().keySet()));
                 }
             }
-        } catch (Exception ignored) {
-            // Group may be offline
+        } catch (MQClientException exception) {
+            if (exception.getResponseCode() == ResponseCode.CONSUMER_NOT_ONLINE) {
+                log.debug("Consumer group {} is offline", name);
+                return vo;
+            }
+            throw new BusinessException(502, "Failed to get consumer group: " + exception.getMessage());
+        } catch (Exception exception) {
+            throw new BusinessException(502, "Failed to get consumer group: " + exception.getMessage());
         }
         return vo;
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImplTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.rocketmq;
+
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
+import org.apache.rocketmq.studio.ops.audit.AuditService;
+import org.apache.rocketmq.studio.persistence.mapper.RmqGroupMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqTopicMapper;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RocketMQAdminClientImplTest {
+
+    @Mock
+    private DefaultMQAdminExt adminExt;
+
+    @Mock
+    private RocketMQProperties properties;
+
+    @Mock
+    private RmqTopicMapper topicMapper;
+
+    @Mock
+    private RmqGroupMapper groupMapper;
+
+    @Mock
+    private AuditService auditService;
+
+    private RocketMQAdminClientImpl adminClient;
+
+    @BeforeEach
+    void setUp() {
+        adminClient = new RocketMQAdminClientImpl(
+                adminExt, properties, topicMapper, groupMapper, auditService);
+    }
+
+    @Test
+    void getConsumerGroupReturnsOfflineDetailForConsumerNotOnline() throws Exception {
+        when(adminExt.examineConsumerConnectionInfo("orders"))
+                .thenThrow(new MQClientException(
+                        ResponseCode.CONSUMER_NOT_ONLINE, "Not found the consumer group connection"));
+
+        ConsumerGroupVO group = adminClient.getConsumerGroup("orders");
+
+        assertThat(group.getId()).isEqualTo("orders");
+        assertThat(group.getName()).isEqualTo("orders");
+        assertThat(group.getOnlineInstances()).isZero();
+    }
+
+    @Test
+    void getConsumerGroupSurfacesAdminTimeout() throws Exception {
+        when(adminExt.examineConsumerConnectionInfo("orders"))
+                .thenThrow(new RemotingTimeoutException("broker-0", 3_000));
+
+        assertThatThrownBy(() -> adminClient.getConsumerGroup("orders"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException businessException = (BusinessException) exception;
+                    assertThat(businessException.getCode()).isEqualTo(502);
+                    assertThat(businessException.getMessage()).contains("Failed to get consumer group");
+                });
+    }
+
+    @Test
+    void getConsumerGroupSurfacesBrokerFailures() throws Exception {
+        when(adminExt.examineConsumerConnectionInfo("orders"))
+                .thenThrow(new MQBrokerException(16, "ACL denied"));
+
+        assertThatThrownBy(() -> adminClient.getConsumerGroup("orders"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException businessException = (BusinessException) exception;
+                    assertThat(businessException.getCode()).isEqualTo(502);
+                    assertThat(businessException.getMessage()).contains("ACL denied");
+                });
+    }
+}


### PR DESCRIPTION
Closes #965

## Summary

- preserve the successful offline fallback only for `MQClientException` with `CONSUMER_NOT_ONLINE`
- convert timeout, broker, ACL, and other Admin call failures into explicit HTTP 502 business responses
- add regression coverage for offline, timeout, and broker/ACL failure paths

## Related

This is intentionally separate from #786 / #787, which cover unconfigured default providers rather than the real `RocketMQAdminClientImpl` Admin path.

## Verification

`JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=RocketMQAdminClientImplTest test`