### PR TITLE
[Studio][Test] Avoid hard-coded Vitest worker counts

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,9 +20,6 @@ export default defineConfig(({ mode }) => {
       environment: 'jsdom',
       setupFiles: './src/test/setup.ts',
       css: true,
-      // 32-core box: run test files with full parallelism.
-      maxWorkers: 32,
-      minWorkers: 4,
       // antd interactions driven through userEvent are slow in jsdom, and the default
       // 5s budget is exceeded once the whole suite runs in parallel.
       testTimeout: 20000,


### PR DESCRIPTION
Closes #969

## Summary
- remove the machine-specific Vitest worker-count overrides
- retain the extended jsdom interaction timeouts

## Verification
- `cd web && npm test -- --run` (74 files, 341 tests)
- `cd web && npm run lint` (0 errors; 4 pre-existing Fast Refresh warnings)
- `cd web && npm run build`