### PR TITLE
chore(web): stabilize development and test runtime

### DIFF
--- a/web/src/StudioApp.tsx
+++ b/web/src/StudioApp.tsx
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { App as AntdApp, ConfigProvider, theme } from 'antd';
+import enUS from 'antd/locale/en_US';
+import zhCN from 'antd/locale/zh_CN';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import { useLang } from './i18n/LangContext';
+import { useTheme } from './theme/useTheme';
+
+const StudioApp = () => {
+  const { lang } = useLang();
+  const { darkMode } = useTheme();
+
+  return (
+    <ConfigProvider
+      locale={lang === 'zh' ? zhCN : enUS}
+      theme={{
+        algorithm: darkMode ? theme.darkAlgorithm : theme.defaultAlgorithm,
+        token: {
+          colorPrimary: '#1677ff',
+          borderRadius: 8,
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif',
+          ...(darkMode
+            ? {
+                colorBgBase: '#2a2a2e',
+                colorBgContainer: '#323236',
+                colorBgElevated: '#3a3a3e',
+                colorBorder: '#3a3a3e',
+                colorBorderSecondary: '#333337',
+              }
+            : {}),
+        },
+        components: {
+          Card: { borderRadiusLG: 12 },
+          Table: { borderRadius: 8 },
+          Button: { borderRadius: 8 },
+          Tag: { borderRadiusSM: 6 },
+        },
+      }}
+    >
+      <AntdApp>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AntdApp>
+    </ConfigProvider>
+  );
+};
+
+export default StudioApp;

--- a/web/src/layouts/MainLayout.test.tsx
+++ b/web/src/layouts/MainLayout.test.tsx
@@ -21,7 +21,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { logout } from '../api/auth';
 import { LangProvider } from '../i18n/LangContext';
 import useAuthStore from '../stores/authStore';
-import { ThemeProvider } from '../theme/ThemeContext';
+import { ThemeProvider } from '../theme/ThemeProvider';
 import MainLayout from './MainLayout';
 
 vi.mock('../api/auth', () => ({ logout: vi.fn() }));
@@ -46,16 +46,15 @@ vi.mock('antd', async () => {
         'div',
         null,
         children,
-        menu.items
-          .map((item) =>
-            item.key
-              ? React.createElement(
-                  'button',
-                  { key: item.key, onClick: () => menu.onClick({ key: item.key! }) },
-                  item.label,
-                )
-              : null,
-          ),
+        menu.items.map((item) =>
+          item.key
+            ? React.createElement(
+                'button',
+                { key: item.key, onClick: () => menu.onClick({ key: item.key! }) },
+                item.label,
+              )
+            : null,
+        ),
       ),
     Empty: () => null,
     Input: () => null,

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -41,7 +41,7 @@ import {
   Warning,
 } from '@phosphor-icons/react';
 import { useLang } from '../i18n/LangContext';
-import { useTheme } from '../theme/ThemeContext';
+import { useTheme } from '../theme/useTheme';
 import { logout as requestLogout } from '../api/auth';
 import useAuthStore from '../stores/authStore';
 import {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -17,61 +17,16 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
-import { App as AntdApp, ConfigProvider, theme } from 'antd';
-import zhCN from 'antd/locale/zh_CN';
-import enUS from 'antd/locale/en_US';
-import { LangProvider, useLang } from './i18n/LangContext';
-import { ThemeProvider, useTheme } from './theme/ThemeContext';
-import App from './App';
+import { LangProvider } from './i18n/LangContext';
+import { ThemeProvider } from './theme/ThemeProvider';
+import StudioApp from './StudioApp';
 import './index.css';
-
-const ThemedApp = () => {
-  const { lang } = useLang();
-  const { darkMode } = useTheme();
-
-  return (
-    <ConfigProvider
-      locale={lang === 'zh' ? zhCN : enUS}
-      theme={{
-        algorithm: darkMode ? theme.darkAlgorithm : theme.defaultAlgorithm,
-        token: {
-          colorPrimary: '#1677ff',
-          borderRadius: 8,
-          fontFamily:
-            '-apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif',
-          ...(darkMode
-            ? {
-                colorBgBase: '#2a2a2e',
-                colorBgContainer: '#323236',
-                colorBgElevated: '#3a3a3e',
-                colorBorder: '#3a3a3e',
-                colorBorderSecondary: '#333337',
-              }
-            : {}),
-        },
-        components: {
-          Card: { borderRadiusLG: 12 },
-          Table: { borderRadius: 8 },
-          Button: { borderRadius: 8 },
-          Tag: { borderRadiusSM: 6 },
-        },
-      }}
-    >
-      <AntdApp>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </AntdApp>
-    </ConfigProvider>
-  );
-};
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <LangProvider>
       <ThemeProvider>
-        <ThemedApp />
+        <StudioApp />
       </ThemeProvider>
     </LangProvider>
   </React.StrictMode>,

--- a/web/src/theme/ThemeProvider.tsx
+++ b/web/src/theme/ThemeProvider.tsx
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState, type ReactNode } from 'react';
+import ThemeContext from './ThemeContext';
+import {
+  getStoredThemePreference,
+  getSystemDarkMode,
+  persistThemePreference,
+} from './themePreference';
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [themeState, setThemeState] = useState(() => {
+    const preference = getStoredThemePreference();
+    return {
+      darkMode: preference ? preference === 'dark' : getSystemDarkMode(),
+      followsSystem: preference === null,
+    };
+  });
+
+  const setDarkMode = (darkMode: boolean) => {
+    persistThemePreference(darkMode);
+    setThemeState({ darkMode, followsSystem: false });
+  };
+
+  const toggleTheme = () => setDarkMode(!themeState.darkMode);
+
+  useEffect(() => {
+    if (!themeState.followsSystem || !window.matchMedia) return;
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const updateTheme = (event: MediaQueryListEvent) => {
+      setThemeState((current) =>
+        current.followsSystem ? { ...current, darkMode: event.matches } : current,
+      );
+    };
+    mediaQuery.addEventListener('change', updateTheme);
+    return () => mediaQuery.removeEventListener('change', updateTheme);
+  }, [themeState.followsSystem]);
+
+  return (
+    <ThemeContext.Provider value={{ darkMode: themeState.darkMode, setDarkMode, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/web/src/theme/__tests__/ThemeContext.test.tsx
+++ b/web/src/theme/__tests__/ThemeContext.test.tsx
@@ -18,7 +18,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { ThemeProvider, useTheme } from '../ThemeContext';
+import { ThemeProvider } from '../ThemeProvider';
+import { useTheme } from '../useTheme';
 
 /** Helper component that displays theme state and provides toggle button. */
 const ThemeConsumer = () => {

--- a/web/src/theme/useTheme.ts
+++ b/web/src/theme/useTheme.ts
@@ -15,18 +15,7 @@
  * limitations under the License.
  */
 
-import { createContext } from 'react';
+import { useContext } from 'react';
+import ThemeContext from './ThemeContext';
 
-export interface ThemeContextType {
-  darkMode: boolean;
-  setDarkMode: (dark: boolean) => void;
-  toggleTheme: () => void;
-}
-
-const ThemeContext = createContext<ThemeContextType>({
-  darkMode: false,
-  setDarkMode: () => {},
-  toggleTheme: () => {},
-});
-
-export default ThemeContext;
+export const useTheme = () => useContext(ThemeContext);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,9 +20,6 @@ export default defineConfig(({ mode }) => {
       environment: 'jsdom',
       setupFiles: './src/test/setup.ts',
       css: true,
-      // 32-core box: run test files with full parallelism.
-      maxWorkers: 32,
-      minWorkers: 4,
       // antd interactions driven through userEvent are slow in jsdom, and the default
       // 5s budget is exceeded once the whole suite runs in parallel.
       testTimeout: 20000,


### PR DESCRIPTION
## Summary

Consolidates #970 into the Web runtime stability work.

- Move the root Studio component out of the Vite entry module and separate theme context, provider, and hook exports for Fast Refresh safety.
- Export ThemeContextType so the composite TypeScript build can name the useTheme return type.
- Remove machine-specific Vitest worker-count overrides while retaining interaction timeouts.

## Verification

- npm test -- --run (341 passed)
- npm test -- --run src/theme/__tests__/ThemeContext.test.tsx src/layouts/MainLayout.test.tsx (9 passed)
- npm run lint (0 errors; 2 existing LangContext Fast Refresh warnings)
- npm run build
- git diff --check origin/rocketmq-studio...HEAD

Closes #971
Closes #969