### PR TITLE
fix: preserve CLI LLM configuration after restart

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
@@ -203,19 +203,20 @@ public class LlmConfigService {
 
     private LlmConfigVO fromGeneralSettings(GeneralSettingsVO settings) {
         String provider = normalizeProvider(settings.getLlmProvider());
+        String engine = normalizeEngine(settings.getLlmEngine());
         // Token injected via RMQ_LLM_TOKEN takes precedence over the key saved in settings.
         String apiKey = defaultString(envToken(), defaultString(settings.getApiKey(), ""));
         String apiBase = normalizeApiBase(defaultString(settings.getBaseUrl(), defaultApiBase(provider)));
         String model = defaultString(settings.getModel(), defaultModel(provider));
         return LlmConfigVO.builder()
                 .provider(provider)
-                .engine(normalizeEngine(settings.getLlmEngine()))
+                .engine(engine)
                 .apiKey(apiKey)
                 .apiBase(apiBase)
                 .model(model)
                 .maxTokens(DEFAULT_MAX_TOKENS)
                 .temperature(DEFAULT_TEMPERATURE)
-                .enabled(!requiresApiKey(provider) || !isBlank(apiKey))
+                .enabled(!requiresApiKey(provider, engine) || !isBlank(apiKey))
                 .apiVersion("2024-02-15-preview")
                 .awsRegion("us-east-1")
                 .build();
@@ -249,7 +250,7 @@ public class LlmConfigService {
 
     private LlmConfigVO normalizeWithStoredApiKey(LlmConfigVO config) {
         LlmConfigVO normalized = normalize(config);
-        if (!requiresApiKey(normalized.getProvider())) {
+        if (!requiresApiKey(normalized.getProvider(), normalized.getEngine())) {
             normalized.setApiKey("");
             return normalized;
         }
@@ -271,8 +272,8 @@ public class LlmConfigService {
                 exception.getMessage(), exception.getCode(), exception.getHint());
     }
 
-    private boolean requiresApiKey(String provider) {
-        return !"ollama".equals(provider);
+    private boolean requiresApiKey(String provider, String engine) {
+        return LlmConfigVO.ENGINE_HTTP.equalsIgnoreCase(engine) && !"ollama".equals(provider);
     }
 
     private String normalizeProvider(String provider) {
@@ -281,7 +282,7 @@ public class LlmConfigService {
     }
 
     private String normalizeEngine(String engine) {
-        String normalized = defaultString(engine, LlmConfigVO.ENGINE_CLAUDE_CODE).toLowerCase(Locale.ROOT);
+        String normalized = defaultString(engine, LlmConfigVO.ENGINE_HTTP).toLowerCase(Locale.ROOT);
         return switch (normalized) {
             case LlmConfigVO.ENGINE_HTTP, LlmConfigVO.ENGINE_CLAUDE_CODE, LlmConfigVO.ENGINE_QODER -> normalized;
             default -> LlmConfigVO.ENGINE_HTTP;

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
@@ -153,6 +153,51 @@ class LlmConfigServiceTest {
     }
 
     @Test
+    void getConfigShouldKeepSavedCliEngineEnabledWithoutApiKeyAfterRestart() {
+        when(settingsService.getGeneralSettings()).thenReturn(GeneralSettingsVO.builder()
+                .theme("dark")
+                .compact(true)
+                .desktopNotify(true)
+                .notifySound(false)
+                .sessionTimeout(45)
+                .requireLogin(true)
+                .llmProvider("openai")
+                .llmEngine(LlmConfigVO.ENGINE_CLAUDE_CODE)
+                .apiKey("")
+                .model("gpt-4o")
+                .baseUrl("https://api.openai.com/v1")
+                .build());
+
+        LlmConfigVO config = llmConfigService.getConfig();
+
+        assertThat(config.getEngine()).isEqualTo(LlmConfigVO.ENGINE_CLAUDE_CODE);
+        assertThat(config.isEnabled()).isTrue();
+        assertThat(config.isReady()).isTrue();
+    }
+
+    @Test
+    void getConfigShouldKeepSavedHttpEngineDisabledWithoutApiKeyAfterRestart() {
+        when(settingsService.getGeneralSettings()).thenReturn(GeneralSettingsVO.builder()
+                .theme("dark")
+                .compact(true)
+                .desktopNotify(true)
+                .notifySound(false)
+                .sessionTimeout(45)
+                .requireLogin(true)
+                .llmProvider("openai")
+                .llmEngine(LlmConfigVO.ENGINE_HTTP)
+                .apiKey("")
+                .model("gpt-4o")
+                .baseUrl("https://api.openai.com/v1")
+                .build());
+
+        LlmConfigVO config = llmConfigService.getConfig();
+
+        assertThat(config.isEnabled()).isFalse();
+        assertThat(config.isReady()).isFalse();
+    }
+
+    @Test
     void saveConfigShouldPreserveGeneralSettingsAndStoreLlmFields() {
         LlmConfigVO config = LlmConfigVO.builder()
                 .provider("deepseek")


### PR DESCRIPTION
Closes #975

Persisted LLM configuration now decides whether an API key is required from both the provider and selected engine. Explicit CLI engines remain enabled after restart without an HTTP key, while HTTP engines still require one.

Tests:
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=LlmConfigServiceTest test`