### PR TITLE
[ISSUE #989] fix: generate unique names for short-lived RocketMQ clients

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProvider.java
@@ -267,7 +267,7 @@ public class RocketMQDLQProvider implements DLQProvider {
 
     private DefaultMQPullConsumer newPullConsumer() {
         DefaultMQPullConsumer consumer = new DefaultMQPullConsumer("studio-dlq-query-group");
-        consumer.setInstanceName("studio-dlq-query-" + System.currentTimeMillis());
+        consumer.setInstanceName(ShortLivedClientName.next("studio-dlq-query"));
         if (StringUtils.hasText(properties.getNamesrvAddr())) {
             consumer.setNamesrvAddr(properties.getNamesrvAddr());
         }
@@ -276,7 +276,7 @@ public class RocketMQDLQProvider implements DLQProvider {
 
     private DefaultMQProducer newProducer(String groupName) {
         DefaultMQProducer producer = new DefaultMQProducer("studio-dlq-resend-" + groupName);
-        producer.setInstanceName("studio-dlq-resend-" + System.currentTimeMillis());
+        producer.setInstanceName(ShortLivedClientName.next("studio-dlq-resend"));
         producer.setRetryTimesWhenSendFailed(2);
         if (StringUtils.hasText(properties.getNamesrvAddr())) {
             producer.setNamesrvAddr(properties.getNamesrvAddr());

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProvider.java
@@ -407,7 +407,7 @@ public class RocketMQMessageProvider implements MessageProvider {
 
     private DefaultMQPullConsumer newPullConsumer(String groupPrefix) {
         DefaultMQPullConsumer consumer = new DefaultMQPullConsumer(groupPrefix + "-group");
-        consumer.setInstanceName(groupPrefix + "-" + System.currentTimeMillis());
+        consumer.setInstanceName(ShortLivedClientName.next(groupPrefix));
         if (StringUtils.hasText(properties.getNamesrvAddr())) {
             consumer.setNamesrvAddr(properties.getNamesrvAddr());
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/ShortLivedClientName.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/ShortLivedClientName.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.rocketmq;
+
+import java.util.UUID;
+
+final class ShortLivedClientName {
+
+    private ShortLivedClientName() {
+    }
+
+    static String next(String prefix) {
+        return prefix + "-" + UUID.randomUUID();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/ShortLivedClientNameTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/ShortLivedClientNameTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.rocketmq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class ShortLivedClientNameTest {
+
+    @Test
+    void generatesUniqueNamesWithoutClockDelays() {
+        Set<String> names = IntStream.range(0, 100)
+                .mapToObj(ignored -> ShortLivedClientName.next("studio-query"))
+                .collect(Collectors.toSet());
+
+        assertThat(names).hasSize(100).allMatch(name -> name.startsWith("studio-query-"));
+    }
+}


### PR DESCRIPTION
Closes #989\n\nGenerate UUID-backed instance names for message-query and DLQ client paths, with a unit test proving uniqueness without clock delays.\n\nTests: mvn -q -Dtest=ShortLivedClientNameTest,RocketMQMessageProviderTest,RocketMQDLQProviderTest test