### PR TITLE
[ISSUE #988] docs: make Docker Compose quick start complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@ RocketMQ Studio is a unified management platform for RocketMQ, supporting multi-
 ## Quick Start
 
 ```bash
-cd deploy && docker compose up -d --build
+cd deploy/rocketmq && docker compose up -d
+cd .. && docker compose up -d --build
 ```
 
 Visit **http://127.0.0.1:6789** after startup.
+
+The first command starts the bundled RocketMQ topology and creates the
+`rocketmq_default` Docker network used by the Studio services. Check that it
+is healthy before starting Studio with `docker compose ps` from `deploy/rocketmq`.
 
 **Studio ports:** Frontend 6789 (Nginx), Backend 8888 (Spring Boot)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -9,8 +9,13 @@ RocketMQ Studio 是一个面向多集群、多架构、多云环境的 RocketMQ 
 ## 一键构建 & 运行
 
 ```bash
-cd deploy && docker compose up -d --build
+cd deploy/rocketmq && docker compose up -d
+cd .. && docker compose up -d --build
 ```
+
+第一条命令会启动内置 RocketMQ 拓扑，并创建 Studio 服务所需的
+`rocketmq_default` Docker 网络。启动 Studio 前，可在 `deploy/rocketmq` 目录执行
+`docker compose ps` 确认 RocketMQ 已就绪。
 
 启动后访问 **http://127.0.0.1:6789** 即可使用。
 


### PR DESCRIPTION
Closes #988\n\nDocument the required bundled RocketMQ Compose startup before Studio so the external rocketmq_default network exists in a clean environment.\n\nValidation: docker compose -f deploy/rocketmq/docker-compose.yml config and docker compose -f deploy/docker-compose.yml config.