### PR TITLE
[ISSUE #984] fix: reject divergent broker default queue counts

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -92,6 +92,7 @@ public class ClusterService {
 
     public ClusterVO updateClusterConfig(UpdateConfigDTO command) {
         log.info("Updating cluster config for: {}", command.getId());
+        requireMatchingDefaultQueueNums(command);
         ClusterVO cluster = clusterRepository.findById(command.getId())
                 .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + command.getId()));
 
@@ -183,6 +184,14 @@ public class ClusterService {
             props.setProperty("brokerPermission", command.getBrokerPermission().toString());
         }
         return props;
+    }
+
+    private void requireMatchingDefaultQueueNums(UpdateConfigDTO command) {
+        if (command.getWriteQueueNums() != null && command.getReadQueueNums() != null
+                && !command.getWriteQueueNums().equals(command.getReadQueueNums())) {
+            throw new BusinessException(400,
+                    "RocketMQ broker default queue count requires matching writeQueueNums and readQueueNums");
+        }
     }
 
     private FlushDiskType parseFlushDiskType(String value) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -123,6 +123,21 @@ class ClusterServiceTest {
     }
 
     @Test
+    void updateClusterConfigShouldRejectDifferentDefaultReadAndWriteQueueNums() {
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .writeQueueNums(8)
+                .readQueueNums(16)
+                .build();
+
+        assertThatThrownBy(() -> clusterService.updateClusterConfig(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("requires matching writeQueueNums and readQueueNums");
+
+        verifyNoInteractions(clusterRepository, clusterProvider);
+    }
+
+    @Test
     void listClustersShouldReturnEmptyListWhenNoClusters() {
         when(clusterRepository.findAll()).thenReturn(Collections.emptyList());
 

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -570,6 +570,9 @@ const ClusterPage = () => {
               <Form.Item label={t('cluster.readQueues')} name="readQueueNums">
                 <InputNumber min={1} max={256} style={{ width: '100%' }} />
               </Form.Item>
+              <Text type="secondary" style={{ display: 'block', marginTop: -16, marginBottom: 16 }}>
+                RocketMQ Broker uses one default Topic queue count; read and write values must match.
+              </Text>
               <Form.Item label={t('cluster.brokerPermission')} name="brokerPermission">
                 <InputNumber min={0} max={7} style={{ width: '100%' }} />
               </Form.Item>


### PR DESCRIPTION
Closes #984\n\nRocketMQ Broker exposes one default Topic queue count. Reject differing read/write values rather than silently allowing the read value to overwrite the write value; add UI guidance and a service regression test.\n\nTests: mvn -q -Dtest=ClusterServiceTest test.