### PR TITLE
[ISSUE #1002] fix(auth): honor persisted session timeout

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/StudioApplication.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/StudioApplication.java
@@ -19,8 +19,10 @@ package org.apache.rocketmq.studio;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class StudioApplication {
     public static void main(String[] args) {
         SpringApplication.run(StudioApplication.class, args);

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
@@ -18,11 +18,15 @@
 package org.apache.rocketmq.studio.auth;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
+import org.apache.rocketmq.studio.settings.SettingsRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,20 +36,24 @@ import java.util.UUID;
 @Service
 public class AuthService {
 
-    private static final int TOKEN_TTL_SECONDS = 86400;
+    private static final int DEFAULT_SESSION_TIMEOUT_MINUTES = 30;
+    private static final int MIN_SESSION_TIMEOUT_MINUTES = 5;
+    private static final int MAX_SESSION_TIMEOUT_MINUTES = 1440;
     private static final String TOKEN_PREFIX = "Bearer ";
 
     private final AuthProperties authProperties;
+    private final SettingsRepository settingsRepository;
     private final Clock clock;
     private final Map<String, AuthSession> activeTokens = new ConcurrentHashMap<>();
 
     @Autowired
-    public AuthService(AuthProperties authProperties) {
-        this(authProperties, Clock.systemUTC());
+    public AuthService(AuthProperties authProperties, SettingsRepository settingsRepository) {
+        this(authProperties, settingsRepository, Clock.systemUTC());
     }
 
-    AuthService(AuthProperties authProperties, Clock clock) {
+    AuthService(AuthProperties authProperties, SettingsRepository settingsRepository, Clock clock) {
         this.authProperties = authProperties;
+        this.settingsRepository = settingsRepository;
         this.clock = clock;
     }
 
@@ -65,13 +73,14 @@ public class AuthService {
 
         LoginVO.UserInfo user = authenticate(request);
         long now = clock.millis();
-        activeTokens.entrySet().removeIf(entry -> entry.getValue().expiresAtMillis() <= now);
+        purgeExpiredSessions(now);
+        int tokenTtlSeconds = sessionTimeoutSeconds();
         String token = "studio-jwt-" + UUID.randomUUID();
-        activeTokens.put(token, new AuthSession(user, now + TOKEN_TTL_SECONDS * 1000L));
+        activeTokens.put(token, new AuthSession(user, now + tokenTtlSeconds * 1000L));
 
         LoginVO response = LoginVO.builder()
                 .token(token)
-                .expiresIn(TOKEN_TTL_SECONDS)
+                .expiresIn(tokenTtlSeconds)
                 .user(user)
                 .build();
 
@@ -98,6 +107,25 @@ public class AuthService {
     public void logout(String authorization) {
         tokenFromAuthorization(authorization).ifPresent(activeTokens::remove);
         log.info("User logged out");
+    }
+
+    @Scheduled(fixedDelayString = "${studio.auth.session-cleanup-interval:PT5M}")
+    public void purgeExpiredSessions() {
+        purgeExpiredSessions(clock.millis());
+    }
+
+    private void purgeExpiredSessions(long now) {
+        activeTokens.entrySet().removeIf(entry -> entry.getValue().expiresAtMillis() <= now);
+    }
+
+    private int sessionTimeoutSeconds() {
+        GeneralSettingsVO settings = settingsRepository.loadGeneralSettings();
+        int minutes = settings == null ? DEFAULT_SESSION_TIMEOUT_MINUTES : settings.getSessionTimeout();
+        if (minutes < MIN_SESSION_TIMEOUT_MINUTES || minutes > MAX_SESSION_TIMEOUT_MINUTES) {
+            log.warn("Ignoring invalid persisted session timeout: {} minutes", minutes);
+            minutes = DEFAULT_SESSION_TIMEOUT_MINUTES;
+        }
+        return Math.toIntExact(Duration.ofMinutes(minutes).toSeconds());
     }
 
     private LoginVO.UserInfo authenticate(LoginDTO request) {

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.rocketmq.studio.auth;
 
+import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
+import org.apache.rocketmq.studio.settings.SettingsRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -25,13 +27,15 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class AuthInterceptorTest {
 
     @Test
     void shouldAllowRequestsWhenLoginIsDisabled() throws Exception {
         AuthProperties properties = new AuthProperties();
-        AuthInterceptor interceptor = new AuthInterceptor(properties, new AuthService(properties));
+        AuthInterceptor interceptor = new AuthInterceptor(properties, authService(properties));
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/clusters");
 
         boolean allowed = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
@@ -43,7 +47,7 @@ class AuthInterceptorTest {
     void shouldRejectProtectedApiWithoutTokenWhenLoginIsEnabled() throws Exception {
         AuthProperties properties = new AuthProperties();
         properties.setLoginRequired(true);
-        AuthInterceptor interceptor = new AuthInterceptor(properties, new AuthService(properties));
+        AuthInterceptor interceptor = new AuthInterceptor(properties, authService(properties));
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/clusters");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
@@ -63,7 +67,7 @@ class AuthInterceptorTest {
         user.setPassword("secret");
         user.setAdmin(true);
         properties.setUsers(List.of(user));
-        AuthService authService = new AuthService(properties);
+        AuthService authService = authService(properties);
         AuthInterceptor interceptor = new AuthInterceptor(properties, authService);
         LoginDTO login = new LoginDTO();
         login.setUsername("admin");
@@ -81,7 +85,7 @@ class AuthInterceptorTest {
     void shouldAllowLoginEndpointWhenLoginIsEnabled() throws Exception {
         AuthProperties properties = new AuthProperties();
         properties.setLoginRequired(true);
-        AuthInterceptor interceptor = new AuthInterceptor(properties, new AuthService(properties));
+        AuthInterceptor interceptor = new AuthInterceptor(properties, authService(properties));
         MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/auth/login");
 
         boolean allowed = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
@@ -93,7 +97,7 @@ class AuthInterceptorTest {
     void shouldAllowLoginEndpointWithTrailingSlashWhenLoginIsEnabled() throws Exception {
         AuthProperties properties = new AuthProperties();
         properties.setLoginRequired(true);
-        AuthInterceptor interceptor = new AuthInterceptor(properties, new AuthService(properties));
+        AuthInterceptor interceptor = new AuthInterceptor(properties, authService(properties));
         MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/auth/login/");
 
         boolean allowed = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
@@ -105,7 +109,7 @@ class AuthInterceptorTest {
     void shouldAllowAuthStatusEndpointWhenLoginIsEnabled() throws Exception {
         AuthProperties properties = new AuthProperties();
         properties.setLoginRequired(true);
-        AuthInterceptor interceptor = new AuthInterceptor(properties, new AuthService(properties));
+        AuthInterceptor interceptor = new AuthInterceptor(properties, authService(properties));
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/auth/status");
 
         boolean allowed = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
@@ -117,11 +121,19 @@ class AuthInterceptorTest {
     void shouldAllowAuthStatusEndpointWithTrailingSlashWhenLoginIsEnabled() throws Exception {
         AuthProperties properties = new AuthProperties();
         properties.setLoginRequired(true);
-        AuthInterceptor interceptor = new AuthInterceptor(properties, new AuthService(properties));
+        AuthInterceptor interceptor = new AuthInterceptor(properties, authService(properties));
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/auth/status/");
 
         boolean allowed = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
 
         assertThat(allowed).isTrue();
+    }
+
+    private AuthService authService(AuthProperties properties) {
+        SettingsRepository settingsRepository = mock(SettingsRepository.class);
+        when(settingsRepository.loadGeneralSettings()).thenReturn(GeneralSettingsVO.builder()
+                .sessionTimeout(30)
+                .build());
+        return new AuthService(properties, settingsRepository);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceTest.java
@@ -18,6 +18,8 @@
 package org.apache.rocketmq.studio.auth;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
+import org.apache.rocketmq.studio.settings.SettingsRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +35,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,11 +43,14 @@ class AuthServiceTest {
 
     private AuthService authService;
     private AuthProperties authProperties;
+    private SettingsRepository settingsRepository;
 
     @BeforeEach
     void setUp() {
         authProperties = new AuthProperties();
-        authService = new AuthService(authProperties, Clock.fixed(Instant.EPOCH, ZoneOffset.UTC));
+        settingsRepository = mock(SettingsRepository.class);
+        lenient().when(settingsRepository.loadGeneralSettings()).thenReturn(sessionSettings(30));
+        authService = new AuthService(authProperties, settingsRepository, Clock.fixed(Instant.EPOCH, ZoneOffset.UTC));
     }
 
     @Test
@@ -61,7 +67,7 @@ class AuthServiceTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getToken()).startsWith("studio-jwt-");
-        assertThat(response.getExpiresIn()).isEqualTo(86400);
+        assertThat(response.getExpiresIn()).isEqualTo(1800);
         assertThat(response.getUser()).isNotNull();
         assertThat(response.getUser().getUsername()).isEqualTo("testuser");
         assertThat(response.getUser().isAdmin()).isFalse();
@@ -168,10 +174,10 @@ class AuthServiceTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void loginShouldRemoveExpiredSessions() {
+    void scheduledCleanupShouldRemoveExpiredSessions() {
         Clock clock = mock(Clock.class);
         when(clock.millis()).thenReturn(0L);
-        authService = new AuthService(authProperties, clock);
+        authService = new AuthService(authProperties, settingsRepository, clock);
         AuthProperties.User user = new AuthProperties.User();
         user.setUsername("testuser");
         user.setPassword("testpass");
@@ -182,10 +188,42 @@ class AuthServiceTest {
         LoginVO expiredSession = authService.login(request);
         when(clock.millis()).thenReturn(expiredSession.getExpiresIn() * 1000L);
 
-        LoginVO activeSession = authService.login(request);
+        authService.purgeExpiredSessions();
 
         Map<String, ?> activeTokens = (Map<String, ?>) ReflectionTestUtils.getField(authService, "activeTokens");
-        assertThat(activeTokens).containsOnlyKeys(activeSession.getToken());
+        assertThat(activeTokens).isEmpty();
+    }
+
+    @Test
+    void loginShouldUsePersistedSessionTimeout() {
+        AuthProperties.User user = new AuthProperties.User();
+        user.setUsername("testuser");
+        user.setPassword("testpass");
+        authProperties.setUsers(List.of(user));
+        when(settingsRepository.loadGeneralSettings()).thenReturn(sessionSettings(45));
+        LoginDTO request = new LoginDTO();
+        request.setUsername("testuser");
+        request.setPassword("testpass");
+
+        LoginVO response = authService.login(request);
+
+        assertThat(response.getExpiresIn()).isEqualTo(2700);
+    }
+
+    @Test
+    void loginShouldFallBackToDefaultForInvalidPersistedSessionTimeout() {
+        AuthProperties.User user = new AuthProperties.User();
+        user.setUsername("testuser");
+        user.setPassword("testpass");
+        authProperties.setUsers(List.of(user));
+        when(settingsRepository.loadGeneralSettings()).thenReturn(sessionSettings(0));
+        LoginDTO request = new LoginDTO();
+        request.setUsername("testuser");
+        request.setPassword("testpass");
+
+        LoginVO response = authService.login(request);
+
+        assertThat(response.getExpiresIn()).isEqualTo(1800);
     }
 
     @Test
@@ -243,5 +281,9 @@ class AuthServiceTest {
     @Test
     void logoutShouldCompleteWithoutError() {
         authService.logout(null);
+    }
+
+    private GeneralSettingsVO sessionSettings(int minutes) {
+        return GeneralSettingsVO.builder().sessionTimeout(minutes).build();
     }
 }

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -191,13 +191,20 @@ const GeneralSettingsTab = () => {
         </Title>
       </Divider>
 
-      <Form.Item label="会话超时" name="sessionTimeout">
+      <Form.Item
+        label="会话超时"
+        name="sessionTimeout"
+        extra="应用于新创建的会话，已登录用户保持原到期时间"
+      >
         <InputNumber min={5} max={1440} addonAfter="分钟" />
       </Form.Item>
 
-      <Form.Item label="需要登录" name="requireLogin" valuePropName="checked">
-        <Switch />
+      <Form.Item name="requireLogin" hidden>
+        <Input />
       </Form.Item>
+      <Text type="secondary">
+        登录保护由服务端 STUDIO_AUTH_LOGIN_REQUIRED 配置决定，修改后重启服务生效。
+      </Text>
 
       {/* ── AI 配置 ── */}
       <Divider orientation="left">


### PR DESCRIPTION
## Summary

- derive newly issued token TTLs from the persisted session timeout, with a validated 30-minute fallback
- periodically reclaim expired in-memory sessions instead of waiting for another login
- keep `studio.auth.login-required` deployment-controlled and replace the non-functional UI switch with an explicit configuration notice

## Verification

- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) mvn -q test`
- `npm test -- --run src/api/generalSettings.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`

Closes #1002