### PR TITLE
fix(metadata): report unsupported namespace discovery

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
@@ -119,7 +119,7 @@ public class MetadataService {
 
 
     public List<NamespaceVO> listNamespaces() {
-        throw new UnsupportedOperationException("Not implemented");
+        throw new BusinessException(501, "Namespace discovery is not implemented by the current metadata provider");
     }
 
     private String normalizeFilter(String value) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
@@ -196,4 +196,12 @@ class MetadataServiceTest {
         assertThat(result).containsExactly(group);
         verify(metadataProvider).listConsumerGroups("cluster-1", "order");
     }
+
+    @Test
+    void listNamespacesShouldReportUnsupportedProviderCapability() {
+        assertThatThrownBy(() -> metadataService.listNamespaces())
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Namespace discovery is not implemented by the current metadata provider")
+                .satisfies(exception -> assertThat(((BusinessException) exception).getCode()).isEqualTo(501));
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/NamespaceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/NamespaceControllerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.topic;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NamespaceController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class NamespaceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MetadataService metadataService;
+
+    @Test
+    void listNamespacesShouldReturnStructuredUnsupportedCapabilityError() throws Exception {
+        when(metadataService.listNamespaces()).thenThrow(
+                new BusinessException(501, "Namespace discovery is not implemented by the current metadata provider"));
+
+        mockMvc.perform(get("/api/namespaces"))
+                .andExpect(status().isNotImplemented())
+                .andExpect(jsonPath("$.code").value(501))
+                .andExpect(jsonPath("$.message")
+                        .value("Namespace discovery is not implemented by the current metadata provider"));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1010.

- Convert the exposed but unsupported namespace listing path from an unhandled exception to a structured HTTP 501 response.
- Do not introduce namespace data, a namespace UI, or new provider behavior.
- Add service and controller regression coverage for the capability error contract.

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=MetadataServiceTest,NamespaceControllerTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q test`
- `git diff --check origin/rocketmq-studio...HEAD`