### PR TITLE
fix: preserve RocketMQ metadata semantics

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
@@ -140,6 +140,11 @@ public class RocketMQAdminClientImpl implements AdminClient {
         int readQueues = topic.getReadQueues() > 0 ? topic.getReadQueues() : 8;
 
         try {
+            RmqTopic existing = topicMapper.selectOne(
+                    new LambdaQueryWrapper<RmqTopic>().eq(RmqTopic::getName, topicName));
+            TopicPerm effectivePerm = topic.getPerm() != null
+                    ? topic.getPerm()
+                    : existing == null ? TopicPerm.RW : fromRocketMQPerm(existing.getPerm());
             Set<String> brokerAddrs = getAllMasterBrokerAddrs();
             if (brokerAddrs.isEmpty()) {
                 throw new BusinessException(500, "No broker available to create topic");
@@ -149,7 +154,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
             topicConfig.setTopicName(topicName);
             topicConfig.setWriteQueueNums(writeQueues);
             topicConfig.setReadQueueNums(readQueues);
-            topicConfig.setPerm(toRocketMQPerm(topic.getPerm()));
+            topicConfig.setPerm(toRocketMQPerm(effectivePerm));
 
             for (String addr : brokerAddrs) {
                 adminExt.createAndUpdateTopicConfig(addr, topicConfig);
@@ -214,6 +219,11 @@ public class RocketMQAdminClientImpl implements AdminClient {
         int readQueues = topic.getReadQueues() > 0 ? topic.getReadQueues() : 8;
 
         try {
+            RmqTopic existing = topicMapper.selectOne(
+                    new LambdaQueryWrapper<RmqTopic>().eq(RmqTopic::getName, topicName));
+            TopicPerm effectivePerm = topic.getPerm() != null
+                    ? topic.getPerm()
+                    : existing == null ? TopicPerm.RW : fromRocketMQPerm(existing.getPerm());
             Set<String> brokerAddrs = getAllMasterBrokerAddrs();
             if (brokerAddrs.isEmpty()) {
                 throw new BusinessException(500, "No broker available to update topic");
@@ -223,15 +233,13 @@ public class RocketMQAdminClientImpl implements AdminClient {
             topicConfig.setTopicName(topicName);
             topicConfig.setWriteQueueNums(writeQueues);
             topicConfig.setReadQueueNums(readQueues);
-            topicConfig.setPerm(toRocketMQPerm(topic.getPerm()));
+            topicConfig.setPerm(toRocketMQPerm(effectivePerm));
 
             for (String addr : brokerAddrs) {
                 adminExt.createAndUpdateTopicConfig(addr, topicConfig);
             }
 
             // Update DB record
-            RmqTopic existing = topicMapper.selectOne(
-                    new LambdaQueryWrapper<RmqTopic>().eq(RmqTopic::getName, topicName));
             if (existing != null) {
                 existing.setWriteQueueNums(writeQueues);
                 existing.setReadQueueNums(readQueues);
@@ -500,5 +508,15 @@ public class RocketMQAdminClientImpl implements AdminClient {
             return 2;
         }
         return 6;
+    }
+
+    private TopicPerm fromRocketMQPerm(Integer perm) {
+        if (perm != null && perm == 4) {
+            return TopicPerm.RO;
+        }
+        if (perm != null && perm == 2) {
+            return TopicPerm.WO;
+        }
+        return TopicPerm.RW;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
@@ -24,6 +24,7 @@ import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.topic.AdminClient;
 import org.apache.rocketmq.studio.instance.topic.SendMessageDTO;
@@ -148,7 +149,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
             topicConfig.setTopicName(topicName);
             topicConfig.setWriteQueueNums(writeQueues);
             topicConfig.setReadQueueNums(readQueues);
-            topicConfig.setPerm(6); // RW
+            topicConfig.setPerm(toRocketMQPerm(topic.getPerm()));
 
             for (String addr : brokerAddrs) {
                 adminExt.createAndUpdateTopicConfig(addr, topicConfig);
@@ -174,7 +175,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
             entity.setTopicType(topic.getType() != null ? topic.getType().name() : "NORMAL");
             entity.setReadQueueNums(readQueues);
             entity.setWriteQueueNums(writeQueues);
-            entity.setPerm(6);
+            entity.setPerm(topicConfig.getPerm());
             if (StringUtils.hasText(topic.getRemark())) {
                 entity.setRemark(topic.getRemark());
             }
@@ -222,7 +223,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
             topicConfig.setTopicName(topicName);
             topicConfig.setWriteQueueNums(writeQueues);
             topicConfig.setReadQueueNums(readQueues);
-            topicConfig.setPerm(6); // RW
+            topicConfig.setPerm(toRocketMQPerm(topic.getPerm()));
 
             for (String addr : brokerAddrs) {
                 adminExt.createAndUpdateTopicConfig(addr, topicConfig);
@@ -234,6 +235,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
             if (existing != null) {
                 existing.setWriteQueueNums(writeQueues);
                 existing.setReadQueueNums(readQueues);
+                existing.setPerm(topicConfig.getPerm());
                 existing.setUpdatedAt(LocalDateTime.now());
                 topicMapper.updateById(existing);
             }
@@ -488,5 +490,15 @@ public class RocketMQAdminClientImpl implements AdminClient {
         } catch (Exception ignored) {
         }
         return "DefaultCluster";
+    }
+
+    private int toRocketMQPerm(TopicPerm perm) {
+        if (perm == TopicPerm.RO) {
+            return 4;
+        }
+        if (perm == TopicPerm.WO) {
+            return 2;
+        }
+        return 6;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMetadataProvider.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.rocketmq;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.remoting.protocol.admin.ConsumeStats;
 import org.apache.rocketmq.remoting.protocol.admin.OffsetWrapper;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
@@ -215,7 +216,10 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                     BrokerData bd = brokerDataMap.get(qd.getBrokerName());
                     String brokerAddr = "";
                     if (bd != null && bd.getBrokerAddrs() != null && !bd.getBrokerAddrs().isEmpty()) {
-                        brokerAddr = bd.getBrokerAddrs().values().iterator().next();
+                        brokerAddr = bd.getBrokerAddrs().get(MixAll.MASTER_ID);
+                        if (brokerAddr == null) {
+                            brokerAddr = bd.getBrokerAddrs().values().iterator().next();
+                        }
                     }
 
                     routes.add(BrokerRouteVO.builder()
@@ -271,11 +275,9 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                     String messageModel = "CLUSTERING";
                     try {
                         ConsumerConnection conn = adminExt.examineConsumerConnectionInfo(group);
-                        if (conn != null && conn.getConsumeType() != null) {
-                            messageModel = conn.getConsumeType().name();
-                            if (conn.getMessageModel() != null) {
-                                messageModel = conn.getMessageModel().name();
-                            }
+                        if (conn != null && conn.getMessageModel() != null) {
+                            messageModel = conn.getMessageModel().name();
+                            consumeType = parseConsumeType(messageModel);
                         }
                     } catch (Exception ignored) {
                         // group may be offline
@@ -376,7 +378,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                         .topic(sd.getTopic())
                         .expression(sd.getSubString())
                         .type(sd.getExpressionType())
-                        .filterMode("CLASS_FILTER".equals(sd.getExpressionType()) ? "SQL" : "TAG")
+                        .filterMode(filterMode(sd.getExpressionType()))
                         .build());
             }
             return subscriptions;
@@ -424,13 +426,6 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                 if (conn.getConnectionSet() != null) {
                     vo.setOnlineInstances(conn.getConnectionSet().size());
                 }
-                if (conn.getMessageModel() != null) {
-                    vo.setSubscriptionMode(
-                            "BROADCASTING".equals(conn.getMessageModel().name())
-                                    ? org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode.Pop
-                                    : org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode.Push
-                    );
-                }
                 if (conn.getSubscriptionTable() != null) {
                     vo.setSubscribedTopics(new ArrayList<>(conn.getSubscriptionTable().keySet()));
                 }
@@ -452,6 +447,16 @@ public class RocketMQMetadataProvider implements MetadataProvider {
         } catch (Exception ignored) {
             // No stats available
         }
+    }
+
+    private String filterMode(String expressionType) {
+        if ("SQL92".equals(expressionType)) {
+            return "SQL";
+        }
+        if ("CLASS_FILTER".equals(expressionType)) {
+            return "CLASS_FILTER";
+        }
+        return "TAG";
     }
 
     private Set<String> getBrokerNames() {


### PR DESCRIPTION
Closes #1015

- Preserve requested Topic permissions when creating or updating broker configuration.
- Prefer the master address in topic route output.
- Correct consumer message-model and subscription filter mappings.
- Stop deriving Push/Pop semantics from BROADCASTING/CLUSTERING.

Validation:
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -f server/pom.xml -DskipTests compile`
- `git diff --check`