### PR TITLE
fix: harden client connection response contract

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientConnectionVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientConnectionVO.java
@@ -40,5 +40,6 @@ public class ClientConnectionVO {
     private ClientLanguage language;
     private String version;
     private LocalDateTime connectedAt;
+    private boolean partial;
     private String clusterName;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProvider.java
@@ -26,6 +26,7 @@ import org.apache.rocketmq.remoting.protocol.body.TopicList;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.client.ClientConnectionVO;
 import org.apache.rocketmq.studio.cluster.client.ClientProvider;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.ClientLanguage;
 import org.apache.rocketmq.studio.common.domain.enums.ClientType;
 import org.apache.rocketmq.studio.common.domain.enums.Protocol;
@@ -96,12 +97,11 @@ public class RocketMQClientProvider implements ClientProvider {
         }
 
         int scanned = 0;
-        for (String topic : topics) {
-            if (isSystemTopic(topic)) {
-                continue;
-            }
+        boolean capped = false;
+        for (String topic : topics.stream().filter(topic -> !isSystemTopic(topic)).sorted().toList()) {
             if (scanned >= MAX_PRODUCER_TOPIC_SCAN) {
-                log.info("Producer connection scan capped at {} non-system topics", MAX_PRODUCER_TOPIC_SCAN);
+                log.warn("Producer connection scan capped at {} non-system topics", MAX_PRODUCER_TOPIC_SCAN);
+                capped = true;
                 break;
             }
             scanned++;
@@ -119,6 +119,9 @@ public class RocketMQClientProvider implements ClientProvider {
             } catch (Exception e) {
                 log.warn("Failed to examine producer connection for topic={}, skipping", topic, e);
             }
+        }
+        if (capped) {
+            result.forEach(connection -> connection.setPartial(true));
         }
         return result;
     }
@@ -210,8 +213,7 @@ public class RocketMQClientProvider implements ClientProvider {
             if (normalized.startsWith("cons")) {
                 return ClientType.Consumer;
             }
-            log.warn("Unknown client type filter: {}", type);
-            return null;
+            throw new BusinessException(400, "Unknown client type filter: " + type);
         }
     }
 

--- a/web/src/api/connections.ts
+++ b/web/src/api/connections.ts
@@ -9,7 +9,8 @@ export interface ClientConnection {
   address: string;
   language: string;
   version: string;
-  connectedAt: string;
+  connectedAt?: string | null;
+  partial?: boolean;
   clusterName: string;
 }
 

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -290,10 +290,10 @@ const ClientsPage = () => {
       dataIndex: 'connectedAt',
       key: 'connectedAt',
       width: 170,
-      sorter: (a, b) => a.connectedAt.localeCompare(b.connectedAt),
-      render: (d: string) => (
+      sorter: (a, b) => (a.connectedAt ?? '').localeCompare(b.connectedAt ?? ''),
+      render: (d?: string | null) => (
         <Text type="secondary" style={{ fontSize: 13 }}>
-          {formatDateTime(d)}
+          {d ? formatDateTime(d) : '-'}
         </Text>
       ),
     },
@@ -328,6 +328,14 @@ const ClientsPage = () => {
 
       {loadError && (
         <Alert showIcon type="warning" message={loadError} style={{ marginBottom: 16 }} />
+      )}
+      {connections.some((connection) => connection.partial) && (
+        <Alert
+          showIcon
+          type="warning"
+          message="Producer connections are sampled because the topic scan limit was reached."
+          style={{ marginBottom: 16 }}
+        />
       )}
 
       {/* ─── Filter Bar ─── */}
@@ -418,7 +426,7 @@ const ClientsPage = () => {
         <Table
           columns={columns}
           dataSource={filtered}
-          rowKey="clientId"
+          rowKey={(connection) => `${connection.type}:${connection.clientId}:${connection.groupOrTopic}`}
           loading={loading}
           scroll={{ x: 1320 }}
           pagination={{
@@ -471,7 +479,7 @@ const ClientsPage = () => {
               {selectedConnection.version}
             </Descriptions.Item>
             <Descriptions.Item label={t('cluster.heartbeat')}>
-              {selectedConnection.connectedAt}
+              {selectedConnection.connectedAt ?? '-'}
             </Descriptions.Item>
           </Descriptions>
         )}

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -154,18 +154,20 @@ const ClientsPage = () => {
     [connections, clusterFilter],
   );
 
-  const connectionStats = useMemo(
-    () => ({
-      total: clusterConnections.length,
-      producers: clusterConnections.filter((connection) => connection.type === 'Producer').length,
-      consumers: clusterConnections.filter((connection) => connection.type === 'Consumer').length,
-      protocols: countBy(clusterConnections.map((connection) => connection.protocol)),
+  const connectionStats = useMemo(() => {
+    const instances = Array.from(
+      new Map(clusterConnections.map((connection) => [`${connection.type}:${connection.clientId}`, connection])).values(),
+    );
+    return {
+      total: instances.length,
+      producers: instances.filter((connection) => connection.type === 'Producer').length,
+      consumers: instances.filter((connection) => connection.type === 'Consumer').length,
+      protocols: countBy(instances.map((connection) => connection.protocol)),
       languageVersions: countBy(
-        clusterConnections.map((connection) => `${connection.language} ${connection.version}`),
+        instances.map((connection) => `${connection.language} ${connection.version}`),
       ),
-    }),
-    [clusterConnections],
-  );
+    };
+  }, [clusterConnections]);
 
   /* ─── Filtered data (search + cluster only, table handles column filters) ─── */
   const filtered = useMemo(() => {


### PR DESCRIPTION
Closes #1016

- Reject invalid client type filters instead of silently scanning both types.
- Sort producer topics before applying the scan cap and mark returned records as partial when capped.
- Make connection timestamps optional in the web contract and safe to sort/render.
- Use a composite row key so multi-topic producers do not collide in the table.

Validation:
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -f server/pom.xml -DskipTests compile`
- `git diff --check`
- Frontend lint/test not run: dependencies are not installed in the isolated worktree.