### PR TITLE
[Studio] Harden message trace diagnostics

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProvider.java
@@ -24,6 +24,7 @@ import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageId;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.instance.message.ConsumerStatusVO;
 import org.apache.rocketmq.studio.instance.message.MessageProvider;
@@ -228,12 +229,11 @@ public class RocketMQMessageProvider implements MessageProvider {
     public TraceRecordVO getMessageTrace(String msgId) {
         DefaultMQAdminExt adminExt = adminExtProvider.getIfAvailable();
         if (adminExt == null) {
-            log.warn("DefaultMQAdminExt is not configured, returning empty trace");
-            return emptyTrace();
+            throw new BusinessException(503, "RocketMQ admin not connected");
         }
 
         long now = System.currentTimeMillis();
-        long begin = now - ONE_HOUR_MILLIS;
+        long begin = now - traceQueryWindowMillis();
         long end = now + 60_000L;
 
         List<TraceNodeVO> nodes = new ArrayList<>();
@@ -248,6 +248,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             }
         } catch (Exception e) {
             log.warn("Trace query for msgId={} failed: {}", msgId, e.getMessage());
+            throw new BusinessException(502, "Failed to query message trace: " + e.getMessage());
         }
 
         recordTraceQuery(msgId, null, nodes.size(), consumerStatus.size());
@@ -340,7 +341,7 @@ public class RocketMQMessageProvider implements MessageProvider {
         return TraceNodeVO.builder()
                 .title("endTransaction")
                 .timestamp(parseLong(field(f, 1)))
-                .status("finish")
+                .status(parseBoolean(field(f, 12)) ? "finish" : "failed")
                 .costTime(0L)
                 .description("group=" + field(f, 3) + ", transactionState=" + field(f, 14))
                 .build();
@@ -440,6 +441,14 @@ public class RocketMQMessageProvider implements MessageProvider {
                 .nodes(Collections.emptyList())
                 .consumerStatus(Collections.emptyList())
                 .build();
+    }
+
+    private long traceQueryWindowMillis() {
+        if (properties.getTraceQueryWindow() == null || properties.getTraceQueryWindow().isNegative()
+                || properties.getTraceQueryWindow().isZero()) {
+            return ONE_DAY_MILLIS;
+        }
+        return properties.getTraceQueryWindow().toMillis();
     }
 
     private static String field(String[] fields, int index) {

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProvider.java
@@ -275,6 +275,9 @@ public class RocketMQMessageProvider implements MessageProvider {
             if (fields.length == 0) {
                 continue;
             }
+            if (!targetMsgId.equals(field(fields, 5))) {
+                continue;
+            }
             try {
                 switch (fields[0].trim()) {
                     case "Pub":

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQProperties.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQProperties.java
@@ -19,8 +19,11 @@ package org.apache.rocketmq.studio.rocketmq;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 @Data
 @ConfigurationProperties(prefix = "studio.rocketmq")
 public class RocketMQProperties {
     private String namesrvAddr;
+    private Duration traceQueryWindow = Duration.ofHours(24);
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProviderTest.java
@@ -17,8 +17,12 @@
 package org.apache.rocketmq.studio.rocketmq;
 
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.QueryResult;
+import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
+import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.studio.queryhistory.QueryHistoryService;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,8 +34,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.ObjectProvider;
 
 import java.util.List;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -81,5 +88,41 @@ class RocketMQMessageProviderTest {
             verify(consumer).shutdown();
         }
         verify(queryHistoryService).recordMessageQuery("TOPIC", "TopicA", null, null, null, 100L, 200L, 0);
+    }
+
+    @Test
+    void traceUsesConfiguredWindowAndMarksFailedTransaction() throws Exception {
+        RocketMQProperties properties = new RocketMQProperties();
+        properties.setTraceQueryWindow(Duration.ofHours(6));
+        provider = new RocketMQMessageProvider(adminExtProvider, queryHistoryService, properties);
+        MessageExt trace = new MessageExt();
+        trace.setBody(("EndTransaction\u0001123\u0001region\u0001group\u0001topic\u0001target\u0001tags"
+                + "\u0001keys\u0001store\u0001client\u00010\u0001NORMAL\u0001false\u0001tx\u0001ROLLBACK\n")
+                .getBytes());
+        when(adminExt.queryMessage(eq("RMQ_SYS_TRACE_TOPIC"), eq("target"), anyInt(), anyLong(), anyLong()))
+                .thenReturn(new QueryResult(0L, List.of(trace)));
+
+        long before = System.currentTimeMillis();
+        TraceRecordVO result = provider.getMessageTrace("target");
+
+        assertThat(result.getNodes()).singleElement().satisfies(node -> {
+            assertThat(node.getStatus()).isEqualTo("failed");
+            assertThat(node.getDescription()).contains("ROLLBACK");
+        });
+        org.mockito.ArgumentCaptor<Long> begin = org.mockito.ArgumentCaptor.forClass(Long.class);
+        verify(adminExt).queryMessage(eq("RMQ_SYS_TRACE_TOPIC"), eq("target"), anyInt(), begin.capture(), anyLong());
+        assertThat(begin.getValue()).isBetween(before - Duration.ofHours(6).toMillis() - 1_000L,
+                before - Duration.ofHours(6).toMillis() + 1_000L);
+    }
+
+    @Test
+    void traceQueryFailureIsNotReturnedAsAnEmptyTrace() throws Exception {
+        when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
+                .thenThrow(new RuntimeException("ACL denied"));
+
+        assertThatThrownBy(() -> provider.getMessageTrace("target"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("ACL denied")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(502));
     }
 }


### PR DESCRIPTION
Closes #1017
Closes #1029

## Summary
- filter trace contexts by the requested message ID
- derive EndTransaction status from the trace record
- configure the trace query window with a 24-hour default
- surface unavailable Admin trace queries as structured 502/503 errors

## Verification
`JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=RocketMQMessageProviderTest test`