### PR TITLE
[Track 3] Validate AI API inputs and preserve gateway failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiCommandDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiCommandDTO.java
@@ -16,6 +16,8 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,11 +30,19 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AiCommandDTO {
+    @NotBlank(message = "command is required")
+    @Size(max = 256, message = "command must not exceed 256 characters")
     private String command;
+    @Size(max = 64, message = "mode must not exceed 64 characters")
     private String mode;
+    @Size(max = 256, message = "model must not exceed 256 characters")
     private String model;
+    @Size(max = 64, message = "engine must not exceed 64 characters")
     private String engine;
+    @Size(max = 128, message = "conversationId must not exceed 128 characters")
     private String conversationId;
+    @Size(max = 16_384, message = "prompt must not exceed 16384 characters")
     private String prompt;
+    @Size(max = 32, message = "context must not contain more than 32 entries")
     private Map<String, Object> context;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiController.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import jakarta.validation.Valid;
 import org.apache.rocketmq.studio.common.domain.Result;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -41,12 +42,12 @@ public class AiController {
     private final AiService aiService;
 
     @PostMapping(value = "/chat", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter chat(@RequestBody ChatDTO request) {
+    public SseEmitter chat(@Valid @RequestBody ChatDTO request) {
         return aiService.chat(request);
     }
 
     @PostMapping("/execute")
-    public Result<AiExecuteResultVO> execute(@RequestBody AiCommandDTO command) {
+    public Result<AiExecuteResultVO> execute(@Valid @RequestBody AiCommandDTO command) {
         return Result.ok(aiService.execute(command));
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,26 +35,25 @@ public class AiService {
 
 
     public SseEmitter chat(ChatDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "AI chat request is required");
+        }
         log.info("Chat request received: mode={}, conversationId={}", request.getMode(), request.getConversationId());
         return llmGateway.chat(request);
     }
 
 
     public AiExecuteResultVO execute(AiCommandDTO command) {
-        log.info("Executing AI command: {}", command.getCommand());
-        try {
-            String result = llmGateway.execute(command);
-            return AiExecuteResultVO.builder()
-                    .success(true)
-                    .result(result)
-                    .build();
-        } catch (Exception e) {
-            log.error("Failed to execute AI command", e);
-            return AiExecuteResultVO.builder()
-                    .success(false)
-                    .result("Error: " + e.getMessage())
-                    .build();
+        if (command == null) {
+            throw new BusinessException(400, "AI command request is required");
         }
+        validateContext(command.getContext());
+        log.info("Executing AI command: {}", command.getCommand());
+        String result = llmGateway.execute(command);
+        return AiExecuteResultVO.builder()
+                .success(true)
+                .result(result)
+                .build();
     }
 
 
@@ -82,5 +82,22 @@ public class AiService {
 
     public String minimumClientVersion() {
         return mcpServerRegistry.minimumClientVersion();
+    }
+
+    private void validateContext(Map<String, Object> context) {
+        if (context == null) {
+            return;
+        }
+        if (context.size() > 32) {
+            throw new BusinessException(400, "context must not contain more than 32 entries");
+        }
+        for (Map.Entry<String, Object> entry : context.entrySet()) {
+            if (entry.getKey() == null || entry.getKey().length() > 128) {
+                throw new BusinessException(400, "context keys must not exceed 128 characters");
+            }
+            if (String.valueOf(entry.getValue()).length() > 4096) {
+                throw new BusinessException(400, "context values must not exceed 4096 characters");
+            }
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ChatDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ChatDTO.java
@@ -16,6 +16,8 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,10 +28,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatDTO {
+    @NotBlank(message = "message is required")
+    @Size(max = 16_384, message = "message must not exceed 16384 characters")
     private String message;
+    @Size(max = 64, message = "mode must not exceed 64 characters")
     private String mode;
+    @Size(max = 256, message = "model must not exceed 256 characters")
     private String model;
+    @Size(max = 64, message = "engine must not exceed 64 characters")
     private String engine;
     private boolean enhance;
+    @Size(max = 128, message = "conversationId must not exceed 128 characters")
     private String conversationId;
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiControllerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import org.apache.rocketmq.studio.common.exception.GlobalExceptionHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -45,7 +47,9 @@ class AiControllerTest {
     @BeforeEach
     void setUp() {
         aiService = mock(AiService.class);
-        mockMvc = MockMvcBuilders.standaloneSetup(new AiController(aiService)).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(new AiController(aiService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
 
         when(aiService.catalogVersion()).thenReturn("1.0.0");
         when(aiService.catalogDigest()).thenReturn(DIGEST);
@@ -124,5 +128,27 @@ class AiControllerTest {
                 .andExpect(jsonPath("$.data").isArray());
 
         verify(aiService).executeTool("rmq.cluster.list", Collections.emptyMap());
+    }
+
+    @Test
+    void chatRejectsBlankMessagesBeforeCallingService() throws Exception {
+        mockMvc.perform(post("/api/ai/chat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400));
+    }
+
+    @Test
+    void executePreservesGatewayFailureStatus() throws Exception {
+        when(aiService.execute(any(AiCommandDTO.class)))
+                .thenThrow(new LlmGatewayException(502, "llm.provider.error", "Provider rejected request", "Check config"));
+
+        mockMvc.perform(post("/api/ai/execute")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"command\":\"rmq.topic.list\"}"))
+                .andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.code").value(502))
+                .andExpect(jsonPath("$.message").value("Provider rejected request"));
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiServiceTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.ops.ai;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -95,7 +97,7 @@ class AiServiceTest {
     }
 
     @Test
-    void executeShouldReturnFailureWhenGatewayThrows() {
+    void executePropagatesGatewayFailures() {
         AiCommandDTO command = AiCommandDTO.builder()
                 .command("delete_topic")
                 .mode("agent")
@@ -103,21 +105,9 @@ class AiServiceTest {
                 .build();
         when(llmGateway.execute(command)).thenThrow(new RuntimeException("Permission denied"));
 
-        AiExecuteResultVO result = aiService.execute(command);
-
-        assertThat(result.isSuccess()).isFalse();
-        assertThat(result.getResult()).contains("Error: Permission denied");
-    }
-
-    @Test
-    void executeShouldHandleNullMessageInException() {
-        AiCommandDTO command = AiCommandDTO.builder().command("bad_cmd").build();
-        when(llmGateway.execute(command)).thenThrow(new RuntimeException());
-
-        AiExecuteResultVO result = aiService.execute(command);
-
-        assertThat(result.isSuccess()).isFalse();
-        assertThat(result.getResult()).startsWith("Error:");
+        assertThatThrownBy(() -> aiService.execute(command))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Permission denied");
     }
 
     @Test
@@ -136,6 +126,18 @@ class AiServiceTest {
 
         assertThat(result.isSuccess()).isTrue();
         assertThat(result.getResult()).contains("CPU: 45%");
+    }
+
+    @Test
+    void executeRejectsOversizedContextValuesBeforeCallingGateway() {
+        AiCommandDTO command = AiCommandDTO.builder()
+                .command("query_metrics")
+                .context(Map.of("query", "x".repeat(4097)))
+                .build();
+
+        assertThatThrownBy(() -> aiService.execute(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("context values must not exceed 4096 characters");
     }
 
     @Test


### PR DESCRIPTION
Closes #1023

## Summary
- validate required and bounded chat/execute DTO fields
- cap structured command context entries and value size before gateway invocation
- preserve LLM gateway HTTP failure status instead of returning a successful wrapper with `success=false`

## Verification
`JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=AiServiceTest,AiControllerTest test`