### PR TITLE
[Studio] Return not-found for absent alert and ACL deletes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclRepository.java
@@ -31,7 +31,7 @@ public interface AclRepository {
      */
     Optional<AclRuleVO> replaceRule(AclRuleVO rule);
 
-    void deleteRule(String id);
+    boolean deleteRule(String id);
 
     List<AclUserVO> findUsers();
 
@@ -39,5 +39,5 @@ public interface AclRepository {
 
     AclUserVO saveUser(AclUserVO user);
 
-    void deleteUser(String id);
+    boolean deleteUser(String id);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -67,7 +67,9 @@ public class AclService {
 
     public void deleteRule(String id) {
         log.info("Deleting ACL rule id={}", id);
-        aclRepository.deleteRule(id);
+        if (!aclRepository.deleteRule(id)) {
+            throw new BusinessException(404, "ACL rule not found: " + id);
+        }
     }
 
 
@@ -112,7 +114,9 @@ public class AclService {
 
     public void deleteUser(String id) {
         log.info("Deleting ACL user id={}", id);
-        aclRepository.deleteUser(id);
+        if (!aclRepository.deleteUser(id)) {
+            throw new BusinessException(404, "ACL user not found: " + id);
+        }
     }
 
     /**

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -82,8 +82,8 @@ public class MybatisPlusAclRepository implements AclRepository {
     }
 
     @Override
-    public void deleteRule(String id) {
-        ruleMapper.deleteById(id);
+    public boolean deleteRule(String id) {
+        return ruleMapper.deleteById(id) > 0;
     }
 
     @Override
@@ -111,8 +111,8 @@ public class MybatisPlusAclRepository implements AclRepository {
     }
 
     @Override
-    public void deleteUser(String id) {
-        userMapper.deleteById(id);
+    public boolean deleteUser(String id) {
+        return userMapper.deleteById(id) > 0;
     }
 
     // ── Mapping ────────────────────────────────────────────────────

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
@@ -26,7 +26,7 @@ public interface AlertRepository {
 
     boolean replaceRule(AlertRuleVO rule);
 
-    void deleteRule(String id);
+    boolean deleteRule(String id);
 
     List<SystemAlertVO> findAlerts(String level);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -104,7 +104,9 @@ public class AlertService {
 
     public void deleteRule(String id) {
         log.info("Deleting alert rule id={}", id);
-        alertRepository.deleteRule(id);
+        if (!alertRepository.deleteRule(id)) {
+            throw ruleNotFound(id);
+        }
     }
 
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -72,8 +72,8 @@ public class MybatisPlusAlertRepository implements AlertRepository {
     }
 
     @Override
-    public void deleteRule(String id) {
-        ruleMapper.deleteById(id);
+    public boolean deleteRule(String id) {
+        return ruleMapper.deleteById(id) > 0;
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -111,6 +111,7 @@ class AclServiceTest {
 
     @Test
     void deleteRuleShouldDelegateToRepository() {
+        when(aclRepository.deleteRule("rule-1")).thenReturn(true);
         aclService.deleteRule("rule-1");
 
         verify(aclRepository).deleteRule("rule-1");
@@ -310,9 +311,28 @@ class AclServiceTest {
 
     @Test
     void deleteUserShouldDelegateToRepository() {
+        when(aclRepository.deleteUser("user-1")).thenReturn(true);
         aclService.deleteUser("user-1");
 
         verify(aclRepository).deleteUser("user-1");
+    }
+
+    @Test
+    void deleteRuleShouldRejectUnknownRule() {
+        when(aclRepository.deleteRule("missing")).thenReturn(false);
+
+        assertThatThrownBy(() -> aclService.deleteRule("missing"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
+    }
+
+    @Test
+    void deleteUserShouldRejectUnknownUser() {
+        when(aclRepository.deleteUser("missing")).thenReturn(false);
+
+        assertThatThrownBy(() -> aclService.deleteUser("missing"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -33,7 +33,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -351,11 +350,20 @@ class AlertServiceTest {
 
     @Test
     void deleteRuleShouldCallRepository() {
-        doNothing().when(alertRepository).deleteRule("rule-1");
+        when(alertRepository.deleteRule("rule-1")).thenReturn(true);
 
         alertService.deleteRule("rule-1");
 
         verify(alertRepository).deleteRule("rule-1");
+    }
+
+    @Test
+    void deleteRuleShouldRejectUnknownRule() {
+        when(alertRepository.deleteRule("missing")).thenReturn(false);
+
+        assertThatThrownBy(() -> alertService.deleteRule("missing"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
     }
 
     @Test


### PR DESCRIPTION
Closes #1032

## Summary
- make alert and ACL delete repository calls report affected-row results
- return 404 for unknown alert rules, ACL rules, and ACL users
- cover successful and missing delete paths

## Verification
`JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=AclServiceTest,AlertServiceTest test`