### PR TITLE
[Studio] Surface corrupt K8s certificate persistence data

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -119,7 +119,7 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         try {
             return CertType.valueOf(value);
         } catch (IllegalArgumentException exception) {
-            return null;
+            throw new IllegalStateException("Invalid persisted certificate type: " + value, exception);
         }
     }
 
@@ -130,7 +130,7 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         try {
             return CertStatus.valueOf(value);
         } catch (IllegalArgumentException exception) {
-            return null;
+            throw new IllegalStateException("Invalid persisted certificate status: " + value, exception);
         }
     }
 
@@ -142,7 +142,7 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
             return objectMapper.readValue(json, new TypeReference<List<String>>() {
             });
         } catch (JsonProcessingException exception) {
-            return List.of();
+            throw new IllegalStateException("Invalid persisted certificate SAN JSON", exception);
         }
     }
 
@@ -153,7 +153,7 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         try {
             return objectMapper.writeValueAsString(san);
         } catch (JsonProcessingException exception) {
-            return "[]";
+            throw new IllegalStateException("Failed to serialize certificate SAN values", exception);
         }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.k8s;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.persistence.entity.RmqK8sCertificate;
+import org.apache.rocketmq.studio.persistence.mapper.RmqK8sCertificateMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MybatisPlusK8sCertRepositoryTest {
+
+    @Test
+    void findByIdSurfacesInvalidPersistedCertificateType() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        RmqK8sCertificate entity = certificate();
+        entity.setCertType("UNKNOWN_TYPE");
+        when(mapper.selectById("cert-1")).thenReturn(entity);
+
+        assertThatThrownBy(() -> repository(mapper).findById("cert-1"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("certificate type");
+    }
+
+    @Test
+    void findByIdSurfacesMalformedPersistedSanJson() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        RmqK8sCertificate entity = certificate();
+        entity.setSan("not-json");
+        when(mapper.selectById("cert-1")).thenReturn(entity);
+
+        assertThatThrownBy(() -> repository(mapper).findById("cert-1"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("SAN JSON");
+    }
+
+    private MybatisPlusK8sCertRepository repository(RmqK8sCertificateMapper mapper) {
+        return new MybatisPlusK8sCertRepository(mapper, new ObjectMapper());
+    }
+
+    private RmqK8sCertificate certificate() {
+        RmqK8sCertificate entity = new RmqK8sCertificate();
+        entity.setId("cert-1");
+        entity.setCertType("TLS");
+        entity.setStatus("valid");
+        entity.setSan("[\"broker.example\"]");
+        return entity;
+    }
+}


### PR DESCRIPTION
Closes #1031

## Summary
- reject invalid persisted certificate type/status values
- surface malformed stored SAN JSON instead of returning an empty list
- preserve serialization failures instead of writing valid-looking empty data

## Verification
`JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=MybatisPlusK8sCertRepositoryTest test`