### PR TITLE
[ISSUE #995] Harden cluster page against null component lists for real clusters

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProvider.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.broker;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.cluster.config.ClusterConfigVO;
 import org.apache.rocketmq.studio.cluster.nameserver.NameServerVO;
 import org.apache.rocketmq.studio.common.domain.enums.BrokerStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
@@ -105,6 +106,8 @@ public class RealClusterProvider implements ClusterProvider {
                 .map(addr -> NameServerVO.builder().addr(addr).status(ClusterStatus.healthy).build())
                 .toList();
 
+        // A live cluster has no proxy or config history until one is provisioned;
+        // default to empty collections so the web UI never dereferences nulls.
         ClusterVO cluster = ClusterVO.builder()
                 .name(clusterName)
                 .nsClusterName(clusterName)
@@ -114,6 +117,8 @@ public class RealClusterProvider implements ClusterProvider {
                 .brokers(brokers)
                 .proxies(List.of())
                 .nameServers(nameServers)
+                .config(new ClusterConfigVO())
+                .tpsHistory(List.of())
                 .build();
         cluster.setId(clusterName);
         return cluster;

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProviderTest.java
@@ -97,6 +97,19 @@ class RealClusterProviderTest {
     }
 
     @Test
+    void describeClusterShouldDefaultAbsentRuntimeCollectionsToEmpty() throws Exception {
+        stubClusterInfo("10.0.0.1:9876", sampleClusterInfo());
+
+        ClusterVO cluster = provider.describeCluster("10.0.0.1:9876");
+
+        // A live cluster without a proxy must still serialize non-null collections
+        // so the web UI never dereferences null component lists.
+        assertThat(cluster.getProxies()).isEmpty();
+        assertThat(cluster.getTpsHistory()).isEmpty();
+        assertThat(cluster.getConfig()).isNotNull();
+    }
+
+    @Test
     void discoverClustersShouldReturnEmptyWhenNoNamesrvConfigured() {
         properties.setNamesrvAddr("  ");
 

--- a/web/src/pages/cluster/clusterStats.test.ts
+++ b/web/src/pages/cluster/clusterStats.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ClusterInfo } from '../../api/cluster';
+import { countClusterComponents } from './clusterStats';
+
+const baseCluster: ClusterInfo = {
+  id: 'c1',
+  name: 'rmq-prod',
+  nsClusterName: 'ns-prod',
+  type: 'V5_PROXY_CLUSTER',
+  endpoint: '10.0.0.1:9876',
+  status: 'healthy',
+  version: '5.2.0',
+  brokers: [],
+  proxies: [],
+  nameServers: [],
+  config: {
+    flushDiskType: 'SYNC_FLUSH',
+    autoCreateTopicEnable: false,
+    autoCreateSubscriptionGroup: false,
+    maxMessageSize: 4194304,
+    msgTraceTopicName: 'RMQ_SYS_TRACE_TOPIC',
+    fileReservedTime: 72,
+    writeQueueNums: 16,
+    readQueueNums: 16,
+    brokerPermission: 6,
+    deleteWhen: '04',
+  },
+  topicCount: 10,
+  groupCount: 5,
+  tpsHistory: [1, 2, 3],
+};
+
+describe('countClusterComponents', () => {
+  it('returns zero counts for an empty cluster list', () => {
+    expect(countClusterComponents([])).toEqual({ brokers: 0, nameServers: 0, proxies: 0 });
+  });
+
+  it('counts components across clusters', () => {
+    const clusters: ClusterInfo[] = [
+      {
+        ...baseCluster,
+        brokers: [
+          {
+            addr: 'a:10911',
+            name: 'b1',
+            status: 'running',
+            tpsIn: 1,
+            tpsOut: 2,
+            diskUsage: 3,
+            version: '5.2.0',
+          },
+        ],
+        proxies: [{ addr: 'p:8081' } as ClusterInfo['proxies'][number]],
+        nameServers: [{ addr: 'ns:9876' } as ClusterInfo['nameServers'][number]],
+      },
+      {
+        ...baseCluster,
+        id: 'c2',
+        brokers: [
+          {
+            addr: 'a2:10911',
+            name: 'b2',
+            status: 'running',
+            tpsIn: 1,
+            tpsOut: 2,
+            diskUsage: 3,
+            version: '5.2.0',
+          },
+          {
+            addr: 'a3:10911',
+            name: 'b3',
+            status: 'running',
+            tpsIn: 1,
+            tpsOut: 2,
+            diskUsage: 3,
+            version: '5.2.0',
+          },
+        ],
+      },
+    ];
+    expect(countClusterComponents(clusters)).toEqual({ brokers: 3, nameServers: 1, proxies: 1 });
+  });
+
+  it('treats missing component lists as empty instead of crashing', () => {
+    // A cluster without a proxy serializes its component lists as null.
+    const clusters = [
+      { ...baseCluster, proxies: null as unknown as ClusterInfo['proxies'] },
+      { ...baseCluster, id: 'c2', brokers: null as unknown as ClusterInfo['brokers'] },
+      { ...baseCluster, id: 'c3', nameServers: undefined as unknown as ClusterInfo['nameServers'] },
+    ];
+    expect(countClusterComponents(clusters)).toEqual({ brokers: 0, nameServers: 0, proxies: 0 });
+  });
+});

--- a/web/src/pages/cluster/clusterStats.ts
+++ b/web/src/pages/cluster/clusterStats.ts
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ClusterInfo } from '../../api/cluster';
+
+export interface ClusterComponentCounts {
+  brokers: number;
+  nameServers: number;
+  proxies: number;
+}
+
+/**
+ * Aggregate per-component counts across a list of clusters.
+ *
+ * The backend may serialize a cluster without its runtime component lists
+ * (e.g. a real cluster without a proxy), leaving `brokers`/`proxies`/
+ * `nameServers` as null. Guard every field so the summary never crashes on
+ * such payloads.
+ */
+export function countClusterComponents(clusters: ClusterInfo[]): ClusterComponentCounts {
+  return clusters.reduce(
+    (acc, c) => ({
+      brokers: acc.brokers + (c.brokers ?? []).length,
+      nameServers: acc.nameServers + (c.nameServers ?? []).length,
+      proxies: acc.proxies + (c.proxies ?? []).length,
+    }),
+    { brokers: 0, nameServers: 0, proxies: 0 },
+  );
+}

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -47,6 +47,7 @@ import {
 import { Cpu, HardDrives, Globe } from '@phosphor-icons/react';
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
+import { countClusterComponents } from './clusterStats';
 import type {
   BrokerInfo,
   ProxyInfo,
@@ -934,9 +935,11 @@ const ClusterPage = () => {
 
   // ─── Render ─────────────────────────────────────────────────────────────────
 
-  const totalBrokers = clusters.reduce((s, c) => s + (c.brokers?.length ?? 0), 0);
-  const totalNameServers = clusters.reduce((s, c) => s + (c.nameServers?.length ?? 0), 0);
-  const totalProxies = clusters.reduce((s, c) => s + (c.proxies?.length ?? 0), 0);
+  const {
+    brokers: totalBrokers,
+    nameServers: totalNameServers,
+    proxies: totalProxies,
+  } = countClusterComponents(clusters);
 
   return (
     <div style={{ padding: 24 }}>


### PR DESCRIPTION
## What is the purpose of the change

When a real RocketMQ cluster (configured via `STUDIO_ROCKETMQ_NAMESRV_ADDR`) is described by `RealClusterProvider` and no proxy is provisioned, the produced `ClusterVO` leaves `proxies`, `tpsHistory` and `config` as `null`. The cluster page dereferences them directly (`c.proxies.length`, `cluster.config`, summary counts), so a null payload throws a `TypeError` and the page goes blank.

This PR makes the payload safe on both sides:

- **Backend**: `RealClusterProvider` now defaults a live cluster's absent runtime collections to empty — `proxies`/`tpsHistory` as `List.of()`, `config` as an empty `ClusterConfigVO` — so the API never serializes JSON `null` for these component lists.
- **Frontend**: every `brokers`/`proxies`/`nameServers`/`config` access in the cluster page is guarded with `?? []` / `?? {}`, and the summary counts are extracted into a pure `countClusterComponents` helper with unit tests.

## Brief changelog

- `server/.../cluster/broker/RealClusterProvider.java`: default `config` and `tpsHistory` to safe empty values (proxies already defaulted to `List.of()`).
- `web/src/pages/cluster/index.tsx`: null-safe access to `brokers`, `proxies`, `nameServers`, `selectedProxy.proxies`, `cluster.config`; use `countClusterComponents`.
- `web/src/pages/cluster/clusterStats.ts` (new): pure summary-count helper with empty-collection fallbacks.
- `web/src/pages/cluster/clusterStats.test.ts` (new): unit tests for empty, mixed and null component lists.
- `server/.../cluster/broker/RealClusterProviderTest.java`: new test asserting non-null `proxies`/`tpsHistory`/`config` for a live cluster without a proxy.

## Verifying this change

- `mvn test -Dtest=RealClusterProviderTest` — 4 tests pass (3 existing + 1 new).
- `npm test` (`vitest run`) — 391 tests pass, including the new `clusterStats.test.ts`.
- `eslint src/pages/cluster` — no errors.

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).

Closes #995