### PR TITLE
[ISSUE #1040] Guard dashboard provider against null NameServer topology

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProvider.java
@@ -77,8 +77,19 @@ public class RocketMQDashboardProvider implements DashboardProvider {
 
         try {
             ClusterInfo clusterInfo = adminExt.examineBrokerClusterInfo();
-            Map<String, Set<String>> clusterAddrTable = clusterInfo.getClusterAddrTable();
-            Map<String, BrokerData> brokerAddrTable = clusterInfo.getBrokerAddrTable();
+            if (clusterInfo == null) {
+                log.warn("NameServer returned no cluster topology, returning empty dashboard");
+                return emptyDashboard();
+            }
+            // The NameServer topology is decoded from JSON; a payload missing either
+            // table yields null here. Treat it as empty so a partial topology degrades
+            // instead of throwing and zeroing the whole dashboard.
+            Map<String, Set<String>> clusterAddrTable =
+                    clusterInfo.getClusterAddrTable() == null
+                            ? Map.of() : clusterInfo.getClusterAddrTable();
+            Map<String, BrokerData> brokerAddrTable =
+                    clusterInfo.getBrokerAddrTable() == null
+                            ? Map.of() : clusterInfo.getBrokerAddrTable();
 
             totalClusters = clusterAddrTable.size();
             totalBrokers = brokerAddrTable.size();
@@ -86,6 +97,9 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             // Collect all unique broker addresses (master only, brokerId=0)
             Set<String> masterAddrs = new HashSet<>();
             for (BrokerData brokerData : brokerAddrTable.values()) {
+                if (brokerData == null || brokerData.getBrokerAddrs() == null) {
+                    continue;
+                }
                 String masterAddr = brokerData.getBrokerAddrs().get(0L);
                 if (masterAddr != null) {
                     masterAddrs.add(masterAddr);
@@ -154,7 +168,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
 
                 for (String brokerName : brokerNames) {
                     BrokerData brokerData = brokerAddrTable.get(brokerName);
-                    if (brokerData != null) {
+                    if (brokerData != null && brokerData.getBrokerAddrs() != null) {
                         clusterBrokers++;
                         String masterAddr = brokerData.getBrokerAddrs().get(0L);
                         if (masterAddr != null) {

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProviderTest.java
@@ -48,6 +48,47 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getClusters().get(0).getVersion()).isEqualTo("V5_3_3");
     }
 
+    @Test
+    void dashboardShouldSurviveNullTopologyTables() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        ClusterInfo bare = new ClusterInfo();
+        bare.setBrokerAddrTable(null);
+        bare.setClusterAddrTable(null);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(bare);
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+
+        RocketMQDashboardProvider provider = new RocketMQDashboardProvider(adminExt);
+
+        DashboardDataVO dashboard = provider.getDashboardData();
+
+        // A partial NameServer payload must not throw and zero the page.
+        assertThat(dashboard.getStats()).isNotNull();
+        assertThat(dashboard.getClusters()).isEmpty();
+    }
+
+    @Test
+    void dashboardShouldSkipBrokerWithoutAddressTable() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        ClusterInfo info = new ClusterInfo();
+        HashMap<String, BrokerData> brokerAddrTable = new HashMap<>();
+        brokerAddrTable.put("broker-no-addr", new BrokerData("DefaultCluster", "broker-no-addr", null));
+        info.setBrokerAddrTable(brokerAddrTable);
+        HashMap<String, Set<String>> clusterAddrTable = new HashMap<>();
+        clusterAddrTable.put("DefaultCluster", Set.of("broker-no-addr"));
+        info.setClusterAddrTable(clusterAddrTable);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(info);
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+
+        RocketMQDashboardProvider provider = new RocketMQDashboardProvider(adminExt);
+
+        DashboardDataVO dashboard = provider.getDashboardData();
+
+        // A broker without an address table is skipped instead of throwing.
+        assertThat(dashboard.getStats()).isNotNull();
+        assertThat(dashboard.getClusters()).hasSize(1);
+        assertThat(dashboard.getClusters().get(0).getBrokers()).isZero();
+    }
+
     private ClusterInfo clusterInfo() {
         ClusterInfo info = new ClusterInfo();
         HashMap<Long, String> addrs = new HashMap<>();


### PR DESCRIPTION
## What is the purpose of the change

`RocketMQDashboardProvider` reads the live NameServer topology without guarding the fields that come back from the wire. `clusterInfo.getClusterAddrTable()` / `getBrokerAddrTable()` are dereferenced directly, and `brokerData.getBrokerAddrs().get(0L)` has no null check. Because the whole computation sits inside one outer `try`, a single NPE on a partial payload falls into `catch (Exception e) { return emptyDashboard(); }` and **every number on the dashboard is silently zeroed** — cluster, broker, topic and group counts plus TPS all become 0, masking the data that could have been collected.

Sibling providers already defend these exact fields (`RealClusterProvider` defaults the maps to `Map.of()`, `RocketMQClusterProvider` null-checks `getBrokerAddrs()`); `RocketMQDashboardProvider` was the remaining one that did not.

## Brief changelog

- `RocketMQDashboardProvider.getDashboardData()`:
  - Treat a null `clusterAddrTable` / `brokerAddrTable` as empty (no NPE, no dashboard zeroing).
  - Skip brokers with a null `getBrokerAddrs()` when collecting master addresses and when building per-cluster overviews.
  - Return an empty dashboard early when the NameServer returns no topology at all.

## Verifying this change

- `mvn test -Dtest=RocketMQDashboardProviderTest` — 3 tests pass (1 existing + 2 new: null topology tables, broker without address table).
- Full unit suite verified via CI.

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).

Closes #1040