### PR TITLE
[ISSUE #1041] Return empty producer connections for a non-existent topic

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProvider.java
@@ -16,7 +16,9 @@
  */
 package org.apache.rocketmq.studio.rocketmq;
 
+import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.remoting.protocol.LanguageCode;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.Connection;
 import org.apache.rocketmq.remoting.protocol.body.ConsumerConnection;
@@ -93,10 +95,27 @@ public class RocketMQClientProvider implements ClientProvider {
                     .map(connection -> toConnectionVO(
                             connection, ClientType.Producer, topic, producerGroup, null))
                     .toList();
+        } catch (MQClientException e) {
+            if (isTopicNotExist(e)) {
+                // A non-existent topic is a normal "nothing here" outcome — the client
+                // page should show an empty list, not a 502 that looks like a failure.
+                return List.of();
+            }
+            throw new BusinessException(502,
+                    "Failed to query producer connections: " + rootMessage(e));
         } catch (Exception e) {
             throw new BusinessException(502,
                     "Failed to query producer connections: " + rootMessage(e));
         }
+    }
+
+    private boolean isTopicNotExist(MQClientException e) {
+        if (e.getResponseCode() == ResponseCode.TOPIC_NOT_EXIST) {
+            return true;
+        }
+        String message = e.getErrorMessage() == null ? e.getMessage() : e.getErrorMessage();
+        return message != null && message.contains("route info of topic")
+                || message != null && message.contains("route info not found");
     }
 
     private List<ClientConnectionVO> findAllProducerConnections(

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProviderTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.rocketmq.studio.rocketmq;
 
+import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.remoting.protocol.LanguageCode;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.Connection;
 import org.apache.rocketmq.remoting.protocol.body.ConsumerConnection;
@@ -163,6 +165,29 @@ class RocketMQClientProviderTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Failed to query producer connections: broker unavailable")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    @Test
+    void exactProducerQueryReturnsEmptyForNonExistentTopic() throws Exception {
+        when(adminExt.examineProducerConnectionInfo("pg-order", "NoSuchTopic"))
+                .thenThrow(new MQClientException(ResponseCode.TOPIC_NOT_EXIST,
+                        "CAN'T FIND BROKER FOR TOPIC: NoSuchTopic"));
+
+        List<ClientConnectionVO> connections = provider.findProducerConnections("NoSuchTopic", "pg-order");
+
+        assertThat(connections).isEmpty();
+        verify(adminExt).examineProducerConnectionInfo("pg-order", "NoSuchTopic");
+    }
+
+    @Test
+    void exactProducerQueryReturnsEmptyWhenTopicHasNoRoute() throws Exception {
+        when(adminExt.examineProducerConnectionInfo("pg-order", "NoRouteTopic"))
+                .thenThrow(new MQClientException(ResponseCode.TOPIC_NOT_EXIST,
+                        "connect to ns failed, route info of this topic not found"));
+
+        List<ClientConnectionVO> connections = provider.findProducerConnections("NoRouteTopic", "pg-order");
+
+        assertThat(connections).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

`RocketMQClientProvider.findProducerConnections(topic, producerGroup)` calls `examineProducerConnectionInfo`, which throws `MQClientException` (`ResponseCode.TOPIC_NOT_EXIST`) when the topic has no route. The method converted every exception into `BusinessException(502)`, so querying the Clients page for a not-yet-created or already-deleted topic showed a hard "query failed" error instead of an empty list — and conflated "this topic does not exist" with real network/authorization failures.

## Brief changelog

- `RocketMQClientProvider.findProducerConnections()`:
  - Catch `MQClientException` and return an empty connection list when the topic does not exist (`TOPIC_NOT_EXIST` or a missing topic route).
  - Keep surfacing genuine failures (broker unreachable, auth) as 502.

## Verifying this change

- `mvn test -Dtest=RocketMQClientProviderTest` — 10 tests pass (8 existing + 2 new: `TOPIC_NOT_EXIST` → empty, missing route → empty).
- Full unit suite verified via CI.

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).

Closes #1041