### PR TITLE
fix: harden Studio message producers and DLQ resend

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
@@ -62,6 +62,7 @@ import java.util.Set;
 public class RocketMQAdminClientImpl implements AdminClient {
 
     private static final Logger log = LoggerFactory.getLogger(RocketMQAdminClientImpl.class);
+    private static final String MESSAGE_SENDER_GROUP_PREFIX = "studio-msg-sender";
 
     private final DefaultMQAdminExt adminExt;
     private final RocketMQProperties properties;
@@ -323,7 +324,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
             throw new BusinessException(500, "Nameserver address not configured");
         }
 
-        DefaultMQProducer producer = new DefaultMQProducer("studio_msg_sender_" + System.currentTimeMillis());
+        DefaultMQProducer producer = new DefaultMQProducer(nextMessageSenderGroup());
         producer.setNamesrvAddr(namesrvAddr);
         producer.setSendMsgTimeout(5000);
 
@@ -361,6 +362,10 @@ public class RocketMQAdminClientImpl implements AdminClient {
         } finally {
             producer.shutdown();
         }
+    }
+
+    static String nextMessageSenderGroup() {
+        return ShortLivedClientName.next(MESSAGE_SENDER_GROUP_PREFIX);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProvider.java
@@ -154,7 +154,7 @@ public class RocketMQDLQProvider implements DLQProvider {
         int resent = 0;
         int failed = 0;
         if (!deadLetters.isEmpty()) {
-            DefaultMQProducer producer = newProducer(groupName);
+            DefaultMQProducer producer = newProducer();
             try {
                 producer.start();
                 for (MessageExt deadLetter : deadLetters) {
@@ -281,14 +281,18 @@ public class RocketMQDLQProvider implements DLQProvider {
         return consumer;
     }
 
-    private DefaultMQProducer newProducer(String groupName) {
-        DefaultMQProducer producer = new DefaultMQProducer("studio-dlq-resend-" + groupName);
+    private DefaultMQProducer newProducer() {
+        DefaultMQProducer producer = new DefaultMQProducer(nextResendProducerGroup());
         producer.setInstanceName(ShortLivedClientName.next("studio-dlq-resend"));
         producer.setRetryTimesWhenSendFailed(2);
         if (StringUtils.hasText(properties.getNamesrvAddr())) {
             producer.setNamesrvAddr(properties.getNamesrvAddr());
         }
         return producer;
+    }
+
+    static String nextResendProducerGroup() {
+        return ShortLivedClientName.next("studio-dlq-resend");
     }
 
     private void recordAudit(String groupName, String detail, String result) {

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProviderTest.java
@@ -38,6 +38,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -59,7 +60,7 @@ class RocketMQDLQProviderTest {
 
     @BeforeEach
     void setUp() {
-        when(adminExtProvider.getIfAvailable()).thenReturn(adminExt);
+        lenient().when(adminExtProvider.getIfAvailable()).thenReturn(adminExt);
         provider = new RocketMQDLQProvider(adminExtProvider, auditService, new RocketMQProperties());
     }
 
@@ -89,5 +90,14 @@ class RocketMQDLQProviderTest {
                 eq("group-a"),
                 contains("matched=0, resent=0, failed=0"),
                 eq("SUCCESS"));
+    }
+
+    @Test
+    void createsUniqueProducerGroupsForConcurrentDlqResends() {
+        String first = RocketMQDLQProvider.nextResendProducerGroup();
+        String second = RocketMQDLQProvider.nextResendProducerGroup();
+
+        assertThat(first).startsWith("studio-dlq-resend-");
+        assertThat(second).startsWith("studio-dlq-resend-").isNotEqualTo(first);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/ShortLivedClientNameTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/ShortLivedClientNameTest.java
@@ -28,9 +28,10 @@ class ShortLivedClientNameTest {
     @Test
     void generatesUniqueNamesWithoutClockDelays() {
         Set<String> names = IntStream.range(0, 100)
-                .mapToObj(ignored -> ShortLivedClientName.next("studio-query"))
+                .parallel()
+                .mapToObj(ignored -> RocketMQAdminClientImpl.nextMessageSenderGroup())
                 .collect(Collectors.toSet());
 
-        assertThat(names).hasSize(100).allMatch(name -> name.startsWith("studio-query-"));
+        assertThat(names).hasSize(100).allMatch(name -> name.startsWith("studio-msg-sender-"));
     }
 }


### PR DESCRIPTION
## Summary
- generate unique RocketMQ producer groups for Studio test-message sends and DLQ resends
- preserve short-lived instance-name behavior
- treat null and non-`SEND_OK` DLQ resend results as failures
- retain failed replay details in audit output

Closes #1045
Closes #1051

## Verification
- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=RocketMQAdminClientImplTest,RocketMQDLQProviderTest,ShortLivedClientNameTest test`