### PR TITLE
ci(web): run Studio frontend tests and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run frontend tests
+        run: npm test
+
+      - name: Lint frontend
+        run: npm run lint
+
       - name: Build frontend
         run: npm run build
 


### PR DESCRIPTION
Closes #754

## Summary
- Run the existing Vitest suite in the existing Node 20 frontend CI job.
- Run ESLint after tests and before the production build.
- Preserve the existing frontend job name and Docker build coverage.

## Verification
- `npm test -- --reporter=dot` (81 files, 401 tests)
- `npm run lint` (0 errors; 3 existing warnings)
- `npm run build`