### PR TITLE
fix: load Proxy nodes after page mount

### DIFF
--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useState, useRef } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   Card,
   Table,
@@ -71,13 +71,7 @@ const ProxyPage: React.FC = () => {
     totalTPS: null as number | null,
   });
 
-  const initialized = useRef<boolean | null>(null);
-  if (initialized.current == null) {
-    initialized.current = true;
-    loadProxyNodes();
-  }
-
-  async function loadProxyNodes() {
+  const loadProxyNodes = useCallback(async () => {
     setLoading(true);
     try {
       const { proxyAddrList, currentProxyAddr } = await queryProxyHomePage();
@@ -114,7 +108,13 @@ const ProxyPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }
+  }, [message, t]);
+
+  useEffect(() => {
+    // The state updates are performed by the asynchronous Proxy API request, not by this effect itself.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void loadProxyNodes();
+  }, [loadProxyNodes]);
 
   const handleViewConfig = (node: ProxyNode) => {
     setSelectedNode(node);

--- a/web/src/pages/studio/__tests__/Proxy.test.tsx
+++ b/web/src/pages/studio/__tests__/Proxy.test.tsx
@@ -66,6 +66,13 @@ describe('ProxyPage', () => {
     vi.mocked(queryProxyHomePage).mockResolvedValue(proxyHome);
   });
 
+  it('loads Proxy nodes once after the page mounts', async () => {
+    renderPage();
+
+    await screen.findByText('127.0.0.1:8081');
+    expect(queryProxyHomePage).toHaveBeenCalledTimes(1);
+  });
+
   it('shows success after the proxy list refreshes', async () => {
     const user = userEvent.setup();
     renderPage();


### PR DESCRIPTION
Closes #1053

## Summary
- move initial Proxy node loading from render into a lifecycle effect
- stabilize the loader callback for hooks dependency tracking
- add a regression test that asserts one initial request

## Verification
- `npm test -- --run src/pages/studio/__tests__/Proxy.test.tsx`
- `npm run lint` (0 errors; 3 existing warnings)
- `npm run build`