### PR TITLE
fix: preserve live multi-cluster topology

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProvider.java
@@ -31,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -59,16 +60,23 @@ public class RealClusterProvider implements ClusterProvider {
             log.info("No NameServer configured; skipping cluster discovery");
             return List.of();
         }
-        return List.of(describeCluster(namesrvAddr));
+        return describeClusters(namesrvAddr);
     }
 
     @Override
     public ClusterVO refreshClusterDetail(String clusterId) {
+        if (clusterId == null || clusterId.isBlank()) {
+            throw new BusinessException(400, "Cluster ID is required");
+        }
         String namesrvAddr = properties.getNamesrvAddr();
         if (namesrvAddr == null || namesrvAddr.isBlank()) {
             throw new BusinessException(400, "No NameServer configured for cluster " + clusterId);
         }
-        return describeCluster(namesrvAddr);
+        return adminFactory.execute(namesrvAddr, null, admin -> toClusterVOs(namesrvAddr,
+                        admin.examineBrokerClusterInfo()).stream()
+                .filter(cluster -> clusterId.equals(cluster.getId()))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(404, "Cluster not found: " + clusterId)));
     }
 
     /**
@@ -79,26 +87,44 @@ public class RealClusterProvider implements ClusterProvider {
      * @throws BusinessException if the NameServer is unreachable or returns an error
      */
     public ClusterVO describeCluster(String namesrvAddr) {
-        return adminFactory.execute(namesrvAddr, null,
-                admin -> toClusterVO(namesrvAddr, admin.examineBrokerClusterInfo()));
+        return describeClusters(namesrvAddr).stream()
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(404, "No cluster found from NameServer " + namesrvAddr));
     }
 
-    private ClusterVO toClusterVO(String namesrvAddr, ClusterInfo clusterInfo) {
+    /**
+     * Returns one topology snapshot for every cluster reported by the configured NameServer.
+     */
+    public List<ClusterVO> describeClusters(String namesrvAddr) {
+        return adminFactory.execute(namesrvAddr, null,
+                admin -> toClusterVOs(namesrvAddr, admin.examineBrokerClusterInfo()));
+    }
+
+    private List<ClusterVO> toClusterVOs(String namesrvAddr, ClusterInfo clusterInfo) {
         Map<String, BrokerData> brokerAddrTable =
                 clusterInfo.getBrokerAddrTable() == null ? Map.of() : clusterInfo.getBrokerAddrTable();
         Map<String, Set<String>> clusterAddrTable =
                 clusterInfo.getClusterAddrTable() == null ? Map.of() : clusterInfo.getClusterAddrTable();
 
-        List<BrokerVO> brokers = brokerAddrTable.values().stream()
+        if (clusterAddrTable.isEmpty()) {
+            return List.of(toClusterVO(namesrvAddr, "DefaultCluster", brokerAddrTable.values()));
+        }
+
+        return clusterAddrTable.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> toClusterVO(namesrvAddr, entry.getKey(), entry.getValue().stream()
+                        .map(brokerAddrTable::get)
+                        .filter(java.util.Objects::nonNull)
+                        .toList()))
+                .toList();
+    }
+
+    private ClusterVO toClusterVO(String namesrvAddr, String clusterName, Collection<BrokerData> brokerData) {
+        List<BrokerVO> brokers = brokerData.stream()
                 .map(this::toBrokerVO)
                 .sorted(Comparator.comparing(BrokerVO::getName,
                         Comparator.nullsLast(Comparator.naturalOrder())))
                 .toList();
-
-        String clusterName = clusterAddrTable.keySet().stream()
-                .sorted()
-                .findFirst()
-                .orElse("DefaultCluster");
 
         List<NameServerVO> nameServers = Arrays.stream(namesrvAddr.split("[;,]"))
                 .map(String::trim)

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProviderTest.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.common.domain.enums.BrokerStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -76,6 +78,16 @@ class RealClusterProviderTest {
         HashMap<String, Set<String>> clusterAddrTable = new HashMap<>();
         clusterAddrTable.put("DefaultCluster", Set.of("broker-a", "broker-b"));
         info.setClusterAddrTable(clusterAddrTable);
+        return info;
+    }
+
+    private ClusterInfo multiClusterInfo() {
+        ClusterInfo info = sampleClusterInfo();
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(0L, "10.0.0.21:10911");
+        info.getBrokerAddrTable().put("broker-c",
+                new BrokerData("AnalyticsCluster", "broker-c", addrs));
+        info.getClusterAddrTable().put("AnalyticsCluster", Set.of("broker-c"));
         return info;
     }
 
@@ -125,5 +137,34 @@ class RealClusterProviderTest {
 
         assertThat(clusters).hasSize(1);
         assertThat(clusters.get(0).getBrokers()).hasSize(2);
+    }
+
+    @Test
+    void discoversAndRefreshesEachClusterWithOnlyItsOwnBrokers() throws Exception {
+        properties.setNamesrvAddr("10.0.0.1:9876");
+        stubClusterInfo("10.0.0.1:9876", multiClusterInfo());
+
+        List<ClusterVO> clusters = provider.discoverClusters();
+
+        assertThat(clusters).extracting(ClusterVO::getId)
+                .containsExactly("AnalyticsCluster", "DefaultCluster");
+        assertThat(clusters.get(0).getBrokers()).extracting(BrokerVO::getName)
+                .containsExactly("broker-c");
+        assertThat(clusters.get(1).getBrokers()).extracting(BrokerVO::getName)
+                .containsExactly("broker-a", "broker-b");
+
+        ClusterVO refreshed = provider.refreshClusterDetail("AnalyticsCluster");
+        assertThat(refreshed.getId()).isEqualTo("AnalyticsCluster");
+        assertThat(refreshed.getBrokers()).extracting(BrokerVO::getName).containsExactly("broker-c");
+    }
+
+    @Test
+    void rejectsUnknownClusterRefreshes() throws Exception {
+        properties.setNamesrvAddr("10.0.0.1:9876");
+        stubClusterInfo("10.0.0.1:9876", sampleClusterInfo());
+
+        assertThatThrownBy(() -> provider.refreshClusterDetail("missing"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Cluster not found");
     }
 }


### PR DESCRIPTION
Closes #1033

## Summary
- discover every cluster returned by NameServer topology rather than collapsing to the first name
- associate each cluster only with its own brokers
- refresh the requested cluster ID and return a structured not-found error for unknown IDs

## Verification
- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=RealClusterProviderTest test`

Health probing remains outside this focused topology and identity change.