### PR TITLE
fix(rocketmq): tolerate missing broker tables in dashboard overview

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProvider.java
@@ -96,6 +96,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
 
             // Collect all unique broker addresses (master only, brokerId=0)
             Set<String> masterAddrs = new HashSet<>();
+
             for (BrokerData brokerData : brokerAddrTable.values()) {
                 if (brokerData == null || brokerData.getBrokerAddrs() == null) {
                     continue;
@@ -104,6 +105,9 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 if (masterAddr != null) {
                     masterAddrs.add(masterAddr);
                 }
+            }
+            if (masterAddrs.isEmpty()) {
+                log.warn("No master broker addresses discovered for dashboard overview");
             }
 
             // Count topics

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProviderTest.java
@@ -17,6 +17,8 @@
 package org.apache.rocketmq.studio.rocketmq;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
@@ -87,6 +89,28 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getStats()).isNotNull();
         assertThat(dashboard.getClusters()).hasSize(1);
         assertThat(dashboard.getClusters().get(0).getBrokers()).isZero();
+    }
+
+    @Test
+    void dashboardShouldNotFailWhenBrokerAddrTableIsNull() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        ClusterInfo info = new ClusterInfo();
+        HashMap<String, Set<String>> clusterAddrTable = new HashMap<>();
+        clusterAddrTable.put("cluster-1", new HashSet<>(List.of("broker-a")));
+        info.setClusterAddrTable(clusterAddrTable);
+        // brokerAddrTable intentionally left null
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(info);
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+
+        RocketMQDashboardProvider provider = new RocketMQDashboardProvider(adminExt);
+
+        DashboardDataVO dashboard = provider.getDashboardData();
+
+        // The cluster is still surfaced (name, status) but no broker statistics exist.
+        assertThat(dashboard.getClusters()).hasSize(1);
+        assertThat(dashboard.getClusters().get(0).getBrokers()).isZero();
+        assertThat(dashboard.getStats().getTotalClusters()).isEqualTo(1);
+        assertThat(dashboard.getStats().getTotalBrokers()).isZero();
     }
 
     private ClusterInfo clusterInfo() {


### PR DESCRIPTION
The dashboard overview dereferenced clusterInfo.getClusterAddrTable()/getBrokerAddrTable() and brokerData.getBrokerAddrs() without null checks; a broker going up or down could NPE and the outer catch turned the whole dashboard into an empty page. Missing tables are now tolerated and partial data is returned. Includes a unit test.