### PR TITLE
fix(cluster): keep write/read queue counts in sync on partial updates

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -154,11 +154,14 @@ public class ClusterService {
         if (command.getFileReservedTime() != null) {
             config.setFileReservedTime(command.getFileReservedTime());
         }
-        if (command.getWriteQueueNums() != null) {
-            config.setWriteQueueNums(command.getWriteQueueNums());
-        }
-        if (command.getReadQueueNums() != null) {
-            config.setReadQueueNums(command.getReadQueueNums());
+        // The broker exposes a single defaultTopicQueueNums property, so a partial update of only
+        // one of the write/read queues must mirror the value onto the other to keep the stored
+        // config consistent with what the broker actually applies.
+        if (command.getWriteQueueNums() != null || command.getReadQueueNums() != null) {
+            int queueNums = command.getWriteQueueNums() != null
+                    ? command.getWriteQueueNums() : command.getReadQueueNums();
+            config.setWriteQueueNums(queueNums);
+            config.setReadQueueNums(queueNums);
         }
         if (command.getBrokerPermission() != null) {
             config.setBrokerPermission(command.getBrokerPermission());

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -559,6 +559,22 @@ class ClusterServiceTest {
     }
 
     @Test
+    void updateClusterConfigShouldMirrorSingleQueueNumsUpdate() {
+        when(clusterProvider.refreshClusterDetail("cluster-1")).thenReturn(sampleCluster);
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .writeQueueNums(12)
+                .build();
+
+        ClusterConfigUpdateResultVO result = clusterService.updateClusterConfig(command);
+
+        // The broker exposes a single defaultTopicQueueNums property, so the stored write and read
+        // queue counts must stay in sync after a partial update.
+        assertThat(result.getCluster().getConfig().getWriteQueueNums()).isEqualTo(12);
+        assertThat(result.getCluster().getConfig().getReadQueueNums()).isEqualTo(12);
+    }
+
+    @Test
     void updateClusterConfigShouldUseLiveClusterWhenItIsNotPersisted() {
         when(clusterProvider.refreshClusterDetail("cluster-1")).thenReturn(sampleCluster);
         UpdateConfigDTO command = UpdateConfigDTO.builder()


### PR DESCRIPTION
The broker exposes a single defaultTopicQueueNums property, but updating only writeQueueNums or only readQueueNums left the two stored counts inconsistent with what the broker applies. A partial update now mirrors the value onto both counts. Includes a unit test.