### PR TITLE
fix(dlq): tolerate single-queue scan failures during resend collection

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProvider.java
@@ -196,27 +196,33 @@ public class RocketMQDLQProvider implements DLQProvider {
             }
             outer:
             for (MessageQueue queue : queues) {
-                long minOffset = consumer.searchOffset(queue, begin);
-                long maxOffset = consumer.searchOffset(queue, end);
-                for (long offset = minOffset; offset <= maxOffset; ) {
-                    if (result.size() >= RESEND_HARD_CAP) {
-                        break outer;
-                    }
-                    PullResult pullResult = consumer.pull(queue, "*", offset, 32);
-                    offset = pullResult.getNextBeginOffset();
-                    if (pullResult.getPullStatus() != PullStatus.FOUND
-                            || pullResult.getMsgFoundList() == null) {
-                        break;
-                    }
-                    for (MessageExt messageExt : pullResult.getMsgFoundList()) {
-                        if (messageExt.getStoreTimestamp() >= begin
-                                && messageExt.getStoreTimestamp() <= end) {
-                            result.add(messageExt);
-                            if (result.size() >= RESEND_HARD_CAP) {
-                                break outer;
+                // A single queue failing (e.g. an illegal offset under concurrent consumption)
+                // must not abort the whole DLQ scan silently; skip it and keep collecting the rest.
+                try {
+                    long minOffset = consumer.searchOffset(queue, begin);
+                    long maxOffset = consumer.searchOffset(queue, end);
+                    for (long offset = minOffset; offset <= maxOffset; ) {
+                        if (result.size() >= RESEND_HARD_CAP) {
+                            break outer;
+                        }
+                        PullResult pullResult = consumer.pull(queue, "*", offset, 32);
+                        offset = pullResult.getNextBeginOffset();
+                        if (pullResult.getPullStatus() != PullStatus.FOUND
+                                || pullResult.getMsgFoundList() == null) {
+                            break;
+                        }
+                        for (MessageExt messageExt : pullResult.getMsgFoundList()) {
+                            if (messageExt.getStoreTimestamp() >= begin
+                                    && messageExt.getStoreTimestamp() <= end) {
+                                result.add(messageExt);
+                                if (result.size() >= RESEND_HARD_CAP) {
+                                    break outer;
+                                }
                             }
                         }
                     }
+                } catch (Exception e) {
+                    log.warn("Failed to scan DLQ queue {} in {}: {}", queue, dlqTopic, e.getMessage());
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
collectDeadLetters ran searchOffset/pull for every queue inside one big try; a single queue error (e.g. illegal offset under concurrent consumption) aborted the whole scan, silently skipping the remaining queues while resendMessages still reported SUCCESS. Each queue is now scanned in its own try/catch and failures are logged and skipped.