### PR TITLE
fix(topic): validate required topic on message send

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/SendMessageDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/SendMessageDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.instance.topic;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,6 +29,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SendMessageDTO {
+    @NotBlank(message = "topic is required")
     private String topic;
     private String tag;
     private String key;

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/TopicController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/TopicController.java
@@ -75,7 +75,7 @@ public class TopicController {
     }
 
     @PostMapping("/send")
-    public Result<SendMessageVO> sendMessage(@RequestBody(required = false) SendMessageDTO request) {
+    public Result<SendMessageVO> sendMessage(@Valid @RequestBody(required = false) SendMessageDTO request) {
         requireSendMessageRequest(request);
         return Result.ok(metadataService.sendMessage(request));
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/TopicControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/TopicControllerTest.java
@@ -256,4 +256,16 @@ class TopicControllerTest {
 
         verifyNoInteractions(metadataService);
     }
+
+    @Test
+    void sendMessageShouldRejectMissingTopic() throws Exception {
+        mockMvc.perform(post("/api/topics/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"hello\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("topic is required"));
+
+        verifyNoInteractions(metadataService);
+    }
 }


### PR DESCRIPTION
POST /api/topics/send did not validate the request body, so a missing topic fell through to the producer and surfaced as a generic 500. SendMessageDTO.topic is now @NotBlank and the controller validates it, returning a 400 with a clear message. Includes a unit test.