### PR TITLE
feat: add mqctl diagnostic CLI and runbooks

### DIFF
--- a/mqctl/go.mod
+++ b/mqctl/go.mod
@@ -1,0 +1,3 @@
+module github.com/apache/rocketmq-dashboard/mqctl
+
+go 1.22

--- a/mqctl/main.go
+++ b/mqctl/main.go
@@ -1,0 +1,212 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main implements mqctl, a CLI for RocketMQ Studio.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/apache/rocketmq-dashboard/mqctl/skill"
+	"github.com/apache/rocketmq-dashboard/mqctl/skill/brokerbusy"
+	"github.com/apache/rocketmq-dashboard/mqctl/skill/consumerlag"
+	"github.com/apache/rocketmq-dashboard/mqctl/studio"
+)
+
+func main() {
+	for _, a := range os.Args[1:] {
+		if a == "-h" || a == "--help" {
+			usage()
+			return
+		}
+	}
+
+	fs := flag.NewFlagSet("mqctl", flag.ExitOnError)
+	studioURL := fs.String("studio", envOr("STUDIO_URL", "http://127.0.0.1:8888"), "studio base url")
+	cluster := fs.String("cluster", "", "cluster id (required by remote tools)")
+	pretty := fs.Bool("pretty", true, "pretty-print diagnosis output")
+	inputJSON := fs.String("input", "", "tool input JSON for the call command")
+	fs.Parse(reorderArgs(os.Args[1:]))
+
+	args := fs.Args()
+	if len(args) == 0 {
+		usage()
+		os.Exit(2)
+	}
+
+	registry := skill.NewRegistry()
+	registry.Register(consumerlag.Skill{})
+	registry.Register(brokerbusy.Skill{})
+
+	client := studio.New(*studioURL)
+	sctx := skill.Context{Client: client, Cluster: *cluster}
+
+	switch args[0] {
+	case "tools":
+		listTools(client, *cluster)
+	case "call":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: mqctl [--input 'JSON'] call <tool>")
+			os.Exit(2)
+		}
+		callTool(client, *cluster, args[1], *inputJSON)
+	case "skills":
+		listSkills(registry)
+	case "diagnose":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "usage: mqctl diagnose <skill>")
+			os.Exit(2)
+		}
+		runDiagnose(registry, args[1], sctx, *pretty)
+	case "-h", "--help", "help":
+		usage()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
+		usage()
+		os.Exit(2)
+	}
+}
+
+func listTools(c *studio.Client, cluster string) {
+	tools, err := c.ListTools(cluster)
+	if err != nil {
+		fatal(err)
+	}
+	fmt.Printf("%-28s  %-8s  %s\n", "NAME", "RISK", "DESCRIPTION")
+	for _, t := range tools {
+		fmt.Printf("%-28s  %-8s  %s\n", t.Name, t.RiskLevel, t.Description)
+	}
+}
+
+func callTool(c *studio.Client, cluster, name, inputJSON string) {
+	input := map[string]any{}
+	if cluster != "" {
+		input["cluster"] = cluster
+	}
+	if inputJSON != "" {
+		var extra map[string]any
+		if err := json.Unmarshal([]byte(inputJSON), &extra); err != nil {
+			fatal(fmt.Errorf("invalid --input: %w", err))
+		}
+		for k, v := range extra {
+			input[k] = v
+		}
+	}
+	out, err := c.ExecuteTool(name, input)
+	if err != nil {
+		fatal(err)
+	}
+	b, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		fatal(err)
+	}
+	fmt.Println(string(b))
+}
+
+func listSkills(r *skill.Registry) {
+	for _, name := range r.Names() {
+		s, _ := r.Get(name)
+		fmt.Printf("%-20s  %s\n", name, s.Description())
+	}
+}
+
+func runDiagnose(r *skill.Registry, name string, sctx skill.Context, pretty bool) {
+	s, ok := r.Get(name)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "unknown skill: %s (try 'skills')\n", name)
+		os.Exit(2)
+	}
+	diag, err := s.Run(context.Background(), sctx)
+	if err != nil {
+		fatal(err)
+	}
+	var b []byte
+	if pretty {
+		b, err = json.MarshalIndent(diag, "", "  ")
+	} else {
+		b, err = json.Marshal(diag)
+	}
+	if err != nil {
+		fatal(err)
+	}
+	fmt.Println(string(b))
+}
+
+func usage() {
+	fmt.Println(`mqctl - RocketMQ Studio CLI
+
+usage:
+  mqctl [--studio URL] [--cluster ID] <command>
+
+commands:
+  tools                 list AI tools exposed by Studio
+  call <tool>            call a Studio tool and print the result
+  skills                 list built-in diagnostic skills
+  diagnose <skill>       run a diagnostic skill (e.g. consumer-lag, broker-busy)
+
+flags:
+  --studio URL   studio base url (env STUDIO_URL, default http://127.0.0.1:8888)
+  --cluster ID   cluster id (required by remote tools)
+  --input JSON   tool input JSON for the call command
+  --pretty       pretty-print diagnosis output (default true)`)
+}
+
+func fatal(err error) {
+	fmt.Fprintf(os.Stderr, "mqctl: %v\n", err)
+	os.Exit(1)
+}
+
+func envOr(key, dflt string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return dflt
+}
+
+var stringFlags = map[string]bool{"studio": true, "cluster": true, "input": true}
+var boolFlags = map[string]bool{"pretty": true}
+
+func reorderArgs(argv []string) []string {
+	var flags, pos []string
+	for i := 0; i < len(argv); i++ {
+		a := argv[i]
+		if strings.HasPrefix(a, "--") {
+			name := strings.TrimPrefix(a, "--")
+			if strings.IndexByte(name, '=') >= 0 {
+				flags = append(flags, a)
+				continue
+			}
+			if boolFlags[name] {
+				flags = append(flags, a)
+				continue
+			}
+			if stringFlags[name] {
+				flags = append(flags, a)
+				if i+1 < len(argv) {
+					flags = append(flags, argv[i+1])
+					i++
+				}
+				continue
+			}
+		}
+		pos = append(pos, a)
+	}
+	return append(flags, pos...)
+}

--- a/mqctl/skill/brokerbusy/brokerbusy.go
+++ b/mqctl/skill/brokerbusy/brokerbusy.go
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package brokerbusy implements the broker-busy diagnostic skill. See runbooks/broker-busy.md.
+package brokerbusy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/rocketmq-dashboard/mqctl/skill"
+)
+
+const SkillName = "broker-busy"
+
+type Skill struct{}
+
+func (Skill) Name() string        { return SkillName }
+func (Skill) Description() string { return "Diagnose broker busy / write rejection." }
+
+func (s Skill) Run(ctx context.Context, sctx skill.Context) (*skill.Diagnosis, error) {
+	diag := &skill.Diagnosis{Skill: SkillName, Severity: skill.SeverityUnknown}
+
+	out, err := sctx.Client.ExecuteTool("rmq.cluster.list", map[string]any{})
+	if err != nil {
+		diag.Summary = "Cannot fetch cluster list from Studio"
+		diag.Notes = append(diag.Notes, err.Error())
+		return diag, nil
+	}
+	clusters, err := asClusterList(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse rmq.cluster.list output: %w", err)
+	}
+
+	diag.Summary = fmt.Sprintf("%d clusters found; missing broker-level data sources, cannot judge busy", len(clusters))
+	for _, c := range clusters {
+		diag.Findings = append(diag.Findings, skill.Finding{
+			Item: c.name(),
+			Detail: map[string]any{
+				"id":      c.id(),
+				"status":  c.status(),
+				"version": c.version(),
+			},
+		})
+	}
+
+	diag.Notes = append(diag.Notes,
+		"Judging IO/GC/lock needs rmq.broker.status and rmq.broker.config (both unexposed); "+
+			"host-level CPU/disk/GC needs agent/JMX. Until then, mqadmin brokerStatus / getBrokerConfig can be used directly.")
+	return diag, nil
+}
+
+func asClusterList(out any) ([]clusterView, error) {
+	arr, ok := out.([]any)
+	if !ok {
+		return nil, fmt.Errorf("expected array, got %T", out)
+	}
+	clusters := make([]clusterView, 0, len(arr))
+	for i, el := range arr {
+		m, ok := el.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("element %d: expected object, got %T", i, el)
+		}
+		clusters = append(clusters, clusterView{raw: m})
+	}
+	return clusters, nil
+}
+
+type clusterView struct{ raw map[string]any }
+
+func (c clusterView) name() string    { return asString(c.raw["name"]) }
+func (c clusterView) id() string      { return asString(c.raw["id"]) }
+func (c clusterView) status() string  { return asString(c.raw["status"]) }
+func (c clusterView) version() string { return asString(c.raw["version"]) }
+
+func asString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+var _ skill.Skill = Skill{}

--- a/mqctl/skill/brokerbusy/brokerbusy_test.go
+++ b/mqctl/skill/brokerbusy/brokerbusy_test.go
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package brokerbusy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/apache/rocketmq-dashboard/mqctl/skill"
+)
+
+type fakeClient struct {
+	resp map[string]any
+	errs map[string]error
+}
+
+func (f fakeClient) ExecuteTool(name string, _ map[string]any) (any, error) {
+	if e, ok := f.errs[name]; ok {
+		return nil, e
+	}
+	if r, ok := f.resp[name]; ok {
+		return r, nil
+	}
+	return nil, fmt.Errorf("unexpected tool call: %s", name)
+}
+
+func TestRun_ReportsGapWhenNoBrokerData(t *testing.T) {
+	c := fakeClient{resp: map[string]any{
+		"rmq.cluster.list": []any{
+			map[string]any{"id": "c1", "name": "cluster1", "status": "ONLINE", "version": "5.x"},
+		},
+	}}
+	diag, err := Skill{}.Run(context.Background(), skill.Context{Client: c})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diag.Severity != skill.SeverityUnknown {
+		t.Errorf("want UNKNOWN, got %s", diag.Severity)
+	}
+	if len(diag.Findings) != 1 {
+		t.Fatalf("want 1 cluster finding, got %d", len(diag.Findings))
+	}
+	if diag.Findings[0].Item != "cluster1" {
+		t.Errorf("want item cluster1, got %s", diag.Findings[0].Item)
+	}
+	joined := strings.Join(diag.Notes, " ")
+	if !strings.Contains(joined, "broker.status") || !strings.Contains(joined, "broker.config") {
+		t.Errorf("want gap note about broker.status/broker.config, got %v", diag.Notes)
+	}
+}
+
+func TestRun_UnknownWhenFetchFails(t *testing.T) {
+	c := fakeClient{errs: map[string]error{"rmq.cluster.list": errors.New("boom")}}
+	diag, err := Skill{}.Run(context.Background(), skill.Context{Client: c})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diag.Severity != skill.SeverityUnknown {
+		t.Errorf("want UNKNOWN, got %s", diag.Severity)
+	}
+}

--- a/mqctl/skill/consumerlag/consumerlag.go
+++ b/mqctl/skill/consumerlag/consumerlag.go
@@ -1,0 +1,148 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package consumerlag implements the consumer-lag diagnostic skill. See runbooks/consumer-lag.md.
+package consumerlag
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/apache/rocketmq-dashboard/mqctl/skill"
+)
+
+const SkillName = "consumer-lag"
+
+const LagThreshold int64 = 1000
+
+type Skill struct{}
+
+func (Skill) Name() string        { return SkillName }
+func (Skill) Description() string { return "Diagnose consumer-group message lag." }
+
+func (s Skill) Run(ctx context.Context, sctx skill.Context) (*skill.Diagnosis, error) {
+	if sctx.Cluster == "" {
+		return nil, fmt.Errorf("consumer-lag requires --cluster")
+	}
+	diag := &skill.Diagnosis{Skill: SkillName}
+
+	out, err := sctx.Client.ExecuteTool("rmq.group.list", map[string]any{
+		"cluster": sctx.Cluster,
+	})
+	if err != nil {
+		diag.Severity = skill.SeverityUnknown
+		diag.Summary = "Cannot fetch consumer groups from Studio"
+		diag.Notes = append(diag.Notes, err.Error())
+		return diag, nil
+	}
+	groups, err := asGroupList(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse rmq.group.list output: %w", err)
+	}
+
+	var lagging []groupLag
+	for _, g := range groups {
+		lag := g.totalLag()
+		if lag >= LagThreshold {
+			lagging = append(lagging, groupLag{name: g.name(), lag: lag, online: g.onlineInstances()})
+		}
+	}
+
+	switch {
+	case len(lagging) == 0:
+		diag.Severity = skill.SeverityOK
+		diag.Summary = fmt.Sprintf("No significant lag (threshold %d), %d groups", LagThreshold, len(groups))
+	case len(lagging) == 1:
+		diag.Severity = skill.SeverityWarning
+		diag.Summary = fmt.Sprintf("1 lagging group (threshold %d)", LagThreshold)
+	default:
+		diag.Severity = skill.SeverityCritical
+		diag.Summary = fmt.Sprintf("%d lagging groups (threshold %d)", len(lagging), LagThreshold)
+	}
+
+	for _, l := range lagging {
+		hint := "likely client not started / rebalance issue"
+		if l.online > 0 {
+			hint = "online but falling behind; need client stack to tell client vs broker"
+		}
+		diag.Findings = append(diag.Findings, skill.Finding{
+			Item: l.name,
+			Detail: map[string]any{
+				"totalLag":        l.lag,
+				"onlineInstances": l.online,
+				"interpretation":  hint,
+			},
+		})
+	}
+
+	diag.Notes = append(diag.Notes,
+		"Root-cause split (client vs broker) needs rmq.group.progress and rmq.client.stack, neither exposed yet; integrate once available.")
+	return diag, nil
+}
+
+type groupLag struct {
+	name   string
+	lag    int64
+	online int64
+}
+
+func asGroupList(out any) ([]groupView, error) {
+	arr, ok := out.([]any)
+	if !ok {
+		return nil, fmt.Errorf("expected array, got %T", out)
+	}
+	groups := make([]groupView, 0, len(arr))
+	for i, el := range arr {
+		m, ok := el.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("element %d: expected object, got %T", i, el)
+		}
+		groups = append(groups, groupView{raw: m})
+	}
+	return groups, nil
+}
+
+type groupView struct{ raw map[string]any }
+
+func (g groupView) name() string {
+	if v, ok := g.raw["name"].(string); ok {
+		return v
+	}
+	return "<unknown>"
+}
+
+func (g groupView) totalLag() int64        { return toInt64(g.raw["totalLag"]) }
+func (g groupView) onlineInstances() int64 { return toInt64(g.raw["onlineInstances"]) }
+
+func toInt64(v any) int64 {
+	switch n := v.(type) {
+	case nil:
+		return 0
+	case float64:
+		return int64(n)
+	case int:
+		return int64(n)
+	case int64:
+		return n
+	case string:
+		x, _ := strconv.ParseInt(n, 10, 64)
+		return x
+	default:
+		return 0
+	}
+}
+
+var _ skill.Skill = Skill{}

--- a/mqctl/skill/consumerlag/consumerlag_test.go
+++ b/mqctl/skill/consumerlag/consumerlag_test.go
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consumerlag
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/apache/rocketmq-dashboard/mqctl/skill"
+)
+
+type fakeClient struct {
+	resp map[string]any
+	errs map[string]error
+}
+
+func (f fakeClient) ExecuteTool(name string, _ map[string]any) (any, error) {
+	if e, ok := f.errs[name]; ok {
+		return nil, e
+	}
+	if r, ok := f.resp[name]; ok {
+		return r, nil
+	}
+	return nil, fmt.Errorf("unexpected tool call: %s", name)
+}
+
+func TestRun_RequiresCluster(t *testing.T) {
+	s := Skill{}
+	ctx := skill.Context{}
+	if _, err := s.Run(context.Background(), ctx); err == nil {
+		t.Fatal("want error when cluster is empty")
+	}
+}
+
+func TestRun_NoLag(t *testing.T) {
+	c := fakeClient{resp: map[string]any{
+		"rmq.group.list": []any{
+			map[string]any{"name": "g1", "totalLag": float64(10), "onlineInstances": float64(1)},
+		},
+	}}
+	diag, err := Skill{}.Run(context.Background(), skill.Context{Client: c, Cluster: "c1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diag.Severity != skill.SeverityOK {
+		t.Errorf("want OK, got %s", diag.Severity)
+	}
+	if len(diag.Findings) != 0 {
+		t.Errorf("want 0 findings, got %d", len(diag.Findings))
+	}
+}
+
+func TestRun_LaggingGroups(t *testing.T) {
+	c := fakeClient{resp: map[string]any{
+		"rmq.group.list": []any{
+			map[string]any{"name": "ok", "totalLag": float64(500), "onlineInstances": float64(2)},
+			map[string]any{"name": "lag-online", "totalLag": float64(5000), "onlineInstances": float64(1)},
+			map[string]any{"name": "lag-offline", "totalLag": float64(2000), "onlineInstances": float64(0)},
+		},
+	}}
+	diag, err := Skill{}.Run(context.Background(), skill.Context{Client: c, Cluster: "c1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diag.Severity != skill.SeverityCritical {
+		t.Errorf("want CRITICAL, got %s", diag.Severity)
+	}
+	if len(diag.Findings) != 2 {
+		t.Fatalf("want 2 findings, got %d", len(diag.Findings))
+	}
+	if got := diag.Findings[0].Detail["interpretation"]; got == "" {
+		t.Errorf("want non-empty interpretation")
+	}
+}
+
+func TestRun_UnknownWhenFetchFails(t *testing.T) {
+	c := fakeClient{errs: map[string]error{"rmq.group.list": errors.New("boom")}}
+	diag, err := Skill{}.Run(context.Background(), skill.Context{Client: c, Cluster: "c1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diag.Severity != skill.SeverityUnknown {
+		t.Errorf("want UNKNOWN, got %s", diag.Severity)
+	}
+	if len(diag.Notes) == 0 {
+		t.Errorf("want failure note recorded")
+	}
+}

--- a/mqctl/skill/skill.go
+++ b/mqctl/skill/skill.go
@@ -1,0 +1,88 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package skill defines the diagnostic skill interface.
+package skill
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+type ToolClient interface {
+	ExecuteTool(name string, input map[string]any) (any, error)
+}
+
+type Context struct {
+	Client  ToolClient
+	Cluster string
+}
+
+type Severity string
+
+const (
+	SeverityOK       Severity = "OK"
+	SeverityWarning  Severity = "WARNING"
+	SeverityCritical Severity = "CRITICAL"
+	SeverityUnknown  Severity = "UNKNOWN"
+)
+
+type Finding struct {
+	Item   string         `json:"item"`
+	Detail map[string]any `json:"detail"`
+	Note   string         `json:"note,omitempty"`
+}
+
+type Diagnosis struct {
+	Skill    string    `json:"skill"`
+	Severity Severity  `json:"severity"`
+	Summary  string    `json:"summary"`
+	Findings []Finding `json:"findings"`
+	Notes    []string  `json:"notes,omitempty"`
+}
+
+type Skill interface {
+	Name() string
+	Description() string
+	Run(ctx context.Context, sctx Context) (*Diagnosis, error)
+}
+
+type Registry struct {
+	skills map[string]Skill
+}
+
+func NewRegistry() *Registry { return &Registry{skills: map[string]Skill{}} }
+
+func (r *Registry) Register(s Skill) {
+	if _, dup := r.skills[s.Name()]; dup {
+		panic(fmt.Sprintf("duplicate skill: %s", s.Name()))
+	}
+	r.skills[s.Name()] = s
+}
+
+func (r *Registry) Get(name string) (Skill, bool) {
+	s, ok := r.skills[name]
+	return s, ok
+}
+
+func (r *Registry) Names() []string {
+	out := make([]string, 0, len(r.skills))
+	for n := range r.skills {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/mqctl/studio/client.go
+++ b/mqctl/studio/client.go
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package studio is a client for RocketMQ Studio over /api/ai.
+package studio
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type Result[T any] struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    T      `json:"data"`
+}
+
+const successCode = 200
+
+type ToolVO struct {
+	Name               string   `json:"name"`
+	Description        string   `json:"description"`
+	Parameters         any      `json:"parameters"`
+	RiskLevel          string   `json:"riskLevel"`
+	Permission         string   `json:"permission"`
+	RequiredCapability []string `json:"requiredCapabilities"`
+	OutputSchema       any      `json:"outputSchema"`
+	ViewHint           string   `json:"viewHint"`
+	Deprecated         bool     `json:"deprecated"`
+	Replacement        string   `json:"replacement"`
+}
+
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+func New(baseURL string) *Client {
+	return &Client{
+		BaseURL:    strings.TrimRight(baseURL, "/"),
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (c *Client) ListTools(cluster string) ([]ToolVO, error) {
+	u := c.BaseURL + "/api/ai/tools"
+	if cluster != "" {
+		q := url.Values{}
+		q.Set("cluster", cluster)
+		u = u + "?" + q.Encode()
+	}
+	resp, err := c.HTTPClient.Get(u)
+	if err != nil {
+		return nil, fmt.Errorf("list tools: %w", err)
+	}
+	defer resp.Body.Close()
+	var res Result[[]ToolVO]
+	if err := decodeBody(resp, &res); err != nil {
+		return nil, err
+	}
+	if res.Code != successCode {
+		return nil, fmt.Errorf("list tools: studio error %d: %s", res.Code, res.Message)
+	}
+	return res.Data, nil
+}
+
+func (c *Client) ExecuteTool(name string, input map[string]any) (any, error) {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("execute %s: marshal input: %w", name, err)
+	}
+	u := c.BaseURL + "/api/ai/tools/" + url.PathEscape(name) + "/execute"
+	req, err := http.NewRequest(http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute %s: %w", name, err)
+	}
+	defer resp.Body.Close()
+	var res Result[any]
+	if err := decodeBody(resp, &res); err != nil {
+		return nil, err
+	}
+	if res.Code != successCode {
+		return nil, fmt.Errorf("execute %s: studio error %d: %s", name, res.Code, res.Message)
+	}
+	return res.Data, nil
+}
+
+func decodeBody(resp *http.Response, dst any) error {
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}

--- a/mqctl/studio/client_test.go
+++ b/mqctl/studio/client_test.go
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package studio
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestListTools(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/ai/tools" || r.URL.Query().Get("cluster") != "c1" {
+			t.Errorf("unexpected request: %s?%s", r.URL.Path, r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":200,"message":"success","data":[{"name":"rmq.cluster.list","description":"d","riskLevel":"L1"}]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	tools, err := c.ListTools("c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "rmq.cluster.list" {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+}
+
+func TestListTools_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	if _, err := New(srv.URL).ListTools(""); err == nil {
+		t.Fatal("want error on http 500")
+	}
+}
+
+func TestListTools_ErrorCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"code":404,"message":"not found","data":null}`))
+	}))
+	defer srv.Close()
+
+	if _, err := New(srv.URL).ListTools(""); err == nil {
+		t.Fatal("want error on non-success code")
+	}
+}
+
+func TestExecuteTool(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/api/ai/tools/rmq.group.list/execute") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"code":200,"message":"success","data":[{"name":"g1","totalLag":3}]}`))
+	}))
+	defer srv.Close()
+
+	out, err := New(srv.URL).ExecuteTool("rmq.group.list", map[string]any{"cluster": "c1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	arr, ok := out.([]any)
+	if !ok || len(arr) != 1 {
+		t.Fatalf("want 1-element array, got %T %+v", out, out)
+	}
+}

--- a/runbooks/broker-busy.md
+++ b/runbooks/broker-busy.md
@@ -1,0 +1,71 @@
+---
+name: broker-busy
+description: 排查 broker busy / 写入拒绝。当用户报"broker busy""REJECT""写不进""CPU 打满""broker 卡"时触发。通过 mqctl 调 studio 工具拿 broker 运行状态和关键配置,判断是 IO 瓶颈、GC 还是锁竞争,给出调优建议。
+---
+
+# broker busy 排查
+
+## 适用场景
+
+broker 报 `REJECT[BROKER_BUSY]` / 写入拒绝;CPU 打满;磁盘跟不上;put TPS 异常下降。
+
+## 诊断流程
+
+### 第 1 步:看 broker 运行状态
+
+```
+mqctl diagnose broker-busy
+```
+
+或单独取 broker 状态(需 studio 已暴露该 tool,见数据源):
+
+```
+mqctl call rmq.broker.status --cluster <集群> --input '<入参 JSON,以 studio 暴露时的 schema 为准>'
+```
+
+> `rmq.broker.status` 当前未暴露,上面的命令会失败;可用主仓库 mqadmin 兜底(直连):`mqadmin brokerStatus -n <namesrv> -b <brokerAddr>`。
+
+关注:
+- put/get TPS —— 是否吞吐异常。
+- store 统计 —— 积压、commit/flush 是否滞后。
+- runtime —— JVM、线程状态。
+
+### 第 2 步:看关键 IO 配置
+
+```
+mqctl call rmq.broker.config --cluster <集群> --input '<入参 JSON,以 studio 暴露时的 schema 为准>'
+```
+
+> 同样未暴露,mqadmin 兜底:`mqadmin getBrokerConfig -n <namesrv> -b <brokerAddr>`。
+
+关注这几个 IO 相关配置:
+- `flushDiskType` —— 同步刷盘 / 异步刷盘。
+- `transientStorePoolEnable` —— 是否开了堆外内存池(写绕开 page cache)。
+- `useReentrantLockWhenPutMessage` —— 写锁类型(ReentrantLock vs 自旋)。
+- `flushCommitLogLeastPages` / `commitCommitLogLeastPages` —— 刷盘/commit 攒页阈值。
+
+### 第 3 步:机器级指标(CPU/磁盘/GC)
+
+> **卡点**:OS 级 CPU/磁盘 util、JVM GC 这些机器指标,studio 直连拿不到,需在 broker 机器装 agent 或接 JMX(待确认)。目前没有现成 tool,需现场配合(登机器 top/iostat/jstat)。
+
+## 判读规则
+
+| 现象 | 判断 | 建议 |
+|---|---|---|
+| 磁盘 util 高 + flush 滞后 | IO 瓶颈 | 开 `transientStorePoolEnable=true`(堆外池)、改异步刷盘、换更快磁盘 |
+| GC 频繁 / 停顿长 | JVM 内存问题 | 调堆/直接内存、查内存泄漏 |
+| `putMessageLock` 等待高 | 写入串行瓶颈 | 调 `useReentrantLockWhenPutMessage`、拆 topic 分散写入 |
+| CPU 用户态高(非 IO) | 计算密集 | 查是否有重过滤/序列化开销,扩 broker |
+
+## 与消费堆积的关系
+
+若消费堆积排查走到"不是客户端的锅、broker 给不动",转入本 skill 看 broker 是否 busy。
+
+## 数据源(依赖的 tool)
+
+| tool | 现状 | 用途 |
+|---|---|---|
+| `rmq.cluster.list` | 已暴露(集群级,非 broker 级) | 连通性确认、集群上下文 |
+| `rmq.broker.status` | 未暴露(mqadmin brokerStatus 有数据) | broker 运行状态 |
+| `rmq.broker.config` | 未暴露(mqadmin getBrokerConfig 有数据) | broker IO 配置 |
+| broker 机器级指标(CPU/磁盘/GC) | 无采集机制,需 agent/JMX(待确认) | OS 与 JVM 指标 |

--- a/runbooks/consumer-lag.md
+++ b/runbooks/consumer-lag.md
@@ -1,0 +1,69 @@
+---
+name: consumer-lag
+description: 排查消费堆积(consumer lag)。当用户说"消费堆积了""lag 高""消费跟不上""消息堆着"时触发。通过 mqctl 调 studio 工具拿消费组堆积量(lag)和客户端线程栈,判断是卡在客户端还是 broker,给出处置建议。
+---
+
+# 消费堆积排查
+
+## 适用场景
+
+某消费组 lag 持续走高、不收敛;消费 TPS 远低于生产 TPS;消费端无报错但消息不前进。
+
+## 诊断流程
+
+### 第 1 步:量化堆积
+
+直接跑诊断 skill,它会调 `rmq.group.list` 取堆积并按阈值分级:
+
+```
+mqctl diagnose consumer-lag --cluster <集群>
+```
+
+或单独取原始数据:
+
+```
+mqctl call rmq.group.list --cluster <集群>
+```
+
+关注:
+- `totalLag` —— 总堆积量。
+- per-queue lag —— 堆积分布是否均匀(需 `rmq.group.progress`,见数据源)。
+- `onlineInstances` —— 消费端在线实例数。
+
+### 第 2 步:区分根因(卡客户端 vs broker)
+
+**lag 高 + `onlineInstances == 0`**:消费端没起来 / 重平衡异常。先查客户端日志、重启、确认订阅关系。
+
+**lag 高 + 在线 > 0**:需要看消费端线程栈,判断卡没卡。取客户端 stack(按社区说明,机制为 studio 经 broker 转发、由 client 上报线程栈):
+
+```
+mqctl call rmq.client.stack --cluster <集群> --input '{"group":"<消费组>","clientId":"<id>"}'
+```
+
+> `rmq.client.stack` 当前 studio 未暴露(501 stub),上面的命令会失败;mqadmin 也没有取消费端线程栈的命令,需登消费端机器用 `jstack <pid>` 取栈。
+
+判读:
+- 线程卡在某行(死锁 / 慢调用 / 阻塞 IO,如卡在查 DB、调外部接口)→ **卡在客户端**。处置:修消费代码、扩并发、排查阻塞点。
+- 线程正常在跑、没卡 → 不是客户端的锅,broker 给不动或生产太快 → 转入 `broker-busy` 排查。
+
+### 第 3 步:细化(若 lag 分布不均)
+
+- lag 集中在个别 queue → 可能单 broker / 分区倾斜。
+- lag 各 queue 均匀 → 整体处理不过来,扩并发或扩 broker。
+
+## 处置建议
+
+| 根因 | 处置 |
+|---|---|
+| 客户端未启动/重平衡异常 | 查客户端日志、重启、确认订阅关系 |
+| 客户端处理慢(线程卡) | 扩并发、优化消费逻辑、排查阻塞点 |
+| broker 给不动 | 转 `broker-busy` 排查 IO/GC/锁 |
+| 生产太快 | 限流上游、扩 broker |
+
+## 数据源(依赖的 tool)
+
+| tool | 现状                                                             | 用途 |
+|---|------------------------------------------------------------------|---|
+| `rmq.group.list` | 已暴露(含 totalLag)                                              | 量化堆积 |
+| `rmq.group.progress` | 未暴露                                                           | per-queue lag 分布 |
+| `rmq.client.stack` | 501 stub;按社区说明机制为 studio 经 broker 让 client 上报,待实现 | 消费端线程栈 |


### PR DESCRIPTION
What is the purpose of the change

  Add the track-3 (AI Native) diagnostic skill layer: a short-lived Go CLI (mqctl) that fetches data from Studio's /api/ai tool gateway, plus two diagnostic skills (consumer-lag, broker-busy) and their runbooks.
  AI tools (Claude Code/Cursor/Trae) load the runbooks and call the CLI to diagnose consumer lag and broker-busy.

  Brief changelog

  - mqctl/: short-lived Go CLI (stdlib-only). Commands: tools / call <tool> / skills / diagnose <skill>.
    - skill/consumerlag: finds lagging consumer groups via rmq.group.list (by totalLag).
    - skill/brokerbusy: lists clusters via rmq.cluster.list, flags broker-level data-source gaps.
    - studio/: JSON/REST client for /api/ai.
  - runbooks/consumer-lag.md, runbooks/broker-busy.md: troubleshooting runbooks for AI tools to load.

  Verifying this change

  cd mqctl
  gofmt -l .          # clean
  go vet ./...        # clean
  go build -o mqctl .
  go test ./...        # all pass (studio client + both skills, httptest-mocked)

  ./mqctl skills
  ./mqctl diagnose consumer-lag --cluster <cluster>   # against a running Studio

  Known gaps (data sources Studio has not exposed yet): rmq.group.progress, rmq.client.stack (501 stub), rmq.broker.status, rmq.broker.config. The skills report these gaps rather than guessing a conclusion.

  Checklist

  - [x] Format the pull request title like [ISSUE #123] Fix xxx. The commits in the pull request should have a meaningful subject line and body.
  - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
  - [x] Write necessary unit-test to verify the logic correction.
  - [ ] Run mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle — N/A: the added code is Go; verified with go vet / go build / go test instead of Maven.
  - [x] Sign the Apache ICLA / DCO (commit carries Signed-off-by).
