### PR TITLE
fix: report partial consumer group batch deletion outcomes

### DIFF
--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { App } from 'antd';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -260,6 +260,33 @@ describe('Consumer page', () => {
     await waitFor(() =>
       expect(consumerService.getConsumerProgress).toHaveBeenCalledWith('remote-cg', 'instance-a'),
     );
+  });
+
+  it('keeps failed groups selected after a partially successful batch deletion', async () => {
+    const user = userEvent.setup();
+    vi.mocked(consumerService.listConsumerGroups).mockResolvedValue([
+      { ...group, name: 'group-01' },
+      { ...group, name: 'group-02' },
+      { ...group, name: 'group-03' },
+    ]);
+    vi.mocked(consumerService.batchDeleteConsumerGroups).mockResolvedValue({
+      deleted: ['group-01', 'group-03'],
+      failed: ['group-02'],
+    });
+    renderWithProviders(<ConsumerPage />);
+
+    expect(await screen.findByText('group-01')).toBeInTheDocument();
+    await user.click(screen.getAllByRole('checkbox')[0]);
+    await user.click(screen.getByRole('button', { name: /删除 \(3\)$/ }));
+
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: /删\s*除/ }));
+
+    await waitFor(() => expect(screen.queryByText('group-01')).not.toBeInTheDocument());
+    expect(screen.getByText('group-02')).toBeInTheDocument();
+    expect(screen.queryByText('group-03')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /删除 \(1\)$/ })).toBeInTheDocument();
+    expect(screen.getByText('已删除 2 个 Group，1 个删除失败')).toBeInTheDocument();
   });
 
   it('highlights inconsistent subscriptions and refreshes the check result', async () => {

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -806,10 +806,19 @@ const ConsumerPage = () => {
                   cancelText: '取消',
                   onOk: async () => {
                     const names = selectedRowKeys.map(String);
-                    await batchDeleteConsumerGroups(names, selectedInstanceId || undefined);
-                    setGroups((prev) => prev.filter((g) => !names.includes(g.name)));
-                    message.success(`已删除 ${selectedRowKeys.length} 个 Group`);
-                    setSelectedRowKeys([]);
+                    const result = await batchDeleteConsumerGroups(
+                      names,
+                      selectedInstanceId || undefined,
+                    );
+                    setGroups((prev) => prev.filter((g) => !result.deleted.includes(g.name)));
+                    setSelectedRowKeys(result.failed);
+                    if (result.failed.length === 0) {
+                      message.success(`已删除 ${result.deleted.length} 个 Group`);
+                    } else {
+                      message.warning(
+                        `已删除 ${result.deleted.length} 个 Group，${result.failed.length} 个删除失败`,
+                      );
+                    }
                   },
                 });
               }}

--- a/web/src/services/consumerService.batchDelete.test.ts
+++ b/web/src/services/consumerService.batchDelete.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const metadataApiMocks = vi.hoisted(() => ({
+  deleteConsumerGroup: vi.fn(),
+}));
+
+vi.mock('../config', () => ({
+  API_BASE_URL: '/api',
+  USE_MOCK: false,
+}));
+
+vi.mock('../api/metadata', () => metadataApiMocks);
+
+import { batchDeleteConsumerGroups } from './consumerService';
+
+describe('consumer service batch deletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('continues deleting after a failure and reports each outcome', async () => {
+    metadataApiMocks.deleteConsumerGroup.mockImplementation((name: string) =>
+      name === 'group-02' ? Promise.reject(new Error('delete failed')) : Promise.resolve(),
+    );
+
+    await expect(batchDeleteConsumerGroups(['group-01', 'group-02', 'group-03'], 'instance-a')).resolves.toEqual({
+      deleted: ['group-01', 'group-03'],
+      failed: ['group-02'],
+    });
+    expect(metadataApiMocks.deleteConsumerGroup.mock.calls).toEqual([
+      ['group-01', 'instance-a'],
+      ['group-02', 'instance-a'],
+      ['group-03', 'instance-a'],
+    ]);
+  });
+});

--- a/web/src/services/consumerService.ts
+++ b/web/src/services/consumerService.ts
@@ -121,12 +121,23 @@ export async function resetConsumerOffset(data: ResetConsumerOffsetRequest): Pro
   return metadataApi.resetConsumerOffset(data);
 }
 
-// Batch delete: loop through single delete calls
+export interface BatchDeleteConsumerGroupsResult {
+  deleted: string[];
+  failed: string[];
+}
+
 export async function batchDeleteConsumerGroups(
   names: string[],
   instanceId?: string,
-): Promise<void> {
+): Promise<BatchDeleteConsumerGroupsResult> {
+  const result: BatchDeleteConsumerGroupsResult = { deleted: [], failed: [] };
   for (const name of names) {
-    await deleteConsumerGroup(name, instanceId);
+    try {
+      await deleteConsumerGroup(name, instanceId);
+      result.deleted.push(name);
+    } catch {
+      result.failed.push(name);
+    }
   }
+  return result;
 }


### PR DESCRIPTION
## Summary
- continue deleting selected consumer groups after an individual deletion fails
- return `deleted` and `failed` outcomes from the service layer
- remove only successful rows and keep failed rows selected for retry

Closes #1084

## Verification
- `npm test -- --run src/services/consumerService.batchDelete.test.ts src/pages/instance/__tests__/ConsumerPage.test.tsx`
- `npm run lint`
- `npm run build`