### PR TITLE
fix: prevent stale async detail responses in management views

### DIFF
--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -31,7 +31,7 @@ import {
   Switch,
   message,
 } from 'antd';
-import { MagnifyingGlass, Plus, ArrowClockwise, Users, Eye } from '@phosphor-icons/react';
+import { MagnifyingGlass, ArrowClockwise, Users, Eye } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
 import type { ConsumerGroup, QueueProgress, SubscriptionEntry } from '../../api/metadata';
 import {
@@ -210,14 +210,9 @@ const GroupManagementPage = () => {
       title: t('common.actions'),
       key: 'action',
       render: (_: unknown, record: ConsumerGroup) => (
-        <Space size="small">
-          <Button type="link" size="small" onClick={() => void handleViewDetail(record)}>
-            {t('common.detail')}
-          </Button>
-          <Button type="link" size="small">
-            {t('brokerCluster.config')}
-          </Button>
-        </Space>
+        <Button type="link" size="small" onClick={() => void handleViewDetail(record)}>
+          {t('common.detail')}
+        </Button>
       ),
     },
   ];
@@ -292,9 +287,6 @@ const GroupManagementPage = () => {
             style={{ width: 240 }}
             allowClear
           />
-          <Button type="primary" icon={<Plus size={14} />}>
-            {t('groupMgmt.createGroup')}
-          </Button>
           <Switch
             checked={autoRefresh}
             onChange={setAutoRefresh}

--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Table,
   Button,
@@ -65,6 +65,7 @@ const GroupManagementPage = () => {
   const [subscriptions, setSubscriptions] = useState<SubscriptionEntry[]>([]);
   const [progress, setProgress] = useState<QueueProgress[]>([]);
   const [detailLoading, setDetailLoading] = useState(false);
+  const detailRequestId = useRef(0);
   const { t } = useLang();
 
   useEffect(() => {
@@ -101,6 +102,7 @@ const GroupManagementPage = () => {
 
   const handleViewDetail = useCallback(
     async (group: ConsumerGroup) => {
+      const requestId = ++detailRequestId.current;
       setSelectedGroup(group);
       setModalVisible(true);
       setSubscriptions([]);
@@ -111,12 +113,16 @@ const GroupManagementPage = () => {
           getConsumerSubscriptions(group.name),
           getConsumerProgress(group.name),
         ]);
+        if (requestId !== detailRequestId.current) return;
         setSubscriptions(subs);
         setProgress(prog);
       } catch {
+        if (requestId !== detailRequestId.current) return;
         message.error(t('consumer.fetchProgressFailed', { name: group.name }));
       } finally {
-        setDetailLoading(false);
+        if (requestId === detailRequestId.current) {
+          setDetailLoading(false);
+        }
       }
     },
     [t],
@@ -317,7 +323,10 @@ const GroupManagementPage = () => {
       <Modal
         title={null}
         open={modalVisible}
-        onCancel={() => setModalVisible(false)}
+        onCancel={() => {
+          ++detailRequestId.current;
+          setModalVisible(false);
+        }}
         footer={null}
         width={720}
         destroyOnClose

--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -31,7 +31,7 @@ import {
   Switch,
   message,
 } from 'antd';
-import { MagnifyingGlass, ArrowClockwise, Users, Eye } from '@phosphor-icons/react';
+import { MagnifyingGlass, ArrowClockwise, Users } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
 import type { ConsumerGroup, QueueProgress, SubscriptionEntry } from '../../api/metadata';
 import {
@@ -243,15 +243,6 @@ const GroupManagementPage = () => {
         <code style={{ background: '#f5f5f5', padding: '2px 6px', borderRadius: 4, fontSize: 12 }}>
           {text}
         </code>
-      ),
-    },
-    {
-      title: t('common.actions'),
-      key: 'action',
-      render: () => (
-        <Button type="link" size="small" icon={<Eye size={14} />}>
-          {t('groupMgmt.viewDistribution')}
-        </Button>
       ),
     },
   ];

--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -44,6 +44,7 @@ import {
 type GroupStatus = 'running' | 'warning' | 'stopped';
 
 const BACKLOG_WARNING_THRESHOLD = 10000;
+const GROUP_REFRESH_INTERVAL_MS = 2000;
 
 const deriveStatus = (group: ConsumerGroup): GroupStatus => {
   if (group.onlineInstances <= 0) return 'stopped';
@@ -65,40 +66,46 @@ const GroupManagementPage = () => {
   const [subscriptions, setSubscriptions] = useState<SubscriptionEntry[]>([]);
   const [progress, setProgress] = useState<QueueProgress[]>([]);
   const [detailLoading, setDetailLoading] = useState(false);
+  const listRequestId = useRef(0);
   const detailRequestId = useRef(0);
   const { t } = useLang();
 
-  useEffect(() => {
-    let cancelled = false;
-
-    const fetchGroups = async () => {
-      try {
-        const data = await listConsumerGroups();
-        if (!cancelled) setGroups(data);
-      } catch {
-        if (!cancelled) message.error(t('consumer.fetchListFailed'));
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-
-    void fetchGroups();
-    return () => {
-      cancelled = true;
-    };
-  }, [t]);
-
-  const handleRefresh = useCallback(async () => {
+  const loadGroups = useCallback(async () => {
+    const requestId = ++listRequestId.current;
     setLoading(true);
     try {
       const data = await listConsumerGroups();
+      if (requestId !== listRequestId.current) return;
       setGroups(data);
     } catch {
+      if (requestId !== listRequestId.current) return;
       message.error(t('consumer.fetchListFailed'));
     } finally {
-      setLoading(false);
+      if (requestId === listRequestId.current) {
+        setLoading(false);
+      }
     }
   }, [t]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      void loadGroups();
+    });
+    return () => window.clearTimeout(timeoutId);
+  }, [loadGroups]);
+
+  useEffect(() => {
+    if (!autoRefresh) return;
+
+    const intervalId = window.setInterval(() => {
+      void loadGroups();
+    }, GROUP_REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(intervalId);
+  }, [autoRefresh, loadGroups]);
+
+  const handleRefresh = useCallback(() => {
+    void loadGroups();
+  }, [loadGroups]);
 
   const handleViewDetail = useCallback(
     async (group: ConsumerGroup) => {
@@ -295,11 +302,7 @@ const GroupManagementPage = () => {
             unCheckedChildren={t('groupMgmt.manual')}
             size="small"
           />
-          <Button
-            icon={<ArrowClockwise size={14} />}
-            size="small"
-            onClick={() => void handleRefresh()}
-          >
+          <Button icon={<ArrowClockwise size={14} />} size="small" onClick={handleRefresh}>
             {t('common.reset')}
           </Button>
         </Space>

--- a/web/src/pages/studio/LiteTopic.tsx
+++ b/web/src/pages/studio/LiteTopic.tsx
@@ -130,6 +130,7 @@ const LiteTopicPage: React.FC = () => {
   const mountedRef = useRef(false);
   const bootstrapRequestId = useRef(0);
   const displayRequestId = useRef(0);
+  const sessionRequestId = useRef(0);
 
   useEffect(() => {
     messageRef.current = message;
@@ -250,16 +251,22 @@ const LiteTopicPage: React.FC = () => {
   };
 
   const handleViewSessions = async (sessionId: string) => {
+    const requestId = ++sessionRequestId.current;
     setSessionDrawerOpen(true);
     setSessionLoading(true);
+    setSessionData(null);
     try {
       const data = await queryLiteTopicSession(sessionId);
+      if (requestId !== sessionRequestId.current) return;
       setSessionData(data);
     } catch {
+      if (requestId !== sessionRequestId.current) return;
       message.error(t('liteTopic.fetchSessionFailed'));
       setSessionData(null);
     } finally {
-      setSessionLoading(false);
+      if (requestId === sessionRequestId.current) {
+        setSessionLoading(false);
+      }
     }
   };
 

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -16,11 +16,11 @@
  */
 
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
-import type { ConsumerGroup } from '../../../api/metadata';
+import type { ConsumerGroup, QueueProgress, SubscriptionEntry } from '../../../api/metadata';
 import * as consumerService from '../../../services/consumerService';
 import GroupManagement from '../GroupManagement';
 
@@ -84,6 +84,14 @@ const renderWithProviders = (ui: React.ReactElement) => {
   );
 };
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
 describe('GroupManagement Page', () => {
   beforeEach(() => {
     vi.mocked(consumerService.listConsumerGroups).mockResolvedValue(groups);
@@ -126,6 +134,58 @@ describe('GroupManagement Page', () => {
     });
     const detailButtons = screen.getAllByText('详情');
     expect(detailButtons.length).toBeGreaterThan(0);
+  });
+
+  it('keeps the latest group detail when an earlier request resolves last', async () => {
+    const firstSubscriptions = createDeferred<SubscriptionEntry[]>();
+    const firstProgress = createDeferred<QueueProgress[]>();
+    const secondSubscriptions = createDeferred<SubscriptionEntry[]>();
+    const secondProgress = createDeferred<QueueProgress[]>();
+    vi.mocked(consumerService.getConsumerSubscriptions).mockImplementation((groupName) =>
+      groupName === 'order-consumer-group'
+        ? firstSubscriptions.promise
+        : secondSubscriptions.promise,
+    );
+    vi.mocked(consumerService.getConsumerProgress).mockImplementation((groupName) =>
+      groupName === 'order-consumer-group' ? firstProgress.promise : secondProgress.promise,
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<GroupManagement />);
+    await screen.findByText('order-consumer-group');
+
+    const detailButtons = screen.getAllByText('详情');
+    await user.click(detailButtons[0]);
+    await user.click(detailButtons[1]);
+
+    await act(async () => {
+      secondSubscriptions.resolve([
+        {
+          topic: 'SECOND_GROUP_TOPIC',
+          expression: '*',
+          type: 'TAG',
+          filterMode: 'TAG',
+          consistency: 'consistent',
+        },
+      ]);
+      secondProgress.resolve([]);
+    });
+    expect(await screen.findByText('SECOND_GROUP_TOPIC')).toBeInTheDocument();
+
+    await act(async () => {
+      firstSubscriptions.resolve([
+        {
+          topic: 'FIRST_GROUP_TOPIC',
+          expression: '*',
+          type: 'TAG',
+          filterMode: 'TAG',
+          consistency: 'consistent',
+        },
+      ]);
+      firstProgress.resolve([]);
+    });
+    expect(screen.getByText('SECOND_GROUP_TOPIC')).toBeInTheDocument();
+    expect(screen.queryByText('FIRST_GROUP_TOPIC')).not.toBeInTheDocument();
   });
 
   it('should filter groups by search text', async () => {

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -114,9 +114,13 @@ describe('GroupManagement Page', () => {
     expect(screen.getByPlaceholderText('搜索消费组')).toBeInTheDocument();
   });
 
-  it('should render create group button', () => {
+  it('should not render unsupported mutation actions in the global view', async () => {
     renderWithProviders(<GroupManagement />);
-    expect(screen.getByText('创建消费组')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('order-consumer-group')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('创建消费组')).not.toBeInTheDocument();
+    expect(screen.queryByText('配置')).not.toBeInTheDocument();
   });
 
   it('should render reset button', () => {

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
@@ -94,9 +94,14 @@ const createDeferred = <T,>() => {
 
 describe('GroupManagement Page', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(consumerService.listConsumerGroups).mockResolvedValue(groups);
     vi.mocked(consumerService.getConsumerProgress).mockResolvedValue([]);
     vi.mocked(consumerService.getConsumerSubscriptions).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should render the page title', () => {
@@ -186,6 +191,57 @@ describe('GroupManagement Page', () => {
     });
     expect(screen.getByText('SECOND_GROUP_TOPIC')).toBeInTheDocument();
     expect(screen.queryByText('FIRST_GROUP_TOPIC')).not.toBeInTheDocument();
+  });
+
+  it('keeps the latest group list when an earlier refresh resolves last', async () => {
+    const initialGroups = createDeferred<ConsumerGroup[]>();
+    const refreshedGroups = createDeferred<ConsumerGroup[]>();
+    vi.mocked(consumerService.listConsumerGroups)
+      .mockReturnValueOnce(initialGroups.promise)
+      .mockReturnValueOnce(refreshedGroups.promise);
+    vi.useFakeTimers();
+    renderWithProviders(<GroupManagement />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    fireEvent.click(screen.getByText('重置'));
+
+    await act(async () => {
+      refreshedGroups.resolve([makeGroup({ name: 'fresh-group' })]);
+      await Promise.resolve();
+    });
+    expect(screen.getByText('fresh-group')).toBeInTheDocument();
+
+    await act(async () => {
+      initialGroups.resolve([makeGroup({ name: 'stale-group' })]);
+      await Promise.resolve();
+    });
+    expect(screen.getByText('fresh-group')).toBeInTheDocument();
+    expect(screen.queryByText('stale-group')).not.toBeInTheDocument();
+  });
+
+  it('polls only while auto refresh is enabled', async () => {
+    vi.useFakeTimers();
+    renderWithProviders(<GroupManagement />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(1);
+
+    const autoRefreshSwitch = screen.getByRole('switch');
+    fireEvent.click(autoRefreshSwitch);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(autoRefreshSwitch);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(2);
   });
 
   it('should filter groups by search text', async () => {

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -121,6 +121,7 @@ describe('GroupManagement Page', () => {
     });
     expect(screen.queryByText('创建消费组')).not.toBeInTheDocument();
     expect(screen.queryByText('配置')).not.toBeInTheDocument();
+    expect(screen.queryByText('查看分布')).not.toBeInTheDocument();
   });
 
   it('should render reset button', () => {

--- a/web/src/pages/studio/__tests__/LiteTopic.test.tsx
+++ b/web/src/pages/studio/__tests__/LiteTopic.test.tsx
@@ -114,6 +114,46 @@ describe('LiteTopic Page', () => {
     expect(within(popProgressLabel.parentElement!).getByText('96%')).toBeInTheDocument();
   });
 
+  it('keeps the latest session detail when an earlier request resolves last', async () => {
+    const firstSession = createDeferred<{
+      sessionId: string;
+      totalMessages: number;
+      consumedMessages: number;
+    }>();
+    const secondSession = createDeferred<{
+      sessionId: string;
+      totalMessages: number;
+      consumedMessages: number;
+    }>();
+    apiMocks.queryLiteTopicList.mockResolvedValue([
+      { namespace: 'default', topicPattern: 'first-*', sessionIds: ['session-1'] },
+      { namespace: 'default', topicPattern: 'second-*', sessionIds: ['session-2'] },
+    ]);
+    apiMocks.queryLiteTopicSession.mockImplementation((sessionId: string) =>
+      sessionId === 'session-1' ? firstSession.promise : secondSession.promise,
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    const viewSessionButtons = await screen.findAllByText('查看会话');
+    await user.click(viewSessionButtons[0]);
+    await user.click(viewSessionButtons[1]);
+
+    await act(async () => {
+      secondSession.resolve({ sessionId: 'session-2', totalMessages: 222, consumedMessages: 22 });
+    });
+    expect(await screen.findByText('session-2')).toBeInTheDocument();
+    expect(screen.getByText('222')).toBeInTheDocument();
+
+    await act(async () => {
+      firstSession.resolve({ sessionId: 'session-1', totalMessages: 111, consumedMessages: 11 });
+    });
+    expect(screen.getByText('session-2')).toBeInTheDocument();
+    expect(screen.getByText('222')).toBeInTheDocument();
+    expect(screen.queryByText('111')).not.toBeInTheDocument();
+  });
+
   it('keeps namespace identity in the table and builds stable options from the initial list', async () => {
     const initialItems: LiteTopicItem[] = [
       { namespace: 'zeta', topicPattern: 'shared-*' },


### PR DESCRIPTION
## Summary
- retain Consumer Group detail data from the latest selected group request
- prevent stale LiteTopic session responses from overwriting the active drawer
- keep independent regression coverage for both out-of-order response paths

Closes #1088
Closes #1086

Consolidates #1087.