### PR TITLE
fix: remove unsupported group actions

### DIFF
--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -31,7 +31,7 @@ import {
   Switch,
   message,
 } from 'antd';
-import { MagnifyingGlass, ArrowClockwise, Users, Eye } from '@phosphor-icons/react';
+import { MagnifyingGlass, ArrowClockwise, Users } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
 import type { ConsumerGroup, QueueProgress, SubscriptionEntry } from '../../api/metadata';
 import {
@@ -230,15 +230,6 @@ const GroupManagementPage = () => {
         <code style={{ background: '#f5f5f5', padding: '2px 6px', borderRadius: 4, fontSize: 12 }}>
           {text}
         </code>
-      ),
-    },
-    {
-      title: t('common.actions'),
-      key: 'action',
-      render: () => (
-        <Button type="link" size="small" icon={<Eye size={14} />}>
-          {t('groupMgmt.viewDistribution')}
-        </Button>
       ),
     },
   ];

--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -31,7 +31,7 @@ import {
   Switch,
   message,
 } from 'antd';
-import { MagnifyingGlass, Plus, ArrowClockwise, Users, Eye } from '@phosphor-icons/react';
+import { MagnifyingGlass, ArrowClockwise, Users, Eye } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
 import type { ConsumerGroup, QueueProgress, SubscriptionEntry } from '../../api/metadata';
 import {
@@ -197,14 +197,9 @@ const GroupManagementPage = () => {
       title: t('common.actions'),
       key: 'action',
       render: (_: unknown, record: ConsumerGroup) => (
-        <Space size="small">
-          <Button type="link" size="small" onClick={() => void handleViewDetail(record)}>
-            {t('common.detail')}
-          </Button>
-          <Button type="link" size="small">
-            {t('brokerCluster.config')}
-          </Button>
-        </Space>
+        <Button type="link" size="small" onClick={() => void handleViewDetail(record)}>
+          {t('common.detail')}
+        </Button>
       ),
     },
   ];
@@ -279,9 +274,6 @@ const GroupManagementPage = () => {
             style={{ width: 240 }}
             allowClear
           />
-          <Button type="primary" icon={<Plus size={14} />}>
-            {t('groupMgmt.createGroup')}
-          </Button>
           <Switch
             checked={autoRefresh}
             onChange={setAutoRefresh}

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -108,6 +108,7 @@ describe('GroupManagement Page', () => {
     });
     expect(screen.queryByText('创建消费组')).not.toBeInTheDocument();
     expect(screen.queryByText('配置')).not.toBeInTheDocument();
+    expect(screen.queryByText('查看分布')).not.toBeInTheDocument();
   });
 
   it('should render reset button', () => {

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -101,9 +101,13 @@ describe('GroupManagement Page', () => {
     expect(screen.getByPlaceholderText('搜索消费组')).toBeInTheDocument();
   });
 
-  it('should render create group button', () => {
+  it('should not render unsupported mutation actions in the global view', async () => {
     renderWithProviders(<GroupManagement />);
-    expect(screen.getByText('创建消费组')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('order-consumer-group')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('创建消费组')).not.toBeInTheDocument();
+    expect(screen.queryByText('配置')).not.toBeInTheDocument();
   });
 
   it('should render reset button', () => {


### PR DESCRIPTION
## Summary
- remove inert Create Group and Config controls from the global aggregate view
- remove the unsupported subscription distribution action
- preserve implemented read-only group details
- add regression coverage that unsupported actions are absent

Closes #1100

## Test
- `npm test -- --run src/pages/studio/__tests__/GroupManagement.test.tsx`
- `npm run lint` (existing warnings only)
- `npm run build`