### PR TITLE
fix: report DLQ resend send failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProvider.java
@@ -21,6 +21,7 @@ import org.apache.rocketmq.client.consumer.PullResult;
 import org.apache.rocketmq.client.consumer.PullStatus;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendStatus;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageConst;
@@ -62,6 +63,8 @@ public class RocketMQDLQProvider implements DLQProvider {
 
     private static final long ONE_HOUR_MILLIS = 3600_000L;
     private static final int RESEND_HARD_CAP = 5000;
+    private static final String ORIGIN_MESSAGE_ID_PROPERTY = "studio_dlq_origin_message_id";
+    private static final String ORIGIN_TOPIC_PROPERTY = "studio_dlq_origin_topic";
 
     private final ObjectProvider<DefaultMQAdminExt> adminExtProvider;
     private final AuditService auditService;
@@ -241,9 +244,15 @@ public class RocketMQDLQProvider implements DLQProvider {
             if (StringUtils.hasText(deadLetter.getKeys())) {
                 message.setKeys(deadLetter.getKeys());
             }
-            message.putUserProperty("DLQ_ORIGIN_MESSAGE_ID", deadLetter.getMsgId());
-            message.putUserProperty("DLQ_ORIGIN_TOPIC", deadLetter.getTopic());
+            message.putUserProperty(ORIGIN_MESSAGE_ID_PROPERTY, deadLetter.getMsgId());
+            message.putUserProperty(ORIGIN_TOPIC_PROPERTY, deadLetter.getTopic());
             SendResult sendResult = producer.send(message);
+            if (sendResult == null || sendResult.getSendStatus() != SendStatus.SEND_OK) {
+                log.warn("DLQ resend was not accepted: msgId={} topic={} sendStatus={}",
+                        deadLetter.getMsgId(), destination,
+                        sendResult == null ? "<null>" : sendResult.getSendStatus());
+                return false;
+            }
             log.debug("Resent dead letter msgId={} to topic={}, sendStatus={}",
                     deadLetter.getMsgId(), destination, sendResult.getSendStatus());
             return true;

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDLQProviderTest.java
@@ -17,8 +17,14 @@
 package org.apache.rocketmq.studio.rocketmq;
 
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.PullStatus;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendStatus;
 import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.studio.ops.audit.AuditService;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
@@ -29,6 +35,9 @@ import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -90,6 +99,49 @@ class RocketMQDLQProviderTest {
                 eq("group-a"),
                 contains("matched=0, resent=0, failed=0"),
                 eq("SUCCESS"));
+    }
+
+    @Test
+    void resendMessagesCountsNonSendOkResultsAsFailures() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        MessageQueue queue = new MessageQueue(dlqTopic, "broker-a", 0);
+        MessageExt deadLetter = new MessageExt();
+        deadLetter.setMsgId("msg-1");
+        deadLetter.setTopic(dlqTopic);
+        deadLetter.setBody(new byte[] {1});
+        deadLetter.setStoreTimestamp(150L);
+        PullResult pullResult = new PullResult(PullStatus.FOUND, 1L, 0L, 0L, List.of(deadLetter));
+        SendResult sendResult = new SendResult();
+        sendResult.setSendStatus(SendStatus.FLUSH_DISK_TIMEOUT);
+
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(Set.of(queue));
+                         when(consumer.searchOffset(queue, 100L)).thenReturn(0L);
+                         when(consumer.searchOffset(queue, 200L)).thenReturn(0L);
+                         when(consumer.pull(queue, "*", 0L, 32)).thenReturn(pullResult);
+                         doNothing().when(consumer).shutdown();
+                     });
+             MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class, (producer, context) -> {
+                         doNothing().when(producer).start();
+                         when(producer.send(any(Message.class))).thenReturn(sendResult);
+                         doNothing().when(producer).shutdown();
+                     })) {
+            assertThat(provider.resendMessages("group-a", 100L, 200L, "target-topic"))
+                    .extracting("matched", "resent", "failed", "outcome")
+                    .containsExactly(1, 0, 1, "PARTIAL");
+
+            assertThat(mockedConsumers.constructed()).hasSize(1);
+            assertThat(mockedProducers.constructed()).hasSize(1);
+            verify(mockedProducers.constructed().get(0)).send(any(Message.class));
+        }
+        verify(auditService).record(
+                eq("RESEND_DLQ"),
+                eq("group-a"),
+                contains("matched=1, resent=0, failed=1"),
+                eq("PARTIAL"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- treat null and non-SEND_OK DLQ resend results as failures
- retain failed replay details in audit output
- use Studio-owned provenance keys rather than RocketMQ-reserved user property keys

Closes #1051

## Verification
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=RocketMQDLQProviderTest test`