### PR TITLE
fix(cluster): prevent new admin connection during shutdown

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
@@ -68,8 +68,14 @@ public class MqAdminExtFactory {
         if (closed) {
             throw new BusinessException(503, "Admin factory is shutting down");
         }
-        DefaultMQAdminExt admin = cache.computeIfAbsent(namesrvAddr.trim(),
-                addr -> createAndStart(addr, rpcHook));
+        DefaultMQAdminExt admin = cache.computeIfAbsent(namesrvAddr.trim(), addr -> {
+            // Re-check under the cache lock so a request that passed the initial closed check cannot
+            // create a fresh connection while the factory is shutting down.
+            if (closed) {
+                throw new BusinessException(503, "Admin factory is shutting down");
+            }
+            return createAndStart(addr, rpcHook);
+        });
         try {
             return action.apply(admin);
         } catch (BusinessException ex) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
@@ -92,4 +92,17 @@ class MqAdminExtFactoryTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("shutting down");
     }
+
+    @Test
+    void executeShouldNotCreateConnectionAfterShutdown() {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+        factory.shutdown();
+
+        assertThatThrownBy(() -> factory.execute("10.0.0.1:9876", null, a -> "unused"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("shutting down");
+        // No fresh admin connection may be established while the factory is shut down.
+        assertThat(factory.created.get()).isZero();
+    }
 }


### PR DESCRIPTION
MqAdminExtFactory.execute checked the closed flag before the cache lookup, but a request that passed that check could still create a fresh admin connection while the factory was shutting down. The cache mapping function now re-checks closed under the lock, so no new connection is established after shutdown. Includes a unit test.