### PR TITLE
fix: scope metadata deletes to the current cluster

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
@@ -309,8 +309,11 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 adminExt.deleteTopicInNameServer(nsAddrs, getClusterName(), name);
             }
 
-            // Delete from DB
-            topicMapper.delete(new LambdaQueryWrapper<RmqTopic>().eq(RmqTopic::getName, name));
+            // Delete only the current cluster's record. Topic names can be shared by several
+            // clusters managed by the same Studio instance.
+            topicMapper.delete(new LambdaQueryWrapper<RmqTopic>()
+                    .eq(RmqTopic::getClusterId, getClusterName())
+                    .eq(RmqTopic::getName, name));
 
             auditService.record("DELETE_TOPIC", name, "", "SUCCESS");
         } catch (BusinessException e) {
@@ -462,8 +465,11 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 adminExt.deleteSubscriptionGroup(addr, name, true);
             }
 
-            // Delete from DB
-            groupMapper.delete(new LambdaQueryWrapper<RmqGroup>().eq(RmqGroup::getName, name));
+            // Delete only the current cluster's record. Consumer group names can be shared by
+            // several clusters managed by the same Studio instance.
+            groupMapper.delete(new LambdaQueryWrapper<RmqGroup>()
+                    .eq(RmqGroup::getClusterId, getClusterName())
+                    .eq(RmqGroup::getName, name));
 
             auditService.record("DELETE_GROUP", name, "", "SUCCESS");
         } catch (BusinessException e) {

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImplTest.java
@@ -30,6 +30,7 @@ import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.apache.rocketmq.studio.instance.topic.SendMessageDTO;
 import org.apache.rocketmq.studio.instance.topic.SendMessageVO;
 import org.apache.rocketmq.studio.ops.audit.AuditService;
+import org.apache.rocketmq.studio.persistence.entity.RmqGroup;
 import org.apache.rocketmq.studio.persistence.entity.RmqTopic;
 import org.apache.rocketmq.studio.persistence.mapper.RmqGroupMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqTopicMapper;
@@ -162,5 +163,39 @@ class RocketMQAdminClientImplTest {
             // The message was already delivered; an audit failure must not turn this into an error.
             assertThat(result.getMsgId()).isEqualTo("msg-1");
         }
+    }
+
+    @Test
+    void deleteTopicScopesDatabaseDeleteToCurrentCluster() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqTopic.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo("cluster-1"));
+
+        adminClient.deleteTopic("orders");
+
+        ArgumentCaptor<LambdaQueryWrapper<RmqTopic>> captor =
+                ArgumentCaptor.forClass(LambdaQueryWrapper.class);
+        verify(topicMapper).delete(captor.capture());
+        assertThat(captor.getValue().getSqlSegment()).contains("cluster_id", "name");
+    }
+
+    @Test
+    void deleteConsumerGroupScopesDatabaseDeleteToCurrentCluster() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqGroup.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo("cluster-1"));
+
+        adminClient.deleteConsumerGroup("cg-orders");
+
+        ArgumentCaptor<LambdaQueryWrapper<RmqGroup>> captor =
+                ArgumentCaptor.forClass(LambdaQueryWrapper.class);
+        verify(groupMapper).delete(captor.capture());
+        assertThat(captor.getValue().getSqlSegment()).contains("cluster_id", "name");
+    }
+
+    private ClusterInfo clusterInfo(String clusterName) {
+        ClusterInfo clusterInfo = new ClusterInfo();
+        Map<String, Set<String>> clusterAddrTable = new HashMap<>();
+        clusterAddrTable.put(clusterName, new HashSet<>(List.of("broker-1")));
+        clusterInfo.setClusterAddrTable(clusterAddrTable);
+        return clusterInfo;
     }
 }


### PR DESCRIPTION
## Summary
- scope Topic and Consumer Group metadata deletes by `(cluster_id, name)`
- retain same-named resources stored for other clusters
- add regression coverage for both delete paths

Closes #1044

## Verification
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=RocketMQAdminClientImplTest test`