### PR TITLE
fix: require instance scope for metadata writes

### DIFF
--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -36,21 +36,9 @@ vi.mock('../../../services/consumerService', () => ({
   listConsumerGroups: vi.fn(),
   resetConsumerOffset: vi.fn(),
 }));
-vi.mock('../../../services/instanceService', () => ({
-  listInstances: vi.fn().mockResolvedValue([
-    {
-      id: 'instance-1',
-      name: 'instance-1',
-      remark: '',
-      type: 'PROXY',
-      endpoint: '10.0.0.1:8080',
-      topicCount: 0,
-      consumerGroupCount: 0,
-      createdAt: '2026-01-01T00:00:00Z',
-      updatedAt: '2026-01-01T00:00:00Z',
-    },
-  ]),
-}));
+const instanceServiceMocks = vi.hoisted(() => ({ listInstances: vi.fn() }));
+
+vi.mock('../../../services/instanceService', () => instanceServiceMocks);
 
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
@@ -94,11 +82,11 @@ const group: ConsumerGroup = {
   instances: [],
 };
 
-const renderWithProviders = (ui: React.ReactElement) =>
+const renderWithProviders = (ui: React.ReactElement, initialEntry = '/instance/consumer') =>
   render(
     <App>
       <LangProvider>
-        <MemoryRouter>{ui}</MemoryRouter>
+        <MemoryRouter initialEntries={[initialEntry]}>{ui}</MemoryRouter>
       </LangProvider>
     </App>,
   );
@@ -139,6 +127,19 @@ describe('Consumer page', () => {
         type: 'NORMAL',
         filterMode: '全量',
         consistency: '一致',
+      },
+    ]);
+    instanceServiceMocks.listInstances.mockResolvedValue([
+      {
+        id: 'instance-1',
+        name: 'instance-1',
+        remark: '',
+        type: 'PROXY',
+        endpoint: '10.0.0.1:8080',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
       },
     ]);
   });
@@ -322,7 +323,20 @@ describe('Consumer page', () => {
     );
 
     const user = userEvent.setup();
-    renderWithProviders(<ConsumerPage />);
+    instanceServiceMocks.listInstances.mockResolvedValue([
+      {
+        id: 'instance-proxy-1',
+        name: 'instance-proxy-1',
+        remark: '',
+        type: 'PROXY',
+        endpoint: '10.0.2.21:8080',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ]);
+    renderWithProviders(<ConsumerPage />, '/instance/instance-proxy-1/consumer');
 
     await screen.findByText(/共 0 个 Group/);
     const csv = [
@@ -345,7 +359,7 @@ describe('Consumer page', () => {
       retryMaxTimes: 16,
       subscriptionDataType: 'NORMAL',
       subscribedTopics: [],
-      instanceId: 'instance-1',
+      instanceId: 'instance-proxy-1',
     });
     expect(await screen.findByText('已导入 1 个 Group，1 个失败')).toBeInTheDocument();
     expect(screen.getByText('broker rejected group')).toBeInTheDocument();
@@ -353,5 +367,14 @@ describe('Consumer page', () => {
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /重试失败项/ })).toBeInTheDocument(),
     );
+  });
+
+  it('disables Consumer Group writes until an instance is available', async () => {
+    instanceServiceMocks.listInstances.mockResolvedValue([]);
+    renderWithProviders(<ConsumerPage />);
+
+    expect(await screen.findByText('选择实例')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /导入/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '创建 Group' })).toBeDisabled();
   });
 });

--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -86,6 +86,18 @@ const buildTopics = (count: number): Topic[] =>
     };
   });
 
+const selectedInstance = {
+  id: 'instance-proxy-1',
+  name: 'instance-proxy-1',
+  remark: '',
+  type: 'PROXY' as const,
+  endpoint: '10.0.2.21:8080',
+  topicCount: 0,
+  consumerGroupCount: 0,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
 const renderWithProviders = (initialEntry = '/instance/topic') =>
   render(
     <App>
@@ -275,19 +287,7 @@ describe('TopicPage', () => {
   it('imports valid topic CSV rows through the create service with the selected instance', async () => {
     const user = userEvent.setup();
     topicServiceMocks.listTopics.mockResolvedValue([]);
-    instanceServiceMocks.listInstances.mockResolvedValue([
-      {
-        id: 'instance-proxy-1',
-        name: 'instance-proxy-1',
-        remark: '',
-        type: 'PROXY',
-        endpoint: '10.0.2.21:8080',
-        topicCount: 0,
-        consumerGroupCount: 0,
-        createdAt: '2026-01-01T00:00:00Z',
-        updatedAt: '2026-01-01T00:00:00Z',
-      },
-    ]);
+    instanceServiceMocks.listInstances.mockResolvedValue([selectedInstance]);
     renderWithProviders('/instance/instance-proxy-1/topic');
 
     await screen.findByText(/共 0 个 Topic/);
@@ -316,9 +316,14 @@ describe('TopicPage', () => {
 
   it('does not call createTopic when imported topic CSV is invalid or duplicated', async () => {
     const user = userEvent.setup();
-    renderWithProviders();
+    instanceServiceMocks.listInstances.mockResolvedValue([selectedInstance]);
+    topicServiceMocks.listTopics.mockResolvedValue([
+      { ...buildTopics(1)[0], instanceId: 'instance-proxy-1' },
+    ]);
+    renderWithProviders('/instance/instance-proxy-1/topic');
 
     expect(await screen.findByText('topic-01')).toBeInTheDocument();
+    expect(await screen.findByText('10.0.2.21:8080')).toBeInTheDocument();
     const csv = [
       '"Name","Type","Write Queues","Read Queues","Permission"',
       '"bad topic","NORMAL","8","8","RW"',
@@ -336,9 +341,11 @@ describe('TopicPage', () => {
   it('imports valid topic rows while skipping duplicate rows', async () => {
     const user = userEvent.setup();
     topicServiceMocks.listTopics.mockResolvedValue([]);
-    renderWithProviders();
+    instanceServiceMocks.listInstances.mockResolvedValue([selectedInstance]);
+    renderWithProviders('/instance/instance-proxy-1/topic');
 
     await screen.findByText(/共 0 个 Topic/);
+    await screen.findByText('10.0.2.21:8080');
     const csv = [
       '"Name","Type","Write Queues","Read Queues","Permission"',
       '"topic-a","NORMAL","8","8","RW"',
@@ -354,12 +361,21 @@ describe('TopicPage', () => {
     await waitFor(() => expect(topicServiceMocks.createTopic).toHaveBeenCalledTimes(2));
     expect(topicServiceMocks.createTopic).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ name: 'topic-a' }),
+      expect.objectContaining({ name: 'topic-a', instanceId: 'instance-proxy-1' }),
     );
     expect(topicServiceMocks.createTopic).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ name: 'topic-b' }),
+      expect.objectContaining({ name: 'topic-b', instanceId: 'instance-proxy-1' }),
     );
     expect(await screen.findByText('已导入 2 个 Topic，1 行无效已跳过')).toBeInTheDocument();
+  });
+
+  it('disables Topic writes until an instance is available', async () => {
+    instanceServiceMocks.listInstances.mockResolvedValue([]);
+    renderWithProviders();
+
+    expect(await screen.findByText('共 0 个 Topic')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /导入/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /创建 Topic/ })).toBeDisabled();
   });
 });

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -185,6 +185,7 @@ const ConsumerPage = () => {
     useInstanceFilter();
   const isCloudInstance =
     selectedInstance?.vendor === 'ALIYUN' || selectedInstance?.vendor === 'TENCENT';
+  const hasSelectedInstance = Boolean(selectedInstanceId);
   const [groups, setGroups] = useState<ConsumerGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -324,6 +325,10 @@ const ConsumerPage = () => {
   const selectedProgress = selectedGroup ? (progressByGroup[selectedGroup.name] ?? []) : [];
 
   const handleImportFile = async (file: File) => {
+    if (!selectedInstanceId) {
+      message.error('请先选择实例');
+      return;
+    }
     setImportFilename(file.name);
     setImporting(false);
     setImportModalOpen(true);
@@ -341,6 +346,10 @@ const ConsumerPage = () => {
   };
 
   const handleImportConsumerGroups = async () => {
+    if (!selectedInstanceId) {
+      message.error('请先选择实例');
+      return;
+    }
     const targetIndexes = importRows
       .map((row, index) => ({ row, index }))
       .filter(({ row }) => row.status === 'pending' || row.status === 'failed');
@@ -821,7 +830,7 @@ const ConsumerPage = () => {
           />
           <Button
             icon={<ImportOutlined />}
-            disabled={importing}
+            disabled={!hasSelectedInstance || importing}
             onClick={() => importInputRef.current?.click()}
           >
             导入
@@ -841,6 +850,7 @@ const ConsumerPage = () => {
           <Button
             type="primary"
             icon={<Plus size={14} weight="bold" />}
+            disabled={!hasSelectedInstance}
             onClick={() => setCreateModalOpen(true)}
           >
             创建 Group
@@ -1208,6 +1218,10 @@ const ConsumerPage = () => {
           form
             .validateFields()
             .then((values) => {
+              if (!selectedInstanceId) {
+                message.error('请先选择实例');
+                return;
+              }
               Modal.confirm({
                 title: '确认创建',
                 content: `将创建消费组 "${values.name}"`,
@@ -1224,7 +1238,7 @@ const ConsumerPage = () => {
                       subscriptionDataType: values.dataType || 'NORMAL',
                       deliveryOrderType: values.deliveryOrderType,
                       subscribedTopics: [],
-                      ...(selectedInstanceId ? { instanceId: selectedInstanceId } : {}),
+                      instanceId: selectedInstanceId,
                     });
                     setGroups((prev) => [
                       created,

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -271,6 +271,7 @@ const TopicPage = () => {
     useInstanceFilter();
   const isCloudInstance =
     selectedInstance?.vendor === 'ALIYUN' || selectedInstance?.vendor === 'TENCENT';
+  const hasSelectedInstance = Boolean(selectedInstanceId);
 
   // ─── State ─────────────────────────────────────────────────────
   const [topics, setTopics] = useState<Topic[]>([]);
@@ -669,11 +670,15 @@ const TopicPage = () => {
 
   // ─── Create modal submit ──────────────────────────────────────
   const handleCreate = async () => {
+    if (!selectedInstanceId) {
+      message.error('请先选择实例');
+      return;
+    }
     try {
       const values = await form.validateFields();
       const created = await createTopic({
         ...values,
-        ...(selectedInstanceId ? { instanceId: selectedInstanceId } : {}),
+        instanceId: selectedInstanceId,
       });
       setTopics((previous) => [created, ...previous]);
       message.success(`Topic「${created.name}」创建成功`);
@@ -685,6 +690,10 @@ const TopicPage = () => {
   };
 
   const handleImportFile = async (file: File) => {
+    if (!selectedInstanceId) {
+      message.error('请先选择实例');
+      return;
+    }
     setImportFilename(file.name);
     setImporting(false);
     setImportModalOpen(true);
@@ -702,6 +711,10 @@ const TopicPage = () => {
   };
 
   const handleImportTopics = async () => {
+    if (!selectedInstanceId) {
+      message.error('请先选择实例');
+      return;
+    }
     const targetIndexes = importRows
       .map((row, index) => ({ row, index }))
       .filter(({ row }) => row.status === 'pending' || row.status === 'failed');
@@ -947,7 +960,7 @@ const TopicPage = () => {
           />
           <Button
             icon={<ImportOutlined />}
-            disabled={importing}
+            disabled={!hasSelectedInstance || importing}
             onClick={() => importInputRef.current?.click()}
           >
             导入
@@ -964,7 +977,12 @@ const TopicPage = () => {
           >
             导出
           </Button>
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            disabled={!hasSelectedInstance}
+            onClick={() => setModalOpen(true)}
+          >
             创建 Topic
           </Button>
         </Space>


### PR DESCRIPTION
## Summary
- disable Topic and Consumer Group creation/import until an instance is selected
- guard write handlers so requests cannot be sent without an instance ID
- preserve the selected instance on imported and created resources

The earlier list-scoping portion is now covered by the current instance Provider layer, so this PR keeps the remaining write-safety behavior focused.

Closes #1116

## Validation
- npm test -- --run src/pages/instance/__tests__/TopicPage.test.tsx src/pages/instance/__tests__/ConsumerPage.test.tsx