### PR TITLE
feat: scope Producer connections to selected instance

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientProvider.java
@@ -22,5 +22,5 @@ import java.util.List;
 public interface ClientProvider {
     List<ClientConnectionVO> findConnections(String instanceId, String clusterId, String type);
 
-    List<ClientConnectionVO> findProducerConnections(String topic, String producerGroup);
+    List<ClientConnectionVO> findProducerConnections(String instanceId, String topic, String producerGroup);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientProviderStub.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientProviderStub.java
@@ -26,15 +26,16 @@ public class ClientProviderStub implements ClientProvider {
 
     @Override
     public List<ClientConnectionVO> findConnections(String instanceId, String clusterId, String type) {
-        log.warn("ClientProviderStub.findConnections called without a real client provider. instanceId={}, clusterId={}, type={}",
+        log.warn("ClientProviderStub.findConnections called without a real client provider. "
+                        + "instanceId={}, clusterId={}, type={}",
                 instanceId, clusterId, type);
         throw new BusinessException(501, "Client connection provider is not configured");
     }
 
     @Override
-    public List<ClientConnectionVO> findProducerConnections(String topic, String producerGroup) {
+    public List<ClientConnectionVO> findProducerConnections(String instanceId, String topic, String producerGroup) {
         log.warn("ClientProviderStub.findProducerConnections called without a real client provider. "
-                + "topic={}, producerGroup={}", topic, producerGroup);
+                + "instanceId={}, topic={}, producerGroup={}", instanceId, topic, producerGroup);
         throw new BusinessException(501, "Client connection provider is not configured");
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionService.java
@@ -31,17 +31,21 @@ public class ProducerConnectionService {
 
     private final ClientProvider clientProvider;
 
-    public List<ProducerConnectionVO> listConnections(String topic, String producerGroup) {
-        log.info("Listing producer connections, topic={}, producerGroup={}", topic, producerGroup);
+    public List<ProducerConnectionVO> listConnections(String instanceId, String topic, String producerGroup) {
+        log.info("Listing producer connections, instanceId={}, topic={}, producerGroup={}",
+                instanceId, topic, producerGroup);
+        String normalizedInstanceId = requireFilter(instanceId, "instanceId");
         String normalizedTopic = requireFilter(topic, "topic");
         String normalizedProducerGroup = requireFilter(producerGroup, "producerGroup");
-        return clientProvider.findProducerConnections(normalizedTopic, normalizedProducerGroup).stream()
+        return clientProvider.findProducerConnections(normalizedInstanceId, normalizedTopic, normalizedProducerGroup)
+                .stream()
                 .map(this::toProducerConnection)
                 .toList();
     }
 
-    public List<String> listProducerGroups() {
-        return clientProvider.findConnections(null, null, ClientType.Producer.name()).stream()
+    public List<String> listProducerGroups(String instanceId) {
+        String normalizedInstanceId = requireFilter(instanceId, "instanceId");
+        return clientProvider.findConnections(normalizedInstanceId, null, ClientType.Producer.name()).stream()
                 .map(ClientConnectionVO::getProducerGroup)
                 .filter(this::hasText)
                 .map(String::trim)

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerController.java
@@ -34,17 +34,20 @@ public class ProducerController {
     private final ProducerConnectionService producerConnectionService;
 
     @GetMapping("/groups")
-    public Result<List<String>> listProducerGroups() {
-        return Result.ok(producerConnectionService.listProducerGroups());
+    public Result<List<String>> listProducerGroups(@RequestParam String instanceId) {
+        return Result.ok(producerConnectionService.listProducerGroups(instanceId));
     }
 
     @GetMapping("/connection")
     public ProducerConnectionResultVO listConnections(
+            @RequestParam(required = false) String instanceId,
             @RequestParam(required = false) String topic,
             @RequestParam(required = false) String producerGroup) {
+        requireParameter(instanceId, "instanceId");
         requireParameter(topic, "topic");
         requireParameter(producerGroup, "producerGroup");
-        return new ProducerConnectionResultVO(producerConnectionService.listConnections(topic, producerGroup));
+        return new ProducerConnectionResultVO(
+                producerConnectionService.listConnections(instanceId, topic, producerGroup));
     }
 
     private void requireParameter(String value, String name) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -64,9 +64,7 @@ public class RocketMQClientProvider implements ClientProvider {
 
     private static final long SUBSCRIPTION_GROUP_TIMEOUT_MILLIS = 5000L;
 
-    private final MqAdminExtFactory adminFactory;
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
-    private final RocketMQProperties properties;
 
     @Override
     public List<ClientConnectionVO> findConnections(String instanceId, String clusterId, String type) {
@@ -86,36 +84,35 @@ public class RocketMQClientProvider implements ClientProvider {
     }
 
     @Override
-    public List<ClientConnectionVO> findProducerConnections(String topic, String producerGroup) {
-        String namesrvAddr = properties.getNamesrvAddr();
-        if (!StringUtils.hasText(namesrvAddr)) {
-            throw new BusinessException(501, "Client connection provider is not configured");
-        }
-        return adminFactory.execute(namesrvAddr, null, admin -> {
-            try {
-                ProducerConnection producerConnection =
-                        admin.examineProducerConnectionInfo(producerGroup, topic);
-                if (producerConnection == null || producerConnection.getConnectionSet() == null) {
-                    return List.<ClientConnectionVO>of();
-                }
-                return producerConnection.getConnectionSet().stream()
-                        .filter(Objects::nonNull)
-                        .map(connection -> toConnectionVO(
-                                connection, ClientType.Producer, topic, producerGroup, null))
-                        .toList();
-            } catch (MQClientException e) {
-                if (isTopicNotExist(e)) {
-                    // A non-existent topic is a normal "nothing here" outcome — the client
-                    // page should show an empty list, not a 502 that looks like a failure.
-                    return List.<ClientConnectionVO>of();
-                }
-                throw new BusinessException(502,
-                        "Failed to query producer connections: " + rootMessage(e));
-            } catch (Exception e) {
-                throw new BusinessException(502,
-                        "Failed to query producer connections: " + rootMessage(e));
+    public List<ClientConnectionVO> findProducerConnections(String instanceId, String topic, String producerGroup) {
+        return runtimeAdminClientResolver.execute(instanceId,
+                adminExt -> findProducerConnections(adminExt, topic, producerGroup));
+    }
+
+    private List<ClientConnectionVO> findProducerConnections(MQAdminExt adminExt, String topic, String producerGroup) {
+        try {
+            ProducerConnection producerConnection =
+                    adminExt.examineProducerConnectionInfo(producerGroup, topic);
+            if (producerConnection == null || producerConnection.getConnectionSet() == null) {
+                return List.of();
             }
-        });
+            return producerConnection.getConnectionSet().stream()
+                    .filter(Objects::nonNull)
+                    .map(connection -> toConnectionVO(
+                            connection, ClientType.Producer, topic, producerGroup, null))
+                    .toList();
+        } catch (MQClientException e) {
+            if (isTopicNotExist(e)) {
+                // A non-existent topic is a normal "nothing here" outcome — the client
+                // page should show an empty list, not a 502 that looks like a failure.
+                return List.of();
+            }
+            throw new BusinessException(502,
+                    "Failed to query producer connections: " + rootMessage(e));
+        } catch (Exception e) {
+            throw new BusinessException(502,
+                    "Failed to query producer connections: " + rootMessage(e));
+        }
     }
 
     private boolean isTopicNotExist(MQClientException e) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -29,7 +29,6 @@ import org.apache.rocketmq.remoting.protocol.body.SubscriptionGroupWrapper;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.client.ClientConnectionVO;
 import org.apache.rocketmq.studio.cluster.client.ClientProvider;
-import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.ClientLanguage;
@@ -40,7 +39,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientProviderStubTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientProviderStubTest.java
@@ -35,7 +35,7 @@ class ClientProviderStubTest {
 
     @Test
     void findProducerConnectionsShouldFailWhenRealProviderIsMissing() {
-        assertThatThrownBy(() -> provider.findProducerConnections("order-topic", "order-producer"))
+        assertThatThrownBy(() -> provider.findProducerConnections("instance-1", "order-topic", "order-producer"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Client connection provider is not configured")
                 .satisfies(ex -> assertThatBusinessExceptionCode(ex, 501));

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionServiceTest.java
@@ -53,22 +53,23 @@ class ProducerConnectionServiceTest {
                 .language(ClientLanguage.Java)
                 .version("5.1.0")
                 .build();
-        when(clientProvider.findProducerConnections("order-topic", "pg-order"))
+        when(clientProvider.findProducerConnections("instance-1", "order-topic", "pg-order"))
                 .thenReturn(List.of(producer));
 
-        List<ProducerConnectionVO> result = producerConnectionService.listConnections("order-topic", "pg-order");
+        List<ProducerConnectionVO> result = producerConnectionService.listConnections(
+                "instance-1", "order-topic", "pg-order");
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getClientId()).isEqualTo("producer-1");
         assertThat(result.get(0).getClientAddr()).isEqualTo("10.0.0.1:38888");
         assertThat(result.get(0).getLanguage()).isEqualTo("Java");
         assertThat(result.get(0).getVersionDesc()).isEqualTo("5.1.0");
-        verify(clientProvider).findProducerConnections("order-topic", "pg-order");
+        verify(clientProvider).findProducerConnections("instance-1", "order-topic", "pg-order");
     }
 
     @Test
     void listConnectionsShouldRejectMissingTopic() {
-        assertThatThrownBy(() -> producerConnectionService.listConnections(" ", "pg-order"))
+        assertThatThrownBy(() -> producerConnectionService.listConnections("instance-1", " ", "pg-order"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("topic is required")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
@@ -77,7 +78,7 @@ class ProducerConnectionServiceTest {
 
     @Test
     void listConnectionsShouldRejectMissingProducerGroup() {
-        assertThatThrownBy(() -> producerConnectionService.listConnections("order-topic", null))
+        assertThatThrownBy(() -> producerConnectionService.listConnections("instance-1", "order-topic", null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("producerGroup is required")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
@@ -86,18 +87,18 @@ class ProducerConnectionServiceTest {
 
     @Test
     void listConnectionsShouldTrimRequiredValues() {
-        when(clientProvider.findProducerConnections("order-topic", "pg-order"))
+        when(clientProvider.findProducerConnections("instance-1", "order-topic", "pg-order"))
                 .thenReturn(List.of());
 
         List<ProducerConnectionVO> result = producerConnectionService.listConnections(
-                " order-topic ", " pg-order ");
+                " instance-1 ", " order-topic ", " pg-order ");
         assertThat(result).isEmpty();
-        verify(clientProvider).findProducerConnections("order-topic", "pg-order");
+        verify(clientProvider).findProducerConnections("instance-1", "order-topic", "pg-order");
     }
 
     @Test
     void listProducerGroupsShouldReturnSortedUniqueActiveGroups() {
-        when(clientProvider.findConnections(null, null, ClientType.Producer.name()))
+        when(clientProvider.findConnections("instance-1", null, ClientType.Producer.name()))
                 .thenReturn(List.of(
                         ClientConnectionVO.builder().producerGroup(" pg-payment ").build(),
                         ClientConnectionVO.builder().producerGroup("pg-order").build(),
@@ -105,8 +106,17 @@ class ProducerConnectionServiceTest {
                         ClientConnectionVO.builder().producerGroup(" ").build(),
                         ClientConnectionVO.builder().build()));
 
-        assertThat(producerConnectionService.listProducerGroups())
+        assertThat(producerConnectionService.listProducerGroups("instance-1"))
                 .containsExactly("pg-order", "pg-payment");
-        verify(clientProvider).findConnections(null, null, ClientType.Producer.name());
+        verify(clientProvider).findConnections("instance-1", null, ClientType.Producer.name());
+    }
+
+    @Test
+    void listConnectionsShouldRejectMissingInstanceId() {
+        assertThatThrownBy(() -> producerConnectionService.listConnections(null, "order-topic", "pg-order"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("instanceId is required")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+        verifyNoInteractions(clientProvider);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerControllerTest.java
@@ -44,15 +44,15 @@ class ProducerControllerTest {
 
     @Test
     void listProducerGroupsShouldReturnSuggestions() throws Exception {
-        when(producerConnectionService.listProducerGroups())
+        when(producerConnectionService.listProducerGroups("instance-1"))
                 .thenReturn(List.of("pg-order", "pg-payment"));
 
-        mockMvc.perform(get("/api/producer/groups"))
+        mockMvc.perform(get("/api/producer/groups").param("instanceId", "instance-1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0]").value("pg-order"))
                 .andExpect(jsonPath("$.data[1]").value("pg-payment"));
 
-        verify(producerConnectionService).listProducerGroups();
+        verify(producerConnectionService).listProducerGroups("instance-1");
     }
 
     @Test
@@ -63,10 +63,11 @@ class ProducerControllerTest {
                 .language("Java")
                 .versionDesc("5.1.0")
                 .build();
-        when(producerConnectionService.listConnections("order-topic", "pg-order"))
+        when(producerConnectionService.listConnections("instance-1", "order-topic", "pg-order"))
                 .thenReturn(List.of(connection));
 
         mockMvc.perform(get("/api/producer/connection")
+                        .param("instanceId", "instance-1")
                         .param("topic", "order-topic")
                         .param("producerGroup", "pg-order"))
                 .andExpect(status().isOk())
@@ -76,12 +77,13 @@ class ProducerControllerTest {
                 .andExpect(jsonPath("$.connectionSet[0].language").value("Java"))
                 .andExpect(jsonPath("$.connectionSet[0].versionDesc").value("5.1.0"));
 
-        verify(producerConnectionService).listConnections("order-topic", "pg-order");
+        verify(producerConnectionService).listConnections("instance-1", "order-topic", "pg-order");
     }
 
     @Test
     void listConnectionsShouldRequireTopic() throws Exception {
         mockMvc.perform(get("/api/producer/connection")
+                        .param("instanceId", "instance-1")
                         .param("producerGroup", "pg-order"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
@@ -93,6 +95,7 @@ class ProducerControllerTest {
     @Test
     void listConnectionsShouldRequireProducerGroup() throws Exception {
         mockMvc.perform(get("/api/producer/connection")
+                        .param("instanceId", "instance-1")
                         .param("topic", "order-topic"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
@@ -104,10 +107,23 @@ class ProducerControllerTest {
     @Test
     void listConnectionsShouldRejectBlankParameters() throws Exception {
         mockMvc.perform(get("/api/producer/connection")
+                        .param("instanceId", "instance-1")
                         .param("topic", " ")
                         .param("producerGroup", "pg-order"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("topic is required"));
+
+        verifyNoInteractions(producerConnectionService);
+    }
+
+    @Test
+    void listConnectionsShouldRequireInstanceId() throws Exception {
+        mockMvc.perform(get("/api/producer/connection")
+                        .param("topic", "order-topic")
+                        .param("producerGroup", "pg-order"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("instanceId is required"));
 
         verifyNoInteractions(producerConnectionService);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class RocketMQClientProviderTest {
 
+    @Mock
     private DefaultMQAdminExt adminExt;
 
     @Mock

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
@@ -47,9 +47,10 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -58,10 +59,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class RocketMQClientProviderTest {
 
-    @Mock
-    private MqAdminExtFactory adminFactory;
-
-    @Mock
     private DefaultMQAdminExt adminExt;
 
     @Mock
@@ -71,11 +68,7 @@ class RocketMQClientProviderTest {
 
     @BeforeEach
     void setUp() {
-        lenient().when(adminFactory.execute(anyString(), any(), any())).thenAnswer(invocation ->
-                invocation.<MqAdminExtFactory.AdminAction<Object>>getArgument(2).apply(adminExt));
-        RocketMQProperties properties = new RocketMQProperties();
-        properties.setNamesrvAddr("10.0.0.1:9876");
-        provider = new RocketMQClientProvider(adminFactory, runtimeAdminClientResolver, properties);
+        provider = new RocketMQClientProvider(runtimeAdminClientResolver);
         lenient().when(runtimeAdminClientResolver.execute(anyString(), any())).thenAnswer(invocation ->
                 invocation.<MqAdminExtFactory.AdminAction<Object>>
                         getArgument(1).apply(adminExt));
@@ -159,7 +152,7 @@ class RocketMQClientProviderTest {
         when(adminExt.examineProducerConnectionInfo("pg-order", "TopicA"))
                 .thenReturn(producerConnection);
 
-        List<ClientConnectionVO> connections = provider.findProducerConnections("TopicA", "pg-order");
+        List<ClientConnectionVO> connections = provider.findProducerConnections("instance-a", "TopicA", "pg-order");
 
         assertThat(connections).singleElement().satisfies(connection -> {
             assertThat(connection.getClientId()).isEqualTo("producer-client");
@@ -167,6 +160,7 @@ class RocketMQClientProviderTest {
             assertThat(connection.getProducerGroup()).isEqualTo("pg-order");
         });
         verify(adminExt).examineProducerConnectionInfo("pg-order", "TopicA");
+        verify(runtimeAdminClientResolver).execute(eq("instance-a"), any());
     }
 
     @Test
@@ -174,7 +168,7 @@ class RocketMQClientProviderTest {
         when(adminExt.examineProducerConnectionInfo("pg-order", "TopicA"))
                 .thenThrow(new IllegalStateException("broker unavailable"));
 
-        assertThatThrownBy(() -> provider.findProducerConnections("TopicA", "pg-order"))
+        assertThatThrownBy(() -> provider.findProducerConnections("instance-a", "TopicA", "pg-order"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Failed to query producer connections: broker unavailable")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
@@ -186,7 +180,8 @@ class RocketMQClientProviderTest {
                 .thenThrow(new MQClientException(ResponseCode.TOPIC_NOT_EXIST,
                         "CAN'T FIND BROKER FOR TOPIC: NoSuchTopic"));
 
-        List<ClientConnectionVO> connections = provider.findProducerConnections("NoSuchTopic", "pg-order");
+        List<ClientConnectionVO> connections = provider.findProducerConnections(
+                "instance-a", "NoSuchTopic", "pg-order");
 
         assertThat(connections).isEmpty();
         verify(adminExt).examineProducerConnectionInfo("pg-order", "NoSuchTopic");
@@ -198,7 +193,8 @@ class RocketMQClientProviderTest {
                 .thenThrow(new MQClientException(ResponseCode.TOPIC_NOT_EXIST,
                         "connect to ns failed, route info of this topic not found"));
 
-        List<ClientConnectionVO> connections = provider.findProducerConnections("NoRouteTopic", "pg-order");
+        List<ClientConnectionVO> connections = provider.findProducerConnections(
+                "instance-a", "NoRouteTopic", "pg-order");
 
         assertThat(connections).isEmpty();
     }

--- a/web/src/api/producer.test.ts
+++ b/web/src/api/producer.test.ts
@@ -65,7 +65,7 @@ describe('Producer API', () => {
       data: ['pg-order', 'pg-payment'],
     });
 
-    await expect(fetchProducerGroups()).resolves.toEqual(['pg-order', 'pg-payment']);
+    await expect(fetchProducerGroups('instance-1')).resolves.toEqual(['pg-order', 'pg-payment']);
   });
 
   it('queries producer connections by topic and group', async () => {
@@ -86,10 +86,11 @@ describe('Producer API', () => {
     mock.onGet('/producer/connection').reply((config) => {
       expect(config.params.topic).toBe('order-events');
       expect(config.params.producerGroup).toBe('order-producer');
+      expect(config.params.instanceId).toBe('instance-1');
       return [200, { connectionSet: connections }];
     });
 
-    const result = await queryProducerConnection('order-events', 'order-producer');
+    const result = await queryProducerConnection('instance-1', 'order-events', 'order-producer');
     expect(result).toHaveLength(2);
     expect(result[0].clientId).toBe('producer-1');
   });
@@ -97,7 +98,7 @@ describe('Producer API', () => {
   it('handles empty producer connections', async () => {
     mock.onGet('/producer/connection').reply(200, { connectionSet: [] });
 
-    const result = await queryProducerConnection('topic', 'group');
+    const result = await queryProducerConnection('instance-1', 'topic', 'group');
     expect(result).toEqual([]);
   });
 });

--- a/web/src/api/producer.ts
+++ b/web/src/api/producer.ts
@@ -44,18 +44,19 @@ export async function fetchTopicList(): Promise<string[]> {
 }
 
 /** Fetch active producer groups for query suggestions */
-export async function fetchProducerGroups(): Promise<string[]> {
-  const res = await client.get<{ data?: string[] }>('/producer/groups');
+export async function fetchProducerGroups(instanceId: string): Promise<string[]> {
+  const res = await client.get<{ data?: string[] }>('/producer/groups', { params: { instanceId } });
   return res.data.data ?? [];
 }
 
 /** Query producer connections by topic and producer group */
 export async function queryProducerConnection(
+  instanceId: string,
   topic: string,
   producerGroup: string,
 ): Promise<ProducerConnection[]> {
   const res = await client.get<{ connectionSet: ProducerConnection[] }>('/producer/connection', {
-    params: { topic, producerGroup },
+    params: { instanceId, topic, producerGroup },
   });
   return res.data?.connectionSet ?? [];
 }

--- a/web/src/pages/studio/Producer.tsx
+++ b/web/src/pages/studio/Producer.tsx
@@ -25,12 +25,16 @@ import {
   queryProducerConnection,
   type ProducerConnection,
 } from '../../api/producer';
+import type { Instance } from '../../api/instance';
+import { listInstances } from '../../services/instanceService';
 
 const ProducerPage = () => {
   const [form] = Form.useForm();
   const [topicList, setTopicList] = useState<string[]>([]);
   const [producerGroups, setProducerGroups] = useState<string[]>([]);
   const [connectionList, setConnectionList] = useState<ProducerConnection[]>([]);
+  const [instances, setInstances] = useState<Instance[]>([]);
+  const [selectedInstanceId, setSelectedInstanceId] = useState('');
   const [loading, setLoading] = useState(false);
   const { t } = useLang();
   const { message } = App.useApp();
@@ -39,44 +43,81 @@ const ProducerPage = () => {
   useEffect(() => {
     let cancelled = false;
 
-    const loadTopics = async () => {
-      try {
-        const topics = await fetchTopicList();
+    void listInstances()
+      .then((nextInstances) => {
+        if (cancelled) return;
+        setInstances(nextInstances);
+        setSelectedInstanceId((current) => current || nextInstances[0]?.id || '');
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setInstances([]);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void fetchTopicList()
+      .then((topics) => {
         if (!cancelled) {
           setTopicList(topics);
         }
-      } catch {
+      })
+      .catch(() => {
         if (!cancelled) {
           message.error(fetchTopicFailedMessage);
         }
-      }
-    };
-
-    const loadProducerGroups = async () => {
-      try {
-        const groups = await fetchProducerGroups();
-        if (!cancelled) {
-          setProducerGroups(groups);
-        }
-      } catch {
-        if (!cancelled) {
-          setProducerGroups([]);
-        }
-      }
-    };
-
-    void loadTopics();
-    void loadProducerGroups();
+      });
 
     return () => {
       cancelled = true;
     };
   }, [fetchTopicFailedMessage, message]);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!selectedInstanceId) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    void fetchProducerGroups(selectedInstanceId)
+      .then((groups) => {
+        if (!cancelled) {
+          setProducerGroups(groups);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setProducerGroups([]);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedInstanceId]);
+
   const onFinish = async (values: { selectedTopic: string; producerGroup: string }) => {
+    if (!selectedInstanceId) {
+      message.error('Select an instance before querying producer connections.');
+      return;
+    }
     setLoading(true);
     try {
-      const connections = await queryProducerConnection(values.selectedTopic, values.producerGroup);
+      const connections = await queryProducerConnection(
+        selectedInstanceId,
+        values.selectedTopic,
+        values.producerGroup,
+      );
       setConnectionList(connections);
       if (connections.length === 0) {
         message.info(t('producer.noConnections'));
@@ -125,6 +166,16 @@ const ProducerPage = () => {
 
       <Card bordered={false} style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}>
         <Form form={form} layout="inline" onFinish={onFinish} style={{ marginBottom: 20 }}>
+          <Form.Item label="INSTANCE">
+            <Select
+              aria-label="Instance"
+              value={selectedInstanceId || undefined}
+              onChange={setSelectedInstanceId}
+              placeholder="Select instance"
+              style={{ width: 220 }}
+              options={instances.map((instance) => ({ value: instance.id, label: instance.name }))}
+            />
+          </Form.Item>
           <Form.Item
             label="TOPIC"
             name="selectedTopic"
@@ -158,6 +209,7 @@ const ProducerPage = () => {
               type="primary"
               htmlType="submit"
               loading={loading}
+              disabled={!selectedInstanceId}
               icon={<MagnifyingGlass size={14} />}
             >
               {t('common.search')}

--- a/web/src/pages/studio/__tests__/Producer.test.tsx
+++ b/web/src/pages/studio/__tests__/Producer.test.tsx
@@ -26,11 +26,16 @@ import {
   fetchTopicList,
   queryProducerConnection,
 } from '../../../api/producer';
+import { listInstances } from '../../../services/instanceService';
 
 vi.mock('../../../api/producer', () => ({
   fetchProducerGroups: vi.fn(),
   fetchTopicList: vi.fn(),
   queryProducerConnection: vi.fn(),
+}));
+
+vi.mock('../../../services/instanceService', () => ({
+  listInstances: vi.fn(),
 }));
 
 beforeAll(() => {
@@ -60,6 +65,19 @@ const renderWithProviders = (ui: React.ReactElement) => {
 describe('ProducerPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'instance-1',
+        name: 'Primary instance',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '127.0.0.1:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-08-01T00:00:00',
+        updatedAt: '2026-08-01T00:00:00',
+      },
+    ]);
     vi.mocked(fetchTopicList).mockResolvedValue(['order-events', 'payment-events']);
     vi.mocked(fetchProducerGroups).mockResolvedValue(['pg-order', 'pg-payment']);
     vi.mocked(queryProducerConnection).mockResolvedValue([]);
@@ -81,7 +99,7 @@ describe('ProducerPage', () => {
       expect(fetchTopicList).toHaveBeenCalledTimes(1);
     });
 
-    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(screen.getAllByRole('combobox')[1]);
     await screen.findByRole('option', { name: 'order-events' });
     expect(await screen.findByRole('option', { name: 'payment-events' })).toBeInTheDocument();
   });
@@ -91,7 +109,7 @@ describe('ProducerPage', () => {
     renderWithProviders(<ProducerPage />);
 
     await waitFor(() => expect(fetchProducerGroups).toHaveBeenCalledTimes(1));
-    const groupInput = screen.getAllByRole('combobox')[1];
+    const groupInput = screen.getAllByRole('combobox')[2];
     await user.type(groupInput, 'payment');
 
     expect(await screen.findByRole('option', { name: 'pg-payment' })).toBeInTheDocument();
@@ -110,7 +128,7 @@ describe('ProducerPage', () => {
     renderWithProviders(<ProducerPage />);
 
     await waitFor(() => expect(fetchTopicList).toHaveBeenCalledTimes(1));
-    const [topicSelect, groupInput] = screen.getAllByRole('combobox');
+    const [, topicSelect, groupInput] = screen.getAllByRole('combobox');
     fireEvent.mouseDown(topicSelect.parentElement!);
     await user.click(
       await screen.findByText('order-events', { selector: '.ant-select-item-option-content' }),
@@ -119,7 +137,11 @@ describe('ProducerPage', () => {
     await user.click(screen.getByRole('button', { name: /搜索/ }));
 
     await waitFor(() => {
-      expect(queryProducerConnection).toHaveBeenCalledWith('order-events', 'order-producer');
+      expect(queryProducerConnection).toHaveBeenCalledWith(
+        'instance-1',
+        'order-events',
+        'order-producer',
+      );
     });
     expect(await screen.findByText('producer-1')).toBeInTheDocument();
   });
@@ -129,7 +151,7 @@ describe('ProducerPage', () => {
     renderWithProviders(<ProducerPage />);
 
     await waitFor(() => expect(fetchTopicList).toHaveBeenCalledTimes(1));
-    const [topicSelect] = screen.getAllByRole('combobox');
+    const [, topicSelect] = screen.getAllByRole('combobox');
     fireEvent.mouseDown(topicSelect.parentElement!);
     await user.click(
       await screen.findByText('order-events', { selector: '.ant-select-item-option-content' }),
@@ -148,7 +170,7 @@ describe('ProducerPage', () => {
     renderWithProviders(<ProducerPage />);
 
     await waitFor(() => expect(fetchTopicList).toHaveBeenCalledTimes(1));
-    const [topicSelect, groupInput] = screen.getAllByRole('combobox');
+    const [, topicSelect, groupInput] = screen.getAllByRole('combobox');
     fireEvent.mouseDown(topicSelect.parentElement!);
     await user.click(
       await screen.findByText('order-events', { selector: '.ant-select-item-option-content' }),
@@ -157,7 +179,11 @@ describe('ProducerPage', () => {
     await user.click(screen.getByRole('button', { name: /搜索/ }));
 
     await waitFor(() => {
-      expect(queryProducerConnection).toHaveBeenCalledWith('order-events', 'manual-producer');
+      expect(queryProducerConnection).toHaveBeenCalledWith(
+        'instance-1',
+        'order-events',
+        'manual-producer',
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- require selected instance context for Producer connection and Producer Group requests
- resolve live Producer queries through the runtime AdminClient resolver introduced by #1058
- forward the selected instance through the Producer page, API client, controller, provider, and service layers

Closes #1102

The branch has been rebased to remove DLQ and client-connection changes already delivered by #1058.