### PR TITLE
feat(ai): add rmq.message.query tool to the AI tool catalog

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageQueryToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageQueryToolHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import org.apache.rocketmq.studio.instance.message.MessageProvider;
+import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Queries messages in a RocketMQ cluster by topic, message id, business key or time range. Read-only
+ * and safe for AI/MCP/CLI callers; delegates to the standard message provider used by the web UI.
+ */
+@Component
+@RequiredArgsConstructor
+public class MessageQueryToolHandler implements ToolHandler {
+
+    private static final String NAME = "rmq.message.query";
+
+    private final MessageProvider messageProvider;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public Object execute(Map<String, Object> input) {
+        String topic = (String) input.get("topic");
+        String msgId = (String) input.get("msgId");
+        String tag = (String) input.get("tag");
+        String key = (String) input.get("key");
+        Long startTime = asLong(input.get("startTime"));
+        Long endTime = asLong(input.get("endTime"));
+        return messageProvider.queryMessages(topic, msgId, tag, key, startTime, endTime).stream()
+                .map(MessageQueryToolHandler::safeProjection)
+                .toList();
+    }
+
+    private static Map<String, Object> safeProjection(MessageRecordVO message) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("msgId", require(message.getMsgId(), "msgId"));
+        result.put("topic", blankIfNull(message.getTopic()));
+        result.put("tag", blankIfNull(message.getTag()));
+        result.put("key", blankIfNull(message.getKey()));
+        result.put("storeTime", message.getStoreTime());
+        result.put("storeHost", blankIfNull(message.getStoreHost()));
+        result.put("bornHost", blankIfNull(message.getBornHost()));
+        result.put("body", blankIfNull(message.getBody()));
+        result.put("bodyEncoding", blankIfNull(message.getBodyEncoding()));
+        result.put("bodyTruncated", message.isBodyTruncated());
+        result.put("size", message.getSize());
+        return result;
+    }
+
+    private static Long asLong(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        return Long.parseLong(value.toString());
+    }
+
+    private static String require(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Message " + field + " is unavailable");
+        }
+        return value;
+    }
+
+    private static String blankIfNull(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/server/src/main/resources/tool-catalog/rmq-tools.yaml
+++ b/server/src/main/resources/tool-catalog/rmq-tools.yaml
@@ -457,3 +457,65 @@ tools:
                         - 'null'
     viewHint: object
     deprecated: false
+  - name: rmq.message.query
+    cli:
+      resource: message
+      verb: query
+    description: Query messages in a RocketMQ cluster by topic, message id, key or time range.
+    riskLevel: L1
+    permission: message:read
+    requiredCapabilities: []
+    inputSchema:
+      type: object
+      required:
+        - cluster
+      additionalProperties: false
+      properties:
+        cluster:
+          type: string
+          minLength: 1
+        topic:
+          type: string
+        msgId:
+          type: string
+        key:
+          type: string
+        tag:
+          type: string
+        startTime:
+          type: integer
+        endTime:
+          type: integer
+    outputSchema:
+      type: array
+      items:
+        type: object
+        required:
+          - msgId
+          - topic
+        additionalProperties: false
+        properties:
+          msgId:
+            type: string
+          topic:
+            type: string
+          tag:
+            type: string
+          key:
+            type: string
+          storeTime:
+            type: integer
+          storeHost:
+            type: string
+          bornHost:
+            type: string
+          body:
+            type: string
+          bodyEncoding:
+            type: string
+          bodyTruncated:
+            type: boolean
+          size:
+            type: integer
+    viewHint: table
+    deprecated: false

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageQueryToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageQueryToolHandlerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import org.apache.rocketmq.studio.instance.message.MessageProvider;
+import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MessageQueryToolHandlerTest {
+
+    @Mock
+    private MessageProvider messageProvider;
+
+    @InjectMocks
+    private MessageQueryToolHandler handler;
+
+    @Test
+    void executeShouldDelegateToMessageProviderAndProject() {
+        MessageRecordVO message = MessageRecordVO.builder()
+                .msgId("msg-1")
+                .topic("TopicA")
+                .tag("tag1")
+                .key("key1")
+                .body("hello")
+                .bodyEncoding("UTF-8")
+                .bodyTruncated(false)
+                .storeTime(1000L)
+                .bornHost("10.0.0.1")
+                .storeHost("10.0.0.2")
+                .size(5)
+                .build();
+        when(messageProvider.queryMessages(eq("TopicA"), any(), any(), any(), any(), any()))
+                .thenReturn(List.of(message));
+
+        Object result = handler.execute(Map.of("cluster", "cluster-1", "topic", "TopicA"));
+
+        assertThat(result).isInstanceOf(List.class);
+        List<?> rows = (List<?>) result;
+        assertThat(rows).hasSize(1);
+        Map<?, ?> row = (Map<?, ?>) rows.get(0);
+        assertThat(row.get("msgId")).isEqualTo("msg-1");
+        assertThat(row.get("topic")).isEqualTo("TopicA");
+        assertThat(row.get("tag")).isEqualTo("tag1");
+        assertThat(row.get("storeTime")).isEqualTo(1000L);
+        assertThat(row.get("body")).isEqualTo("hello");
+        assertThat(row.get("size")).isEqualTo(5);
+    }
+
+    @Test
+    void executeShouldConvertNumericTimeArguments() {
+        when(messageProvider.queryMessages(any(), any(), any(), any(), any(), any()))
+                .thenReturn(List.of());
+
+        handler.execute(Map.of("cluster", "cluster-1", "topic", "TopicA",
+                "startTime", 1000L, "endTime", 2000L));
+
+        org.mockito.Mockito.verify(messageProvider)
+                .queryMessages(any(), any(), any(), any(), eq(1000L), eq(2000L));
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
@@ -45,7 +45,8 @@ class ToolCatalogTest {
                         "rmq.topic.list",
                         "rmq.group.list",
                         "rmq.alert.rule.list",
-                        "rmq.nameserver.config.diff");
+                        "rmq.nameserver.config.diff",
+                        "rmq.message.query");
         assertThat(catalog.find("rmq.cluster.list")).isPresent();
         assertThat(catalog.find("rmq.unknown")).isEmpty();
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -45,6 +45,7 @@ import org.springframework.core.io.ClassPathResource;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -122,7 +123,8 @@ class ToolGatewayServiceTest {
                         "rmq.topic.list",
                         "rmq.group.list",
                         "rmq.alert.rule.list",
-                        "rmq.nameserver.config.diff");
+                        "rmq.nameserver.config.diff",
+                        "rmq.message.query");
     }
 
     @Test
@@ -507,7 +509,8 @@ class ToolGatewayServiceTest {
 
     @Test
     void failsStartupWhenCatalogAndHandlersDoNotMatch() {
-        assertThatThrownBy(() -> gateway(catalog, clusterListHandler))
+        assertThatThrownBy(() -> new ToolGatewayService(
+                catalog, capabilityResolver, new ObjectMapper(), List.of(clusterListHandler)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("missing handler");
     }
@@ -600,11 +603,22 @@ class ToolGatewayServiceTest {
     }
 
     private ToolGatewayService gateway(ToolCatalog toolCatalog, ToolHandler... handlers) {
+        List<ToolHandler> all = new ArrayList<>(List.of(handlers));
+        // The canonical catalog gains tools over time; fill any handler the test did not pass in
+        // with a stub so gateway construction stays valid for every catalog entry.
+        for (ToolDefinition definition : toolCatalog.list()) {
+            boolean provided = all.stream().anyMatch(h -> h.name().equals(definition.name()));
+            if (!provided) {
+                ToolHandler stub = mock(ToolHandler.class);
+                when(stub.name()).thenReturn(definition.name());
+                all.add(stub);
+            }
+        }
         return new ToolGatewayService(
                 toolCatalog,
                 capabilityResolver,
                 new ObjectMapper(),
-                List.of(handlers));
+                all);
     }
 
     private static ToolCatalog canonicalCatalog() {


### PR DESCRIPTION
Extends the Studio AI tool catalog (shared by Web/AI/MCP/CLI — the foundation for track 3 "AI Native") with a message query tool.

- New ToolHandler `rmq.message.query` backed by the standard MessageProvider, so it behaves exactly like the web UI query.
- Tool definition registered in the YAML contract (`rmq-tools.yaml`) with input/output JSON Schema, requiring a cluster per the catalog convention.
- Read-only, L1 risk level, no side effects.
- Unit tests for the handler, plus updated catalog/gateway tests.

Related: #1024 (track 3 AI Native), #998 (MCP server and CLI).
