### PR TITLE
fix: do not seed demo resources by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ cd deploy && docker compose up -d --build
 
 Visit **http://127.0.0.1:6789** after startup.
 
+The default schema creates only Studio tables. It does not seed instances, topics, consumer groups, or ACL
+records. Development-only sample data can be imported explicitly from `deploy/mysql/`; it is not part of the
+default deployment.
+
 **Studio ports:** Frontend 6789 (Nginx), Backend 8888 (Spring Boot)
 
 **RocketMQ ports:** NameServer 9876, Broker 10911, Proxy Remoting 8080, Proxy gRPC 8081

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -32,6 +32,9 @@ cd deploy && docker compose up -d --build
 
 默认访问地址为 `http://127.0.0.1:6789`。
 
+默认 schema 只创建 Studio 所需的表，不会写入实例、Topic、消费组或 ACL 示例数据。需要演示数据时，
+请在开发环境中显式导入 `deploy/mysql/upgrade-demo-instance.sql` 和
+`deploy/mysql/upgrade-demo-acl.sql`，不要在生产环境导入这些脚本。
 ## 开启登录保护
 
 `studio.auth.login-required` 默认为 `false`，便于本地开发和演示环境直接访问。共享环境建议在

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -17,7 +17,6 @@ CREATE TABLE IF NOT EXISTS rmq_nameserver (
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
 -- 2. 实例注册表（实例管理页的数据源，topic/group 按 instance_id 归属统计）
 CREATE TABLE IF NOT EXISTS rmq_instance (
   id VARCHAR(64) PRIMARY KEY,
@@ -25,10 +24,6 @@ CREATE TABLE IF NOT EXISTS rmq_instance (
   remark VARCHAR(255),
   type VARCHAR(32) NOT NULL COMMENT 'PROXY/DIRECT',
   endpoint VARCHAR(512) NOT NULL,
-  vendor VARCHAR(32) NOT NULL DEFAULT 'APACHE' COMMENT 'APACHE/ALIYUN/TENCENT',
-  cloud_instance_id VARCHAR(128) COMMENT '云厂商实例 ID（vendor 非 APACHE 时必填）',
-  credential_id VARCHAR(64) COMMENT '引用 rmq_cloud_credential.id',
-  region_id VARCHAR(64) COMMENT '云 region',
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -213,161 +208,15 @@ CREATE TABLE IF NOT EXISTS rmq_system_alert (
   INDEX idx_acknowledged (acknowledged)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 15. 云厂商凭据（secret_key 为 base64 编码，禁止明文；access_key 明文用于唯一键与打码展示）
+-- 15. Cloud provider credentials (secret_key is base64-encoded and never seeded).
 CREATE TABLE IF NOT EXISTS rmq_cloud_credential (
   id VARCHAR(64) PRIMARY KEY,
-  name VARCHAR(128) NOT NULL COMMENT '凭据显示名',
+  name VARCHAR(128) NOT NULL COMMENT 'Credential display name',
   vendor VARCHAR(32) NOT NULL COMMENT 'ALIYUN/TENCENT',
   access_key VARCHAR(255) NOT NULL,
-  secret_key VARCHAR(512) NOT NULL COMMENT 'base64 编码的 SK',
+  secret_key VARCHAR(512) NOT NULL COMMENT 'Base64-encoded secret key',
   remark VARCHAR(255),
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   UNIQUE KEY uk_vendor_access_key (vendor, access_key)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- ============================================================
--- 样例数据（幂等）：instance / topic / group 列表以本库为准，创建时写库、读取时读库。
--- 实例管理页默认 5 个实例：2 个 DIRECT（instance-direct-1/2）+ 3 个 PROXY（instance-proxy-1/2/3）。
--- topic/group 通过 instance_id 归属实例，实例页的 topic/group 数量按 instance_id group by 实时统计。
--- cluster_id 需与 NameServer 上报的集群名一致，否则页面按集群过滤时查不到。
--- ============================================================
-
-INSERT IGNORE INTO rmq_instance (id, name, remark, type, endpoint) VALUES
-  ('instance-direct-1', 'instance-direct-1', '直连实例 1，交易核心链路（NameServer 直连）', 'DIRECT', '10.0.1.11:9876'),
-  ('instance-direct-2', 'instance-direct-2', '直连实例 2，风控与审计链路（NameServer 直连）', 'DIRECT', '10.0.1.12:9876'),
-  ('instance-proxy-1',  'instance-proxy-1',  'Proxy 实例 1，电商交易主链路', 'PROXY', '10.0.2.21:8080'),
-  ('instance-proxy-2',  'instance-proxy-2',  'Proxy 实例 2，营销与会员链路', 'PROXY', '10.0.2.22:8080'),
-  ('instance-proxy-3',  'instance-proxy-3',  'Proxy 实例 3，物流与大数据链路', 'PROXY', '10.0.2.23:8080');
-
-INSERT IGNORE INTO rmq_topic
-  (cluster_id, instance_id, name, topic_type, read_queue_nums, write_queue_nums, perm, remark, status, created_by)
-VALUES
-  -- instance-proxy-1：电商交易主链路
-  ('rocketmq-studio', 'instance-proxy-1', 'order_create_event',        'NORMAL',      8,  8, 6,
-   '下单成功事件，履约、营销、风控多方订阅', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'order_status_change',       'FIFO',        4,  4, 6,
-   '订单状态流转，按订单号分区保证同单有序', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'order_timeout_cancel',      'DELAY',       8,  8, 6,
-   '未支付订单超时关单，延迟 30 分钟投递', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'payment_result_notify',     'TRANSACTION', 8,  8, 6,
-   '支付结果通知，与支付流水落库同事务', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'inventory_deduct_command',  'NORMAL',     16, 16, 6,
-   '库存扣减指令，大促期间扩容至 16 队列', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'refund_apply_event',        'NORMAL',      4,  4, 6,
-   '退款申请事件，客服与财务系统订阅', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'cart_sync_event',           'NORMAL',      4,  4, 6,
-   '购物车多端同步事件', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'trade_close_archive',       'NORMAL',      2,  2, 4,
-   '交易关单归档，只读供对账回溯', 'ACTIVE', 'seed'),
-  -- instance-proxy-2：营销与会员链路
-  ('rocketmq-studio', 'instance-proxy-2', 'marketing_coupon_issue',    'NORMAL',      4,  4, 6,
-   '营销发券，活动期间异步发放优惠券', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'marketing_campaign_push',   'NORMAL',      8,  8, 6,
-   '大促活动 push 触达，按人群包分批投递', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'member_register_event',     'NORMAL',      4,  4, 6,
-   '新会员注册事件，积分与权益系统订阅', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'member_points_change',      'FIFO',        4,  4, 6,
-   '会员积分变动，按会员 ID 分区保序', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'member_level_upgrade',      'DELAY',       4,  4, 6,
-   '会员升级权益延迟发放', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'sms_send_command',          'NORMAL',      8,  8, 6,
-   '短信下发指令，网关限流后消费', 'ACTIVE', 'seed'),
-  -- instance-proxy-3：物流与大数据链路
-  ('rocketmq-studio', 'instance-proxy-3', 'logistics_tracking_update', 'NORMAL',      8,  8, 6,
-   '物流轨迹更新，承运商回调后投递', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'logistics_dispatch_order',  'FIFO',        8,  8, 6,
-   '运单调度指令，同单有序', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'settlement_daily_archive',  'NORMAL',      2,  2, 4,
-   '日结账单归档，已停止写入仅供回溯消费', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'bi_realtime_report',        'NORMAL',     16, 16, 6,
-   '实时报表数据流，BI 大屏消费', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'user_behavior_log',         'NORMAL',     16, 16, 6,
-   '用户行为埋点日志，离线分析入湖', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'click_stream_etl',          'NORMAL',      8,  8, 6,
-   '点击流 ETL 中间结果', 'ACTIVE', 'seed'),
-  -- instance-direct-1：交易核心直连链路
-  ('rocketmq-studio', 'instance-direct-1', 'trade_core_order_flow',    'FIFO',        8,  8, 6,
-   '交易核心订单流水，直连低延迟链路', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-1', 'payment_channel_callback', 'NORMAL',      8,  8, 6,
-   '支付渠道回调通知', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-1', 'account_ledger_entry',     'TRANSACTION', 8,  8, 6,
-   '账户记账分录，与账务落库同事务', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-1', 'ledger_reconcile_task',    'DELAY',       4,  4, 6,
-   '对账任务延迟触发，T+1 凌晨执行', 'ACTIVE', 'seed'),
-  -- instance-direct-2：风控与审计链路
-  ('rocketmq-studio', 'instance-direct-2', 'risk_control_audit',       'NORMAL',      4,  4, 2,
-   '风控审计流水，仅生产侧写入，消费方待接入', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-2', 'risk_event_alert',         'NORMAL',      4,  4, 6,
-   '风控命中事件告警，实时推送处置平台', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-2', 'audit_operation_log',      'NORMAL',      8,  8, 6,
-   '操作审计日志，合规留存 180 天', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-2', 'compliance_report_daily',  'DELAY',       2,  2, 6,
-   '合规日报延迟生成任务', 'ACTIVE', 'seed');
-
-INSERT IGNORE INTO rmq_group
-  (cluster_id, instance_id, name, consume_type, message_model, max_retry, status, created_by)
-VALUES
-  -- instance-proxy-1
-  ('rocketmq-studio', 'instance-proxy-1', 'GID_fulfillment_order',  'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'GID_inventory_deduct',   'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'GID_payment_result',     'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'GID_refund_process',     'PUSH', 'CLUSTERING',    8, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'GID_cart_sync',          'PUSH', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'GID_trade_archive',      'PULL', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  -- instance-proxy-2
-  ('rocketmq-studio', 'instance-proxy-2', 'GID_marketing_coupon',   'PUSH', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'GID_campaign_push',      'PUSH', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'GID_member_points',      'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'GID_member_benefit',     'PUSH', 'CLUSTERING',    8, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'GID_sms_gateway',        'PUSH', 'CLUSTERING',    5, 'ACTIVE', 'seed'),
-  -- instance-proxy-3
-  ('rocketmq-studio', 'instance-proxy-3', 'GID_logistics_tracking', 'PUSH', 'CLUSTERING',    5, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'GID_logistics_dispatch', 'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'GID_settlement_archive', 'PULL', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'GID_bi_realtime_report', 'PUSH', 'BROADCASTING',  1, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'GID_behavior_ingest',    'PUSH', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'GID_click_stream_etl',   'PUSH', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  -- instance-direct-1
-  ('rocketmq-studio', 'instance-direct-1', 'GID_trade_core_flow',   'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-1', 'GID_pay_channel_cb',    'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-1', 'GID_ledger_entry',      'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-1', 'GID_reconcile_task',    'PULL', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  -- instance-direct-2
-  ('rocketmq-studio', 'instance-direct-2', 'GID_risk_alert',        'PUSH', 'CLUSTERING',    8, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-2', 'GID_audit_archive',     'PUSH', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-2', 'GID_compliance_daily',  'PULL', 'CLUSTERING',    1, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-2', 'studio-trace-consumer', 'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed');
-
--- ACL 规则种子：principal 对应下方 ACL 用户，资源对齐上面的 seed topic/group，scope 为实例 id
-INSERT IGNORE INTO rmq_acl_rule
-  (id, principal, resource, resource_type, resource_pattern, actions, decision, scope, acl_version)
-VALUES
-  ('acl-001', 'user-order-service',         'order_*',                 'Topic',   'PREFIX',  'PUB,SUB', 'ALLOW', 'instance-proxy-1',  '2.0'),
-  ('acl-002', 'user-payment-service',       'payment_*',               'Topic',   'PREFIX',  'PUB,SUB', 'ALLOW', 'instance-proxy-1',  '2.0'),
-  ('acl-003', 'user-admin',                 '*',                       'Cluster', 'LITERAL', 'ALL',     'ALLOW', 'instance-proxy-1',  '2.0'),
-  ('acl-004', 'user-log-collector',         'audit_operation_log',     'Topic',   'LITERAL', 'SUB',     'ALLOW', 'instance-direct-2', '1.0'),
-  ('acl-005', 'user-order-service',         'GID_fulfillment_*',       'Group',   'PREFIX',  'SUB',     'ALLOW', 'instance-proxy-1',  '2.0'),
-  ('acl-006', 'user-inventory-service',     'inventory_deduct_command','Topic',   'LITERAL', 'PUB,SUB', 'ALLOW', 'instance-proxy-1',  '2.0'),
-  ('acl-007', 'user-guest',                 'payment_result_notify',   'Topic',   'LITERAL', 'PUB,SUB', 'DENY',  'instance-proxy-1',  '1.0'),
-  ('acl-008', 'user-notification-service',  'sms_send_command',        'Topic',   'LITERAL', 'PUB',     'ALLOW', 'instance-proxy-2',  '2.0'),
-  ('acl-009', 'user-risk-control',          'risk_event_alert',        'Topic',   'LITERAL', 'SUB',     'ALLOW', 'instance-direct-2', '1.0'),
-  ('acl-010', 'user-guest',                 '*',                       'Cluster', 'LITERAL', 'PUB',     'DENY',  'instance-proxy-2',  '2.0'),
-  ('acl-011', 'user-payment-service',       'GID_payment_*',           'Group',   'PREFIX',  'SUB',     'ALLOW', 'instance-proxy-1',  '2.0'),
-  ('acl-012', 'user-monitor',               'user_behavior_log',       'Topic',   'LITERAL', 'SUB',     'ALLOW', 'instance-proxy-3',  '1.0'),
-  ('acl-013', 'user-ai-service',            'click_stream_etl',        'Topic',   'LITERAL', 'PUB,SUB', 'ALLOW', 'instance-proxy-3',  '2.0');
-
--- ACL 用户种子：secret_key 为密码的 base64 编码（如 user-admin 明文 Admin@Studio#2026）
-INSERT IGNORE INTO rmq_acl_user
-  (id, username, access_key, secret_key, admin, clusters)
-VALUES
-  ('u-001', 'user-admin',                 'AKSTUDIOadmin0001', 'QWRtaW5AU3R1ZGlvIzIwMjY=',     1,
-   'instance-proxy-1,instance-proxy-2,instance-proxy-3,instance-direct-1,instance-direct-2'),
-  ('u-002', 'user-order-service',         'AKSTUDIOordr0002',  'T3JkZXJTdmNAMjAyNiNQcm9k',     0, 'instance-proxy-1'),
-  ('u-003', 'user-payment-service',       'AKSTUDIOpaym0003',  'UGF5U3ZjQDIwMjYjUHJvZA==',     0, 'instance-proxy-1'),
-  ('u-004', 'user-log-collector',         'AKSTUDIOlogs0004',  'TG9nQ29sbGVjdEAyMDI2I09wcw==', 0, 'instance-direct-2'),
-  ('u-005', 'user-guest',                 'AKSTUDIOgues0005',  'R3Vlc3RAMjAyNiNSZWFk',         0, 'instance-proxy-2'),
-  ('u-006', 'user-inventory-service',     'AKSTUDIOinvn0006',  'SW52U3ZjQDIwMjYjUHJvZA==',     0, 'instance-proxy-1'),
-  ('u-007', 'user-notification-service',  'AKSTUDIONtfy0007',  'Tm90aWZ5U3ZjQDIwMjYjTXNn',     0, 'instance-proxy-2'),
-  ('u-008', 'user-monitor',               'AKSTUDIOmonr0008',  'TW9uaXRvckAyMDI2I09icw==',     0,
-   'instance-proxy-3,instance-direct-2');


### PR DESCRIPTION
## Summary
- remove instances, topics, consumer groups, ACL rules, and ACL users from the default MySQL schema
- keep the default deployment DDL-only
- document the explicit development-only demo-data import path

Closes #974

## Verification
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -q -DskipTests compile`
- `docker compose -f deploy/docker-compose.yml config`
- verified `server/src/main/resources/db/schema.sql` contains no `INSERT` statements
- `git diff --check origin/rocketmq-studio...HEAD`