### PR TITLE
feat(ai): add rmq.message.trace tool to the AI tool catalog

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandler.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import org.apache.rocketmq.studio.instance.message.ConsumerStatusVO;
+import org.apache.rocketmq.studio.instance.message.MessageProvider;
+import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
+import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Returns the message trace timeline for one message id. Read-only and safe for AI/MCP/CLI callers.
+ */
+@Component
+@RequiredArgsConstructor
+public class MessageTraceToolHandler implements ToolHandler {
+
+    private static final String NAME = "rmq.message.trace";
+
+    private final MessageProvider messageProvider;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public Object execute(Map<String, Object> input) {
+        String msgId = (String) input.get("msgId");
+        TraceRecordVO trace = messageProvider.getMessageTrace(msgId);
+        return project(msgId, trace);
+    }
+
+    private static Map<String, Object> project(String msgId, TraceRecordVO trace) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("msgId", msgId);
+        result.put("nodes", trace.getNodes().stream()
+                .map(MessageTraceToolHandler::projectNode)
+                .toList());
+        result.put("consumerStatus", trace.getConsumerStatus().stream()
+                .map(MessageTraceToolHandler::projectConsumerStatus)
+                .toList());
+        return result;
+    }
+
+    private static Map<String, Object> projectNode(TraceNodeVO node) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("title", blankIfNull(node.getTitle()));
+        result.put("timestamp", node.getTimestamp());
+        result.put("status", blankIfNull(node.getStatus()));
+        result.put("costTime", node.getCostTime());
+        result.put("description", blankIfNull(node.getDescription()));
+        return result;
+    }
+
+    private static Map<String, Object> projectConsumerStatus(ConsumerStatusVO status) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("group", blankIfNull(status.getGroup()));
+        result.put("deliveryStatus",
+                status.getDeliveryStatus() == null ? "" : status.getDeliveryStatus().name());
+        result.put("consumeTime", status.getConsumeTime());
+        result.put("retryCount", status.getRetryCount());
+        return result;
+    }
+
+    private static String blankIfNull(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/server/src/main/resources/tool-catalog/rmq-tools.yaml
+++ b/server/src/main/resources/tool-catalog/rmq-tools.yaml
@@ -457,3 +457,70 @@ tools:
                         - 'null'
     viewHint: object
     deprecated: false
+  - name: rmq.message.trace
+    cli:
+      resource: message
+      verb: trace
+    description: Get the message trace timeline for one message id in a RocketMQ cluster.
+    riskLevel: L1
+    permission: message:read
+    requiredCapabilities: []
+    inputSchema:
+      type: object
+      required:
+        - cluster
+        - msgId
+      additionalProperties: false
+      properties:
+        cluster:
+          type: string
+          minLength: 1
+        msgId:
+          type: string
+          minLength: 1
+    outputSchema:
+      type: object
+      required:
+        - msgId
+        - nodes
+        - consumerStatus
+      additionalProperties: false
+      properties:
+        msgId:
+          type: string
+        nodes:
+          type: array
+          items:
+            type: object
+            required:
+              - title
+            additionalProperties: false
+            properties:
+              title:
+                type: string
+              timestamp:
+                type: integer
+              status:
+                type: string
+              costTime:
+                type: integer
+              description:
+                type: string
+        consumerStatus:
+          type: array
+          items:
+            type: object
+            required:
+              - group
+            additionalProperties: false
+            properties:
+              group:
+                type: string
+              deliveryStatus:
+                type: string
+              consumeTime:
+                type: integer
+              retryCount:
+                type: integer
+    viewHint: object
+    deprecated: false

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandlerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
+import org.apache.rocketmq.studio.instance.message.ConsumerStatusVO;
+import org.apache.rocketmq.studio.instance.message.MessageProvider;
+import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
+import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MessageTraceToolHandlerTest {
+
+    @Mock
+    private MessageProvider messageProvider;
+
+    @InjectMocks
+    private MessageTraceToolHandler handler;
+
+    @Test
+    void executeShouldProjectTraceTimeline() {
+        TraceRecordVO trace = TraceRecordVO.builder()
+                .nodes(List.of(TraceNodeVO.builder()
+                        .title("produce")
+                        .timestamp(1000L)
+                        .status("finish")
+                        .costTime(5L)
+                        .description("prod-group")
+                        .build()))
+                .consumerStatus(List.of(ConsumerStatusVO.builder()
+                        .group("cons-group")
+                        .deliveryStatus(DeliveryStatus.success)
+                        .consumeTime(2000L)
+                        .retryCount(0)
+                        .build()))
+                .build();
+        when(messageProvider.getMessageTrace("msg-1")).thenReturn(trace);
+
+        Object result = handler.execute(Map.of("cluster", "cluster-1", "msgId", "msg-1"));
+
+        assertThat(result).isInstanceOf(Map.class);
+        Map<?, ?> map = (Map<?, ?>) result;
+        assertThat(map.get("msgId")).isEqualTo("msg-1");
+
+        List<?> nodes = (List<?>) map.get("nodes");
+        assertThat(nodes).hasSize(1);
+        Map<?, ?> node = (Map<?, ?>) nodes.get(0);
+        assertThat(node.get("title")).isEqualTo("produce");
+        assertThat(node.get("status")).isEqualTo("finish");
+        assertThat(node.get("timestamp")).isEqualTo(1000L);
+
+        List<?> consumers = (List<?>) map.get("consumerStatus");
+        assertThat(consumers).hasSize(1);
+        Map<?, ?> consumer = (Map<?, ?>) consumers.get(0);
+        assertThat(consumer.get("group")).isEqualTo("cons-group");
+        assertThat(consumer.get("deliveryStatus")).isEqualTo("success");
+        assertThat(consumer.get("retryCount")).isEqualTo(0);
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
@@ -45,7 +45,8 @@ class ToolCatalogTest {
                         "rmq.topic.list",
                         "rmq.group.list",
                         "rmq.alert.rule.list",
-                        "rmq.nameserver.config.diff");
+                        "rmq.nameserver.config.diff",
+                        "rmq.message.trace");
         assertThat(catalog.find("rmq.cluster.list")).isPresent();
         assertThat(catalog.find("rmq.unknown")).isEmpty();
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -45,6 +45,7 @@ import org.springframework.core.io.ClassPathResource;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -122,7 +123,8 @@ class ToolGatewayServiceTest {
                         "rmq.topic.list",
                         "rmq.group.list",
                         "rmq.alert.rule.list",
-                        "rmq.nameserver.config.diff");
+                        "rmq.nameserver.config.diff",
+                        "rmq.message.trace");
     }
 
     @Test
@@ -507,7 +509,8 @@ class ToolGatewayServiceTest {
 
     @Test
     void failsStartupWhenCatalogAndHandlersDoNotMatch() {
-        assertThatThrownBy(() -> gateway(catalog, clusterListHandler))
+        assertThatThrownBy(() -> new ToolGatewayService(
+                catalog, capabilityResolver, new ObjectMapper(), List.of(clusterListHandler)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("missing handler");
     }
@@ -600,11 +603,22 @@ class ToolGatewayServiceTest {
     }
 
     private ToolGatewayService gateway(ToolCatalog toolCatalog, ToolHandler... handlers) {
+        List<ToolHandler> all = new ArrayList<>(List.of(handlers));
+        // The canonical catalog gains tools over time; fill any handler the test did not pass in
+        // with a stub so gateway construction stays valid for every catalog entry.
+        for (ToolDefinition definition : toolCatalog.list()) {
+            boolean provided = all.stream().anyMatch(h -> h.name().equals(definition.name()));
+            if (!provided) {
+                ToolHandler stub = mock(ToolHandler.class);
+                when(stub.name()).thenReturn(definition.name());
+                all.add(stub);
+            }
+        }
         return new ToolGatewayService(
                 toolCatalog,
                 capabilityResolver,
                 new ObjectMapper(),
-                List.of(handlers));
+                all);
     }
 
     private static ToolCatalog canonicalCatalog() {


### PR DESCRIPTION
Extends the Studio AI tool catalog (shared by Web/AI/MCP/CLI — track 3 "AI Native") with a message trace tool.

- New ToolHandler `rmq.message.trace` backed by the standard `MessageProvider.getMessageTrace`, surfacing the produce/consume/transaction timeline for a message id.
- Tool definition registered in the YAML contract (`rmq-tools.yaml`) with input/output JSON Schema; requires cluster + msgId per the catalog convention.
- Read-only, L1 risk level, no side effects.
- Unit tests for the handler, plus updated catalog/gateway tests.

Related: #1024 (track 3 AI Native), #998 (MCP server and CLI).
