### PR TITLE
fix(cluster): return errors instead of a success envelope for failed operations

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterController.java
@@ -66,8 +66,10 @@ public class ClusterController {
     public Result<Map<String, Object>> restartBroker(@PathVariable String clusterId,
                                                      @PathVariable String name) {
         boolean success = clusterService.restartBroker(clusterId, name);
+        if (!success) {
+            throw new BusinessException(500, "Failed to restart broker: " + name);
+        }
         return Result.ok(Map.of(
-                "success", success,
                 "message", "Broker restart initiated for " + name
         ));
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerController.java
@@ -27,8 +27,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
 @RestController
 @RequestMapping("/api/nameservers")
 @RequiredArgsConstructor
@@ -50,27 +48,36 @@ public class NameServerController {
     }
 
     @PostMapping("/restart")
-    public Result<Map<String, Boolean>> restartNameServer(
+    public Result<Void> restartNameServer(
             @Valid @RequestBody(required = false) RestartNameServerDTO command) {
         requireCommand(command);
         boolean success = clusterService.restartNameServer(command);
-        return Result.ok(Map.of("success", success));
+        requireOperationSuccess(success, "restart");
+        return Result.ok();
     }
 
     @PostMapping("/upgrade")
-    public Result<Map<String, Boolean>> upgradeNameServer(
+    public Result<Void> upgradeNameServer(
             @Valid @RequestBody(required = false) UpgradeNameServerDTO command) {
         requireCommand(command);
         boolean success = clusterService.upgradeNameServer(command);
-        return Result.ok(Map.of("success", success));
+        requireOperationSuccess(success, "upgrade");
+        return Result.ok();
     }
 
     @PostMapping("/delete")
-    public Result<Map<String, Boolean>> deleteNameServer(
+    public Result<Void> deleteNameServer(
             @Valid @RequestBody(required = false) DeleteNameServerDTO command) {
         requireCommand(command);
         boolean success = clusterService.deleteNameServer(command);
-        return Result.ok(Map.of("success", success));
+        requireOperationSuccess(success, "delete");
+        return Result.ok();
+    }
+
+    private void requireOperationSuccess(boolean success, String operation) {
+        if (!success) {
+            throw new BusinessException(500, "Failed to " + operation + " NameServer");
+        }
     }
 
     private void requireCommand(Object command) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyController.java
@@ -18,14 +18,13 @@ package org.apache.rocketmq.studio.cluster.proxy;
 
 import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/proxies")
@@ -35,8 +34,11 @@ public class ProxyController {
     private final ClusterService clusterService;
 
     @PostMapping("/restart")
-    public Result<Map<String, Boolean>> restartProxy(@Valid @RequestBody RestartProxyDTO command) {
+    public Result<Void> restartProxy(@Valid @RequestBody RestartProxyDTO command) {
         boolean success = clusterService.restartProxy(command);
-        return Result.ok(Map.of("success", success));
+        if (!success) {
+            throw new BusinessException(500, "Failed to restart proxy");
+        }
+        return Result.ok();
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterControllerTest.java
@@ -299,7 +299,6 @@ class ClusterControllerTest {
         mockMvc.perform(post("/api/clusters/cluster-1/brokers/broker-0/restart"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.success").value(true))
                 .andExpect(jsonPath("$.data.message").value("Broker restart initiated for broker-0"));
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerControllerTest.java
@@ -122,8 +122,7 @@ class NameServerControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.success").value(true));
+                .andExpect(jsonPath("$.code").value(200));
 
         verify(clusterService).restartNameServer(any(RestartNameServerDTO.class));
     }
@@ -173,8 +172,7 @@ class NameServerControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.success").value(true));
+                .andExpect(jsonPath("$.code").value(200));
 
         verify(clusterService).deleteNameServer(any(DeleteNameServerDTO.class));
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyControllerTest.java
@@ -59,8 +59,7 @@ class ProxyControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.success").value(true));
+                .andExpect(jsonPath("$.code").value(200));
 
         verify(clusterService).restartProxy(any(RestartProxyDTO.class));
     }


### PR DESCRIPTION
The restart/upgrade/delete endpoints for brokers, NameServers and proxies wrapped a boolean `success` flag in `Result.ok`, so a failed operation (if a service ever returned `false` instead of throwing) would reach the client as HTTP 200 with `success=false` — a success envelope masking a failure.

The controllers now throw a `BusinessException` when the operation reports failure, so a failed operation is an actual error response, and the success-flag field is gone from the payload. Updated the affected controller tests.
