### PR TITLE
fix: scope Consumer Group offset resets to selected instance

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupController.java
@@ -81,7 +81,7 @@ public class ConsumerGroupController {
 
     @PostMapping("/reset-offset")
     public Result<Void> resetOffset(@Valid @RequestBody ResetConsumerOffsetDTO request) {
-        metadataService.resetOffset(request.getName(), request.getTimestamp(), request.getTopic());
+        metadataService.resetOffset(request.getInstanceId(), request.getName(), request.getTimestamp(), request.getTopic());
         return Result.ok();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ResetConsumerOffsetDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ResetConsumerOffsetDTO.java
@@ -29,6 +29,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ResetConsumerOffsetDTO {
+    @NotBlank(message = "instanceId is required")
+    private String instanceId;
+
     @NotBlank(message = "name is required")
     private String name;
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/AdminClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/AdminClient.java
@@ -28,5 +28,5 @@ public interface AdminClient {
     SendMessageVO sendMessage(SendMessageDTO request);
     ConsumerGroupVO createConsumerGroup(ConsumerGroupVO group);
     void deleteConsumerGroup(String name);
-    void resetOffset(String name, long timestamp, String topic);
+    void resetOffset(String instanceId, String name, long timestamp, String topic);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
@@ -111,8 +111,8 @@ public class MetadataService {
     }
 
 
-    public void resetOffset(String name, long timestamp, String topic) {
-        adminClient.resetOffset(name, timestamp, topic);
+    public void resetOffset(String instanceId, String name, long timestamp, String topic) {
+        adminClient.resetOffset(instanceId, name, timestamp, topic);
     }
 
     // ── NamespaceVO ───────────────────────────────────────────────────

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/NameSrvAdminClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/NameSrvAdminClient.java
@@ -68,7 +68,7 @@ public class NameSrvAdminClient implements AdminClient {
     }
 
     @Override
-    public void resetOffset(String name, long timestamp, String topic) {
+    public void resetOffset(String instanceId, String name, long timestamp, String topic) {
         throw consumerGroupAdminUnavailable();
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
@@ -69,6 +70,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
     private final RmqTopicMapper topicMapper;
     private final RmqGroupMapper groupMapper;
     private final AuditService auditService;
+    private final RuntimeAdminClientResolver runtimeAdminClientResolver;
 
     @Autowired
     public RocketMQAdminClientImpl(
@@ -76,12 +78,14 @@ public class RocketMQAdminClientImpl implements AdminClient {
             RocketMQProperties properties,
             RmqTopicMapper topicMapper,
             RmqGroupMapper groupMapper,
-            AuditService auditService) {
+            AuditService auditService,
+            RuntimeAdminClientResolver runtimeAdminClientResolver) {
         this.adminExt = adminExt;
         this.properties = properties;
         this.topicMapper = topicMapper;
         this.groupMapper = groupMapper;
         this.auditService = auditService;
+        this.runtimeAdminClientResolver = runtimeAdminClientResolver;
     }
 
     @Override
@@ -476,15 +480,15 @@ public class RocketMQAdminClientImpl implements AdminClient {
     }
 
     @Override
-    public void resetOffset(String name, long timestamp, String topic) {
-        if (adminExt == null) {
-            throw new BusinessException(503, "RocketMQ admin not connected");
-        }
-
+    public void resetOffset(String instanceId, String name, long timestamp, String topic) {
         try {
-            adminExt.resetOffsetByTimestamp(getClusterName(), topic, name, timestamp, false);
+            runtimeAdminClientResolver.execute(instanceId, resolvedAdmin -> {
+                DefaultMQAdminExt targetAdmin = (DefaultMQAdminExt) resolvedAdmin;
+                targetAdmin.resetOffsetByTimestamp(getClusterName(targetAdmin), topic, name, timestamp, false);
+                return null;
+            });
             auditService.record("RESET_OFFSET", name,
-                    "topic=" + topic + ", timestamp=" + timestamp, "SUCCESS");
+                    "instanceId=" + instanceId + ", topic=" + topic + ", timestamp=" + timestamp, "SUCCESS");
         } catch (Exception e) {
             auditService.record("RESET_OFFSET", name, e.getMessage(), "FAILED");
             throw new BusinessException(500, "Failed to reset offset: " + e.getMessage());
@@ -517,8 +521,12 @@ public class RocketMQAdminClientImpl implements AdminClient {
     }
 
     private String getClusterName() {
+        return getClusterName(adminExt);
+    }
+
+    private String getClusterName(DefaultMQAdminExt targetAdmin) {
         try {
-            ClusterInfo clusterInfo = adminExt.examineBrokerClusterInfo();
+            ClusterInfo clusterInfo = targetAdmin.examineBrokerClusterInfo();
             if (clusterInfo != null && clusterInfo.getClusterAddrTable() != null
                     && !clusterInfo.getClusterAddrTable().isEmpty()) {
                 return clusterInfo.getClusterAddrTable().keySet().iterator().next();

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupControllerTest.java
@@ -62,6 +62,7 @@ class ConsumerGroupControllerTest {
     @Test
     void createConsumerGroupShouldPassValidatedRequest() throws Exception {
         Map<String, Object> body = Map.of(
+                "instanceId", "instance-a",
                 "name", "cg-orders",
                 "clusterId", "cluster-a",
                 "retryMaxTimes", 8,
@@ -109,6 +110,7 @@ class ConsumerGroupControllerTest {
     @Test
     void createConsumerGroupShouldRejectNegativeRetryMaxTimes() throws Exception {
         Map<String, Object> body = Map.of(
+                "instanceId", "instance-a",
                 "name", "cg-orders",
                 "retryMaxTimes", -1
         );
@@ -157,6 +159,7 @@ class ConsumerGroupControllerTest {
     @Test
     void resetOffsetShouldPassValidatedRequest() throws Exception {
         Map<String, Object> body = Map.of(
+                "instanceId", "instance-a",
                 "name", "cg-orders",
                 "topic", "orders",
                 "timestamp", 1784246400000L
@@ -169,7 +172,7 @@ class ConsumerGroupControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success"));
 
-        verify(metadataService).resetOffset(eq("cg-orders"), eq(1784246400000L), eq("orders"));
+        verify(metadataService).resetOffset(eq("instance-a"), eq("cg-orders"), eq(1784246400000L), eq("orders"));
     }
 
     @Test
@@ -211,6 +214,7 @@ class ConsumerGroupControllerTest {
     @Test
     void resetOffsetShouldRejectMissingName() throws Exception {
         Map<String, Object> body = Map.of(
+                "instanceId", "instance-a",
                 "topic", "orders",
                 "timestamp", 1784246400000L
         );
@@ -228,6 +232,7 @@ class ConsumerGroupControllerTest {
     @Test
     void resetOffsetShouldRejectMissingTimestamp() throws Exception {
         Map<String, Object> body = Map.of(
+                "instanceId", "instance-a",
                 "name", "cg-orders",
                 "topic", "orders"
         );
@@ -245,6 +250,7 @@ class ConsumerGroupControllerTest {
     @Test
     void resetOffsetShouldRejectNonPositiveTimestamp() throws Exception {
         Map<String, Object> body = Map.of(
+                "instanceId", "instance-a",
                 "name", "cg-orders",
                 "topic", "orders",
                 "timestamp", 0L
@@ -263,6 +269,7 @@ class ConsumerGroupControllerTest {
     @Test
     void resetOffsetShouldRejectInvalidTimestampType() throws Exception {
         Map<String, Object> body = Map.of(
+                "instanceId", "instance-a",
                 "name", "cg-orders",
                 "topic", "orders",
                 "timestamp", "invalid"

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/NameSrvAdminClientTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/NameSrvAdminClientTest.java
@@ -36,7 +36,7 @@ class NameSrvAdminClientTest {
         assertUnavailable(() -> adminClient.getConsumerGroup("cg-order"));
         assertUnavailable(() -> adminClient.createConsumerGroup(group));
         assertUnavailable(() -> adminClient.deleteConsumerGroup("cg-order"));
-        assertUnavailable(() -> adminClient.resetOffset("cg-order", 1784246400000L, "order-topic"));
+        assertUnavailable(() -> adminClient.resetOffset("instance-a", "cg-order", 1784246400000L, "order-topic"));
     }
 
     private void assertUnavailable(ThrowableAssert.ThrowingCallable callable) {

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImplTest.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.apache.rocketmq.studio.instance.topic.SendMessageDTO;
@@ -72,12 +73,15 @@ class RocketMQAdminClientImplTest {
     private RmqGroupMapper groupMapper;
     @Mock
     private AuditService auditService;
+    @Mock
+    private RuntimeAdminClientResolver runtimeAdminClientResolver;
 
     private RocketMQAdminClientImpl adminClient;
 
     @BeforeEach
     void setUp() {
-        adminClient = new RocketMQAdminClientImpl(adminExt, properties, topicMapper, groupMapper, auditService);
+        adminClient = new RocketMQAdminClientImpl(adminExt, properties, topicMapper, groupMapper, auditService,
+                runtimeAdminClientResolver);
     }
 
     @Test
@@ -90,6 +94,15 @@ class RocketMQAdminClientImplTest {
 
         assertThat(group.getId()).isEqualTo("orders");
         assertThat(group.getOnlineInstances()).isZero();
+    }
+
+    @Test
+    void resetOffsetShouldUseSelectedInstanceRuntimeClient() {
+        adminClient.resetOffset("instance-a", "cg-orders", 1784246400000L, "orders");
+
+        verify(runtimeAdminClientResolver).execute(org.mockito.ArgumentMatchers.eq("instance-a"), any());
+        verify(auditService).record("RESET_OFFSET", "cg-orders",
+                "instanceId=instance-a, topic=orders, timestamp=1784246400000", "SUCCESS");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- require `instanceId` for Consumer Group offset reset requests
- execute resets through the selected instance runtime AdminClient instead of the process-wide client
- retain request validation and add resolver-routing regression coverage

Closes #1131

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -q -Dtest=RocketMQAdminClientImplTest,NameSrvAdminClientTest,ConsumerGroupControllerTest test`
- `git diff --check`