### PR TITLE
fix: route test messages through selected instance

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/SendMessageDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/SendMessageDTO.java
@@ -34,5 +34,6 @@ public class SendMessageDTO {
     private String tag;
     private String key;
     private String body;
+    private String instanceId;
     private Map<String, String> properties;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.topic.AdminClient;
 import org.apache.rocketmq.studio.instance.topic.SendMessageDTO;
@@ -69,6 +70,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
     private final RmqTopicMapper topicMapper;
     private final RmqGroupMapper groupMapper;
     private final AuditService auditService;
+    private final RuntimeAdminClientResolver runtimeAdminClientResolver;
 
     @Autowired
     public RocketMQAdminClientImpl(
@@ -76,12 +78,14 @@ public class RocketMQAdminClientImpl implements AdminClient {
             RocketMQProperties properties,
             RmqTopicMapper topicMapper,
             RmqGroupMapper groupMapper,
-            AuditService auditService) {
+            AuditService auditService,
+            RuntimeAdminClientResolver runtimeAdminClientResolver) {
         this.adminExt = adminExt;
         this.properties = properties;
         this.topicMapper = topicMapper;
         this.groupMapper = groupMapper;
         this.auditService = auditService;
+        this.runtimeAdminClientResolver = runtimeAdminClientResolver;
     }
 
     @Override
@@ -328,7 +332,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
             throw new BusinessException(503, "RocketMQ admin not connected");
         }
 
-        String namesrvAddr = properties.getNamesrvAddr();
+        String namesrvAddr = StringUtils.hasText(request.getInstanceId())
+                ? runtimeAdminClientResolver.resolveEndpoint(request.getInstanceId())
+                : properties.getNamesrvAddr();
         if (namesrvAddr == null || namesrvAddr.isEmpty()) {
             throw new BusinessException(500, "Nameserver address not configured");
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImplTest.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.apache.rocketmq.studio.instance.topic.SendMessageDTO;
@@ -72,12 +73,15 @@ class RocketMQAdminClientImplTest {
     private RmqGroupMapper groupMapper;
     @Mock
     private AuditService auditService;
+    @Mock
+    private RuntimeAdminClientResolver runtimeAdminClientResolver;
 
     private RocketMQAdminClientImpl adminClient;
 
     @BeforeEach
     void setUp() {
-        adminClient = new RocketMQAdminClientImpl(adminExt, properties, topicMapper, groupMapper, auditService);
+        adminClient = new RocketMQAdminClientImpl(
+                adminExt, properties, topicMapper, groupMapper, auditService, runtimeAdminClientResolver);
     }
 
     @Test
@@ -161,6 +165,30 @@ class RocketMQAdminClientImplTest {
             SendMessageVO result = adminClient.sendMessage(request);
             // The message was already delivered; an audit failure must not turn this into an error.
             assertThat(result.getMsgId()).isEqualTo("msg-1");
+        }
+    }
+
+    @Test
+    void sendMessageUsesSelectedInstanceEndpoint() throws Exception {
+        when(runtimeAdminClientResolver.resolveEndpoint("instance-a")).thenReturn("10.0.0.2:9876");
+        try (MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class, (producer, context) -> {
+                         doNothing().when(producer).start();
+                         SendResult sendResult = new SendResult();
+                         sendResult.setMsgId("msg-1");
+                         sendResult.setOffsetMsgId("offset-1");
+                         when(producer.send(any(Message.class))).thenReturn(sendResult);
+                         doNothing().when(producer).shutdown();
+                     })) {
+            SendMessageDTO request = new SendMessageDTO();
+            request.setTopic("TopicA");
+            request.setBody("hello");
+            request.setInstanceId("instance-a");
+
+            adminClient.sendMessage(request);
+
+            DefaultMQProducer producer = mockedProducers.constructed().getFirst();
+            verify(producer).setNamesrvAddr("10.0.0.2:9876");
         }
     }
 }

--- a/web/src/api/metadata.test.ts
+++ b/web/src/api/metadata.test.ts
@@ -88,14 +88,18 @@ describe('topic metadata API', () => {
       return [200, { code: 200, data: null }];
     });
     mock.onPost('/topics/send').reply((config) => {
-      expect(JSON.parse(config.data)).toMatchObject({ topic: topic.name, body: '{"id":1}' });
+      expect(JSON.parse(config.data)).toMatchObject({
+        topic: topic.name,
+        instanceId: 'instance-a',
+        body: '{"id":1}',
+      });
       return [200, { code: 200, data: { msgId: 'msg-1', sendTime: 1, offsetMsgId: 'offset-1' } }];
     });
 
     await expect(createTopic(topic)).resolves.toEqual(topic);
     await expect(deleteTopic(topic.name)).resolves.toBeUndefined();
-    await expect(sendTopicMessage({ topic: topic.name, body: '{"id":1}' })).resolves.toMatchObject({
-      msgId: 'msg-1',
-    });
+    await expect(
+      sendTopicMessage({ topic: topic.name, instanceId: 'instance-a', body: '{"id":1}' }),
+    ).resolves.toMatchObject({ msgId: 'msg-1' });
   });
 });

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -142,6 +142,7 @@ export async function getTopicConsumers(name: string) {
 
 export interface SendTopicMessageRequest {
   topic: string;
+  instanceId?: string;
   tag?: string;
   key?: string;
   body: string;

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -781,6 +781,7 @@ const TopicPage = () => {
       }
       const result = await sendTopicMessage({
         topic: values.topic,
+        instanceId: selectedInstanceId || undefined,
         tag: values.tag || undefined,
         key: values.key || undefined,
         body: values.body,


### PR DESCRIPTION
## Summary
- include selected instance context in the Topic test-message request
- configure the short-lived producer with the selected instance endpoint
- retain the configured NameServer fallback when instance context is absent
- add API serialization and producer endpoint regression coverage

Closes #1138

## Verification
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=RocketMQAdminClientImplTest,TopicControllerTest test`
- `npm test -- --run src/api/metadata.test.ts`
- `npm run build`