### PR TITLE
fix(persistence): make read-check-write repository saves transactional

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.studio.common.domain.enums.CertType;
 import org.apache.rocketmq.studio.persistence.entity.RmqK8sCertificate;
 import org.apache.rocketmq.studio.persistence.mapper.RmqK8sCertificateMapper;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 
@@ -57,6 +58,7 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
     }
 
     @Override
+    @Transactional
     public K8sCertVO save(K8sCertVO cert) {
         RmqK8sCertificate entity = toEntity(cert);
         if (entity.getId() != null && certMapper.selectById(entity.getId()) != null) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
@@ -28,6 +28,7 @@ import org.apache.rocketmq.studio.persistence.mapper.RmqInstanceMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqTopicMapper;
 import org.springframework.stereotype.Repository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -93,6 +94,7 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
     }
 
     @Override
+    @Transactional
     public InstanceVO save(InstanceVO instance) {
         RmqInstance entity = toEntity(instance);
         if (instanceMapper.selectById(entity.getId()) != null) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.studio.persistence.entity.RmqSystemAlert;
 import org.apache.rocketmq.studio.persistence.mapper.RmqAlertRuleMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqSystemAlertMapper;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 
@@ -49,6 +50,7 @@ public class MybatisPlusAlertRepository implements AlertRepository {
     }
 
     @Override
+    @Transactional
     public AlertRuleVO saveRule(AlertRuleVO rule) {
         RmqAlertRule entity = toRuleEntity(rule);
         if (entity.getId() != null && ruleMapper.selectById(entity.getId()) != null) {

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.studio.settings.DataSourceVO;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.apache.rocketmq.studio.settings.SettingsRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -88,6 +89,7 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
     }
 
     @Override
+    @Transactional
     public void saveGeneralSettings(GeneralSettingsVO settings) {
         try {
             String json = objectMapper.writeValueAsString(settings);


### PR DESCRIPTION
Four MyBatis-Plus repositories perform a non-atomic read-check-write (select by id, then insert or update). Under concurrent writes two requests can both see a missing row and both insert (duplicate key), or a read can interleave between the two update writes.

- `MybatisPlusSettingsRepository.saveGeneralSettings`
- `MybatisPlusInstanceRepository.save`
- `MybatisPlusAlertRepository.saveRule`
- `MybatisPlusK8sCertRepository.save`

Each write method is now annotated `@Transactional`, so the existence check and the insert/update run in the same transaction.
