### PR TITLE
fix: distinguish unavailable runtime diagnostics from empty data

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -245,8 +245,9 @@ public class RocketMQClientProvider implements ClientProvider {
         try {
             clusterInfo = adminExt.examineBrokerClusterInfo();
         } catch (Exception e) {
-            throw new BusinessException(502,
-                    "Failed to discover brokers for consumer connections: " + rootMessage(e));
+            log.warn("Failed to fetch cluster info for consumer connection scan", e);
+            throw new BusinessException(502, "Failed to discover brokers for consumer connections: "
+                    + rootMessage(e));
         }
         if (clusterInfo == null || clusterInfo.getBrokerAddrTable() == null) {
             return groups;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -212,12 +212,14 @@ public class RocketMQClientProvider implements ClientProvider {
     private List<ClientConnectionVO> findConsumerConnections(MQAdminExt adminExt, String clusterId) {
         List<ClientConnectionVO> result = new ArrayList<>();
         Set<String> groups = collectSubscriptionGroups(adminExt);
+        int successfulGroupQueries = 0;
         for (String group : groups) {
             if (isSystemGroup(group)) {
                 continue;
             }
             try {
                 ConsumerConnection consumerConnection = adminExt.examineConsumerConnectionInfo(group);
+                successfulGroupQueries++;
                 if (consumerConnection == null || consumerConnection.getConnectionSet() == null) {
                     continue;
                 }
@@ -231,6 +233,9 @@ public class RocketMQClientProvider implements ClientProvider {
                 log.warn("Failed to examine consumer connection for group={}, skipping", group, e);
             }
         }
+        if (!groups.isEmpty() && successfulGroupQueries == 0) {
+            throw new BusinessException(502, "Failed to query consumer connections from all groups");
+        }
         return result;
     }
 
@@ -240,12 +245,14 @@ public class RocketMQClientProvider implements ClientProvider {
         try {
             clusterInfo = adminExt.examineBrokerClusterInfo();
         } catch (Exception e) {
-            log.warn("Failed to fetch cluster info for consumer connection scan", e);
-            return groups;
+            throw new BusinessException(502,
+                    "Failed to discover brokers for consumer connections: " + rootMessage(e));
         }
         if (clusterInfo == null || clusterInfo.getBrokerAddrTable() == null) {
             return groups;
         }
+        int attemptedBrokerQueries = 0;
+        int successfulBrokerQueries = 0;
         for (BrokerData brokerData : clusterInfo.getBrokerAddrTable().values()) {
             if (brokerData == null) {
                 continue;
@@ -255,14 +262,19 @@ public class RocketMQClientProvider implements ClientProvider {
                 continue;
             }
             try {
+                attemptedBrokerQueries++;
                 SubscriptionGroupWrapper wrapper =
                         adminExt.getAllSubscriptionGroup(brokerAddr, SUBSCRIPTION_GROUP_TIMEOUT_MILLIS);
+                successfulBrokerQueries++;
                 if (wrapper != null && wrapper.getSubscriptionGroupTable() != null) {
                     groups.addAll(wrapper.getSubscriptionGroupTable().keySet());
                 }
             } catch (Exception e) {
                 log.warn("Failed to fetch subscription groups from broker={}, skipping", brokerAddr, e);
             }
+        }
+        if (attemptedBrokerQueries > 0 && successfulBrokerQueries == 0) {
+            throw new BusinessException(502, "Failed to query subscription groups from all brokers");
         }
         return groups;
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -29,6 +29,7 @@ import org.apache.rocketmq.remoting.protocol.route.QueueData;
 import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
@@ -243,7 +244,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
             return routes;
         } catch (Exception e) {
             log.warn("Failed to get routes for topic {}: {}", name, e.getMessage());
-            return Collections.emptyList();
+            throw new BusinessException(502, "Failed to get routes for topic " + name + ": " + e.getMessage());
         }
     }
 
@@ -376,7 +377,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
             return progress;
         } catch (Exception e) {
             log.warn("Failed to get progress for group {}: {}", name, e.getMessage());
-            return Collections.emptyList();
+            throw new BusinessException(502, "Failed to get progress for group " + name + ": " + e.getMessage());
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -244,6 +245,62 @@ class RocketMQClientProviderTest {
 
         assertThat(connections).hasSize(1);
         assertThat(connections.get(0).getClientId()).isEqualTo("consumer-client");
+    }
+
+    @Test
+    void consumerScanFailsWhenEveryBrokerGroupQueryFails() throws Exception {
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo(
+                "127.0.0.1:10911", "127.0.0.2:10911"));
+        when(adminExt.getAllSubscriptionGroup(anyString(), anyLong())).thenThrow(
+                new IllegalStateException("broker unavailable"));
+
+        assertThatThrownBy(() -> provider.findConnections("instance-a", "cluster-a", "Consumer"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Failed to query subscription groups from all brokers")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    @Test
+    void consumerScanFailsWhenEveryGroupConnectionQueryFails() throws Exception {
+        SubscriptionGroupWrapper wrapper = subscriptionGroups("group-a", "group-b");
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo("127.0.0.1:10911"));
+        when(adminExt.getAllSubscriptionGroup("127.0.0.1:10911", 5000L)).thenReturn(wrapper);
+        when(adminExt.examineConsumerConnectionInfo(anyString()))
+                .thenThrow(new IllegalStateException("broker unavailable"));
+
+        assertThatThrownBy(() -> provider.findConnections("instance-a", "cluster-a", "Consumer"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Failed to query consumer connections from all groups")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    @Test
+    void consumerScanReturnsPartialResultsWhenOneGroupQueryFails() throws Exception {
+        SubscriptionGroupWrapper wrapper = subscriptionGroups("group-a", "group-b");
+        ConsumerConnection consumerConnection = new ConsumerConnection();
+        consumerConnection.setConnectionSet(new HashSet<>(List.of(connection("consumer-client", "10.0.0.2:1000"))));
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo("127.0.0.1:10911"));
+        when(adminExt.getAllSubscriptionGroup("127.0.0.1:10911", 5000L)).thenReturn(wrapper);
+        when(adminExt.examineConsumerConnectionInfo("group-a"))
+                .thenThrow(new IllegalStateException("broker unavailable"));
+        when(adminExt.examineConsumerConnectionInfo("group-b")).thenReturn(consumerConnection);
+
+        List<ClientConnectionVO> connections = provider.findConnections("instance-a", "cluster-a", "Consumer");
+
+        assertThat(connections).singleElement().satisfies(connection -> {
+            assertThat(connection.getClientId()).isEqualTo("consumer-client");
+            assertThat(connection.getGroupOrTopic()).isEqualTo("group-b");
+        });
+    }
+
+    private static SubscriptionGroupWrapper subscriptionGroups(String... names) {
+        SubscriptionGroupWrapper wrapper = new SubscriptionGroupWrapper();
+        ConcurrentHashMap<String, SubscriptionGroupConfig> groups = new ConcurrentHashMap<>();
+        for (String name : names) {
+            groups.put(name, new SubscriptionGroupConfig());
+        }
+        wrapper.setSubscriptionGroupTable(groups);
+        return wrapper;
     }
 
     private static Connection connection(String clientId, String clientAddr) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
@@ -224,6 +224,16 @@ class RocketMQClientProviderTest {
     }
 
     @Test
+    void consumerScanFailsWhenBrokerDiscoveryFails() throws Exception {
+        when(adminExt.examineBrokerClusterInfo()).thenThrow(new IllegalStateException("broker unavailable"));
+
+        assertThatThrownBy(() -> provider.findConnections("instance-a", "cluster-a", "Consumer"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Failed to discover brokers for consumer connections: broker unavailable")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    @Test
     void consumerScanSkipsNullConnectionEntries() throws Exception {
         ClusterInfo clusterInfo = new ClusterInfo();
         clusterInfo.setBrokerAddrTable(Map.of("broker-a", new BrokerData("cluster-a", "broker-a",

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
@@ -18,6 +18,9 @@ package org.apache.rocketmq.studio.provider.apache;
 
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
 import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
@@ -35,7 +38,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -128,5 +134,37 @@ class RocketMQMetadataProviderTest {
         assertThat(provider.getGroupSubscriptions("instance-a", "cg-orders"))
                 .containsExactlyElementsOf(subscriptions);
         verify(runtimeAdminClientResolver, org.mockito.Mockito.times(2)).execute(eq("instance-a"), any());
+    }
+
+    @Test
+    void getTopicRoutesSurfacesAdminFailure() throws Exception {
+        DefaultMQAdminExt admin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        when(admin.examineTopicRouteInfo("TopicA")).thenThrow(new IllegalStateException("broker unavailable"));
+
+        assertThatThrownBy(() -> newLiveProvider(admin).getTopicRoutes(null, "TopicA"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Failed to get routes for topic TopicA: broker unavailable")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    @Test
+    void getGroupProgressSurfacesAdminFailure() throws Exception {
+        DefaultMQAdminExt admin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        when(admin.examineConsumeStats("group-a")).thenThrow(new IllegalStateException("broker unavailable"));
+
+        assertThatThrownBy(() -> newLiveProvider(admin).getGroupProgress(null, "group-a"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Failed to get progress for group group-a: broker unavailable")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    private RocketMQMetadataProvider newLiveProvider(MQAdminExt admin) throws Exception {
+        MqAdminExtFactory factory = mock(MqAdminExtFactory.class);
+        RocketMQProperties liveProperties = new RocketMQProperties();
+        liveProperties.setNamesrvAddr("10.0.0.1:9876");
+        lenient().when(factory.execute(anyString(), any(), any())).thenAnswer(invocation ->
+                invocation.<MqAdminExtFactory.AdminAction<Object>>getArgument(2).apply(admin));
+        return new RocketMQMetadataProvider(factory, liveProperties, topicMapper, groupMapper,
+                runtimeAdminClientResolver);
     }
 }


### PR DESCRIPTION
## Summary

- return actionable failures instead of empty results for unavailable Topic routes and Consumer Group progress
- preserve selected-instance runtime client routing for metadata diagnostics
- mark Topic consumer metrics unavailable when the broker cannot return statistics
- render unavailable consumer metrics explicitly in the Topic view

Closes #1142
Closes #1207

## Verification

- mvn -Dtest=RocketMQMetadataProviderTest test
- npm run build