### PR TITLE
fix: isolate broker config audit failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -189,7 +189,11 @@ public class ClusterService {
                 + ", failedBrokers=" + failedBrokers.stream()
                 .map(failure -> failure.getAddress() + ": " + failure.getMessage())
                 .toList();
-        auditService.record("UPDATE_CLUSTER_CONFIG", "CLUSTER:" + clusterId, detail, status.name());
+        try {
+            auditService.record("UPDATE_CLUSTER_CONFIG", "CLUSTER:" + clusterId, detail, status.name());
+        } catch (Exception e) {
+            log.warn("Failed to record cluster config update audit for {}: {}", clusterId, e.getMessage());
+        }
     }
 
     private ClusterVO resolveCluster(String clusterId) {

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQBrokerConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQBrokerConfigService.java
@@ -61,13 +61,22 @@ public class RocketMQBrokerConfigService {
         try {
             adminExt.updateBrokerConfig(brokerAddr, newConfig);
             String detail = "brokerAddr=" + brokerAddr + ", config=" + newConfig;
-            auditService.record("UPDATE_BROKER_CONFIG", "CLUSTER:" + clusterId, detail, "SUCCESS");
+            recordAudit(clusterId, detail, "SUCCESS");
             log.info("Broker config updated successfully: {}", brokerAddr);
         } catch (Exception e) {
             log.error("Failed to update broker config at {}", brokerAddr, e);
             String detail = "brokerAddr=" + brokerAddr + ", error=" + e.getMessage();
-            auditService.record("UPDATE_BROKER_CONFIG", "CLUSTER:" + clusterId, detail, "FAILURE");
+            recordAudit(clusterId, detail, "FAILURE");
             throw new BusinessException(500, "Failed to update broker config: " + e.getMessage());
+        }
+    }
+
+    private void recordAudit(String clusterId, String detail, String result) {
+        try {
+            auditService.record("UPDATE_BROKER_CONFIG", "CLUSTER:" + clusterId, detail, result);
+        } catch (Exception auditFailure) {
+            log.warn("Failed to record broker config audit for cluster {}: {}", clusterId,
+                    auditFailure.getMessage());
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -195,6 +195,21 @@ class ClusterServiceTest {
     }
 
     @Test
+    void updateConfigShouldSucceedWhenAuditRecordingFails() {
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+        doThrow(new IllegalStateException("audit storage unavailable")).when(auditService)
+                .record(any(), any(), any(), any());
+
+        ClusterConfigUpdateResultVO result = clusterService.updateClusterConfig(UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .flushDiskType("SYNC_FLUSH")
+                .build());
+
+        assertThat(result.getStatus()).isEqualTo(ClusterConfigUpdateResultVO.Status.SUCCESS);
+        verify(clusterRepository).updateConfig(eq("cluster-1"), any(ClusterConfigVO.class));
+    }
+
+    @Test
     void updateConfigShouldUpdateMultipleFields() {
         when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
 

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQBrokerConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQBrokerConfigServiceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ */
+package org.apache.rocketmq.studio.rocketmq;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.ops.audit.AuditService;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+
+@ExtendWith(MockitoExtension.class)
+class RocketMQBrokerConfigServiceTest {
+
+    @Mock
+    private DefaultMQAdminExt adminExt;
+    @Mock
+    private AuditService auditService;
+
+    private RocketMQBrokerConfigService brokerConfigService;
+
+    @BeforeEach
+    void setUp() {
+        brokerConfigService = new RocketMQBrokerConfigService(adminExt, auditService);
+    }
+
+    @Test
+    void updateSucceedsWhenAuditRecordingFails() throws Exception {
+        Properties config = new Properties();
+        config.setProperty("flushDiskType", "ASYNC_FLUSH");
+        doNothing().when(adminExt).updateBrokerConfig("broker-a:10911", config);
+        doThrow(new IllegalStateException("audit db down")).when(auditService)
+                .record(anyString(), anyString(), anyString(), anyString());
+
+        brokerConfigService.updateBrokerConfig("broker-a:10911", "cluster-a", config);
+    }
+
+    @Test
+    void updatePreservesBrokerFailureWhenAuditRecordingFails() throws Exception {
+        Properties config = new Properties();
+        doThrow(new IllegalStateException("broker unavailable")).when(adminExt)
+                .updateBrokerConfig("broker-a:10911", config);
+        doThrow(new IllegalStateException("audit db down")).when(auditService)
+                .record(anyString(), anyString(), anyString(), anyString());
+
+        assertThatThrownBy(() -> brokerConfigService.updateBrokerConfig("broker-a:10911", "cluster-a", config))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Failed to update broker config: broker unavailable");
+    }
+}


### PR DESCRIPTION
## Summary
- keep broker configuration updates independent from audit persistence availability
- preserve the remote broker failure when audit recording also fails
- keep cluster configuration update results available when final audit recording fails

Closes #1144

## Verification
- `cd server && mvn -Dtest=RocketMQBrokerConfigServiceTest,ClusterServiceTest test`