### PR TITLE
build: add aliyun openapi and tencentcloud sdks, upgrade rocketmq-tools to 5.5.0

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <rocketmq.version>5.3.3</rocketmq.version>
+        <rocketmq.version>5.5.0</rocketmq.version>
     </properties>
 
     <dependencies>
@@ -97,6 +97,18 @@
                     <artifactId>logback-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Aliyun RocketMQ 5.x OpenAPI (async V2 SDK), used by provider/alibaba -->
+        <dependency>
+            <groupId>com.aliyun</groupId>
+            <artifactId>alibabacloud-rocketmq20220801</artifactId>
+            <version>5.0.8</version>
+        </dependency>
+        <!-- Tencent Cloud TDMQ OpenAPI, reserved for provider/tencent (not implemented yet) -->
+        <dependency>
+            <groupId>com.tencentcloudapi</groupId>
+            <artifactId>tencentcloud-sdk-java-tdmq</artifactId>
+            <version>3.1.1500</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- Add `com.aliyun:alibabacloud-rocketmq20220801` (async V2 OpenAPI SDK) for the upcoming Aliyun vendor provider
- Add `com.tencentcloudapi:tencentcloud-sdk-java-tdmq` reserved for the Tencent vendor package (not wired yet)
- Upgrade `rocketmq-tools` to open-source 5.5.0

Part of the multi-vendor instance support (1/4, dependency-only change).

## Verification
- `mvn compile` and full unit test suite (755 tests) pass locally