### PR TITLE
fix(rocketmq): scope topic deletion to the current cluster

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -291,8 +291,11 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 }
                 admin.deleteTopicInNameServer(nsAddrs, getClusterName(admin), name);
 
-                // Delete from DB
-                topicMapper.delete(new LambdaQueryWrapper<RmqTopic>().eq(RmqTopic::getName, name));
+                // Delete from DB, scoped to the current cluster so same-named topics in other
+                // clusters are not removed.
+                topicMapper.delete(new LambdaQueryWrapper<RmqTopic>()
+                        .eq(RmqTopic::getClusterId, getClusterName(admin))
+                        .eq(RmqTopic::getName, name));
 
                 recordAudit("DELETE_TOPIC", name, "", "SUCCESS");
                 return null;


### PR DESCRIPTION
deleteTopic deleted the DB record by name alone, so a same-named topic in another cluster was removed too. The delete is now scoped to (cluster_id, name).