### PR TITLE
fix(audit): persist resource type, cluster id and error message

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
@@ -62,10 +62,12 @@ public class MybatisPlusAuditRepository implements AuditRepository {
     public void save(AuditRecordVO record) {
         RmqOperationAudit entity = new RmqOperationAudit();
         entity.setOperation(record.getOperationType());
-        entity.setResourceType("GENERAL");
+        entity.setResourceType(record.getResourceType() == null ? "GENERAL" : record.getResourceType());
         entity.setResourceName(record.getTarget());
+        entity.setClusterId(record.getClusterId());
         entity.setDetail(record.getDetail());
         entity.setResult(record.getResult());
+        entity.setErrorMessage(record.getErrorMessage());
         entity.setOperator(record.getOperator());
         entity.setOperatedAt(record.getTimestamp() == null ? LocalDateTime.now() : record.getTimestamp());
         auditMapper.insert(entity);


### PR DESCRIPTION
MybatisPlusAuditRepository.save hard-coded resourceType and dropped clusterId/errorMessage even though the VO and read path support them. They are now persisted.