### PR TITLE
fix(model): correct lite topic TTL status ordering

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicSummary.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicSummary.java
@@ -55,10 +55,12 @@ public class LiteTopicSummary {
         long now = System.currentTimeMillis();
         long elapsed = now - lastActiveTime.getTime();
 
-        if (averageTTL != null && elapsed > averageTTL * 0.8) {
-            return "EXPIRING_SOON";
-        } else if (averageTTL != null && elapsed > averageTTL) {
+        // EXPIRED must be checked first: elapsed > averageTTL implies elapsed > averageTTL * 0.8,
+        // so ordering it second would make EXPIRED unreachable.
+        if (averageTTL != null && elapsed > averageTTL) {
             return "EXPIRED";
+        } else if (averageTTL != null && elapsed > averageTTL * 0.8) {
+            return "EXPIRING_SOON";
         } else {
             return "ACTIVE";
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSummaryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSummaryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.rocketmq.studio.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LiteTopicSummaryTest {
+
+    @Test
+    void ttlStatusShouldPreferExpiredOverExpiringSoon() {
+        LiteTopicSummary summary = new LiteTopicSummary();
+        summary.setLastActiveTime(new Date(System.currentTimeMillis() - 20_000));
+        summary.setAverageTTL(10_000L);
+
+        assertThat(summary.getTTLStatus()).isEqualTo("EXPIRED");
+    }
+
+    @Test
+    void ttlStatusShouldReturnExpiringSoonWithinThreshold() {
+        LiteTopicSummary summary = new LiteTopicSummary();
+        summary.setLastActiveTime(new Date(System.currentTimeMillis() - 9_000));
+        summary.setAverageTTL(10_000L);
+
+        assertThat(summary.getTTLStatus()).isEqualTo("EXPIRING_SOON");
+    }
+
+    @Test
+    void ttlStatusShouldReturnActiveWhenNoTTLConfigured() {
+        LiteTopicSummary summary = new LiteTopicSummary();
+        summary.setLastActiveTime(new Date(System.currentTimeMillis() - 1_000));
+
+        assertThat(summary.getTTLStatus()).isEqualTo("ACTIVE");
+    }
+}


### PR DESCRIPTION
getTTLStatus checked EXPIRING_SOON before EXPIRED, and since elapsed > TTL implies elapsed > TTL*0.8, EXPIRED was unreachable. The order is swapped and covered by tests.