### PR TITLE
fix(model): guard lite topic quota null fields

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicQuota.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicQuota.java
@@ -56,7 +56,9 @@ public class LiteTopicQuota {
     }
 
     public boolean isQuotaExceeded() {
-        return currentTopicCount >= maxTopicCount;
+        // Guard against unset fields, mirroring getUsageRate; an unconfigured max is not exceeded.
+        return maxTopicCount != null && currentTopicCount != null
+                && currentTopicCount >= maxTopicCount;
     }
 
     public Integer getRemainingQuota() {

--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.rocketmq.studio.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LiteTopicQuotaTest {
+
+    @Test
+    void quotaShouldNotBeExceededWhenMaxIsUnset() {
+        LiteTopicQuota quota = new LiteTopicQuota();
+        quota.setCurrentTopicCount(10);
+
+        assertThat(quota.isQuotaExceeded()).isFalse();
+    }
+
+    @Test
+    void quotaShouldBeExceededWhenCurrentReachesMax() {
+        LiteTopicQuota quota = new LiteTopicQuota();
+        quota.setMaxTopicCount(10);
+        quota.setCurrentTopicCount(10);
+
+        assertThat(quota.isQuotaExceeded()).isTrue();
+    }
+}


### PR DESCRIPTION
isQuotaExceeded unboxed nullable Integer fields and could NPE; it now treats an unset max as not exceeded. Covered by tests.