### PR TITLE
fix(audit): use FAILED result value consistently

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigService.java
@@ -66,7 +66,7 @@ public class RocketMQBrokerConfigService {
             } catch (Exception e) {
                 log.error("Failed to update broker config at {}", brokerAddr, e);
                 String detail = "brokerAddr=" + brokerAddr + ", error=" + e.getMessage();
-                recordAudit(clusterId, detail, "FAILURE");
+                recordAudit(clusterId, detail, "FAILED");
                 throw new BusinessException(500, "Failed to update broker config: " + e.getMessage());
             }
         });


### PR DESCRIPTION
Broker config update failures wrote result=FAILURE while every other caller and the schema use FAILED; the audit filter would miss them. Now uses FAILED.