### PR TITLE
fix(rocketmq): read getTransferredTps key for outbound tps

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -199,7 +199,7 @@ public class RocketMQClusterProvider implements ClusterProvider {
                 builder.tpsIn(parseFirstTpsValue(putTps));
             }
 
-            String getTransferredTps = table.get("getTransferedTps");
+            String getTransferredTps = table.get("getTransferredTps");
             if (getTransferredTps != null && !getTransferredTps.isEmpty()) {
                 builder.tpsOut(parseFirstTpsValue(getTransferredTps));
             }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -147,7 +147,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                     if (runtimeInfo != null && runtimeInfo.getTable() != null) {
                         Map<String, String> table = runtimeInfo.getTable();
                         tpsIn += parseTps(table.get("putTps"));
-                        tpsOut += parseTps(table.get("getTransferedTps"));
+                        tpsOut += parseTps(table.get("getTransferredTps"));
 
                         String msgPutToday = table.get("msgPutTotalTodayMorning");
                         if (msgPutToday != null) {
@@ -182,7 +182,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                                 KVTable rt = admin.fetchBrokerRuntimeStats(masterAddr);
                                 if (rt != null && rt.getTable() != null) {
                                     clusterTpsIn += (int) parseTps(rt.getTable().get("putTps"));
-                                    clusterTpsOut += (int) parseTps(rt.getTable().get("getTransferedTps"));
+                                    clusterTpsOut += (int) parseTps(rt.getTable().get("getTransferredTps"));
                                     String v = rt.getTable().get("brokerVersionDesc");
                                     if (v != null && "unknown".equals(version)) {
                                         String brokerVersion = v.trim();

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
@@ -113,7 +113,7 @@ class RocketMQClusterProviderTest {
         KVTable table = new KVTable();
         HashMap<String, String> stats = new HashMap<>();
         stats.put("putTps", "  12.7   10.0  9.0");
-        stats.put("getTransferedTps", "\t34.2  30.0  29.0");
+        stats.put("getTransferredTps", "\t34.2  30.0  29.0");
         table.setTable(stats);
         return table;
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -150,7 +150,7 @@ class RocketMQDashboardProviderTest {
         HashMap<String, String> table = new HashMap<>();
         table.put("brokerVersionDesc", "  V5_3_3  ");
         table.put("putTps", "1.0 2.0 3.0");
-        table.put("getTransferedTps", "4.0 5.0 6.0");
+        table.put("getTransferredTps", "4.0 5.0 6.0");
         table.put("msgPutTotalTodayMorning", "42");
 
         KVTable kvTable = new KVTable();


### PR DESCRIPTION
Outbound TPS was always zero: the code read getTransferedTps (one r) but RocketMQ 5.3.3 StoreStatsService writes getTransferredTps (two r), confirmed by decompiling the jar. Both providers and their tests are fixed.