### PR TITLE
fix: scope query history to selected instance

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProvider.java
@@ -84,16 +84,13 @@ public class RocketMQMessageProvider implements MessageProvider {
     private final ObjectProvider<DefaultMQAdminExt> adminExtProvider;
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
     private final QueryHistoryService queryHistoryService;
-    private final RocketMQProperties properties;
 
     public RocketMQMessageProvider(ObjectProvider<DefaultMQAdminExt> adminExtProvider,
                                    RuntimeAdminClientResolver runtimeAdminClientResolver,
-                                   QueryHistoryService queryHistoryService,
-                                   RocketMQProperties properties) {
+                                   QueryHistoryService queryHistoryService) {
         this.adminExtProvider = adminExtProvider;
         this.runtimeAdminClientResolver = runtimeAdminClientResolver;
         this.queryHistoryService = queryHistoryService;
-        this.properties = properties;
     }
 
     @Override
@@ -101,10 +98,12 @@ public class RocketMQMessageProvider implements MessageProvider {
                                                Long startTime, Long endTime) {
         String endpoint = runtimeAdminClientResolver.resolveEndpoint(instanceId);
         return runtimeAdminClientResolver.execute(instanceId,
-                adminExt -> queryMessages((DefaultMQAdminExt) adminExt, endpoint, topic, msgId, tag, key, startTime, endTime));
+                adminExt -> queryMessages(instanceId, (DefaultMQAdminExt) adminExt, endpoint,
+                        topic, msgId, tag, key, startTime, endTime));
     }
 
-    private List<MessageRecordVO> queryMessages(DefaultMQAdminExt adminExt, String endpoint, String topic, String msgId, String tag, String key,
+    private List<MessageRecordVO> queryMessages(String instanceId, DefaultMQAdminExt adminExt, String endpoint,
+                                                 String topic, String msgId, String tag, String key,
                                                  Long startTime, Long endTime) {
 
         long end = endTime != null ? endTime : System.currentTimeMillis();
@@ -126,7 +125,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             return Collections.emptyList();
         }
 
-        recordMessageQuery(queryType, topic, msgId, tag, key, startTime, endTime, result.size());
+        recordMessageQuery(instanceId, queryType, topic, msgId, tag, key, startTime, endTime, result.size());
         return result;
     }
 
@@ -244,10 +243,10 @@ public class RocketMQMessageProvider implements MessageProvider {
     @Override
     public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
         return runtimeAdminClientResolver.execute(instanceId,
-                adminExt -> getMessageTrace((DefaultMQAdminExt) adminExt, msgId));
+                adminExt -> getMessageTrace(instanceId, (DefaultMQAdminExt) adminExt, msgId));
     }
 
-    private TraceRecordVO getMessageTrace(DefaultMQAdminExt adminExt, String msgId) {
+    private TraceRecordVO getMessageTrace(String instanceId, DefaultMQAdminExt adminExt, String msgId) {
 
         long now = System.currentTimeMillis();
         long begin = now - ONE_HOUR_MILLIS;
@@ -267,7 +266,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             log.warn("Trace query for msgId={} failed: {}", msgId, e.getMessage());
         }
 
-        recordTraceQuery(msgId, null, nodes.size(), consumerStatus.size());
+        recordTraceQuery(instanceId, msgId, null, nodes.size(), consumerStatus.size());
         return TraceRecordVO.builder()
                 .nodes(nodes)
                 .consumerStatus(consumerStatus)
@@ -490,26 +489,22 @@ public class RocketMQMessageProvider implements MessageProvider {
         return consumer;
     }
 
-    private void recordMessageQuery(String queryType, String topic, String msgId, String tag, String key,
+    private void recordMessageQuery(String instanceId, String queryType, String topic, String msgId, String tag, String key,
                                     Long startTime, Long endTime, int resultCount) {
         try {
-            queryHistoryService.recordMessageQuery(clusterContext(), queryType, topic, msgId, tag, key,
+            queryHistoryService.recordMessageQuery(instanceId, queryType, topic, msgId, tag, key,
                     startTime, endTime, resultCount);
         } catch (Exception e) {
             log.warn("Failed to record message query history: {}", e.getMessage());
         }
     }
 
-    private void recordTraceQuery(String msgId, String topic, int nodeCount, int consumerCount) {
+    private void recordTraceQuery(String instanceId, String msgId, String topic, int nodeCount, int consumerCount) {
         try {
-            queryHistoryService.recordTraceQuery(clusterContext(), msgId, topic, nodeCount, consumerCount);
+            queryHistoryService.recordTraceQuery(instanceId, msgId, topic, nodeCount, consumerCount);
         } catch (Exception e) {
             log.warn("Failed to record trace query history: {}", e.getMessage());
         }
-    }
-
-    private String clusterContext() {
-        return StringUtils.hasText(properties.getNamesrvAddr()) ? properties.getNamesrvAddr() : null;
     }
 
     private static TraceRecordVO emptyTrace() {

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQMessageProviderTest.java
@@ -77,8 +77,7 @@ class RocketMQMessageProviderTest {
             MqAdminExtFactory.AdminAction<Object> action = invocation.getArgument(1);
             return action == null ? null : action.apply(adminExt);
         });
-        provider = new RocketMQMessageProvider(adminExtProvider, runtimeAdminClientResolver, queryHistoryService,
-                new RocketMQProperties());
+        provider = new RocketMQMessageProvider(adminExtProvider, runtimeAdminClientResolver, queryHistoryService);
     }
 
     @Test
@@ -102,7 +101,7 @@ class RocketMQMessageProviderTest {
         }
         verify(runtimeAdminClientResolver).resolveEndpoint("instance-a");
         verify(runtimeAdminClientResolver).execute(eq("instance-a"), any());
-        verify(queryHistoryService).recordMessageQuery(null, "TOPIC", "TopicA", null, null, null,
+        verify(queryHistoryService).recordMessageQuery("instance-a", "TOPIC", "TopicA", null, null, null,
                 100L, 200L, 0);
     }
 
@@ -166,6 +165,7 @@ class RocketMQMessageProviderTest {
         TraceRecordVO record = provider.getMessageTrace("instance-a", "msg-123");
 
         assertThat(record.getNodes()).hasSize(2);
+        verify(queryHistoryService).recordTraceQuery(eq("instance-a"), eq("msg-123"), eq(null), eq(2), eq(1));
         TraceNodeVO produce = record.getNodes().get(0);
         assertThat(produce.getTitle()).isEqualTo("produce");
         assertThat(produce.getStatus()).isEqualTo("finish");


### PR DESCRIPTION
## Summary
- record message-query history against the selected `instanceId`
- record message-trace history against the selected `instanceId`
- remove the stale process-wide NameServer context from this runtime path

Closes #1157

## Verification
- `cd server && mvn -Dtest=RocketMQMessageProviderTest,QueryHistoryServiceTest test`