### PR TITLE
fix: harden instance-scoped message query semantics

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -51,7 +52,16 @@ public class MessageService {
     }
 
     private void validateTopicQueryWindow(String topic, String msgId, String key, Long startTime, Long endTime) {
-        if (msgId != null && !msgId.isBlank() || key != null && !key.isBlank() || topic == null || topic.isBlank()) {
+        boolean hasTopic = StringUtils.hasText(topic);
+        boolean hasMessageId = StringUtils.hasText(msgId);
+        boolean hasKey = StringUtils.hasText(key);
+        if (hasKey && !hasTopic) {
+            throw new BusinessException(400, "topic is required when key is specified");
+        }
+        if (!hasTopic && !hasMessageId) {
+            throw new BusinessException(400, "topic or msgId is required");
+        }
+        if (hasMessageId || hasKey) {
             return;
         }
         long end = endTime == null ? System.currentTimeMillis() : endTime;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -83,17 +83,18 @@ public class RocketMQMessageProvider implements MessageProvider {
 
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
     private final QueryHistoryService queryHistoryService;
-    private final RocketMQProperties properties;
 
     @Override
     public List<MessageRecordVO> queryMessages(String instanceId, String topic, String msgId, String tag, String key,
                                                Long startTime, Long endTime) {
         String endpoint = runtimeAdminClientResolver.resolveEndpoint(instanceId);
         return runtimeAdminClientResolver.execute(instanceId,
-                adminExt -> queryMessages((DefaultMQAdminExt) adminExt, endpoint, topic, msgId, tag, key, startTime, endTime));
+                adminExt -> queryMessages(instanceId, (DefaultMQAdminExt) adminExt, endpoint,
+                        topic, msgId, tag, key, startTime, endTime));
     }
 
-    private List<MessageRecordVO> queryMessages(DefaultMQAdminExt adminExt, String endpoint, String topic, String msgId, String tag, String key,
+    private List<MessageRecordVO> queryMessages(String instanceId, DefaultMQAdminExt adminExt, String endpoint,
+                                                 String topic, String msgId, String tag, String key,
                                                  Long startTime, Long endTime) {
 
         long end = endTime != null ? endTime : System.currentTimeMillis();
@@ -115,7 +116,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             return Collections.emptyList();
         }
 
-        recordMessageQuery(queryType, topic, msgId, tag, key, startTime, endTime, result.size());
+        recordMessageQuery(instanceId, queryType, topic, msgId, tag, key, startTime, endTime, result.size());
         return result;
     }
 
@@ -234,10 +235,10 @@ public class RocketMQMessageProvider implements MessageProvider {
     @Override
     public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
         return runtimeAdminClientResolver.execute(instanceId,
-                adminExt -> getMessageTrace((DefaultMQAdminExt) adminExt, msgId));
+                adminExt -> getMessageTrace(instanceId, (DefaultMQAdminExt) adminExt, msgId));
     }
 
-    private TraceRecordVO getMessageTrace(DefaultMQAdminExt adminExt, String msgId) {
+    private TraceRecordVO getMessageTrace(String instanceId, DefaultMQAdminExt adminExt, String msgId) {
 
         long now = System.currentTimeMillis();
         long begin = now - ONE_HOUR_MILLIS;
@@ -257,7 +258,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             log.warn("Trace query for msgId={} failed: {}", msgId, e.getMessage());
         }
 
-        recordTraceQuery(msgId, null, nodes.size(), consumerStatus.size());
+        recordTraceQuery(instanceId, msgId, null, nodes.size(), consumerStatus.size());
         return TraceRecordVO.builder()
                 .nodes(nodes)
                 .consumerStatus(consumerStatus)
@@ -480,26 +481,22 @@ public class RocketMQMessageProvider implements MessageProvider {
         return consumer;
     }
 
-    private void recordMessageQuery(String queryType, String topic, String msgId, String tag, String key,
+    private void recordMessageQuery(String instanceId, String queryType, String topic, String msgId, String tag, String key,
                                     Long startTime, Long endTime, int resultCount) {
         try {
-            queryHistoryService.recordMessageQuery(clusterContext(), queryType, topic, msgId, tag, key,
+            queryHistoryService.recordMessageQuery(instanceId, queryType, topic, msgId, tag, key,
                     startTime, endTime, resultCount);
         } catch (Exception e) {
             log.warn("Failed to record message query history: {}", e.getMessage());
         }
     }
 
-    private void recordTraceQuery(String msgId, String topic, int nodeCount, int consumerCount) {
+    private void recordTraceQuery(String instanceId, String msgId, String topic, int nodeCount, int consumerCount) {
         try {
-            queryHistoryService.recordTraceQuery(clusterContext(), msgId, topic, nodeCount, consumerCount);
+            queryHistoryService.recordTraceQuery(instanceId, msgId, topic, nodeCount, consumerCount);
         } catch (Exception e) {
             log.warn("Failed to record trace query history: {}", e.getMessage());
         }
-    }
-
-    private String clusterContext() {
-        return StringUtils.hasText(properties.getNamesrvAddr()) ? properties.getNamesrvAddr() : null;
     }
 
     private static TraceRecordVO emptyTrace() {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageId;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.instance.message.ConsumerStatusVO;
 import org.apache.rocketmq.studio.instance.message.MessageProvider;
@@ -175,7 +176,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             return result;
         } catch (Exception e) {
             log.warn("queryMessage(topic={}, key={}) failed: {}", topic, key, e.getMessage());
-            return Collections.emptyList();
+            throw new BusinessException(502, "Failed to query messages by key: " + e.getMessage());
         }
     }
 
@@ -223,6 +224,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             }
         } catch (Exception e) {
             log.warn("queryByTopic(topic={}) failed: {}", topic, e.getMessage());
+            throw new BusinessException(502, "Failed to query messages by topic: " + e.getMessage());
         } finally {
             consumer.shutdown();
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -14,11 +14,39 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class MessageServiceTest {
+
+    @Test
+    void rejectsKeyQueryWithoutTopicBeforeCallingProvider() {
+        MessageProvider provider = mock(MessageProvider.class);
+        MessageService service = new MessageService(provider);
+
+        assertThatThrownBy(() -> service.queryMessages(null, null, null, "order-1", null, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topic is required when key is specified");
+
+        verifyNoInteractions(provider);
+    }
+
+    @Test
+    void keepsMessageIdQueryWithoutTopicValid() {
+        MessageProvider provider = mock(MessageProvider.class);
+        when(provider.queryMessages(null, "msg-001", null, null, null, null))
+                .thenReturn(Collections.emptyList());
+        MessageService service = new MessageService(provider);
+
+        service.queryMessages(null, "msg-001", null, null, null, null);
+
+        verify(provider).queryMessages(null, "msg-001", null, null, null, null);
+    }
 
     @Test
     void rejectsReversedTopicQueryWindowBeforeCallingProvider() {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -27,9 +27,10 @@ class MessageServiceTest {
     @Test
     void rejectsKeyQueryWithoutTopicBeforeCallingProvider() {
         MessageProvider provider = mock(MessageProvider.class);
-        MessageService service = new MessageService(provider);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(provider, registry);
 
-        assertThatThrownBy(() -> service.queryMessages(null, null, null, "order-1", null, null))
+        assertThatThrownBy(() -> service.queryMessages(null, null, null, null, "order-1", null, null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("topic is required when key is specified");
 
@@ -39,13 +40,14 @@ class MessageServiceTest {
     @Test
     void keepsMessageIdQueryWithoutTopicValid() {
         MessageProvider provider = mock(MessageProvider.class);
-        when(provider.queryMessages(null, "msg-001", null, null, null, null))
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        when(provider.queryMessages(null, null, "msg-001", null, null, null, null))
                 .thenReturn(Collections.emptyList());
-        MessageService service = new MessageService(provider);
+        MessageService service = new MessageService(provider, registry);
 
-        service.queryMessages(null, "msg-001", null, null, null, null);
+        service.queryMessages(null, null, "msg-001", null, null, null, null);
 
-        verify(provider).queryMessages(null, "msg-001", null, null, null, null);
+        verify(provider).queryMessages(null, null, "msg-001", null, null, null, null);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -100,7 +100,7 @@ class RocketMQMessageProviderTest {
         }
         verify(runtimeAdminClientResolver).resolveEndpoint("instance-a");
         verify(runtimeAdminClientResolver).execute(eq("instance-a"), any());
-        verify(queryHistoryService).recordMessageQuery(null, "TOPIC", "TopicA", null, null, null,
+        verify(queryHistoryService).recordMessageQuery("instance-a", "TOPIC", "TopicA", null, null, null,
                 100L, 200L, 0);
     }
 
@@ -191,6 +191,7 @@ class RocketMQMessageProviderTest {
         TraceRecordVO record = provider.getMessageTrace("instance-a", "msg-123");
 
         assertThat(record.getNodes()).hasSize(2);
+        verify(queryHistoryService).recordTraceQuery(eq("instance-a"), eq("msg-123"), eq(null), eq(2), eq(1));
         TraceNodeVO produce = record.getNodes().get(0);
         assertThat(produce.getTitle()).isEqualTo("produce");
         assertThat(produce.getStatus()).isEqualTo("finish");

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -22,6 +22,7 @@ import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
 import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
@@ -39,12 +40,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
@@ -99,6 +102,33 @@ class RocketMQMessageProviderTest {
         verify(runtimeAdminClientResolver).execute(eq("instance-a"), any());
         verify(queryHistoryService).recordMessageQuery(null, "TOPIC", "TopicA", null, null, null,
                 100L, 200L, 0);
+    }
+
+    @Test
+    void queryByKeySurfacesAdminFailure() throws Exception {
+        when(adminExt.queryMessage("TopicA", "order-1", 64, 100L, 200L))
+                .thenThrow(new IllegalStateException("broker unavailable"));
+
+        assertThatThrownBy(() -> provider.queryMessages(
+                "instance-a", "TopicA", null, null, "order-1", 100L, 200L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Failed to query messages by key: broker unavailable")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    @Test
+    void queryByTopicSurfacesPullConsumerFailure() throws Exception {
+        try (MockedConstruction<DefaultMQPullConsumer> ignored =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doThrow(new IllegalStateException("nameserver unavailable")).when(consumer).start();
+                         doNothing().when(consumer).shutdown();
+                     })) {
+            assertThatThrownBy(() -> provider.queryMessages(
+                    "instance-a", "TopicA", null, null, null, 100L, 200L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("Failed to query messages by topic: nameserver unavailable")
+                    .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+        }
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -75,8 +75,7 @@ class RocketMQMessageProviderTest {
             MqAdminExtFactory.AdminAction<Object> action = invocation.getArgument(1);
             return action == null ? null : action.apply(adminExt);
         });
-        provider = new RocketMQMessageProvider(runtimeAdminClientResolver, queryHistoryService,
-                new RocketMQProperties());
+        provider = new RocketMQMessageProvider(runtimeAdminClientResolver, queryHistoryService);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- keep message query and trace history scoped to the selected instance
- reject key-only queries while retaining MessageId-only lookup
- surface remote Topic and Key query failures instead of returning empty data

Absorbs #1158 and #1119.

## Validation
- mvn -q -Dtest=MessageServiceTest,RocketMQMessageProviderTest test