### PR TITLE
fix: route Apache Topic deletion by selected instance

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/AdminClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/AdminClient.java
@@ -24,7 +24,7 @@ public interface AdminClient {
     ConsumerGroupVO getConsumerGroup(String name);
     TopicVO createTopic(TopicVO topic);
     TopicVO updateTopic(TopicVO topic);
-    void deleteTopic(String name);
+    void deleteTopic(String instanceId, String name);
     SendMessageVO sendMessage(SendMessageDTO request);
     ConsumerGroupVO createConsumerGroup(ConsumerGroupVO group);
     void deleteConsumerGroup(String name);

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
@@ -82,7 +82,7 @@ public class MetadataService {
         if (provider.isPresent()) {
             provider.get().deleteTopic(instanceId, name);
         } else {
-            adminClient.deleteTopic(name);
+            adminClient.deleteTopic(instanceId, name);
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/NameSrvAdminClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/NameSrvAdminClient.java
@@ -48,7 +48,7 @@ public class NameSrvAdminClient implements AdminClient {
     }
 
     @Override
-    public void deleteTopic(String name) {
+    public void deleteTopic(String instanceId, String name) {
         throw new UnsupportedOperationException("Not implemented");
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
@@ -76,7 +76,7 @@ public class ApacheInstanceProvider implements InstanceProvider {
 
     @Override
     public void deleteTopic(String instanceId, String topicName) {
-        adminClient.deleteTopic(topicName);
+        adminClient.deleteTopic(instanceId, topicName);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImpl.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
@@ -69,6 +70,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
     private final RmqTopicMapper topicMapper;
     private final RmqGroupMapper groupMapper;
     private final AuditService auditService;
+    private final RuntimeAdminClientResolver runtimeAdminClientResolver;
 
     @Autowired
     public RocketMQAdminClientImpl(
@@ -76,12 +78,14 @@ public class RocketMQAdminClientImpl implements AdminClient {
             RocketMQProperties properties,
             RmqTopicMapper topicMapper,
             RmqGroupMapper groupMapper,
-            AuditService auditService) {
+            AuditService auditService,
+            RuntimeAdminClientResolver runtimeAdminClientResolver) {
         this.adminExt = adminExt;
         this.properties = properties;
         this.topicMapper = topicMapper;
         this.groupMapper = groupMapper;
         this.auditService = auditService;
+        this.runtimeAdminClientResolver = runtimeAdminClientResolver;
     }
 
     @Override
@@ -283,21 +287,31 @@ public class RocketMQAdminClientImpl implements AdminClient {
     }
 
     @Override
-    public void deleteTopic(String name) {
-        if (adminExt == null) {
+    public void deleteTopic(String instanceId, String name) {
+        if (StringUtils.hasText(instanceId)) {
+            runtimeAdminClientResolver.execute(instanceId, admin -> {
+                deleteTopic((DefaultMQAdminExt) admin, name, ((DefaultMQAdminExt) admin).getNamesrvAddr());
+                return null;
+            });
+            return;
+        }
+        deleteTopic(adminExt, name, properties.getNamesrvAddr());
+    }
+
+    private void deleteTopic(DefaultMQAdminExt activeAdmin, String name, String namesrvAddr) {
+        if (activeAdmin == null) {
             throw new BusinessException(503, "RocketMQ admin not connected");
         }
 
         try {
-            Set<String> brokerAddrs = getAllMasterBrokerAddrs();
+            Set<String> brokerAddrs = getAllMasterBrokerAddrs(activeAdmin);
 
             // Delete from brokers
             if (!brokerAddrs.isEmpty()) {
-                adminExt.deleteTopicInBroker(brokerAddrs, name);
+                activeAdmin.deleteTopicInBroker(brokerAddrs, name);
             }
 
             // Delete from nameserver
-            String namesrvAddr = properties.getNamesrvAddr();
             if (namesrvAddr != null && !namesrvAddr.isEmpty()) {
                 Set<String> nsAddrs = new HashSet<>();
                 for (String addr : namesrvAddr.split("[;,]")) {
@@ -306,7 +320,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
                         nsAddrs.add(trimmed);
                     }
                 }
-                adminExt.deleteTopicInNameServer(nsAddrs, getClusterName(), name);
+                activeAdmin.deleteTopicInNameServer(nsAddrs, getClusterName(activeAdmin), name);
             }
 
             // Delete from DB
@@ -494,8 +508,12 @@ public class RocketMQAdminClientImpl implements AdminClient {
     // ── Helper methods ──────────────────────────────────────────────────
 
     private Set<String> getAllMasterBrokerAddrs() throws Exception {
+        return getAllMasterBrokerAddrs(adminExt);
+    }
+
+    private Set<String> getAllMasterBrokerAddrs(DefaultMQAdminExt activeAdmin) throws Exception {
         Set<String> addrs = new HashSet<>();
-        ClusterInfo clusterInfo = adminExt.examineBrokerClusterInfo();
+        ClusterInfo clusterInfo = activeAdmin.examineBrokerClusterInfo();
         if (clusterInfo == null || clusterInfo.getBrokerAddrTable() == null) {
             return addrs;
         }
@@ -517,8 +535,12 @@ public class RocketMQAdminClientImpl implements AdminClient {
     }
 
     private String getClusterName() {
+        return getClusterName(adminExt);
+    }
+
+    private String getClusterName(DefaultMQAdminExt activeAdmin) {
         try {
-            ClusterInfo clusterInfo = adminExt.examineBrokerClusterInfo();
+            ClusterInfo clusterInfo = activeAdmin.examineBrokerClusterInfo();
             if (clusterInfo != null && clusterInfo.getClusterAddrTable() != null
                     && !clusterInfo.getClusterAddrTable().isEmpty()) {
                 return clusterInfo.getClusterAddrTable().keySet().iterator().next();

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
@@ -139,7 +139,7 @@ class MetadataServiceTest {
     void deleteTopicShouldDelegateToAdminClient() {
         metadataService.deleteTopic("topic-to-delete");
 
-        verify(adminClient).deleteTopic("topic-to-delete");
+        verify(adminClient).deleteTopic(null, "topic-to-delete");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQAdminClientImplTest.java
@@ -24,6 +24,8 @@ import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
@@ -57,6 +59,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -72,12 +75,15 @@ class RocketMQAdminClientImplTest {
     private RmqGroupMapper groupMapper;
     @Mock
     private AuditService auditService;
+    @Mock
+    private RuntimeAdminClientResolver runtimeAdminClientResolver;
 
     private RocketMQAdminClientImpl adminClient;
 
     @BeforeEach
     void setUp() {
-        adminClient = new RocketMQAdminClientImpl(adminExt, properties, topicMapper, groupMapper, auditService);
+        adminClient = new RocketMQAdminClientImpl(adminExt, properties, topicMapper, groupMapper, auditService,
+                runtimeAdminClientResolver);
     }
 
     @Test
@@ -139,6 +145,33 @@ class RocketMQAdminClientImplTest {
         for (LambdaQueryWrapper<RmqTopic> wrapper : captor.getAllValues()) {
             assertThat(wrapper.getSqlSegment()).contains("cluster_id");
         }
+    }
+
+    @Test
+    void deleteTopicUsesSelectedInstanceAdmin() throws Exception {
+        DefaultMQAdminExt selectedAdmin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        when(selectedAdmin.getNamesrvAddr()).thenReturn("10.0.0.2:9876");
+        ClusterInfo clusterInfo = new ClusterInfo();
+        clusterInfo.setClusterAddrTable(new HashMap<>(Map.of("cluster-1", new HashSet<>(List.of("broker-1")))));
+        BrokerData brokerData = new BrokerData();
+        brokerData.setBrokerName("broker-1");
+        brokerData.setBrokerAddrs(new HashMap<>(Map.of(0L, "10.0.0.1:10911")));
+        clusterInfo.setBrokerAddrTable(new HashMap<>(Map.of("broker-1", brokerData)));
+        when(selectedAdmin.examineBrokerClusterInfo()).thenReturn(clusterInfo);
+        doNothing().when(selectedAdmin).deleteTopicInBroker(any(), anyString());
+        doNothing().when(selectedAdmin).deleteTopicInNameServer(any(), anyString(), anyString());
+        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("instance-a"), any()))
+                .thenAnswer(invocation -> {
+                    MqAdminExtFactory.AdminAction<?> action = invocation.getArgument(1);
+                    return action.apply(selectedAdmin);
+                });
+
+        adminClient.deleteTopic("instance-a", "orders");
+
+        verify(runtimeAdminClientResolver).execute(org.mockito.ArgumentMatchers.eq("instance-a"), any());
+        verify(selectedAdmin).deleteTopicInBroker(Set.of("10.0.0.1:10911"), "orders");
+        verify(selectedAdmin).deleteTopicInNameServer(Set.of("10.0.0.2:9876"), "cluster-1", "orders");
+        verify(adminExt, never()).deleteTopicInBroker(any(), anyString());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- propagate `instanceId` through the Topic deletion AdminClient contract
- use the selected Apache instance's runtime Admin client for Broker and NameServer deletion
- retain the existing no-instance path and verify it does not use the global Admin when an instance is selected

Closes #1167

Related: #982, #1136, #1165.

Note: PR #1150 independently scopes the persisted database deletion by `(cluster_id, name)`.