### PR TITLE
fix(ui): wire up the live refresh toggle with polling

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Table, Button, Tag, Tabs, Card, Space, Switch, Progress, Tooltip, Spin, App } from 'antd';
 import {
   Plus,
@@ -157,6 +157,15 @@ const BrokerClusterPage = () => {
       setLoading(false);
     }
   }, [message, t]);
+
+  // Live refresh: poll while the auto-refresh switch is on.
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const timer = setInterval(() => {
+      void loadData();
+    }, 5000);
+    return () => clearInterval(timer);
+  }, [autoRefresh, loadData]);
 
   const initialized = useRef<boolean | null>(null);
   if (initialized.current == null) {

--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -99,6 +99,15 @@ const GroupManagementPage = () => {
     }
   }, [t]);
 
+  // Live refresh: poll while the auto-refresh switch is on.
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const timer = setInterval(() => {
+      void handleRefresh();
+    }, 5000);
+    return () => clearInterval(timer);
+  }, [autoRefresh, handleRefresh]);
+
   const handleViewDetail = useCallback(
     async (group: ConsumerGroup) => {
       setSelectedGroup(group);


### PR DESCRIPTION
The "Live Refresh / 自动刷新" toggles on the Broker Cluster and Group Management pages set state but nothing polled, so the switch did nothing. Both pages now run a 5s interval that reloads data while the toggle is on, cleaned up when it is turned off or the component unmounts.
