### PR TITLE
[ISSUE #1178] Bind metrics data sources to configured instances

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolver.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolver.java
@@ -20,12 +20,16 @@ public class RuntimeAdminClientResolver {
     private final InstanceRepository instanceRepository;
     private final MqAdminExtFactory adminFactory;
 
-    public String resolveEndpoint(String instanceId) {
+    public InstanceVO resolveInstance(String instanceId) {
         if (!StringUtils.hasText(instanceId)) {
             throw new BusinessException(400, "instanceId is required");
         }
-        InstanceVO instance = instanceRepository.findById(instanceId)
+        return instanceRepository.findById(instanceId)
                 .orElseThrow(() -> new BusinessException(404, "Instance not found: " + instanceId));
+    }
+
+    public String resolveEndpoint(String instanceId) {
+        InstanceVO instance = resolveInstance(instanceId);
         if (!StringUtils.hasText(instance.getEndpoint())) {
             throw new BusinessException(400, "Instance has no endpoint: " + instanceId);
         }
@@ -33,6 +37,13 @@ public class RuntimeAdminClientResolver {
     }
 
     public <T> T execute(String instanceId, MqAdminExtFactory.AdminAction<T> action) {
-        return adminFactory.execute(resolveEndpoint(instanceId), null, action);
+        return execute(resolveInstance(instanceId), action);
+    }
+
+    public <T> T execute(InstanceVO instance, MqAdminExtFactory.AdminAction<T> action) {
+        if (instance == null || !StringUtils.hasText(instance.getEndpoint())) {
+            throw new BusinessException(400, "Instance endpoint is required");
+        }
+        return adminFactory.execute(instance.getEndpoint().trim(), null, action);
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardController.java
@@ -21,6 +21,7 @@ import org.apache.rocketmq.studio.common.domain.Result;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -31,7 +32,7 @@ public class DashboardController {
     private final DashboardService dashboardService;
 
     @GetMapping
-    public Result<DashboardDataVO> getDashboard() {
-        return Result.ok(dashboardService.getDashboard());
+    public Result<DashboardDataVO> getDashboard(@RequestParam(required = false) String instanceId) {
+        return Result.ok(dashboardService.getDashboard(instanceId));
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardProvider.java
@@ -20,4 +20,8 @@ package org.apache.rocketmq.studio.ops.dashboard;
 
 public interface DashboardProvider {
     DashboardDataVO getDashboardData();
+
+    default DashboardDataVO getDashboardData(String instanceId) {
+        return getDashboardData();
+    }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardService.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.studio.ops.dashboard;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Service
@@ -31,5 +32,13 @@ public class DashboardService {
     public DashboardDataVO getDashboard() {
         log.debug("Fetching dashboard data");
         return dashboardProvider.getDashboardData();
+    }
+
+    public DashboardDataVO getDashboard(String instanceId) {
+        if (!StringUtils.hasText(instanceId)) {
+            return getDashboard();
+        }
+        log.debug("Fetching dashboard data for instance={}", instanceId);
+        return dashboardProvider.getDashboardData(instanceId.trim());
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProvider.java
@@ -30,11 +30,15 @@ import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.apache.rocketmq.studio.ops.dashboard.ClusterOverviewVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardProvider;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardStatsVO;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Primary;
@@ -54,9 +58,12 @@ public class RocketMQDashboardProvider implements DashboardProvider {
     );
 
     private final DefaultMQAdminExt adminExt;
+    private final RuntimeAdminClientResolver runtimeAdminClientResolver;
 
-    public RocketMQDashboardProvider(@Nullable DefaultMQAdminExt adminExt) {
+    public RocketMQDashboardProvider(@Nullable DefaultMQAdminExt adminExt,
+                                     RuntimeAdminClientResolver runtimeAdminClientResolver) {
         this.adminExt = adminExt;
+        this.runtimeAdminClientResolver = runtimeAdminClientResolver;
     }
 
     @Override
@@ -65,6 +72,17 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             log.warn("DefaultMQAdminExt not available, returning empty dashboard");
             return emptyDashboard();
         }
+        return getDashboardData(adminExt, ClusterType.V5_PROXY_CLUSTER);
+    }
+
+    @Override
+    public DashboardDataVO getDashboardData(String instanceId) {
+        InstanceVO instance = runtimeAdminClientResolver.resolveInstance(instanceId);
+        return runtimeAdminClientResolver.execute(instance,
+                resolvedAdmin -> getDashboardData(resolvedAdmin, clusterTypeFor(instance)));
+    }
+
+    private DashboardDataVO getDashboardData(MQAdminExt adminExt, ClusterType clusterType) {
 
         int totalClusters = 0;
         int totalBrokers = 0;
@@ -198,7 +216,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 clusters.add(ClusterOverviewVO.builder()
                         .id(clusterName)
                         .name(clusterName)
-                        .type(ClusterType.V5_PROXY_CLUSTER)
+                        .type(clusterType)
                         .status(ClusterStatus.healthy)
                         .brokers(clusterBrokers)
                         .proxies(0)
@@ -236,6 +254,11 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 .stats(stats)
                 .clusters(clusters)
                 .build();
+    }
+
+    private ClusterType clusterTypeFor(InstanceVO instance) {
+        return instance.getType() == InstanceType.DIRECT
+                ? ClusterType.V4_DIRECT : ClusterType.V5_PROXY_CLUSTER;
     }
 
     private DashboardDataVO emptyDashboard() {

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/DataSourceVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/DataSourceVO.java
@@ -22,6 +22,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -36,4 +38,6 @@ public class DataSourceVO {
     private String url;
     private String auth;
     private String status;
+    /** Instance IDs this source serves; an empty list keeps the source globally available. */
+    private List<String> instanceIds;
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardControllerTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -80,7 +81,7 @@ class DashboardControllerTest {
                 .clusters(List.of(cluster))
                 .build();
 
-        when(dashboardService.getDashboard()).thenReturn(data);
+        when(dashboardService.getDashboard(isNull())).thenReturn(data);
 
         mockMvc.perform(get("/api/dashboard"))
                 .andExpect(status().isOk())
@@ -97,7 +98,7 @@ class DashboardControllerTest {
                 .andExpect(jsonPath("$.data.clusters[0].status").value("healthy"))
                 .andExpect(jsonPath("$.data.clusters[0].version").value("5.1.0"));
 
-        verify(dashboardService).getDashboard();
+        verify(dashboardService).getDashboard(isNull());
     }
 
     @Test
@@ -107,12 +108,27 @@ class DashboardControllerTest {
                 .clusters(List.of())
                 .build();
 
-        when(dashboardService.getDashboard()).thenReturn(data);
+        when(dashboardService.getDashboard(isNull())).thenReturn(data);
 
         mockMvc.perform(get("/api/dashboard"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.stats.totalClusters").value(0))
                 .andExpect(jsonPath("$.data.clusters").isArray())
                 .andExpect(jsonPath("$.data.clusters").isEmpty());
+    }
+
+    @Test
+    void getDashboardShouldForwardSelectedInstance() throws Exception {
+        DashboardDataVO data = DashboardDataVO.builder()
+                .stats(DashboardStatsVO.builder().totalClusters(1).build())
+                .clusters(List.of())
+                .build();
+        when(dashboardService.getDashboard("instance-prod")).thenReturn(data);
+
+        mockMvc.perform(get("/api/dashboard").param("instanceId", "instance-prod"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.stats.totalClusters").value(1));
+
+        verify(dashboardService).getDashboard("instance-prod");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardServiceTest.java
@@ -110,4 +110,32 @@ class DashboardServiceTest {
         assertThat(result.getClusters()).isEmpty();
         verify(dashboardProvider).getDashboardData();
     }
+
+    @Test
+    void getDashboardShouldUseSelectedInstanceWhenProvided() {
+        DashboardDataVO instanceData = DashboardDataVO.builder()
+                .stats(DashboardStatsVO.builder().totalClusters(1).build())
+                .clusters(List.of())
+                .build();
+        when(dashboardProvider.getDashboardData("instance-a")).thenReturn(instanceData);
+
+        DashboardDataVO result = dashboardService.getDashboard(" instance-a ");
+
+        assertThat(result).isSameAs(instanceData);
+        verify(dashboardProvider).getDashboardData("instance-a");
+    }
+
+    @Test
+    void getDashboardShouldKeepDefaultPathForBlankInstance() {
+        DashboardDataVO defaultData = DashboardDataVO.builder()
+                .stats(DashboardStatsVO.builder().build())
+                .clusters(List.of())
+                .build();
+        when(dashboardProvider.getDashboardData()).thenReturn(defaultData);
+
+        DashboardDataVO result = dashboardService.getDashboard(" ");
+
+        assertThat(result).isSameAs(defaultData);
+        verify(dashboardProvider).getDashboardData();
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProviderTest.java
@@ -25,12 +25,20 @@ import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.KVTable;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RocketMQDashboardProviderTest {
@@ -42,7 +50,7 @@ class RocketMQDashboardProviderTest {
         when(adminExt.fetchAllTopicList()).thenReturn(topicList());
         when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
 
-        RocketMQDashboardProvider provider = new RocketMQDashboardProvider(adminExt);
+        RocketMQDashboardProvider provider = provider(adminExt);
 
         DashboardDataVO dashboard = provider.getDashboardData();
 
@@ -59,7 +67,7 @@ class RocketMQDashboardProviderTest {
         when(adminExt.examineBrokerClusterInfo()).thenReturn(bare);
         when(adminExt.fetchAllTopicList()).thenReturn(topicList());
 
-        RocketMQDashboardProvider provider = new RocketMQDashboardProvider(adminExt);
+        RocketMQDashboardProvider provider = provider(adminExt);
 
         DashboardDataVO dashboard = provider.getDashboardData();
 
@@ -81,7 +89,7 @@ class RocketMQDashboardProviderTest {
         when(adminExt.examineBrokerClusterInfo()).thenReturn(info);
         when(adminExt.fetchAllTopicList()).thenReturn(topicList());
 
-        RocketMQDashboardProvider provider = new RocketMQDashboardProvider(adminExt);
+        RocketMQDashboardProvider provider = provider(adminExt);
 
         DashboardDataVO dashboard = provider.getDashboardData();
 
@@ -102,7 +110,7 @@ class RocketMQDashboardProviderTest {
         when(adminExt.examineBrokerClusterInfo()).thenReturn(info);
         when(adminExt.fetchAllTopicList()).thenReturn(topicList());
 
-        RocketMQDashboardProvider provider = new RocketMQDashboardProvider(adminExt);
+        RocketMQDashboardProvider provider = provider(adminExt);
 
         DashboardDataVO dashboard = provider.getDashboardData();
 
@@ -111,6 +119,36 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getClusters().get(0).getBrokers()).isZero();
         assertThat(dashboard.getStats().getTotalClusters()).isEqualTo(1);
         assertThat(dashboard.getStats().getTotalBrokers()).isZero();
+    }
+
+    @Test
+    void dashboardShouldUseSelectedDirectInstanceAndReportDirectType() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        InstanceVO instance = InstanceVO.builder()
+                .type(InstanceType.DIRECT)
+                .endpoint("namesrv-direct:9876")
+                .build();
+        instance.setId("instance-direct");
+        when(resolver.resolveInstance("instance-direct")).thenReturn(instance);
+        when(resolver.execute(eq(instance), any())).thenAnswer(invocation -> {
+            MqAdminExtFactory.AdminAction<DashboardDataVO> action = invocation.getArgument(1);
+            return action.apply(adminExt);
+        });
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = new RocketMQDashboardProvider(null, resolver)
+                .getDashboardData("instance-direct");
+
+        assertThat(dashboard.getClusters()).hasSize(1);
+        assertThat(dashboard.getClusters().get(0).getType()).isEqualTo(ClusterType.V4_DIRECT);
+        verify(resolver).execute(eq(instance), any());
+    }
+
+    private RocketMQDashboardProvider provider(DefaultMQAdminExt adminExt) {
+        return new RocketMQDashboardProvider(adminExt, mock(RuntimeAdminClientResolver.class));
     }
 
     private ClusterInfo clusterInfo() {

--- a/web/src/api/metrics.test.ts
+++ b/web/src/api/metrics.test.ts
@@ -63,6 +63,15 @@ describe('metrics API', () => {
     await expect(getDashboard()).resolves.toEqual(dashboard);
   });
 
+  it('forwards the selected instance to the dashboard endpoint', async () => {
+    mock.onGet('/dashboard').reply((config) => {
+      expect(config.params).toEqual({ instanceId: 'instance-prod' });
+      return [200, { code: 200, data: dashboard }];
+    });
+
+    await expect(getDashboard('instance-prod')).resolves.toEqual(dashboard);
+  });
+
   it('posts a metrics query and returns its result', async () => {
     const query = { metric: 'TPS_IN', start: 1, end: 2, step: '1m' };
     const result = {

--- a/web/src/api/metrics.ts
+++ b/web/src/api/metrics.ts
@@ -92,8 +92,10 @@ export interface MetricProfile {
 }
 
 // ─── Dashboard ──────────────────────────────────────────────────
-export async function getDashboard() {
-  const res = await client.get<{ data: DashboardData }>('/dashboard');
+export async function getDashboard(instanceId?: string) {
+  const res = await client.get<{ data: DashboardData }>('/dashboard', {
+    params: instanceId ? { instanceId } : undefined,
+  });
   return res.data.data;
 }
 

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -46,6 +46,7 @@ export interface DataSource {
   password?: string;
   bearerToken?: string;
   status: string;
+  instanceIds?: string[];
 }
 
 // ─── General Settings ───────────────────────────────────────────

--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -211,7 +211,11 @@ const MetricChart = ({ data, metric, locale, noSamples }: MetricChartProps) => {
   );
 };
 
-const MetricsExplorer = () => {
+interface MetricsExplorerProps {
+  instanceId?: string;
+}
+
+const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
   const { lang } = useLang();
   const copy =
     lang === 'zh'
@@ -262,6 +266,14 @@ const MetricsExplorer = () => {
     [metricId, selectedProfile],
   );
   const selectedRange = RANGE_OPTIONS.find((range) => range.value === rangeId) ?? RANGE_OPTIONS[0];
+  const availableDataSources = useMemo(
+    () =>
+      dataSources.filter(
+        (source) =>
+          !source.instanceIds?.length || (instanceId !== undefined && source.instanceIds.includes(instanceId)),
+      ),
+    [dataSources, instanceId],
+  );
 
   const loadMetrics = useCallback(
     async (metric: MetricMapping | undefined, range: (typeof RANGE_OPTIONS)[number]) => {
@@ -365,6 +377,13 @@ const MetricsExplorer = () => {
     };
   }, []);
 
+  useEffect(() => {
+    if (dataSourceKey && !availableDataSources.some((source) => source.key === dataSourceKey)) {
+      setDataSourceKey('');
+      setData(null);
+    }
+  }, [availableDataSources, dataSourceKey]);
+
   return (
     <section aria-labelledby="metrics-explorer-title" style={{ marginTop: 24 }}>
       <Flex
@@ -389,7 +408,7 @@ const MetricsExplorer = () => {
             onChange={handleDataSourceChange}
             options={[
               { label: copy.defaultDataSource, value: '' },
-              ...dataSources.map((ds) => ({ label: ds.name, value: ds.key })),
+              ...availableDataSources.map((ds) => ({ label: ds.name, value: ds.key })),
             ]}
             style={{ width: 200, maxWidth: '100%' }}
           />

--- a/web/src/components/__tests__/MetricsExplorer.test.tsx
+++ b/web/src/components/__tests__/MetricsExplorer.test.tsx
@@ -269,4 +269,45 @@ describe('MetricsExplorer', () => {
     );
     expect(vi.mocked(queryMetrics).mock.calls.length).toBe(queryMetricsCallsBefore);
   });
+
+  it('only offers data sources bound to the selected instance or globally available', async () => {
+    vi.mocked(listDataSources).mockResolvedValue([
+      {
+        key: 'ds-global',
+        name: 'Global Prometheus',
+        type: 'Prometheus',
+        url: '',
+        auth: 'None',
+        status: 'healthy',
+      },
+      {
+        key: 'ds-instance-a',
+        name: 'Instance A Prometheus',
+        type: 'Prometheus',
+        url: '',
+        auth: 'None',
+        status: 'healthy',
+        instanceIds: ['instance-a'],
+      },
+      {
+        key: 'ds-instance-b',
+        name: 'Instance B Prometheus',
+        type: 'Prometheus',
+        url: '',
+        auth: 'None',
+        status: 'healthy',
+        instanceIds: ['instance-b'],
+      },
+    ]);
+
+    const user = userEvent.setup();
+    renderWithProviders(<MetricsExplorer instanceId="instance-a" />);
+
+    await screen.findByRole('combobox', { name: '数据源' });
+    await user.click(screen.getByRole('combobox', { name: '数据源' }));
+
+    expect(await screen.findByText('Global Prometheus')).toBeInTheDocument();
+    expect(screen.getByText('Instance A Prometheus')).toBeInTheDocument();
+    expect(screen.queryByText('Instance B Prometheus')).not.toBeInTheDocument();
+  });
 });

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Alert, Button, Card, Col, Row, Skeleton, Statistic, Table, Tag, Typography } from 'antd';
+import { Alert, Button, Card, Col, Row, Select, Skeleton, Space, Statistic, Table, Tag, Typography } from 'antd';
 import { ClusterOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { ListDashes, ArrowDown } from '@phosphor-icons/react';
 import PageHeader from '../../components/PageHeader';
@@ -10,6 +10,8 @@ import MetricsExplorer from '../../components/MetricsExplorer';
 import { CLUSTER_TYPE_MAP } from '../../constants/theme';
 import { getDashboard } from '../../services/dashboardService';
 import type { DashboardData } from '../../api/metrics';
+import { listInstances } from '../../services/instanceService';
+import type { Instance } from '../../api/instance';
 import { useLang } from '../../i18n/LangContext';
 
 const { Text } = Typography;
@@ -18,6 +20,8 @@ const DashboardPage = () => {
   const navigate = useNavigate();
   const { t } = useLang();
   const [dashboard, setDashboard] = useState<DashboardData | null>(null);
+  const [instances, setInstances] = useState<Instance[]>([]);
+  const [selectedInstanceId, setSelectedInstanceId] = useState<string>();
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
 
@@ -25,22 +29,59 @@ const DashboardPage = () => {
     setLoading(true);
     setLoadError(false);
     try {
-      setDashboard(await getDashboard());
+      setDashboard(await getDashboard(selectedInstanceId));
     } catch {
       setLoadError(true);
     } finally {
       setLoading(false);
     }
+  }, [selectedInstanceId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void listInstances()
+      .then((nextInstances) => {
+        if (!cancelled) setInstances(nextInstances);
+      })
+      .catch(() => {
+        if (!cancelled) setInstances([]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
     void Promise.resolve().then(loadDashboard);
   }, [loadDashboard]);
 
+  const dashboardHeader = (
+    <PageHeader
+      title={t('dashboard.title')}
+      subtitle={t('dashboard.subtitle')}
+      extra={
+        <Space>
+          <Select
+            aria-label="Dashboard instance"
+            allowClear
+            placeholder="All configured instances"
+            value={selectedInstanceId}
+            onChange={setSelectedInstanceId}
+            options={instances.map((instance) => ({ value: instance.id, label: instance.name }))}
+            style={{ width: 220 }}
+          />
+          <Button onClick={() => void loadDashboard()} loading={loading}>
+            Refresh
+          </Button>
+        </Space>
+      }
+    />
+  );
+
   if (loading && !dashboard) {
     return (
       <div style={{ padding: 24 }}>
-        <PageHeader title={t('dashboard.title')} subtitle={t('dashboard.subtitle')} />
+        {dashboardHeader}
         <Skeleton active paragraph={{ rows: 8 }} />
       </div>
     );
@@ -49,7 +90,7 @@ const DashboardPage = () => {
   if (loadError || !dashboard) {
     return (
       <div style={{ padding: 24 }}>
-        <PageHeader title={t('dashboard.title')} subtitle={t('dashboard.subtitle')} />
+        {dashboardHeader}
         <Alert
           type="error"
           showIcon
@@ -203,7 +244,7 @@ const DashboardPage = () => {
 
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader title={t('dashboard.title')} subtitle={t('dashboard.subtitle')} />
+      {dashboardHeader}
 
       <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
         {statCards.map((card) => (

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -283,7 +283,7 @@ const DashboardPage = () => {
         />
       </Card>
 
-      <MetricsExplorer />
+      <MetricsExplorer instanceId={selectedInstanceId} />
     </div>
   );
 };

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -61,6 +61,8 @@ import {
 } from '../../api/settings';
 import type { DataSource } from '../../api/settings';
 import { STATUS_MAP } from '../../constants/theme';
+import { listInstances } from '../../services/instanceService';
+import type { Instance } from '../../api/instance';
 
 const { Title, Text, Link: TypoLink } = Typography;
 
@@ -279,6 +281,7 @@ const GeneralSettingsTab = () => {
 
 export const DataSourceTab = () => {
   const [dataSources, setDataSources] = useState<DataSource[]>([]);
+  const [instances, setInstances] = useState<Instance[]>([]);
   const [loading, setLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
   const [editingDataSource, setEditingDataSource] = useState<DataSource | null>(null);
@@ -300,6 +303,20 @@ export const DataSourceTab = () => {
         if (!cancelled) setLoading(false);
       });
 
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void listInstances()
+      .then((nextInstances) => {
+        if (!cancelled) setInstances(nextInstances);
+      })
+      .catch(() => {
+        if (!cancelled) setInstances([]);
+      });
     return () => {
       cancelled = true;
     };
@@ -380,6 +397,17 @@ export const DataSourceTab = () => {
       render: (t: string) => <Tag color={typeTagColor[t]}>{t}</Tag>,
     },
     { title: 'URL', dataIndex: 'url', key: 'url' },
+    {
+      title: '适用实例',
+      dataIndex: 'instanceIds',
+      key: 'instanceIds',
+      render: (instanceIds: string[] | undefined) => {
+        if (!instanceIds?.length) return '全局';
+        return instanceIds
+          .map((instanceId) => instances.find((instance) => instance.id === instanceId)?.name ?? instanceId)
+          .join('、');
+      },
+    },
     { title: '认证方式', dataIndex: 'auth', key: 'auth' },
     {
       title: '状态',
@@ -479,6 +507,15 @@ export const DataSourceTab = () => {
             rules={[{ required: true, message: '请输入数据源 URL' }]}
           >
             <Input placeholder="http://localhost:9090" />
+          </Form.Item>
+
+          <Form.Item label="适用实例" name="instanceIds" extra="留空时可用于所有实例">
+            <Select
+              mode="multiple"
+              allowClear
+              placeholder="选择此数据源对应的实例"
+              options={instances.map((instance) => ({ value: instance.id, label: instance.name }))}
+            />
           </Form.Item>
 
           <Form.Item label="认证方式" name="auth" initialValue="None">

--- a/web/src/services/dashboardService.ts
+++ b/web/src/services/dashboardService.ts
@@ -10,12 +10,12 @@ function copyClusterOverview(cluster: DashboardData['clusters'][number]) {
   };
 }
 
-export async function getDashboard(): Promise<DashboardData> {
+export async function getDashboard(instanceId?: string): Promise<DashboardData> {
   if (isMockMode()) {
     return {
       stats: { ...dashboardStats },
       clusters: (clusterOverview as DashboardData['clusters']).map(copyClusterOverview),
     };
   }
-  return metricsApi.getDashboard();
+  return metricsApi.getDashboard(instanceId);
 }


### PR DESCRIPTION
Closes #1178

> Depends on #1177 for the dashboard-selected instance context. This branch is stacked on that change; once #1177 is merged, this PR can be rebased so its standalone diff contains only the data-source binding changes.

## Summary
- add optional `instanceIds` to persisted metrics data sources; unbound sources remain globally available
- let administrators assign data sources to configured Studio instances
- filter the dashboard metrics data-source selector by the selected instance

## Verification
- `mvn -q -Dtest=SettingsControllerTest,SettingsServiceTest test`
- `npm test -- --run src/components/__tests__/MetricsExplorer.test.tsx src/pages/settings/__tests__/DataSourceTab.test.tsx`
- `npm run build`