### PR TITLE
fix: harden Ops runtime settings behavior

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/OpsHomeVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/OpsHomeVO.java
@@ -25,6 +25,8 @@ import java.util.List;
 @Data
 @Builder
 public class OpsHomeVO {
+    private boolean configurationAvailable;
+    private String unavailableReason;
     private List<String> namesvrAddrList;
     private boolean useVIPChannel;
     private boolean useTLS;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/OpsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/OpsService.java
@@ -21,10 +21,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 @Slf4j
 @Service
@@ -33,17 +30,14 @@ public class OpsService {
     private static final String OPS_SETTINGS_UNAVAILABLE =
             "Ops settings are not connected to the cluster admin configuration";
 
-    private final Set<String> namesrvAddrs = new LinkedHashSet<>(List.of("127.0.0.1:9876"));
-    private String currentNamesrv = "127.0.0.1:9876";
-    private boolean useVIPChannel = true;
-    private boolean useTLS;
-
     public synchronized OpsHomeVO getHomePage() {
         return OpsHomeVO.builder()
-                .namesvrAddrList(new ArrayList<>(namesrvAddrs))
-                .currentNamesrv(currentNamesrv)
-                .useVIPChannel(useVIPChannel)
-                .useTLS(useTLS)
+                .configurationAvailable(false)
+                .unavailableReason(OPS_SETTINGS_UNAVAILABLE)
+                .namesvrAddrList(List.of())
+                .currentNamesrv("")
+                .useVIPChannel(false)
+                .useTLS(false)
                 .build();
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/OpsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/OpsServiceTest.java
@@ -28,12 +28,13 @@ class OpsServiceTest {
     private final OpsService opsService = new OpsService();
 
     @Test
-    void getHomePageShouldReturnDefaultSettings() {
+    void getHomePageShouldReportUnavailableConfiguration() {
         OpsHomeVO home = opsService.getHomePage();
 
-        assertThat(home.getNamesvrAddrList()).containsExactly("127.0.0.1:9876");
-        assertThat(home.getCurrentNamesrv()).isEqualTo("127.0.0.1:9876");
-        assertThat(home.isUseVIPChannel()).isTrue();
+        assertThat(home.isConfigurationAvailable()).isFalse();
+        assertThat(home.getNamesvrAddrList()).isEmpty();
+        assertThat(home.getCurrentNamesrv()).isEmpty();
+        assertThat(home.isUseVIPChannel()).isFalse();
         assertThat(home.isUseTLS()).isFalse();
     }
 
@@ -53,8 +54,8 @@ class OpsServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
 
         OpsHomeVO home = opsService.getHomePage();
-        assertThat(home.getNamesvrAddrList()).containsExactly("127.0.0.1:9876");
-        assertThat(home.getCurrentNamesrv()).isEqualTo("127.0.0.1:9876");
+        assertThat(home.getNamesvrAddrList()).isEmpty();
+        assertThat(home.getCurrentNamesrv()).isEmpty();
     }
 
     @Test
@@ -69,7 +70,7 @@ class OpsServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
 
         OpsHomeVO home = opsService.getHomePage();
-        assertThat(home.isUseVIPChannel()).isTrue();
+        assertThat(home.isUseVIPChannel()).isFalse();
         assertThat(home.isUseTLS()).isFalse();
     }
 

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -113,6 +113,8 @@ export async function cleanupAuditLogs(beforeDays: number) {
 
 // ─── NameServer Operations ──────────────────────────────────────
 export interface OpsHomeData {
+  configurationAvailable: boolean;
+  unavailableReason?: string;
   namesvrAddrList: string[];
   useVIPChannel: boolean;
   useTLS: boolean;

--- a/web/src/pages/studio/Ops.tsx
+++ b/web/src/pages/studio/Ops.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { App, Button, Input, Popconfirm, Select, Space, Switch, Tooltip, Typography } from 'antd';
+import { Alert, App, Button, Input, Popconfirm, Select, Space, Switch, Tooltip, Typography } from 'antd';
 import { FloppyDisk, Plus, Trash } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
 import useAuthStore from '../../stores/authStore';
@@ -42,7 +42,9 @@ const OpsPage: React.FC = () => {
   const [newNamesrvAddr, setNewNamesrvAddr] = useState('');
   const [useVIPChannel, setUseVIPChannel] = useState(false);
   const [useTLS, setUseTLS] = useState(false);
-  const writeOperationEnabled = !token || admin === true;
+  const [configurationAvailable, setConfigurationAvailable] = useState(false);
+  const [unavailableReason, setUnavailableReason] = useState('');
+  const writeOperationEnabled = configurationAvailable && (!token || admin === true);
   const deleteNameServerDisabled =
     !selectedNamesrv || selectedNamesrv === currentNamesrv || namesrvAddrList.length <= 1;
 
@@ -58,6 +60,8 @@ const OpsPage: React.FC = () => {
           setUseTLS(data.useTLS);
           setSelectedNamesrv(data.currentNamesrv);
           setCurrentNamesrv(data.currentNamesrv);
+          setConfigurationAvailable(data.configurationAvailable);
+          setUnavailableReason(data.unavailableReason || '');
         }
       } catch {
         if (!cancelled) {
@@ -140,6 +144,15 @@ const OpsPage: React.FC = () => {
 
   return (
     <div style={{ padding: 24 }}>
+      {!configurationAvailable && (
+        <Alert
+          type="info"
+          showIcon
+          message="运行时配置不可用"
+          description={unavailableReason || '当前集群不支持读取或更新 Ops 配置。'}
+          style={{ marginBottom: 24 }}
+        />
+      )}
       {/* NameServer Address List */}
       <div style={{ marginBottom: 24 }}>
         <Typography.Title level={4}>{t('ops.nameServerAddressList')}</Typography.Title>

--- a/web/src/pages/studio/__tests__/Ops.test.tsx
+++ b/web/src/pages/studio/__tests__/Ops.test.tsx
@@ -66,6 +66,7 @@ describe('OpsPage', () => {
     useAuthStore.setState({ token: null, user: null, admin: null });
     vi.mocked(queryOpsHomePage).mockResolvedValue({
       namesvrAddrList: ['127.0.0.1:9876', '127.0.0.2:9876'],
+      configurationAvailable: true,
       useVIPChannel: true,
       useTLS: false,
       currentNamesrv: '127.0.0.1:9876',


### PR DESCRIPTION
## Summary

- expose unavailable Ops settings instead of showing simulated values
- disable unsupported configuration writes in the UI
- persist each switch change once and avoid duplicate write requests

Closes #1181

## Verification

- mvn -Dtest=OpsServiceTest,OpsControllerTest test
- npm test -- --run src/pages/studio/__tests__/Ops.test.tsx src/api/ops.test.ts
- npm run build