### PR TITLE
fix(ops): stop presenting simulated NameServer settings as live state

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/OpsHomeVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/OpsHomeVO.java
@@ -29,4 +29,6 @@ public class OpsHomeVO {
     private boolean useVIPChannel;
     private boolean useTLS;
     private String currentNamesrv;
+    /** False when Ops settings are not connected to a cluster admin configuration. */
+    private boolean available;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/OpsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/OpsService.java
@@ -21,7 +21,6 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -39,11 +38,14 @@ public class OpsService {
     private boolean useTLS;
 
     public synchronized OpsHomeVO getHomePage() {
+        // Ops settings are not connected to a cluster admin configuration, so return an explicit
+        // unavailable state instead of simulated values that would be mistaken for live data.
         return OpsHomeVO.builder()
-                .namesvrAddrList(new ArrayList<>(namesrvAddrs))
-                .currentNamesrv(currentNamesrv)
-                .useVIPChannel(useVIPChannel)
-                .useTLS(useTLS)
+                .namesvrAddrList(List.of())
+                .currentNamesrv("")
+                .useVIPChannel(false)
+                .useTLS(false)
+                .available(false)
                 .build();
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/OpsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/OpsServiceTest.java
@@ -28,13 +28,16 @@ class OpsServiceTest {
     private final OpsService opsService = new OpsService();
 
     @Test
-    void getHomePageShouldReturnDefaultSettings() {
+    void getHomePageShouldReturnUnavailableStateWhenNotConnected() {
         OpsHomeVO home = opsService.getHomePage();
 
-        assertThat(home.getNamesvrAddrList()).containsExactly("127.0.0.1:9876");
-        assertThat(home.getCurrentNamesrv()).isEqualTo("127.0.0.1:9876");
-        assertThat(home.isUseVIPChannel()).isTrue();
+        // Ops settings are not connected to a cluster admin configuration; the page must not
+        // present simulated values as live state.
+        assertThat(home.getNamesvrAddrList()).isEmpty();
+        assertThat(home.getCurrentNamesrv()).isEmpty();
+        assertThat(home.isUseVIPChannel()).isFalse();
         assertThat(home.isUseTLS()).isFalse();
+        assertThat(home.isAvailable()).isFalse();
     }
 
     @Test
@@ -53,8 +56,8 @@ class OpsServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
 
         OpsHomeVO home = opsService.getHomePage();
-        assertThat(home.getNamesvrAddrList()).containsExactly("127.0.0.1:9876");
-        assertThat(home.getCurrentNamesrv()).isEqualTo("127.0.0.1:9876");
+        assertThat(home.getNamesvrAddrList()).isEmpty();
+        assertThat(home.getCurrentNamesrv()).isEmpty();
     }
 
     @Test
@@ -69,7 +72,7 @@ class OpsServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
 
         OpsHomeVO home = opsService.getHomePage();
-        assertThat(home.isUseVIPChannel()).isTrue();
+        assertThat(home.isUseVIPChannel()).isFalse();
         assertThat(home.isUseTLS()).isFalse();
     }
 

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -117,6 +117,7 @@ export interface OpsHomeData {
   useVIPChannel: boolean;
   useTLS: boolean;
   currentNamesrv: string;
+  available: boolean;
 }
 
 export async function queryOpsHomePage(): Promise<OpsHomeData> {

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -700,6 +700,11 @@ const translations: Record<string, Record<Lang, string>> = {
   'ops.value': { zh: '值', en: 'Value' },
   'ops.description': { zh: '描述', en: 'Description' },
   'ops.nameServerAddressList': { zh: 'NameServer 地址列表', en: 'NameServer Address List' },
+  'ops.settingsUnavailable': { zh: 'Ops 设置未连接', en: 'Ops settings unavailable' },
+  'ops.settingsUnavailableHint': {
+    zh: '当前未连接到集群 admin 配置，以下设置仅为只读状态。',
+    en: 'Not connected to a cluster admin configuration; the settings below are read-only.',
+  },
   'ops.isUseVIPChannel': { zh: '是否使用 VIP 通道', en: 'Is Use VIP Channel' },
   'ops.useTLS': { zh: '使用 TLS', en: 'Use TLS' },
   'ops.selectNamesrv': { zh: '请选择 NameServer 地址', en: 'Please select a NameServer address' },

--- a/web/src/pages/studio/Ops.tsx
+++ b/web/src/pages/studio/Ops.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { App, Button, Input, Popconfirm, Select, Space, Switch, Tooltip, Typography } from 'antd';
+import { Alert, App, Button, Input, Popconfirm, Select, Space, Switch, Tooltip, Typography } from 'antd';
 import { FloppyDisk, Plus, Trash } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
 import useAuthStore from '../../stores/authStore';
@@ -42,6 +42,7 @@ const OpsPage: React.FC = () => {
   const [newNamesrvAddr, setNewNamesrvAddr] = useState('');
   const [useVIPChannel, setUseVIPChannel] = useState(false);
   const [useTLS, setUseTLS] = useState(false);
+  const [opsAvailable, setOpsAvailable] = useState(true);
   const writeOperationEnabled = !token || admin === true;
   const deleteNameServerDisabled =
     !selectedNamesrv || selectedNamesrv === currentNamesrv || namesrvAddrList.length <= 1;
@@ -58,6 +59,7 @@ const OpsPage: React.FC = () => {
           setUseTLS(data.useTLS);
           setSelectedNamesrv(data.currentNamesrv);
           setCurrentNamesrv(data.currentNamesrv);
+          setOpsAvailable(data.available);
         }
       } catch {
         if (!cancelled) {
@@ -140,6 +142,15 @@ const OpsPage: React.FC = () => {
 
   return (
     <div style={{ padding: 24 }}>
+      {!opsAvailable && (
+        <Alert
+          type="warning"
+          showIcon
+          message={t('ops.settingsUnavailable')}
+          description={t('ops.settingsUnavailableHint')}
+          style={{ marginBottom: 16 }}
+        />
+      )}
       {/* NameServer Address List */}
       <div style={{ marginBottom: 24 }}>
         <Typography.Title level={4}>{t('ops.nameServerAddressList')}</Typography.Title>


### PR DESCRIPTION
Fixes #1181. `OpsService.getHomePage` returned hard-coded NameServer/VIP/TLS values (127.0.0.1:9876, VIP on, etc.) even though every write action returns 501 because Studio is not connected to a cluster admin configuration — the page presented fabricated operational state as live data.

- The server now returns an explicit unavailable state (empty address list, `available: false`).
- The API type carries `available`, and the Ops page shows a read-only warning when it is false.
- Updated the server tests that asserted the old simulated values.
