### PR TITLE
fix: harden Apache instance lifecycle and endpoint validation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
@@ -25,9 +25,11 @@ import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * Central lifecycle owner for real {@link DefaultMQAdminExt} connections.
@@ -68,7 +70,11 @@ public class MqAdminExtFactory {
         if (closed) {
             throw new BusinessException(503, "Admin factory is shutting down");
         }
-        DefaultMQAdminExt admin = cache.computeIfAbsent(namesrvAddr.trim(),
+        String normalizedNamesrvAddr = normalizeNamesrvAddr(namesrvAddr);
+        if (normalizedNamesrvAddr.isEmpty()) {
+            throw new BusinessException(400, "NameServer address is required");
+        }
+        DefaultMQAdminExt admin = cache.computeIfAbsent(normalizedNamesrvAddr,
                 addr -> createAndStart(addr, rpcHook));
         try {
             return action.apply(admin);
@@ -122,6 +128,15 @@ public class MqAdminExtFactory {
     private String buildInstanceName(String namesrvAddr) {
         return "rmq-studio-" + Integer.toHexString(namesrvAddr.hashCode())
                 + "-" + instanceCounter.incrementAndGet();
+    }
+
+    static String normalizeNamesrvAddr(String namesrvAddr) {
+        return Arrays.stream(namesrvAddr.split("[;,]"))
+                .map(String::trim)
+                .filter(address -> !address.isEmpty())
+                .distinct()
+                .sorted()
+                .collect(Collectors.joining(";"));
     }
 
     private void safeShutdown(MQAdminExt admin) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
@@ -80,6 +80,22 @@ public class MqAdminExtFactory {
         }
     }
 
+    /**
+     * Stops and removes the cached client for an endpoint that is no longer referenced by Studio.
+     *
+     * <p>Callers must ensure the endpoint is not still used by another configured instance.
+     */
+    public void release(String namesrvAddr) {
+        if (namesrvAddr == null || namesrvAddr.isBlank()) {
+            return;
+        }
+        DefaultMQAdminExt admin = cache.remove(namesrvAddr.trim());
+        if (admin != null) {
+            safeShutdown(admin);
+            log.info("Released RocketMQ admin client for namesrv {}", namesrvAddr.trim());
+        }
+    }
+
     private DefaultMQAdminExt createAndStart(String namesrvAddr, RPCHook rpcHook) {
         DefaultMQAdminExt admin = newAdmin(rpcHook);
         admin.setNamesrvAddr(namesrvAddr);

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
@@ -95,10 +95,14 @@ public class MqAdminExtFactory {
         if (namesrvAddr == null || namesrvAddr.isBlank()) {
             return;
         }
-        DefaultMQAdminExt admin = cache.remove(namesrvAddr.trim());
+        String normalizedNamesrvAddr = normalizeNamesrvAddr(namesrvAddr);
+        if (normalizedNamesrvAddr.isEmpty()) {
+            return;
+        }
+        DefaultMQAdminExt admin = cache.remove(normalizedNamesrvAddr);
         if (admin != null) {
             safeShutdown(admin);
-            log.info("Released RocketMQ admin client for namesrv {}", namesrvAddr.trim());
+            log.info("Released RocketMQ admin client for namesrv {}", normalizedNamesrvAddr);
         }
     }
 
@@ -130,7 +134,7 @@ public class MqAdminExtFactory {
                 + "-" + instanceCounter.incrementAndGet();
     }
 
-    static String normalizeNamesrvAddr(String namesrvAddr) {
+    public static String normalizeNamesrvAddr(String namesrvAddr) {
         return Arrays.stream(namesrvAddr.split("[;,]"))
                 .map(String::trim)
                 .filter(address -> !address.isEmpty())

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -102,9 +102,7 @@ public class InstanceService {
         if (instance.getName() == null || instance.getName().isBlank()) {
             throw new BusinessException(400, "InstanceVO name is required");
         }
-        if (instance.getEndpoint() == null || instance.getEndpoint().isBlank()) {
-            throw new BusinessException(400, "InstanceVO endpoint is required");
-        }
+        instance.setEndpoint(requireValidEndpoint(instance.getEndpoint()));
     }
 
     /**
@@ -160,6 +158,19 @@ public class InstanceService {
     }
 
 
+    private String requireValidEndpoint(String endpoint) {
+        if (!StringUtils.hasText(endpoint)) {
+            throw new BusinessException(400, "InstanceVO endpoint is required");
+        }
+        String normalized = endpoint.trim();
+        for (String address : normalized.split("[;,]", -1)) {
+            if (address.isBlank()) {
+                throw new BusinessException(400, "InstanceVO endpoint must not contain empty addresses");
+            }
+        }
+        return normalized;
+    }
+
     public InstanceVO updateInstance(InstanceVO instance) {
         requireInstance(instance);
         log.info("Updating instance: {}", instance.getId());
@@ -174,9 +185,6 @@ public class InstanceService {
         if (instance.getName() != null && instance.getName().isBlank()) {
             throw new BusinessException(400, "InstanceVO name is required");
         }
-        if (instance.getEndpoint() != null && instance.getEndpoint().isBlank()) {
-            throw new BusinessException(400, "InstanceVO endpoint is required");
-        }
 
         InstanceVO updated = copyOf(existing);
         boolean cloudInstance = existing.getVendor() != null && existing.getVendor() != InstanceVendor.APACHE;
@@ -188,7 +196,7 @@ public class InstanceService {
                 updated.setType(instance.getType());
             }
             if (instance.getEndpoint() != null) {
-                updated.setEndpoint(instance.getEndpoint());
+                updated.setEndpoint(requireValidEndpoint(instance.getEndpoint()));
             }
         }
         if (instance.getRemark() != null) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -21,6 +21,7 @@ import org.springframework.util.StringUtils;
 
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialRepository;
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialVO;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -43,6 +44,7 @@ public class InstanceService {
     private final InstanceRepository instanceRepository;
     private final CloudCredentialRepository cloudCredentialRepository;
     private final InstanceProviderRegistry providerRegistry;
+    private final MqAdminExtFactory adminFactory;
 
     public List<InstanceVO> listInstances(InstanceType type, String search) {
         log.debug("Listing instances, type={}, search={}", type, search);
@@ -194,7 +196,9 @@ public class InstanceService {
         }
         updated.setUpdatedAt(LocalDateTime.now());
 
-        return instanceRepository.save(updated);
+        InstanceVO saved = instanceRepository.save(updated);
+        releaseApacheEndpointIfUnused(existing, saved.getEndpoint());
+        return saved;
     }
 
     public void deleteInstance(String id) {
@@ -213,6 +217,7 @@ public class InstanceService {
                     existing.getTopicCount(), existing.getConsumerGroupCount()));
         }
         instanceRepository.deleteById(id);
+        releaseApacheEndpointIfUnused(existing, null);
     }
 
     private void requireInstance(InstanceVO instance) {
@@ -238,5 +243,34 @@ public class InstanceService {
         copy.setCreatedAt(instance.getCreatedAt());
         copy.setUpdatedAt(instance.getUpdatedAt());
         return copy;
+    }
+
+    private void releaseApacheEndpointIfUnused(InstanceVO existing, String currentEndpoint) {
+        InstanceVendor vendor = existing.getVendor() == null ? InstanceVendor.APACHE : existing.getVendor();
+        if (vendor != InstanceVendor.APACHE) {
+            return;
+        }
+        releaseEndpointIfUnused(existing.getEndpoint(), currentEndpoint, existing.getId());
+    }
+
+    private void releaseEndpointIfUnused(String previousEndpoint, String currentEndpoint, String excludedInstanceId) {
+        String oldEndpoint = normalizeEndpoint(previousEndpoint);
+        if (oldEndpoint == null || oldEndpoint.equals(normalizeEndpoint(currentEndpoint))) {
+            return;
+        }
+        boolean stillReferenced = instanceRepository.findAll().stream()
+                .anyMatch(instance -> !excludedInstanceId.equals(instance.getId())
+                        && oldEndpoint.equals(normalizeEndpoint(instance.getEndpoint())));
+        if (!stillReferenced) {
+            adminFactory.release(oldEndpoint);
+        }
+    }
+
+    private String normalizeEndpoint(String endpoint) {
+        if (endpoint == null || endpoint.isBlank()) {
+            return null;
+        }
+        String normalizedEndpoint = MqAdminExtFactory.normalizeNamesrvAddr(endpoint);
+        return normalizedEndpoint.isEmpty() ? null : normalizedEndpoint;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
@@ -71,6 +71,20 @@ class MqAdminExtFactoryTest {
     }
 
     @Test
+    void releaseShouldShutdownAndEvictCachedClient() throws Exception {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+
+        factory.execute("10.0.0.1:9876", null, ignored -> "first");
+        factory.release(" 10.0.0.1:9876 ");
+        factory.execute("10.0.0.1:9876", null, ignored -> "second");
+
+        assertThat(factory.created.get()).isEqualTo(2);
+        verify(admin, times(2)).start();
+        verify(admin).shutdown();
+    }
+
+    @Test
     void executeShouldWrapConnectionFailure() throws Exception {
         DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
         doThrow(new RuntimeException("connection refused")).when(admin).start();

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
@@ -85,6 +85,27 @@ class MqAdminExtFactoryTest {
     }
 
     @Test
+    void executeShouldReuseClientForEquivalentNameServerAddressLists() throws Exception {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+
+        factory.execute("10.0.0.2:9876, 10.0.0.1:9876;10.0.0.2:9876", null, ignored -> null);
+        factory.execute("10.0.0.1:9876;10.0.0.2:9876", null, ignored -> null);
+
+        assertThat(factory.created.get()).isEqualTo(1);
+        verify(admin).setNamesrvAddr("10.0.0.1:9876;10.0.0.2:9876");
+    }
+
+    @Test
+    void executeShouldRejectAddressListsWithoutUsableEntries() {
+        MqAdminExtFactory factory = new MqAdminExtFactory();
+
+        assertThatThrownBy(() -> factory.execute(" ; , ", null, ignored -> null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("NameServer address is required");
+    }
+
+    @Test
     void executeShouldWrapConnectionFailure() throws Exception {
         DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
         doThrow(new RuntimeException("connection refused")).when(admin).start();

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
@@ -85,6 +85,19 @@ class MqAdminExtFactoryTest {
     }
 
     @Test
+    void releaseShouldEvictClientUsingEquivalentNameServerAddressList() throws Exception {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+
+        factory.execute("10.0.0.2:9876,10.0.0.1:9876", null, ignored -> "first");
+        factory.release("10.0.0.1:9876;10.0.0.2:9876");
+        factory.execute("10.0.0.1:9876;10.0.0.2:9876", null, ignored -> "second");
+
+        assertThat(factory.created.get()).isEqualTo(2);
+        verify(admin).shutdown();
+    }
+
+    @Test
     void executeShouldReuseClientForEquivalentNameServerAddressLists() throws Exception {
         DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
         RecordingFactory factory = new RecordingFactory(admin);

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -279,6 +279,23 @@ class InstanceServiceTest {
     }
 
     @Test
+    void createInstanceShouldRejectEndpointWithEmptyAddressSegment() {
+        InstanceVO input = InstanceVO.builder().name("valid-name").endpoint("namesrv:9876;").build();
+
+        assertThatThrownBy(() -> instanceService.createInstance(input))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO endpoint must not contain empty addresses");
+    }
+
+    @Test
+    void createInstanceShouldTrimEndpointBeforeSaving() {
+        InstanceVO input = InstanceVO.builder().name("valid-name").endpoint("  namesrv:9876  ").build();
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThat(instanceService.createInstance(input).getEndpoint()).isEqualTo("namesrv:9876");
+    }
+
+    @Test
     void updateInstanceShouldMergeFieldsOntoExisting() {
         LocalDateTime originalCreatedAt = LocalDateTime.of(2025, 1, 2, 3, 4, 5);
         LocalDateTime originalUpdatedAt = LocalDateTime.of(2025, 2, 3, 4, 5, 6);
@@ -513,6 +530,20 @@ class InstanceServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
         assertThat(existing.getName()).isEqualTo("existing-name");
         assertThat(existing.getEndpoint()).isEqualTo("10.0.1.1:8080");
+        verify(instanceRepository, never()).save(any(InstanceVO.class));
+    }
+
+    @Test
+    void updateInstanceShouldRejectEndpointWithEmptyAddressSegment() {
+        InstanceVO existing = InstanceVO.builder().name("instance").endpoint("namesrv:9876").build();
+        existing.setId("inst-1");
+        InstanceVO update = InstanceVO.builder().endpoint("; ;").build();
+        update.setId("inst-1");
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> instanceService.updateInstance(update))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO endpoint must not contain empty addresses");
         verify(instanceRepository, never()).save(any(InstanceVO.class));
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.instance;
 
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialRepository;
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialVO;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -58,6 +59,9 @@ class InstanceServiceTest {
 
     @Mock
     private InstanceProvider instanceProvider;
+
+    @Mock
+    private MqAdminExtFactory adminFactory;
 
     @InjectMocks
     private InstanceService instanceService;
@@ -360,6 +364,49 @@ class InstanceServiceTest {
     }
 
     @Test
+    void updateInstanceShouldReleaseUnusedPreviousEndpoint() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("instance")
+                .endpoint("old-namesrv:9876")
+                .build();
+        existing.setId("inst-1");
+        InstanceVO update = InstanceVO.builder().endpoint("new-namesrv:9876").build();
+        update.setId("inst-1");
+
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(instanceRepository.findAll()).thenReturn(List.of());
+
+        instanceService.updateInstance(update);
+
+        verify(adminFactory).release("old-namesrv:9876");
+    }
+
+    @Test
+    void updateInstanceShouldKeepEndpointClientWhenAnotherInstanceReferencesIt() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("instance")
+                .endpoint("shared-namesrv:9876")
+                .build();
+        existing.setId("inst-1");
+        InstanceVO shared = InstanceVO.builder()
+                .name("shared-instance")
+                .endpoint(" shared-namesrv:9876 ")
+                .build();
+        shared.setId("inst-2");
+        InstanceVO update = InstanceVO.builder().endpoint("new-namesrv:9876").build();
+        update.setId("inst-1");
+
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(instanceRepository.findAll()).thenReturn(List.of(shared));
+
+        instanceService.updateInstance(update);
+
+        verify(adminFactory, never()).release("shared-namesrv:9876");
+    }
+
+    @Test
     void updateInstanceShouldThrowWhenRequestIsNull() {
         assertThatThrownBy(() -> instanceService.updateInstance(null))
                 .isInstanceOf(BusinessException.class)
@@ -489,6 +536,22 @@ class InstanceServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(409));
 
         verify(instanceRepository, never()).deleteById("inst-1");
+    }
+
+    @Test
+    void deleteInstanceShouldReleaseUnusedEndpoint() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("to-delete")
+                .endpoint("namesrv:9876")
+                .build();
+        existing.setId("inst-1");
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.findAll()).thenReturn(List.of());
+
+        instanceService.deleteInstance("inst-1");
+
+        verify(instanceRepository).deleteById("inst-1");
+        verify(adminFactory).release("namesrv:9876");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -407,6 +407,30 @@ class InstanceServiceTest {
     }
 
     @Test
+    void updateInstanceShouldKeepEndpointClientWhenAnotherInstanceUsesEquivalentAddressList() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("instance")
+                .endpoint("namesrv-b:9876;namesrv-a:9876")
+                .build();
+        existing.setId("inst-1");
+        InstanceVO shared = InstanceVO.builder()
+                .name("shared-instance")
+                .endpoint(" namesrv-a:9876, namesrv-b:9876 ")
+                .build();
+        shared.setId("inst-2");
+        InstanceVO update = InstanceVO.builder().endpoint("new-namesrv:9876").build();
+        update.setId("inst-1");
+
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(instanceRepository.findAll()).thenReturn(List.of(shared));
+
+        instanceService.updateInstance(update);
+
+        verifyNoInteractions(adminFactory);
+    }
+
+    @Test
     void updateInstanceShouldThrowWhenRequestIsNull() {
         assertThatThrownBy(() -> instanceService.updateInstance(null))
                 .isInstanceOf(BusinessException.class)


### PR DESCRIPTION
## Summary

- normalize and release Apache runtime AdminClient cache entries as instances change
- validate Apache NameServer endpoint lists before persistence
- preserve the merged instance-deletion guard that rejects managed Topic or Consumer Group metadata
- keep cloud instances out of Apache MQAdminClient lifecycle operations

Closes #1184
Closes #1194

## Verification

- mvn -Dtest=InstanceServiceTest,InstanceControllerTest,MqAdminExtFactoryTest test