### PR TITLE
[ISSUE #1186] Reject config updates without broker targets

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -35,6 +35,7 @@ import org.apache.rocketmq.studio.rocketmq.RocketMQBrokerConfigService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -102,24 +103,28 @@ public class ClusterService {
         ClusterConfigVO config = copyConfig(cluster.getConfig());
         applyConfig(command, config);
 
+        List<BrokerVO> brokerTargets = cluster.getBrokers() == null ? List.of()
+                : cluster.getBrokers().stream()
+                        .filter(broker -> StringUtils.hasText(broker.getAddr()))
+                        .toList();
+        if (brokerTargets.isEmpty()) {
+            throw new BusinessException(409,
+                    "Cluster has no addressable brokers for config update: " + command.getId());
+        }
+
         List<String> successfulBrokers = new ArrayList<>();
         List<BrokerConfigUpdateFailureVO> failedBrokers = new ArrayList<>();
-        if (cluster.getBrokers() != null && !cluster.getBrokers().isEmpty()) {
-            Properties brokerProps = buildBrokerProperties(command);
-            for (BrokerVO broker : cluster.getBrokers()) {
-                String address = broker.getAddr();
-                if (address == null || address.isEmpty()) {
-                    continue;
-                }
-                try {
-                    brokerConfigService.updateBrokerConfig(address, command.getId(), brokerProps);
-                    successfulBrokers.add(address);
-                } catch (Exception e) {
-                    failedBrokers.add(BrokerConfigUpdateFailureVO.builder()
-                            .address(address)
-                            .message(e.getMessage())
-                            .build());
-                }
+        Properties brokerProps = buildBrokerProperties(command);
+        for (BrokerVO broker : brokerTargets) {
+            String address = broker.getAddr();
+            try {
+                brokerConfigService.updateBrokerConfig(address, command.getId(), brokerProps);
+                successfulBrokers.add(address);
+            } catch (Exception e) {
+                failedBrokers.add(BrokerConfigUpdateFailureVO.builder()
+                        .address(address)
+                        .message(e.getMessage())
+                        .build());
             }
         }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -89,6 +89,7 @@ class ClusterServiceTest {
                 .version("5.1.0")
                 .brokers(List.of(BrokerVO.builder()
                         .name("broker-0")
+                        .addr("10.0.0.1:10911")
                         .build()))
                 .proxies(List.of(ProxyVO.builder()
                         .addr("10.0.0.10:8081")
@@ -192,6 +193,21 @@ class ClusterServiceTest {
 
         assertThat(result.getCluster().getConfig().getFlushDiskType()).isEqualTo(FlushDiskType.SYNC_FLUSH);
         verify(clusterRepository).updateConfig(eq("cluster-1"), any(ClusterConfigVO.class));
+    }
+
+    @Test
+    void updateConfigShouldRejectClusterWithoutAddressableBrokers() {
+        sampleCluster.setBrokers(List.of(BrokerVO.builder().name("broker-0").addr(" ").build()));
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+
+        assertThatThrownBy(() -> clusterService.updateClusterConfig(
+                UpdateConfigDTO.builder().id("cluster-1").flushDiskType("SYNC_FLUSH").build()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("no addressable brokers")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(409));
+
+        verify(clusterRepository, never()).updateConfig(eq("cluster-1"), any(ClusterConfigVO.class));
+        verifyNoInteractions(brokerConfigService, auditService);
     }
 
     @Test
@@ -318,6 +334,7 @@ class ClusterServiceTest {
         ClusterVO clusterWithNullConfig = ClusterVO.builder()
                 .name("null-config-cluster")
                 .status(ClusterStatus.healthy)
+                .brokers(List.of(BrokerVO.builder().addr("10.0.0.1:10911").build()))
                 .config(null)
                 .build();
         clusterWithNullConfig.setId("cluster-nc");
@@ -361,6 +378,7 @@ class ClusterServiceTest {
         ClusterVO clusterWithNullConfig = ClusterVO.builder()
                 .name("null-config-cluster")
                 .status(ClusterStatus.healthy)
+                .brokers(List.of(BrokerVO.builder().addr("10.0.0.1:10911").build()))
                 .config(null)
                 .build();
         clusterWithNullConfig.setId("cluster-nc");


### PR DESCRIPTION
## Summary
- reject Broker configuration updates when the target cluster has no addressable Broker
- prevent persisting a configuration that was never sent to a Broker
- keep partial per-Broker failure behavior unchanged

## Validation
- `cd server && mvn -q -Dtest=ClusterServiceTest,ClusterControllerTest test`

Closes #1186