### PR TITLE
[ISSUE #1188] Reuse dashboard Broker runtime snapshots

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProvider.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.rocketmq;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +75,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
         long tpsOut = 0;
         long messagesToday = 0;
         List<ClusterOverviewVO> clusters = new ArrayList<>();
+        Map<String, KVTable> runtimeStatsByBroker = new HashMap<>();
 
         try {
             ClusterInfo clusterInfo = adminExt.examineBrokerClusterInfo();
@@ -142,6 +144,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 // Get runtime stats for TPS
                 try {
                     KVTable runtimeInfo = adminExt.fetchBrokerRuntimeStats(brokerAddr);
+                    runtimeStatsByBroker.put(brokerAddr, runtimeInfo);
                     if (runtimeInfo != null && runtimeInfo.getTable() != null) {
                         Map<String, String> table = runtimeInfo.getTable();
                         tpsIn += parseTps(table.get("putTps"));
@@ -176,20 +179,17 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                         clusterBrokers++;
                         String masterAddr = brokerData.getBrokerAddrs().get(0L);
                         if (masterAddr != null) {
-                            try {
-                                KVTable rt = adminExt.fetchBrokerRuntimeStats(masterAddr);
-                                if (rt != null && rt.getTable() != null) {
-                                    clusterTpsIn += (int) parseTps(rt.getTable().get("putTps"));
-                                    clusterTpsOut += (int) parseTps(rt.getTable().get("getTransferedTps"));
-                                    String v = rt.getTable().get("brokerVersionDesc");
-                                    if (v != null && "unknown".equals(version)) {
-                                        String brokerVersion = v.trim();
-                                        if (!brokerVersion.isEmpty()) {
-                                            version = brokerVersion;
-                                        }
+                            KVTable runtimeInfo = runtimeStatsByBroker.get(masterAddr);
+                            if (runtimeInfo != null && runtimeInfo.getTable() != null) {
+                                clusterTpsIn += (int) parseTps(runtimeInfo.getTable().get("putTps"));
+                                clusterTpsOut += (int) parseTps(runtimeInfo.getTable().get("getTransferedTps"));
+                                String value = runtimeInfo.getTable().get("brokerVersionDesc");
+                                if (value != null && "unknown".equals(version)) {
+                                    String brokerVersion = value.trim();
+                                    if (!brokerVersion.isEmpty()) {
+                                        version = brokerVersion;
                                     }
                                 }
-                            } catch (Exception ignored) {
                             }
                         }
                     }

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQDashboardProviderTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RocketMQDashboardProviderTest {
@@ -48,6 +50,7 @@ class RocketMQDashboardProviderTest {
 
         assertThat(dashboard.getClusters()).hasSize(1);
         assertThat(dashboard.getClusters().get(0).getVersion()).isEqualTo("V5_3_3");
+        verify(adminExt, times(1)).fetchBrokerRuntimeStats("10.0.0.11:10911");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- collect each master Broker runtime snapshot once per dashboard request
- reuse the snapshot for aggregate and per-cluster TPS/version fields
- preserve existing per-Broker error isolation

## Validation
- `cd server && mvn -q -Dtest=RocketMQDashboardProviderTest test`

Closes #1188