### PR TITLE
[ISSUE #1194] Validate Apache instance endpoints

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -100,9 +100,7 @@ public class InstanceService {
         if (instance.getName() == null || instance.getName().isBlank()) {
             throw new BusinessException(400, "InstanceVO name is required");
         }
-        if (instance.getEndpoint() == null || instance.getEndpoint().isBlank()) {
-            throw new BusinessException(400, "InstanceVO endpoint is required");
-        }
+        instance.setEndpoint(requireValidEndpoint(instance.getEndpoint()));
     }
 
     /**
@@ -161,6 +159,19 @@ public class InstanceService {
         return value == null || value.isBlank();
     }
 
+    private String requireValidEndpoint(String endpoint) {
+        if (isBlank(endpoint)) {
+            throw new BusinessException(400, "InstanceVO endpoint is required");
+        }
+        String normalized = endpoint.trim();
+        for (String address : normalized.split("[;,]", -1)) {
+            if (address.isBlank()) {
+                throw new BusinessException(400, "InstanceVO endpoint must not contain empty addresses");
+            }
+        }
+        return normalized;
+    }
+
     public InstanceVO updateInstance(InstanceVO instance) {
         requireInstance(instance);
         log.info("Updating instance: {}", instance.getId());
@@ -175,9 +186,6 @@ public class InstanceService {
         if (instance.getName() != null && instance.getName().isBlank()) {
             throw new BusinessException(400, "InstanceVO name is required");
         }
-        if (instance.getEndpoint() != null && instance.getEndpoint().isBlank()) {
-            throw new BusinessException(400, "InstanceVO endpoint is required");
-        }
 
         InstanceVO updated = copyOf(existing);
         boolean cloudInstance = existing.getVendor() != null && existing.getVendor() != InstanceVendor.APACHE;
@@ -189,7 +197,7 @@ public class InstanceService {
                 updated.setType(instance.getType());
             }
             if (instance.getEndpoint() != null) {
-                updated.setEndpoint(instance.getEndpoint());
+                updated.setEndpoint(requireValidEndpoint(instance.getEndpoint()));
             }
         }
         if (instance.getRemark() != null) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -226,6 +226,23 @@ class InstanceServiceTest {
     }
 
     @Test
+    void createInstanceShouldRejectEndpointWithEmptyAddressSegment() {
+        InstanceVO input = InstanceVO.builder().name("valid-name").endpoint("namesrv:9876;").build();
+
+        assertThatThrownBy(() -> instanceService.createInstance(input))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO endpoint must not contain empty addresses");
+    }
+
+    @Test
+    void createInstanceShouldTrimEndpointBeforeSaving() {
+        InstanceVO input = InstanceVO.builder().name("valid-name").endpoint("  namesrv:9876  ").build();
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThat(instanceService.createInstance(input).getEndpoint()).isEqualTo("namesrv:9876");
+    }
+
+    @Test
     void updateInstanceShouldMergeFieldsOntoExisting() {
         LocalDateTime originalCreatedAt = LocalDateTime.of(2025, 1, 2, 3, 4, 5);
         LocalDateTime originalUpdatedAt = LocalDateTime.of(2025, 2, 3, 4, 5, 6);
@@ -393,6 +410,20 @@ class InstanceServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
         assertThat(existing.getName()).isEqualTo("existing-name");
         assertThat(existing.getEndpoint()).isEqualTo("10.0.1.1:8080");
+        verify(instanceRepository, never()).save(any(InstanceVO.class));
+    }
+
+    @Test
+    void updateInstanceShouldRejectEndpointWithEmptyAddressSegment() {
+        InstanceVO existing = InstanceVO.builder().name("instance").endpoint("namesrv:9876").build();
+        existing.setId("inst-1");
+        InstanceVO update = InstanceVO.builder().endpoint("; ;").build();
+        update.setId("inst-1");
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> instanceService.updateInstance(update))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO endpoint must not contain empty addresses");
         verify(instanceRepository, never()).save(any(InstanceVO.class));
     }
 


### PR DESCRIPTION
## Summary
- reject endpoint lists containing empty address segments
- trim valid Apache instance endpoints before persisting
- cover create and update validation paths

## Validation
- `cd server && mvn -q -Dtest=InstanceServiceTest test`

Closes #1194