### PR TITLE
[ISSUE #1196] Fix local docker compose bootstrap on Docker Engine

### DIFF
--- a/deploy/rocketmq/docker-compose.yml
+++ b/deploy/rocketmq/docker-compose.yml
@@ -120,6 +120,10 @@ services:
 networks:
   default:
     name: rocketmq_default
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.89.2.0/24
 
 volumes:
   broker-0-store:

--- a/web/15-resolver.envsh
+++ b/web/15-resolver.envsh
@@ -1,11 +1,18 @@
 #!/bin/sh
 # Sourced by docker-entrypoint.sh (*.envsh), so RESOLVER is visible to the
-# later 20-envsubst-on-templates.sh step. Uses the podman network gateway
-# (the container DNS server) only — the host resolv.conf may leak public DNS
-# servers that cannot resolve container names and cause random 502s.
-RESOLVER="$(ip route | awk '/default/ {print $3; exit}')"
-if [ -z "$RESOLVER" ]; then
-    RESOLVER="127.0.0.11"
+# later 20-envsubst-on-templates.sh step.
+#
+# Prefer Docker's embedded DNS (127.0.0.11): it resolves container names and
+# is the correct choice on Docker Engine. Fall back to the default gateway
+# (podman's container DNS server) only when 127.0.0.11 is unreachable.
+# The host resolv.conf may leak public DNS servers that cannot resolve
+# container names and cause random 502s, so never use it directly.
+RESOLVER="127.0.0.11"
+if ! nc -z -w2 127.0.0.11 53 >/dev/null 2>&1; then
+    GW="$(ip route | awk '/default/ {print $3; exit}')"
+    if [ -n "$GW" ]; then
+        RESOLVER="$GW"
+    fi
 fi
 export RESOLVER
 echo "15-resolver.envsh: resolver=$RESOLVER"


### PR DESCRIPTION
## Summary
- declare a `10.89.2.0/24` bridge subnet on the RocketMQ dev-cluster compose network so the pinned static IPs are accepted on Docker Engine
- use Docker's embedded DNS (`127.0.0.11`) for the web nginx upstream resolver, falling back to the default gateway (podman) only when it is unreachable

## Why
Two blockers prevented the documented local `docker compose` bootstrap from working on Docker Engine:
- cluster `up` failed on the static-IP subnet validation
- the web nginx `/api/` proxy returned 502 because the upstream resolver pointed at the (DNS-less) gateway IP, so the frontend could not verify login status

## Validation
- `cd deploy/rocketmq && docker compose up -d` starts nameserver, broker-0/1, proxy, producer and consumer; `mqadmin clusterList` shows both brokers ACTIVATED
- `curl -s http://127.0.0.1:6789/api/auth/status` returns `{"code":200,...,"loginRequired":false,"authenticated":false}` (200, no 502)
- podman path preserved via the gateway fallback branch

Closes #1196
