### PR TITLE
fix: harden bundled dashboard and alert asset loading

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
@@ -59,6 +59,10 @@ public class GrafanaDashboardService {
             }
             try (InputStream in = resource.getInputStream()) {
                 JsonNode root = objectMapper.readTree(in);
+                if (root == null || !root.isObject()) {
+                    log.warn("Skipping invalid Grafana dashboard resource {}: expected a JSON object", resource);
+                    continue;
+                }
                 String title = textOr(root, "title", uid);
                 String description = textOr(root, "description", "");
                 List<String> tags = parseTags(root);
@@ -116,7 +120,7 @@ public class GrafanaDashboardService {
         return null;
     }
 
-    private Resource[] resolveResources() {
+    protected Resource[] resolveResources() {
         try {
             return resourceResolver.getResources(LOCATION_PATTERN);
         } catch (IOException e) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -100,7 +101,7 @@ public class GrafanaDashboardService {
             throw new BusinessException(404, "Grafana dashboard not found: " + uid);
         }
         try (InputStream in = resource.getInputStream()) {
-            return new String(in.readAllBytes());
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new BusinessException(500, "Failed to read Grafana dashboard: " + uid);
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetService.java
@@ -60,6 +60,10 @@ public class AlertRuleAssetService {
             }
             try (InputStream in = resource.getInputStream()) {
                 JsonNode root = yamlMapper.readTree(in);
+                if (root == null || !root.isObject()) {
+                    log.warn("Skipping invalid alert rule asset {}: expected a YAML object", resource);
+                    continue;
+                }
                 List<PrometheusAlertRule> rules = parseRules(root);
                 Set<String> severities = new LinkedHashSet<>();
                 String group = rules.isEmpty() ? "" : rules.get(0).group();
@@ -100,7 +104,12 @@ public class AlertRuleAssetService {
                 continue;
             }
             try (InputStream in = resource.getInputStream()) {
-                rules.addAll(parseRules(yamlMapper.readTree(in)));
+                JsonNode root = yamlMapper.readTree(in);
+                if (root == null || !root.isObject()) {
+                    log.warn("Skipping invalid alert rule asset {}: expected a YAML object", resource);
+                    continue;
+                }
+                rules.addAll(parseRules(root));
             } catch (IOException e) {
                 log.warn("Skipping unreadable alert rule asset {}: {}", resource, e.getMessage());
             }
@@ -110,6 +119,9 @@ public class AlertRuleAssetService {
 
     private List<PrometheusAlertRule> parseRules(JsonNode root) {
         List<PrometheusAlertRule> rules = new ArrayList<>();
+        if (root == null || !root.isObject()) {
+            return rules;
+        }
         JsonNode groups = root.get("groups");
         if (groups == null || !groups.isArray()) {
             return rules;
@@ -126,6 +138,10 @@ public class AlertRuleAssetService {
                 }
                 String alert = textOr(rule, "alert", "");
                 String expr = textOr(rule, "expr", "");
+                if (alert.isBlank() || expr.isBlank()) {
+                    log.warn("Skipping incomplete alert rule in group {}", groupName);
+                    continue;
+                }
                 String duration = textOr(rule, "for", "5m");
                 String severity = textOr(labelsOf(rule), "severity", "warning");
                 String team = textOr(labelsOf(rule), "team", "broker");
@@ -146,7 +162,7 @@ public class AlertRuleAssetService {
         return null;
     }
 
-    private Resource[] resolveResources() {
+    protected Resource[] resolveResources() {
         try {
             return resourceResolver.getResources(LOCATION_PATTERN);
         } catch (IOException e) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -69,6 +71,17 @@ class GrafanaDashboardServiceTest {
         assertFalse(json.isBlank());
         assertTrue(json.contains("\"uid\""));
         assertTrue(json.contains("rocketmq-broker"));
+    }
+
+    @Test
+    void getDashboardJsonShouldDecodeBundledAssetAsUtf8() throws Exception {
+        try (InputStream input = getClass().getClassLoader()
+                .getResourceAsStream("grafana/rocketmq-broker.json")) {
+            assertTrue(input != null, "expected bundled dashboard resource");
+            String expected = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+
+            assertEquals(expected, service.getDashboardJson("rocketmq-broker"));
+        }
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
@@ -19,6 +19,8 @@ package org.apache.rocketmq.studio.cluster.metrics.grafana;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -89,5 +91,35 @@ class GrafanaDashboardServiceTest {
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> service.getDashboardJson("no-such-dashboard"));
         assertEquals(404, exception.getCode());
+    }
+
+    @Test
+    void listDashboardsShouldSkipEmptyAndNonObjectAssets() {
+        GrafanaDashboardService service = serviceWithResources(
+                resource("empty.json", ""),
+                resource("array.json", "[]"),
+                resource("valid.json", "{\"title\":\"Valid\",\"tags\":[\"rocketmq\"]}"));
+
+        List<GrafanaDashboardInfo> dashboards = service.listDashboards();
+
+        assertEquals(List.of(new GrafanaDashboardInfo("valid", "Valid", "", List.of("rocketmq"))), dashboards);
+    }
+
+    private static GrafanaDashboardService serviceWithResources(Resource... resources) {
+        return new GrafanaDashboardService(new ObjectMapper()) {
+            @Override
+            protected Resource[] resolveResources() {
+                return resources;
+            }
+        };
+    }
+
+    private static Resource resource(String filename, String content) {
+        return new ByteArrayResource(content.getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        };
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
@@ -18,7 +18,10 @@ package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -80,5 +83,53 @@ class AlertRuleAssetServiceTest {
         boolean hasBroker = rules.stream().anyMatch(r -> "broker".equals(r.team()));
         assertTrue(hasCritical, "expected at least one critical rule");
         assertTrue(hasBroker, "expected at least one broker rule");
+    }
+    @Test
+    void assetLoadingShouldSkipEmptyAndNonObjectYaml() {
+        AlertRuleAssetService service = serviceWithResources(
+                resource("empty.yaml", ""),
+                resource("array.yaml", "[]"),
+                resource("valid.yaml", "groups:\n  - name: broker\n    rules:\n      - alert: BrokerDown\n        expr: up == 0\n"));
+
+        assertEquals(List.of(new AlertRuleAssetInfo("valid", "broker", 1, List.of("warning"))),
+                service.listAssets());
+        assertEquals(List.of(new PrometheusAlertRule("broker", "BrokerDown", "up == 0", "5m",
+                "warning", "broker", "BrokerDown", "")), service.loadDefaultRules());
+    }
+
+    @Test
+    void assetLoadingShouldSkipRulesWithoutAlertOrExpression() {
+        AlertRuleAssetService service = serviceWithResources(resource("mixed.yaml", """
+                groups:
+                  - name: broker
+                    rules:
+                      - alert: MissingExpression
+                      - expr: up == 0
+                      - alert: BrokerDown
+                        expr: up == 0
+                """));
+
+        assertEquals(List.of(new AlertRuleAssetInfo("mixed", "broker", 1, List.of("warning"))),
+                service.listAssets());
+        assertEquals(List.of(new PrometheusAlertRule("broker", "BrokerDown", "up == 0", "5m",
+                "warning", "broker", "BrokerDown", "")), service.loadDefaultRules());
+    }
+
+    private static AlertRuleAssetService serviceWithResources(Resource... resources) {
+        return new AlertRuleAssetService() {
+            @Override
+            protected Resource[] resolveResources() {
+                return resources;
+            }
+        };
+    }
+
+    private static Resource resource(String filename, String content) {
+        return new ByteArrayResource(content.getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        };
     }
 }


### PR DESCRIPTION
## Summary

- decode bundled Grafana dashboard JSON as UTF-8
- skip malformed or non-object Grafana dashboard assets
- skip empty, invalid, and incomplete bundled Prometheus alert rules

Closes #1199
Closes #1201
Closes #1209

## Verification

- mvn -Dtest=GrafanaDashboardServiceTest,AlertRuleAssetServiceTest test