### PR TITLE
fix: harden dashboard runtime overview

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/ClusterOverviewVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/ClusterOverviewVO.java
@@ -39,8 +39,8 @@ public class ClusterOverviewVO {
     private int proxies;
     private int topics;
     private int groups;
-    private int tpsIn;
-    private int tpsOut;
+    private long tpsIn;
+    private long tpsOut;
     private String version;
     private List<Integer> throughput;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -115,7 +115,8 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             // Count topics
             try {
                 TopicList topicList = admin.fetchAllTopicList();
-                Set<String> topics = topicList.getTopicList();
+                Set<String> topics = topicList == null || topicList.getTopicList() == null
+                        ? Set.of() : topicList.getTopicList();
                 totalTopics = (int) topics.stream()
                         .filter(t -> !isSystemTopic(t))
                         .count();
@@ -166,7 +167,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             // Build per-cluster overview
             for (Map.Entry<String, Set<String>> clusterEntry : clusterAddrTable.entrySet()) {
                 String clusterName = clusterEntry.getKey();
-                Set<String> brokerNames = clusterEntry.getValue();
+                Set<String> brokerNames = clusterEntry.getValue() == null ? Set.of() : clusterEntry.getValue();
                 int clusterBrokers = 0;
                 long clusterTpsIn = 0;
                 long clusterTpsOut = 0;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -168,8 +168,8 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 String clusterName = clusterEntry.getKey();
                 Set<String> brokerNames = clusterEntry.getValue();
                 int clusterBrokers = 0;
-                int clusterTpsIn = 0;
-                int clusterTpsOut = 0;
+                long clusterTpsIn = 0;
+                long clusterTpsOut = 0;
                 String version = "unknown";
                 boolean runtimeMetricsUnavailable = false;
 
@@ -182,8 +182,8 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                             try {
                                 KVTable rt = admin.fetchBrokerRuntimeStats(masterAddr);
                                 if (rt != null && rt.getTable() != null) {
-                                    clusterTpsIn += (int) parseTps(rt.getTable().get("putTps"));
-                                    clusterTpsOut += (int) parseTps(rt.getTable().get("getTransferedTps"));
+                                    clusterTpsIn += parseTps(rt.getTable().get("putTps"));
+                                    clusterTpsOut += parseTps(rt.getTable().get("getTransferedTps"));
                                     String v = rt.getTable().get("brokerVersionDesc");
                                     if (v != null && "unknown".equals(version)) {
                                         String brokerVersion = v.trim();

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.provider.apache;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +77,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
         long tpsOut = 0;
         long messagesToday = 0;
         List<ClusterOverviewVO> clusters = new ArrayList<>();
+        Map<String, KVTable> runtimeStatsByBroker = new HashMap<>();
 
         try {
             ClusterInfo clusterInfo = admin.examineBrokerClusterInfo();
@@ -145,6 +147,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 // Get runtime stats for TPS
                 try {
                     KVTable runtimeInfo = admin.fetchBrokerRuntimeStats(brokerAddr);
+                    runtimeStatsByBroker.put(brokerAddr, runtimeInfo);
                     if (runtimeInfo != null && runtimeInfo.getTable() != null) {
                         Map<String, String> table = runtimeInfo.getTable();
                         tpsIn += parseTps(table.get("putTps"));
@@ -180,25 +183,19 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                         clusterBrokers++;
                         String masterAddr = brokerData.getBrokerAddrs().get(0L);
                         if (masterAddr != null) {
-                            try {
-                                KVTable rt = admin.fetchBrokerRuntimeStats(masterAddr);
-                                if (rt != null && rt.getTable() != null) {
-                                    clusterTpsIn += parseTps(rt.getTable().get("putTps"));
-                                    clusterTpsOut += parseTps(rt.getTable().get("getTransferedTps"));
-                                    String v = rt.getTable().get("brokerVersionDesc");
-                                    if (v != null && "unknown".equals(version)) {
-                                        String brokerVersion = v.trim();
-                                        if (!brokerVersion.isEmpty()) {
-                                            version = brokerVersion;
-                                        }
+                            KVTable runtimeInfo = runtimeStatsByBroker.get(masterAddr);
+                            if (runtimeInfo != null && runtimeInfo.getTable() != null) {
+                                clusterTpsIn += parseTps(runtimeInfo.getTable().get("putTps"));
+                                clusterTpsOut += parseTps(runtimeInfo.getTable().get("getTransferedTps"));
+                                String value = runtimeInfo.getTable().get("brokerVersionDesc");
+                                if (value != null && "unknown".equals(version)) {
+                                    String brokerVersion = value.trim();
+                                    if (!brokerVersion.isEmpty()) {
+                                        version = brokerVersion;
                                     }
-                                } else {
-                                    runtimeMetricsUnavailable = true;
                                 }
-                            } catch (Exception e) {
+                            } else {
                                 runtimeMetricsUnavailable = true;
-                                log.warn("Failed to get runtime info for dashboard cluster {} from broker {}: {}",
-                                        clusterName, masterAddr, e.getMessage());
                             }
                         }
                     }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -207,7 +207,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 clusters.add(ClusterOverviewVO.builder()
                         .id(clusterName)
                         .name(clusterName)
-                        .type(ClusterType.V5_PROXY_CLUSTER)
+                        .type(ClusterType.V4_DIRECT)
                         .status(runtimeMetricsUnavailable ? ClusterStatus.warning : ClusterStatus.healthy)
                         .brokers(clusterBrokers)
                         .proxies(0)

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -171,6 +171,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 int clusterTpsIn = 0;
                 int clusterTpsOut = 0;
                 String version = "unknown";
+                boolean runtimeMetricsUnavailable = false;
 
                 for (String brokerName : brokerNames) {
                     BrokerData brokerData = brokerAddrTable.get(brokerName);
@@ -190,8 +191,13 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                                             version = brokerVersion;
                                         }
                                     }
+                                } else {
+                                    runtimeMetricsUnavailable = true;
                                 }
-                            } catch (Exception ignored) {
+                            } catch (Exception e) {
+                                runtimeMetricsUnavailable = true;
+                                log.warn("Failed to get runtime info for dashboard cluster {} from broker {}: {}",
+                                        clusterName, masterAddr, e.getMessage());
                             }
                         }
                     }
@@ -201,7 +207,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                         .id(clusterName)
                         .name(clusterName)
                         .type(ClusterType.V5_PROXY_CLUSTER)
-                        .status(ClusterStatus.healthy)
+                        .status(runtimeMetricsUnavailable ? ClusterStatus.warning : ClusterStatus.healthy)
                         .brokers(clusterBrokers)
                         .proxies(0)
                         .topics(0)

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -36,6 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RocketMQDashboardProviderTest {
@@ -54,7 +56,7 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getClusters()).hasSize(1);
         assertThat(dashboard.getClusters().get(0).getVersion()).isEqualTo("V5_3_3");
         assertThat(dashboard.getClusters().get(0).getType()).isEqualTo(ClusterType.V4_DIRECT);
-        assertThat(dashboard.getClusters().get(0).getType()).isEqualTo(ClusterType.V4_DIRECT);
+        verify(adminExt, times(1)).fetchBrokerRuntimeStats("10.0.0.11:10911");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -26,6 +26,7 @@ import org.apache.rocketmq.remoting.protocol.body.KVTable;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.Test;
@@ -114,6 +115,21 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getClusters().get(0).getBrokers()).isZero();
         assertThat(dashboard.getStats().getTotalClusters()).isEqualTo(1);
         assertThat(dashboard.getStats().getTotalBrokers()).isZero();
+    }
+
+    @Test
+    void dashboardShouldMarkClusterWarningWhenBrokerRuntimeStatsFail() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911"))
+                .thenThrow(new RuntimeException("broker unavailable"));
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getClusters()).singleElement()
+                .extracting(cluster -> cluster.getStatus())
+                .isEqualTo(ClusterStatus.warning);
     }
 
     private RocketMQDashboardProvider newProvider(DefaultMQAdminExt adminExt) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -132,6 +132,22 @@ class RocketMQDashboardProviderTest {
                 .isEqualTo(ClusterStatus.warning);
     }
 
+    @Test
+    void dashboardShouldKeepPerClusterTpsAboveIntegerRange() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911"))
+                .thenReturn(runtimeStats("3000000000.0", "4000000000.0"));
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getClusters()).singleElement().satisfies(cluster -> {
+            assertThat(cluster.getTpsIn()).isEqualTo(3_000_000_000L);
+            assertThat(cluster.getTpsOut()).isEqualTo(4_000_000_000L);
+        });
+    }
+
     private RocketMQDashboardProvider newProvider(DefaultMQAdminExt adminExt) {
         MqAdminExtFactory adminFactory = mock(MqAdminExtFactory.class);
         when(adminFactory.execute(anyString(), any(), any())).thenAnswer(invocation ->
@@ -163,10 +179,14 @@ class RocketMQDashboardProviderTest {
     }
 
     private KVTable runtimeStats() {
+        return runtimeStats("2.0", "5.0");
+    }
+
+    private KVTable runtimeStats(String putTps, String getTransferredTps) {
         HashMap<String, String> table = new HashMap<>();
         table.put("brokerVersionDesc", "  V5_3_3  ");
-        table.put("putTps", "1.0 2.0 3.0");
-        table.put("getTransferedTps", "4.0 5.0 6.0");
+        table.put("putTps", "1.0 " + putTps + " 3.0");
+        table.put("getTransferedTps", "4.0 " + getTransferredTps + " 6.0");
         table.put("msgPutTotalTodayMorning", "42");
 
         KVTable kvTable = new KVTable();

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -148,6 +148,26 @@ class RocketMQDashboardProviderTest {
         });
     }
 
+    @Test
+    void dashboardShouldTolerateMissingTopicListAndClusterMembership() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        ClusterInfo info = new ClusterInfo();
+        info.setBrokerAddrTable(new HashMap<>());
+        HashMap<String, Set<String>> clusterAddrTable = new HashMap<>();
+        clusterAddrTable.put("cluster-without-members", null);
+        info.setClusterAddrTable(clusterAddrTable);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(info);
+        when(adminExt.fetchAllTopicList()).thenReturn(null);
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getStats().getTotalTopics()).isZero();
+        assertThat(dashboard.getClusters()).singleElement().satisfies(cluster -> {
+            assertThat(cluster.getName()).isEqualTo("cluster-without-members");
+            assertThat(cluster.getBrokers()).isZero();
+        });
+    }
+
     private RocketMQDashboardProvider newProvider(DefaultMQAdminExt adminExt) {
         MqAdminExtFactory adminFactory = mock(MqAdminExtFactory.class);
         when(adminFactory.execute(anyString(), any(), any())).thenAnswer(invocation ->
@@ -156,7 +176,6 @@ class RocketMQDashboardProviderTest {
         properties.setNamesrvAddr("10.0.0.1:9876");
         return new RocketMQDashboardProvider(adminFactory, properties);
     }
-
     private ClusterInfo clusterInfo() {
         ClusterInfo info = new ClusterInfo();
         HashMap<Long, String> addrs = new HashMap<>();

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.remoting.protocol.body.TopicList;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
+import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,8 @@ class RocketMQDashboardProviderTest {
 
         assertThat(dashboard.getClusters()).hasSize(1);
         assertThat(dashboard.getClusters().get(0).getVersion()).isEqualTo("V5_3_3");
+        assertThat(dashboard.getClusters().get(0).getType()).isEqualTo(ClusterType.V4_DIRECT);
+        assertThat(dashboard.getClusters().get(0).getType()).isEqualTo(ClusterType.V4_DIRECT);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- tolerate partial NameServer topology and missing topic lists
- classify NameServer-discovered dashboards as V4 direct clusters
- reuse each Broker runtime snapshot for aggregate and per-cluster values
- surface unavailable runtime statistics and preserve long TPS values

Closes #1204
Closes #1206
Closes #1192
Closes #1190
Closes #1188

## Verification

- mvn -Dtest=RocketMQDashboardProviderTest test