### PR TITLE
fix: expose unavailable topic consumer metrics

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/TopicConsumerVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/TopicConsumerVO.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.instance.topic;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -32,4 +33,6 @@ public class TopicConsumerVO {
     private String messageModel;
     private double consumeTps;
     private long diffTotal;
+    @Default
+    private boolean metricsAvailable = true;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQMetadataProvider.java
@@ -300,6 +300,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                             .messageModel("CLUSTERING")
                             .consumeTps(0)
                             .diffTotal(0)
+                            .metricsAvailable(false)
                             .build());
                 }
             }

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQMetadataProviderTest.java
@@ -18,14 +18,18 @@ package org.apache.rocketmq.studio.rocketmq;
 
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
+import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.apache.rocketmq.studio.persistence.entity.RmqGroup;
 import org.apache.rocketmq.studio.persistence.mapper.RmqGroupMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqTopicMapper;
+import org.apache.rocketmq.remoting.protocol.body.GroupList;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashSet;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +44,9 @@ class RocketMQMetadataProviderTest {
 
     @Mock
     private RmqGroupMapper groupMapper;
+
+    @Mock
+    private DefaultMQAdminExt adminExt;
 
     @Test
     void listConsumerGroupsReadsConsumeTypeColumn() {
@@ -75,5 +82,25 @@ class RocketMQMetadataProviderTest {
 
         assertThat(groups).hasSize(1);
         assertThat(groups.get(0).getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
+    }
+
+    @Test
+    void topicConsumersShouldMarkMetricsUnavailableWhenStatsCannotBeRead() throws Exception {
+        GroupList groups = new GroupList();
+        groups.setGroupList(new HashSet<>(List.of("order-consumer")));
+        when(adminExt.queryTopicConsumeByWho("orders")).thenReturn(groups);
+        when(adminExt.examineConsumeStats("order-consumer", "orders"))
+                .thenThrow(new RuntimeException("broker unavailable"));
+
+        RocketMQMetadataProvider provider =
+                new RocketMQMetadataProvider(adminExt, topicMapper, groupMapper);
+
+        List<TopicConsumerVO> consumers = provider.getTopicConsumers("orders");
+
+        assertThat(consumers).singleElement().satisfies(consumer -> {
+            assertThat(consumer.getDiffTotal()).isZero();
+            assertThat(consumer.getConsumeTps()).isZero();
+            assertThat(consumer.isMetricsAvailable()).isFalse();
+        });
     }
 }

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -44,6 +44,7 @@ export interface ConsumerGroupInfo {
   messageModel: string;
   consumeTps: number;
   diffTotal: number;
+  metricsAvailable?: boolean;
 }
 
 // ─── Consumer Group (matches mock/consumers.ts) ─────────────────

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -550,13 +550,17 @@ const TopicPage = () => {
       title: '消费 TPS',
       dataIndex: 'consumeTps',
       key: 'consumeTps',
-      render: (n: number) => formatNumber(n),
+      render: (n: number, record) => record.metricsAvailable === false
+        ? <Text type="secondary">不可用</Text>
+        : formatNumber(n),
     },
     {
       title: '堆积量',
       dataIndex: 'diffTotal',
       key: 'diffTotal',
-      render: (n: number) => <Text type={n > 100 ? 'warning' : undefined}>{formatNumber(n)}</Text>,
+      render: (n: number, record) => record.metricsAvailable === false
+        ? <Text type="secondary">不可用</Text>
+        : <Text type={n > 100 ? 'warning' : undefined}>{formatNumber(n)}</Text>,
     },
   ];
 


### PR DESCRIPTION
## Summary
- expose Topic consumer metric availability separately from TPS and lag values
- mark per-group stats failures as unavailable instead of presenting zero metrics
- render unavailable values distinctly in the Topic consumer table

## Validation
- `cd server && mvn -q -Dtest=RocketMQMetadataProviderTest test`
- frontend typecheck not run: the isolated worktree has no web/node_modules

Closes #1207