### PR TITLE
fix: harden alert rule asset loading

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetService.java
@@ -60,6 +60,10 @@ public class AlertRuleAssetService {
             }
             try (InputStream in = resource.getInputStream()) {
                 JsonNode root = yamlMapper.readTree(in);
+                if (root == null || !root.isObject()) {
+                    log.warn("Skipping invalid alert rule asset {}: expected a YAML object", resource);
+                    continue;
+                }
                 List<PrometheusAlertRule> rules = parseRules(root);
                 Set<String> severities = new LinkedHashSet<>();
                 String group = rules.isEmpty() ? "" : rules.get(0).group();
@@ -109,6 +113,9 @@ public class AlertRuleAssetService {
     }
 
     private List<PrometheusAlertRule> parseRules(JsonNode root) {
+        if (root == null || !root.isObject()) {
+            return List.of();
+        }
         List<PrometheusAlertRule> rules = new ArrayList<>();
         JsonNode groups = root.get("groups");
         if (groups == null || !groups.isArray()) {
@@ -146,7 +153,7 @@ public class AlertRuleAssetService {
         return null;
     }
 
-    private Resource[] resolveResources() {
+    protected Resource[] resolveResources() {
         try {
             return resourceResolver.getResources(LOCATION_PATTERN);
         } catch (IOException e) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetService.java
@@ -133,6 +133,10 @@ public class AlertRuleAssetService {
                 }
                 String alert = textOr(rule, "alert", "");
                 String expr = textOr(rule, "expr", "");
+                if (alert.isBlank() || expr.isBlank()) {
+                    log.warn("Skipping incomplete alert rule in group {}", groupName);
+                    continue;
+                }
                 String duration = textOr(rule, "for", "5m");
                 String severity = textOr(labelsOf(rule), "severity", "warning");
                 String team = textOr(labelsOf(rule), "team", "broker");

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
@@ -98,6 +98,24 @@ class AlertRuleAssetServiceTest {
                 "warning", "broker", "BrokerDown", "")), service.loadDefaultRules());
     }
 
+    @Test
+    void assetLoadingShouldSkipRulesWithoutAlertOrExpression() {
+        AlertRuleAssetService service = serviceWithResources(resource("mixed.yaml", """
+                groups:
+                  - name: broker
+                    rules:
+                      - alert: MissingExpression
+                      - expr: up == 0
+                      - alert: BrokerDown
+                        expr: up == 0
+                """));
+
+        assertEquals(List.of(new AlertRuleAssetInfo("mixed", "broker", 1, List.of("warning"))),
+                service.listAssets());
+        assertEquals(List.of(new PrometheusAlertRule("broker", "BrokerDown", "up == 0", "5m",
+                "warning", "broker", "BrokerDown", "")), service.loadDefaultRules());
+    }
+
     private static AlertRuleAssetService serviceWithResources(Resource... resources) {
         return new AlertRuleAssetService() {
             @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
@@ -18,7 +18,10 @@ package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -80,5 +83,36 @@ class AlertRuleAssetServiceTest {
         boolean hasBroker = rules.stream().anyMatch(r -> "broker".equals(r.team()));
         assertTrue(hasCritical, "expected at least one critical rule");
         assertTrue(hasBroker, "expected at least one broker rule");
+    }
+
+    @Test
+    void assetLoadingShouldSkipEmptyAndNonObjectYaml() {
+        AlertRuleAssetService service = serviceWithResources(
+                resource("empty.yaml", ""),
+                resource("array.yaml", "[]"),
+                resource("valid.yaml", "groups:\n  - name: broker\n    rules:\n      - alert: BrokerDown\n        expr: up == 0\n"));
+
+        assertEquals(List.of(new AlertRuleAssetInfo("valid", "broker", 1, List.of("warning"))),
+                service.listAssets());
+        assertEquals(List.of(new PrometheusAlertRule("broker", "BrokerDown", "up == 0", "5m",
+                "warning", "broker", "BrokerDown", "")), service.loadDefaultRules());
+    }
+
+    private static AlertRuleAssetService serviceWithResources(Resource... resources) {
+        return new AlertRuleAssetService() {
+            @Override
+            protected Resource[] resolveResources() {
+                return resources;
+            }
+        };
+    }
+
+    private static Resource resource(String filename, String content) {
+        return new ByteArrayResource(content.getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        };
     }
 }


### PR DESCRIPTION
## Summary
- skip empty and non-object alert YAML assets while listing
- skip incomplete rules that do not provide both alert and expr
- keep valid bundled rule assets available
- cover invalid assets and mixed valid/invalid rules

## Validation
Maven test: AlertRuleAssetServiceTest

Closes #1209
Closes #1211