### PR TITLE
fix: invalidate Aliyun clients after credential changes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactory.java
@@ -65,6 +65,20 @@ public class AliyunClientFactory {
     }
 
     /**
+     * Releases all clients created with a credential so the next call observes rotated secrets.
+     */
+    public void invalidateCredential(String credentialId) {
+        String prefix = credentialId + "#";
+        clients.entrySet().removeIf(entry -> {
+            if (!entry.getKey().startsWith(prefix)) {
+                return false;
+            }
+            entry.getValue().close();
+            return true;
+        });
+    }
+
+    /**
      * Executes an SDK call with a bounded wait and unified exception mapping.
      */
     public <T> T call(String credentialId, String region, Function<AsyncClient, CompletableFuture<T>> action) {
@@ -106,7 +120,7 @@ public class AliyunClientFactory {
         return "rocketmq." + region + ".aliyuncs.com";
     }
 
-    private AsyncClient createClient(String credentialId, String region) {
+    protected AsyncClient createClient(String credentialId, String region) {
         CloudCredentialVO credential = credentialRepository.findById(credentialId)
                 .orElseThrow(() -> new BusinessException(404, "Cloud credential not found: " + credentialId));
         StaticCredentialProvider credentialProvider = StaticCredentialProvider.create(

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
@@ -21,6 +21,7 @@ import org.springframework.util.StringUtils;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.provider.alibaba.AliyunClientFactory;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,7 @@ public class CloudCredentialService {
 
     private final CloudCredentialRepository credentialRepository;
     private final InstanceRepository instanceRepository;
+    private final AliyunClientFactory aliyunClientFactory;
 
     public List<CloudCredentialVO> listMasked() {
         log.info("Listing cloud credentials (masked)");
@@ -90,7 +92,9 @@ public class CloudCredentialService {
             existing.setRemark(request.getRemark());
         }
         existing.setUpdatedAt(LocalDateTime.now());
-        return maskAccessKey(credentialRepository.save(existing));
+        CloudCredentialVO saved = credentialRepository.save(existing);
+        invalidateAliyunClients(saved);
+        return maskAccessKey(saved);
     }
 
     public void delete(String id) {
@@ -98,12 +102,13 @@ public class CloudCredentialService {
             throw new BusinessException(400, "Cloud credential id is required");
         }
         log.info("Deleting cloud credential id={}", id);
-        credentialRepository.findById(id)
+        CloudCredentialVO existing = credentialRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(404, "Cloud credential not found: " + id));
         if (instanceRepository.existsByCredentialId(id)) {
             throw new BusinessException(400, "Cloud credential is referenced by existing instances");
         }
         credentialRepository.deleteById(id);
+        invalidateAliyunClients(existing);
     }
 
     public CloudCredentialVO reveal(String id) {
@@ -125,5 +130,10 @@ public class CloudCredentialService {
         masked.setCreatedAt(credential.getCreatedAt());
         masked.setUpdatedAt(credential.getUpdatedAt());
         return masked;
+    }
+    private void invalidateAliyunClients(CloudCredentialVO credential) {
+        if (credential.getVendor() == org.apache.rocketmq.studio.common.domain.enums.InstanceVendor.ALIYUN) {
+            aliyunClientFactory.invalidateCredential(credential.getId());
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactoryTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -90,6 +91,25 @@ class AliyunClientFactoryTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
                 .isEqualTo(404);
+    }
+
+    @Test
+    void invalidateCredentialShouldCloseAndRemoveClientsForEveryRegionTest() {
+        AsyncClient first = Mockito.mock(AsyncClient.class);
+        AsyncClient second = Mockito.mock(AsyncClient.class);
+        AtomicInteger created = new AtomicInteger();
+        factory = new AliyunClientFactory(credentialRepository) {
+            @Override
+            protected AsyncClient createClient(String credentialId, String region) {
+                return created.getAndIncrement() == 0 ? first : second;
+            }
+        };
+
+        assertThat(factory.client(CREDENTIAL_ID, REGION)).isSameAs(first);
+        factory.invalidateCredential(CREDENTIAL_ID);
+
+        Mockito.verify(first).close();
+        assertThat(factory.client(CREDENTIAL_ID, REGION)).isSameAs(second);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.provider.alibaba.AliyunClientFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -44,6 +45,9 @@ class CloudCredentialServiceTest {
 
     @Mock
     private InstanceRepository instanceRepository;
+
+    @Mock
+    private AliyunClientFactory aliyunClientFactory;
 
     @InjectMocks
     private CloudCredentialService service;
@@ -133,6 +137,40 @@ class CloudCredentialServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("referenced");
         verify(credentialRepository, never()).deleteById(any());
+    }
+
+    @Test
+    void updateShouldInvalidateAliyunClientsAfterSavingCredentialTest() {
+        CloudCredentialVO stored = new CloudCredentialVO();
+        stored.setId("cred-1");
+        stored.setVendor(InstanceVendor.ALIYUN);
+        stored.setAccessKey("LTAI5tUpdateKey000000001");
+        stored.setSecretKey("old-secret");
+        when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
+        when(credentialRepository.save(any(CloudCredentialVO.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateCloudCredentialDTO request = new UpdateCloudCredentialDTO();
+        request.setId("cred-1");
+        request.setSecretKey("new-secret");
+
+        service.update(request);
+
+        verify(aliyunClientFactory).invalidateCredential("cred-1");
+    }
+
+    @Test
+    void deleteShouldInvalidateAliyunClientsAfterRemovingCredentialTest() {
+        CloudCredentialVO stored = new CloudCredentialVO();
+        stored.setId("cred-1");
+        stored.setVendor(InstanceVendor.ALIYUN);
+        when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
+        when(instanceRepository.existsByCredentialId("cred-1")).thenReturn(false);
+
+        service.delete("cred-1");
+
+        verify(credentialRepository).deleteById("cred-1");
+        verify(aliyunClientFactory).invalidateCredential("cred-1");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- release cached Aliyun OpenAPI clients for a credential after successful update or delete
- close clients across every cached region before removal
- cover credential lifecycle and client cache invalidation

## Validation
- `cd server && mvn -q -Dtest=CloudCredentialServiceTest,AliyunClientFactoryTest test`

Closes #1212