### PR TITLE
fix: bound Prometheus time-series labels

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
@@ -57,6 +57,9 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
     private static final int MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
     private static final int MAX_SERIES = 1_000;
     private static final int MAX_TOTAL_SAMPLES = 100_000;
+    private static final int MAX_LABELS_PER_SERIES = 64;
+    private static final int MAX_LABEL_KEY_LENGTH = 256;
+    private static final int MAX_LABEL_VALUE_LENGTH = 4_096;
 
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
@@ -220,10 +223,22 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
             throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
                     backendLabel() + " returned a malformed time series");
         }
+        if (metric.size() > MAX_LABELS_PER_SERIES) {
+            throw new PrometheusException(HttpStatus.PAYLOAD_TOO_LARGE.value(),
+                    backendLabel() + " query returned too many labels in a time series; narrow the query");
+        }
 
         Map<String, String> labels = new LinkedHashMap<>();
         Iterator<Map.Entry<String, JsonNode>> fields = metric.fields();
-        fields.forEachRemaining(entry -> labels.put(entry.getKey(), entry.getValue().asText()));
+        fields.forEachRemaining(entry -> {
+            String key = entry.getKey();
+            String value = entry.getValue().asText();
+            if (key.length() > MAX_LABEL_KEY_LENGTH || value.length() > MAX_LABEL_VALUE_LENGTH) {
+                throw new PrometheusException(HttpStatus.PAYLOAD_TOO_LARGE.value(),
+                        backendLabel() + " query returned an oversized time-series label; narrow the query");
+            }
+            labels.put(key, value);
+        });
 
         List<MetricDataVO.MetricSampleVO> samples = hasValues
                 ? StreamSupport.stream(values.spliterator(), false).map(this::parseSample).toList()

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusMetricsSourceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusMetricsSourceTest.java
@@ -252,6 +252,30 @@ class PrometheusMetricsSourceTest {
     }
 
     @Test
+    void queryShouldRejectResponseWithTooManyLabelsInOneSeries() {
+        server.createContext("/api/v1/query_range", exchange -> respond(exchange, 200, responseWithLabels(65)));
+
+        assertThatThrownBy(() -> source(Duration.ofSeconds(2)).query(query()))
+                .isInstanceOf(PrometheusException.class)
+                .satisfies(exception -> assertThat(((PrometheusException) exception).getStatusCode())
+                        .isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE.value()))
+                .hasMessage("Prometheus query returned too many labels in a time series; narrow the query");
+    }
+
+    @Test
+    void queryShouldRejectResponseWithOversizedLabelValue() {
+        server.createContext("/api/v1/query_range", exchange -> respond(exchange, 200,
+                "{\"status\":\"success\",\"data\":{\"resultType\":\"matrix\",\"result\":[{\"metric\":{\"topic\":\""
+                        + "x".repeat(4_097) + "\"},\"values\":[[1784107658,\"1\"]]}]}}"));
+
+        assertThatThrownBy(() -> source(Duration.ofSeconds(2)).query(query()))
+                .isInstanceOf(PrometheusException.class)
+                .satisfies(exception -> assertThat(((PrometheusException) exception).getStatusCode())
+                        .isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE.value()))
+                .hasMessage("Prometheus query returned an oversized time-series label; narrow the query");
+    }
+
+    @Test
     void queryShouldRejectResponseLargerThanFiveMebibytes() {
         server.createContext("/api/v1/query_range", exchange -> respond(exchange, 200,
                 "{\"status\":\"success\",\"padding\":\"" + "x".repeat(5 * 1024 * 1024) + "\"}"));
@@ -434,5 +458,17 @@ class PrometheusMetricsSourceTest {
         }
         return "{\"status\":\"success\",\"data\":{\"resultType\":\"matrix\",\"result\":[{\"metric\":{},\"values\":["
                 + values + "]}]}}";
+    }
+
+    private String responseWithLabels(int count) {
+        StringBuilder labels = new StringBuilder();
+        for (int index = 0; index < count; index++) {
+            if (index > 0) {
+                labels.append(',');
+            }
+            labels.append("\"label_").append(index).append("\":\"value\"");
+        }
+        return "{\"status\":\"success\",\"data\":{\"resultType\":\"matrix\",\"result\":[{\"metric\":{" + labels
+                + "},\"values\":[[1784107658,\"1\"]]}]}}";
     }
 }


### PR DESCRIPTION
## Summary
- bound label count and label key/value sizes for each parsed Prometheus series
- retain existing structured 413 metrics errors for oversized responses
- cover excessive cardinality and value length responses

## Validation
- `cd server && mvn -q -Dtest=PrometheusMetricsSourceTest test`

Closes #1216