### PR TITLE
fix: harden DLQ runtime stats, pull scans, and resend outcomes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQGroupVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQGroupVO.java
@@ -34,4 +34,6 @@ public class DLQGroupVO {
     private LocalDateTime lastEnqueueTime;
     private int retryCount;
     private String status;
+    @Builder.Default
+    private boolean statsAvailable = true;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -21,6 +21,7 @@ import org.apache.rocketmq.client.consumer.PullResult;
 import org.apache.rocketmq.client.consumer.PullStatus;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendStatus;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageConst;
@@ -62,6 +63,8 @@ public class RocketMQDLQProvider implements DLQProvider {
 
     private static final long ONE_HOUR_MILLIS = 3600_000L;
     private static final int RESEND_HARD_CAP = 5000;
+    private static final String ORIGIN_MESSAGE_ID_PROPERTY = "studio_dlq_origin_message_id";
+    private static final String ORIGIN_TOPIC_PROPERTY = "studio_dlq_origin_topic";
 
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
     private final AuditService auditService;
@@ -245,9 +248,15 @@ public class RocketMQDLQProvider implements DLQProvider {
             if (StringUtils.hasText(deadLetter.getKeys())) {
                 message.setKeys(deadLetter.getKeys());
             }
-            message.putUserProperty("DLQ_ORIGIN_MESSAGE_ID", deadLetter.getMsgId());
-            message.putUserProperty("DLQ_ORIGIN_TOPIC", deadLetter.getTopic());
+            message.putUserProperty(ORIGIN_MESSAGE_ID_PROPERTY, deadLetter.getMsgId());
+            message.putUserProperty(ORIGIN_TOPIC_PROPERTY, deadLetter.getTopic());
             SendResult sendResult = producer.send(message);
+            if (sendResult == null || sendResult.getSendStatus() != SendStatus.SEND_OK) {
+                log.warn("DLQ resend was not accepted: msgId={} topic={} sendStatus={}",
+                        deadLetter.getMsgId(), destination,
+                        sendResult == null ? "<null>" : sendResult.getSendStatus());
+                return false;
+            }
             log.debug("Resent dead letter msgId={} to topic={}, sendStatus={}",
                     deadLetter.getMsgId(), destination, sendResult.getSendStatus());
             return true;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -194,7 +194,17 @@ public class RocketMQDLQProvider implements DLQProvider {
                             break outer;
                         }
                         PullResult pullResult = consumer.pull(queue, "*", offset, 32);
-                        offset = pullResult.getNextBeginOffset();
+                        if (pullResult == null) {
+                            log.warn("Stop DLQ scan for {} because queue {} returned no pull result", dlqTopic, queue);
+                            break;
+                        }
+                        long nextOffset = pullResult.getNextBeginOffset();
+                        if (nextOffset <= offset) {
+                            log.warn("Stop DLQ scan for {} because queue {} did not advance offset {}",
+                                    dlqTopic, queue, offset);
+                            break;
+                        }
+                        offset = nextOffset;
                         if (pullResult.getPullStatus() != PullStatus.FOUND
                                 || pullResult.getMsgFoundList() == null) {
                             break;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -93,6 +93,7 @@ public class RocketMQDLQProvider implements DLQProvider {
     private DLQGroupVO buildDLQGroup(MQAdminExt adminExt, String groupName, String dlqTopic) {
         long messageCount = 0L;
         LocalDateTime lastEnqueueTime = null;
+        boolean statsAvailable = true;
         try {
             TopicStatsTable statsTable = adminExt.examineTopicStats(dlqTopic);
             if (statsTable != null && statsTable.getOffsetTable() != null) {
@@ -113,6 +114,7 @@ public class RocketMQDLQProvider implements DLQProvider {
                 }
             }
         } catch (Exception e) {
+            statsAvailable = false;
             log.warn("Failed to examine stats for DLQ topic {}: {}", dlqTopic, e.getMessage());
         }
 
@@ -122,7 +124,8 @@ public class RocketMQDLQProvider implements DLQProvider {
                 .messageCount(messageCount)
                 .lastEnqueueTime(lastEnqueueTime)
                 .retryCount(0)
-                .status(messageCount > 0 ? "ACTIVE" : "EMPTY")
+                .status(statsAvailable ? (messageCount > 0 ? "ACTIVE" : "EMPTY") : "UNAVAILABLE")
+                .statsAvailable(statsAvailable)
                 .build();
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -201,7 +201,16 @@ public class RocketMQMessageProvider implements MessageProvider {
                         break outer;
                     }
                     PullResult pullResult = consumer.pull(queue, "*", offset, 32);
-                    offset = pullResult.getNextBeginOffset();
+                    if (pullResult == null) {
+                        log.warn("Stop topic query for {} because queue {} returned no pull result", topic, queue);
+                        break;
+                    }
+                    long nextOffset = pullResult.getNextBeginOffset();
+                    if (nextOffset <= offset) {
+                        log.warn("Stop topic query for {} because queue {} did not advance offset {}", topic, queue, offset);
+                        break;
+                    }
+                    offset = nextOffset;
                     if (pullResult.getPullStatus() != PullStatus.FOUND
                             || pullResult.getMsgFoundList() == null) {
                         break;

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -17,6 +17,8 @@
 package org.apache.rocketmq.studio.provider.apache;
 
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.PullStatus;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.message.MessageQueue;
@@ -29,6 +31,7 @@ import org.apache.rocketmq.studio.ops.audit.AuditService;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
@@ -36,6 +39,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -48,6 +52,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -135,6 +140,29 @@ class RocketMQDLQProviderTest {
                 contains("matched=0, resent=0, failed=0"),
                 eq("SUCCESS"));
         verify(runtimeAdminClientResolver).resolveEndpoint("instance-a");
+    }
+
+    @Test
+    @Timeout(value = 1, unit = TimeUnit.SECONDS)
+    void resendMessagesStopsWhenPullOffsetDoesNotAdvance() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        MessageQueue queue = new MessageQueue(dlqTopic, "broker-a", 0);
+        PullResult stalledResult = new PullResult(PullStatus.FOUND, 10, 0, 10, List.of());
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(Set.of(queue));
+                         when(consumer.searchOffset(eq(queue), anyLong())).thenReturn(10L);
+                         when(consumer.pull(eq(queue), eq("*"), eq(10L), eq(32))).thenReturn(stalledResult);
+                         doNothing().when(consumer).shutdown();
+                     });
+             MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class)) {
+            provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic");
+
+            verify(mockedConsumers.constructed().get(0), times(1)).pull(queue, "*", 10L, 32);
+            assertThat(mockedProducers.constructed()).isEmpty();
+        }
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -20,7 +20,11 @@ import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
 import org.apache.rocketmq.client.consumer.PullResult;
 import org.apache.rocketmq.client.consumer.PullStatus;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendStatus;
 import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.remoting.protocol.admin.TopicStatsTable;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
@@ -40,6 +44,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -163,6 +170,49 @@ class RocketMQDLQProviderTest {
             verify(mockedConsumers.constructed().get(0), times(1)).pull(queue, "*", 10L, 32);
             assertThat(mockedProducers.constructed()).isEmpty();
         }
+    }
+
+    @Test
+    void resendMessagesCountsNonSendOkResultsAsFailures() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        MessageQueue queue = new MessageQueue(dlqTopic, "broker-a", 0);
+        MessageExt deadLetter = new MessageExt();
+        deadLetter.setMsgId("msg-1");
+        deadLetter.setTopic(dlqTopic);
+        deadLetter.setBody(new byte[] {1});
+        deadLetter.setStoreTimestamp(150L);
+        PullResult pullResult = new PullResult(PullStatus.FOUND, 1L, 0L, 0L, List.of(deadLetter));
+        SendResult sendResult = new SendResult();
+        sendResult.setSendStatus(SendStatus.FLUSH_DISK_TIMEOUT);
+
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(Set.of(queue));
+                         when(consumer.searchOffset(queue, 100L)).thenReturn(0L);
+                         when(consumer.searchOffset(queue, 200L)).thenReturn(0L);
+                         when(consumer.pull(queue, "*", 0L, 32)).thenReturn(pullResult);
+                         doNothing().when(consumer).shutdown();
+                     });
+             MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class, (producer, context) -> {
+                         doNothing().when(producer).start();
+                         when(producer.send(any(Message.class))).thenReturn(sendResult);
+                         doNothing().when(producer).shutdown();
+                     })) {
+            assertThat(provider.resendMessages("group-a", 100L, 200L, "target-topic"))
+                    .extracting("matched", "resent", "failed", "outcome")
+                    .containsExactly(1, 0, 1, "PARTIAL");
+
+            assertThat(mockedConsumers.constructed()).hasSize(1);
+            assertThat(mockedProducers.constructed()).hasSize(1);
+            verify(mockedProducers.constructed().get(0)).send(any(Message.class));
+        }
+        verify(auditService).record(
+                eq("RESEND_DLQ"),
+                eq("group-a"),
+                contains("matched=1, resent=0, failed=1"),
+                eq("PARTIAL"));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -45,9 +45,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import java.util.List;
-import java.util.Set;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -200,7 +197,7 @@ class RocketMQDLQProviderTest {
                          when(producer.send(any(Message.class))).thenReturn(sendResult);
                          doNothing().when(producer).shutdown();
                      })) {
-            assertThat(provider.resendMessages("group-a", 100L, 200L, "target-topic"))
+            assertThat(provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic"))
                     .extracting("matched", "resent", "failed", "outcome")
                     .containsExactly(1, 0, 1, "PARTIAL");
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -20,14 +20,22 @@ import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.protocol.admin.TopicStatsTable;
+import org.apache.rocketmq.remoting.protocol.body.TopicList;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.instance.dlq.DLQGroupVO;
 import org.apache.rocketmq.studio.ops.audit.AuditService;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -52,12 +60,51 @@ class RocketMQDLQProviderTest {
     @Mock
     private AuditService auditService;
 
+    @Mock
+    private MQAdminExt adminExt;
+
     private RocketMQDLQProvider provider;
 
     @BeforeEach
     void setUp() {
         lenient().when(runtimeAdminClientResolver.resolveEndpoint("instance-a")).thenReturn("namesrv-a:9876");
+        lenient().when(runtimeAdminClientResolver.execute(anyString(), any())).thenAnswer(invocation -> {
+            MqAdminExtFactory.AdminAction<Object> action = invocation.getArgument(1);
+            return action.apply(adminExt);
+        });
         provider = new RocketMQDLQProvider(runtimeAdminClientResolver, auditService);
+    }
+
+    @Test
+    void marksStatsUnavailableWhenTopicStatsCannotBeRead() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        TopicList topicList = new TopicList();
+        topicList.setTopicList(Set.of(dlqTopic));
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList);
+        when(adminExt.examineTopicStats(dlqTopic)).thenThrow(new IllegalStateException("access denied"));
+
+        List<DLQGroupVO> groups = provider.listDLQGroups("instance-a");
+
+        assertThat(groups).singleElement().satisfies(group -> {
+            assertThat(group.isStatsAvailable()).isFalse();
+            assertThat(group.getStatus()).isEqualTo("UNAVAILABLE");
+        });
+    }
+
+    @Test
+    void keepsEmptyStatusWhenTopicStatsAreSuccessfullyRead() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        TopicList topicList = new TopicList();
+        topicList.setTopicList(Set.of(dlqTopic));
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList);
+        when(adminExt.examineTopicStats(dlqTopic)).thenReturn(new TopicStatsTable());
+
+        List<DLQGroupVO> groups = provider.listDLQGroups("instance-a");
+
+        assertThat(groups).singleElement().satisfies(group -> {
+            assertThat(group.isStatsAvailable()).isTrue();
+            assertThat(group.getStatus()).isEqualTo("EMPTY");
+        });
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -18,6 +18,8 @@ package org.apache.rocketmq.studio.provider.apache;
 
 import org.apache.rocketmq.client.QueryResult;
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.PullStatus;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
@@ -30,6 +32,7 @@ import org.apache.rocketmq.studio.instance.message.QueryHistoryService;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
@@ -37,6 +40,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -48,6 +53,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -99,6 +105,27 @@ class RocketMQMessageProviderTest {
         verify(runtimeAdminClientResolver).execute(eq("instance-a"), any());
         verify(queryHistoryService).recordMessageQuery(null, "TOPIC", "TopicA", null, null, null,
                 100L, 200L, 0);
+    }
+
+    @Test
+    @Timeout(value = 1, unit = TimeUnit.SECONDS)
+    void queryByTopicStopsWhenPullOffsetDoesNotAdvance() throws Exception {
+        MessageQueue queue = new MessageQueue("TopicA", "broker-a", 0);
+        PullResult stalledResult = new PullResult(PullStatus.FOUND, 10, 0, 10, List.of());
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues("TopicA")).thenReturn(Set.of(queue));
+                         when(consumer.searchOffset(eq(queue), anyLong())).thenReturn(10L);
+                         when(consumer.pull(eq(queue), eq("*"), eq(10L), eq(32))).thenReturn(stalledResult);
+                         doNothing().when(consumer).shutdown();
+                     })) {
+            List<MessageRecordVO> messages = provider.queryMessages(
+                    "instance-a", "TopicA", null, null, null, 100L, 200L);
+
+            assertThat(messages).isEmpty();
+            verify(mockedConsumers.constructed().get(0), times(1)).pull(queue, "*", 10L, 32);
+        }
     }
 
     @Test

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -62,6 +62,7 @@ export interface DLQGroup {
   lastEnqueueTime: string;
   retryCount: number;
   status: string;
+  statsAvailable?: boolean;
 }
 
 export interface DLQResendResult {

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -59,7 +59,7 @@ export interface DLQGroup {
   groupName: string;
   dlqTopic: string;
   messageCount: number;
-  lastEnqueueTime: string;
+  lastEnqueueTime?: string | null;
   retryCount: number;
   status: string;
   statsAvailable?: boolean;

--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -55,6 +55,13 @@ const dlqGroup: DLQGroup = {
   status: 'ACTIVE',
 };
 
+const unavailableDlqGroup: DLQGroup = {
+  ...dlqGroup,
+  messageCount: 0,
+  statsAvailable: false,
+  status: 'UNAVAILABLE',
+};
+
 const secondDlqGroup: DLQGroup = {
   groupName: '-cg-"payment"',
   dlqTopic: '%DLQ%cg-payment',
@@ -129,6 +136,19 @@ describe('DLQ page', () => {
     renderWithProviders(<DLQPage />);
 
     expect(await screen.findByText('DLQ provider is not configured')).toBeInTheDocument();
+  });
+
+  it('does not present unavailable DLQ statistics as an empty queue', async () => {
+    vi.mocked(messageService.listDLQGroups).mockResolvedValue([unavailableDlqGroup]);
+    renderWithProviders(<DLQPage />);
+
+    const row = (await screen.findByText('cg-order')).closest('tr');
+    if (!row) throw new Error('DLQ group row not found');
+
+    expect(within(row).getByText('不可用')).toBeInTheDocument();
+    expect(within(row).getByRole('button', { name: '重投消息' })).toBeDisabled();
+    expect(within(row).getByRole('button', { name: '导出' })).toBeDisabled();
+    expect(within(row).getByRole('checkbox')).toBeDisabled();
   });
 
   it('opens a detail dialog with the selected group metadata', async () => {

--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -151,6 +151,20 @@ describe('DLQ page', () => {
     expect(within(row).getByRole('checkbox')).toBeDisabled();
   });
 
+  it('sorts DLQ rows with missing enqueue timestamps', async () => {
+    vi.mocked(messageService.listDLQGroups).mockResolvedValue([
+      dlqGroup,
+      { ...secondDlqGroup, lastEnqueueTime: null },
+    ]);
+    const user = userEvent.setup();
+    renderWithProviders(<DLQPage />);
+
+    await screen.findByText('cg-order');
+    await user.click(screen.getByText('最近入队时间'));
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
   it('opens a detail dialog with the selected group metadata', async () => {
     const user = userEvent.setup();
     renderWithProviders(<DLQPage />);

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -259,15 +259,22 @@ const DLQPage = () => {
       width: 100,
       align: 'right',
       sorter: (a, b) => a.messageCount - b.messageCount,
-      render: (count: number) => (
+      render: (count: number, record: DLQGroup) => (
         <Text
           style={{
             fontFamily: 'monospace',
             fontWeight: 600,
-            color: count > 50 ? '#ff4d4f' : count > 0 ? '#fa8c16' : undefined,
+            color:
+              record.statsAvailable === false
+                ? undefined
+                : count > 50
+                  ? '#ff4d4f'
+                  : count > 0
+                    ? '#fa8c16'
+                    : undefined,
           }}
         >
-          {count.toLocaleString()}
+          {record.statsAvailable === false ? '不可用' : count.toLocaleString()}
         </Text>
       ),
     },
@@ -302,7 +309,7 @@ const DLQPage = () => {
             icon={<ArrowsCounterClockwise size={14} />}
             style={{ borderColor: '#fa8c16', color: '#fa8c16' }}
             onClick={() => openRetryModal(record)}
-            disabled={record.messageCount === 0}
+            disabled={record.statsAvailable === false || record.messageCount === 0}
           >
             重投消息
           </Button>
@@ -311,7 +318,7 @@ const DLQPage = () => {
             icon={<Download size={14} />}
             style={{ borderColor: '#52c41a', color: '#52c41a' }}
             onClick={() => handleExport(record)}
-            disabled={record.messageCount === 0}
+            disabled={record.statsAvailable === false || record.messageCount === 0}
           >
             导出
           </Button>
@@ -373,7 +380,9 @@ const DLQPage = () => {
             selectedRowKeys: selectedGroupNames,
             preserveSelectedRowKeys: true,
             onChange: (keys) => setSelectedGroupNames(keys.map(String)),
-            getCheckboxProps: (record) => ({ disabled: record.messageCount === 0 }),
+            getCheckboxProps: (record) => ({
+              disabled: record.statsAvailable === false || record.messageCount === 0,
+            }),
           }}
           pagination={{
             pageSize: 20,
@@ -511,7 +520,9 @@ const DLQPage = () => {
                   strong
                   style={{ color: detailGroup.messageCount > 0 ? '#fa8c16' : undefined }}
                 >
-                  {detailGroup.messageCount.toLocaleString()}
+                  {detailGroup.statsAvailable === false
+                    ? '不可用'
+                    : detailGroup.messageCount.toLocaleString()}
                 </Text>
               </div>
               <div>
@@ -524,7 +535,7 @@ const DLQPage = () => {
                 <Text type="secondary" style={{ fontSize: 13, display: 'block', marginBottom: 4 }}>
                   状态
                 </Text>
-                <Text>{detailGroup.status}</Text>
+                <Text>{detailGroup.statsAvailable === false ? '统计不可用' : detailGroup.status}</Text>
               </div>
             </Flex>
             <div style={{ marginTop: 16 }}>

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -69,8 +69,10 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
   return fallback;
 };
 
-const formatDateTime = (iso: string): string => {
+const formatDateTime = (iso?: string | null): string => {
+  if (!iso) return '-';
   const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '-';
   const pad = (n: number) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 };
@@ -89,7 +91,7 @@ const exportDLQGroups = (groups: DLQGroup[], filename: string) => {
       String(group.messageCount),
       String(group.retryCount),
       group.status,
-      group.lastEnqueueTime,
+      group.lastEnqueueTime || '',
     ]),
   ];
   const csv = rows.map((row) => row.map(escapeCSVValue).join(',')).join('\n');
@@ -283,8 +285,8 @@ const DLQPage = () => {
       dataIndex: 'lastEnqueueTime',
       key: 'lastEnqueueTime',
       width: 180,
-      sorter: (a, b) => a.lastEnqueueTime.localeCompare(b.lastEnqueueTime),
-      render: (time: string) => (
+      sorter: (a, b) => (a.lastEnqueueTime || '').localeCompare(b.lastEnqueueTime || ''),
+      render: (time?: string | null) => (
         <Text type="secondary" style={{ fontSize: 13 }}>
           {formatDateTime(time)}
         </Text>


### PR DESCRIPTION
## Summary

- distinguish unavailable DLQ statistics from empty queues and render missing enqueue timestamps safely
- stop Topic and DLQ pull scans when a result is absent or does not advance the offset
- report null and non-`SEND_OK` DLQ resend results as failures
- disable DLQ actions when runtime statistics are unavailable

Closes #1218
Closes #1159

## Verification

- `mvn -Dtest=RocketMQDLQProviderTest,RocketMQMessageProviderTest test`