### PR TITLE
fix: expose client scan discovery failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProvider.java
@@ -239,7 +239,8 @@ public class RocketMQClientProvider implements ClientProvider {
             clusterInfo = adminExt.examineBrokerClusterInfo();
         } catch (Exception e) {
             log.warn("Failed to fetch cluster info for consumer connection scan", e);
-            return groups;
+            throw new BusinessException(502, "Failed to discover brokers for consumer connections: "
+                    + rootMessage(e));
         }
         if (clusterInfo == null || clusterInfo.getBrokerAddrTable() == null) {
             return groups;

--- a/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/rocketmq/RocketMQClientProviderTest.java
@@ -220,6 +220,16 @@ class RocketMQClientProviderTest {
     }
 
     @Test
+    void consumerScanFailsWhenBrokerDiscoveryFails() throws Exception {
+        when(adminExt.examineBrokerClusterInfo()).thenThrow(new IllegalStateException("broker unavailable"));
+
+        assertThatThrownBy(() -> provider.findConnections("instance-a", "cluster-a", "Consumer"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Failed to discover brokers for consumer connections: broker unavailable")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    @Test
     void consumerScanSkipsNullConnectionEntries() throws Exception {
         ClusterInfo clusterInfo = new ClusterInfo();
         clusterInfo.setBrokerAddrTable(Map.of("broker-a", new BrokerData("cluster-a", "broker-a",


### PR DESCRIPTION
## Summary

- return a structured 502 when consumer connection discovery cannot read broker topology
- preserve an empty list only for a successfully read empty topology
- add regression coverage for the failed discovery path

Closes #1220

## Verification

- `mvn -Dtest=RocketMQClientProviderTest test`