### PR TITLE
fix: harden Broker Cluster runtime diagnostics and actions

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerVO.java
@@ -34,4 +34,6 @@ public class BrokerVO {
     private double diskUsage;
     private int tpsIn;
     private int tpsOut;
+    @Builder.Default
+    private boolean runtimeStatsAvailable = true;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -24,6 +24,7 @@ import org.apache.rocketmq.studio.cluster.broker.ClusterProvider;
 import org.apache.rocketmq.studio.cluster.broker.ClusterVO;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.nameserver.NameServerVO;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.BrokerStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
@@ -85,7 +86,8 @@ public class RocketMQClusterProvider implements ClusterProvider {
             });
         } catch (Exception e) {
             log.warn("Failed to discover clusters via NameServer: {}", e.getMessage());
-            return Collections.emptyList();
+            throw new BusinessException(502,
+                    "Failed to discover clusters via NameServer: " + rootMessage(e));
         }
     }
 
@@ -176,6 +178,17 @@ public class RocketMQClusterProvider implements ClusterProvider {
             brokers.add(builder.build());
         }
         return brokers;
+    }
+
+    private String rootMessage(Throwable error) {
+        Throwable current = error;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        String message = current.getMessage();
+        return message == null || message.isBlank()
+                ? current.getClass().getSimpleName()
+                : message;
     }
 
     private boolean enrichBrokerWithRuntimeInfo(MQAdminExt admin, BrokerVO.BrokerVOBuilder builder, String brokerAddr) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -131,7 +131,7 @@ public class RocketMQClusterProvider implements ClusterProvider {
                                      List<NameServerVO> nameServers) {
         ClusterVO cluster = ClusterVO.builder()
                 .name(clusterName)
-                .status(ClusterStatus.healthy)
+                .status(hasUnavailableRuntimeStats(brokers) ? ClusterStatus.warning : ClusterStatus.healthy)
                 .brokers(brokers != null ? brokers : Collections.emptyList())
                 .proxies(Collections.emptyList())
                 .nameServers(nameServers != null ? nameServers : Collections.emptyList())
@@ -171,18 +171,18 @@ public class RocketMQClusterProvider implements ClusterProvider {
                     .status(BrokerStatus.running);
 
             // Try to get runtime info for version and TPS
-            enrichBrokerWithRuntimeInfo(admin, builder, masterAddr);
+            builder.runtimeStatsAvailable(enrichBrokerWithRuntimeInfo(admin, builder, masterAddr));
 
             brokers.add(builder.build());
         }
         return brokers;
     }
 
-    private void enrichBrokerWithRuntimeInfo(MQAdminExt admin, BrokerVO.BrokerVOBuilder builder, String brokerAddr) {
+    private boolean enrichBrokerWithRuntimeInfo(MQAdminExt admin, BrokerVO.BrokerVOBuilder builder, String brokerAddr) {
         try {
             KVTable runtimeInfo = admin.fetchBrokerRuntimeStats(brokerAddr);
             if (runtimeInfo == null || runtimeInfo.getTable() == null) {
-                return;
+                return false;
             }
 
             Map<String, String> table = runtimeInfo.getTable();
@@ -213,9 +213,15 @@ public class RocketMQClusterProvider implements ClusterProvider {
                     // keep default
                 }
             }
+            return true;
         } catch (Exception e) {
-            log.debug("Failed to get runtime info for broker at {}: {}", brokerAddr, e.getMessage());
+            log.warn("Failed to get runtime info for broker at {}: {}", brokerAddr, e.getMessage());
+            return false;
         }
+    }
+
+    private boolean hasUnavailableRuntimeStats(List<BrokerVO> brokers) {
+        return brokers != null && brokers.stream().anyMatch(broker -> !broker.isRuntimeStatsAvailable());
     }
 
     /**

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
@@ -21,6 +21,7 @@ import org.apache.rocketmq.remoting.protocol.body.KVTable;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.ClusterVO;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.Test;
 
@@ -50,6 +51,8 @@ class RocketMQClusterProviderTest {
         assertThat(clusters.get(0).getBrokers()).hasSize(1);
         assertThat(clusters.get(0).getBrokers().get(0).getTpsIn()).isEqualTo(12);
         assertThat(clusters.get(0).getBrokers().get(0).getTpsOut()).isEqualTo(34);
+        assertThat(clusters.get(0).getBrokers().get(0).isRuntimeStatsAvailable()).isTrue();
+        assertThat(clusters.get(0).getStatus()).isEqualTo(ClusterStatus.healthy);
     }
 
     @Test
@@ -84,6 +87,22 @@ class RocketMQClusterProviderTest {
         assertThat(cluster.getId()).isEqualTo("DefaultCluster");
         assertThat(cluster.getProxies()).isNotNull().isEmpty();
         assertThat(cluster.getTpsHistory()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void discoverClustersMarksWarningWhenBrokerRuntimeStatsAreUnavailable() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RocketMQClusterProvider provider = newProvider(adminExt);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911"))
+                .thenThrow(new IllegalStateException("broker unavailable"));
+
+        ClusterVO cluster = provider.discoverClusters().get(0);
+
+        assertThat(cluster.getStatus()).isEqualTo(ClusterStatus.warning);
+        assertThat(cluster.getBrokers()).singleElement()
+                .extracting(broker -> broker.isRuntimeStatsAvailable())
+                .isEqualTo(false);
     }
 
     private RocketMQClusterProvider newProvider(DefaultMQAdminExt adminExt) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
@@ -22,6 +22,7 @@ import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.ClusterVO;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -112,6 +114,20 @@ class RocketMQClusterProviderTest {
         RocketMQProperties properties = new RocketMQProperties();
         properties.setNamesrvAddr("10.0.0.1:9876");
         return new RocketMQClusterProvider(adminFactory, properties);
+    }
+
+    @Test
+    void discoverClustersShouldExposeNameServerFailures() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RocketMQClusterProvider provider = newProvider(adminExt);
+
+        when(adminExt.examineBrokerClusterInfo()).thenThrow(new IllegalStateException("NameServer unavailable"));
+
+        assertThatThrownBy(provider::discoverClusters)
+                .isInstanceOfSatisfying(BusinessException.class, error -> {
+                    assertThat(error.getCode()).isEqualTo(502);
+                    assertThat(error.getMessage()).contains("NameServer unavailable");
+                });
     }
 
     private ClusterInfo clusterInfo() {

--- a/web/src/api/cluster.ts
+++ b/web/src/api/cluster.ts
@@ -45,6 +45,7 @@ export interface BrokerInfo {
   tpsOut: number;
   diskUsage: number;
   version: string;
+  runtimeStatsAvailable?: boolean;
 }
 
 export interface ProxyInfo {

--- a/web/src/api/cluster.ts
+++ b/web/src/api/cluster.ts
@@ -44,7 +44,7 @@ export interface BrokerInfo {
   tpsIn: number;
   tpsOut: number;
   diskUsage: number;
-  version: string;
+  version?: string | null;
   runtimeStatsAvailable?: boolean;
 }
 

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -574,6 +574,14 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Proxy 重启已提交: {addr}',
     en: 'Proxy restart submitted: {addr}',
   },
+  'cluster.restartBrokerConfirm': {
+    zh: '确定要重启 Broker "{name}" 吗？',
+    en: 'Are you sure to restart Broker "{name}"?',
+  },
+  'cluster.restartBrokerSubmitted': {
+    zh: 'Broker 重启已提交: {name}',
+    en: 'Broker restart submitted: {name}',
+  },
 
   // ─── Topic ───
   'topic.type': { zh: '类型', en: 'Type' },

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -403,8 +403,8 @@ const ClusterPage = () => {
         key: 'version',
         width: 80,
         align: 'right',
-        sorter: (a, b) => a.version.localeCompare(b.version),
-        render: (v: string) => <span style={{ fontSize: 13 }}>{v}</span>,
+        sorter: (a, b) => (a.version || '').localeCompare(b.version || ''),
+        render: (v?: string | null) => <span style={{ fontSize: 13 }}>{v || '-'}</span>,
       },
       {
         title: t('cluster.diskUsage'),

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   Table,
   Button,
@@ -43,6 +43,8 @@ import type { ClusterInfo } from '../../api/cluster';
 
 // ─── Types ──────────────────────────────────────────────────────
 type NodeStatus = 'running' | 'readonly' | 'maintenance';
+
+const REFRESH_INTERVAL_MS = 2000;
 
 interface BrokerRecord {
   key: string;
@@ -187,11 +189,21 @@ const BrokerClusterPage = () => {
     }
   };
 
-  const initialized = useRef<boolean | null>(null);
-  if (initialized.current == null) {
-    initialized.current = true;
-    void loadData();
-  }
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      void loadData();
+    });
+    return () => window.clearTimeout(timeoutId);
+  }, [loadData]);
+
+  useEffect(() => {
+    if (!autoRefresh) return;
+
+    const intervalId = window.setInterval(() => {
+      void loadData();
+    }, REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(intervalId);
+  }, [autoRefresh, loadData]);
 
   const renderStatus = (status: string) => {
     const config: Record<string, { color: string; label: string }> = {

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -39,10 +39,10 @@ interface BrokerRecord {
   brokerName: string;
   status: NodeStatus;
   version: string;
-  diskUsage: number;
+  diskUsage: number | null;
   address: string;
-  tpsIn: number;
-  tpsOut: number;
+  tpsIn: number | null;
+  tpsOut: number | null;
 }
 
 interface NameServerRecord {
@@ -94,11 +94,11 @@ function mapClusters(clusters: ClusterInfo[]): {
         k8sCluster: clusterLabel,
         brokerName: broker.name || broker.addr,
         status: normalizeStatus(broker.status),
-        version: broker.version || cluster.version,
-        diskUsage: broker.diskUsage ?? 0,
+        version: broker.version || '-',
+        diskUsage: broker.runtimeStatsAvailable === false ? null : broker.diskUsage ?? 0,
         address: broker.addr,
-        tpsIn: broker.tpsIn ?? 0,
-        tpsOut: broker.tpsOut ?? 0,
+        tpsIn: broker.runtimeStatsAvailable === false ? null : broker.tpsIn ?? 0,
+        tpsOut: broker.runtimeStatsAvailable === false ? null : broker.tpsOut ?? 0,
       });
     });
 
@@ -177,7 +177,8 @@ const BrokerClusterPage = () => {
     return <Tag color={color}>{label}</Tag>;
   };
 
-  const renderDiskUsage = (percent: number) => {
+  const renderDiskUsage = (percent: number | null) => {
+    if (percent == null) return '-';
     let status: 'normal' | 'active' | 'exception' = 'normal';
     let color = '#52c41a';
     if (percent > 85) {
@@ -249,15 +250,15 @@ const BrokerClusterPage = () => {
       title: t('brokerCluster.tpsIn'),
       dataIndex: 'tpsIn',
       key: 'tpsIn',
-      render: (value: number) => <span style={{ fontWeight: 500 }}>{value.toLocaleString()}</span>,
-      sorter: (a: BrokerRecord, b: BrokerRecord) => a.tpsIn - b.tpsIn,
+      render: (value: number | null) => <span style={{ fontWeight: 500 }}>{value?.toLocaleString() ?? '-'}</span>,
+      sorter: (a: BrokerRecord, b: BrokerRecord) => (a.tpsIn ?? -1) - (b.tpsIn ?? -1),
     },
     {
       title: t('brokerCluster.tpsOut'),
       dataIndex: 'tpsOut',
       key: 'tpsOut',
-      render: (value: number) => <span style={{ fontWeight: 500 }}>{value.toLocaleString()}</span>,
-      sorter: (a: BrokerRecord, b: BrokerRecord) => a.tpsOut - b.tpsOut,
+      render: (value: number | null) => <span style={{ fontWeight: 500 }}>{value?.toLocaleString() ?? '-'}</span>,
+      sorter: (a: BrokerRecord, b: BrokerRecord) => (a.tpsOut ?? -1) - (b.tpsOut ?? -1),
     },
     {
       title: t('common.actions'),

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -16,7 +16,20 @@
  */
 
 import { useCallback, useRef, useState } from 'react';
-import { Table, Button, Tag, Tabs, Card, Space, Switch, Progress, Tooltip, Spin, App } from 'antd';
+import {
+  Table,
+  Button,
+  Tag,
+  Tabs,
+  Card,
+  Space,
+  Switch,
+  Progress,
+  Tooltip,
+  Spin,
+  App,
+  Modal,
+} from 'antd';
 import {
   Plus,
   ArrowClockwise,
@@ -27,7 +40,7 @@ import {
   PlugsConnected,
 } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
-import { listClusters } from '../../services/clusterService';
+import { listClusters, restartBroker } from '../../services/clusterService';
 import type { ClusterInfo } from '../../api/cluster';
 
 // ─── Types ──────────────────────────────────────────────────────
@@ -35,6 +48,7 @@ type NodeStatus = 'running' | 'readonly' | 'maintenance';
 
 interface BrokerRecord {
   key: string;
+  clusterId: string;
   k8sCluster: string;
   brokerName: string;
   status: NodeStatus;
@@ -91,6 +105,7 @@ function mapClusters(clusters: ClusterInfo[]): {
     cluster.brokers.forEach((broker, index) => {
       brokers.push({
         key: `${cluster.id}-broker-${broker.addr || index}`,
+        clusterId: cluster.id,
         k8sCluster: clusterLabel,
         brokerName: broker.name || broker.addr,
         status: normalizeStatus(broker.status),
@@ -157,6 +172,22 @@ const BrokerClusterPage = () => {
       setLoading(false);
     }
   }, [message, t]);
+
+  const handleRestartBroker = async (broker: BrokerRecord) => {
+    try {
+      const result = await restartBroker(broker.clusterId, broker.brokerName);
+      if (!result.success) {
+        message.error(result.message || t('common.failure'));
+        return;
+      }
+      await loadData();
+      message.success(
+        result.message || t('cluster.restartBrokerSubmitted', { name: broker.brokerName }),
+      );
+    } catch {
+      message.error(t('common.failure'));
+    }
+  };
 
   const initialized = useRef<boolean | null>(null);
   if (initialized.current == null) {
@@ -263,7 +294,7 @@ const BrokerClusterPage = () => {
     {
       title: t('common.actions'),
       key: 'action',
-      render: () => (
+      render: (_: unknown, record: BrokerRecord) => (
         <Space size="small">
           <Tooltip title={t('brokerCluster.config')}>
             <Button type="link" size="small" icon={<GearSix size={14} />}>
@@ -271,7 +302,20 @@ const BrokerClusterPage = () => {
             </Button>
           </Tooltip>
           <Tooltip title={t('brokerCluster.restart')}>
-            <Button type="link" size="small" icon={<ArrowsClockwise size={14} />}>
+            <Button
+              type="link"
+              size="small"
+              icon={<ArrowsClockwise size={14} />}
+              onClick={() => {
+                Modal.confirm({
+                  title: t('cluster.confirmRestart'),
+                  content: t('cluster.restartBrokerConfirm', { name: record.brokerName }),
+                  okText: t('common.confirm'),
+                  cancelText: t('common.cancel'),
+                  onOk: () => handleRestartBroker(record),
+                });
+              }}
+            >
               {t('brokerCluster.restart')}
             </Button>
           </Tooltip>

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -31,9 +31,7 @@ import {
   Modal,
 } from 'antd';
 import {
-  Plus,
   ArrowClockwise,
-  GearSix,
   ArrowsClockwise,
   Cloud,
   ChartBar,
@@ -295,31 +293,24 @@ const BrokerClusterPage = () => {
       title: t('common.actions'),
       key: 'action',
       render: (_: unknown, record: BrokerRecord) => (
-        <Space size="small">
-          <Tooltip title={t('brokerCluster.config')}>
-            <Button type="link" size="small" icon={<GearSix size={14} />}>
-              {t('brokerCluster.config')}
-            </Button>
-          </Tooltip>
-          <Tooltip title={t('brokerCluster.restart')}>
-            <Button
-              type="link"
-              size="small"
-              icon={<ArrowsClockwise size={14} />}
-              onClick={() => {
-                Modal.confirm({
-                  title: t('cluster.confirmRestart'),
-                  content: t('cluster.restartBrokerConfirm', { name: record.brokerName }),
-                  okText: t('common.confirm'),
-                  cancelText: t('common.cancel'),
-                  onOk: () => handleRestartBroker(record),
-                });
-              }}
-            >
-              {t('brokerCluster.restart')}
-            </Button>
-          </Tooltip>
-        </Space>
+        <Tooltip title={t('brokerCluster.restart')}>
+          <Button
+            type="link"
+            size="small"
+            icon={<ArrowsClockwise size={14} />}
+            onClick={() => {
+              Modal.confirm({
+                title: t('cluster.confirmRestart'),
+                content: t('cluster.restartBrokerConfirm', { name: record.brokerName }),
+                okText: t('common.confirm'),
+                cancelText: t('common.cancel'),
+                onOk: () => handleRestartBroker(record),
+              });
+            }}
+          >
+            {t('brokerCluster.restart')}
+          </Button>
+        </Tooltip>
       ),
     },
   ];
@@ -366,20 +357,6 @@ const BrokerClusterPage = () => {
       dataIndex: 'connections',
       key: 'connections',
       render: (text: number) => <span style={{ fontWeight: 500 }}>{text.toLocaleString()}</span>,
-    },
-    {
-      title: t('common.actions'),
-      key: 'action',
-      render: () => (
-        <Space size="small">
-          <Button type="link" size="small" icon={<GearSix size={14} />}>
-            {t('brokerCluster.config')}
-          </Button>
-          <Button type="link" size="small" icon={<ArrowsClockwise size={14} />}>
-            {t('brokerCluster.restart')}
-          </Button>
-        </Space>
-      ),
     },
   ];
 
@@ -443,20 +420,6 @@ const BrokerClusterPage = () => {
       key: 'connections',
       render: (text: number) => <span style={{ fontWeight: 500 }}>{text.toLocaleString()}</span>,
     },
-    {
-      title: t('common.actions'),
-      key: 'action',
-      render: () => (
-        <Space size="small">
-          <Button type="link" size="small" icon={<GearSix size={14} />}>
-            {t('brokerCluster.config')}
-          </Button>
-          <Button type="link" size="small" icon={<ArrowsClockwise size={14} />}>
-            {t('brokerCluster.restart')}
-          </Button>
-        </Space>
-      ),
-    },
   ];
 
   return (
@@ -491,9 +454,6 @@ const BrokerClusterPage = () => {
           />
           <Button icon={<ArrowClockwise size={14} />} size="small" onClick={() => void loadData()}>
             {t('common.reset')}
-          </Button>
-          <Button type="primary" icon={<Plus size={14} />}>
-            {t('brokerCluster.createCluster')}
           </Button>
         </Space>
       </div>

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
@@ -124,6 +124,10 @@ describe('BrokerCluster Page', () => {
     vi.mocked(restartBroker).mockResolvedValue({ success: true, message: 'restarted' });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should render the page title', () => {
     renderWithProviders(<BrokerCluster />);
     expect(screen.getByText('Broker 集群')).toBeInTheDocument();
@@ -209,5 +213,28 @@ describe('BrokerCluster Page', () => {
     expect(screen.queryByText('broker-b')).not.toBeInTheDocument();
     expect(screen.queryByText('nameserver-a')).not.toBeInTheDocument();
     expect(screen.queryByText('proxy-a')).not.toBeInTheDocument();
+  });
+
+  it('polls only while live refresh is enabled', async () => {
+    vi.useFakeTimers();
+    renderWithProviders(<BrokerCluster />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(listClusters).toHaveBeenCalledTimes(1);
+
+    const liveRefreshSwitch = screen.getByRole('switch');
+    fireEvent.click(liveRefreshSwitch);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(listClusters).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(liveRefreshSwitch);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(listClusters).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -129,11 +129,6 @@ describe('BrokerCluster Page', () => {
     expect(screen.getByText('Broker 集群')).toBeInTheDocument();
   });
 
-  it('should render create cluster button', () => {
-    renderWithProviders(<BrokerCluster />);
-    expect(screen.getByText('创建集群')).toBeInTheDocument();
-  });
-
   it('should render reset button', () => {
     renderWithProviders(<BrokerCluster />);
     expect(screen.getByText('重置')).toBeInTheDocument();
@@ -178,13 +173,13 @@ describe('BrokerCluster Page', () => {
     expect(screen.getAllByText('10.0.1.30:8080').length).toBeGreaterThan(0);
   });
 
-  it('should render config and restart action buttons', async () => {
+  it('should render only supported broker restart actions', async () => {
     renderWithProviders(<BrokerCluster />);
     await screen.findByText('broker-api-a');
-    const configButtons = screen.getAllByText('配置');
-    expect(configButtons.length).toBeGreaterThan(0);
+    expect(screen.queryByText('创建集群')).not.toBeInTheDocument();
+    expect(screen.queryByText('配置')).not.toBeInTheDocument();
     const restartButtons = screen.getAllByText('重启');
-    expect(restartButtons.length).toBeGreaterThan(0);
+    expect(restartButtons).toHaveLength(2);
   });
 
   it('restarts a broker after confirmation and refreshes the cluster data', async () => {

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -20,12 +20,13 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
-import { listClusters } from '../../../services/clusterService';
+import { listClusters, restartBroker } from '../../../services/clusterService';
 import type { ClusterInfo } from '../../../api/cluster';
 import BrokerCluster from '../BrokerCluster';
 
 vi.mock('../../../services/clusterService', () => ({
   listClusters: vi.fn(),
+  restartBroker: vi.fn(),
 }));
 
 // Mock matchMedia for antd responsive components
@@ -120,6 +121,7 @@ describe('BrokerCluster Page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(listClusters).mockResolvedValue(clusterFixture);
+    vi.mocked(restartBroker).mockResolvedValue({ success: true, message: 'restarted' });
   });
 
   it('should render the page title', () => {
@@ -183,6 +185,23 @@ describe('BrokerCluster Page', () => {
     expect(configButtons.length).toBeGreaterThan(0);
     const restartButtons = screen.getAllByText('重启');
     expect(restartButtons.length).toBeGreaterThan(0);
+  });
+
+  it('restarts a broker after confirmation and refreshes the cluster data', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<BrokerCluster />);
+    await screen.findByText('broker-api-a');
+
+    await user.click(screen.getAllByText('重启')[0]);
+    expect(await screen.findByText('确定要重启 Broker "broker-api-a" 吗？')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /确\s*认/ }));
+
+    await waitFor(() => {
+      expect(restartBroker).toHaveBeenCalledWith('cluster-1', 'broker-api-a');
+    });
+    await waitFor(() => {
+      expect(listClusters).toHaveBeenCalledTimes(2);
+    });
   });
 
   it('does not show mock infrastructure data when the API fails', async () => {


### PR DESCRIPTION
## Summary

- surface unavailable Broker runtime statistics and missing versions without synthetic values
- render runtime diagnostics safely across Cluster and Broker views
- expose only supported Broker Cluster actions and refresh state after restart
- return an actionable error when NameServer cluster discovery fails

Closes #1222

## Verification

- mvn -Dtest=RocketMQClusterProviderTest test
- npm test -- --run src/pages/studio/__tests__/BrokerCluster.test.tsx
- npm run build