### PR TITLE
fix: expose unavailable cloud resource counts

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -72,7 +72,9 @@ public class InstanceService {
             InstanceProvider provider = providerRegistry.forVendor(vendor);
             instance.setTopicCount(provider.countTopics(instance.getId()));
             instance.setConsumerGroupCount(provider.countGroups(instance.getId()));
+            instance.setResourceCountsAvailable(true);
         } catch (RuntimeException ex) {
+            instance.setResourceCountsAvailable(false);
             log.warn("Failed to load resource counts for instance {}: {}",
                     instance.getId(), ex.getMessage());
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceVO.java
@@ -42,4 +42,6 @@ public class InstanceVO extends BaseEntity {
     private String regionId;
     private int topicCount;
     private int consumerGroupCount;
+    @Builder.Default
+    private boolean resourceCountsAvailable = true;
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -24,8 +24,8 @@ import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.CloudCatalogProvider;
 import org.apache.rocketmq.studio.provider.CloudInstanceDetailVO;
-import org.apache.rocketmq.studio.provider.InstanceProvider;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
+import org.apache.rocketmq.studio.provider.InstanceProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -75,6 +75,37 @@ class InstanceServiceTest {
 
         assertThat(result).hasSize(2);
         verify(instanceRepository).findAll();
+    }
+
+    @Test
+    void listInstancesMarksCloudCountsUnavailableWhenProviderFails() {
+        InstanceVO instance = InstanceVO.builder().vendor(InstanceVendor.ALIYUN).build();
+        instance.setId("cloud-1");
+        InstanceProvider provider = org.mockito.Mockito.mock(InstanceProvider.class);
+        when(instanceRepository.findAll()).thenReturn(List.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(provider);
+        when(provider.countTopics("cloud-1")).thenThrow(new IllegalStateException("access denied"));
+
+        InstanceVO result = instanceService.listInstances(null, null).get(0);
+
+        assertThat(result.isResourceCountsAvailable()).isFalse();
+    }
+
+    @Test
+    void listInstancesKeepsCloudCountsAvailableWhenProviderReturnsEmptyLists() {
+        InstanceVO instance = InstanceVO.builder().vendor(InstanceVendor.ALIYUN).build();
+        instance.setId("cloud-1");
+        InstanceProvider provider = org.mockito.Mockito.mock(InstanceProvider.class);
+        when(instanceRepository.findAll()).thenReturn(List.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(provider);
+        when(provider.countTopics("cloud-1")).thenReturn(0);
+        when(provider.countGroups("cloud-1")).thenReturn(0);
+
+        InstanceVO result = instanceService.listInstances(null, null).get(0);
+
+        assertThat(result.isResourceCountsAvailable()).isTrue();
+        assertThat(result.getTopicCount()).isZero();
+        assertThat(result.getConsumerGroupCount()).isZero();
     }
 
     @Test

--- a/web/src/api/instance.ts
+++ b/web/src/api/instance.ts
@@ -32,6 +32,7 @@ export interface Instance {
   regionId?: string;
   topicCount: number;
   consumerGroupCount: number;
+  resourceCountsAvailable?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -312,6 +312,8 @@ const InstancePage = () => {
       width: 80,
       align: 'center' as const,
       sorter: (a, b) => a.topicCount - b.topicCount,
+      render: (count: number, record: Instance) =>
+        record.resourceCountsAvailable === false ? '不可用' : count,
     },
     {
       title: 'Group',
@@ -320,6 +322,8 @@ const InstancePage = () => {
       width: 80,
       align: 'center' as const,
       sorter: (a, b) => a.consumerGroupCount - b.consumerGroupCount,
+      render: (count: number, record: Instance) =>
+        record.resourceCountsAvailable === false ? '不可用' : count,
     },
     {
       title: '创建时间',


### PR DESCRIPTION
## Summary

- expose whether cloud Topic and consumer-group counts were successfully loaded
- retain valid zero counts after successful provider calls
- render unavailable cloud resource counts distinctly in the instance list

Closes #1224

## Verification

- `mvn -Dtest=InstanceServiceTest test`