### PR TITLE
fix: handle missing DLQ enqueue timestamps

### DIFF
--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -59,7 +59,7 @@ export interface DLQGroup {
   groupName: string;
   dlqTopic: string;
   messageCount: number;
-  lastEnqueueTime: string;
+  lastEnqueueTime?: string | null;
   retryCount: number;
   status: string;
 }

--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -131,6 +131,20 @@ describe('DLQ page', () => {
     expect(await screen.findByText('DLQ provider is not configured')).toBeInTheDocument();
   });
 
+  it('sorts DLQ rows with missing enqueue timestamps', async () => {
+    vi.mocked(messageService.listDLQGroups).mockResolvedValue([
+      dlqGroup,
+      { ...secondDlqGroup, lastEnqueueTime: null },
+    ]);
+    const user = userEvent.setup();
+    renderWithProviders(<DLQPage />);
+
+    await screen.findByText('cg-order');
+    await user.click(screen.getByText('最近入队时间'));
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
   it('opens a detail dialog with the selected group metadata', async () => {
     const user = userEvent.setup();
     renderWithProviders(<DLQPage />);

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -69,8 +69,10 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
   return fallback;
 };
 
-const formatDateTime = (iso: string): string => {
+const formatDateTime = (iso?: string | null): string => {
+  if (!iso) return '-';
   const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '-';
   const pad = (n: number) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 };
@@ -89,7 +91,7 @@ const exportDLQGroups = (groups: DLQGroup[], filename: string) => {
       String(group.messageCount),
       String(group.retryCount),
       group.status,
-      group.lastEnqueueTime,
+      group.lastEnqueueTime || '',
     ]),
   ];
   const csv = rows.map((row) => row.map(escapeCSVValue).join(',')).join('\n');
@@ -276,8 +278,8 @@ const DLQPage = () => {
       dataIndex: 'lastEnqueueTime',
       key: 'lastEnqueueTime',
       width: 180,
-      sorter: (a, b) => a.lastEnqueueTime.localeCompare(b.lastEnqueueTime),
-      render: (time: string) => (
+      sorter: (a, b) => (a.lastEnqueueTime || '').localeCompare(b.lastEnqueueTime || ''),
+      render: (time?: string | null) => (
         <Text type="secondary" style={{ fontSize: 13 }}>
           {formatDateTime(time)}
         </Text>


### PR DESCRIPTION
## Summary

- model DLQ enqueue timestamps as nullable API data
- keep timestamp sorting stable when a value is missing
- render and export missing timestamps safely

Closes #1227

## Verification

- `npm test -- --run src/pages/instance/__tests__/DLQPage.test.tsx`
- `npm run build`