### PR TITLE
fix: handle unavailable Broker versions

### DIFF
--- a/web/src/api/cluster.ts
+++ b/web/src/api/cluster.ts
@@ -44,7 +44,7 @@ export interface BrokerInfo {
   tpsIn: number;
   tpsOut: number;
   diskUsage: number;
-  version: string;
+  version?: string | null;
 }
 
 export interface ProxyInfo {

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -403,8 +403,8 @@ const ClusterPage = () => {
         key: 'version',
         width: 80,
         align: 'right',
-        sorter: (a, b) => a.version.localeCompare(b.version),
-        render: (v: string) => <span style={{ fontSize: 13 }}>{v}</span>,
+        sorter: (a, b) => (a.version || '').localeCompare(b.version || ''),
+        render: (v?: string | null) => <span style={{ fontSize: 13 }}>{v || '-'}</span>,
       },
       {
         title: t('cluster.diskUsage'),


### PR DESCRIPTION
## Summary

- model Broker version as nullable runtime data
- render a fallback when runtime statistics do not provide a version
- keep Broker version sorting safe for missing values

Closes #1229

## Verification

- `npm run build`