### PR TITLE
fix(lite-topic): return 400 for invalid extendTTL input

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/LiteTopicService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/LiteTopicService.java
@@ -37,10 +37,10 @@ public class LiteTopicService {
 
     public void extendTTL(String topicPattern, Long newTTL) {
         if (topicPattern == null || topicPattern.isBlank()) {
-            throw new IllegalArgumentException("topicPattern is required");
+            throw new BusinessException(400, "topicPattern is required");
         }
         if (newTTL == null || newTTL <= 0) {
-            throw new IllegalArgumentException("newTTL must be positive");
+            throw new BusinessException(400, "newTTL must be positive");
         }
         throw new BusinessException(NOT_IMPLEMENTED, PROVIDER_UNAVAILABLE_MESSAGE);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicServiceTest.java
@@ -57,11 +57,13 @@ class LiteTopicServiceTest {
     @Test
     void extendTTLShouldRejectInvalidInput() {
         assertThatThrownBy(() -> liteTopicService.extendTTL("", 1L))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("topicPattern is required");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topicPattern is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
         assertThatThrownBy(() -> liteTopicService.extendTTL("chat/{sessionId}", 0L))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("newTTL must be positive");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("newTTL must be positive")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
     }
 
     @Test


### PR DESCRIPTION
`LiteTopicService.extendTTL` threw `IllegalArgumentException` for invalid input, which the global exception handler does not map, so clients got a 500 instead of a 400 (and the real input problem). It now throws `BusinessException(400, ...)` consistently with the rest of the codebase. Updated the affected test.
