### PR TITLE
fix: check current resources before deleting instance

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -207,10 +207,14 @@ public class InstanceService {
         InstanceVO existing = instanceRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(404, "InstanceVO not found: " + id));
 
-        if (existing.getTopicCount() > 0 || existing.getConsumerGroupCount() > 0) {
+        InstanceProvider provider = providerRegistry.forVendor(
+                existing.getVendor() == null ? InstanceVendor.APACHE : existing.getVendor());
+        int topicCount = provider.countTopics(id);
+        int consumerGroupCount = provider.countGroups(id);
+        if (topicCount > 0 || consumerGroupCount > 0) {
             throw new BusinessException(409, String.format(
                     "Cannot delete instance with managed resources: topics=%d, consumerGroups=%d",
-                    existing.getTopicCount(), existing.getConsumerGroupCount()));
+                    topicCount, consumerGroupCount));
         }
         instanceRepository.deleteById(id);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -451,6 +451,9 @@ class InstanceServiceTest {
         existing.setId("inst-1");
 
         when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("inst-1")).thenReturn(0);
+        when(instanceProvider.countGroups("inst-1")).thenReturn(0);
 
         instanceService.deleteInstance("inst-1");
 
@@ -461,10 +464,13 @@ class InstanceServiceTest {
     void deleteInstanceShouldRejectInstanceWithTopics() {
         InstanceVO existing = InstanceVO.builder()
                 .name("with-topics")
-                .topicCount(2)
+                .topicCount(0)
                 .build();
         existing.setId("inst-1");
         when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("inst-1")).thenReturn(2);
+        when(instanceProvider.countGroups("inst-1")).thenReturn(0);
 
         assertThatThrownBy(() -> instanceService.deleteInstance("inst-1"))
                 .isInstanceOf(BusinessException.class)
@@ -478,10 +484,13 @@ class InstanceServiceTest {
     void deleteInstanceShouldRejectInstanceWithConsumerGroups() {
         InstanceVO existing = InstanceVO.builder()
                 .name("with-consumer-groups")
-                .consumerGroupCount(3)
+                .consumerGroupCount(0)
                 .build();
         existing.setId("inst-1");
         when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("inst-1")).thenReturn(0);
+        when(instanceProvider.countGroups("inst-1")).thenReturn(3);
 
         assertThatThrownBy(() -> instanceService.deleteInstance("inst-1"))
                 .isInstanceOf(BusinessException.class)


### PR DESCRIPTION
## Summary

Closes #1235.

- resolve managed Topic and Consumer Group counts from the instance provider immediately before deletion
- reject deletion when current provider counts are non-zero rather than trusting stale response-only fields
- cover successful deletion and both conflict paths with live-count tests

## Verification

`JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=InstanceServiceTest test` (from `server/`)

## Scope

Track 1 instance lifecycle; 2 files changed.