### PR TITLE
fix: validate Apache instance type before persistence

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -103,6 +103,9 @@ public class InstanceService {
         if (instance.getEndpoint() == null || instance.getEndpoint().isBlank()) {
             throw new BusinessException(400, "InstanceVO endpoint is required");
         }
+        if (instance.getType() == null) {
+            throw new BusinessException(400, "InstanceVO type is required");
+        }
     }
 
     /**

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -516,13 +516,32 @@ class InstanceServiceTest {
 
     @Test
     void createInstanceShouldDefaultToApacheVendorTest() {
-        InstanceVO instance = InstanceVO.builder().name("inst").endpoint("10.0.0.1:8080").build();
+        InstanceVO instance = InstanceVO.builder()
+                .name("inst")
+                .endpoint("10.0.0.1:8080")
+                .type(InstanceType.PROXY)
+                .build();
         when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         InstanceVO created = instanceService.createInstance(instance);
 
         assertThat(created.getVendor()).isEqualTo(InstanceVendor.APACHE);
         verifyNoInteractions(cloudCredentialRepository, providerRegistry);
+    }
+
+    @Test
+    void createApacheInstanceShouldRequireTypeTest() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("inst")
+                .endpoint("10.0.0.1:8080")
+                .build();
+
+        assertThatThrownBy(() -> instanceService.createInstance(instance))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO type is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(instanceRepository, never()).save(any(InstanceVO.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1237.

- reject Apache instance creation without a type before reaching the database constraint
- retain the existing default Apache vendor behavior
- add regression coverage for the structured HTTP-400 business error

## Verification

`JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=InstanceServiceTest test` (from `server/`)

## Scope

Track 1 instance registration validation; 2 files changed.