### PR TITLE
fix: report unavailable LiteTopic provider consistently

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/LiteTopicService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/LiteTopicService.java
@@ -28,7 +28,7 @@ public class LiteTopicService {
     private static final int NOT_IMPLEMENTED = 501;
 
     public List<LiteTopicItemVO> listLiteTopics(String pattern, String namespace) {
-        return List.of();
+        throw new BusinessException(NOT_IMPLEMENTED, PROVIDER_UNAVAILABLE_MESSAGE);
     }
 
     public LiteTopicSessionVO getSession(String sessionId) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicServiceTest.java
@@ -20,8 +20,6 @@ package org.apache.rocketmq.studio.instance.topic;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -30,10 +28,12 @@ class LiteTopicServiceTest {
     private final LiteTopicService liteTopicService = new LiteTopicService();
 
     @Test
-    void listLiteTopicsShouldNotReturnSampleData() {
-        List<LiteTopicItemVO> result = liteTopicService.listLiteTopics("hat", " DEFAULT ");
-
-        assertThat(result).isEmpty();
+    void listLiteTopicsShouldReturnUnsupportedWhenProviderIsUnavailable() {
+        assertThatThrownBy(() -> liteTopicService.listLiteTopics("hat", " DEFAULT "))
+                .isInstanceOfSatisfying(BusinessException.class, ex -> {
+                    assertThat(ex.getCode()).isEqualTo(501);
+                    assertThat(ex.getMessage()).isEqualTo("LiteTopic provider integration is not available");
+                });
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1239.

- make LiteTopic list return the same explicit 501 response as session, quota, and TTL operations when no provider exists
- prevent API clients from mistaking an unavailable provider for an empty LiteTopic resource set
- retain the existing capability endpoint for frontend discovery

## Verification

`JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=LiteTopicServiceTest test` (from `server/`)

## Scope

Track 1 LiteTopic capability semantics; 2 files changed.