### PR TITLE
fix(grafana): use attachment disposition type for dashboard export

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -66,7 +67,8 @@ public class GrafanaDashboardController {
         String json = grafanaDashboardService.getDashboardJson(uid);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setContentDispositionFormData("attachment", uid + ".json");
+        headers.setContentDisposition(
+                ContentDisposition.attachment().filename(uid + ".json").build());
         return new ResponseEntity<>(json.getBytes(StandardCharsets.UTF_8), headers, HttpStatus.OK);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardControllerTest.java
@@ -81,7 +81,7 @@ class GrafanaDashboardControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(header().string("Content-Type", "application/json"))
                 .andExpect(header().string("Content-Disposition",
-                        "form-data; name=\"attachment\"; filename=\"rocketmq-overview.json\""))
+                        "attachment; filename=\"rocketmq-overview.json\""))
                 .andExpect(content().json("{\"uid\":\"rocketmq-overview\"}"));
     }
 }


### PR DESCRIPTION
setContentDispositionFormData produced a form-data Content-Disposition, which some clients do not treat as a file download. It now uses the standard attachment disposition type. Updated the test.