### PR TITLE
fix(metrics): pass through upstream 504 and guard null result elements

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
@@ -208,6 +208,10 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
     }
 
     private MetricDataVO.MetricSeriesVO parseSeries(JsonNode seriesNode) {
+        if (seriesNode == null) {
+            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                    backendLabel() + " returned a malformed time series");
+        }
         JsonNode metric = seriesNode.path("metric");
         JsonNode values = seriesNode.path("values");
         JsonNode histograms = seriesNode.path("histograms");
@@ -239,7 +243,8 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
     }
 
     private MetricDataVO.MetricSampleVO parseSample(JsonNode sampleNode) {
-        if (!sampleNode.isArray() || sampleNode.size() != 2 || !sampleNode.get(0).isNumber()) {
+        if (sampleNode == null || !sampleNode.isArray() || sampleNode.size() != 2
+                || !sampleNode.get(0).isNumber()) {
             throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
                     backendLabel() + " returned a malformed sample");
         }
@@ -292,6 +297,9 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
         }
         long totalSamples = 0;
         for (JsonNode series : result) {
+            if (series == null) {
+                continue;
+            }
             totalSamples += series.path("values").size();
             totalSamples += series.path("histograms").size();
             if (totalSamples > MAX_TOTAL_SAMPLES) {
@@ -304,7 +312,7 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
     private int responseStatus(HttpStatusCode statusCode) {
         int upstreamStatus = statusCode.value();
         return switch (upstreamStatus) {
-            case 400, 422, 503 -> upstreamStatus;
+            case 400, 422, 503, 504 -> upstreamStatus;
             default -> HttpStatus.BAD_GATEWAY.value();
         };
     }


### PR DESCRIPTION
The metrics query response mapping folded an upstream 504 into 502 (contradicting the documented 504 meaning) and could NPE on a malformed response containing null elements in the result array. 504 is now passed through, and null series/sample nodes are rejected as malformed instead of crashing. 