### PR TITLE
fix(metrics): report non-JSON error bodies with their real status

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
@@ -97,11 +97,24 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
                     .headers(this::applyAuthentication)
                     .body(form)
                     .exchange((request, clientResponse) -> {
-                        JsonNode body = objectMapper.readTree(readResponseBody(clientResponse.getBody()));
+                        byte[] rawBody = readResponseBody(clientResponse.getBody());
+                        int upstreamStatus = responseStatus(clientResponse.getStatusCode());
                         if (clientResponse.getStatusCode().isError()) {
-                            throw responseBodyException(body, responseStatus(clientResponse.getStatusCode()));
+                            // Check the status before parsing so a non-JSON error body (e.g. a proxy
+                            // HTML/plain-text page) is not misreported as a connection failure.
+                            try {
+                                throw responseBodyException(objectMapper.readTree(rawBody), upstreamStatus);
+                            } catch (IOException nonJsonBody) {
+                                throw new PrometheusException(upstreamStatus,
+                                        backendLabel() + " query failed (HTTP " + upstreamStatus + ")");
+                            }
                         }
-                        return body;
+                        try {
+                            return objectMapper.readTree(rawBody);
+                        } catch (IOException malformedBody) {
+                            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                                    backendLabel() + " returned a non-JSON response");
+                        }
                     });
             return parseResponse(response);
         } catch (PrometheusException exception) {


### PR DESCRIPTION
The metrics query exchange parsed the response body before checking the HTTP status, so a non-JSON error body (proxy HTML page, plain-text 503, ...) made JSON parsing throw and the error was reported as "Failed to connect to Prometheus" with the real upstream status lost.

The status is now checked first, and a non-JSON error body reports the real upstream status while a non-JSON success body is rejected as malformed.
