### PR TITLE
fix(ui): make DLQ group search case-insensitive

### DIFF
--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -153,7 +153,8 @@ const DLQPage = () => {
     if (!search) return groups;
     return groups.filter(
       (g) =>
-        g.groupName.includes(search) || g.dlqTopic.toLowerCase().includes(search.toLowerCase()),
+        g.groupName.toLowerCase().includes(search.toLowerCase()) ||
+        g.dlqTopic.toLowerCase().includes(search.toLowerCase()),
     );
   }, [groups, search]);
 


### PR DESCRIPTION
The DLQ group list filtered groupName with a case-sensitive includes while dlqTopic was lower-cased, so a lowercase search missed uppercase groups. Both fields are now compared case-insensitively.