### PR TITLE
fix(ui): do not report form validation failure as a save failure

### DIFF
--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -122,7 +122,10 @@ const InstancePage = () => {
       message.success(`实例「${created.name}」添加成功`);
       setAddModalOpen(false);
       addForm.resetFields();
-    } catch {
+    } catch (error) {
+      if (error && typeof error === 'object' && 'errorFields' in error) {
+        return; // validation failure; antd already shows field-level errors
+      }
       message.error('添加实例失败，请稍后重试');
     } finally {
       setSubmitting(false);
@@ -139,7 +142,10 @@ const InstancePage = () => {
       message.success(`实例「${updated.name}」备注已更新`);
       setEditModalOpen(false);
       editForm.resetFields();
-    } catch {
+    } catch (error) {
+      if (error && typeof error === 'object' && 'errorFields' in error) {
+        return; // validation failure; antd already shows field-level errors
+      }
       message.error('更新实例失败，请稍后重试');
     } finally {
       setSubmitting(false);

--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -308,7 +308,10 @@ const AlertsPage = () => {
       }
       setModalVisible(false);
       form.resetFields();
-    } catch {
+    } catch (error) {
+      if (error && typeof error === 'object' && 'errorFields' in error) {
+        return; // validation failure; antd already shows field-level errors
+      }
       message.error('保存告警规则失败，请稍后重试');
     } finally {
       setSubmitting(false);

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -354,7 +354,10 @@ export const DataSourceTab = () => {
       message.success(editingDataSource ? '数据源已更新' : '数据源已添加');
       setModalOpen(false);
       dsForm.resetFields();
-    } catch {
+    } catch (error) {
+      if (error && typeof error === 'object' && 'errorFields' in error) {
+        return; // validation failure; antd already shows field-level errors
+      }
       message.error('保存数据源失败，请稍后重试');
     } finally {
       setSubmitting(false);


### PR DESCRIPTION
Three forms (alerts, instance, settings) called form.validateFields inside try and showed a misleading save-failure toast when validation rejected. Validation failures are now left to antd's field-level errors instead of a generic save-failure message.