### PR TITLE
fix(ui): clear topic dropdown when the instance has no topics

### DIFF
--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -219,9 +219,9 @@ const MessagePage = () => {
         const scoped = selectedInstanceId
           ? nextTopics.filter((topic) => topic.instanceId === selectedInstanceId)
           : nextTopics;
-        if (scoped.length > 0) {
-          setTopicOptions(scoped.map((topic) => topic.name));
-        }
+        // Always update so an instance with no topics empties the dropdown instead of showing
+        // topics from another instance or the static defaults.
+        setTopicOptions(scoped.map((topic) => topic.name));
       })
       .catch(() => {
         // 加载失败保持静态选项可用


### PR DESCRIPTION
The message query topic dropdown only updated when the selected instance had at least one topic, so an instance with no topics kept showing another instance's topics or static defaults. The options are now always replaced (possibly empty).