### PR TITLE
fix(ui): reset audit page when changing page size

### DIFF
--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -281,8 +281,13 @@ const AuditPage: React.FC = () => {
             total,
             showSizeChanger: true,
             onChange: (nextPage, nextPageSize) => {
-              setPage(nextPage);
-              setPageSize(nextPageSize);
+              if (nextPageSize !== pageSize) {
+                // A larger page size can make the current page exceed the new total page count.
+                setPage(1);
+                setPageSize(nextPageSize);
+              } else {
+                setPage(nextPage);
+              }
             },
           }}
         />


### PR DESCRIPTION
Changing the audit log page size kept the current page number, which could exceed the new total page count and return an empty list. The page now resets to 1 when the page size changes.