### PR TITLE
fix(ui): normalize ACL version to a string for filtering and coloring

### DIFF
--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -70,7 +70,9 @@ const normalizeRule = (rule: AclRule): AclRule => ({
   actions: rule.actions ?? [],
   decision: rule.decision ?? '',
   scope: rule.scope ?? '',
-  aclVersion: rule.aclVersion ?? '2.0',
+  // Normalize to a string so version filters and tag coloring work whether the backend
+  // returns a number (2.0) or a string ("2.0").
+  aclVersion: String(rule.aclVersion ?? '2.0'),
   createdAt: rule.createdAt ?? null,
 });
 


### PR DESCRIPTION
The ACL rule version was kept as-is, so a numeric 2.0 from the backend failed the '2.0' filter and tag color check (String(2.0) === '2'). The version is now normalized to a string in the rule mapper, fixing both the filter and the tag color.