### PR TITLE
fix: populate structured cluster IDs for runtime audit records

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -190,7 +190,7 @@ public class ClusterService {
                 .map(failure -> failure.getAddress() + ": " + failure.getMessage())
                 .toList();
         try {
-            auditService.record("UPDATE_CLUSTER_CONFIG", "CLUSTER:" + clusterId, detail, status.name());
+            auditService.record("UPDATE_CLUSTER_CONFIG", "CLUSTER:" + clusterId, clusterId, detail, status.name());
         } catch (Exception e) {
             log.warn("Failed to record cluster config update audit for {}: {}", clusterId, e.getMessage());
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditService.java
@@ -78,11 +78,16 @@ public class AuditService {
 
 
     public void record(String operationType, String target, String detail, String result) {
+        record(operationType, target, null, detail, result);
+    }
+
+    public void record(String operationType, String target, String clusterId, String detail, String result) {
         AuditRecordVO record = AuditRecordVO.builder()
                 .timestamp(LocalDateTime.now())
                 .operator(AuthenticatedUserContext.currentUsernameOrSystem())
                 .operationType(operationType)
                 .target(target)
+                .clusterId(clusterId)
                 .detail(detail)
                 .result(result)
                 .build();

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigService.java
@@ -74,7 +74,7 @@ public class RocketMQBrokerConfigService {
 
     private void recordAudit(String clusterId, String detail, String result) {
         try {
-            auditService.record("UPDATE_BROKER_CONFIG", "CLUSTER:" + clusterId, detail, result);
+            auditService.record("UPDATE_BROKER_CONFIG", "CLUSTER:" + clusterId, clusterId, detail, result);
         } catch (Exception auditFailure) {
             log.warn("Failed to record broker config audit for cluster {}: {}", clusterId,
                     auditFailure.getMessage());

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -198,7 +198,7 @@ class ClusterServiceTest {
     void updateConfigShouldSucceedWhenAuditRecordingFails() {
         when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
         doThrow(new IllegalStateException("audit storage unavailable")).when(auditService)
-                .record(any(), any(), any(), any());
+                .record(any(), any(), any(), any(), any());
 
         ClusterConfigUpdateResultVO result = clusterService.updateClusterConfig(UpdateConfigDTO.builder()
                 .id("cluster-1")
@@ -294,6 +294,7 @@ class ClusterServiceTest {
         verify(auditService).record(
                 eq("UPDATE_CLUSTER_CONFIG"),
                 eq("CLUSTER:cluster-1"),
+                eq("cluster-1"),
                 org.mockito.ArgumentMatchers.contains("10.0.0.2:10911"),
                 eq("PARTIAL"));
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
@@ -64,6 +64,16 @@ class AuditServiceTest {
     }
 
     @Test
+    void recordShouldPreserveClusterIdWhenProvided() {
+        auditService.record("UPDATE_CLUSTER_CONFIG", "CLUSTER:prod-cn", "prod-cn",
+                "updated broker config", "SUCCESS");
+
+        ArgumentCaptor<AuditRecordVO> captor = ArgumentCaptor.forClass(AuditRecordVO.class);
+        verify(auditRepository).save(captor.capture());
+        assertThat(captor.getValue().getClusterId()).isEqualTo("prod-cn");
+    }
+
+    @Test
     void queryLogsDelegatesPaginationAndFiltersToRepository() {
         AuditRecordVO record = AuditRecordVO.builder().operationType("CREATE").build();
         when(auditRepository.findPage(eq("topic-a"), eq("CREATE"), isNull(), isNull(), eq("SUCCESS"),

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class RocketMQBrokerConfigServiceTest {
@@ -53,7 +54,7 @@ class RocketMQBrokerConfigServiceTest {
         config.setProperty("flushDiskType", "ASYNC_FLUSH");
         doNothing().when(adminExt).updateBrokerConfig("broker-a:10911", config);
         doThrow(new IllegalStateException("audit db down")).when(auditService)
-                .record(anyString(), anyString(), anyString(), anyString());
+                .record(anyString(), anyString(), anyString(), anyString(), anyString());
 
         brokerConfigService.updateBrokerConfig("broker-a:10911", "cluster-a", config);
     }
@@ -64,10 +65,22 @@ class RocketMQBrokerConfigServiceTest {
         doThrow(new IllegalStateException("broker unavailable")).when(adminExt)
                 .updateBrokerConfig("broker-a:10911", config);
         doThrow(new IllegalStateException("audit db down")).when(auditService)
-                .record(anyString(), anyString(), anyString(), anyString());
+                .record(anyString(), anyString(), anyString(), anyString(), anyString());
 
         assertThatThrownBy(() -> brokerConfigService.updateBrokerConfig("broker-a:10911", "cluster-a", config))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Failed to update broker config: broker unavailable");
+    }
+
+    @Test
+    void updateRecordsStructuredClusterId() throws Exception {
+        Properties config = new Properties();
+        doNothing().when(adminExt).updateBrokerConfig("broker-a:10911", config);
+
+        brokerConfigService.updateBrokerConfig("broker-a:10911", "cluster-a", config);
+
+        verify(auditService).record(
+                "UPDATE_BROKER_CONFIG", "CLUSTER:cluster-a", "cluster-a",
+                "brokerAddr=broker-a:10911, config={}", "SUCCESS");
     }
 }


### PR DESCRIPTION
Closes #1262

## Summary
- add a cluster-aware audit recording overload while preserving existing callers
- persist known cluster IDs for Broker and cluster configuration updates
- retain the non-blocking audit-failure behavior

## Validation
- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=AuditServiceTest,RocketMQBrokerConfigServiceTest,ClusterServiceTest test`