### PR TITLE
fix: clean Metrics data source bindings when deleting instances

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -28,9 +28,11 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.CloudInstanceDetailVO;
 import org.apache.rocketmq.studio.provider.InstanceProvider;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
+import org.apache.rocketmq.studio.settings.SettingsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -45,6 +47,7 @@ public class InstanceService {
     private final CloudCredentialRepository cloudCredentialRepository;
     private final InstanceProviderRegistry providerRegistry;
     private final MqAdminExtFactory adminFactory;
+    private final SettingsService settingsService;
 
     public List<InstanceVO> listInstances(InstanceType type, String search) {
         log.debug("Listing instances, type={}, search={}", type, search);
@@ -214,6 +217,7 @@ public class InstanceService {
         return saved;
     }
 
+    @Transactional
     public void deleteInstance(String id) {
         log.info("Deleting instance: {}", id);
 
@@ -234,6 +238,7 @@ public class InstanceService {
                     topicCount, consumerGroupCount));
         }
         instanceRepository.deleteById(id);
+        settingsService.removeInstanceBindings(id);
         releaseApacheEndpointIfUnused(existing, null);
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -39,6 +39,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -130,6 +131,28 @@ public class SettingsService {
         log.info("Deleting data source: {}", normalizedKey);
         if (!settingsRepository.deleteDataSource(normalizedKey)) {
             throw new BusinessException(404, "Data source not found: " + normalizedKey);
+        }
+    }
+
+    /**
+     * Removes a deleted instance from data-source bindings. An empty binding list
+     * remains the existing representation for a globally available source.
+     */
+    public void removeInstanceBindings(String instanceId) {
+        if (!StringUtils.hasText(instanceId)) {
+            return;
+        }
+        for (DataSourceVO dataSource : settingsRepository.findAllDataSources()) {
+            List<String> instanceIds = dataSource.getInstanceIds();
+            if (instanceIds == null || !instanceIds.contains(instanceId)) {
+                continue;
+            }
+            dataSource.setInstanceIds(new ArrayList<>(instanceIds.stream()
+                    .filter(id -> !instanceId.equals(id))
+                    .toList()));
+            if (!settingsRepository.replaceDataSource(dataSource)) {
+                throw new BusinessException(404, "Data source not found: " + dataSource.getKey());
+            }
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.studio.provider.CloudCatalogProvider;
 import org.apache.rocketmq.studio.provider.CloudInstanceDetailVO;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
 import org.apache.rocketmq.studio.provider.InstanceProvider;
+import org.apache.rocketmq.studio.settings.SettingsService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -62,6 +63,9 @@ class InstanceServiceTest {
 
     @Mock
     private MqAdminExtFactory adminFactory;
+
+    @Mock
+    private SettingsService settingsService;
 
     @InjectMocks
     private InstanceService instanceService;
@@ -592,6 +596,7 @@ class InstanceServiceTest {
         instanceService.deleteInstance("inst-1");
 
         verify(instanceRepository).deleteById("inst-1");
+        verify(settingsService).removeInstanceBindings("inst-1");
     }
 
     @Test
@@ -612,6 +617,7 @@ class InstanceServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(409));
 
         verify(instanceRepository, never()).deleteById("inst-1");
+        verifyNoInteractions(settingsService);
     }
 
     @Test
@@ -632,6 +638,7 @@ class InstanceServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(409));
 
         verify(instanceRepository, never()).deleteById("inst-1");
+        verifyNoInteractions(settingsService);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestClient;
 
@@ -114,6 +115,25 @@ class SettingsServiceTest {
 
         assertThat(update.getApiKey()).isEqualTo("sk-existing");
         verify(settingsRepository).saveGeneralSettings(update);
+    }
+
+    @Test
+    void removeInstanceBindingsUpdatesOnlyBoundDataSources() {
+        DataSourceVO bound = DataSourceVO.builder()
+                .key("bound")
+                .instanceIds(List.of("instance-a", "instance-b"))
+                .build();
+        DataSourceVO global = DataSourceVO.builder().key("global").instanceIds(List.of()).build();
+        DataSourceVO unrelated = DataSourceVO.builder().key("other").instanceIds(List.of("instance-b")).build();
+        when(settingsRepository.findAllDataSources()).thenReturn(List.of(bound, global, unrelated));
+        when(settingsRepository.replaceDataSource(any(DataSourceVO.class))).thenReturn(true);
+
+        settingsService.removeInstanceBindings("instance-a");
+
+        ArgumentCaptor<DataSourceVO> captor = ArgumentCaptor.forClass(DataSourceVO.class);
+        verify(settingsRepository).replaceDataSource(captor.capture());
+        assertThat(captor.getValue().getKey()).isEqualTo("bound");
+        assertThat(captor.getValue().getInstanceIds()).containsExactly("instance-b");
     }
 
     @Test


### PR DESCRIPTION
Closes #1264

## Summary
- remove a deleted instance from configured Metrics data-source bindings
- retain empty bindings as globally available sources
- execute instance deletion and binding cleanup in one transaction

## Validation
- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) PATH="$JAVA_HOME/bin:$PATH" mvn -Dtest=InstanceServiceTest,SettingsServiceTest test`