### PR TITLE
[Studio] feat: add cloud credential management

### DIFF
--- a/web/src/api/cloudCredential.test.ts
+++ b/web/src/api/cloudCredential.test.ts
@@ -18,7 +18,12 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { listCloudCredentials } from './cloudCredential';
+import {
+  createCloudCredential,
+  deleteCloudCredential,
+  listCloudCredentials,
+  updateCloudCredential,
+} from './cloudCredential';
 
 const mock = new MockAdapter(client);
 
@@ -52,5 +57,83 @@ describe('cloudCredential API', () => {
     expect(credentials).toHaveLength(1);
     expect(credentials[0].vendor).toBe('ALIYUN');
     expect(credentials[0].secretKey).toBeUndefined();
+  });
+
+  it('creates a cloud credential', async () => {
+    mock.onPost('/cloud-credentials/create').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({
+        name: 'aliyun-prod',
+        vendor: 'ALIYUN',
+        accessKey: 'LTAI5tUnitTestKey000000001',
+        secretKey: 'secret',
+        remark: 'prod',
+      });
+      return [
+        200,
+        {
+          code: 200,
+          data: {
+            id: 'cred-1',
+            name: 'aliyun-prod',
+            vendor: 'ALIYUN',
+            accessKey: 'LTAI****0001',
+            remark: 'prod',
+            createdAt: '2026-08-06T00:00:00Z',
+          },
+        },
+      ];
+    });
+
+    const credential = await createCloudCredential({
+      name: 'aliyun-prod',
+      vendor: 'ALIYUN',
+      accessKey: 'LTAI5tUnitTestKey000000001',
+      secretKey: 'secret',
+      remark: 'prod',
+    });
+
+    expect(credential.accessKey).toBe('LTAI****0001');
+    expect(credential.secretKey).toBeUndefined();
+  });
+
+  it('updates a cloud credential without requiring the access key', async () => {
+    mock.onPost('/cloud-credentials/update').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({
+        id: 'cred-1',
+        name: 'aliyun-renamed',
+        remark: 'updated',
+      });
+      return [
+        200,
+        {
+          code: 200,
+          data: {
+            id: 'cred-1',
+            name: 'aliyun-renamed',
+            vendor: 'ALIYUN',
+            accessKey: 'LTAI****0001',
+            remark: 'updated',
+            createdAt: '2026-08-06T00:00:00Z',
+          },
+        },
+      ];
+    });
+
+    const credential = await updateCloudCredential({
+      id: 'cred-1',
+      name: 'aliyun-renamed',
+      remark: 'updated',
+    });
+
+    expect(credential.name).toBe('aliyun-renamed');
+  });
+
+  it('deletes a cloud credential by id', async () => {
+    mock.onPost('/cloud-credentials/delete').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ id: 'cred-1' });
+      return [200, { code: 200 }];
+    });
+
+    await expect(deleteCloudCredential('cred-1')).resolves.toBeUndefined();
   });
 });

--- a/web/src/api/cloudCredential.ts
+++ b/web/src/api/cloudCredential.ts
@@ -14,9 +14,39 @@ export interface CloudCredential {
   secretKey?: string;
   remark?: string;
   createdAt: string;
+  updatedAt?: string;
+}
+
+export interface CreateCloudCredentialRequest {
+  name: string;
+  vendor: Exclude<InstanceVendor, 'APACHE'>;
+  accessKey: string;
+  secretKey: string;
+  remark?: string;
+}
+
+export interface UpdateCloudCredentialRequest {
+  id: string;
+  name?: string;
+  secretKey?: string;
+  remark?: string;
 }
 
 export async function listCloudCredentials() {
   const res = await client.get<{ data: CloudCredential[] }>('/cloud-credentials');
   return res.data.data;
+}
+
+export async function createCloudCredential(data: CreateCloudCredentialRequest) {
+  const res = await client.post<{ data: CloudCredential }>('/cloud-credentials/create', data);
+  return res.data.data;
+}
+
+export async function updateCloudCredential(data: UpdateCloudCredentialRequest) {
+  const res = await client.post<{ data: CloudCredential }>('/cloud-credentials/update', data);
+  return res.data.data;
+}
+
+export async function deleteCloudCredential(id: string) {
+  await client.post('/cloud-credentials/delete', { id });
 }

--- a/web/src/mock/cloudCredentials.ts
+++ b/web/src/mock/cloudCredentials.ts
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CloudCredential } from '../api/cloudCredential';
+
+export const mockCloudCredentials: CloudCredential[] = [
+  {
+    id: 'cred-aliyun-prod',
+    name: '阿里云生产账号',
+    vendor: 'ALIYUN',
+    accessKey: 'LTAI****0001',
+    remark: '用于生产 RocketMQ 实例接入',
+    createdAt: '2026-08-01 10:00:00',
+    updatedAt: '2026-08-01 10:00:00',
+  },
+  {
+    id: 'cred-aliyun-dr',
+    name: '阿里云灾备账号',
+    vendor: 'ALIYUN',
+    accessKey: 'LTAI****0002',
+    remark: '用于灾备环境接入',
+    createdAt: '2026-08-02 11:00:00',
+    updatedAt: '2026-08-02 11:00:00',
+  },
+];

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -38,7 +38,7 @@ import { Plus, MagnifyingGlass } from '@phosphor-icons/react';
 import { EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import type { Instance, InstanceQuery } from '../../api/instance';
-import { listCloudCredentials, type CloudCredential } from '../../api/cloudCredential';
+import type { CloudCredential } from '../../api/cloudCredential';
 import {
   listAliyunInstances,
   listAliyunRegions,
@@ -53,6 +53,7 @@ import {
   listInstances,
   updateInstance,
 } from '../../services/instanceService';
+import { listCloudCredentials } from '../../services/cloudCredentialService';
 import { DEFAULT_VENDOR, VENDOR_OPTIONS, type InstanceVendor } from './vendorOptions';
 
 const { Text } = Typography;

--- a/web/src/pages/settings/__tests__/CloudCredentialTab.test.tsx
+++ b/web/src/pages/settings/__tests__/CloudCredentialTab.test.tsx
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { App } from 'antd';
+
+import type { CloudCredential } from '../../../api/cloudCredential';
+import {
+  createCloudCredential,
+  deleteCloudCredential,
+  listCloudCredentials,
+  updateCloudCredential,
+} from '../../../services/cloudCredentialService';
+import { CloudCredentialTab } from '../index';
+
+vi.mock('../../../services/cloudCredentialService', () => ({
+  createCloudCredential: vi.fn(),
+  deleteCloudCredential: vi.fn(),
+  listCloudCredentials: vi.fn(),
+  updateCloudCredential: vi.fn(),
+}));
+
+const credentials: CloudCredential[] = [
+  {
+    id: 'cred-1',
+    name: 'aliyun-prod',
+    vendor: 'ALIYUN',
+    accessKey: 'LTAI****0001',
+    remark: 'production account',
+    createdAt: '2026-08-06T00:00:00Z',
+    updatedAt: '2026-08-07T00:00:00Z',
+  },
+];
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+describe('CloudCredentialTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listCloudCredentials).mockResolvedValue(credentials);
+  });
+
+  it('lists masked cloud credentials', async () => {
+    render(
+      <App>
+        <CloudCredentialTab />
+      </App>,
+    );
+
+    expect(await screen.findByText('aliyun-prod')).toBeInTheDocument();
+    expect(screen.getByText('LTAI****0001')).toBeInTheDocument();
+    expect(screen.getByText('Alibaba Cloud RocketMQ')).toBeInTheDocument();
+    expect(screen.queryByText('plain-secret')).not.toBeInTheDocument();
+  });
+
+  it('creates a cloud credential from the settings tab', async () => {
+    vi.mocked(createCloudCredential).mockResolvedValue({
+      id: 'cred-2',
+      name: 'aliyun-dr',
+      vendor: 'ALIYUN',
+      accessKey: 'LTAI****0002',
+      remark: 'dr account',
+      createdAt: '2026-08-08T00:00:00Z',
+    });
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <App>
+        <CloudCredentialTab />
+      </App>,
+    );
+
+    await screen.findByText('aliyun-prod');
+    await user.click(screen.getByRole('button', { name: /添加云凭据/ }));
+    await user.type(screen.getByLabelText('名称'), 'aliyun-dr');
+    await user.type(screen.getByLabelText('AccessKey'), 'LTAI5tUnitTestKey000000002');
+    await user.type(screen.getByLabelText('Secret Key'), 'secret-2');
+    await user.type(screen.getByLabelText('备注'), 'dr account');
+    await user.click(screen.getByRole('button', { name: 'OK' }));
+
+    await waitFor(() => {
+      expect(createCloudCredential).toHaveBeenCalledWith({
+        name: 'aliyun-dr',
+        vendor: 'ALIYUN',
+        accessKey: 'LTAI5tUnitTestKey000000002',
+        secretKey: 'secret-2',
+        remark: 'dr account',
+      });
+    });
+    expect(await screen.findByText('aliyun-dr')).toBeInTheDocument();
+  });
+
+  it('updates metadata without overwriting an existing secret when left blank', async () => {
+    vi.mocked(updateCloudCredential).mockResolvedValue({
+      ...credentials[0],
+      name: 'aliyun-renamed',
+      remark: '',
+      updatedAt: '2026-08-08T00:00:00Z',
+    });
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <App>
+        <CloudCredentialTab />
+      </App>,
+    );
+
+    await screen.findByText('aliyun-prod');
+    await user.click(screen.getByRole('button', { name: /编辑/ }));
+    await user.clear(screen.getByLabelText('名称'));
+    await user.type(screen.getByLabelText('名称'), 'aliyun-renamed');
+    await user.clear(screen.getByLabelText('备注'));
+    await user.click(screen.getByRole('button', { name: 'OK' }));
+
+    await waitFor(() => {
+      expect(updateCloudCredential).toHaveBeenCalledWith({
+        id: 'cred-1',
+        name: 'aliyun-renamed',
+        remark: '',
+      });
+    });
+    expect(updateCloudCredential).not.toHaveBeenCalledWith(
+      expect.objectContaining({ secretKey: expect.any(String) }),
+    );
+    expect(await screen.findByText('aliyun-renamed')).toBeInTheDocument();
+  });
+
+  it('confirms before deleting a cloud credential', async () => {
+    vi.mocked(deleteCloudCredential).mockResolvedValue(undefined);
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <App>
+        <CloudCredentialTab />
+      </App>,
+    );
+
+    await screen.findByText('aliyun-prod');
+    await user.click(screen.getByRole('button', { name: /删除/ }));
+
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: /删\s*除/ }));
+
+    await waitFor(() => {
+      expect(deleteCloudCredential).toHaveBeenCalledWith('cred-1');
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('aliyun-prod')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -17,6 +17,7 @@
 
 import { useEffect, useState } from 'react';
 import {
+  Alert,
   Button,
   Checkbox,
   Descriptions,
@@ -61,6 +62,17 @@ import {
   updateDataSource,
 } from '../../api/settings';
 import type { DataSource } from '../../api/settings';
+import {
+  createCloudCredential,
+  deleteCloudCredential,
+  listCloudCredentials,
+  updateCloudCredential,
+} from '../../services/cloudCredentialService';
+import type {
+  CloudCredential,
+  CreateCloudCredentialRequest,
+  UpdateCloudCredentialRequest,
+} from '../../api/cloudCredential';
 import { STATUS_MAP } from '../../constants/theme';
 import { listInstances } from '../../services/instanceService';
 import type { Instance } from '../../api/instance';
@@ -87,7 +99,18 @@ const DATA_SOURCE_TYPE_OPTIONS = [
   { value: 'ARMS', label: 'ARMS' },
 ];
 
+const CLOUD_CREDENTIAL_VENDOR_OPTIONS: Array<{
+  value: CreateCloudCredentialRequest['vendor'];
+  label: string;
+}> = [
+  { value: 'ALIYUN', label: 'Alibaba Cloud RocketMQ' },
+  { value: 'TENCENT', label: 'Tencent Cloud TDMQ' },
+];
+
 type DataSourceFormValues = Partial<DataSource>;
+type CloudCredentialFormValues = Partial<
+  CreateCloudCredentialRequest & UpdateCloudCredentialRequest
+>;
 
 const secretFieldNames = ['username', 'password', 'bearerToken'] as const;
 const authNeedsSecret = (auth?: string) => auth === 'Basic Auth' || auth === 'Bearer Token';
@@ -596,6 +619,265 @@ export const DataSourceTab = () => {
   );
 };
 
+// ─── Cloud Credential Tab ───────────────────────────────────────────────────
+
+export const CloudCredentialTab = () => {
+  const [credentials, setCredentials] = useState<CloudCredential[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingCredential, setEditingCredential] = useState<CloudCredential | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [credentialForm] = Form.useForm<CloudCredentialFormValues>();
+
+  useEffect(() => {
+    let cancelled = false;
+    void listCloudCredentials()
+      .then((items) => {
+        if (!cancelled) setCredentials(items);
+      })
+      .catch(() => {
+        if (!cancelled) message.error('云凭据加载失败，请稍后重试');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const openCreateModal = () => {
+    setEditingCredential(null);
+    credentialForm.resetFields();
+    credentialForm.setFieldValue('vendor', 'ALIYUN');
+    setModalOpen(true);
+  };
+
+  const openEditModal = (credential: CloudCredential) => {
+    setEditingCredential(credential);
+    credentialForm.setFieldsValue({
+      name: credential.name,
+      vendor: credential.vendor === 'APACHE' ? 'ALIYUN' : credential.vendor,
+      remark: credential.remark,
+      secretKey: undefined,
+    });
+    setModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setModalOpen(false);
+    setEditingCredential(null);
+    credentialForm.resetFields();
+  };
+
+  const handleSubmit = async () => {
+    try {
+      const values = await credentialForm.validateFields();
+      setSubmitting(true);
+      if (editingCredential) {
+        const payload: UpdateCloudCredentialRequest = {
+          id: editingCredential.id,
+          name: values.name,
+          remark: values.remark ?? '',
+        };
+        if (values.secretKey?.trim()) {
+          payload.secretKey = values.secretKey.trim();
+        }
+        const saved = await updateCloudCredential(payload);
+        setCredentials((previous) =>
+          previous.map((credential) => (credential.id === saved.id ? saved : credential)),
+        );
+        message.success('云凭据已更新');
+      } else {
+        const saved = await createCloudCredential({
+          name: values.name!,
+          vendor: values.vendor as CreateCloudCredentialRequest['vendor'],
+          accessKey: values.accessKey!,
+          secretKey: values.secretKey!,
+          remark: values.remark,
+        });
+        setCredentials((previous) => [...previous, saved]);
+        message.success('云凭据已添加');
+      }
+      closeModal();
+    } catch {
+      message.error(
+        editingCredential ? '更新云凭据失败，请稍后重试' : '添加云凭据失败，请稍后重试',
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = (credential: CloudCredential) => {
+    Modal.confirm({
+      title: '删除云凭据',
+      content: `确认删除云凭据「${credential.name}」？已被实例引用的凭据会由服务端拒绝删除。`,
+      okText: '删除',
+      okButtonProps: { danger: true },
+      cancelText: '取消',
+      onOk: async () => {
+        try {
+          await deleteCloudCredential(credential.id);
+          setCredentials((previous) => previous.filter((item) => item.id !== credential.id));
+          message.success('云凭据已删除');
+        } catch {
+          message.error('删除云凭据失败，请稍后重试');
+        }
+      },
+    });
+  };
+
+  const columns: ColumnsType<CloudCredential> = [
+    { title: '名称', dataIndex: 'name', key: 'name' },
+    {
+      title: '云厂商',
+      dataIndex: 'vendor',
+      key: 'vendor',
+      render: (vendor: CloudCredential['vendor']) => {
+        const label =
+          CLOUD_CREDENTIAL_VENDOR_OPTIONS.find((option) => option.value === vendor)?.label ??
+          vendor;
+        return <Tag color={vendor === 'ALIYUN' ? 'orange' : 'blue'}>{label}</Tag>;
+      },
+    },
+    {
+      title: 'AccessKey',
+      dataIndex: 'accessKey',
+      key: 'accessKey',
+      render: (accessKey: string) => (
+        <Text copyable style={{ fontFamily: 'monospace' }}>
+          {accessKey}
+        </Text>
+      ),
+    },
+    {
+      title: '备注',
+      dataIndex: 'remark',
+      key: 'remark',
+      render: (remark?: string) => remark || '-',
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updatedAt',
+      key: 'updatedAt',
+      render: (_: unknown, record) => record.updatedAt || record.createdAt || '-',
+    },
+    {
+      title: '操作',
+      key: 'action',
+      render: (_: unknown, record) => (
+        <Space size="small">
+          <Button
+            type="link"
+            size="small"
+            icon={<EditOutlined />}
+            onClick={() => openEditModal(record)}
+          >
+            编辑
+          </Button>
+          <Button
+            type="link"
+            size="small"
+            danger
+            icon={<DeleteOutlined />}
+            onClick={() => handleDelete(record)}
+          >
+            删除
+          </Button>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <Alert
+        type="info"
+        showIcon
+        style={{ marginBottom: 16 }}
+        message="云凭据用于接入云上 RocketMQ 实例"
+        description="列表只展示脱敏 AccessKey；Secret Key 仅在创建或编辑时提交给服务端，编辑时留空会保留现有密钥。"
+      />
+
+      <Flex justify="flex-end" style={{ marginBottom: 16 }}>
+        <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
+          添加云凭据
+        </Button>
+      </Flex>
+
+      <Table<CloudCredential>
+        columns={columns}
+        dataSource={credentials}
+        rowKey="id"
+        loading={loading}
+        pagination={false}
+        size="middle"
+      />
+
+      <Modal
+        title={editingCredential ? '编辑云凭据' : '添加云凭据'}
+        open={modalOpen}
+        onCancel={closeModal}
+        onOk={() => void handleSubmit()}
+        confirmLoading={submitting}
+        destroyOnHidden
+      >
+        <Form form={credentialForm} layout="vertical" preserve={false}>
+          <Form.Item
+            label="名称"
+            name="name"
+            rules={[{ required: true, message: '请输入云凭据名称' }]}
+          >
+            <Input placeholder="例如：阿里云生产账号" />
+          </Form.Item>
+
+          <Form.Item
+            label="云厂商"
+            name="vendor"
+            rules={[{ required: true, message: '请选择云厂商' }]}
+          >
+            <Select
+              placeholder="请选择云厂商"
+              disabled={Boolean(editingCredential)}
+              virtual={false}
+              options={CLOUD_CREDENTIAL_VENDOR_OPTIONS}
+            />
+          </Form.Item>
+
+          {editingCredential ? (
+            <Form.Item label="AccessKey">
+              <Input value={editingCredential.accessKey} disabled />
+            </Form.Item>
+          ) : (
+            <Form.Item
+              label="AccessKey"
+              name="accessKey"
+              rules={[{ required: true, message: '请输入 AccessKey' }]}
+            >
+              <Input autoComplete="off" placeholder="请输入云账号 AccessKey" />
+            </Form.Item>
+          )}
+
+          <Form.Item
+            label="Secret Key"
+            name="secretKey"
+            rules={editingCredential ? [] : [{ required: true, message: '请输入 Secret Key' }]}
+            extra={editingCredential ? '留空将保留现有 Secret Key' : undefined}
+          >
+            <Input.Password autoComplete="new-password" placeholder="请输入云账号 Secret Key" />
+          </Form.Item>
+
+          <Form.Item label="备注" name="remark">
+            <Input.TextArea rows={3} placeholder="可填写账号用途、环境或负责人" />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+};
+
 // ─── About Tab ──────────────────────────────────────────────────────────────
 
 const AboutTab = () => (
@@ -639,13 +921,14 @@ const SettingsPage = () => {
 
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader title={t('settings.title')} subtitle="管理应用配置与数据源" />
+      <PageHeader title={t('settings.title')} subtitle="管理应用配置、数据源与云凭据" />
 
       <Tabs
         defaultActiveKey="general"
         items={[
           { key: 'general', label: '通用设置', children: <GeneralSettingsTab /> },
           { key: 'datasource', label: '数据源管理', children: <DataSourceTab /> },
+          { key: 'cloudCredential', label: '云凭据管理', children: <CloudCredentialTab /> },
           { key: 'about', label: '关于', children: <AboutTab /> },
         ]}
       />

--- a/web/src/services/cloudCredentialService.test.ts
+++ b/web/src/services/cloudCredentialService.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./dataMode', () => ({ isMockMode: () => true }));
+vi.mock('../config', () => ({
+  API_BASE_URL: '/api',
+}));
+
+import {
+  createCloudCredential,
+  deleteCloudCredential,
+  listCloudCredentials,
+  updateCloudCredential,
+} from './cloudCredentialService';
+
+describe('cloudCredentialService mock credentials', () => {
+  it('returns defensive copies from list reads', async () => {
+    const first = await listCloudCredentials();
+    const originalName = first[0].name;
+
+    first[0].name = 'mutated-name';
+
+    const second = await listCloudCredentials();
+    expect(second[0].name).toBe(originalName);
+    expect(second[0]).not.toBe(first[0]);
+  });
+
+  it('creates masked mock credentials without exposing the secret key', async () => {
+    const created = await createCloudCredential({
+      name: 'mock-created-credential',
+      vendor: 'ALIYUN',
+      accessKey: 'LTAI5tCreatedKey0000000001',
+      secretKey: 'plain-secret',
+      remark: 'created in mock mode',
+    });
+
+    expect(created).toMatchObject({
+      name: 'mock-created-credential',
+      vendor: 'ALIYUN',
+      accessKey: 'LTAI****0001',
+      remark: 'created in mock mode',
+    });
+    expect(created.secretKey).toBeUndefined();
+
+    const listed = await listCloudCredentials();
+    expect(listed.find((item) => item.id === created.id)?.secretKey).toBeUndefined();
+  });
+
+  it('updates metadata while keeping secret replacement write-only in mock mode', async () => {
+    const created = await createCloudCredential({
+      name: 'mock-update-credential',
+      vendor: 'ALIYUN',
+      accessKey: 'LTAI5tUpdateKey0000000001',
+      secretKey: 'old-secret',
+    });
+
+    const updated = await updateCloudCredential({
+      id: created.id,
+      name: 'mock-updated-credential',
+      secretKey: 'new-secret',
+      remark: '',
+    });
+
+    expect(updated).toMatchObject({
+      id: created.id,
+      name: 'mock-updated-credential',
+      accessKey: 'LTAI****0001',
+      remark: '',
+    });
+    expect(updated.secretKey).toBeUndefined();
+  });
+
+  it('rejects deleting missing mock credentials', async () => {
+    const before = await listCloudCredentials();
+
+    await expect(deleteCloudCredential('missing-credential')).rejects.toThrow(
+      'Cloud credential not found: missing-credential',
+    );
+
+    await expect(listCloudCredentials()).resolves.toEqual(before);
+  });
+});

--- a/web/src/services/cloudCredentialService.ts
+++ b/web/src/services/cloudCredentialService.ts
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isMockMode } from './dataMode';
+import * as cloudCredentialApi from '../api/cloudCredential';
+import type {
+  CloudCredential,
+  CreateCloudCredentialRequest,
+  UpdateCloudCredentialRequest,
+} from '../api/cloudCredential';
+import { mockCloudCredentials } from '../mock/cloudCredentials';
+
+let mockCredentialStore = mockCloudCredentials.map(copyCredential);
+
+function copyCredential(credential: CloudCredential): CloudCredential {
+  return { ...credential };
+}
+
+function nowText(): string {
+  return new Date().toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function maskAccessKey(accessKey: string): string {
+  if (accessKey.length <= 8) return '****';
+  return `${accessKey.slice(0, 4)}****${accessKey.slice(-4)}`;
+}
+
+export async function listCloudCredentials(): Promise<CloudCredential[]> {
+  if (isMockMode()) return mockCredentialStore.map(copyCredential);
+  return cloudCredentialApi.listCloudCredentials();
+}
+
+export async function createCloudCredential(
+  data: CreateCloudCredentialRequest,
+): Promise<CloudCredential> {
+  if (!isMockMode()) return cloudCredentialApi.createCloudCredential(data);
+
+  const timestamp = nowText();
+  const credential: CloudCredential = {
+    id: `cred-${Date.now()}`,
+    name: data.name,
+    vendor: data.vendor,
+    accessKey: maskAccessKey(data.accessKey),
+    remark: data.remark,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  mockCredentialStore = [...mockCredentialStore, credential];
+  return copyCredential(credential);
+}
+
+export async function updateCloudCredential(
+  data: UpdateCloudCredentialRequest,
+): Promise<CloudCredential> {
+  if (!isMockMode()) return cloudCredentialApi.updateCloudCredential(data);
+
+  const index = mockCredentialStore.findIndex((credential) => credential.id === data.id);
+  if (index < 0) throw new Error(`Cloud credential not found: ${data.id}`);
+
+  const updated: CloudCredential = {
+    ...mockCredentialStore[index],
+    ...(data.name !== undefined ? { name: data.name } : {}),
+    ...(data.remark !== undefined ? { remark: data.remark } : {}),
+    updatedAt: nowText(),
+  };
+  mockCredentialStore = mockCredentialStore.map((credential) =>
+    credential.id === data.id ? updated : credential,
+  );
+  return copyCredential(updated);
+}
+
+export async function deleteCloudCredential(id: string): Promise<void> {
+  if (!isMockMode()) return cloudCredentialApi.deleteCloudCredential(id);
+
+  const nextStore = mockCredentialStore.filter((credential) => credential.id !== id);
+  if (nextStore.length === mockCredentialStore.length) {
+    throw new Error(`Cloud credential not found: ${id}`);
+  }
+  mockCredentialStore = nextStore;
+}


### PR DESCRIPTION
## What is the purpose of the change

Add a Settings entry for managing cloud credentials used by cloud RocketMQ instance onboarding. The page lets users create, update, and delete cloud credentials while keeping Secret Key write-only and showing only masked AccessKey values after save.

## Brief changelog

- Added cloud credential create/update/delete API helpers.
- Added a cloud credential service with mock-mode support.
- Added a Cloud Credential Management tab under Settings.
- Reused the cloud credential service from the instance onboarding page.
- Added API, service, and Settings tab tests.

## Verifying this change

- `npm test -- --run --api.host 127.0.0.1 src/api/cloudCredential.test.ts src/services/cloudCredentialService.test.ts src/pages/settings/__tests__/CloudCredentialTab.test.tsx src/pages/instance/__tests__/InstancePage.test.tsx`
- `npm run build`
- `npm test -- --run --api.host 127.0.0.1`
- `npm run lint`
- `mvn -q -Dtest=CloudCredentialServiceTest test`
- `git diff --check`