### PR TITLE
[Studio] feat: add AI tool execution audit history

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiService.java
@@ -32,6 +32,7 @@ public class AiService {
 
     private final LlmGateway llmGateway;
     private final McpServerRegistry mcpServerRegistry;
+    private final AiToolAuditService aiToolAuditService;
 
 
     public SseEmitter chat(ChatDTO request) {
@@ -81,7 +82,14 @@ public class AiService {
 
     public Object executeTool(String name, Map<String, Object> input) {
         log.info("Executing registered AI tool: {}", name);
-        return mcpServerRegistry.execute(name, input);
+        try {
+            Object result = mcpServerRegistry.execute(name, input);
+            aiToolAuditService.recordSuccess(name, input);
+            return result;
+        } catch (RuntimeException exception) {
+            aiToolAuditService.recordFailure(name, input, exception);
+            throw exception;
+        }
     }
 
     public String catalogVersion() {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiToolAuditService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiToolAuditService.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiToolAuditService {
+
+    private static final int MAX_ERROR_MESSAGE_LENGTH = 300;
+
+    private final OperationAuditService operationAuditService;
+
+    public void recordSuccess(String toolName, Map<String, Object> input) {
+        record(toolName, input, "SUCCESS", null);
+    }
+
+    public void recordFailure(String toolName, Map<String, Object> input, Throwable error) {
+        record(toolName, input, "FAILED", error == null ? null : error.getMessage());
+    }
+
+    private void record(String toolName, Map<String, Object> input, String result, String errorMessage) {
+        try {
+            operationAuditService.record(
+                    "EXECUTE_AI_TOOL",
+                    "AI_TOOL",
+                    toolName,
+                    clusterId(input),
+                    detail(input),
+                    result,
+                    truncate(errorMessage));
+        } catch (RuntimeException exception) {
+            log.warn("Failed to record AI tool audit for {}: {}", toolName, exception.getMessage());
+        }
+    }
+
+    private String detail(Map<String, Object> input) {
+        return "inputKeys=" + inputKeys(input);
+    }
+
+    private List<String> inputKeys(Map<String, Object> input) {
+        if (input == null || input.isEmpty()) {
+            return List.of();
+        }
+        return input.keySet().stream()
+                .filter(StringUtils::hasText)
+                .sorted(Comparator.naturalOrder())
+                .toList();
+    }
+
+    private String clusterId(Map<String, Object> input) {
+        if (input == null) {
+            return null;
+        }
+        for (String key : List.of("cluster", "clusterId", "instanceId")) {
+            Object value = input.get(key);
+            if (value instanceof String text && StringUtils.hasText(text)) {
+                return text.trim();
+            }
+        }
+        return null;
+    }
+
+    private String truncate(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.length() <= MAX_ERROR_MESSAGE_LENGTH
+                ? trimmed
+                : trimmed.substring(0, MAX_ERROR_MESSAGE_LENGTH);
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiServiceTest.java
@@ -46,6 +46,9 @@ class AiServiceTest {
     @Mock
     private McpServerRegistry mcpServerRegistry;
 
+    @Mock
+    private AiToolAuditService aiToolAuditService;
+
     @InjectMocks
     private AiService aiService;
 
@@ -205,6 +208,19 @@ class AiServiceTest {
 
         assertThat(result).isSameAs(output);
         verify(mcpServerRegistry).execute("rmq.capabilities", input);
+        verify(aiToolAuditService).recordSuccess("rmq.capabilities", input);
+    }
+
+    @Test
+    void executeToolAuditsAndRethrowsFailures() {
+        Map<String, Object> input = Map.of("cluster", "cluster-001");
+        RuntimeException error = new RuntimeException("tool failed");
+        when(mcpServerRegistry.execute("rmq.capabilities", input)).thenThrow(error);
+
+        assertThatThrownBy(() -> aiService.executeTool("rmq.capabilities", input))
+                .isSameAs(error);
+
+        verify(aiToolAuditService).recordFailure("rmq.capabilities", input, error);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiToolAuditServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiToolAuditServiceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AiToolAuditServiceTest {
+
+    @Mock
+    private OperationAuditService operationAuditService;
+
+    @InjectMocks
+    private AiToolAuditService aiToolAuditService;
+
+    @Test
+    void recordSuccessShouldCaptureToolContextWithoutInputValues() {
+        aiToolAuditService.recordSuccess("rmq.capabilities", Map.of(
+                "cluster", "cluster-a",
+                "secretToken", "token-value",
+                "limit", 10));
+
+        ArgumentCaptor<String> detailCaptor = ArgumentCaptor.forClass(String.class);
+        verify(operationAuditService).record(
+                eq("EXECUTE_AI_TOOL"),
+                eq("AI_TOOL"),
+                eq("rmq.capabilities"),
+                eq("cluster-a"),
+                detailCaptor.capture(),
+                eq("SUCCESS"),
+                isNull());
+        assertThat(detailCaptor.getValue()).contains("cluster", "limit", "secretToken")
+                .doesNotContain("token-value");
+    }
+
+    @Test
+    void recordFailureShouldCaptureErrorMessageAndAlternateClusterKey() {
+        RuntimeException error = new RuntimeException("tool failed");
+
+        aiToolAuditService.recordFailure("rmq.topic.list", Map.of("clusterId", "cluster-b"), error);
+
+        verify(operationAuditService).record(
+                eq("EXECUTE_AI_TOOL"),
+                eq("AI_TOOL"),
+                eq("rmq.topic.list"),
+                eq("cluster-b"),
+                eq("inputKeys=[clusterId]"),
+                eq("FAILED"),
+                eq("tool failed"));
+    }
+
+    @Test
+    void auditPersistenceFailureShouldNotEscape() {
+        doThrow(new RuntimeException("audit unavailable"))
+                .when(operationAuditService)
+                .record(any(), any(), any(), any(), any(), any(), any());
+
+        assertThatCode(() -> aiToolAuditService.recordSuccess("rmq.cluster.list", Map.of()))
+                .doesNotThrowAnyException();
+    }
+}

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -73,6 +73,7 @@ const renderPage = () =>
 describe('AiPage tool runner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     vi.mocked(getLlmConfig).mockResolvedValue({
       provider: 'openai',
       apiBase: 'https://api.openai.com/v1',
@@ -136,14 +137,72 @@ describe('AiPage tool runner', () => {
     expect(within(dialog).getByTestId('tool-result')).toHaveTextContent('"GRPC"');
   });
 
+  it('records successful tool executions in recent history', async () => {
+    const user = userEvent.setup();
+    vi.mocked(executeTool).mockResolvedValue({
+      cluster: 'cluster-a',
+      status: 'READY',
+    });
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: '工具' }));
+    const dialog = await screen.findByRole('dialog', { name: 'AI 工具' });
+    await waitFor(() => expect(listTools).toHaveBeenCalledWith('cluster-a'));
+    await user.click(within(dialog).getByRole('button', { name: /执\s*行/ }));
+
+    expect(await within(dialog).findByText('最近执行')).toBeInTheDocument();
+    expect(within(dialog).getByText('成功')).toBeInTheDocument();
+
+    const stored = JSON.parse(
+      localStorage.getItem('rocketmq-studio-ai-tool-execution-history') || '[]',
+    ) as Array<{ toolName: string; status: string; inputKeys: string[] }>;
+    expect(stored[0]).toMatchObject({
+      toolName: 'rmq.capabilities',
+      status: 'SUCCESS',
+      inputKeys: ['cluster'],
+    });
+  });
+
+  it('records failed tool executions in recent history', async () => {
+    const user = userEvent.setup();
+    vi.mocked(executeTool).mockRejectedValue(new Error('broker rejected request'));
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: '工具' }));
+    const dialog = await screen.findByRole('dialog', { name: 'AI 工具' });
+    await waitFor(() => expect(listTools).toHaveBeenCalledWith('cluster-a'));
+    await user.click(within(dialog).getByRole('button', { name: /执\s*行/ }));
+
+    expect(await within(dialog).findByText('最近执行')).toBeInTheDocument();
+    expect(within(dialog).getByText('失败')).toBeInTheDocument();
+
+    const stored = JSON.parse(
+      localStorage.getItem('rocketmq-studio-ai-tool-execution-history') || '[]',
+    ) as Array<{ toolName: string; status: string; inputKeys: string[]; errorMessage?: string }>;
+    expect(stored[0]).toMatchObject({
+      toolName: 'rmq.capabilities',
+      status: 'FAILED',
+      inputKeys: ['cluster'],
+      errorMessage: 'broker rejected request',
+    });
+  });
+
   it('ignores an older tool catalog after the cluster changes', async () => {
     const oldTools = [{ name: 'rmq.old', description: 'old', parameters: {} }];
     const latestTools = [{ name: 'rmq.latest', description: 'latest', parameters: {} }];
     let resolveOld!: (value: typeof oldTools) => void;
     let resolveLatest!: (value: typeof latestTools) => void;
     vi.mocked(listTools)
-      .mockReturnValueOnce(new Promise((resolve) => { resolveOld = resolve; }))
-      .mockReturnValueOnce(new Promise((resolve) => { resolveLatest = resolve; }));
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveOld = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveLatest = resolve;
+        }),
+      );
     const user = userEvent.setup();
     renderPage();
 

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -91,6 +91,17 @@ interface Message {
   actions?: { label: string; type?: 'primary' | 'default' }[];
 }
 
+interface ToolExecutionHistoryItem {
+  id: string;
+  toolName: string;
+  clusterLabel: string;
+  status: 'SUCCESS' | 'FAILED';
+  timestamp: string;
+  inputKeys: string[];
+  resultPreview?: string;
+  errorMessage?: string;
+}
+
 /* ─── Mock Data ─── */
 
 const initialMessages: Message[] = [];
@@ -107,6 +118,8 @@ const quickActions = [
 ];
 
 const GLOBAL_TOOL_SCOPE = '__global__';
+const TOOL_EXECUTION_HISTORY_KEY = 'rocketmq-studio-ai-tool-execution-history';
+const MAX_TOOL_EXECUTION_HISTORY = 8;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -146,6 +159,52 @@ const buildToolInputTemplate = (tool: McpTool, cluster?: string): string => {
 
 const formatToolResult = (result: unknown): string =>
   typeof result === 'string' ? result : (JSON.stringify(result, null, 2) ?? 'null');
+
+const isToolExecutionStatus = (value: unknown): value is ToolExecutionHistoryItem['status'] =>
+  value === 'SUCCESS' || value === 'FAILED';
+
+const isToolExecutionHistoryItem = (value: unknown): value is ToolExecutionHistoryItem => {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === 'string' &&
+    typeof value.toolName === 'string' &&
+    typeof value.clusterLabel === 'string' &&
+    typeof value.timestamp === 'string' &&
+    isToolExecutionStatus(value.status) &&
+    Array.isArray(value.inputKeys) &&
+    value.inputKeys.every((item) => typeof item === 'string') &&
+    (value.resultPreview === undefined || typeof value.resultPreview === 'string') &&
+    (value.errorMessage === undefined || typeof value.errorMessage === 'string')
+  );
+};
+
+const loadToolExecutionHistory = (): ToolExecutionHistoryItem[] => {
+  try {
+    const stored = localStorage.getItem(TOOL_EXECUTION_HISTORY_KEY);
+    if (!stored) return [];
+    const parsed: unknown = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isToolExecutionHistoryItem).slice(0, MAX_TOOL_EXECUTION_HISTORY);
+  } catch {
+    return [];
+  }
+};
+
+const persistToolExecutionHistory = (items: ToolExecutionHistoryItem[]) => {
+  try {
+    localStorage.setItem(TOOL_EXECUTION_HISTORY_KEY, JSON.stringify(items));
+  } catch {
+    // Best-effort UI history should never block tool execution.
+  }
+};
+
+const inputKeys = (input: Record<string, unknown>): string[] =>
+  Object.keys(input)
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b));
+
+const previewText = (value: string, limit = 160): string =>
+  value.length <= limit ? value : `${value.slice(0, limit)}…`;
 
 /* ─── Sub-components ─── */
 
@@ -398,6 +457,8 @@ const AiPage = () => {
   const [toolInput, setToolInput] = useState('{}');
   const [toolResult, setToolResult] = useState<unknown>(undefined);
   const [toolExecuting, setToolExecuting] = useState(false);
+  const [toolExecutionHistory, setToolExecutionHistory] =
+    useState<ToolExecutionHistoryItem[]>(loadToolExecutionHistory);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -673,6 +734,29 @@ const AiPage = () => {
     [loadTools],
   );
 
+  const rememberToolExecution = useCallback(
+    (execution: Omit<ToolExecutionHistoryItem, 'id' | 'timestamp'>) => {
+      setToolExecutionHistory((current) => {
+        const next = [
+          {
+            id: `tool-${Date.now()}`,
+            timestamp: new Date().toISOString(),
+            ...execution,
+          },
+          ...current,
+        ].slice(0, MAX_TOOL_EXECUTION_HISTORY);
+        persistToolExecutionHistory(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const clearToolExecutionHistory = useCallback(() => {
+    setToolExecutionHistory([]);
+    persistToolExecutionHistory([]);
+  }, []);
+
   const handleExecuteTool = useCallback(async () => {
     if (!selectedToolName || toolExecuting) return;
 
@@ -690,15 +774,42 @@ const AiPage = () => {
 
     setToolExecuting(true);
     setToolResult(undefined);
+    const keys = inputKeys(parsedInput);
+    const clusterLabel = selectedClusterId
+      ? (clusterOptions.find((option) => option.value === selectedClusterId)?.label ??
+        selectedClusterId)
+      : '全局工具';
     try {
-      setToolResult(await executeTool(selectedToolName, parsedInput));
+      const result = await executeTool(selectedToolName, parsedInput);
+      setToolResult(result);
+      rememberToolExecution({
+        toolName: selectedToolName,
+        clusterLabel,
+        status: 'SUCCESS',
+        inputKeys: keys,
+        resultPreview: previewText(formatToolResult(result)),
+      });
       message.success('工具执行成功');
-    } catch {
+    } catch (error) {
+      rememberToolExecution({
+        toolName: selectedToolName,
+        clusterLabel,
+        status: 'FAILED',
+        inputKeys: keys,
+        errorMessage: error instanceof Error ? error.message : '工具执行失败',
+      });
       message.error('工具执行失败');
     } finally {
       setToolExecuting(false);
     }
-  }, [selectedToolName, toolExecuting, toolInput]);
+  }, [
+    clusterOptions,
+    rememberToolExecution,
+    selectedClusterId,
+    selectedToolName,
+    toolExecuting,
+    toolInput,
+  ]);
 
   const selectedTool = tools.find((tool) => tool.name === selectedToolName);
 
@@ -946,6 +1057,63 @@ const AiPage = () => {
               >
                 {formatToolResult(toolResult)}
               </pre>
+            </div>
+          )}
+
+          {toolExecutionHistory.length > 0 && (
+            <div>
+              <Flex align="center" justify="space-between" style={{ marginBottom: 8 }}>
+                <Text strong>最近执行</Text>
+                <Button size="small" type="link" onClick={clearToolExecutionHistory}>
+                  清空
+                </Button>
+              </Flex>
+              <Table<ToolExecutionHistoryItem>
+                rowKey="id"
+                size="small"
+                pagination={false}
+                dataSource={toolExecutionHistory}
+                columns={[
+                  {
+                    title: '时间',
+                    dataIndex: 'timestamp',
+                    width: 140,
+                    render: (value: string) => new Date(value).toLocaleString(),
+                  },
+                  {
+                    title: '工具',
+                    dataIndex: 'toolName',
+                    ellipsis: true,
+                  },
+                  {
+                    title: '集群',
+                    dataIndex: 'clusterLabel',
+                    width: 120,
+                  },
+                  {
+                    title: '状态',
+                    dataIndex: 'status',
+                    width: 80,
+                    render: (value: ToolExecutionHistoryItem['status']) => (
+                      <Tag color={value === 'SUCCESS' ? 'green' : 'red'}>
+                        {value === 'SUCCESS' ? '成功' : '失败'}
+                      </Tag>
+                    ),
+                  },
+                  {
+                    title: '输入字段',
+                    dataIndex: 'inputKeys',
+                    render: (value: string[]) => (value.length > 0 ? value.join(', ') : '-'),
+                  },
+                  {
+                    title: '结果预览',
+                    render: (_: unknown, record) =>
+                      record.status === 'SUCCESS'
+                        ? record.resultPreview || '-'
+                        : record.errorMessage || '-',
+                  },
+                ]}
+              />
             </div>
           )}
         </Flex>


### PR DESCRIPTION
## What is the purpose of the change

Add auditability and recent execution visibility for AI tool runs so operators can trace which tools were executed, whether they succeeded, and which input fields were used without exposing input values.

## Brief changelog

- Added backend audit recording for successful and failed AI tool executions.
- Recorded tool name, cluster/instance context, input field names, result status, and sanitized error messages without storing input values.
- Added recent AI tool execution history in the AI tool modal with success/failure status and result previews.
- Added backend service tests and frontend tool-runner tests for the audit/history flow.

## Verifying this change

- `/Users/yx9o/home/env/apache-maven-3.9.1/bin/mvn -Dtest=AiServiceTest,AiToolAuditServiceTest,AiControllerTest test`
- `NODE_OPTIONS="--import=data:text/javascript,import%20dns%20from%20'node:dns';const%20p=dns.promises.lookup.bind(dns.promises);dns.promises.lookup=(h,...a)=>p(h==='localhost'?'127.0.0.1':h,...a);const%20l=dns.lookup.bind(dns);dns.lookup=(h,...a)=>l(h==='localhost'?'127.0.0.1':h,...a);" npx vitest run src/pages/ai/__tests__/AiPage.test.tsx`
- `npm run build`
- `npm run lint`
- `git diff --check`