### PR TITLE
fix: surface failed message trace queries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -263,8 +263,11 @@ public class RocketMQMessageProvider implements MessageProvider {
                     parseTraceBody(traceMessage.getBody(), msgId, nodes, consumerStatus);
                 }
             }
+        } catch (BusinessException e) {
+            throw e;
         } catch (Exception e) {
             log.warn("Trace query for msgId={} failed: {}", msgId, e.getMessage());
+            throw new BusinessException(502, "Failed to query message trace: " + e.getMessage());
         }
 
         recordTraceQuery(instanceId, msgId, null, nodes.size(), consumerStatus.size());

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -256,4 +256,17 @@ class RocketMQMessageProviderTest {
         assertThat(transaction.getDescription()).contains("tx-group").contains("COMMIT_MESSAGE");
         assertThat(record.getConsumerStatus()).isEmpty();
     }
+
+    @Test
+    void getMessageTraceSurfacesAdminFailure() throws Exception {
+        when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
+                .thenThrow(new IllegalStateException("broker unavailable"));
+
+        assertThatThrownBy(() -> provider.getMessageTrace("instance-a", "msg-123"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Failed to query message trace: broker unavailable")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+
+        verify(queryHistoryService, never()).recordTraceQuery(anyString(), anyString(), any(), anyInt(), anyInt());
+    }
 }


### PR DESCRIPTION
Closes #1275

## Summary
- distinguish a failed Trace Topic query from a successful empty trace
- preserve structured gateway failures for Broker, ACL, and network errors
- avoid recording a successful trace-history entry after a failed query

## Validation
- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) PATH="$JAVA_HOME/bin:$PATH" mvn -q -Dtest=RocketMQMessageProviderTest test`