### PR TITLE
fix: scope Consumer Group diagnostics caches by instance

### DIFF
--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -262,6 +262,57 @@ describe('Consumer page', () => {
     );
   });
 
+  it('reloads same-named group diagnostics after changing the selected instance', async () => {
+    vi.mocked(instanceService.listInstances).mockResolvedValue([
+      {
+        id: 'instance-a',
+        name: 'Instance A',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '127.0.0.1:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-07-23T00:00:00Z',
+        updatedAt: '2026-07-23T00:00:00Z',
+      },
+      {
+        id: 'instance-b',
+        name: 'Instance B',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '127.0.0.2:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-07-23T00:00:00Z',
+        updatedAt: '2026-07-23T00:00:00Z',
+      },
+    ]);
+    vi.mocked(consumerService.listConsumerGroups).mockImplementation(async (params) => [
+      { ...group, instanceId: params?.instanceId ?? 'instance-a' },
+    ]);
+    const user = userEvent.setup();
+    renderWithProviders(<ConsumerPage />, '/instance/instance-a/consumer');
+
+    await user.click(await screen.findByRole('button', { name: /详情/ }));
+    await waitFor(() =>
+      expect(consumerService.getConsumerSubscriptions).toHaveBeenCalledWith('remote-cg', 'instance-a'),
+    );
+
+    await user.click(screen.getByText('Instance A'));
+    await user.click(await screen.findByText('Instance B'));
+    await waitFor(() =>
+      expect(consumerService.listConsumerGroups).toHaveBeenCalledWith({ instanceId: 'instance-b' }),
+    );
+    await user.click(await screen.findByRole('button', { name: /详情/ }));
+
+    await waitFor(() =>
+      expect(consumerService.getConsumerSubscriptions).toHaveBeenCalledWith('remote-cg', 'instance-b'),
+    );
+    await waitFor(() =>
+      expect(consumerService.getConsumerProgress).toHaveBeenCalledWith('remote-cg', 'instance-b'),
+    );
+  });
+
   it('highlights inconsistent subscriptions and refreshes the check result', async () => {
     vi.mocked(consumerService.getConsumerSubscriptions)
       .mockResolvedValueOnce([

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -176,6 +176,9 @@ const isConsistentSubscription = (subscription: SubscriptionEntry): boolean =>
 const isInconsistentSubscription = (subscription: SubscriptionEntry): boolean =>
   isInconsistentValue(subscription.consistency);
 
+export const diagnosticCacheKey = (instanceId: string, groupName: string) =>
+  `${instanceId}\u0000${groupName}`;
+
 /* ═══════════════════════════════════════════
    ConsumerPage
    ═══════════════════════════════════════════ */
@@ -223,6 +226,13 @@ const ConsumerPage = () => {
   const groupRequestIdRef = useRef(0);
 
   useEffect(() => {
+    setSelectedGroup(null);
+    setModalOpen(false);
+    setResetGroup(null);
+    setResetModalOpen(false);
+  }, [selectedInstanceId]);
+
+  useEffect(() => {
     if (!selectedInstanceId) {
       return;
     }
@@ -247,20 +257,21 @@ const ConsumerPage = () => {
 
   const loadSubscriptions = useCallback(
     async (groupName: string, force = false) => {
-      if (!force && subscriptionsByGroup[groupName]) return;
-      setSubscriptionLoadingByGroup((prev) => ({ ...prev, [groupName]: true }));
-      setSubscriptionErrorByGroup((prev) => ({ ...prev, [groupName]: false }));
+      const cacheKey = diagnosticCacheKey(selectedInstanceId, groupName);
+      if (!force && subscriptionsByGroup[cacheKey]) return;
+      setSubscriptionLoadingByGroup((prev) => ({ ...prev, [cacheKey]: true }));
+      setSubscriptionErrorByGroup((prev) => ({ ...prev, [cacheKey]: false }));
       try {
         const subscriptions = await getConsumerSubscriptions(
           groupName,
           selectedInstanceId || undefined,
         );
-        setSubscriptionsByGroup((prev) => ({ ...prev, [groupName]: subscriptions }));
+        setSubscriptionsByGroup((prev) => ({ ...prev, [cacheKey]: subscriptions }));
       } catch {
-        setSubscriptionErrorByGroup((prev) => ({ ...prev, [groupName]: true }));
+        setSubscriptionErrorByGroup((prev) => ({ ...prev, [cacheKey]: true }));
         message.error(t('consumer.fetchSubscriptionsFailed', { name: groupName }));
       } finally {
-        setSubscriptionLoadingByGroup((prev) => ({ ...prev, [groupName]: false }));
+        setSubscriptionLoadingByGroup((prev) => ({ ...prev, [cacheKey]: false }));
       }
     },
     [subscriptionsByGroup, t, selectedInstanceId],
@@ -268,10 +279,11 @@ const ConsumerPage = () => {
 
   const loadProgress = useCallback(
     async (groupName: string) => {
-      if (progressByGroup[groupName]) return;
+      const cacheKey = diagnosticCacheKey(selectedInstanceId, groupName);
+      if (progressByGroup[cacheKey]) return;
       try {
         const progress = await getConsumerProgress(groupName, selectedInstanceId || undefined);
-        setProgressByGroup((prev) => ({ ...prev, [groupName]: progress }));
+        setProgressByGroup((prev) => ({ ...prev, [cacheKey]: progress }));
       } catch {
         message.error(t('consumer.fetchProgressFailed', { name: groupName }));
       }
@@ -311,8 +323,11 @@ const ConsumerPage = () => {
     void loadProgress(group.name);
   };
 
+  const selectedDiagnosticKey = selectedGroup
+    ? diagnosticCacheKey(selectedInstanceId, selectedGroup.name)
+    : '';
   const selectedSubscriptions = selectedGroup
-    ? (subscriptionsByGroup[selectedGroup.name] ?? [])
+    ? (subscriptionsByGroup[selectedDiagnosticKey] ?? [])
     : [];
   const inconsistentSubscriptions = selectedSubscriptions.filter(isInconsistentSubscription);
   const unknownSubscriptions = selectedSubscriptions.filter(
@@ -322,7 +337,7 @@ const ConsumerPage = () => {
   const visibleSubscriptions = showOnlyInconsistent
     ? inconsistentSubscriptions
     : selectedSubscriptions;
-  const selectedProgress = selectedGroup ? (progressByGroup[selectedGroup.name] ?? []) : [];
+  const selectedProgress = selectedGroup ? (progressByGroup[selectedDiagnosticKey] ?? []) : [];
 
   const handleImportFile = async (file: File) => {
     if (!selectedInstanceId) {
@@ -895,9 +910,11 @@ const ConsumerPage = () => {
               <div style={{ padding: '8px 0' }}>
                 <Table
                   columns={subscriptionSubColumns}
-                  dataSource={subscriptionsByGroup[record.name] ?? []}
+                  dataSource={
+                    subscriptionsByGroup[diagnosticCacheKey(selectedInstanceId, record.name)] ?? []
+                  }
                   rowKey="topic"
-                  loading={subscriptionLoadingByGroup[record.name]}
+                  loading={subscriptionLoadingByGroup[diagnosticCacheKey(selectedInstanceId, record.name)]}
                   pagination={false}
                   size="small"
                 />
@@ -1073,7 +1090,7 @@ const ConsumerPage = () => {
                         <Button
                           size="small"
                           icon={<ArrowsClockwise size={14} />}
-                          loading={subscriptionLoadingByGroup[selectedGroup.name]}
+                          loading={subscriptionLoadingByGroup[selectedDiagnosticKey]}
                           onClick={() => {
                             setShowOnlyInconsistent(false);
                             void loadSubscriptions(selectedGroup.name, true);
@@ -1085,7 +1102,7 @@ const ConsumerPage = () => {
                       <Alert
                         showIcon
                         type={
-                          subscriptionErrorByGroup[selectedGroup.name]
+                          subscriptionErrorByGroup[selectedDiagnosticKey]
                             ? 'error'
                             : inconsistentSubscriptions.length > 0 ||
                                 unknownSubscriptions.length > 0
@@ -1095,9 +1112,9 @@ const ConsumerPage = () => {
                                 : 'info'
                         }
                         message={
-                          subscriptionErrorByGroup[selectedGroup.name]
+                          subscriptionErrorByGroup[selectedDiagnosticKey]
                             ? '订阅一致性检查失败，当前保留上次检查结果'
-                            : subscriptionLoadingByGroup[selectedGroup.name] &&
+                            : subscriptionLoadingByGroup[selectedDiagnosticKey] &&
                                 selectedSubscriptions.length === 0
                               ? '正在检查订阅一致性'
                               : inconsistentSubscriptions.length > 0
@@ -1123,7 +1140,7 @@ const ConsumerPage = () => {
                         columns={subscriptionSubColumns}
                         dataSource={visibleSubscriptions}
                         rowKey="topic"
-                        loading={subscriptionLoadingByGroup[selectedGroup.name]}
+                        loading={subscriptionLoadingByGroup[selectedDiagnosticKey]}
                         pagination={false}
                         size="small"
                       />


### PR DESCRIPTION
Closes #1277

## Summary
- qualify Consumer Group subscription and progress caches with the selected instance
- close stale detail and reset dialogs when the instance changes
- reload diagnostics for same-named groups in a different instance

## Validation
- `npm test -- --run src/pages/instance/__tests__/ConsumerPage.test.tsx`
- `npm run build`