### PR TITLE
fix: clear stale DLQ state when switching instances

### DIFF
--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -43,6 +43,17 @@ vi.mock('../../../services/instanceService', () => ({
       createdAt: '',
       updatedAt: '',
     },
+    {
+      id: 'instance-2',
+      name: 'Instance 2',
+      endpoint: 'namesrv-2:9876',
+      type: 'DIRECT',
+      remark: '',
+      topicCount: 0,
+      consumerGroupCount: 0,
+      createdAt: '',
+      updatedAt: '',
+    },
   ]),
 }));
 
@@ -252,5 +263,40 @@ describe('DLQ page', () => {
     await user.click(screen.getByRole('button', { name: '确认重投' }));
 
     expect(await screen.findByText('DLQ provider is not configured')).toBeInTheDocument();
+  });
+
+  it('clears retry state before loading groups for a newly selected instance', async () => {
+    let resolveSecondInstance!: (groups: DLQGroup[]) => void;
+    vi.mocked(messageService.listDLQGroups)
+      .mockResolvedValueOnce([dlqGroup])
+      .mockImplementationOnce(
+        () =>
+          new Promise<DLQGroup[]>((resolve) => {
+            resolveSecondInstance = resolve;
+          }),
+      );
+    const user = userEvent.setup();
+    renderWithProviders(<DLQPage />);
+
+    const orderRow = (await screen.findByText('cg-order')).closest('tr');
+    if (!orderRow) throw new Error('DLQ group row not found');
+
+    await user.click(within(orderRow).getByRole('button', { name: '重投消息' }));
+    expect(await screen.findByText('重投死信消息')).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(
+      await screen.findByText('Instance 2', { selector: '.ant-select-item-option-content' }),
+    );
+
+    await waitFor(() => {
+      expect(messageService.listDLQGroups).toHaveBeenLastCalledWith('instance-2');
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('row', { name: /cg-order/ })).not.toBeInTheDocument();
+    });
+
+    resolveSecondInstance([secondDlqGroup]);
+    expect(await screen.findByText('-cg-"payment"')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -125,12 +125,22 @@ const DLQPage = () => {
   useEffect(() => {
     let cancelled = false;
 
+    // The retry dialog owns a group name that is meaningful only for the
+    // currently selected instance. Clear all instance-scoped state before
+    // starting the next request so an old group cannot be retried on a new
+    // instance while that request is in flight.
+    setGroups([]);
+    setSelectedGroupNames([]);
+    setDetailGroup(null);
+    setRetryModalOpen(false);
+    setRetryGroup(null);
+    setRetryTargetTopic('');
+    setRetryError(null);
+    setLoadError(null);
+
     if (!selectedInstanceId) {
       void Promise.resolve().then(() => {
         if (cancelled) return;
-        setGroups([]);
-        setSelectedGroupNames([]);
-        setLoadError(null);
         setLoading(false);
       });
       return () => {
@@ -138,6 +148,7 @@ const DLQPage = () => {
       };
     }
 
+    setLoading(true);
     void listDLQGroups(selectedInstanceId)
       .then((nextGroups) => {
         if (!cancelled) {


### PR DESCRIPTION
Closes #1279

Clear instance-scoped DLQ rows, selections, details, and retry state before loading data for a newly selected instance. This prevents a retry dialog opened for one instance from retaining a stale consumer group while the next instance is loading.

Validation:
- `npm test -- --run src/pages/instance/__tests__/DLQPage.test.tsx`
- `npm run build`