### PR TITLE
fix: harden instance-scoped client connection views

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientService.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.client;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -31,7 +32,14 @@ public class ClientService {
 
     public List<ClientConnectionVO> listConnections(String instanceId, String clusterId, String type) {
         log.info("Listing client connections, instanceId={}, clusterId={}, type={}", instanceId, clusterId, type);
-        return clientProvider.findConnections(normalizeFilter(instanceId), normalizeFilter(clusterId), normalizeFilter(type));
+        return clientProvider.findConnections(requireInstanceId(instanceId), normalizeFilter(clusterId), normalizeFilter(type));
+    }
+
+    private String requireInstanceId(String instanceId) {
+        if (instanceId == null || instanceId.isBlank()) {
+            throw new BusinessException(400, "instanceId is required");
+        }
+        return instanceId.trim();
     }
 
     private String normalizeFilter(String value) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientServiceTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.client;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -25,7 +26,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,12 +55,21 @@ class ClientServiceTest {
     }
 
     @Test
-    void listConnectionsShouldTreatBlankFiltersAsUnspecified() {
-        when(clientProvider.findConnections(null, null, null)).thenReturn(List.of());
+    void listConnectionsShouldTreatBlankOptionalFiltersAsUnspecified() {
+        when(clientProvider.findConnections("instance-1", null, null)).thenReturn(List.of());
 
-        List<ClientConnectionVO> result = clientService.listConnections(" ", " ", "\t");
+        List<ClientConnectionVO> result = clientService.listConnections("instance-1", " ", "\t");
 
         assertThat(result).isEmpty();
-        verify(clientProvider).findConnections(null, null, null);
+        verify(clientProvider).findConnections("instance-1", null, null);
+    }
+
+    @Test
+    void listConnectionsShouldRejectBlankInstanceIdBeforeQueryingProvider() {
+        assertThatThrownBy(() -> clientService.listConnections(" ", null, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("instanceId is required");
+
+        verifyNoInteractions(clientProvider);
     }
 }

--- a/web/src/api/producer.test.ts
+++ b/web/src/api/producer.test.ts
@@ -34,12 +34,15 @@ describe('Producer API', () => {
   });
 
   it('fetches Studio topic records sorted alphabetically', async () => {
-    mock.onGet('/topics').reply(200, {
+    mock.onGet('/topics').reply((config) => {
+      expect(config.params.instanceId).toBe('instance-1');
+      return [200, {
       code: 200,
       data: [{ name: 'order-events' }, { name: 'user-signup' }, { name: 'batch-process' }],
+      }];
     });
 
-    const result = await fetchTopicList();
+    const result = await fetchTopicList('instance-1');
     expect(result).toEqual(['batch-process', 'order-events', 'user-signup']);
   });
 
@@ -48,14 +51,14 @@ describe('Producer API', () => {
       topicList: ['order-events', 'user-signup', 'batch-process'],
     });
 
-    const result = await fetchTopicList();
+    const result = await fetchTopicList('instance-1');
     expect(result).toEqual(['batch-process', 'order-events', 'user-signup']);
   });
 
   it('handles empty topic list', async () => {
     mock.onGet('/topics').reply(200, { topicList: [] });
 
-    const result = await fetchTopicList();
+    const result = await fetchTopicList('instance-1');
     expect(result).toEqual([]);
   });
 

--- a/web/src/api/producer.ts
+++ b/web/src/api/producer.ts
@@ -36,9 +36,9 @@ interface TopicListResponse {
 
 // ─── API ────────────────────────────────────────────────────────
 
-/** Fetch all topic names */
-export async function fetchTopicList(): Promise<string[]> {
-  const res = await client.get<TopicListResponse>('/topics');
+/** Fetch topic names for a managed instance. */
+export async function fetchTopicList(instanceId: string): Promise<string[]> {
+  const res = await client.get<TopicListResponse>('/topics', { params: { instanceId } });
   const topics = res.data.data?.map((topic) => topic.name) ?? res.data.topicList ?? [];
   return topics.sort();
 }

--- a/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
@@ -23,6 +23,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import type { ClientConnection } from '../../../api/connections';
 import { LangProvider } from '../../../i18n/LangContext';
 import * as connectionsService from '../../../services/connectionsService';
+import * as instanceService from '../../../services/instanceService';
 import ClientsPage from '../clients';
 
 vi.mock('../../../services/connectionsService', () => ({
@@ -219,6 +220,33 @@ describe('Clients page', () => {
       await screen.findByText('Client connection provider is not configured'),
     ).toBeInTheDocument();
     expect(within(screen.getByTestId('connection-total')).getByText('0')).toBeInTheDocument();
+  });
+
+  it('surfaces instance discovery failures and allows retrying', async () => {
+    vi.mocked(instanceService.listInstances)
+      .mockRejectedValueOnce(new Error('Unable to load managed instances'))
+      .mockResolvedValueOnce([
+        {
+          id: 'instance-1',
+          name: 'Instance 1',
+          endpoint: 'namesrv-1:9876',
+          type: 'DIRECT',
+          remark: '',
+          topicCount: 0,
+          consumerGroupCount: 0,
+          createdAt: '',
+          updatedAt: '',
+        },
+      ]);
+    const user = userEvent.setup();
+    renderWithProviders(<ClientsPage />);
+
+    expect(await screen.findByText('Unable to load managed instances')).toBeInTheDocument();
+    expect(connectionsService.listConnections).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /重\s*试/ }));
+    await screen.findByText('order-svc-0@10.0.1.12:49152');
+    expect(connectionsService.listConnections).toHaveBeenCalledWith({ instanceId: 'instance-1' });
   });
 
   it('opens a client detail dialog from the connection table', async () => {

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -114,18 +114,34 @@ const ClientsPage = () => {
   const [clusterFilter, setClusterFilter] = useState<string>('ALL');
   const [selectedConnection, setSelectedConnection] = useState<ClientConnection | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [instanceLoadKey, setInstanceLoadKey] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
-    void listInstances().then((nextInstances) => {
-      if (cancelled) return;
-      setInstances(nextInstances);
-      setSelectedInstanceId((current) => current || nextInstances[0]?.id || '');
-    });
+
+    setLoading(true);
+    void listInstances()
+      .then((nextInstances) => {
+        if (cancelled) return;
+        setInstances(nextInstances);
+        setSelectedInstanceId((current) => current || nextInstances[0]?.id || '');
+        setLoadError(null);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setInstances([]);
+        setSelectedInstanceId('');
+        setConnections([]);
+        setLoadError(getLoadErrorMessage(error));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [instanceLoadKey]);
 
   useEffect(() => {
     let cancelled = false;
@@ -355,7 +371,17 @@ const ClientsPage = () => {
       />
 
       {loadError && (
-        <Alert showIcon type="warning" message={loadError} style={{ marginBottom: 16 }} />
+        <Alert
+          showIcon
+          type="warning"
+          message={loadError}
+          style={{ marginBottom: 16 }}
+          action={
+            <Button size="small" onClick={() => setInstanceLoadKey((key) => key + 1)}>
+              重试
+            </Button>
+          }
+        />
       )}
       {connections.some((connection) => connection.partial) && (
         <Alert

--- a/web/src/pages/studio/Producer.tsx
+++ b/web/src/pages/studio/Producer.tsx
@@ -63,7 +63,18 @@ const ProducerPage = () => {
   useEffect(() => {
     let cancelled = false;
 
-    void fetchTopicList()
+    setTopicList([]);
+    setProducerGroups([]);
+    setConnectionList([]);
+    form.resetFields(['selectedTopic', 'producerGroup']);
+
+    if (!selectedInstanceId) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    void fetchTopicList(selectedInstanceId)
       .then((topics) => {
         if (!cancelled) {
           setTopicList(topics);
@@ -78,7 +89,7 @@ const ProducerPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [fetchTopicFailedMessage, message]);
+  }, [fetchTopicFailedMessage, form, message, selectedInstanceId]);
 
   useEffect(() => {
     let cancelled = false;

--- a/web/src/pages/studio/__tests__/Producer.test.tsx
+++ b/web/src/pages/studio/__tests__/Producer.test.tsx
@@ -87,7 +87,7 @@ describe('ProducerPage', () => {
     renderWithProviders(<ProducerPage />);
 
     await waitFor(() => {
-      expect(fetchTopicList).toHaveBeenCalledTimes(1);
+      expect(fetchTopicList).toHaveBeenCalledWith('instance-1');
     });
   });
 
@@ -185,5 +185,53 @@ describe('ProducerPage', () => {
         'manual-producer',
       );
     });
+  });
+
+  it('clears stale producer query state before loading a new instance', async () => {
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'instance-1',
+        name: 'Primary instance',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '127.0.0.1:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-08-01T00:00:00',
+        updatedAt: '2026-08-01T00:00:00',
+      },
+      {
+        id: 'instance-2',
+        name: 'Secondary instance',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '127.0.0.2:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-08-01T00:00:00',
+        updatedAt: '2026-08-01T00:00:00',
+      },
+    ]);
+    vi.mocked(fetchTopicList).mockResolvedValueOnce(['order-events']).mockResolvedValueOnce([]);
+    vi.mocked(queryProducerConnection).mockResolvedValue([
+      { clientId: 'producer-1', clientAddr: '192.168.1.10', language: 'JAVA', versionDesc: '5.1.0' },
+    ]);
+    const user = userEvent.setup();
+    renderWithProviders(<ProducerPage />);
+
+    await waitFor(() => expect(fetchTopicList).toHaveBeenCalledWith('instance-1'));
+    const [instanceSelect, topicSelect, groupInput] = screen.getAllByRole('combobox');
+    fireEvent.mouseDown(topicSelect.parentElement!);
+    await user.click(await screen.findByText('order-events', { selector: '.ant-select-item-option-content' }));
+    await user.type(groupInput, 'order-producer');
+    await user.click(screen.getByRole('button', { name: /搜索/ }));
+    expect(await screen.findByText('producer-1')).toBeInTheDocument();
+
+    fireEvent.mouseDown(instanceSelect.parentElement!);
+    await user.click(await screen.findByText('Secondary instance', { selector: '.ant-select-item-option-content' }));
+
+    await waitFor(() => expect(fetchTopicList).toHaveBeenLastCalledWith('instance-2'));
+    expect(screen.queryByText('producer-1')).not.toBeInTheDocument();
+    expect(screen.queryByText('order-events')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- handles selected-instance bootstrap failures before rendering client connection views;
- scopes Producer topic loading to the selected instance;
- requires an instance ID for backend client connection queries to prevent accidental fallback to a default endpoint.

Closes #1281
Closes #1375

## Test

```bash
cd server
JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -q -Dtest=ClientServiceTest,ClientControllerTest test
cd ../web
npm test -- --run src/pages/studio/__tests__/Producer.test.tsx src/api/producer.test.ts
```