### PR TITLE
fix: stop resource loading without an instance

### DIFF
--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -421,6 +421,8 @@ describe('Consumer page', () => {
     renderWithProviders(<ConsumerPage />);
 
     expect(await screen.findByText('选择实例')).toBeInTheDocument();
+    expect(consumerService.listConsumerGroups).not.toHaveBeenCalled();
+    expect(document.querySelector('.ant-spin-spinning')).toBeNull();
     expect(screen.getByRole('button', { name: /导入/ })).toBeDisabled();
     expect(screen.getByRole('button', { name: '创建 Group' })).toBeDisabled();
   });

--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -391,6 +391,8 @@ describe('TopicPage', () => {
     renderWithProviders();
 
     expect(await screen.findByText('共 0 个 Topic')).toBeInTheDocument();
+    expect(topicServiceMocks.listTopics).not.toHaveBeenCalled();
+    expect(document.querySelector('.ant-spin-spinning')).toBeNull();
     expect(screen.getByRole('button', { name: /导入/ })).toBeDisabled();
     expect(screen.getByRole('button', { name: /创建 Topic/ })).toBeDisabled();
   });

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -224,6 +224,10 @@ const ConsumerPage = () => {
 
   useEffect(() => {
     if (!selectedInstanceId) {
+      groupRequestIdRef.current += 1;
+      setGroups([]);
+      setSelectedRowKeys([]);
+      setLoading(false);
       return;
     }
     const requestId = ++groupRequestIdRef.current;

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -307,6 +307,10 @@ const TopicPage = () => {
 
   useEffect(() => {
     if (!selectedInstanceId) {
+      topicRequestIdRef.current += 1;
+      setTopics([]);
+      setSelectedRowKeys([]);
+      setLoading(false);
       return;
     }
     const requestId = ++topicRequestIdRef.current;


### PR DESCRIPTION
Closes #1283

Stop Topic and Consumer Group tables from retaining their initial loading state when no managed instance is available. The no-instance branch now invalidates pending requests, clears instance-scoped selections, and completes loading without issuing resource requests.

Validation:
- `npm test -- --run src/pages/instance/__tests__/TopicPage.test.tsx src/pages/instance/__tests__/ConsumerPage.test.tsx`
- `npm run build`