### PR TITLE
fix: scope producer topics by selected instance

### DIFF
--- a/web/src/api/producer.test.ts
+++ b/web/src/api/producer.test.ts
@@ -34,12 +34,15 @@ describe('Producer API', () => {
   });
 
   it('fetches Studio topic records sorted alphabetically', async () => {
-    mock.onGet('/topics').reply(200, {
+    mock.onGet('/topics').reply((config) => {
+      expect(config.params.instanceId).toBe('instance-1');
+      return [200, {
       code: 200,
       data: [{ name: 'order-events' }, { name: 'user-signup' }, { name: 'batch-process' }],
+      }];
     });
 
-    const result = await fetchTopicList();
+    const result = await fetchTopicList('instance-1');
     expect(result).toEqual(['batch-process', 'order-events', 'user-signup']);
   });
 
@@ -48,14 +51,14 @@ describe('Producer API', () => {
       topicList: ['order-events', 'user-signup', 'batch-process'],
     });
 
-    const result = await fetchTopicList();
+    const result = await fetchTopicList('instance-1');
     expect(result).toEqual(['batch-process', 'order-events', 'user-signup']);
   });
 
   it('handles empty topic list', async () => {
     mock.onGet('/topics').reply(200, { topicList: [] });
 
-    const result = await fetchTopicList();
+    const result = await fetchTopicList('instance-1');
     expect(result).toEqual([]);
   });
 

--- a/web/src/api/producer.ts
+++ b/web/src/api/producer.ts
@@ -36,9 +36,9 @@ interface TopicListResponse {
 
 // ─── API ────────────────────────────────────────────────────────
 
-/** Fetch all topic names */
-export async function fetchTopicList(): Promise<string[]> {
-  const res = await client.get<TopicListResponse>('/topics');
+/** Fetch topic names for a managed instance. */
+export async function fetchTopicList(instanceId: string): Promise<string[]> {
+  const res = await client.get<TopicListResponse>('/topics', { params: { instanceId } });
   const topics = res.data.data?.map((topic) => topic.name) ?? res.data.topicList ?? [];
   return topics.sort();
 }

--- a/web/src/pages/studio/Producer.tsx
+++ b/web/src/pages/studio/Producer.tsx
@@ -63,7 +63,18 @@ const ProducerPage = () => {
   useEffect(() => {
     let cancelled = false;
 
-    void fetchTopicList()
+    setTopicList([]);
+    setProducerGroups([]);
+    setConnectionList([]);
+    form.resetFields(['selectedTopic', 'producerGroup']);
+
+    if (!selectedInstanceId) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    void fetchTopicList(selectedInstanceId)
       .then((topics) => {
         if (!cancelled) {
           setTopicList(topics);
@@ -78,7 +89,7 @@ const ProducerPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [fetchTopicFailedMessage, message]);
+  }, [fetchTopicFailedMessage, form, message, selectedInstanceId]);
 
   useEffect(() => {
     let cancelled = false;

--- a/web/src/pages/studio/__tests__/Producer.test.tsx
+++ b/web/src/pages/studio/__tests__/Producer.test.tsx
@@ -87,7 +87,7 @@ describe('ProducerPage', () => {
     renderWithProviders(<ProducerPage />);
 
     await waitFor(() => {
-      expect(fetchTopicList).toHaveBeenCalledTimes(1);
+      expect(fetchTopicList).toHaveBeenCalledWith('instance-1');
     });
   });
 
@@ -185,5 +185,53 @@ describe('ProducerPage', () => {
         'manual-producer',
       );
     });
+  });
+
+  it('clears stale producer query state before loading a new instance', async () => {
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'instance-1',
+        name: 'Primary instance',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '127.0.0.1:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-08-01T00:00:00',
+        updatedAt: '2026-08-01T00:00:00',
+      },
+      {
+        id: 'instance-2',
+        name: 'Secondary instance',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '127.0.0.2:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-08-01T00:00:00',
+        updatedAt: '2026-08-01T00:00:00',
+      },
+    ]);
+    vi.mocked(fetchTopicList).mockResolvedValueOnce(['order-events']).mockResolvedValueOnce([]);
+    vi.mocked(queryProducerConnection).mockResolvedValue([
+      { clientId: 'producer-1', clientAddr: '192.168.1.10', language: 'JAVA', versionDesc: '5.1.0' },
+    ]);
+    const user = userEvent.setup();
+    renderWithProviders(<ProducerPage />);
+
+    await waitFor(() => expect(fetchTopicList).toHaveBeenCalledWith('instance-1'));
+    const [instanceSelect, topicSelect, groupInput] = screen.getAllByRole('combobox');
+    fireEvent.mouseDown(topicSelect.parentElement!);
+    await user.click(await screen.findByText('order-events', { selector: '.ant-select-item-option-content' }));
+    await user.type(groupInput, 'order-producer');
+    await user.click(screen.getByRole('button', { name: /搜索/ }));
+    expect(await screen.findByText('producer-1')).toBeInTheDocument();
+
+    fireEvent.mouseDown(instanceSelect.parentElement!);
+    await user.click(await screen.findByText('Secondary instance', { selector: '.ant-select-item-option-content' }));
+
+    await waitFor(() => expect(fetchTopicList).toHaveBeenLastCalledWith('instance-2'));
+    expect(screen.queryByText('producer-1')).not.toBeInTheDocument();
+    expect(screen.queryByText('order-events')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #1285

Load Producer Topic options with the selected managed instance and clear topic, producer group, and connection state before switching instances. The existing `/api/topics?instanceId=` endpoint is reused.

Validation:
- `npm test -- --run src/api/producer.test.ts src/pages/studio/__tests__/Producer.test.tsx`
- `npm run build`