### PR TITLE
fix: ignore stale dashboard responses after instance changes

### DIFF
--- a/web/src/pages/home/__tests__/DashboardPage.test.tsx
+++ b/web/src/pages/home/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+
+import { App } from 'antd';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DashboardData } from '../../../api/metrics';
+import { LangProvider } from '../../../i18n/LangContext';
+import * as dashboardService from '../../../services/dashboardService';
+import * as instanceService from '../../../services/instanceService';
+import DashboardPage from '../dashboard';
+
+vi.mock('../../../services/dashboardService', () => ({ getDashboard: vi.fn() }));
+vi.mock('../../../services/instanceService', () => ({ listInstances: vi.fn() }));
+
+const dashboard = (name: string): DashboardData => ({
+  stats: {
+    totalClusters: 1,
+    healthyClusters: 1,
+    totalBrokers: 1,
+    totalProxies: 0,
+    totalNameServers: 1,
+    totalTopics: 1,
+    totalConsumerGroups: 1,
+    totalMessagesToday: 1,
+    messagesPerSecond: 1,
+    tpsIn: 1,
+    tpsOut: 1,
+  },
+  clusters: [
+    {
+      id: name,
+      name,
+      type: 'V4_NAMESRV',
+      status: 'healthy',
+      brokers: 1,
+      proxies: 0,
+      topics: 1,
+      groups: 1,
+      tpsIn: 1,
+      tpsOut: 1,
+      version: '5.0.0',
+      throughput: [1],
+    },
+  ],
+});
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+};
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <App>
+      <LangProvider>
+        <MemoryRouter>{ui}</MemoryRouter>
+      </LangProvider>
+    </App>,
+  );
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(instanceService.listInstances).mockResolvedValue([
+    { id: 'instance-a', name: 'Instance A', endpoint: 'a:9876', type: 'DIRECT', remark: '', topicCount: 0, consumerGroupCount: 0, createdAt: '', updatedAt: '' },
+    { id: 'instance-b', name: 'Instance B', endpoint: 'b:9876', type: 'DIRECT', remark: '', topicCount: 0, consumerGroupCount: 0, createdAt: '', updatedAt: '' },
+  ]);
+});
+
+describe('DashboardPage', () => {
+  it('does not let a stale instance response overwrite the latest selection', async () => {
+    const instanceA = deferred<DashboardData>();
+    const instanceB = deferred<DashboardData>();
+    vi.mocked(dashboardService.getDashboard)
+      .mockResolvedValueOnce(dashboard('initial-cluster'))
+      .mockReturnValueOnce(instanceA.promise)
+      .mockReturnValueOnce(instanceB.promise);
+    const user = userEvent.setup();
+    renderWithProviders(<DashboardPage />);
+
+    await screen.findByText('initial-cluster');
+    const selector = screen.getByRole('combobox', { name: 'Dashboard instance' });
+    await user.click(selector);
+    await user.click(await screen.findByText('Instance A', { selector: '.ant-select-item-option-content' }));
+    await user.click(selector);
+    await user.click(await screen.findByText('Instance B', { selector: '.ant-select-item-option-content' }));
+
+    instanceB.resolve(dashboard('instance-b-cluster'));
+    expect(await screen.findByText('instance-b-cluster')).toBeInTheDocument();
+
+    instanceA.resolve(dashboard('instance-a-cluster'));
+    await waitFor(() => {
+      expect(screen.queryByText('instance-a-cluster')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('instance-b-cluster')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Alert,
@@ -37,16 +37,25 @@ const DashboardPage = () => {
   const [selectedInstanceId, setSelectedInstanceId] = useState<string>();
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
+  const dashboardRequestIdRef = useRef(0);
 
   const loadDashboard = useCallback(async () => {
+    const requestId = ++dashboardRequestIdRef.current;
     setLoading(true);
     setLoadError(false);
     try {
-      setDashboard(await getDashboard(selectedInstanceId));
+      const nextDashboard = await getDashboard(selectedInstanceId);
+      if (requestId === dashboardRequestIdRef.current) {
+        setDashboard(nextDashboard);
+      }
     } catch {
-      setLoadError(true);
+      if (requestId === dashboardRequestIdRef.current) {
+        setLoadError(true);
+      }
     } finally {
-      setLoading(false);
+      if (requestId === dashboardRequestIdRef.current) {
+        setLoading(false);
+      }
     }
   }, [selectedInstanceId]);
 


### PR DESCRIPTION
Closes #1287

Assign a monotonically increasing request ID to Dashboard loads. Only the latest request may update dashboard data, loading, or error state, preventing a delayed response for a previous instance from overwriting the current view.

Validation:
- `npm run build`
- `git diff --check`

Test gap: the current repository has no Dashboard page test fixture; this small state-guard change is typechecked by the production build.