### PR TITLE
fix: initialize the H2 schema for development

### DIFF
--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -5,6 +5,10 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:db/schema.sql
   h2:
     console:
       enabled: true

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -24,6 +24,10 @@ CREATE TABLE IF NOT EXISTS rmq_instance (
   remark VARCHAR(255),
   type VARCHAR(32) NOT NULL COMMENT 'PROXY/DIRECT',
   endpoint VARCHAR(512) NOT NULL,
+  vendor VARCHAR(32),
+  cloud_instance_id VARCHAR(128),
+  credential_id VARCHAR(64),
+  region_id VARCHAR(128),
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -44,7 +48,7 @@ CREATE TABLE IF NOT EXISTS rmq_topic (
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   UNIQUE KEY uk_cluster_topic (cluster_id, name),
-  INDEX idx_instance (instance_id)
+  INDEX idx_topic_instance (instance_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 4. Consumer Group 管理记录
@@ -61,7 +65,7 @@ CREATE TABLE IF NOT EXISTS rmq_group (
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   UNIQUE KEY uk_cluster_group (cluster_id, name),
-  INDEX idx_instance (instance_id)
+  INDEX idx_group_instance (instance_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 5. K8s 证书管理
@@ -95,7 +99,7 @@ CREATE TABLE IF NOT EXISTS rmq_message_query (
   cluster_id VARCHAR(255),
   queried_by VARCHAR(64),
   queried_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  INDEX idx_queried_at (queried_at),
+  INDEX idx_message_query_queried_at (queried_at),
   INDEX idx_topic (topic)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -110,7 +114,7 @@ CREATE TABLE IF NOT EXISTS rmq_trace_query (
   queried_by VARCHAR(64),
   queried_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   INDEX idx_msg_id (msg_id),
-  INDEX idx_queried_at (queried_at)
+  INDEX idx_trace_query_queried_at (queried_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 8. 操作审计日志（所有写操作）
@@ -132,7 +136,7 @@ CREATE TABLE IF NOT EXISTS rmq_operation_audit (
 
 -- 9. 通用设置（单行）
 CREATE TABLE IF NOT EXISTS rmq_settings (
-  id VARCHAR(16) PRIMARY KEY DEFAULT 'singleton',
+  id VARCHAR(16) DEFAULT 'singleton' PRIMARY KEY,
   json TEXT NOT NULL COMMENT 'GeneralSettingsVO JSON',
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/server/src/test/java/org/apache/rocketmq/studio/StudioApplicationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/StudioApplicationTest.java
@@ -18,13 +18,20 @@ package org.apache.rocketmq.studio;
 
 import org.apache.rocketmq.studio.ops.ai.tool.ToolCatalog;
 import org.apache.rocketmq.studio.ops.ai.tool.ToolGatewayService;
+import org.apache.rocketmq.studio.persistence.mapper.RmqInstanceMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class StudioApplicationTest {
 
     @Autowired
@@ -33,9 +40,20 @@ class StudioApplicationTest {
     @Autowired
     private ToolGatewayService toolGatewayService;
 
+    @Autowired
+    private RmqInstanceMapper instanceMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
     @Test
-    void applicationContextLoadsWithToolGateway() {
+    void applicationContextLoadsWithInitializedDevSchema() throws Exception {
         assertThat(toolCatalog.getVersion()).isEqualTo("1.0.0");
         assertThat(toolGatewayService.discover(null)).isNotEmpty();
+        assertThat(instanceMapper.selectList(null)).isEmpty();
+
+        mockMvc.perform(get("/api/instances"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isEmpty());
     }
 }


### PR DESCRIPTION
Closes #1291

## Summary
- initialize the default development H2 datasource from the authoritative schema
- make schema index names portable to H2 and MySQL
- align the instance table with persisted instance fields
- verify the default application context and instance API use initialized persistence

## Validation
- `mvn -q -Dtest=StudioApplicationTest test`
- `mvn -q -DskipTests compile`