### PR TITLE
fix: require a topic for message ID queries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -58,6 +58,9 @@ public class MessageService {
         if (hasKey && !hasTopic) {
             throw new BusinessException(400, "topic is required when key is specified");
         }
+        if (hasMessageId && !hasTopic) {
+            throw new BusinessException(400, "topic is required when msgId is specified");
+        }
         if (!hasTopic && !hasMessageId) {
             throw new BusinessException(400, "topic or msgId is required");
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -14,13 +14,9 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 class MessageServiceTest {
 
@@ -38,16 +34,16 @@ class MessageServiceTest {
     }
 
     @Test
-    void keepsMessageIdQueryWithoutTopicValid() {
+    void rejectsMessageIdQueryWithoutTopicBeforeCallingProvider() {
         MessageProvider provider = mock(MessageProvider.class);
         InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
-        when(provider.queryMessages(null, null, "msg-001", null, null, null, null))
-                .thenReturn(Collections.emptyList());
         MessageService service = new MessageService(provider, registry);
 
-        service.queryMessages(null, null, "msg-001", null, null, null, null);
+        assertThatThrownBy(() -> service.queryMessages(null, null, "msg-001", null, null, null, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topic is required when msgId is specified");
 
-        verify(provider).queryMessages(null, null, "msg-001", null, null, null, null);
+        verifyNoInteractions(provider, registry);
     }
 
     @Test

--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -79,6 +79,8 @@ const renderWithProviders = (ui: React.ReactElement) =>
     </App>,
   );
 
+const lastElement = <T,>(elements: T[]): T => elements[elements.length - 1]!;
+
 describe('Message page query history', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -96,11 +98,14 @@ describe('Message page query history', () => {
     expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
 
     await user.click(screen.getByText('按 Message ID'));
+    await user.click(lastElement(screen.getAllByRole('combobox')));
+    await user.click(lastElement(await screen.findAllByText('order-create')));
     await user.type(screen.getByPlaceholderText('输入 Message ID'), 'MID-001');
     await user.click(screen.getByRole('button', { name: /^search查询$/ }));
 
     await waitFor(() => {
       expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
+        topic: 'order-create',
         msgId: 'MID-001',
         instanceId: '',
       });
@@ -112,11 +117,12 @@ describe('Message page query history', () => {
     renderWithProviders(<MessagePage />);
 
     await user.click(screen.getByRole('button', { name: /最近查询/ }));
-    await user.click(await screen.findByText('Message ID: MID-001'));
+    await user.click(await screen.findByText('Message ID: MID-001 · Topic: order-create'));
 
     expect(screen.getByPlaceholderText('输入 Message ID')).toHaveValue('MID-001');
     await waitFor(() => {
       expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
+        topic: 'order-create',
         msgId: 'MID-001',
         instanceId: '',
       });
@@ -134,11 +140,14 @@ describe('Message page query history', () => {
     renderWithProviders(<MessagePage />);
 
     await user.click(screen.getByText('按 Message ID'));
+    await user.click(lastElement(screen.getAllByRole('combobox')));
+    await user.click(lastElement(await screen.findAllByText('order-create')));
     await user.type(screen.getByPlaceholderText('输入 Message ID'), 'MID-FAILED');
     await user.click(screen.getByRole('button', { name: /^search查询$/ }));
 
     await waitFor(() => {
       expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
+        topic: 'order-create',
         msgId: 'MID-FAILED',
         instanceId: '',
       });
@@ -151,6 +160,8 @@ describe('Message page query history', () => {
     const user = userEvent.setup();
     renderWithProviders(<MessagePage />);
     await user.click(screen.getByText('按 Message ID'));
+    await user.click(lastElement(screen.getAllByRole('combobox')));
+    await user.click(lastElement(await screen.findAllByText('order-create')));
     const messageIdInput = screen.getByPlaceholderText('输入 Message ID');
     const queryButton = screen.getByRole('button', { name: /^search查询$/ });
 
@@ -240,15 +251,16 @@ describe('Message page query history', () => {
       JSON.stringify([
         { mode: 'topic', params: { topic: ['invalid'] } },
         { mode: 'unknown', params: { topic: 'order-create' } },
-        { mode: 'msgid', params: { msgId: 'MID-VALID' } },
+        { mode: 'msgid', params: { msgId: 'MID-VALID', topic: 'order-create' } },
       ]),
     );
     renderWithProviders(<MessagePage />);
 
     await user.click(screen.getByRole('button', { name: /最近查询/ }));
-    expect(await screen.findByText('Message ID: MID-VALID')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Message ID: MID-VALID · Topic: order-create'),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/invalid/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/order-create/)).not.toBeInTheDocument();
   });
 
   it('does not report consume verification success without a backend API', async () => {
@@ -257,6 +269,8 @@ describe('Message page query history', () => {
     renderWithProviders(<MessagePage />);
 
     await user.click(screen.getByText('按 Message ID'));
+    await user.click(lastElement(screen.getAllByRole('combobox')));
+    await user.click(lastElement(await screen.findAllByText('order-create')));
     await user.type(screen.getByPlaceholderText('输入 Message ID'), 'MID-CONSUME-VERIFY-001');
     await user.click(screen.getByRole('button', { name: /^search查询$/ }));
 

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -161,21 +161,23 @@ const isMessageQuery = (value: unknown): value is MessageQuery => {
   );
 };
 
+const isRecentQuery = (value: unknown): value is RecentQuery => {
+  if (typeof value !== 'object' || value === null) return false;
+  const query = value as RecentQuery;
+  return (
+    isQueryMode(query.mode) &&
+    isMessageQuery(query.params) &&
+    (query.mode !== 'msgid' || Boolean(query.params.topic?.trim()))
+  );
+};
+
 const loadRecentQueries = (): RecentQuery[] => {
   try {
     const stored = localStorage.getItem(QUERY_HISTORY_STORAGE_KEY);
     if (!stored) return [];
     const parsed: unknown = JSON.parse(stored);
     if (!Array.isArray(parsed)) return [];
-    return parsed
-      .filter(
-        (item): item is RecentQuery =>
-          typeof item === 'object' &&
-          item !== null &&
-          isQueryMode((item as RecentQuery).mode) &&
-          isMessageQuery((item as RecentQuery).params),
-      )
-      .slice(0, MAX_QUERY_HISTORY);
+    return parsed.filter(isRecentQuery).slice(0, MAX_QUERY_HISTORY);
   } catch {
     return [];
   }
@@ -184,7 +186,8 @@ const loadRecentQueries = (): RecentQuery[] => {
 const querySignature = (query: RecentQuery): string => JSON.stringify(query);
 
 const queryLabel = ({ mode, params }: RecentQuery): string => {
-  if (mode === 'msgid') return `Message ID: ${params.msgId || '全部'}`;
+  if (mode === 'msgid')
+    return `Message ID: ${params.msgId || '全部'} · Topic: ${params.topic || '全部'}`;
   if (mode === 'key') {
     return `Key: ${params.key || '全部'}${params.topic ? ` · Topic: ${params.topic}` : ''}`;
   }
@@ -318,7 +321,7 @@ const MessagePage = () => {
           }
         : queryMode === 'key'
           ? { topic: selectedTopic, key: keyInput || undefined }
-          : { msgId: msgIdInput || undefined };
+          : { topic: selectedTopic, msgId: msgIdInput || undefined };
 
     await executeQuery(queryMode, params);
   };
@@ -749,12 +752,26 @@ const MessagePage = () => {
             )}
 
             {queryMode === 'msgid' && (
-              <Input
-                placeholder="输入 Message ID"
-                style={{ width: 400 }}
-                value={msgIdInput}
-                onChange={(e) => setMsgIdInput(e.target.value)}
-              />
+              <>
+                <Select
+                  placeholder="选择 Topic"
+                  style={{ width: 360 }}
+                  value={selectedTopic}
+                  onChange={setSelectedTopic}
+                  allowClear
+                  showSearch
+                  options={topicOptions.map((t) => ({
+                    value: t,
+                    label: t,
+                  }))}
+                />
+                <Input
+                  placeholder="输入 Message ID"
+                  style={{ width: 400 }}
+                  value={msgIdInput}
+                  onChange={(e) => setMsgIdInput(e.target.value)}
+                />
+              </>
             )}
 
             <Button


### PR DESCRIPTION
Closes #1292

## Summary
- require a topic for message ID lookups so unique IDs are not misinterpreted as offset IDs
- add the Topic selector to the Message ID query form
- retain the topic in message query history and discard legacy Message ID history entries without one

## Validation
- `mvn -q -Dtest=MessageServiceTest test`
- `npm run test -- --run src/pages/instance/__tests__/MessagePage.test.tsx`
- `npm run build`