### PR TITLE
fix: reject cloud instances from Remoting admin resolution

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolver.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolver.java
@@ -7,6 +7,7 @@
 package org.apache.rocketmq.studio.cluster.broker;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.InstanceVO;
@@ -29,7 +30,7 @@ public class RuntimeAdminClientResolver {
     }
 
     public String resolveEndpoint(String instanceId) {
-        InstanceVO instance = resolveInstance(instanceId);
+        InstanceVO instance = requireApacheInstance(resolveInstance(instanceId));
         if (!StringUtils.hasText(instance.getEndpoint())) {
             throw new BusinessException(400, "Instance has no endpoint: " + instanceId);
         }
@@ -41,9 +42,18 @@ public class RuntimeAdminClientResolver {
     }
 
     public <T> T execute(InstanceVO instance, MqAdminExtFactory.AdminAction<T> action) {
+        requireApacheInstance(instance);
         if (instance == null || !StringUtils.hasText(instance.getEndpoint())) {
             throw new BusinessException(400, "Instance endpoint is required");
         }
         return adminFactory.execute(instance.getEndpoint().trim(), null, action);
+    }
+
+    private InstanceVO requireApacheInstance(InstanceVO instance) {
+        if (instance != null && instance.getVendor() != null && instance.getVendor() != InstanceVendor.APACHE) {
+            throw new BusinessException(400,
+                    "Runtime AdminClient only supports Apache instances: " + instance.getId());
+        }
+        return instance;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolverTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolverTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.cluster.broker;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -79,5 +81,24 @@ class RuntimeAdminClientResolverTest {
         String result = resolver.execute("instance-b", admin -> "unused");
         assertThat(result).isEqualTo("done");
         verify(adminFactory).execute(eq("namesrv-b:9876"), isNull(), any());
+    }
+
+    @Test
+    void rejectsCloudInstancesBeforeResolvingOrExecutingAdminClient() {
+        InstanceVO instance = InstanceVO.builder()
+                .vendor(InstanceVendor.ALIYUN)
+                .endpoint("cloud-endpoint:9876")
+                .build();
+        instance.setId("cloud-instance");
+        when(instanceRepository.findById("cloud-instance")).thenReturn(Optional.of(instance));
+        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory);
+
+        assertThatThrownBy(() -> resolver.resolveEndpoint("cloud-instance"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Runtime AdminClient only supports Apache instances: cloud-instance");
+        assertThatThrownBy(() -> resolver.execute(instance, admin -> "unused"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Runtime AdminClient only supports Apache instances: cloud-instance");
+        verifyNoInteractions(adminFactory);
     }
 }


### PR DESCRIPTION
## Summary

- reject non-Apache instances before resolving or using a Remoting MQAdmin client
- preserve legacy instances without a vendor as Apache-compatible
- add regression coverage for endpoint resolution and direct execution paths

## Validation

- JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH=$JAVA_HOME/bin:$PATH mvn -q -Dtest=RuntimeAdminClientResolverTest test
- JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH=$JAVA_HOME/bin:$PATH mvn -q -DskipTests compile

Closes #1295