### PR TITLE
fix: exclude disabled alert rules from Prometheus export

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -42,7 +42,9 @@ public class AlertService {
     }
 
     public String exportPrometheusRulesYaml() {
-        List<AlertRuleVO> rules = alertRepository.findAllRules();
+        List<AlertRuleVO> rules = alertRepository.findAllRules().stream()
+                .filter(AlertRuleVO::isEnabled)
+                .toList();
         List<PrometheusAlertRule> prometheusRules = rules.isEmpty()
                 ? defaultPrometheusRules()
                 : rules.stream().map(this::toPrometheusRule).toList();

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -100,6 +100,7 @@ class AlertServiceTest {
                 .threshold(5000)
                 .duration("3m")
                 .description("Lag too high")
+                .enabled(true)
                 .build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
 
@@ -122,6 +123,7 @@ class AlertServiceTest {
                 .threshold(1000)
                 .duration("3m")
                 .description("First lag alert")
+                .enabled(true)
                 .build();
         AlertRuleVO second = AlertRuleVO.builder()
                 .name("Lag Alert B")
@@ -130,6 +132,7 @@ class AlertServiceTest {
                 .threshold(2000)
                 .duration("5m")
                 .description("Second lag alert")
+                .enabled(true)
                 .build();
         when(alertRepository.findAllRules()).thenReturn(List.of(first, second));
 
@@ -156,6 +159,7 @@ class AlertServiceTest {
                 .clusterName("DefaultCluster")
                 .severity("critical")
                 .description("Slave falls behind master")
+                .enabled(true)
                 .build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
 
@@ -178,6 +182,7 @@ class AlertServiceTest {
                 .brokerName("*")
                 .clusterName(" ")
                 .severity("fatal")
+                .enabled(true)
                 .build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
 
@@ -198,6 +203,7 @@ class AlertServiceTest {
                 .clusterName("prod\"east\\dc\nline")
                 .brokerName("broker\tone")
                 .description("Summary \"quoted\" \\ path\nnext - Details\twith\rline")
+                .enabled(true)
                 .build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
 
@@ -221,6 +227,7 @@ class AlertServiceTest {
                 .metric("rocketmq_consumer_lag_messages")
                 .operator(">")
                 .threshold(1)
+                .enabled(true)
                 .build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
 
@@ -229,6 +236,50 @@ class AlertServiceTest {
         JsonNode exportedRule = new ObjectMapper(new YAMLFactory()).readTree(result)
                 .path("groups").get(0).path("rules").get(0);
         assertThat(exportedRule.path("alert").asText()).isEqualTo("RocketMQAlert");
+    }
+
+    @Test
+    void exportPrometheusRulesYamlShouldExcludeDisabledRules() {
+        AlertRuleVO enabled = AlertRuleVO.builder()
+                .name("Enabled Lag Alert")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(1000)
+                .enabled(true)
+                .build();
+        AlertRuleVO disabled = AlertRuleVO.builder()
+                .name("Disabled Lag Alert")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(2000)
+                .enabled(false)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(enabled, disabled));
+
+        String result = alertService.exportPrometheusRulesYaml();
+
+        assertThat(result)
+                .contains("EnabledLagAlert")
+                .doesNotContain("DisabledLagAlert")
+                .doesNotContain(" > 2000");
+    }
+
+    @Test
+    void exportPrometheusRulesYamlShouldUseDefaultRulesWhenAllConfiguredRulesAreDisabled() {
+        AlertRuleVO disabled = AlertRuleVO.builder()
+                .name("Disabled Lag Alert")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(2000)
+                .enabled(false)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(disabled));
+
+        String result = alertService.exportPrometheusRulesYaml();
+
+        assertThat(result)
+                .contains("RocketMQBrokerDown")
+                .doesNotContain("DisabledLagAlert");
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Disabled alert rules were still serialized into the Prometheus rule YAML export, so loading that YAML could activate a rule that an operator had disabled in Studio.

Closes #1298

## Brief changelog

- Filter persisted alert rules by `enabled` before producing Prometheus YAML.
- Preserve the bundled default rule fallback when no enabled configured rules remain.
- Add mixed enabled/disabled and disabled-only regression coverage.

## Verifying this change

```bash
cd server
JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" \
  mvn -q -Dtest=AlertServiceTest test
```