### PR TITLE
feat: audit Prometheus data source mutations

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -107,7 +107,10 @@ public class SettingsService {
         }
         log.info("Creating data source: {}", dataSource.getName());
         dataSource.setKey(UUID.randomUUID().toString());
-        return settingsRepository.saveDataSource(dataSource);
+        DataSourceVO saved = settingsRepository.saveDataSource(dataSource);
+        operationAuditService.record("CREATE_DATA_SOURCE", "DATA_SOURCE", saved.getKey(), null,
+                dataSourceAuditDetail(saved), "SUCCESS", null);
+        return saved;
     }
 
 
@@ -121,6 +124,8 @@ public class SettingsService {
         if (!settingsRepository.replaceDataSource(dataSource)) {
             throw new BusinessException(404, "Data source not found: " + key);
         }
+        operationAuditService.record("UPDATE_DATA_SOURCE", "DATA_SOURCE", key, null,
+                dataSourceAuditDetail(dataSource), "SUCCESS", null);
         return dataSource;
     }
 
@@ -131,6 +136,8 @@ public class SettingsService {
         if (!settingsRepository.deleteDataSource(normalizedKey)) {
             throw new BusinessException(404, "Data source not found: " + normalizedKey);
         }
+        operationAuditService.record("DELETE_DATA_SOURCE", "DATA_SOURCE", normalizedKey, null,
+                null, "SUCCESS", null);
     }
 
 
@@ -186,6 +193,10 @@ public class SettingsService {
             throw new BusinessException(400, "Data source key is required");
         }
         return key.trim();
+    }
+
+    private String dataSourceAuditDetail(DataSourceVO dataSource) {
+        return "name=" + dataSource.getName() + ", type=" + dataSource.getType();
     }
 
     private void applyAuthentication(HttpHeaders headers, DataSourceTestDTO request) {

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -41,6 +41,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -192,7 +194,7 @@ class SettingsServiceTest {
     @Test
     void createDataSourceShouldAssignKeyBeforeSaving() {
         DataSourceVO input = DataSourceVO.builder().name("New DS").type("rocketmq")
-                .url("new-host:9876").build();
+                .url("https://user:password@new-host:9876").auth("Bearer secret-token").build();
         when(settingsRepository.saveDataSource(any(DataSourceVO.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -201,6 +203,10 @@ class SettingsServiceTest {
         assertThat(result.getKey()).isNotBlank();
         assertThat(result.getName()).isEqualTo("New DS");
         verify(settingsRepository).saveDataSource(input);
+        verify(operationAuditService).record(eq("CREATE_DATA_SOURCE"), eq("DATA_SOURCE"), eq(result.getKey()),
+                eq(null), argThat(detail -> detail.equals("name=New DS, type=rocketmq")
+                        && !detail.contains("password") && !detail.contains("secret-token")),
+                eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -237,6 +243,8 @@ class SettingsServiceTest {
         assertThat(result.getKey()).isEqualTo("ds-1");
         assertThat(result.getName()).isEqualTo("Updated DS");
         verify(settingsRepository).replaceDataSource(input);
+        verify(operationAuditService).record(eq("UPDATE_DATA_SOURCE"), eq("DATA_SOURCE"), eq("ds-1"),
+                eq(null), eq("name=Updated DS, type=rocketmq"), eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -286,6 +294,8 @@ class SettingsServiceTest {
         settingsService.deleteDataSource("ds-1");
 
         verify(settingsRepository).deleteDataSource("ds-1");
+        verify(operationAuditService).record(eq("DELETE_DATA_SOURCE"), eq("DATA_SOURCE"), eq("ds-1"),
+                eq(null), eq(null), eq("SUCCESS"), eq(null));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Prometheus data-source mutations changed Studio control-plane configuration without an operation-audit record.

Closes #1300

## Brief changelog

- Audit successful data-source create, update, and delete operations.
- Store the data-source key, name, and type only.
- Do not include URLs, authentication values, passwords, or bearer tokens in audit details.

## Verifying this change

```bash
cd server
JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" \
  mvn -q -Dtest=SettingsServiceTest test
```