### PR TITLE
feat: audit cloud credential mutations

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
@@ -20,6 +20,7 @@ import org.springframework.util.StringUtils;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.provider.alibaba.AliyunClientFactory;
 import org.springframework.stereotype.Service;
@@ -38,6 +39,7 @@ public class CloudCredentialService {
     private final CloudCredentialRepository credentialRepository;
     private final InstanceRepository instanceRepository;
     private final AliyunClientFactory aliyunClientFactory;
+    private final OperationAuditService operationAuditService;
 
     public List<CloudCredentialVO> listMasked() {
         log.info("Listing cloud credentials (masked)");
@@ -69,7 +71,10 @@ public class CloudCredentialService {
         credential.setId(UUID.randomUUID().toString());
         credential.setCreatedAt(LocalDateTime.now());
         credential.setUpdatedAt(LocalDateTime.now());
-        return maskAccessKey(credentialRepository.save(credential));
+        CloudCredentialVO saved = credentialRepository.save(credential);
+        operationAuditService.record("CREATE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", saved.getId(), null,
+                credentialAuditDetail(saved), "SUCCESS", null);
+        return maskAccessKey(saved);
     }
 
     public CloudCredentialVO update(UpdateCloudCredentialDTO request) {
@@ -94,6 +99,8 @@ public class CloudCredentialService {
         existing.setUpdatedAt(LocalDateTime.now());
         CloudCredentialVO saved = credentialRepository.save(existing);
         invalidateAliyunClients(saved);
+        operationAuditService.record("UPDATE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", saved.getId(), null,
+                credentialAuditDetail(saved), "SUCCESS", null);
         return maskAccessKey(saved);
     }
 
@@ -109,6 +116,8 @@ public class CloudCredentialService {
         }
         credentialRepository.deleteById(id);
         invalidateAliyunClients(existing);
+        operationAuditService.record("DELETE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", id, null,
+                credentialAuditDetail(existing), "SUCCESS", null);
     }
 
     public CloudCredentialVO reveal(String id) {
@@ -131,6 +140,11 @@ public class CloudCredentialService {
         masked.setUpdatedAt(credential.getUpdatedAt());
         return masked;
     }
+
+    private String credentialAuditDetail(CloudCredentialVO credential) {
+        return "name=" + credential.getName() + ", vendor=" + credential.getVendor();
+    }
+
     private void invalidateAliyunClients(CloudCredentialVO credential) {
         if (credential.getVendor() == org.apache.rocketmq.studio.common.domain.enums.InstanceVendor.ALIYUN) {
             aliyunClientFactory.invalidateCredential(credential.getId());

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.provider.alibaba.AliyunClientFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +34,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,6 +51,9 @@ class CloudCredentialServiceTest {
 
     @Mock
     private AliyunClientFactory aliyunClientFactory;
+
+    @Mock
+    private OperationAuditService operationAuditService;
 
     @InjectMocks
     private CloudCredentialService service;
@@ -124,6 +130,10 @@ class CloudCredentialServiceTest {
         assertThat(created.getId()).isNotBlank();
         assertThat(created.getAccessKey()).isEqualTo("LTAI****0001");
         assertThat(created.getSecretKey()).isNull();
+        verify(operationAuditService).record(eq("CREATE_CLOUD_CREDENTIAL"), eq("CLOUD_CREDENTIAL"),
+                eq(created.getId()), eq(null), argThat(detail -> detail.equals("name=ok, vendor=ALIYUN")
+                        && !detail.contains("LTAI5tGoodKey00000000001") && !detail.contains("sk-value")),
+                eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -157,6 +167,8 @@ class CloudCredentialServiceTest {
         service.update(request);
 
         verify(aliyunClientFactory).invalidateCredential("cred-1");
+        verify(operationAuditService).record(eq("UPDATE_CLOUD_CREDENTIAL"), eq("CLOUD_CREDENTIAL"),
+                eq("cred-1"), eq(null), eq("name=null, vendor=ALIYUN"), eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -171,6 +183,8 @@ class CloudCredentialServiceTest {
 
         verify(credentialRepository).deleteById("cred-1");
         verify(aliyunClientFactory).invalidateCredential("cred-1");
+        verify(operationAuditService).record(eq("DELETE_CLOUD_CREDENTIAL"), eq("CLOUD_CREDENTIAL"),
+                eq("cred-1"), eq(null), eq("name=null, vendor=ALIYUN"), eq("SUCCESS"), eq(null));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Cloud credential mutations were not traceable in Studio operation audit records.

Closes #1302

## Brief changelog

- Audit successful create, update, and delete operations for cloud credentials.
- Preserve Aliyun client cache invalidation.
- Store only credential ID, name, and vendor in audit records.
- Do not include access keys, secret keys, or remarks.

## Verifying this change

```bash
cd server
JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" \
  mvn -q -Dtest=CloudCredentialServiceTest test
```