### PR TITLE
feat: audit ACL mutations and clarify local records

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -20,6 +20,7 @@ import org.springframework.util.StringUtils;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,7 @@ import java.util.UUID;
 public class AclService {
 
     private final AclRepository aclRepository;
+    private final OperationAuditService operationAuditService;
 
 
     public List<AclRuleVO> listRules(String clusterId, String principal) {
@@ -52,7 +54,9 @@ public class AclService {
         }
         rule.setId(UUID.randomUUID().toString());
         rule.setCreatedAt(LocalDateTime.now());
-        return aclRepository.saveRule(rule);
+        AclRuleVO saved = aclRepository.saveRule(rule);
+        auditRule("CREATE_ACL_RULE", saved);
+        return saved;
     }
 
     public AclRuleVO updateRule(AclRuleVO rule) {
@@ -60,8 +64,10 @@ public class AclService {
             throw new BusinessException(400, "ACL rule id is required");
         }
         log.info("Updating ACL rule id={}, principal={}", rule.getId(), rule.getPrincipal());
-        return aclRepository.replaceRule(rule)
+        AclRuleVO saved = aclRepository.replaceRule(rule)
                 .orElseThrow(() -> new BusinessException(404, "ACL rule not found: " + rule.getId()));
+        auditRule("UPDATE_ACL_RULE", saved);
+        return saved;
     }
 
     public void deleteRule(String id) {
@@ -69,6 +75,7 @@ public class AclService {
         if (!aclRepository.deleteRule(id)) {
             throw new BusinessException(404, "ACL rule not found: " + id);
         }
+        operationAuditService.record("DELETE_ACL_RULE", "ACL_RULE", id, null, null, "SUCCESS", null);
     }
 
 
@@ -89,7 +96,9 @@ public class AclService {
         user.setAccessKey(UUID.randomUUID().toString().replace("-", ""));
         user.setSecretKey(UUID.randomUUID().toString().replace("-", ""));
         user.setCreatedAt(LocalDateTime.now());
-        return aclRepository.saveUser(user);
+        AclUserVO saved = aclRepository.saveUser(user);
+        auditUser("CREATE_ACL_USER", saved);
+        return saved;
     }
 
     public AclUserVO updateUser(UpdateAclUserDTO user) {
@@ -108,7 +117,9 @@ public class AclService {
                 .clusters(user.getClusters() == null ? existing.getClusters() : user.getClusters())
                 .createdAt(existing.getCreatedAt())
                 .build();
-        return maskCredentials(aclRepository.saveUser(merged));
+        AclUserVO saved = aclRepository.saveUser(merged);
+        auditUser("UPDATE_ACL_USER", saved);
+        return maskCredentials(saved);
     }
 
     public void deleteUser(String id) {
@@ -116,6 +127,7 @@ public class AclService {
         if (!aclRepository.deleteUser(id)) {
             throw new BusinessException(404, "ACL user not found: " + id);
         }
+        operationAuditService.record("DELETE_ACL_USER", "ACL_USER", id, null, null, "SUCCESS", null);
     }
 
     /**
@@ -141,6 +153,16 @@ public class AclService {
                 .clusters(user.getClusters() == null ? null : List.copyOf(user.getClusters()))
                 .createdAt(user.getCreatedAt())
                 .build();
+    }
+
+    private void auditRule(String operation, AclRuleVO rule) {
+        operationAuditService.record(operation, "ACL_RULE", rule.getId(), null,
+                "principal=" + rule.getPrincipal(), "SUCCESS", null);
+    }
+
+    private void auditUser(String operation, AclUserVO user) {
+        operationAuditService.record(operation, "ACL_USER", user.getId(), null,
+                "username=" + user.getUsername() + ", admin=" + user.isAdmin(), "SUCCESS", null);
     }
 
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.studio.instance.acl;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +38,8 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,6 +49,9 @@ class AclServiceTest {
 
     @Mock
     private AclRepository aclRepository;
+
+    @Mock
+    private OperationAuditService operationAuditService;
 
     @InjectMocks
     private AclService aclService;
@@ -107,6 +113,8 @@ class AclServiceTest {
         assertThat(result.getPrincipal()).isEqualTo("user1");
         assertThat(result.getResource()).isEqualTo("topic-1");
         verify(aclRepository).saveRule(any(AclRuleVO.class));
+        verify(operationAuditService).record(eq("CREATE_ACL_RULE"), eq("ACL_RULE"), eq(result.getId()), eq(null),
+                eq("principal=user1"), eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -115,6 +123,8 @@ class AclServiceTest {
         aclService.deleteRule("rule-1");
 
         verify(aclRepository).deleteRule("rule-1");
+        verify(operationAuditService).record(eq("DELETE_ACL_RULE"), eq("ACL_RULE"), eq("rule-1"), eq(null),
+                eq(null), eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -148,6 +158,8 @@ class AclServiceTest {
         assertThat(result.getDecision()).isEqualTo("DENY");
         verify(aclRepository).replaceRule(input);
         verify(aclRepository, never()).saveRule(any(AclRuleVO.class));
+        verify(operationAuditService).record(eq("UPDATE_ACL_RULE"), eq("ACL_RULE"), eq("rule-1"), eq(null),
+                eq("principal=user1"), eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -307,6 +319,10 @@ class AclServiceTest {
         assertThat(result.getCreatedAt()).isNotNull();
         assertThat(result.getUsername()).isEqualTo("newuser");
         verify(aclRepository).saveUser(any(AclUserVO.class));
+        verify(operationAuditService).record(eq("CREATE_ACL_USER"), eq("ACL_USER"), eq(result.getId()), eq(null),
+                argThat(detail -> detail.equals("username=newuser, admin=false")
+                        && !detail.contains(result.getAccessKey()) && !detail.contains(result.getSecretKey())),
+                eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -315,6 +331,8 @@ class AclServiceTest {
         aclService.deleteUser("user-1");
 
         verify(aclRepository).deleteUser("user-1");
+        verify(operationAuditService).record(eq("DELETE_ACL_USER"), eq("ACL_USER"), eq("user-1"), eq(null),
+                eq(null), eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -365,6 +383,8 @@ class AclServiceTest {
         verify(aclRepository).saveUser(captor.capture());
         assertThat(captor.getValue().getAccessKey()).isEqualTo("access-key-123456");
         assertThat(captor.getValue().getSecretKey()).isEqualTo("secret-key-987654");
+        verify(operationAuditService).record(eq("UPDATE_ACL_USER"), eq("ACL_USER"), eq("user-1"), eq(null),
+                eq("username=newuser, admin=true"), eq("SUCCESS"), eq(null));
     }
 
     @Test

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -305,6 +305,14 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: '访问控制规则与用户权限管理，共 {rules} 条规则、{users} 个用户',
     en: 'Access control rules and user permissions, {rules} rules, {users} users',
   },
+  'acl.localMetadataNotice': {
+    zh: '当前 ACL 规则和用户仅保存为 Studio 本地元数据',
+    en: 'Current ACL rules and users are stored as Studio-local metadata',
+  },
+  'acl.localMetadataDescription': {
+    zh: '它们尚不会下发到所选 RocketMQ 实例。实例级 ACL Provider 接入完成前，请在集群侧管理实际 ACL 策略。',
+    en: 'They are not applied to the selected RocketMQ instance. Manage the effective ACL policy on the cluster until instance-scoped provider support is available.',
+  },
   'acl.addRule': { zh: '添加规则', en: 'Add Rule' },
   'acl.addUser': { zh: '添加用户', en: 'Add User' },
   'acl.ruleTab': { zh: 'ACL 规则', en: 'ACL Rules' },

--- a/web/src/pages/instance/__tests__/AclPage.test.tsx
+++ b/web/src/pages/instance/__tests__/AclPage.test.tsx
@@ -103,6 +103,14 @@ describe('ACL page', () => {
     expect(aclService.listAclUsers).toHaveBeenCalledTimes(1);
   });
 
+  it('explains that ACL records are Studio-local metadata', async () => {
+    renderWithProviders(<AclPage />);
+
+    expect(await screen.findByTestId('acl-local-metadata-notice')).toHaveTextContent(
+      '当前 ACL 规则和用户仅保存为 Studio 本地元数据',
+    );
+  });
+
   it('renders backend users on the user tab', async () => {
     const user = userEvent.setup();
     renderWithProviders(<AclPage />);

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -33,6 +33,7 @@ import {
   Badge,
   Typography,
   Flex,
+  Alert,
   message,
 } from 'antd';
 import { Plus, MagnifyingGlass, ShieldCheck, User, Eye, EyeSlash } from '@phosphor-icons/react';
@@ -645,6 +646,15 @@ const AclPage = () => {
             {activeTab === 'rules' ? t('acl.addRule') : t('acl.addUser')}
           </Button>
         }
+      />
+
+      <Alert
+        data-testid="acl-local-metadata-notice"
+        type="warning"
+        showIcon
+        message={t('acl.localMetadataNotice')}
+        description={t('acl.localMetadataDescription')}
+        style={{ marginBottom: 16 }}
       />
 
       <Card bordered={false} bodyStyle={{ padding: 0 }}>


### PR DESCRIPTION
## Summary

- records successful ACL rule and user mutations in the control-plane audit log;
- keeps audit details concise and excludes credential or policy payloads;
- clarifies in the ACL page that these records are Studio-local configuration, not remote cluster ACL state.

Closes #1306
Closes #1312

## Test

```bash
cd server
JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -q -Dtest=AclServiceTest test
cd ../web
npm test -- --run src/pages/instance/__tests__/AclPage.test.tsx
```