### PR TITLE
feat: audit K8s certificate mutations and clarify local records

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.k8s;
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -38,15 +39,17 @@ public class K8sCertService {
     private static final int EXPIRING_THRESHOLD_DAYS = 30;
 
     private final K8sCertRepository k8sCertRepository;
+    private final OperationAuditService operationAuditService;
     private final Clock clock;
 
     @Autowired
-    public K8sCertService(K8sCertRepository k8sCertRepository) {
-        this(k8sCertRepository, Clock.systemDefaultZone());
+    public K8sCertService(K8sCertRepository k8sCertRepository, OperationAuditService operationAuditService) {
+        this(k8sCertRepository, operationAuditService, Clock.systemDefaultZone());
     }
 
-    K8sCertService(K8sCertRepository k8sCertRepository, Clock clock) {
+    K8sCertService(K8sCertRepository k8sCertRepository, OperationAuditService operationAuditService, Clock clock) {
         this.k8sCertRepository = k8sCertRepository;
+        this.operationAuditService = operationAuditService;
         this.clock = clock;
     }
 
@@ -82,6 +85,7 @@ public class K8sCertService {
         cert.setUpdatedAt(now);
 
         K8sCertVO saved = k8sCertRepository.save(cert);
+        auditCertificate("CREATE_K8S_CERTIFICATE", saved);
         log.info("K8s certificate created: {} (id={})", saved.getName(), saved.getId());
         return saved;
     }
@@ -115,6 +119,7 @@ public class K8sCertService {
         updated.setUpdatedAt(now);
 
         K8sCertVO saved = k8sCertRepository.save(refreshExpirationState(updated, now));
+        auditCertificate("UPDATE_K8S_CERTIFICATE", saved);
         log.info("K8s certificate updated: {} (id={})", saved.getName(), saved.getId());
         return saved;
     }
@@ -136,6 +141,7 @@ public class K8sCertService {
         renewed.setUpdatedAt(now);
 
         K8sCertVO saved = k8sCertRepository.save(renewed);
+        auditCertificate("RENEW_K8S_CERTIFICATE", saved);
         log.info("K8s certificate renewed: {} (id={}), new expiry: {}", saved.getName(), saved.getId(), notAfter);
         return saved;
     }
@@ -146,6 +152,8 @@ public class K8sCertService {
         k8sCertRepository.findById(command.getId())
                 .orElseThrow(() -> new BusinessException(404, "Certificate not found: " + command.getId()));
         k8sCertRepository.deleteById(command.getId());
+        operationAuditService.record("DELETE_K8S_CERTIFICATE", "K8S_CERTIFICATE", command.getId(), null,
+                null, "SUCCESS", null);
         log.info("K8s certificate deleted: {}", command.getId());
     }
 
@@ -191,5 +199,12 @@ public class K8sCertService {
         copy.setCreatedAt(cert.getCreatedAt());
         copy.setUpdatedAt(cert.getUpdatedAt());
         return copy;
+    }
+
+    private void auditCertificate(String operation, K8sCertVO certificate) {
+        operationAuditService.record(operation, "K8S_CERTIFICATE", certificate.getId(), null,
+                "name=" + certificate.getName() + ", namespace=" + certificate.getNamespace()
+                        + ", cluster=" + certificate.getCluster(),
+                "SUCCESS", null);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.k8s;
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,6 +39,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -51,13 +53,16 @@ class K8sCertServiceTest {
     @Mock
     private K8sCertRepository k8sCertRepository;
 
+    @Mock
+    private OperationAuditService operationAuditService;
+
     private K8sCertService k8sCertService;
 
     private K8sCertVO sampleCert;
 
     @BeforeEach
     void setUp() {
-        k8sCertService = new K8sCertService(k8sCertRepository, CLOCK);
+        k8sCertService = new K8sCertService(k8sCertRepository, operationAuditService, CLOCK);
         sampleCert = K8sCertVO.builder()
                 .name("rocketmq-tls")
                 .namespace("mq-system")
@@ -169,6 +174,9 @@ class K8sCertServiceTest {
         assertThat(result.getCreatedAt()).isEqualTo(now);
         assertThat(result.getUpdatedAt()).isEqualTo(now);
         verify(k8sCertRepository).save(any(K8sCertVO.class));
+        verify(operationAuditService).record(eq("CREATE_K8S_CERTIFICATE"), eq("K8S_CERTIFICATE"),
+                eq(result.getId()), eq(null), eq("name=new-tls-cert, namespace=default, cluster=test-cluster"),
+                eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -246,6 +254,9 @@ class K8sCertServiceTest {
         assertThat(sampleCert.getType()).isEqualTo(CertType.TLS);
         assertThat(sampleCert.getUpdatedAt()).isEqualTo(LocalDateTime.of(2025, 1, 2, 0, 0));
         verify(k8sCertRepository).save(any(K8sCertVO.class));
+        verify(operationAuditService).record(eq("UPDATE_K8S_CERTIFICATE"), eq("K8S_CERTIFICATE"),
+                eq("cert-1"), eq(null), eq("name=updated-name, namespace=new-namespace, cluster=new-cluster"),
+                eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -351,6 +362,9 @@ class K8sCertServiceTest {
         assertThat(sampleCert.getNotBefore()).isEqualTo(originalNotBefore);
         assertThat(sampleCert.getNotAfter()).isEqualTo(originalNotAfter);
         verify(k8sCertRepository).save(any(K8sCertVO.class));
+        verify(operationAuditService).record(eq("RENEW_K8S_CERTIFICATE"), eq("K8S_CERTIFICATE"),
+                eq("cert-1"), eq(null), eq("name=rocketmq-tls, namespace=mq-system, cluster=prod-cluster"),
+                eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -396,6 +410,8 @@ class K8sCertServiceTest {
         k8sCertService.deleteCert(command);
 
         verify(k8sCertRepository).deleteById("cert-1");
+        verify(operationAuditService).record(eq("DELETE_K8S_CERTIFICATE"), eq("K8S_CERTIFICATE"),
+                eq("cert-1"), eq(null), eq(null), eq("SUCCESS"), eq(null));
     }
 
     @Test

--- a/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
@@ -100,6 +100,14 @@ describe('K8sCertsPage', () => {
     expect(screen.getByText('-')).toBeInTheDocument();
   });
 
+  it('explains that certificate records are Studio-local metadata', async () => {
+    renderPage();
+
+    expect(await screen.findByTestId('k8s-cert-local-metadata-notice')).toHaveTextContent(
+      '当前证书记录仅保存为 Studio 本地元数据',
+    );
+  });
+
   it.each([
     ['platform', 'rocketmq-staging-tls', 'rocketmq-prod-tls'],
     ['broker.prod.example.com', 'rocketmq-prod-tls', 'rocketmq-staging-tls'],

--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -28,6 +28,7 @@ import {
   Space,
   Typography,
   Card,
+  Alert,
   message,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
@@ -351,6 +352,14 @@ const K8sCertsPage = () => {
             添加证书
           </Button>
         }
+      />
+      <Alert
+        data-testid="k8s-cert-local-metadata-notice"
+        type="warning"
+        showIcon
+        message="当前证书记录仅保存为 Studio 本地元数据"
+        description="创建、续期和删除操作尚不会应用到 Kubernetes 集群或 cert-manager。请在集群侧管理实际证书，直到 Kubernetes Provider 接入完成。"
+        style={{ marginBottom: 16 }}
       />
       <Flex justify="space-between" style={{ marginBottom: 16 }}>
         <Space>


### PR DESCRIPTION
## Summary

- records successful K8s certificate create, update, renew, and delete operations in the control-plane audit log;
- keeps audit details concise and does not record certificate material;
- clarifies in the certificate page that entries are Studio-local configuration, not live Kubernetes Secret state.

Closes #1308
Closes #1314

## Test

```bash
cd server
JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -q -Dtest=K8sCertServiceTest test
cd ../web
npm test -- --run src/pages/cluster/__tests__/K8sCertsPage.test.tsx
```