### PR TITLE
feat: harden and audit alert rule lifecycle

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -44,7 +44,9 @@ public class AlertService {
     }
 
     public String exportPrometheusRulesYaml() {
-        List<AlertRuleVO> rules = alertRepository.findAllRules();
+        List<AlertRuleVO> rules = alertRepository.findAllRules().stream()
+                .filter(AlertRuleVO::isEnabled)
+                .toList();
         List<PrometheusAlertRule> prometheusRules = rules.isEmpty()
                 ? defaultPrometheusRules()
                 : rules.stream().map(this::toPrometheusRule).toList();

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,7 @@ public class AlertService {
 
     private final AlertRepository alertRepository;
     private final AlertRuleAssetService alertRuleAssetService;
+    private final OperationAuditService operationAuditService;
 
 
     public List<AlertRuleVO> listRules() {
@@ -83,7 +85,9 @@ public class AlertService {
         }
         log.info("Creating alert rule: {}", rule.getName());
         rule.setId(UUID.randomUUID().toString());
-        return alertRepository.saveRule(rule);
+        AlertRuleVO saved = alertRepository.saveRule(rule);
+        auditRule("CREATE_ALERT_RULE", saved, null);
+        return saved;
     }
 
 
@@ -97,6 +101,7 @@ public class AlertService {
         if (!alertRepository.replaceRule(rule)) {
             throw ruleNotFound(id);
         }
+        auditRule("UPDATE_ALERT_RULE", rule, null);
         return rule;
     }
 
@@ -109,7 +114,9 @@ public class AlertService {
                 .findFirst()
                 .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "Alert rule not found: " + id));
         rule.setEnabled(enabled);
-        return alertRepository.saveRule(rule);
+        AlertRuleVO saved = alertRepository.saveRule(rule);
+        auditRule("TOGGLE_ALERT_RULE", saved, "enabled=" + enabled);
+        return saved;
     }
 
 
@@ -118,6 +125,7 @@ public class AlertService {
         if (!alertRepository.deleteRule(id)) {
             throw ruleNotFound(id);
         }
+        operationAuditService.record("DELETE_ALERT_RULE", "ALERT_RULE", id, null, null, "SUCCESS", null);
     }
 
 
@@ -135,13 +143,19 @@ public class AlertService {
                 .findFirst()
                 .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "System alert not found: " + id));
         alert.setAcknowledged(true);
-        return alertRepository.saveAlert(alert);
+        SystemAlertVO saved = alertRepository.saveAlert(alert);
+        operationAuditService.record("ACKNOWLEDGE_SYSTEM_ALERT", "SYSTEM_ALERT", saved.getId(), null,
+                "acknowledged=true", "SUCCESS", null);
+        return saved;
     }
 
 
     public int clearAcknowledged() {
         log.info("Clearing acknowledged system alerts");
-        return alertRepository.deleteAcknowledgedAlerts();
+        int deleted = alertRepository.deleteAcknowledgedAlerts();
+        operationAuditService.record("CLEAR_ACKNOWLEDGED_SYSTEM_ALERTS", "SYSTEM_ALERT", null, null,
+                "deleted=" + deleted, "SUCCESS", null);
+        return deleted;
     }
 
     private List<PrometheusAlertRule> defaultPrometheusRules() {
@@ -200,6 +214,12 @@ public class AlertService {
             selector.append(',');
         }
         selector.append(label).append("=\"").append(escapeDoubleQuotedValue(value.trim())).append('"');
+    }
+
+    private void auditRule(String operation, AlertRuleVO rule, String detail) {
+        String auditDetail = detail == null ? "name=" + rule.getName() : detail;
+        operationAuditService.record(operation, "ALERT_RULE", rule.getId(), null,
+                auditDetail, "SUCCESS", null);
     }
 
     private String severity(AlertRuleVO rule) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceDefaultRulesTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceDefaultRulesTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
+import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.List;
@@ -36,7 +38,8 @@ class AlertServiceDefaultRulesTest {
         AlertRepository repository = mock(AlertRepository.class);
         when(repository.findAllRules()).thenReturn(Collections.emptyList());
 
-        AlertService service = new AlertService(repository, new AlertRuleAssetService());
+        AlertService service = new AlertService(repository, new AlertRuleAssetService(),
+                Mockito.mock(OperationAuditService.class));
         String yaml = service.exportPrometheusRulesYaml();
 
         int ruleCount = countRules(yaml);
@@ -48,7 +51,8 @@ class AlertServiceDefaultRulesTest {
         AlertRepository repository = mock(AlertRepository.class);
         when(repository.findAllRules()).thenReturn(List.of());
 
-        AlertService service = new AlertService(repository, new AlertRuleAssetService());
+        AlertService service = new AlertService(repository, new AlertRuleAssetService(),
+                Mockito.mock(OperationAuditService.class));
         String yaml = service.exportPrometheusRulesYaml();
 
         assertTrue(yaml.contains("rocketmq-broker.rules"));

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -105,6 +105,7 @@ class AlertServiceTest {
                 .threshold(5000)
                 .duration("3m")
                 .description("Lag too high")
+                .enabled(true)
                 .build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
 
@@ -127,6 +128,7 @@ class AlertServiceTest {
                 .threshold(1000)
                 .duration("3m")
                 .description("First lag alert")
+                .enabled(true)
                 .build();
         AlertRuleVO second = AlertRuleVO.builder()
                 .name("Lag Alert B")
@@ -135,6 +137,7 @@ class AlertServiceTest {
                 .threshold(2000)
                 .duration("5m")
                 .description("Second lag alert")
+                .enabled(true)
                 .build();
         when(alertRepository.findAllRules()).thenReturn(List.of(first, second));
 
@@ -161,6 +164,7 @@ class AlertServiceTest {
                 .clusterName("DefaultCluster")
                 .severity("critical")
                 .description("Slave falls behind master")
+                .enabled(true)
                 .build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
 
@@ -183,6 +187,7 @@ class AlertServiceTest {
                 .brokerName("*")
                 .clusterName(" ")
                 .severity("fatal")
+                .enabled(true)
                 .build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
 
@@ -203,6 +208,7 @@ class AlertServiceTest {
                 .clusterName("prod\"east\\dc\nline")
                 .brokerName("broker\tone")
                 .description("Summary \"quoted\" \\ path\nnext - Details\twith\rline")
+                .enabled(true)
                 .build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
 
@@ -226,6 +232,7 @@ class AlertServiceTest {
                 .metric("rocketmq_consumer_lag_messages")
                 .operator(">")
                 .threshold(1)
+                .enabled(true)
                 .build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
 
@@ -234,6 +241,50 @@ class AlertServiceTest {
         JsonNode exportedRule = new ObjectMapper(new YAMLFactory()).readTree(result)
                 .path("groups").get(0).path("rules").get(0);
         assertThat(exportedRule.path("alert").asText()).isEqualTo("RocketMQAlert");
+    }
+
+    @Test
+    void exportPrometheusRulesYamlShouldExcludeDisabledRules() {
+        AlertRuleVO enabled = AlertRuleVO.builder()
+                .name("Enabled Lag Alert")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(1000)
+                .enabled(true)
+                .build();
+        AlertRuleVO disabled = AlertRuleVO.builder()
+                .name("Disabled Lag Alert")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(2000)
+                .enabled(false)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(enabled, disabled));
+
+        String result = alertService.exportPrometheusRulesYaml();
+
+        assertThat(result)
+                .contains("EnabledLagAlert")
+                .doesNotContain("DisabledLagAlert")
+                .doesNotContain(" > 2000");
+    }
+
+    @Test
+    void exportPrometheusRulesYamlShouldUseDefaultRulesWhenAllConfiguredRulesAreDisabled() {
+        AlertRuleVO disabled = AlertRuleVO.builder()
+                .name("Disabled Lag Alert")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(2000)
+                .enabled(false)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(disabled));
+
+        String result = alertService.exportPrometheusRulesYaml();
+
+        assertThat(result)
+                .contains("RocketMQBrokerDown")
+                .doesNotContain("DisabledLagAlert");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.apache.rocketmq.studio.common.domain.enums.AlertLevel;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -33,6 +34,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,11 +45,14 @@ class AlertServiceTest {
     @Mock
     private AlertRepository alertRepository;
 
+    @Mock
+    private OperationAuditService operationAuditService;
+
     private AlertService alertService;
 
     @org.junit.jupiter.api.BeforeEach
     void setUp() {
-        alertService = new AlertService(alertRepository, new AlertRuleAssetService());
+        alertService = new AlertService(alertRepository, new AlertRuleAssetService(), operationAuditService);
     }
 
     @Test
@@ -252,6 +257,8 @@ class AlertServiceTest {
         assertThat(result.getClusterName()).isEqualTo("DefaultCluster");
         assertThat(result.getSeverity()).isEqualTo("critical");
         verify(alertRepository).saveRule(result);
+        verify(operationAuditService).record(eq("CREATE_ALERT_RULE"), eq("ALERT_RULE"), eq(result.getId()),
+                eq(null), eq("name=Replication Lag High"), eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -300,6 +307,8 @@ class AlertServiceTest {
         assertThat(result.getId()).isEqualTo("rule-1");
         assertThat(result.getThreshold()).isEqualTo(90.0);
         verify(alertRepository).replaceRule(update);
+        verify(operationAuditService).record(eq("UPDATE_ALERT_RULE"), eq("ALERT_RULE"), eq("rule-1"),
+                eq(null), eq("name=CPU Alert"), eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -357,6 +366,8 @@ class AlertServiceTest {
 
         assertThat(result.isEnabled()).isTrue();
         verify(alertRepository).saveRule(result);
+        verify(operationAuditService).record(eq("TOGGLE_ALERT_RULE"), eq("ALERT_RULE"), eq("rule-1"),
+                eq(null), eq("enabled=true"), eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -386,6 +397,8 @@ class AlertServiceTest {
         alertService.deleteRule("rule-1");
 
         verify(alertRepository).deleteRule("rule-1");
+        verify(operationAuditService).record(eq("DELETE_ALERT_RULE"), eq("ALERT_RULE"), eq("rule-1"),
+                eq(null), eq(null), eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -437,6 +450,8 @@ class AlertServiceTest {
 
         assertThat(result.isAcknowledged()).isTrue();
         verify(alertRepository).saveAlert(result);
+        verify(operationAuditService).record(eq("ACKNOWLEDGE_SYSTEM_ALERT"), eq("SYSTEM_ALERT"), eq("a1"),
+                eq(null), eq("acknowledged=true"), eq("SUCCESS"), eq(null));
     }
 
     @Test
@@ -456,6 +471,8 @@ class AlertServiceTest {
 
         assertThat(result).isEqualTo(3);
         verify(alertRepository).deleteAcknowledgedAlerts();
+        verify(operationAuditService).record(eq("CLEAR_ACKNOWLEDGED_SYSTEM_ALERTS"), eq("SYSTEM_ALERT"),
+                eq(null), eq(null), eq("deleted=3"), eq("SUCCESS"), eq(null));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- records successful alert-rule mutations and system-alert acknowledgement or cleanup actions;
- keeps audit details concise and excludes expressions, channels, and descriptions;
- exports only enabled alert rules to Prometheus rule YAML, while retaining fallback defaults when no enabled user rules remain.

Closes #1310
Closes #1298

## Test

```bash
cd server
JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -q -Dtest=AlertServiceTest,AlertServiceDefaultRulesTest test
```