### PR TITLE
fix: clarify that ACL records are Studio-local

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -305,6 +305,14 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: '访问控制规则与用户权限管理，共 {rules} 条规则、{users} 个用户',
     en: 'Access control rules and user permissions, {rules} rules, {users} users',
   },
+  'acl.localMetadataNotice': {
+    zh: '当前 ACL 规则和用户仅保存为 Studio 本地元数据',
+    en: 'Current ACL rules and users are stored as Studio-local metadata',
+  },
+  'acl.localMetadataDescription': {
+    zh: '它们尚不会下发到所选 RocketMQ 实例。实例级 ACL Provider 接入完成前，请在集群侧管理实际 ACL 策略。',
+    en: 'They are not applied to the selected RocketMQ instance. Manage the effective ACL policy on the cluster until instance-scoped provider support is available.',
+  },
   'acl.addRule': { zh: '添加规则', en: 'Add Rule' },
   'acl.addUser': { zh: '添加用户', en: 'Add User' },
   'acl.ruleTab': { zh: 'ACL 规则', en: 'ACL Rules' },

--- a/web/src/pages/instance/__tests__/AclPage.test.tsx
+++ b/web/src/pages/instance/__tests__/AclPage.test.tsx
@@ -103,6 +103,14 @@ describe('ACL page', () => {
     expect(aclService.listAclUsers).toHaveBeenCalledTimes(1);
   });
 
+  it('explains that ACL records are Studio-local metadata', async () => {
+    renderWithProviders(<AclPage />);
+
+    expect(await screen.findByTestId('acl-local-metadata-notice')).toHaveTextContent(
+      '当前 ACL 规则和用户仅保存为 Studio 本地元数据',
+    );
+  });
+
   it('renders backend users on the user tab', async () => {
     const user = userEvent.setup();
     renderWithProviders(<AclPage />);

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -33,6 +33,7 @@ import {
   Badge,
   Typography,
   Flex,
+  Alert,
   message,
 } from 'antd';
 import { Plus, MagnifyingGlass, ShieldCheck, User, Eye, EyeSlash } from '@phosphor-icons/react';
@@ -645,6 +646,15 @@ const AclPage = () => {
             {activeTab === 'rules' ? t('acl.addRule') : t('acl.addUser')}
           </Button>
         }
+      />
+
+      <Alert
+        data-testid="acl-local-metadata-notice"
+        type="warning"
+        showIcon
+        message={t('acl.localMetadataNotice')}
+        description={t('acl.localMetadataDescription')}
+        style={{ marginBottom: 16 }}
       />
 
       <Card bordered={false} bodyStyle={{ padding: 0 }}>


### PR DESCRIPTION
## Summary

Clarifies that the current ACL rule and user screens manage Studio-local metadata and do not apply policies to the selected RocketMQ instance.

This prevents operators from treating the current CRUD flow as an effective cluster ACL change while instance-scoped ACL provider support is designed.

Refs #1312

## Test

- `cd web && npm test -- --run src/pages/instance/__tests__/AclPage.test.tsx`
- `cd web && npm run lint`