### PR TITLE
fix: clarify that K8s certificate records are local

### DIFF
--- a/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
@@ -100,6 +100,14 @@ describe('K8sCertsPage', () => {
     expect(screen.getByText('-')).toBeInTheDocument();
   });
 
+  it('explains that certificate records are Studio-local metadata', async () => {
+    renderPage();
+
+    expect(await screen.findByTestId('k8s-cert-local-metadata-notice')).toHaveTextContent(
+      '当前证书记录仅保存为 Studio 本地元数据',
+    );
+  });
+
   it.each([
     ['platform', 'rocketmq-staging-tls', 'rocketmq-prod-tls'],
     ['broker.prod.example.com', 'rocketmq-prod-tls', 'rocketmq-staging-tls'],

--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -28,6 +28,7 @@ import {
   Space,
   Typography,
   Card,
+  Alert,
   message,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
@@ -351,6 +352,14 @@ const K8sCertsPage = () => {
             添加证书
           </Button>
         }
+      />
+      <Alert
+        data-testid="k8s-cert-local-metadata-notice"
+        type="warning"
+        showIcon
+        message="当前证书记录仅保存为 Studio 本地元数据"
+        description="创建、续期和删除操作尚不会应用到 Kubernetes 集群或 cert-manager。请在集群侧管理实际证书，直到 Kubernetes Provider 接入完成。"
+        style={{ marginBottom: 16 }}
       />
       <Flex justify="space-between" style={{ marginBottom: 16 }}>
         <Space>


### PR DESCRIPTION
## Summary

Clarifies that the current K8s certificate inventory and create, renew, and delete operations manage Studio-local records only. They do not mutate a Kubernetes cluster or cert-manager.

This keeps the existing screen usable without presenting local records as effective cluster certificate management.

Refs #1314

## Test

- `cd web && npm test -- --run src/pages/cluster/__tests__/K8sCertsPage.test.tsx`
- `cd web && npm run lint`