### PR TITLE
fix: reject blank message trace identifiers

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -45,6 +45,9 @@ public class MessageService {
     }
 
     public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
+        if (!StringUtils.hasText(msgId)) {
+            throw new BusinessException(400, "msgId is required");
+        }
         log.info("Getting message trace: msgId={}", msgId);
         return providerRegistry.byInstanceId(instanceId)
                 .map(provider -> provider.getMessageTrace(instanceId, msgId))

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -51,6 +51,19 @@ class MessageServiceTest {
     }
 
     @Test
+    void rejectsBlankMessageTraceIdBeforeCallingProvider() {
+        MessageProvider provider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(provider, registry);
+
+        assertThatThrownBy(() -> service.getMessageTrace("instance-a", "  "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("msgId is required");
+
+        verifyNoInteractions(provider, registry);
+    }
+
+    @Test
     void rejectsReversedTopicQueryWindowBeforeCallingProvider() {
         MessageProvider provider = mock(MessageProvider.class);
         InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);


### PR DESCRIPTION
## Summary

Rejects blank message trace identifiers before provider resolution or RocketMQ admin calls. This prevents an invalid trace request from being reported as an empty trace.

Closes #1316

## Test

- `cd server && JAVA_HOME=$( /usr/libexec/java_home -v 21 ) PATH="$JAVA_HOME/bin:$PATH" mvn -q -Dtest=MessageServiceTest,MessageControllerTest test`