### PR TITLE
fix: validate runtime Topic and Group names

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
@@ -84,11 +84,12 @@ public class MetadataService {
     }
 
     public List<BrokerRouteVO> getTopicRoutes(String instanceId, String name) {
+        String topicName = requireName(name, "topic name");
         if (resolve(instanceId).vendor() != InstanceVendor.APACHE) {
             // broker routing does not apply to serverless cloud instances
             return List.of();
         }
-        return metadataProvider.getTopicRoutes(instanceId, name);
+        return metadataProvider.getTopicRoutes(instanceId, topicName);
     }
 
 
@@ -97,7 +98,8 @@ public class MetadataService {
     }
 
     public List<TopicConsumerVO> getTopicConsumers(String instanceId, String name) {
-        return resolve(instanceId).getTopicConsumers(instanceId, name);
+        String topicName = requireName(name, "topic name");
+        return resolve(instanceId).getTopicConsumers(instanceId, topicName);
     }
 
 
@@ -129,10 +131,11 @@ public class MetadataService {
     }
 
     public ConsumerGroupVO getConsumerGroup(String instanceId, String name) {
+        String groupName = requireName(name, "consumer group name");
         if (resolve(instanceId).vendor() != InstanceVendor.APACHE) {
             throw new BusinessException(501, "Consumer group detail is not supported for cloud instances");
         }
-        return adminClient.getConsumerGroup(instanceId, name);
+        return adminClient.getConsumerGroup(instanceId, groupName);
     }
 
 
@@ -141,7 +144,8 @@ public class MetadataService {
     }
 
     public List<QueueProgressVO> getGroupProgress(String instanceId, String name) {
-        return resolve(instanceId).getGroupProgress(instanceId, name);
+        String groupName = requireName(name, "consumer group name");
+        return resolve(instanceId).getGroupProgress(instanceId, groupName);
     }
 
 
@@ -150,7 +154,8 @@ public class MetadataService {
     }
 
     public List<SubscriptionEntryVO> getGroupSubscriptions(String instanceId, String name) {
-        return resolve(instanceId).getGroupSubscriptions(instanceId, name);
+        String groupName = requireName(name, "consumer group name");
+        return resolve(instanceId).getGroupSubscriptions(instanceId, groupName);
     }
 
 
@@ -205,5 +210,12 @@ public class MetadataService {
         if (request == null) {
             throw new BusinessException(400, "Topic send message request is required");
         }
+    }
+
+    private String requireName(String value, String fieldName) {
+        if (isBlank(value)) {
+            throw new BusinessException(400, fieldName + " is required");
+        }
+        return value.trim();
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
@@ -172,6 +172,27 @@ class MetadataServiceTest {
     }
 
     @Test
+    void runtimeDiagnosticsShouldRejectBlankTopicAndGroupNamesBeforeProviderResolution() {
+        assertThatThrownBy(() -> metadataService.getTopicRoutes("instance-a", " "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topic name is required");
+        assertThatThrownBy(() -> metadataService.getTopicConsumers("instance-a", " "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topic name is required");
+        assertThatThrownBy(() -> metadataService.getConsumerGroup("instance-a", " "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("consumer group name is required");
+        assertThatThrownBy(() -> metadataService.getGroupProgress("instance-a", " "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("consumer group name is required");
+        assertThatThrownBy(() -> metadataService.getGroupSubscriptions("instance-a", " "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("consumer group name is required");
+
+        verifyNoInteractions(metadataProvider, adminClient, providerRegistry, apacheProvider);
+    }
+
+    @Test
     void sendMessageShouldReturnResult() {
         SendMessageDTO request = SendMessageDTO.builder()
                 .topic("test-topic")


### PR DESCRIPTION
## Summary

Rejects blank Topic and Consumer Group names before resolving an instance provider for runtime diagnostics. Valid names are normalized once at the service boundary.

Closes #1318

## Test

- `cd server && JAVA_HOME=$( /usr/libexec/java_home -v 21 ) PATH="$JAVA_HOME/bin:$PATH" mvn -q -Dtest=MetadataServiceTest test`