### PR TITLE
[Studio] feat: export all Grafana dashboards as an archive

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -114,6 +114,10 @@
 | 71 | GET | `/api/ai/tools` | 可用工具列表 |
 | 72 | POST | `/api/ai/tools/:name/execute` | 执行只读 AI 工具 |
 | 73 | POST | `/api/metrics/query` | 查询监控指标数据 |
+| 74 | GET | `/api/metrics/grafana/dashboards` | Grafana 看板列表 |
+| 75 | GET | `/api/metrics/grafana/dashboards/:uid` | Grafana 看板 JSON 模型 |
+| 76 | GET | `/api/metrics/grafana/dashboards/:uid/export` | 导出单个 Grafana 看板 JSON |
+| 77 | GET | `/api/metrics/grafana/dashboards/export` | 打包导出全部 Grafana 看板 |
 
 ## 通用响应格式
 
@@ -1906,6 +1910,108 @@ studio:
 | `502` | 无法连接 Prometheus，或 Prometheus 返回非法响应 |
 | `503` | Prometheus 未配置或暂时不可用 |
 | `504` | Prometheus 查询超时 |
+
+### 16.2 Grafana 看板列表
+
+```
+GET /api/metrics/grafana/dashboards
+```
+
+返回内置的 RocketMQ Grafana 看板资产元数据。服务端只返回可以解析为 JSON
+对象且包含有效 `uid` 的看板；无效资产会被跳过。
+
+**Response `data`:** `GrafanaDashboardInfo[]`
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `uid` | `string` | Grafana 看板 UID，同时用于详情和导出接口 |
+| `title` | `string` | 看板标题 |
+| `description` | `string` | 看板说明 |
+| `tags` | `string[]` | 看板标签 |
+
+**Response 示例：**
+
+```json
+[
+  {
+    "uid": "rocketmq-overview",
+    "title": "RocketMQ Cluster Overview",
+    "description": "Overview dashboard for RocketMQ cluster metrics",
+    "tags": ["rocketmq"]
+  }
+]
+```
+
+### 16.3 获取 Grafana 看板 JSON 模型
+
+```
+GET /api/metrics/grafana/dashboards/:uid
+```
+
+**Path Parameters:**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `uid` | `string` | 是 | Grafana 看板 UID |
+
+**Response `data`:** `Record<string, any>`
+
+响应体是完整 Grafana dashboard JSON 模型，前端可用于预览或复制配置。
+
+**错误响应：**
+
+| HTTP 状态 | 场景 |
+|-----------|------|
+| `404` | 指定 UID 的内置看板不存在 |
+| `500` | 看板 JSON 读取失败 |
+
+### 16.4 导出单个 Grafana 看板
+
+```
+GET /api/metrics/grafana/dashboards/:uid/export
+```
+
+**Path Parameters:**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `uid` | `string` | 是 | Grafana 看板 UID |
+
+**Response:**
+
+- `Content-Type: application/json`
+- `Content-Disposition: attachment; filename="{uid}.json"`
+- Body 为原始 Grafana dashboard JSON 文件内容。
+
+**错误响应：**
+
+| HTTP 状态 | 场景 |
+|-----------|------|
+| `404` | 指定 UID 的内置看板不存在 |
+| `500` | 看板 JSON 读取失败 |
+
+### 16.5 打包导出全部 Grafana 看板
+
+```
+GET /api/metrics/grafana/dashboards/export
+```
+
+返回全部有效内置 Grafana 看板的 zip 压缩包。压缩包内每个条目按
+`{uid}.json` 命名，条目集合与 `GET /api/metrics/grafana/dashboards`
+返回的可见看板列表保持一致。
+
+**Response:**
+
+- `Content-Type: application/zip`
+- `Content-Disposition: attachment; filename="rocketmq-grafana-dashboards.zip"`
+- Body 为 zip 文件二进制内容。
+
+**错误响应：**
+
+| HTTP 状态 | 场景 |
+|-----------|------|
+| `404` | 没有可导出的有效内置看板 |
+| `500` | 看板 JSON 读取或 zip 打包失败 |
 
 ---
 

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardController.java
@@ -58,6 +58,19 @@ public class GrafanaDashboardController {
         return Result.ok(grafanaDashboardService.getDashboard(uid));
     }
 
+    @Operation(summary = "Export all Grafana dashboards",
+            description = "Returns all bundled RocketMQ Grafana dashboards as a downloadable zip archive")
+    @ApiResponse(responseCode = "200", description = "Dashboard archive returned")
+    @GetMapping("/dashboards/export")
+    public ResponseEntity<byte[]> exportDashboards() {
+        byte[] archive = grafanaDashboardService.getDashboardsArchive();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.valueOf("application/zip"));
+        headers.setContentDisposition(
+                ContentDisposition.attachment().filename("rocketmq-grafana-dashboards.zip").build());
+        return new ResponseEntity<>(archive, headers, HttpStatus.OK);
+    }
+
     @Operation(summary = "Export a Grafana dashboard JSON",
             description = "Returns the raw Grafana dashboard JSON as a downloadable attachment")
     @ApiResponse(responseCode = "200", description = "Dashboard JSON returned")

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
@@ -26,12 +26,15 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.stereotype.Service;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 /**
  * Loads the Grafana dashboard JSON assets bundled under {@code classpath*:grafana/*.json}
@@ -108,6 +111,30 @@ public class GrafanaDashboardService {
             return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new BusinessException(500, "Failed to read Grafana dashboard: " + uid);
+        }
+    }
+
+    /**
+     * Returns all valid bundled dashboards as a zip archive. Invalid dashboard assets are skipped
+     * the same way as {@link #listDashboards()} so the archive matches the visible dashboard list.
+     */
+    public byte[] getDashboardsArchive() {
+        List<GrafanaDashboardInfo> dashboards = listDashboards();
+        if (dashboards.isEmpty()) {
+            throw new BusinessException(404, "No Grafana dashboards are available");
+        }
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream();
+             ZipOutputStream zip = new ZipOutputStream(output, StandardCharsets.UTF_8)) {
+            for (GrafanaDashboardInfo dashboard : dashboards) {
+                ZipEntry entry = new ZipEntry(dashboard.uid() + ".json");
+                zip.putNextEntry(entry);
+                zip.write(getDashboardJson(dashboard.uid()).getBytes(StandardCharsets.UTF_8));
+                zip.closeEntry();
+            }
+            zip.finish();
+            return output.toByteArray();
+        } catch (IOException e) {
+            throw new BusinessException(500, "Failed to export Grafana dashboards");
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardControllerTest.java
@@ -84,4 +84,17 @@ class GrafanaDashboardControllerTest {
                         "attachment; filename=\"rocketmq-overview.json\""))
                 .andExpect(content().json("{\"uid\":\"rocketmq-overview\"}"));
     }
+
+    @Test
+    void exportDashboardsShouldReturnZipAttachment() throws Exception {
+        byte[] archive = "zip-content".getBytes();
+        when(grafanaDashboardService.getDashboardsArchive()).thenReturn(archive);
+
+        mockMvc.perform(get("/api/metrics/grafana/dashboards/export"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/zip"))
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"rocketmq-grafana-dashboards.zip\""))
+                .andExpect(content().bytes(archive));
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
@@ -22,13 +22,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipInputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -90,6 +93,33 @@ class GrafanaDashboardServiceTest {
     void getDashboardJsonShouldThrowWhenUidUnknown() {
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> service.getDashboardJson("no-such-dashboard"));
+        assertEquals(404, exception.getCode());
+    }
+
+    @Test
+    void getDashboardsArchiveShouldIncludeAllVisibleDashboards() throws Exception {
+        GrafanaDashboardService service = serviceWithResources(
+                resource("b.json", "{\"uid\":\"b\",\"title\":\"B\",\"tags\":[\"rocketmq\"]}"),
+                resource("invalid.json", "[]"),
+                resource("a.json", "{\"uid\":\"a\",\"title\":\"A\",\"tags\":[\"rocketmq\"]}"));
+
+        byte[] archive = service.getDashboardsArchive();
+
+        try (ZipInputStream zip = new ZipInputStream(new ByteArrayInputStream(archive), StandardCharsets.UTF_8)) {
+            assertEquals("a.json", zip.getNextEntry().getName());
+            assertTrue(new String(zip.readAllBytes(), StandardCharsets.UTF_8).contains("\"uid\":\"a\""));
+            assertEquals("b.json", zip.getNextEntry().getName());
+            assertTrue(new String(zip.readAllBytes(), StandardCharsets.UTF_8).contains("\"uid\":\"b\""));
+            assertNull(zip.getNextEntry());
+        }
+    }
+
+    @Test
+    void getDashboardsArchiveShouldRejectEmptyDashboardSet() {
+        GrafanaDashboardService service = serviceWithResources(resource("invalid.json", "[]"));
+
+        BusinessException exception = assertThrows(BusinessException.class, service::getDashboardsArchive);
+
         assertEquals(404, exception.getCode());
     }
 

--- a/web/src/api/metrics.test.ts
+++ b/web/src/api/metrics.test.ts
@@ -23,6 +23,7 @@ import {
   listGrafanaDashboards,
   getGrafanaDashboard,
   exportGrafanaDashboard,
+  exportGrafanaDashboards,
   listMetricProfiles,
   queryByDataSource,
   queryMetrics,
@@ -190,5 +191,15 @@ describe('metrics API', () => {
     const result = await exportGrafanaDashboard('rocketmq-overview');
     expect(result).toBeInstanceOf(Blob);
     await expect(result.text()).resolves.toContain('rocketmq-overview');
+  });
+
+  it('exports all Grafana dashboards as a blob', async () => {
+    const blob = new Blob(['zip-content'], { type: 'application/zip' });
+
+    mock.onGet('/metrics/grafana/dashboards/export').reply(200, blob);
+
+    const result = await exportGrafanaDashboards();
+    expect(result).toBeInstanceOf(Blob);
+    await expect(result.text()).resolves.toContain('zip-content');
   });
 });

--- a/web/src/api/metrics.ts
+++ b/web/src/api/metrics.ts
@@ -157,3 +157,10 @@ export async function exportGrafanaDashboard(uid: string): Promise<Blob> {
   );
   return res.data;
 }
+
+export async function exportGrafanaDashboards(): Promise<Blob> {
+  const res = await client.get<Blob>('/metrics/grafana/dashboards/export', {
+    responseType: 'blob',
+  });
+  return res.data;
+}

--- a/web/src/components/GrafanaDashboardList.tsx
+++ b/web/src/components/GrafanaDashboardList.tsx
@@ -23,6 +23,7 @@ import { useLang } from '../i18n/LangContext';
 import {
   getGrafanaDashboard,
   exportGrafanaDashboard,
+  exportGrafanaDashboards,
   listGrafanaDashboards,
 } from '../services/grafanaService';
 import type { GrafanaDashboardInfo } from '../api/metrics';
@@ -39,6 +40,7 @@ export const GrafanaDashboardList: React.FC = () => {
   const [viewLoading, setViewLoading] = useState(false);
   const viewRequestId = useRef(0);
   const [exportingUids, setExportingUids] = useState<Set<string>>(() => new Set());
+  const [exportingAll, setExportingAll] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -87,13 +89,13 @@ export const GrafanaDashboardList: React.FC = () => {
     setViewLoading(false);
   };
 
-  const triggerDownload = (uid: string, content: Blob | string) => {
+  const triggerDownload = (filename: string, content: Blob | string) => {
     const blob =
       typeof content === 'string' ? new Blob([content], { type: 'application/json' }) : content;
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${uid}.json`;
+    a.download = filename;
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -102,7 +104,7 @@ export const GrafanaDashboardList: React.FC = () => {
     setExportingUids((current) => new Set(current).add(info.uid));
     try {
       const blob = await exportGrafanaDashboard(info.uid);
-      triggerDownload(info.uid, blob);
+      triggerDownload(`${info.uid}.json`, blob);
       message.success(t('grafana.exported'));
     } catch {
       message.error(t('grafana.exportFailed'));
@@ -112,6 +114,19 @@ export const GrafanaDashboardList: React.FC = () => {
         next.delete(info.uid);
         return next;
       });
+    }
+  };
+
+  const handleExportAll = async () => {
+    setExportingAll(true);
+    try {
+      const blob = await exportGrafanaDashboards();
+      triggerDownload('rocketmq-grafana-dashboards.zip', blob);
+      message.success(t('grafana.exportAllDone'));
+    } catch {
+      message.error(t('grafana.exportAllFailed'));
+    } finally {
+      setExportingAll(false);
     }
   };
 
@@ -166,6 +181,17 @@ export const GrafanaDashboardList: React.FC = () => {
 
   return (
     <div>
+      <Space style={{ marginBottom: 12 }}>
+        <Button
+          icon={<DownloadSimple size={16} />}
+          loading={exportingAll}
+          disabled={loading || dashboards.length === 0}
+          onClick={handleExportAll}
+        >
+          {t('grafana.exportAll')}
+        </Button>
+      </Space>
+
       <Table
         columns={columns}
         dataSource={dashboards}

--- a/web/src/components/__tests__/GrafanaDashboardList.test.tsx
+++ b/web/src/components/__tests__/GrafanaDashboardList.test.tsx
@@ -23,6 +23,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import { LangProvider } from '../../i18n/LangContext';
 import {
   exportGrafanaDashboard,
+  exportGrafanaDashboards,
   getGrafanaDashboard,
   listGrafanaDashboards,
 } from '../../services/grafanaService';
@@ -32,6 +33,7 @@ vi.mock('../../services/grafanaService', () => ({
   listGrafanaDashboards: vi.fn(),
   getGrafanaDashboard: vi.fn(),
   exportGrafanaDashboard: vi.fn(),
+  exportGrafanaDashboards: vi.fn(),
 }));
 
 const dashboards = [
@@ -72,6 +74,9 @@ beforeEach(() => {
   vi.mocked(getGrafanaDashboard).mockResolvedValue(dashboardModel);
   vi.mocked(exportGrafanaDashboard).mockResolvedValue(
     new Blob([JSON.stringify(dashboardModel, null, 2)], { type: 'application/json' }),
+  );
+  vi.mocked(exportGrafanaDashboards).mockResolvedValue(
+    new Blob(['zip-content'], { type: 'application/zip' }),
   );
 });
 
@@ -189,9 +194,41 @@ describe('GrafanaDashboardList', () => {
 
     await screen.findByText('RocketMQ Cluster Overview');
     const exportButtons = screen.getAllByRole('button', { name: /Export|导出/ });
-    await user.click(exportButtons[0]);
+    await user.click(exportButtons[1]);
 
     await waitFor(() => expect(exportGrafanaDashboard).toHaveBeenCalledWith('rocketmq-overview'));
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalled();
+
+    clickSpy.mockRestore();
+  });
+
+  it('exports all dashboards and downloads the archive', async () => {
+    const user = userEvent.setup();
+    const createObjectURL = vi.fn().mockReturnValue('blob:grafana-all');
+    const revokeObjectURL = vi.fn();
+    let downloadedFilename = '';
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      downloadedFilename = this.download;
+    });
+    Object.defineProperty(URL, 'createObjectURL', { writable: true, value: createObjectURL });
+    Object.defineProperty(URL, 'revokeObjectURL', { writable: true, value: revokeObjectURL });
+
+    render(
+      <App>
+        <LangProvider>
+          <GrafanaDashboardList />
+        </LangProvider>
+      </App>,
+    );
+
+    await screen.findByText('RocketMQ Cluster Overview');
+    await user.click(screen.getByRole('button', { name: /Export all|导出全部/ }));
+
+    await waitFor(() => expect(exportGrafanaDashboards).toHaveBeenCalledTimes(1));
+    expect(downloadedFilename).toBe('rocketmq-grafana-dashboards.zip');
     expect(createObjectURL).toHaveBeenCalledTimes(1);
     expect(clickSpy).toHaveBeenCalled();
 

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -804,6 +804,9 @@ const translations: Record<string, Record<Lang, string>> = {
   'grafana.loadFailed': { zh: '加载看板失败', en: 'Failed to load dashboards' },
   'grafana.exported': { zh: '看板已导出', en: 'Dashboard exported' },
   'grafana.exportFailed': { zh: '导出看板失败', en: 'Failed to export dashboard' },
+  'grafana.exportAll': { zh: '导出全部', en: 'Export all' },
+  'grafana.exportAllDone': { zh: '全部看板已导出', en: 'All dashboards exported' },
+  'grafana.exportAllFailed': { zh: '导出全部看板失败', en: 'Failed to export dashboards' },
   // ─── Alert rule templates ───
   'alertAssets.title': { zh: '告警规则模板', en: 'Alert Rule Templates' },
   'alertAssets.name': { zh: '名称', en: 'Name' },

--- a/web/src/services/grafanaService.test.ts
+++ b/web/src/services/grafanaService.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as grafanaApi from '../api/metrics';
 import {
   exportGrafanaDashboard,
+  exportGrafanaDashboards,
   getGrafanaDashboard,
   listGrafanaDashboards,
 } from './grafanaService';
@@ -44,6 +45,13 @@ describe('grafanaService', () => {
     await expect(blob.text()).resolves.toContain('rocketmq-overview');
   });
 
+  it('exports all dashboards as a blob in mock mode', async () => {
+    const blob = await exportGrafanaDashboards();
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('application/zip');
+    await expect(blob.text()).resolves.toContain('rocketmq-overview.json');
+  });
+
   it('delegates to the api in real mode', async () => {
     isMockModeMock.isMockMode = () => false;
     const listSpy = vi
@@ -55,5 +63,16 @@ describe('grafanaService', () => {
     const result = await listGrafanaDashboards();
     expect(listSpy).toHaveBeenCalledTimes(1);
     expect(result[0].uid).toBe('rocketmq-overview');
+  });
+
+  it('delegates bulk export to the api in real mode', async () => {
+    isMockModeMock.isMockMode = () => false;
+    const exportSpy = vi
+      .spyOn(grafanaApi, 'exportGrafanaDashboards')
+      .mockResolvedValue(new Blob(['zip-content'], { type: 'application/zip' }));
+
+    const result = await exportGrafanaDashboards();
+    expect(exportSpy).toHaveBeenCalledTimes(1);
+    expect(result.type).toBe('application/zip');
   });
 });

--- a/web/src/services/grafanaService.ts
+++ b/web/src/services/grafanaService.ts
@@ -37,3 +37,14 @@ export async function exportGrafanaDashboard(uid: string): Promise<Blob> {
   }
   return metricsApi.exportGrafanaDashboard(uid);
 }
+
+export async function exportGrafanaDashboards(): Promise<Blob> {
+  if (isMockMode()) {
+    const bundle = mockGrafanaDashboards.map(({ uid, model }) => ({
+      filename: `${uid}.json`,
+      model,
+    }));
+    return new Blob([JSON.stringify(bundle, null, 2)], { type: 'application/zip' });
+  }
+  return metricsApi.exportGrafanaDashboards();
+}


### PR DESCRIPTION
## What is the purpose of the change

RocketMQ Studio can list, preview, and export individual bundled Grafana dashboards, but users need to download dashboards one by one when importing or backing them up.

This change adds a bulk export flow that packages all valid bundled Grafana dashboards into a zip archive from the dashboard page.

## Brief changelog

- Added a backend endpoint to export all bundled Grafana dashboards as a zip archive.
- Added frontend API/service support and an "Export all" action on the Grafana dashboards page.
- Added i18n labels, API documentation, and focused backend/frontend tests for the archive export flow.

## Verifying this change

- `mvn -Dtest=GrafanaDashboardServiceTest,GrafanaDashboardControllerTest test`
- `npx vitest run src/api/metrics.test.ts src/services/grafanaService.test.ts src/components/__tests__/GrafanaDashboardList.test.tsx`
- `npm run lint`
- `npm run build`
- `git diff --check`