### PR TITLE
fix: normalize managed instance names

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -101,9 +101,7 @@ public class InstanceService {
 
     private void createApacheInstance(InstanceVO instance) {
         instance.setVendor(InstanceVendor.APACHE);
-        if (instance.getName() == null || instance.getName().isBlank()) {
-            throw new BusinessException(400, "InstanceVO name is required");
-        }
+        instance.setName(requireInstanceName(instance.getName()));
         instance.setEndpoint(requireValidEndpoint(instance.getEndpoint()));
         if (instance.getType() == null) {
             throw new BusinessException(400, "InstanceVO type is required");
@@ -131,10 +129,11 @@ public class InstanceService {
         }
         CloudInstanceDetailVO detail = providerRegistry.catalogFor(InstanceVendor.ALIYUN)
                 .getCloudInstance(instance.getCredentialId(), instance.getRegionId(), instance.getCloudInstanceId());
-        if (instance.getName() == null || instance.getName().isBlank()) {
+        if (!StringUtils.hasText(instance.getName())) {
             instance.setName(detail.getInstanceName() != null && !detail.getInstanceName().isBlank()
                     ? detail.getInstanceName() : detail.getInstanceId());
         }
+        instance.setName(requireInstanceName(instance.getName()));
         instance.setType(InstanceType.PROXY);
         instance.setEndpoint(resolveEndpoint(detail));
     }
@@ -176,6 +175,13 @@ public class InstanceService {
         return normalized;
     }
 
+    private String requireInstanceName(String name) {
+        if (!StringUtils.hasText(name)) {
+            throw new BusinessException(400, "InstanceVO name is required");
+        }
+        return name.trim();
+    }
+
     public InstanceVO updateInstance(InstanceVO instance) {
         requireInstance(instance);
         log.info("Updating instance: {}", instance.getId());
@@ -194,7 +200,7 @@ public class InstanceService {
         InstanceVO updated = copyOf(existing);
         boolean cloudInstance = existing.getVendor() != null && existing.getVendor() != InstanceVendor.APACHE;
         if (instance.getName() != null) {
-            updated.setName(instance.getName());
+            updated.setName(requireInstanceName(instance.getName()));
         }
         if (!cloudInstance) {
             if (instance.getType() != null) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -328,6 +328,15 @@ class InstanceServiceTest {
     }
 
     @Test
+    void createInstanceShouldTrimNameBeforeSaving() {
+        InstanceVO input = InstanceVO.builder().name("  production  ").type(InstanceType.PROXY)
+                .endpoint("namesrv:9876").build();
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThat(instanceService.createInstance(input).getName()).isEqualTo("production");
+    }
+
+    @Test
     void updateInstanceShouldMergeFieldsOntoExisting() {
         LocalDateTime originalCreatedAt = LocalDateTime.of(2025, 1, 2, 3, 4, 5);
         LocalDateTime originalUpdatedAt = LocalDateTime.of(2025, 2, 3, 4, 5, 6);
@@ -367,6 +376,18 @@ class InstanceServiceTest {
         assertThat(existing.getName()).isEqualTo("old-name");
         assertThat(existing.getRemark()).isEqualTo("old remark");
         assertThat(existing.getUpdatedAt()).isEqualTo(originalUpdatedAt);
+    }
+
+    @Test
+    void updateInstanceShouldTrimNameBeforeSaving() {
+        InstanceVO existing = InstanceVO.builder().name("old-name").endpoint("namesrv:9876").build();
+        existing.setId("inst-1");
+        InstanceVO update = InstanceVO.builder().name("  production  ").build();
+        update.setId("inst-1");
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThat(instanceService.updateInstance(update).getName()).isEqualTo("production");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Normalizes accepted managed instance names before persistence for Apache and Aliyun creation as well as instance updates. This keeps instance lists, searches, and audit records consistent with user-visible names.

Closes #1321

## Test

- `cd server && JAVA_HOME=$( /usr/libexec/java_home -v 21 ) PATH="$JAVA_HOME/bin:$PATH" mvn -q -Dtest=InstanceServiceTest test`