### PR TITLE
fix: preserve selected instance for Consumer Group details

### DIFF
--- a/web/src/services/consumerService.test.ts
+++ b/web/src/services/consumerService.test.ts
@@ -24,10 +24,16 @@ import {
   listConsumerGroups,
 } from './consumerService';
 
-vi.mock('./dataMode', () => ({ isMockMode: () => true }));
+const { mode, metadataApi } = vi.hoisted(() => ({
+  mode: { mock: true },
+  metadataApi: { getConsumerGroup: vi.fn() },
+}));
+
+vi.mock('./dataMode', () => ({ isMockMode: () => mode.mock }));
 vi.mock('../config', () => ({
   API_BASE_URL: '/api',
 }));
+vi.mock('../api/metadata', () => metadataApi);
 
 describe('consumer service mock data', () => {
   it('returns copied consumer group rows', async () => {
@@ -92,5 +98,22 @@ describe('consumer service mock data', () => {
     const detail = await getConsumerGroup('cg-created-copy-test');
     expect(detail.subscribedTopics).toEqual(['created-topic']);
     expect(detail).not.toBe(created);
+  });
+
+  it('forwards the selected instance when loading consumer group details in API mode', async () => {
+    mode.mock = false;
+    const detail = {
+      name: 'cg-orders',
+      subscribedTopics: [],
+      instances: [],
+    };
+    try {
+      metadataApi.getConsumerGroup.mockResolvedValue(detail);
+
+      await expect(getConsumerGroup('cg-orders', 'instance-a')).resolves.toEqual(detail);
+      expect(metadataApi.getConsumerGroup).toHaveBeenCalledWith('cg-orders', 'instance-a');
+    } finally {
+      mode.mock = true;
+    }
   });
 });

--- a/web/src/services/consumerService.ts
+++ b/web/src/services/consumerService.ts
@@ -61,13 +61,16 @@ export async function getConsumerProgress(
   return metadataApi.getConsumerProgress(name, instanceId);
 }
 
-export async function getConsumerGroup(name: string): Promise<ConsumerGroupDetail> {
+export async function getConsumerGroup(
+  name: string,
+  instanceId?: string,
+): Promise<ConsumerGroupDetail> {
   if (isMockMode()) {
     const group = mockConsumerGroups.find((item) => item.name === name);
     if (!group) throw new Error(`Consumer group not found: ${name}`);
     return copyConsumerGroup(group as unknown as ConsumerGroupDetail) as ConsumerGroupDetail;
   }
-  return metadataApi.getConsumerGroup(name);
+  return metadataApi.getConsumerGroup(name, instanceId);
 }
 
 export async function getConsumerSubscriptions(


### PR DESCRIPTION
## Summary

Preserves the optional selected instance through `consumerService.getConsumerGroup` so detail reads can reach the intended managed instance in real API mode.

Closes #1323

## Test

- `cd web && npm test -- --run src/services/consumerService.test.ts`
- `cd web && npm run lint`