### PR TITLE
fix(ui): handle messages without tags or keys

### DIFF
--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -4,8 +4,8 @@ import client from './client';
 export interface MessageRecord {
   msgId: string;
   topic: string;
-  tag: string;
-  key: string;
+  tag: string | null;
+  key: string | null;
   body: string;
   storeTime: number | string;
   bornHost: string;

--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -21,6 +21,7 @@ import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MessageRecord } from '../../../api/message';
 import { LangProvider } from '../../../i18n/LangContext';
 
 const messageServiceMocks = vi.hoisted(() => ({
@@ -49,7 +50,7 @@ vi.mock('../../../services/topicService', () => ({
 
 import MessagePage from '../message';
 
-const createMessage = (msgId: string) => ({
+const createMessage = (msgId: string): MessageRecord => ({
   msgId,
   topic: `topic-${msgId}`,
   tag: 'tag',
@@ -289,5 +290,27 @@ describe('Message page query history', () => {
       await screen.findByText('消费验证接口尚未接入，无法确认该消息的真实消费状态'),
     ).toBeInTheDocument();
     expect(screen.queryByText(/消费验证成功/)).not.toBeInTheDocument();
+  });
+
+  it('sorts and renders messages without tags or keys', async () => {
+    const user = userEvent.setup();
+    messageServiceMocks.queryMessages.mockResolvedValue([
+      { ...createMessage('MID-NULL-FIELDS'), tag: null, key: null },
+      { ...createMessage('MID-FULL-FIELDS'), tag: 'vip', key: 'order-001' },
+    ]);
+    renderWithProviders(<MessagePage />);
+
+    await user.click(screen.getByText('按 Message ID'));
+    await user.type(screen.getByPlaceholderText('输入 Message ID'), 'MID');
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+
+    expect(await screen.findByText('MID-NULL-FIELDS')).toBeInTheDocument();
+    expect(screen.getByText('MID-FULL-FIELDS')).toBeInTheDocument();
+    expect(screen.getAllByText('-')).toHaveLength(2);
+
+    await user.click(screen.getByRole('columnheader', { name: /Tag/ }));
+    expect(screen.getByText('MID-NULL-FIELDS')).toBeInTheDocument();
+    await user.click(screen.getByRole('columnheader', { name: /Key/ }));
+    expect(screen.getByText('MID-FULL-FIELDS')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -441,16 +441,18 @@ const MessagePage = () => {
       dataIndex: 'tag',
       key: 'tag',
       width: 80,
-      sorter: (a, b) => a.tag.localeCompare(b.tag),
-      render: (tag: string) => <Tag>{tag}</Tag>,
+      sorter: (a, b) => (a.tag ?? '').localeCompare(b.tag ?? ''),
+      render: (tag: string | null) => <Tag>{tag || '-'}</Tag>,
     },
     {
       title: 'Key',
       dataIndex: 'key',
       key: 'key',
       width: 120,
-      sorter: (a, b) => a.key.localeCompare(b.key),
-      render: (key: string) => <span style={{ fontFamily: 'monospace', fontSize: 13 }}>{key}</span>,
+      sorter: (a, b) => (a.key ?? '').localeCompare(b.key ?? ''),
+      render: (key: string | null) => (
+        <span style={{ fontFamily: 'monospace', fontSize: 13 }}>{key || '-'}</span>
+      ),
     },
     {
       title: 'Message ID',


### PR DESCRIPTION
## Summary

- model RocketMQ message tags and keys as nullable values returned by the backend
- make Tag and Key sorting null-safe and render a clear fallback for missing values
- add a regression test that sorts records with null tags and keys

## Testing

- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/instance/__tests__/MessagePage.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npm run lint -- --quiet`

Fixes #1328
