### PR TITLE
fix(ui): make instance remark sorting null-safe

### DIFF
--- a/web/src/api/instance.ts
+++ b/web/src/api/instance.ts
@@ -23,7 +23,7 @@ export type InstanceVendor = 'APACHE' | 'ALIYUN' | 'TENCENT';
 export interface Instance {
   id: string;
   name: string;
-  remark: string;
+  remark: string | null;
   type: 'PROXY' | 'DIRECT';
   endpoint: string;
   vendor?: InstanceVendor;

--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -48,10 +48,15 @@ beforeAll(() => {
   });
 });
 
-const instance = (id: string, name: string, type: Instance['type'] = 'PROXY'): Instance => ({
+const instance = (
+  id: string,
+  name: string,
+  type: Instance['type'] = 'PROXY',
+  remark: Instance['remark'] = '',
+): Instance => ({
   id,
   name,
-  remark: '',
+  remark,
   type,
   endpoint: `${name}:8080`,
   topicCount: 1,
@@ -204,5 +209,21 @@ describe('InstancePage', () => {
 
     await user.click(within(dialog).getByRole('tab', { name: /Aliyun 版/ }));
     expect(within(dialog).getByText(/云凭据与云上实例完成接入/)).toBeInTheDocument();
+  });
+
+  it('sorts and renders instances without remarks', async () => {
+    const user = userEvent.setup();
+    vi.mocked(instanceService.listInstances).mockResolvedValue([
+      instance('no-remark', 'instance-without-remark', 'PROXY', null),
+      instance('with-remark', 'instance-with-remark', 'PROXY', 'production'),
+    ]);
+    renderPage();
+
+    const name = await screen.findByText('instance-without-remark');
+    expect(within(name.closest('tr')!).getByText('-')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('columnheader', { name: /备注/ }));
+    expect(screen.getByText('instance-without-remark')).toBeInTheDocument();
+    expect(screen.getByText('instance-with-remark')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -275,10 +275,10 @@ const InstancePage = () => {
       dataIndex: 'remark',
       key: 'remark',
       width: 240,
-      sorter: (a, b) => a.remark.localeCompare(b.remark),
-      render: (remark: string) => (
+      sorter: (a, b) => (a.remark ?? '').localeCompare(b.remark ?? ''),
+      render: (remark: string | null) => (
         <Text type="secondary" style={{ fontSize: 13 }}>
-          {remark}
+          {remark || '-'}
         </Text>
       ),
     },

--- a/web/src/services/instanceService.ts
+++ b/web/src/services/instanceService.ts
@@ -23,7 +23,7 @@ export async function listInstances(query: InstanceQuery = {}): Promise<Instance
         (instance) =>
           !search ||
           [instance.name, instance.endpoint, instance.remark].some((value) =>
-            value.toLowerCase().includes(search),
+            value?.toLowerCase().includes(search),
           ),
       )
       .map(copyInstance);


### PR DESCRIPTION
## Summary

- model instance remarks as nullable values returned by the backend
- make the Remark column sorter and renderer handle missing remarks safely
- keep mock-mode search null-safe and add a table sorting regression test

## Testing

- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/instance/__tests__/InstancePage.test.tsx src/services/instanceService.test.ts`
- `NODE_OPTIONS=--no-experimental-webstorage npm run lint -- --quiet`
- `NODE_OPTIONS=--no-experimental-webstorage npm run build`

Fixes #1330
