### PR TITLE
fix(ui): remove duplicate Broker Cluster refresh timer

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -173,15 +173,6 @@ const BrokerClusterPage = () => {
     }
   }, [message, t]);
 
-  // Live refresh: poll while the auto-refresh switch is on.
-  useEffect(() => {
-    if (!autoRefresh) return;
-    const timer = setInterval(() => {
-      void loadData();
-    }, 5000);
-    return () => clearInterval(timer);
-  }, [autoRefresh, loadData]);
-
   const handleRestartBroker = async (broker: BrokerRecord) => {
     try {
       const result = await restartBroker(broker.clusterId, broker.brokerName);

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -227,14 +227,14 @@ describe('BrokerCluster Page', () => {
     const liveRefreshSwitch = screen.getByRole('switch');
     fireEvent.click(liveRefreshSwitch);
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(6000);
     });
-    expect(listClusters).toHaveBeenCalledTimes(2);
+    expect(listClusters).toHaveBeenCalledTimes(4);
 
     fireEvent.click(liveRefreshSwitch);
     await act(async () => {
       await vi.advanceTimersByTimeAsync(4000);
     });
-    expect(listClusters).toHaveBeenCalledTimes(2);
+    expect(listClusters).toHaveBeenCalledTimes(4);
   });
 });


### PR DESCRIPTION
## Summary
- remove the second Broker Cluster polling effect
- keep the documented two-second refresh interval as the single scheduler
- strengthen fake-timer coverage across multiple intervals and disablement

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/studio/__tests__/BrokerCluster.test.tsx`

Fixes #1332
