### PR TITLE
fix(ui): ignore stale Broker Cluster list responses

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Table,
   Button,
@@ -155,21 +155,27 @@ const BrokerClusterPage = () => {
   const [brokerData, setBrokerData] = useState<BrokerRecord[]>([]);
   const [nameServerData, setNameServerData] = useState<NameServerRecord[]>([]);
   const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
+  const loadRequestId = useRef(0);
   const { t } = useLang();
   const { message } = App.useApp();
 
   const loadData = useCallback(async () => {
+    const requestId = ++loadRequestId.current;
     setLoading(true);
     try {
       const clusters = await listClusters();
+      if (requestId !== loadRequestId.current) return;
       const mapped = mapClusters(clusters);
       setBrokerData(mapped.brokers);
       setNameServerData(mapped.nameServers);
       setProxyData(mapped.proxies);
     } catch {
+      if (requestId !== loadRequestId.current) return;
       message.error(t('common.refreshFailed'));
     } finally {
-      setLoading(false);
+      if (requestId === loadRequestId.current) {
+        setLoading(false);
+      }
     }
   }, [message, t]);
 
@@ -202,7 +208,10 @@ const BrokerClusterPage = () => {
     const timeoutId = window.setTimeout(() => {
       void loadData();
     });
-    return () => window.clearTimeout(timeoutId);
+    return () => {
+      window.clearTimeout(timeoutId);
+      ++loadRequestId.current;
+    };
   }, [loadData]);
 
   useEffect(() => {

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -117,6 +117,14 @@ const renderWithProviders = (ui: React.ReactElement) => {
   );
 };
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
 describe('BrokerCluster Page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -237,4 +245,31 @@ describe('BrokerCluster Page', () => {
     });
     expect(listClusters).toHaveBeenCalledTimes(2);
   });
+  it('keeps the latest cluster list when an older refresh resolves last', async () => {
+    const older = createDeferred<ClusterInfo[]>();
+    const latest = createDeferred<ClusterInfo[]>();
+    vi.mocked(listClusters)
+      .mockResolvedValueOnce(clusterFixture)
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(latest.promise);
+    const user = userEvent.setup();
+    renderWithProviders(<BrokerCluster />);
+    await screen.findByText('broker-api-a');
+
+    const refreshButton = screen.getByText('重置');
+    await user.click(refreshButton);
+    await user.click(refreshButton);
+
+    const latestFixture = [{
+      ...clusterFixture[0],
+      brokers: [{ ...clusterFixture[0].brokers[0], name: 'latest-broker' }],
+    }];
+    await act(async () => latest.resolve(latestFixture));
+    expect(await screen.findByText('latest-broker')).toBeInTheDocument();
+
+    await act(async () => older.resolve(clusterFixture));
+    expect(screen.getByText('latest-broker')).toBeInTheDocument();
+    expect(screen.queryByText('broker-api-a')).not.toBeInTheDocument();
+  });
+
 });


### PR DESCRIPTION
## Summary
- assign ownership to each Broker Cluster list request
- ignore late success, error, and loading callbacks from obsolete requests
- invalidate pending requests on unmount and cover out-of-order refreshes

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/studio/__tests__/BrokerCluster.test.tsx`

Fixes #1333
