### PR TITLE
fix(ui): format IPv6 Proxy gRPC endpoints correctly

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -88,7 +88,16 @@ const normalizeStatus = (status: string): NodeStatus => {
   return 'running';
 };
 
-const hostOf = (addr: string): string => addr.split(':')[0] ?? addr;
+const hostOf = (addr: string): string => {
+  const value = addr.trim();
+  if (value.startsWith('[')) {
+    const closingBracket = value.indexOf(']');
+    return closingBracket >= 0 ? value.slice(0, closingBracket + 1) : value;
+  }
+  const firstColon = value.indexOf(':');
+  const lastColon = value.lastIndexOf(':');
+  return firstColon >= 0 && firstColon === lastColon ? value.slice(0, lastColon) : value;
+};
 
 function mapClusters(clusters: ClusterInfo[]): {
   brokers: BrokerRecord[];

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -237,4 +237,21 @@ describe('BrokerCluster Page', () => {
     });
     expect(listClusters).toHaveBeenCalledTimes(2);
   });
+  it('formats bracketed IPv6 proxy gRPC endpoints without truncating the host', async () => {
+    vi.mocked(listClusters).mockResolvedValue([{
+      ...clusterFixture[0],
+      proxies: [{
+        ...clusterFixture[0].proxies[0],
+        addr: '[2001:db8::10]:8080',
+        grpcPort: 8081,
+      }],
+    }]);
+    const user = userEvent.setup();
+    renderWithProviders(<BrokerCluster />);
+    await screen.findByText('broker-api-a');
+    await user.click(screen.getByText('Proxy 管理'));
+
+    expect(screen.getByText('[2001:db8::10]:8081')).toBeInTheDocument();
+  });
+
 });


### PR DESCRIPTION
## Summary
- parse bracketed IPv6 Proxy addresses without splitting inside the host
- preserve existing hostname and IPv4 endpoint formatting
- add regression coverage for an IPv6 Proxy gRPC endpoint

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/studio/__tests__/BrokerCluster.test.tsx`

Fixes #1334
