### PR TITLE
fix(ui): do not classify unknown Broker statuses as running

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -42,7 +42,7 @@ import { listClusters, restartBroker } from '../../services/clusterService';
 import type { ClusterInfo } from '../../api/cluster';
 
 // ─── Types ──────────────────────────────────────────────────────
-type NodeStatus = 'running' | 'readonly' | 'maintenance';
+type NodeStatus = 'running' | 'readonly' | 'maintenance' | 'unknown';
 
 const REFRESH_INTERVAL_MS = 2000;
 
@@ -85,7 +85,8 @@ const normalizeStatus = (status: string): NodeStatus => {
   const value = (status || '').toLowerCase();
   if (value === 'readonly' || value === 'warning') return 'readonly';
   if (value === 'maintenance' || value === 'error' || value === 'offline') return 'maintenance';
-  return 'running';
+  if (value === 'running' || value === 'healthy') return 'running';
+  return 'unknown';
 };
 
 const hostOf = (addr: string): string => addr.split(':')[0] ?? addr;
@@ -222,6 +223,7 @@ const BrokerClusterPage = () => {
         color: 'error',
         label: t('brokerCluster.statusMaintenance'),
       },
+      unknown: { color: 'default', label: t('common.na') },
     };
     const { color, label } = config[status] || config.running;
     return <Tag color={color}>{label}</Tag>;

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -237,4 +237,16 @@ describe('BrokerCluster Page', () => {
     });
     expect(listClusters).toHaveBeenCalledTimes(2);
   });
+  it('renders unrecognized broker statuses as unavailable instead of running', async () => {
+    vi.mocked(listClusters).mockResolvedValue([{
+      ...clusterFixture[0],
+      brokers: [{ ...clusterFixture[0].brokers[0], status: 'mystery' }],
+    }]);
+    renderWithProviders(<BrokerCluster />);
+
+    await screen.findByText('broker-api-a');
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+    expect(screen.queryByText('运行中')).not.toBeInTheDocument();
+  });
+
 });


### PR DESCRIPTION
## Summary
- map only explicit healthy/running states to the running presentation
- render empty and unrecognized Broker statuses as unavailable
- add regression coverage for an unknown backend status

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/studio/__tests__/BrokerCluster.test.tsx`

Fixes #1335
