### PR TITLE
fix(ui): ignore stale Proxy list responses

### DIFF
--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Card,
   Table,
@@ -63,6 +63,7 @@ const ProxyPage: React.FC = () => {
   const [configModalOpen, setConfigModalOpen] = useState(false);
   const [addNodeModalOpen, setAddNodeModalOpen] = useState(false);
   const [form] = Form.useForm();
+  const loadRequestId = useRef(0);
 
   const [clusterStats, setClusterStats] = useState({
     totalNodes: 0,
@@ -72,9 +73,11 @@ const ProxyPage: React.FC = () => {
   });
 
   const loadProxyNodes = useCallback(async () => {
+    const requestId = ++loadRequestId.current;
     setLoading(true);
     try {
       const { proxyAddrList, currentProxyAddr } = await queryProxyHomePage();
+      if (requestId !== loadRequestId.current) return false;
       const nodes: ProxyNode[] = (proxyAddrList || []).map((addr) => ({
         key: addr,
         address: addr,
@@ -103,10 +106,13 @@ const ProxyPage: React.FC = () => {
       }
       return true;
     } catch {
+      if (requestId !== loadRequestId.current) return false;
       message.error(t('proxy.fetchListFailed'));
       return false;
     } finally {
-      setLoading(false);
+      if (requestId === loadRequestId.current) {
+        setLoading(false);
+      }
     }
   }, [message, t]);
 
@@ -114,6 +120,9 @@ const ProxyPage: React.FC = () => {
     // The state updates are performed by the asynchronous Proxy API request, not by this effect itself.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void loadProxyNodes();
+    return () => {
+      ++loadRequestId.current;
+    };
   }, [loadProxyNodes]);
 
   const handleViewConfig = (node: ProxyNode) => {

--- a/web/src/pages/studio/__tests__/Proxy.test.tsx
+++ b/web/src/pages/studio/__tests__/Proxy.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { queryProxyHomePage } from '../../../api/proxy';
@@ -59,6 +59,14 @@ function renderPage() {
     </App>,
   );
 }
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
 
 describe('ProxyPage', () => {
   beforeEach(() => {
@@ -119,4 +127,29 @@ describe('ProxyPage', () => {
     expect(screen.queryByText('5.3.0')).not.toBeInTheDocument();
     expect(screen.getAllByText('N/A').length).toBeGreaterThanOrEqual(5);
   });
+  it('keeps the latest Proxy list when an older refresh resolves last', async () => {
+    const older = createDeferred<typeof proxyHome>();
+    const latest = createDeferred<typeof proxyHome>();
+    vi.mocked(queryProxyHomePage)
+      .mockResolvedValueOnce(proxyHome)
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(latest.promise);
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText('127.0.0.1:8081');
+
+    const refresh = screen.getByRole('button', { name: '刷新' });
+    await user.click(refresh);
+    await user.click(refresh);
+    await act(async () => latest.resolve({
+      proxyAddrList: ['127.0.0.2:8081'],
+      currentProxyAddr: '127.0.0.2:8081',
+    }));
+    expect(await screen.findByText('127.0.0.2:8081')).toBeInTheDocument();
+
+    await act(async () => older.resolve(proxyHome));
+    expect(screen.getByText('127.0.0.2:8081')).toBeInTheDocument();
+    expect(screen.queryByText('127.0.0.1:8081')).not.toBeInTheDocument();
+  });
+
 });


### PR DESCRIPTION
## Summary
- assign ownership to Proxy list requests
- ignore obsolete success, failure, storage, and loading callbacks
- invalidate pending loads on unmount and test out-of-order refreshes

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/studio/__tests__/Proxy.test.tsx`

Fixes #1336
