### PR TITLE
fix(ui): keep Proxy loading active through mutation refreshes

### DIFF
--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -121,43 +121,39 @@ const ProxyPage: React.FC = () => {
     setConfigModalOpen(true);
   };
 
-  const handleAddNode = () => {
-    form
-      .validateFields()
-      .then((values) => {
-        setLoading(true);
-        addProxyAddr(values.address)
-          .then(() => {
-            message.success(t('common.success'));
-            setAddNodeModalOpen(false);
-            form.resetFields();
-            loadProxyNodes();
-          })
-          .catch(() => {
-            message.error(t('proxy.addFailed'));
-          })
-          .finally(() => {
-            setLoading(false);
-          });
-      })
-      .catch(() => {
-        // validation failed
-      });
+  const handleAddNode = async () => {
+    let values: { address: string };
+    try {
+      values = await form.validateFields();
+    } catch {
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await addProxyAddr(values.address);
+      message.success(t('common.success'));
+      setAddNodeModalOpen(false);
+      form.resetFields();
+      await loadProxyNodes();
+    } catch {
+      message.error(t('proxy.addFailed'));
+    } finally {
+      setLoading(false);
+    }
   };
 
-  const handleRemoveNode = (node: ProxyNode) => {
+  const handleRemoveNode = async (node: ProxyNode) => {
     setLoading(true);
-    removeProxyAddr(node.address)
-      .then(() => {
-        message.success(t('common.success'));
-        loadProxyNodes();
-      })
-      .catch(() => {
-        message.error(t('proxy.removeFailed'));
-      })
-      .finally(() => {
-        setLoading(false);
-      });
+    try {
+      await removeProxyAddr(node.address);
+      message.success(t('common.success'));
+      await loadProxyNodes();
+    } catch {
+      message.error(t('proxy.removeFailed'));
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleRefresh = async () => {


### PR DESCRIPTION
## Summary
- convert Proxy add/remove flows to awaited async operations
- keep mutation loading active through the follow-up list refresh
- preserve validation and mutation error handling without detached promises

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/studio/__tests__/Proxy.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npm run lint -- --quiet`

Fixes #1337
