### PR TITLE
fix(consumer): scope global group details by instance

### DIFF
--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -117,8 +117,8 @@ const GroupManagementPage = () => {
       setDetailLoading(true);
       try {
         const [subs, prog] = await Promise.all([
-          getConsumerSubscriptions(group.name),
-          getConsumerProgress(group.name),
+          getConsumerSubscriptions(group.name, group.instanceId),
+          getConsumerProgress(group.name, group.instanceId),
         ]);
         if (requestId !== detailRequestId.current) return;
         setSubscriptions(subs);

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -260,4 +260,25 @@ describe('GroupManagement Page', () => {
     expect(screen.getByText('order-consumer-group')).toBeInTheDocument();
     expect(screen.queryByText('payment-consumer-group')).not.toBeInTheDocument();
   });
+  it('scopes global group detail diagnostics to the record instance', async () => {
+    vi.mocked(consumerService.listConsumerGroups).mockResolvedValue([
+      makeGroup({ name: 'shared-group', instanceId: 'instance-b' }),
+    ]);
+    const user = userEvent.setup();
+    renderWithProviders(<GroupManagement />);
+    await screen.findByText('shared-group');
+    await user.click(screen.getByText('详情'));
+
+    await waitFor(() => {
+      expect(consumerService.getConsumerSubscriptions).toHaveBeenCalledWith(
+        'shared-group',
+        'instance-b',
+      );
+      expect(consumerService.getConsumerProgress).toHaveBeenCalledWith(
+        'shared-group',
+        'instance-b',
+      );
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary
- forward each aggregate Consumer Group record's instance ID to subscription and progress reads
- prevent same-named groups from falling back to the wrong cluster
- add focused request-parameter coverage

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/studio/__tests__/GroupManagement.test.tsx`

Fixes #1338
