### PR TITLE
fix(consumer): use instance-scoped global row keys

### DIFF
--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -295,7 +295,9 @@ const GroupManagementPage = () => {
         <Table
           columns={columns}
           dataSource={filteredGroupData}
-          rowKey="name"
+          rowKey={(record) =>
+            `${record.instanceId || record.clusterId || 'unscoped'}\0${record.name}`
+          }
           loading={loading}
           pagination={{
             pageSize: 10,

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -260,4 +260,20 @@ describe('GroupManagement Page', () => {
     expect(screen.getByText('order-consumer-group')).toBeInTheDocument();
     expect(screen.queryByText('payment-consumer-group')).not.toBeInTheDocument();
   });
+  it('uses unique row keys for same-named groups from different instances', async () => {
+    vi.mocked(consumerService.listConsumerGroups).mockResolvedValue([
+      makeGroup({ name: 'shared-group', instanceId: 'instance-a' }),
+      makeGroup({ name: 'shared-group', instanceId: 'instance-b' }),
+    ]);
+    const { container } = renderWithProviders(<GroupManagement />);
+    await screen.findAllByText('shared-group');
+
+    const rowKeys = Array.from(container.querySelectorAll('tbody tr[data-row-key]')).map((row) =>
+      row.getAttribute('data-row-key'),
+    );
+    expect(rowKeys).toContain('instance-a\0shared-group');
+    expect(rowKeys).toContain('instance-b\0shared-group');
+    expect(new Set(rowKeys).size).toBe(rowKeys.length);
+  });
+
 });


### PR DESCRIPTION
## Summary
- key aggregate Consumer Group rows by instance/cluster plus group name
- retain an explicit unscoped fallback for legacy records
- cover same-named groups from two instances

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/studio/__tests__/GroupManagement.test.tsx`

Fixes #1339
