### PR TITLE
fix(consumer): show offline groups as stopped in details

### DIFF
--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -340,8 +340,13 @@ const GroupManagementPage = () => {
                           </div>
                           <div style={{ fontSize: 24, fontWeight: 600 }}>
                             {selectedGroup.onlineInstances}{' '}
-                            <Tag color="success" style={{ marginLeft: 8 }}>
-                              {t('groupMgmt.online')}
+                            <Tag
+                              color={selectedGroup.onlineInstances > 0 ? 'success' : 'error'}
+                              style={{ marginLeft: 8 }}
+                            >
+                              {selectedGroup.onlineInstances > 0
+                                ? t('groupMgmt.online')
+                                : t('groupMgmt.stopped')}
                             </Tag>
                           </div>
                         </Card>

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
@@ -260,4 +260,18 @@ describe('GroupManagement Page', () => {
     expect(screen.getByText('order-consumer-group')).toBeInTheDocument();
     expect(screen.queryByText('payment-consumer-group')).not.toBeInTheDocument();
   });
+  it('shows a stopped status in details when no consumer instance is online', async () => {
+    vi.mocked(consumerService.listConsumerGroups).mockResolvedValue([
+      makeGroup({ name: 'offline-group', onlineInstances: 0 }),
+    ]);
+    const user = userEvent.setup();
+    renderWithProviders(<GroupManagement />);
+    await screen.findByText('offline-group');
+    await user.click(screen.getByText('详情'));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('已停止')).toBeInTheDocument();
+    expect(within(dialog).queryByText('在线')).not.toBeInTheDocument();
+  });
+
 });


### PR DESCRIPTION
## Summary
- derive the detail-card status from the online instance count
- render stopped/error for zero instances and online/success otherwise
- add focused offline modal coverage

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/studio/__tests__/GroupManagement.test.tsx`

Fixes #1340
