### PR TITLE
fix(consumer): avoid overlapping group auto-refresh requests

### DIFF
--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -67,31 +67,54 @@ const GroupManagementPage = () => {
   const [progress, setProgress] = useState<QueueProgress[]>([]);
   const [detailLoading, setDetailLoading] = useState(false);
   const listRequestId = useRef(0);
+  const listInFlight = useRef<Promise<void> | null>(null);
+  const listRefreshQueued = useRef(false);
+  const mountedRef = useRef(true);
   const detailRequestId = useRef(0);
   const { t } = useLang();
 
-  const loadGroups = useCallback(async () => {
-    const requestId = ++listRequestId.current;
+  const loadGroups = useCallback((): Promise<void> => {
+    if (listInFlight.current) {
+      listRefreshQueued.current = true;
+      return listInFlight.current;
+    }
+
     setLoading(true);
-    try {
-      const data = await listConsumerGroups();
-      if (requestId !== listRequestId.current) return;
-      setGroups(data);
-    } catch {
-      if (requestId !== listRequestId.current) return;
-      message.error(t('consumer.fetchListFailed'));
-    } finally {
-      if (requestId === listRequestId.current) {
+    const run = async () => {
+      do {
+        listRefreshQueued.current = false;
+        const requestId = ++listRequestId.current;
+        try {
+          const data = await listConsumerGroups();
+          if (!mountedRef.current || requestId !== listRequestId.current) return;
+          setGroups(data);
+        } catch {
+          if (!mountedRef.current || requestId !== listRequestId.current) return;
+          message.error(t('consumer.fetchListFailed'));
+        }
+      } while (mountedRef.current && listRefreshQueued.current);
+    };
+
+    const cycle = run().finally(() => {
+      listInFlight.current = null;
+      if (mountedRef.current) {
         setLoading(false);
       }
-    }
+    });
+    listInFlight.current = cycle;
+    return cycle;
   }, [t]);
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
       void loadGroups();
     });
-    return () => window.clearTimeout(timeoutId);
+    return () => {
+      window.clearTimeout(timeoutId);
+      mountedRef.current = false;
+      listRefreshQueued.current = false;
+      ++listRequestId.current;
+    };
   }, [loadGroups]);
 
   useEffect(() => {

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -198,32 +198,24 @@ describe('GroupManagement Page', () => {
     expect(screen.queryByText('FIRST_GROUP_TOPIC')).not.toBeInTheDocument();
   });
 
-  it('keeps the latest group list when an earlier refresh resolves last', async () => {
+  it('queues one refresh instead of overlapping an active group request', async () => {
     const initialGroups = createDeferred<ConsumerGroup[]>();
     const refreshedGroups = createDeferred<ConsumerGroup[]>();
     vi.mocked(consumerService.listConsumerGroups)
       .mockReturnValueOnce(initialGroups.promise)
       .mockReturnValueOnce(refreshedGroups.promise);
-    vi.useFakeTimers();
     renderWithProviders(<GroupManagement />);
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
-    });
+    await waitFor(() => expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(1));
     fireEvent.click(screen.getByText('重置'));
+    expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(1);
 
-    await act(async () => {
-      refreshedGroups.resolve([makeGroup({ name: 'fresh-group' })]);
-      await Promise.resolve();
-    });
-    expect(screen.getByText('fresh-group')).toBeInTheDocument();
+    initialGroups.resolve([makeGroup({ name: 'initial-group' })]);
+    await waitFor(() => expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(2));
 
-    await act(async () => {
-      initialGroups.resolve([makeGroup({ name: 'stale-group' })]);
-      await Promise.resolve();
-    });
-    expect(screen.getByText('fresh-group')).toBeInTheDocument();
-    expect(screen.queryByText('stale-group')).not.toBeInTheDocument();
+    refreshedGroups.resolve([makeGroup({ name: 'fresh-group' })]);
+    expect(await screen.findByText('fresh-group')).toBeInTheDocument();
+    expect(screen.queryByText('initial-group')).not.toBeInTheDocument();
   });
 
   it('polls only while auto refresh is enabled', async () => {


### PR DESCRIPTION
## Summary
- serialize aggregate Consumer Group list requests
- coalesce repeated auto/manual triggers into one queued refresh
- retain request ownership and invalidate work on unmount

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/studio/__tests__/GroupManagement.test.tsx`

Fixes #1341
