### PR TITLE
fix(consumer): label manual reload as refresh

### DIFF
--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -286,7 +286,7 @@ const GroupManagementPage = () => {
             size="small"
           />
           <Button icon={<ArrowClockwise size={14} />} size="small" onClick={handleRefresh}>
-            {t('common.reset')}
+            {t('common.refresh')}
           </Button>
         </Space>
       </div>

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -124,9 +124,9 @@ describe('GroupManagement Page', () => {
     expect(screen.queryByText('查看分布')).not.toBeInTheDocument();
   });
 
-  it('should render reset button', () => {
+  it('should render refresh button', () => {
     renderWithProviders(<GroupManagement />);
-    expect(screen.getByText('重置')).toBeInTheDocument();
+    expect(screen.getByText('刷新')).toBeInTheDocument();
   });
 
   it('should display consumer group data from the service in table', async () => {
@@ -210,7 +210,7 @@ describe('GroupManagement Page', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    fireEvent.click(screen.getByText('重置'));
+    fireEvent.click(screen.getByText('刷新'));
 
     await act(async () => {
       refreshedGroups.resolve([makeGroup({ name: 'fresh-group' })]);


### PR DESCRIPTION
## Summary
- label the consumer-group manual reload action as Refresh instead of Reset
- align the component tests with the action's actual behavior

## Test plan
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/studio/__tests__/GroupManagement.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npx eslint src/pages/studio/GroupManagement.tsx src/pages/studio/__tests__/GroupManagement.test.tsx --quiet`

Fixes #1342
