### PR TITLE
fix(ops): serialize channel setting updates

### DIFF
--- a/web/src/pages/studio/Ops.tsx
+++ b/web/src/pages/studio/Ops.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Alert, App, Button, Input, Popconfirm, Select, Space, Switch, Tooltip, Typography } from 'antd';
 import { FloppyDisk, Plus, Trash } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
@@ -42,6 +42,10 @@ const OpsPage: React.FC = () => {
   const [newNamesrvAddr, setNewNamesrvAddr] = useState('');
   const [useVIPChannel, setUseVIPChannel] = useState(false);
   const [useTLS, setUseTLS] = useState(false);
+  const [vipUpdating, setVipUpdating] = useState(false);
+  const [tlsUpdating, setTlsUpdating] = useState(false);
+  const vipUpdateInFlight = useRef(false);
+  const tlsUpdateInFlight = useRef(false);
   const [configurationAvailable, setConfigurationAvailable] = useState(false);
   const [unavailableReason, setUnavailableReason] = useState('');
   const writeOperationEnabled = configurationAvailable && (!token || admin === true);
@@ -121,6 +125,9 @@ const OpsPage: React.FC = () => {
   };
 
   const handleUpdateIsVIPChannel = async (checked: boolean) => {
+    if (vipUpdateInFlight.current) return;
+    vipUpdateInFlight.current = true;
+    setVipUpdating(true);
     setUseVIPChannel(checked);
     try {
       await updateIsVIPChannel(checked);
@@ -128,10 +135,16 @@ const OpsPage: React.FC = () => {
     } catch {
       message.error(t('common.failure'));
       setUseVIPChannel(!checked);
+    } finally {
+      vipUpdateInFlight.current = false;
+      setVipUpdating(false);
     }
   };
 
   const handleUpdateUseTLS = async (checked: boolean) => {
+    if (tlsUpdateInFlight.current) return;
+    tlsUpdateInFlight.current = true;
+    setTlsUpdating(true);
     setUseTLS(checked);
     try {
       await updateUseTLS(checked);
@@ -139,6 +152,9 @@ const OpsPage: React.FC = () => {
     } catch {
       message.error(t('common.failure'));
       setUseTLS(!checked);
+    } finally {
+      tlsUpdateInFlight.current = false;
+      setTlsUpdating(false);
     }
   };
 
@@ -215,13 +231,16 @@ const OpsPage: React.FC = () => {
           <Switch
             checked={useVIPChannel}
             onChange={handleUpdateIsVIPChannel}
-            disabled={!writeOperationEnabled}
+            disabled={!writeOperationEnabled || vipUpdating}
+            loading={vipUpdating}
           />
           {writeOperationEnabled && (
             <Button
               type="primary"
               icon={<FloppyDisk size={16} />}
               onClick={() => handleUpdateIsVIPChannel(useVIPChannel)}
+              loading={vipUpdating}
+              disabled={vipUpdating}
             >
               {t('common.update')}
             </Button>
@@ -236,13 +255,16 @@ const OpsPage: React.FC = () => {
           <Switch
             checked={useTLS}
             onChange={handleUpdateUseTLS}
-            disabled={!writeOperationEnabled}
+            disabled={!writeOperationEnabled || tlsUpdating}
+            loading={tlsUpdating}
           />
           {writeOperationEnabled && (
             <Button
               type="primary"
               icon={<FloppyDisk size={16} />}
               onClick={() => handleUpdateUseTLS(useTLS)}
+              loading={tlsUpdating}
+              disabled={tlsUpdating}
             >
               {t('common.update')}
             </Button>

--- a/web/src/pages/studio/__tests__/Ops.test.tsx
+++ b/web/src/pages/studio/__tests__/Ops.test.tsx
@@ -22,7 +22,7 @@ import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
 import OpsPage from '../Ops';
-import { deleteNameSvrAddr, queryOpsHomePage } from '../../../api/ops';
+import { deleteNameSvrAddr, queryOpsHomePage, updateIsVIPChannel } from '../../../api/ops';
 import useAuthStore from '../../../stores/authStore';
 
 vi.mock('../../../api/ops', () => ({
@@ -83,6 +83,28 @@ describe('OpsPage', () => {
     expect(await screen.findByText('127.0.0.1:9876')).toBeInTheDocument();
     expect(screen.getAllByRole('switch')[0]).toBeChecked();
     expect(screen.getAllByRole('switch')[1]).not.toBeChecked();
+  });
+
+  it('prevents overlapping VIP channel updates', async () => {
+    let resolveUpdate!: () => void;
+    vi.mocked(updateIsVIPChannel).mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveUpdate = resolve;
+      }),
+    );
+    renderWithProviders(<OpsPage />);
+
+    const vipSwitch = (await screen.findAllByRole('switch'))[0];
+    await waitFor(() => expect(vipSwitch).toBeChecked());
+    fireEvent.click(vipSwitch);
+    await waitFor(() => expect(updateIsVIPChannel).toHaveBeenCalledTimes(1));
+    expect(vipSwitch).toBeDisabled();
+
+    fireEvent.click(vipSwitch);
+    expect(updateIsVIPChannel).toHaveBeenCalledTimes(1);
+
+    resolveUpdate();
+    await waitFor(() => expect(vipSwitch).toBeEnabled());
   });
 
   it('hides write controls for read-only users', async () => {


### PR DESCRIPTION
## Summary
- serialize VIP channel and TLS setting mutations with independent in-flight guards
- disable and show loading state on the affected switch and update button until its request settles
- cover rapid repeated VIP interactions with a regression test

## Test plan
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/studio/__tests__/Ops.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npx eslint src/pages/studio/Ops.tsx src/pages/studio/__tests__/Ops.test.tsx --quiet`

Fixes #1343
