### PR TITLE
fix(grafana): isolate dashboard preview requests

### DIFF
--- a/web/src/components/GrafanaDashboardList.tsx
+++ b/web/src/components/GrafanaDashboardList.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { App, Button, Modal, Space, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { DownloadSimple, Eye } from '@phosphor-icons/react';
@@ -37,6 +37,7 @@ export const GrafanaDashboardList: React.FC = () => {
   const [viewing, setViewing] = useState<GrafanaDashboardInfo | null>(null);
   const [viewContent, setViewContent] = useState('');
   const [viewLoading, setViewLoading] = useState(false);
+  const viewRequestId = useRef(0);
   const [exportingUid, setExportingUid] = useState<string | null>(null);
 
   useEffect(() => {
@@ -54,20 +55,36 @@ export const GrafanaDashboardList: React.FC = () => {
     void load();
     return () => {
       cancelled = true;
+      viewRequestId.current += 1;
     };
   }, [t, message]);
 
   const handleView = async (info: GrafanaDashboardInfo) => {
+    const requestId = ++viewRequestId.current;
     setViewing(info);
+    setViewContent('');
     setViewLoading(true);
     try {
       const model = await getGrafanaDashboard(info.uid);
-      setViewContent(JSON.stringify(model, null, 2));
+      if (requestId === viewRequestId.current) {
+        setViewContent(JSON.stringify(model, null, 2));
+      }
     } catch {
-      message.error(t('grafana.loadFailed'));
+      if (requestId === viewRequestId.current) {
+        message.error(t('grafana.loadFailed'));
+      }
     } finally {
-      setViewLoading(false);
+      if (requestId === viewRequestId.current) {
+        setViewLoading(false);
+      }
     }
+  };
+
+  const closeView = () => {
+    viewRequestId.current += 1;
+    setViewing(null);
+    setViewContent('');
+    setViewLoading(false);
   };
 
   const triggerDownload = (uid: string, content: Blob | string) => {
@@ -157,8 +174,8 @@ export const GrafanaDashboardList: React.FC = () => {
       <Modal
         title={viewing ? viewing.title : t('grafana.title')}
         open={viewing !== null}
-        footer={<Button onClick={() => setViewing(null)}>{t('common.close')}</Button>}
-        onCancel={() => setViewing(null)}
+        footer={<Button onClick={closeView}>{t('common.close')}</Button>}
+        onCancel={closeView}
         width={760}
         destroyOnHidden
       >

--- a/web/src/components/__tests__/GrafanaDashboardList.test.tsx
+++ b/web/src/components/__tests__/GrafanaDashboardList.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { App } from 'antd';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -110,6 +110,42 @@ describe('GrafanaDashboardList', () => {
     const dialog = await screen.findByRole('dialog');
     await waitFor(() => expect(getGrafanaDashboard).toHaveBeenCalledWith('rocketmq-overview'));
     expect(within(dialog).getByText(/"uid": "rocketmq-overview"/)).toBeInTheDocument();
+  });
+
+  it('keeps the latest preview when an earlier request resolves last', async () => {
+    let resolveOverview!: (value: typeof dashboardModel) => void;
+    let resolveBroker!: (value: typeof dashboardModel) => void;
+    vi.mocked(getGrafanaDashboard).mockImplementation(
+      (uid) =>
+        new Promise((resolve) => {
+          if (uid === 'rocketmq-overview') resolveOverview = resolve;
+          else resolveBroker = resolve;
+        }),
+    );
+    render(
+      <App>
+        <LangProvider>
+          <GrafanaDashboardList />
+        </LangProvider>
+      </App>,
+    );
+
+    await screen.findByText('RocketMQ Cluster Overview');
+    const viewButtons = screen.getAllByRole('button', { name: /View|查看/ });
+    await userEvent.click(viewButtons[0]);
+    await userEvent.click(viewButtons[1]);
+
+    await act(async () => {
+      resolveBroker({ ...dashboardModel, uid: 'rocketmq-broker', title: 'RocketMQ Broker' });
+    });
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/"uid": "rocketmq-broker"/)).toBeInTheDocument();
+
+    await act(async () => {
+      resolveOverview(dashboardModel);
+    });
+    expect(within(dialog).getByText(/"uid": "rocketmq-broker"/)).toBeInTheDocument();
+    expect(within(dialog).queryByText(/"uid": "rocketmq-overview"/)).not.toBeInTheDocument();
   });
 
   it('exports a dashboard and triggers a download', async () => {


### PR DESCRIPTION
## Summary
- assign each Grafana preview load a request id so stale responses cannot replace the active dashboard
- clear previous preview content immediately and invalidate pending loads when the modal closes or unmounts
- add an out-of-order response regression test

## Test plan
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/components/__tests__/GrafanaDashboardList.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npx eslint src/components/GrafanaDashboardList.tsx src/components/__tests__/GrafanaDashboardList.test.tsx --quiet`

Fixes #1344
