### PR TITLE
fix(alerts): isolate asset preview requests

### DIFF
--- a/web/src/components/AlertRuleAssetList.tsx
+++ b/web/src/components/AlertRuleAssetList.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { App, Button, Modal, Space, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { DownloadSimple, Eye } from '@phosphor-icons/react';
@@ -43,6 +43,7 @@ export const AlertRuleAssetList: React.FC = () => {
   const [viewing, setViewing] = useState<AlertRuleAssetInfo | null>(null);
   const [viewContent, setViewContent] = useState('');
   const [viewLoading, setViewLoading] = useState(false);
+  const viewRequestId = useRef(0);
   const [exportingName, setExportingName] = useState<string | null>(null);
 
   useEffect(() => {
@@ -60,20 +61,36 @@ export const AlertRuleAssetList: React.FC = () => {
     void load();
     return () => {
       cancelled = true;
+      viewRequestId.current += 1;
     };
   }, [t, message]);
 
   const handleView = async (info: AlertRuleAssetInfo) => {
+    const requestId = ++viewRequestId.current;
     setViewing(info);
+    setViewContent('');
     setViewLoading(true);
     try {
       const yaml = await getAlertRuleAsset(info.name);
-      setViewContent(yaml);
+      if (requestId === viewRequestId.current) {
+        setViewContent(yaml);
+      }
     } catch {
-      message.error(t('alertAssets.loadFailed'));
+      if (requestId === viewRequestId.current) {
+        message.error(t('alertAssets.loadFailed'));
+      }
     } finally {
-      setViewLoading(false);
+      if (requestId === viewRequestId.current) {
+        setViewLoading(false);
+      }
     }
+  };
+
+  const closeView = () => {
+    viewRequestId.current += 1;
+    setViewing(null);
+    setViewContent('');
+    setViewLoading(false);
   };
 
   const triggerDownload = (name: string, content: Blob | string) => {
@@ -168,8 +185,8 @@ export const AlertRuleAssetList: React.FC = () => {
       <Modal
         title={viewing ? viewing.name : t('alertAssets.title')}
         open={viewing !== null}
-        footer={<Button onClick={() => setViewing(null)}>{t('common.close')}</Button>}
-        onCancel={() => setViewing(null)}
+        footer={<Button onClick={closeView}>{t('common.close')}</Button>}
+        onCancel={closeView}
         width={760}
         destroyOnHidden
       >

--- a/web/src/components/__tests__/AlertRuleAssetList.test.tsx
+++ b/web/src/components/__tests__/AlertRuleAssetList.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { App as AntdApp } from 'antd';
 import AlertRuleAssetList from '../AlertRuleAssetList';
 import { LangProvider } from '../../i18n/LangContext';
@@ -95,6 +95,36 @@ describe('AlertRuleAssetList', () => {
     const dialog = await screen.findByRole('dialog');
     expect(within(dialog).getByText(/rocketmq-broker.rules/)).toBeInTheDocument();
     expect(alertRuleAssetService.getAlertRuleAsset).toHaveBeenCalledWith('rocketmq-broker-down');
+  });
+
+  it('keeps the latest preview when an earlier request resolves last', async () => {
+    vi.mocked(alertRuleAssetService.listAlertRuleAssets).mockResolvedValue(sampleAssets);
+    let resolveBroker!: (value: string) => void;
+    let resolveConsumer!: (value: string) => void;
+    vi.mocked(alertRuleAssetService.getAlertRuleAsset).mockImplementation(
+      (name) =>
+        new Promise((resolve) => {
+          if (name === 'rocketmq-broker-down') resolveBroker = resolve;
+          else resolveConsumer = resolve;
+        }),
+    );
+    renderWithProviders(<AlertRuleAssetList />);
+
+    const viewButtons = await screen.findAllByRole('button', { name: /查看|View/ });
+    fireEvent.click(viewButtons[0]);
+    fireEvent.click(viewButtons[1]);
+
+    await act(async () => {
+      resolveConsumer('alert: LATEST_CONSUMER_ALERT');
+    });
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/LATEST_CONSUMER_ALERT/)).toBeInTheDocument();
+
+    await act(async () => {
+      resolveBroker('alert: STALE_BROKER_ALERT');
+    });
+    expect(within(dialog).getByText(/LATEST_CONSUMER_ALERT/)).toBeInTheDocument();
+    expect(within(dialog).queryByText(/STALE_BROKER_ALERT/)).not.toBeInTheDocument();
   });
 
   it('downloads the yaml when Export is clicked', async () => {


### PR DESCRIPTION
## Summary
- isolate alert-rule asset preview loads with request ids
- clear preview data on selection changes and invalidate pending work when the modal closes or unmounts
- add an out-of-order YAML response regression test

## Test plan
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/components/__tests__/AlertRuleAssetList.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npx eslint src/components/AlertRuleAssetList.tsx src/components/__tests__/AlertRuleAssetList.test.tsx --quiet`

Fixes #1345
