### PR TITLE
fix(acl): load rules and users independently

### DIFF
--- a/web/src/pages/instance/__tests__/AclPage.test.tsx
+++ b/web/src/pages/instance/__tests__/AclPage.test.tsx
@@ -103,6 +103,24 @@ describe('ACL page', () => {
     expect(aclService.listAclUsers).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps rules available when loading users fails', async () => {
+    vi.mocked(aclService.listAclUsers).mockRejectedValue(new Error('users unavailable'));
+    renderWithProviders(<AclPage />);
+
+    expect(await screen.findByText('remote-user')).toBeInTheDocument();
+    expect(screen.getByText('remote-topic')).toBeInTheDocument();
+  });
+
+  it('keeps users available when loading rules fails', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclService.listAclRules).mockRejectedValue(new Error('rules unavailable'));
+    renderWithProviders(<AclPage />);
+
+    await user.click(await screen.findByText('用户管理'));
+    expect(await screen.findByText('remote-admin')).toBeInTheDocument();
+    expect(screen.getByText('cluster-a')).toBeInTheDocument();
+  });
+
   it('renders backend users on the user tab', async () => {
     const user = userEvent.setup();
     renderWithProviders(<AclPage />);

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -126,19 +126,26 @@ const AclPage = () => {
   useEffect(() => {
     let mounted = true;
 
-    Promise.all([listAclRules(), listAclUsers()])
-      .then(([nextRules, nextUsers]) => {
-        if (!mounted) return;
-        setRules(nextRules.map(normalizeRule));
-        setUsers(nextUsers.map(normalizeUser));
+    void listAclRules()
+      .then((nextRules) => {
+        if (mounted) setRules(nextRules.map(normalizeRule));
       })
       .catch(() => {
         if (mounted) message.error(t('common.fetchDataFailed'));
       })
       .finally(() => {
-        if (!mounted) return;
-        setRulesLoading(false);
-        setUsersLoading(false);
+        if (mounted) setRulesLoading(false);
+      });
+
+    void listAclUsers()
+      .then((nextUsers) => {
+        if (mounted) setUsers(nextUsers.map(normalizeUser));
+      })
+      .catch(() => {
+        if (mounted) message.error(t('common.fetchDataFailed'));
+      })
+      .finally(() => {
+        if (mounted) setUsersLoading(false);
       });
 
     return () => {


### PR DESCRIPTION
## Summary
- load ACL rules and ACL users through independent promise chains
- settle each tab's loading state as soon as its own request completes
- preserve successful tab data when the sibling endpoint fails, with coverage in both directions

## Test plan
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/instance/__tests__/AclPage.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npx eslint src/pages/instance/acl.tsx src/pages/instance/__tests__/AclPage.test.tsx --quiet`

Fixes #1347
