### PR TITLE
fix(acl): preserve missing creation timestamps

### DIFF
--- a/web/src/api/acl.ts
+++ b/web/src/api/acl.ts
@@ -11,7 +11,7 @@ export interface AclRule {
   decision: string;
   scope: string;
   aclVersion: number | string;
-  createdAt: string;
+  createdAt?: string | null;
 }
 
 export interface AclRuleQuery {
@@ -26,7 +26,7 @@ export interface AclUser {
   secretKey: string;
   admin: boolean;
   clusters: string[];
-  createdAt: string;
+  createdAt?: string | null;
 }
 
 export async function listAclRules(params?: AclRuleQuery) {

--- a/web/src/pages/instance/__tests__/AclPage.test.tsx
+++ b/web/src/pages/instance/__tests__/AclPage.test.tsx
@@ -113,6 +113,44 @@ describe('ACL page', () => {
     expect(screen.getByText('cluster-a')).toBeInTheDocument();
   });
 
+  it('shows missing backend timestamps as unavailable', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclService.listAclRules).mockResolvedValue([
+      {
+        id: 'rule-without-time',
+        principal: 'no-time-rule',
+        resource: 'topic-a',
+        resourceType: 'Topic',
+        resourcePattern: 'LITERAL',
+        actions: ['PUB'],
+        decision: 'ALLOW',
+        scope: 'cluster',
+        aclVersion: 2,
+        createdAt: null,
+      },
+    ]);
+    vi.mocked(aclService.listAclUsers).mockResolvedValue([
+      {
+        id: 'user-without-time',
+        username: 'no-time-user',
+        accessKey: 'acce****3456',
+        secretKey: 'secr****7654',
+        admin: false,
+        clusters: [],
+        createdAt: null,
+      },
+    ]);
+    renderWithProviders(<AclPage />);
+
+    expect(await screen.findByText('no-time-rule')).toBeInTheDocument();
+    expect(screen.getByText('-')).toBeInTheDocument();
+
+    await user.click(screen.getByText('用户管理'));
+    const userPanel = screen.getByRole('tabpanel', { name: '用户管理' });
+    expect(await within(userPanel).findByText('no-time-user')).toBeInTheDocument();
+    expect(within(userPanel).getByText('-')).toBeInTheDocument();
+  });
+
   it('does not submit masked credentials when editing a user', async () => {
     const user = userEvent.setup();
     vi.mocked(aclService.updateAclUser).mockResolvedValue({

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -70,7 +70,7 @@ const normalizeRule = (rule: AclRule): AclRule => ({
   decision: rule.decision ?? '',
   scope: rule.scope ?? '',
   aclVersion: rule.aclVersion ?? '2.0',
-  createdAt: rule.createdAt ?? new Date().toISOString(),
+  createdAt: rule.createdAt ?? null,
 });
 
 const normalizeUser = (user: AclUser): AclUser => ({
@@ -80,7 +80,7 @@ const normalizeUser = (user: AclUser): AclUser => ({
   secretKey: user.secretKey ?? '',
   admin: user.admin ?? false,
   clusters: user.clusters ?? [],
-  createdAt: user.createdAt ?? new Date().toISOString(),
+  createdAt: user.createdAt ?? null,
 });
 
 const isFormValidationError = (error: unknown) =>
@@ -343,7 +343,8 @@ const AclPage = () => {
     }
   };
 
-  const formatDate = (iso: string) => {
+  const formatDate = (iso?: string | null) => {
+    if (!iso) return '-';
     const d = new Date(iso);
     if (Number.isNaN(d.getTime())) return '-';
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
@@ -443,8 +444,8 @@ const AclPage = () => {
       dataIndex: 'createdAt',
       key: 'createdAt',
       width: 160,
-      sorter: (a, b) => a.createdAt.localeCompare(b.createdAt),
-      render: (iso: string) => (
+      sorter: (a, b) => (a.createdAt ?? '').localeCompare(b.createdAt ?? ''),
+      render: (iso?: string | null) => (
         <span style={{ fontSize: 13, color: '#8c8c8c' }}>{formatDate(iso)}</span>
       ),
     },
@@ -588,8 +589,8 @@ const AclPage = () => {
       dataIndex: 'createdAt',
       key: 'createdAt',
       width: 160,
-      sorter: (a, b) => a.createdAt.localeCompare(b.createdAt),
-      render: (iso: string) => (
+      sorter: (a, b) => (a.createdAt ?? '').localeCompare(b.createdAt ?? ''),
+      render: (iso?: string | null) => (
         <span style={{ fontSize: 13, color: '#8c8c8c' }}>{formatDate(iso)}</span>
       ),
     },


### PR DESCRIPTION
## Summary
- model ACL creation timestamps as optional backend data
- preserve missing timestamps during normalization instead of fabricating the current client time
- render unavailable timestamps as `-` and make timestamp sorting null-safe

## Test plan
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/instance/__tests__/AclPage.test.tsx src/api/acl.test.ts src/services/aclService.test.ts`
- `NODE_OPTIONS=--no-experimental-webstorage npx eslint src/api/acl.ts src/pages/instance/acl.tsx src/pages/instance/__tests__/AclPage.test.tsx --quiet`

Fixes #1348
