### PR TITLE
fix(alerts): handle unknown system alert levels

### DIFF
--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+
+import { App } from 'antd';
+import { render, screen } from '@testing-library/react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LangProvider } from '../../../i18n/LangContext';
+import { listSystemAlerts } from '../../../services/opsService';
+import SystemAlertsPage from '../systemAlerts';
+
+vi.mock('../../../services/opsService', () => ({
+  acknowledgeAlert: vi.fn(),
+  clearAcknowledgedAlerts: vi.fn(),
+  listSystemAlerts: vi.fn(),
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const renderPage = () =>
+  render(
+    <App>
+      <LangProvider>
+        <SystemAlertsPage />
+      </LangProvider>
+    </App>,
+  );
+
+describe('SystemAlertsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders an alert with an unknown backend level', async () => {
+    vi.mocked(listSystemAlerts).mockResolvedValue([
+      {
+        id: 'alert-critical',
+        level: 'critical',
+        title: 'Critical broker condition',
+        description: 'A newer backend emitted this level',
+        time: '2026-08-10 01:00',
+        acknowledged: false,
+      },
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByText('Critical broker condition')).toBeInTheDocument();
+    expect(screen.getByText('critical')).toBeInTheDocument();
+    expect(screen.getByText('A newer backend emitted this level')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -138,7 +138,12 @@ const SystemAlertsPage = () => {
         {loading && <Card loading />}
         {!loading &&
           filtered.map((alert) => {
-            const cfg = alertLevelConfig[alert.level];
+            const normalizedLevel = alert.level.toLowerCase();
+            const cfg = alertLevelConfig[normalizedLevel] ?? {
+              color: '#8c8c8c',
+              bg: '#fafafa',
+              label: alert.level || t('common.na'),
+            };
             return (
               <div
                 key={alert.id}
@@ -160,11 +165,13 @@ const SystemAlertsPage = () => {
                     </Text>
                     <Tag
                       color={
-                        alert.level === 'error'
+                        normalizedLevel === 'error'
                           ? 'error'
-                          : alert.level === 'warning'
+                          : normalizedLevel === 'warning'
                             ? 'warning'
-                            : 'processing'
+                            : normalizedLevel === 'info'
+                              ? 'processing'
+                              : 'default'
                       }
                       style={{ fontSize: 11, lineHeight: '18px', padding: '0 6px' }}
                     >


### PR DESCRIPTION
## Summary
- normalize known system-alert levels before looking up their presentation
- render unknown backend levels with a neutral fallback instead of dereferencing an undefined config
- preserve the backend level as the fallback tag label and add regression coverage

## Test plan
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/ops/__tests__/SystemAlertsPage.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npx eslint src/pages/ops/systemAlerts.tsx src/pages/ops/__tests__/SystemAlertsPage.test.tsx --quiet`

Fixes #1349
