### PR TITLE
fix(alerts): track concurrent acknowledgements

### DIFF
--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+
+import { App } from 'antd';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LangProvider } from '../../../i18n/LangContext';
+import { acknowledgeAlert, listSystemAlerts } from '../../../services/opsService';
+import SystemAlertsPage from '../systemAlerts';
+
+vi.mock('../../../services/opsService', () => ({
+  acknowledgeAlert: vi.fn(),
+  clearAcknowledgedAlerts: vi.fn(),
+  listSystemAlerts: vi.fn(),
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const renderPage = () =>
+  render(
+    <App>
+      <LangProvider>
+        <SystemAlertsPage />
+      </LangProvider>
+    </App>,
+  );
+
+describe('SystemAlertsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listSystemAlerts).mockResolvedValue([
+      {
+        id: 'alert-a',
+        level: 'error',
+        title: 'Broker unavailable',
+        description: 'broker a',
+        time: '2026-08-10 01:00',
+        acknowledged: false,
+      },
+      {
+        id: 'alert-b',
+        level: 'warning',
+        title: 'Consumer lag',
+        description: 'consumer b',
+        time: '2026-08-10 01:01',
+        acknowledged: false,
+      },
+    ]);
+  });
+
+  it('tracks simultaneous acknowledgements independently', async () => {
+    vi.mocked(acknowledgeAlert).mockImplementation(() => new Promise(() => {}));
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('Broker unavailable');
+    const acknowledgeButtons = screen.getAllByRole('button', { name: /^确认$/ });
+    await user.click(acknowledgeButtons[0]);
+    await user.click(acknowledgeButtons[1]);
+
+    await waitFor(() => {
+      expect(acknowledgeAlert).toHaveBeenCalledWith('alert-a');
+      expect(acknowledgeAlert).toHaveBeenCalledWith('alert-b');
+      expect(acknowledgeButtons[0]).toHaveClass('ant-btn-loading');
+      expect(acknowledgeButtons[1]).toHaveClass('ant-btn-loading');
+    });
+  });
+});

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -41,7 +41,7 @@ const SystemAlertsPage = () => {
   const [alerts, setAlerts] = useState<SystemAlert[]>([]);
   const [levelFilter, setLevelFilter] = useState<string>('all');
   const [loading, setLoading] = useState(true);
-  const [acknowledgingId, setAcknowledgingId] = useState<string | null>(null);
+  const [acknowledgingIds, setAcknowledgingIds] = useState<Set<string>>(() => new Set());
   const [clearing, setClearing] = useState(false);
 
   useEffect(() => {
@@ -68,7 +68,7 @@ const SystemAlertsPage = () => {
   const unackCount = alerts.filter((a) => !a.acknowledged).length;
 
   const handleAck = async (id: string) => {
-    setAcknowledgingId(id);
+    setAcknowledgingIds((current) => new Set(current).add(id));
     try {
       await acknowledgeAlert(id);
       setAlerts((prev) => prev.map((a) => (a.id === id ? { ...a, acknowledged: true } : a)));
@@ -76,7 +76,11 @@ const SystemAlertsPage = () => {
     } catch {
       message.error('确认告警失败，请稍后重试');
     } finally {
-      setAcknowledgingId(null);
+      setAcknowledgingIds((current) => {
+        const next = new Set(current);
+        next.delete(id);
+        return next;
+      });
     }
   };
 
@@ -185,7 +189,7 @@ const SystemAlertsPage = () => {
                       type="link"
                       icon={<CheckCircle size={14} />}
                       onClick={() => handleAck(alert.id)}
-                      loading={acknowledgingId === alert.id}
+                      loading={acknowledgingIds.has(alert.id)}
                     >
                       {t('sysAlerts.acknowledge')}
                     </Button>


### PR DESCRIPTION
## Summary
- track in-flight system-alert acknowledgements by alert id
- keep each alert's confirmation button loading until its own request settles
- add regression coverage for two acknowledgements running at the same time

## Test plan
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/ops/__tests__/SystemAlertsPage.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npx eslint src/pages/ops/systemAlerts.tsx src/pages/ops/__tests__/SystemAlertsPage.test.tsx --quiet`

Fixes #1350
