### PR TITLE
fix(certs): track concurrent renewals

### DIFF
--- a/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
@@ -16,11 +16,11 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { App } from 'antd';
+import { App, Modal } from 'antd';
 import type { K8sCertInfo } from '../../../api/cluster';
-import { listK8sCerts } from '../../../services/clusterService';
+import { listK8sCerts, renewK8sCert } from '../../../services/clusterService';
 import K8sCertsPage from '../certs';
 
 vi.mock('../../../services/clusterService', () => ({
@@ -79,6 +79,7 @@ beforeAll(() => {
 
 describe('K8sCertsPage', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(listK8sCerts).mockResolvedValue(certs);
   });
 
@@ -135,6 +136,29 @@ describe('K8sCertsPage', () => {
 
     expect(screen.getByText('rocketmq-staging-tls')).toBeInTheDocument();
     expect(screen.queryByText('rocketmq-prod-tls')).not.toBeInTheDocument();
+  });
+
+  it('tracks simultaneous certificate renewals independently', async () => {
+    vi.mocked(renewK8sCert).mockImplementation(() => new Promise(() => {}));
+    const confirmSpy = vi.spyOn(Modal, 'confirm');
+    renderPage();
+
+    await screen.findByText('rocketmq-prod-tls');
+    const renewButtons = screen.getAllByRole('button', { name: /续期/ });
+    fireEvent.click(renewButtons[0]);
+    fireEvent.click(renewButtons[1]);
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+
+    void confirmSpy.mock.calls[0][0].onOk?.(() => {});
+    void confirmSpy.mock.calls[1][0].onOk?.(() => {});
+
+    await waitFor(() => {
+      expect(renewK8sCert).toHaveBeenCalledWith('cert-prod');
+      expect(renewK8sCert).toHaveBeenCalledWith('cert-staging');
+      expect(renewButtons[0]).toHaveClass('ant-btn-loading');
+      expect(renewButtons[1]).toHaveClass('ant-btn-loading');
+    });
+    confirmSpy.mockRestore();
   });
 
   it('trims certificate search text before filtering', async () => {

--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -57,7 +57,7 @@ const K8sCertsPage = () => {
   const [certs, setCerts] = useState<K8sCertInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
-  const [renewingId, setRenewingId] = useState<string | null>(null);
+  const [renewingIds, setRenewingIds] = useState<Set<string>>(() => new Set());
   const [certSearch, setCertSearch] = useState('');
   const [certTypeFilter, setCertTypeFilter] = useState<string>('');
   const [certNamespaceFilter, setCertNamespaceFilter] = useState<string>('');
@@ -146,7 +146,7 @@ const K8sCertsPage = () => {
   });
 
   const renewCert = async (cert: K8sCertInfo) => {
-    setRenewingId(cert.id);
+    setRenewingIds((current) => new Set(current).add(cert.id));
     try {
       const renewed = await renewK8sCert(cert.id);
       setCerts((prev) => prev.map((item) => (item.id === renewed.id ? renewed : item)));
@@ -155,7 +155,11 @@ const K8sCertsPage = () => {
       message.error(getErrorMessage(error));
       throw error;
     } finally {
-      setRenewingId(null);
+      setRenewingIds((current) => {
+        const next = new Set(current);
+        next.delete(cert.id);
+        return next;
+      });
     }
   };
 
@@ -297,7 +301,7 @@ const K8sCertsPage = () => {
           <Button
             size="small"
             icon={<SyncOutlined />}
-            loading={renewingId === record.id}
+            loading={renewingIds.has(record.id)}
             onClick={() => {
               Modal.confirm({
                 title: '确认续期',


### PR DESCRIPTION
## Summary
- track K8s certificate renewal requests by certificate id
- keep every affected row loading until its own renewal request settles
- add regression coverage for two simultaneous renewals

## Test plan
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run src/pages/cluster/__tests__/K8sCertsPage.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npx eslint src/pages/cluster/certs.tsx src/pages/cluster/__tests__/K8sCertsPage.test.tsx --quiet`

Fixes #1351
