### PR TITLE
fix: require instance IDs for client connection queries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientService.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.client;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -31,7 +32,14 @@ public class ClientService {
 
     public List<ClientConnectionVO> listConnections(String instanceId, String clusterId, String type) {
         log.info("Listing client connections, instanceId={}, clusterId={}, type={}", instanceId, clusterId, type);
-        return clientProvider.findConnections(normalizeFilter(instanceId), normalizeFilter(clusterId), normalizeFilter(type));
+        return clientProvider.findConnections(requireInstanceId(instanceId), normalizeFilter(clusterId), normalizeFilter(type));
+    }
+
+    private String requireInstanceId(String instanceId) {
+        if (instanceId == null || instanceId.isBlank()) {
+            throw new BusinessException(400, "instanceId is required");
+        }
+        return instanceId.trim();
     }
 
     private String normalizeFilter(String value) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientServiceTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.client;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -25,7 +26,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,12 +55,21 @@ class ClientServiceTest {
     }
 
     @Test
-    void listConnectionsShouldTreatBlankFiltersAsUnspecified() {
-        when(clientProvider.findConnections(null, null, null)).thenReturn(List.of());
+    void listConnectionsShouldTreatBlankOptionalFiltersAsUnspecified() {
+        when(clientProvider.findConnections("instance-1", null, null)).thenReturn(List.of());
 
-        List<ClientConnectionVO> result = clientService.listConnections(" ", " ", "\t");
+        List<ClientConnectionVO> result = clientService.listConnections("instance-1", " ", "\t");
 
         assertThat(result).isEmpty();
-        verify(clientProvider).findConnections(null, null, null);
+        verify(clientProvider).findConnections("instance-1", null, null);
+    }
+
+    @Test
+    void listConnectionsShouldRejectBlankInstanceIdBeforeQueryingProvider() {
+        assertThatThrownBy(() -> clientService.listConnections(" ", null, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("instanceId is required");
+
+        verifyNoInteractions(clientProvider);
     }
 }


### PR DESCRIPTION
## Summary

Rejects blank `instanceId` values before client connection diagnostics call their provider. Optional cluster and client-type filters continue to normalize blank values as unspecified.

Closes #1375

## Test

- `cd server && JAVA_HOME=$( /usr/libexec/java_home -v 21 ) PATH="$JAVA_HOME/bin:$PATH" mvn -q -Dtest=ClientServiceTest test`