### PR TITLE
feat(persistence): add PostgreSQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,18 @@ RocketMQ Studio is a unified management platform for RocketMQ, supporting multi-
 ## Quick Start
 
 ```bash
-cd deploy && docker compose up -d --build
+cd deploy/rocketmq && docker compose up -d
+cd .. && docker compose up -d --build
 ```
 
 Visit **http://127.0.0.1:6789** after startup.
+
+The first command starts the bundled RocketMQ topology and creates the
+`rocketmq_default` Docker network used by the Studio services. Check that it
+is healthy before starting Studio with `docker compose ps` from `deploy/rocketmq`.
+The default schema creates only Studio tables. It does not seed instances, topics, consumer groups, or ACL
+records. Development-only sample data can be imported explicitly from `deploy/mysql/`; it is not part of the
+default deployment.
 
 **Studio ports:** Frontend 6789 (Nginx), Backend 8888 (Spring Boot)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -9,8 +9,13 @@ RocketMQ Studio 是一个面向多集群、多架构、多云环境的 RocketMQ 
 ## 一键构建 & 运行
 
 ```bash
-cd deploy && docker compose up -d --build
+cd deploy/rocketmq && docker compose up -d
+cd .. && docker compose up -d --build
 ```
+
+第一条命令会启动内置 RocketMQ 拓扑，并创建 Studio 服务所需的
+`rocketmq_default` Docker 网络。启动 Studio 前，可在 `deploy/rocketmq` 目录执行
+`docker compose ps` 确认 RocketMQ 已就绪。
 
 启动后访问 **http://127.0.0.1:6789** 即可使用。
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -58,3 +58,19 @@ STUDIO_AUTH_ADMIN_PASSWORD=change-me
 - 本地安装 Docker
 - 远程机器可通过 SSH 免密登录
 - 远程机器已安装 Podman（Alibaba Cloud Linux 3 默认提供）
+
+
+## PostgreSQL 持久化
+
+Studio 默认仍使用 MySQL。需要 PostgreSQL 时，创建空数据库并通过以下环境变量启动后端：
+
+```env
+SPRING_PROFILES_ACTIVE=postgresql
+SPRING_DATASOURCE_URL=jdbc:postgresql://postgres.example:5432/rocketmq
+SPRING_DATASOURCE_USERNAME=rocketmq
+SPRING_DATASOURCE_PASSWORD=change-me
+```
+
+`postgresql` profile 会通过 Flyway 自动执行
+`classpath:db/migration/postgresql` 中的版本化 schema。它只保存 Studio 自有的配置、
+审计和运维记录，不会复制 RocketMQ 消息、消费位点或 Broker 运行时数据。

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -32,6 +32,9 @@ cd deploy && docker compose up -d --build
 
 默认访问地址为 `http://127.0.0.1:6789`。
 
+默认 schema 只创建 Studio 所需的表，不会写入实例、Topic、消费组或 ACL 示例数据。需要演示数据时，
+请在开发环境中显式导入 `deploy/mysql/upgrade-demo-instance.sql` 和
+`deploy/mysql/upgrade-demo-acl.sql`，不要在生产环境导入这些脚本。
 ## 开启登录保护
 
 `studio.auth.login-required` 默认为 `false`，便于本地开发和演示环境直接访问。共享环境建议在

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -57,6 +57,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
             <version>1.3.0</version>
@@ -75,6 +85,20 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerVO.java
@@ -34,4 +34,6 @@ public class BrokerVO {
     private double diskUsage;
     private int tpsIn;
     private int tpsOut;
+    @Builder.Default
+    private boolean runtimeStatsAvailable = true;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
@@ -25,9 +25,11 @@ import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * Central lifecycle owner for real {@link DefaultMQAdminExt} connections.
@@ -68,7 +70,11 @@ public class MqAdminExtFactory {
         if (closed) {
             throw new BusinessException(503, "Admin factory is shutting down");
         }
-        DefaultMQAdminExt admin = cache.computeIfAbsent(namesrvAddr.trim(),
+        String normalizedNamesrvAddr = normalizeNamesrvAddr(namesrvAddr);
+        if (normalizedNamesrvAddr.isEmpty()) {
+            throw new BusinessException(400, "NameServer address is required");
+        }
+        DefaultMQAdminExt admin = cache.computeIfAbsent(normalizedNamesrvAddr,
                 addr -> createAndStart(addr, rpcHook));
         try {
             return action.apply(admin);
@@ -77,6 +83,26 @@ public class MqAdminExtFactory {
         } catch (Exception ex) {
             log.warn("Admin action failed against namesrv {}: {}", namesrvAddr, ex.getMessage());
             throw new BusinessException(502, "RocketMQ admin call failed: " + rootMessage(ex));
+        }
+    }
+
+    /**
+     * Stops and removes the cached client for an endpoint that is no longer referenced by Studio.
+     *
+     * <p>Callers must ensure the endpoint is not still used by another configured instance.
+     */
+    public void release(String namesrvAddr) {
+        if (namesrvAddr == null || namesrvAddr.isBlank()) {
+            return;
+        }
+        String normalizedNamesrvAddr = normalizeNamesrvAddr(namesrvAddr);
+        if (normalizedNamesrvAddr.isEmpty()) {
+            return;
+        }
+        DefaultMQAdminExt admin = cache.remove(normalizedNamesrvAddr);
+        if (admin != null) {
+            safeShutdown(admin);
+            log.info("Released RocketMQ admin client for namesrv {}", normalizedNamesrvAddr);
         }
     }
 
@@ -106,6 +132,15 @@ public class MqAdminExtFactory {
     private String buildInstanceName(String namesrvAddr) {
         return "rmq-studio-" + Integer.toHexString(namesrvAddr.hashCode())
                 + "-" + instanceCounter.incrementAndGet();
+    }
+
+    public static String normalizeNamesrvAddr(String namesrvAddr) {
+        return Arrays.stream(namesrvAddr.split("[;,]"))
+                .map(String::trim)
+                .filter(address -> !address.isEmpty())
+                .distinct()
+                .sorted()
+                .collect(Collectors.joining(";"));
     }
 
     private void safeShutdown(MQAdminExt admin) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolver.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolver.java
@@ -20,12 +20,16 @@ public class RuntimeAdminClientResolver {
     private final InstanceRepository instanceRepository;
     private final MqAdminExtFactory adminFactory;
 
-    public String resolveEndpoint(String instanceId) {
+    public InstanceVO resolveInstance(String instanceId) {
         if (!StringUtils.hasText(instanceId)) {
             throw new BusinessException(400, "instanceId is required");
         }
-        InstanceVO instance = instanceRepository.findById(instanceId)
+        return instanceRepository.findById(instanceId)
                 .orElseThrow(() -> new BusinessException(404, "Instance not found: " + instanceId));
+    }
+
+    public String resolveEndpoint(String instanceId) {
+        InstanceVO instance = resolveInstance(instanceId);
         if (!StringUtils.hasText(instance.getEndpoint())) {
             throw new BusinessException(400, "Instance has no endpoint: " + instanceId);
         }
@@ -33,6 +37,13 @@ public class RuntimeAdminClientResolver {
     }
 
     public <T> T execute(String instanceId, MqAdminExtFactory.AdminAction<T> action) {
-        return adminFactory.execute(resolveEndpoint(instanceId), null, action);
+        return execute(resolveInstance(instanceId), action);
+    }
+
+    public <T> T execute(InstanceVO instance, MqAdminExtFactory.AdminAction<T> action) {
+        if (instance == null || !StringUtils.hasText(instance.getEndpoint())) {
+            throw new BusinessException(400, "Instance endpoint is required");
+        }
+        return adminFactory.execute(instance.getEndpoint().trim(), null, action);
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientProvider.java
@@ -22,5 +22,5 @@ import java.util.List;
 public interface ClientProvider {
     List<ClientConnectionVO> findConnections(String instanceId, String clusterId, String type);
 
-    List<ClientConnectionVO> findProducerConnections(String topic, String producerGroup);
+    List<ClientConnectionVO> findProducerConnections(String instanceId, String topic, String producerGroup);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientProviderStub.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientProviderStub.java
@@ -26,15 +26,16 @@ public class ClientProviderStub implements ClientProvider {
 
     @Override
     public List<ClientConnectionVO> findConnections(String instanceId, String clusterId, String type) {
-        log.warn("ClientProviderStub.findConnections called without a real client provider. instanceId={}, clusterId={}, type={}",
+        log.warn("ClientProviderStub.findConnections called without a real client provider. "
+                        + "instanceId={}, clusterId={}, type={}",
                 instanceId, clusterId, type);
         throw new BusinessException(501, "Client connection provider is not configured");
     }
 
     @Override
-    public List<ClientConnectionVO> findProducerConnections(String topic, String producerGroup) {
+    public List<ClientConnectionVO> findProducerConnections(String instanceId, String topic, String producerGroup) {
         log.warn("ClientProviderStub.findProducerConnections called without a real client provider. "
-                + "topic={}, producerGroup={}", topic, producerGroup);
+                + "instanceId={}, topic={}, producerGroup={}", instanceId, topic, producerGroup);
         throw new BusinessException(501, "Client connection provider is not configured");
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionService.java
@@ -31,17 +31,21 @@ public class ProducerConnectionService {
 
     private final ClientProvider clientProvider;
 
-    public List<ProducerConnectionVO> listConnections(String topic, String producerGroup) {
-        log.info("Listing producer connections, topic={}, producerGroup={}", topic, producerGroup);
+    public List<ProducerConnectionVO> listConnections(String instanceId, String topic, String producerGroup) {
+        log.info("Listing producer connections, instanceId={}, topic={}, producerGroup={}",
+                instanceId, topic, producerGroup);
+        String normalizedInstanceId = requireFilter(instanceId, "instanceId");
         String normalizedTopic = requireFilter(topic, "topic");
         String normalizedProducerGroup = requireFilter(producerGroup, "producerGroup");
-        return clientProvider.findProducerConnections(normalizedTopic, normalizedProducerGroup).stream()
+        return clientProvider.findProducerConnections(normalizedInstanceId, normalizedTopic, normalizedProducerGroup)
+                .stream()
                 .map(this::toProducerConnection)
                 .toList();
     }
 
-    public List<String> listProducerGroups() {
-        return clientProvider.findConnections(null, null, ClientType.Producer.name()).stream()
+    public List<String> listProducerGroups(String instanceId) {
+        String normalizedInstanceId = requireFilter(instanceId, "instanceId");
+        return clientProvider.findConnections(normalizedInstanceId, null, ClientType.Producer.name()).stream()
                 .map(ClientConnectionVO::getProducerGroup)
                 .filter(this::hasText)
                 .map(String::trim)

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerController.java
@@ -34,17 +34,20 @@ public class ProducerController {
     private final ProducerConnectionService producerConnectionService;
 
     @GetMapping("/groups")
-    public Result<List<String>> listProducerGroups() {
-        return Result.ok(producerConnectionService.listProducerGroups());
+    public Result<List<String>> listProducerGroups(@RequestParam String instanceId) {
+        return Result.ok(producerConnectionService.listProducerGroups(instanceId));
     }
 
     @GetMapping("/connection")
     public ProducerConnectionResultVO listConnections(
+            @RequestParam(required = false) String instanceId,
             @RequestParam(required = false) String topic,
             @RequestParam(required = false) String producerGroup) {
+        requireParameter(instanceId, "instanceId");
         requireParameter(topic, "topic");
         requireParameter(producerGroup, "producerGroup");
-        return new ProducerConnectionResultVO(producerConnectionService.listConnections(topic, producerGroup));
+        return new ProducerConnectionResultVO(
+                producerConnectionService.listConnections(instanceId, topic, producerGroup));
     }
 
     private void requireParameter(String value, String name) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
@@ -57,6 +57,9 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
     private static final int MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
     private static final int MAX_SERIES = 1_000;
     private static final int MAX_TOTAL_SAMPLES = 100_000;
+    private static final int MAX_LABELS_PER_SERIES = 64;
+    private static final int MAX_LABEL_KEY_LENGTH = 256;
+    private static final int MAX_LABEL_VALUE_LENGTH = 4_096;
 
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
@@ -220,10 +223,22 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
             throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
                     backendLabel() + " returned a malformed time series");
         }
+        if (metric.size() > MAX_LABELS_PER_SERIES) {
+            throw new PrometheusException(HttpStatus.PAYLOAD_TOO_LARGE.value(),
+                    backendLabel() + " query returned too many labels in a time series; narrow the query");
+        }
 
         Map<String, String> labels = new LinkedHashMap<>();
         Iterator<Map.Entry<String, JsonNode>> fields = metric.fields();
-        fields.forEachRemaining(entry -> labels.put(entry.getKey(), entry.getValue().asText()));
+        fields.forEachRemaining(entry -> {
+            String key = entry.getKey();
+            String value = entry.getValue().asText();
+            if (key.length() > MAX_LABEL_KEY_LENGTH || value.length() > MAX_LABEL_VALUE_LENGTH) {
+                throw new PrometheusException(HttpStatus.PAYLOAD_TOO_LARGE.value(),
+                        backendLabel() + " query returned an oversized time-series label; narrow the query");
+            }
+            labels.put(key, value);
+        });
 
         List<MetricDataVO.MetricSampleVO> samples = hasValues
                 ? StreamSupport.stream(values.spliterator(), false).map(this::parseSample).toList()

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,10 @@ public class GrafanaDashboardService {
             }
             try (InputStream in = resource.getInputStream()) {
                 JsonNode root = objectMapper.readTree(in);
+                if (root == null || !root.isObject()) {
+                    log.warn("Skipping invalid Grafana dashboard resource {}: expected a JSON object", resource);
+                    continue;
+                }
                 String title = textOr(root, "title", uid);
                 String description = textOr(root, "description", "");
                 List<String> tags = parseTags(root);
@@ -100,7 +105,7 @@ public class GrafanaDashboardService {
             throw new BusinessException(404, "Grafana dashboard not found: " + uid);
         }
         try (InputStream in = resource.getInputStream()) {
-            return new String(in.readAllBytes());
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new BusinessException(500, "Failed to read Grafana dashboard: " + uid);
         }
@@ -115,7 +120,7 @@ public class GrafanaDashboardService {
         return null;
     }
 
-    private Resource[] resolveResources() {
+    protected Resource[] resolveResources() {
         try {
             return resourceResolver.getResources(LOCATION_PATTERN);
         } catch (IOException e) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -21,6 +21,7 @@ import org.springframework.util.StringUtils;
 
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialRepository;
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialVO;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -43,6 +44,7 @@ public class InstanceService {
     private final InstanceRepository instanceRepository;
     private final CloudCredentialRepository cloudCredentialRepository;
     private final InstanceProviderRegistry providerRegistry;
+    private final MqAdminExtFactory adminFactory;
 
     public List<InstanceVO> listInstances(InstanceType type, String search) {
         log.debug("Listing instances, type={}, search={}", type, search);
@@ -72,7 +74,9 @@ public class InstanceService {
             InstanceProvider provider = providerRegistry.forVendor(vendor);
             instance.setTopicCount(provider.countTopics(instance.getId()));
             instance.setConsumerGroupCount(provider.countGroups(instance.getId()));
+            instance.setResourceCountsAvailable(true);
         } catch (RuntimeException ex) {
+            instance.setResourceCountsAvailable(false);
             log.warn("Failed to load resource counts for instance {}: {}",
                     instance.getId(), ex.getMessage());
         }
@@ -100,8 +104,9 @@ public class InstanceService {
         if (instance.getName() == null || instance.getName().isBlank()) {
             throw new BusinessException(400, "InstanceVO name is required");
         }
-        if (instance.getEndpoint() == null || instance.getEndpoint().isBlank()) {
-            throw new BusinessException(400, "InstanceVO endpoint is required");
+        instance.setEndpoint(requireValidEndpoint(instance.getEndpoint()));
+        if (instance.getType() == null) {
+            throw new BusinessException(400, "InstanceVO type is required");
         }
     }
 
@@ -158,6 +163,19 @@ public class InstanceService {
     }
 
 
+    private String requireValidEndpoint(String endpoint) {
+        if (!StringUtils.hasText(endpoint)) {
+            throw new BusinessException(400, "InstanceVO endpoint is required");
+        }
+        String normalized = endpoint.trim();
+        for (String address : normalized.split("[;,]", -1)) {
+            if (address.isBlank()) {
+                throw new BusinessException(400, "InstanceVO endpoint must not contain empty addresses");
+            }
+        }
+        return normalized;
+    }
+
     public InstanceVO updateInstance(InstanceVO instance) {
         requireInstance(instance);
         log.info("Updating instance: {}", instance.getId());
@@ -172,9 +190,6 @@ public class InstanceService {
         if (instance.getName() != null && instance.getName().isBlank()) {
             throw new BusinessException(400, "InstanceVO name is required");
         }
-        if (instance.getEndpoint() != null && instance.getEndpoint().isBlank()) {
-            throw new BusinessException(400, "InstanceVO endpoint is required");
-        }
 
         InstanceVO updated = copyOf(existing);
         boolean cloudInstance = existing.getVendor() != null && existing.getVendor() != InstanceVendor.APACHE;
@@ -186,7 +201,7 @@ public class InstanceService {
                 updated.setType(instance.getType());
             }
             if (instance.getEndpoint() != null) {
-                updated.setEndpoint(instance.getEndpoint());
+                updated.setEndpoint(requireValidEndpoint(instance.getEndpoint()));
             }
         }
         if (instance.getRemark() != null) {
@@ -194,7 +209,9 @@ public class InstanceService {
         }
         updated.setUpdatedAt(LocalDateTime.now());
 
-        return instanceRepository.save(updated);
+        InstanceVO saved = instanceRepository.save(updated);
+        releaseApacheEndpointIfUnused(existing, saved.getEndpoint());
+        return saved;
     }
 
     public void deleteInstance(String id) {
@@ -207,12 +224,17 @@ public class InstanceService {
         InstanceVO existing = instanceRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(404, "InstanceVO not found: " + id));
 
-        if (existing.getTopicCount() > 0 || existing.getConsumerGroupCount() > 0) {
+        InstanceProvider provider = providerRegistry.forVendor(
+                existing.getVendor() == null ? InstanceVendor.APACHE : existing.getVendor());
+        int topicCount = provider.countTopics(id);
+        int consumerGroupCount = provider.countGroups(id);
+        if (topicCount > 0 || consumerGroupCount > 0) {
             throw new BusinessException(409, String.format(
                     "Cannot delete instance with managed resources: topics=%d, consumerGroups=%d",
-                    existing.getTopicCount(), existing.getConsumerGroupCount()));
+                    topicCount, consumerGroupCount));
         }
         instanceRepository.deleteById(id);
+        releaseApacheEndpointIfUnused(existing, null);
     }
 
     private void requireInstance(InstanceVO instance) {
@@ -238,5 +260,34 @@ public class InstanceService {
         copy.setCreatedAt(instance.getCreatedAt());
         copy.setUpdatedAt(instance.getUpdatedAt());
         return copy;
+    }
+
+    private void releaseApacheEndpointIfUnused(InstanceVO existing, String currentEndpoint) {
+        InstanceVendor vendor = existing.getVendor() == null ? InstanceVendor.APACHE : existing.getVendor();
+        if (vendor != InstanceVendor.APACHE) {
+            return;
+        }
+        releaseEndpointIfUnused(existing.getEndpoint(), currentEndpoint, existing.getId());
+    }
+
+    private void releaseEndpointIfUnused(String previousEndpoint, String currentEndpoint, String excludedInstanceId) {
+        String oldEndpoint = normalizeEndpoint(previousEndpoint);
+        if (oldEndpoint == null || oldEndpoint.equals(normalizeEndpoint(currentEndpoint))) {
+            return;
+        }
+        boolean stillReferenced = instanceRepository.findAll().stream()
+                .anyMatch(instance -> !excludedInstanceId.equals(instance.getId())
+                        && oldEndpoint.equals(normalizeEndpoint(instance.getEndpoint())));
+        if (!stillReferenced) {
+            adminFactory.release(oldEndpoint);
+        }
+    }
+
+    private String normalizeEndpoint(String endpoint) {
+        if (endpoint == null || endpoint.isBlank()) {
+            return null;
+        }
+        String normalizedEndpoint = MqAdminExtFactory.normalizeNamesrvAddr(endpoint);
+        return normalizedEndpoint.isEmpty() ? null : normalizedEndpoint;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceVO.java
@@ -42,4 +42,6 @@ public class InstanceVO extends BaseEntity {
     private String regionId;
     private int topicCount;
     private int consumerGroupCount;
+    @Builder.Default
+    private boolean resourceCountsAvailable = true;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQGroupVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQGroupVO.java
@@ -34,4 +34,6 @@ public class DLQGroupVO {
     private LocalDateTime lastEnqueueTime;
     private int retryCount;
     private String status;
+    @Builder.Default
+    private boolean statsAvailable = true;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -51,7 +52,16 @@ public class MessageService {
     }
 
     private void validateTopicQueryWindow(String topic, String msgId, String key, Long startTime, Long endTime) {
-        if (msgId != null && !msgId.isBlank() || key != null && !key.isBlank() || topic == null || topic.isBlank()) {
+        boolean hasTopic = StringUtils.hasText(topic);
+        boolean hasMessageId = StringUtils.hasText(msgId);
+        boolean hasKey = StringUtils.hasText(key);
+        if (hasKey && !hasTopic) {
+            throw new BusinessException(400, "topic is required when key is specified");
+        }
+        if (!hasTopic && !hasMessageId) {
+            throw new BusinessException(400, "topic or msgId is required");
+        }
+        if (hasMessageId || hasKey) {
             return;
         }
         long end = endTime == null ? System.currentTimeMillis() : endTime;

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/LiteTopicService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/LiteTopicService.java
@@ -28,7 +28,7 @@ public class LiteTopicService {
     private static final int NOT_IMPLEMENTED = 501;
 
     public List<LiteTopicItemVO> listLiteTopics(String pattern, String namespace) {
-        return List.of();
+        throw new BusinessException(NOT_IMPLEMENTED, PROVIDER_UNAVAILABLE_MESSAGE);
     }
 
     public LiteTopicSessionVO getSession(String sessionId) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/NameSrvAdminClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/NameSrvAdminClient.java
@@ -49,7 +49,7 @@ public class NameSrvAdminClient implements AdminClient {
     }
 
     @Override
-    public void deleteTopic(String name) {
+    public void deleteTopic(String instanceId, String name) {
         throw new UnsupportedOperationException("Not implemented");
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/OpsHomeVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/OpsHomeVO.java
@@ -25,6 +25,8 @@ import java.util.List;
 @Data
 @Builder
 public class OpsHomeVO {
+    private boolean configurationAvailable;
+    private String unavailableReason;
     private List<String> namesvrAddrList;
     private boolean useVIPChannel;
     private boolean useTLS;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/OpsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/OpsService.java
@@ -21,10 +21,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 @Slf4j
 @Service
@@ -33,17 +30,14 @@ public class OpsService {
     private static final String OPS_SETTINGS_UNAVAILABLE =
             "Ops settings are not connected to the cluster admin configuration";
 
-    private final Set<String> namesrvAddrs = new LinkedHashSet<>(List.of("127.0.0.1:9876"));
-    private String currentNamesrv = "127.0.0.1:9876";
-    private boolean useVIPChannel = true;
-    private boolean useTLS;
-
     public synchronized OpsHomeVO getHomePage() {
         return OpsHomeVO.builder()
-                .namesvrAddrList(new ArrayList<>(namesrvAddrs))
-                .currentNamesrv(currentNamesrv)
-                .useVIPChannel(useVIPChannel)
-                .useTLS(useTLS)
+                .configurationAvailable(false)
+                .unavailableReason(OPS_SETTINGS_UNAVAILABLE)
+                .namesvrAddrList(List.of())
+                .currentNamesrv("")
+                .useVIPChannel(false)
+                .useTLS(false)
                 .build();
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetService.java
@@ -60,6 +60,10 @@ public class AlertRuleAssetService {
             }
             try (InputStream in = resource.getInputStream()) {
                 JsonNode root = yamlMapper.readTree(in);
+                if (root == null || !root.isObject()) {
+                    log.warn("Skipping invalid alert rule asset {}: expected a YAML object", resource);
+                    continue;
+                }
                 List<PrometheusAlertRule> rules = parseRules(root);
                 Set<String> severities = new LinkedHashSet<>();
                 String group = rules.isEmpty() ? "" : rules.get(0).group();
@@ -100,7 +104,12 @@ public class AlertRuleAssetService {
                 continue;
             }
             try (InputStream in = resource.getInputStream()) {
-                rules.addAll(parseRules(yamlMapper.readTree(in)));
+                JsonNode root = yamlMapper.readTree(in);
+                if (root == null || !root.isObject()) {
+                    log.warn("Skipping invalid alert rule asset {}: expected a YAML object", resource);
+                    continue;
+                }
+                rules.addAll(parseRules(root));
             } catch (IOException e) {
                 log.warn("Skipping unreadable alert rule asset {}: {}", resource, e.getMessage());
             }
@@ -110,6 +119,9 @@ public class AlertRuleAssetService {
 
     private List<PrometheusAlertRule> parseRules(JsonNode root) {
         List<PrometheusAlertRule> rules = new ArrayList<>();
+        if (root == null || !root.isObject()) {
+            return rules;
+        }
         JsonNode groups = root.get("groups");
         if (groups == null || !groups.isArray()) {
             return rules;
@@ -126,6 +138,10 @@ public class AlertRuleAssetService {
                 }
                 String alert = textOr(rule, "alert", "");
                 String expr = textOr(rule, "expr", "");
+                if (alert.isBlank() || expr.isBlank()) {
+                    log.warn("Skipping incomplete alert rule in group {}", groupName);
+                    continue;
+                }
                 String duration = textOr(rule, "for", "5m");
                 String severity = textOr(labelsOf(rule), "severity", "warning");
                 String team = textOr(labelsOf(rule), "team", "broker");
@@ -146,7 +162,7 @@ public class AlertRuleAssetService {
         return null;
     }
 
-    private Resource[] resolveResources() {
+    protected Resource[] resolveResources() {
         try {
             return resourceResolver.getResources(LOCATION_PATTERN);
         } catch (IOException e) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/ClusterOverviewVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/ClusterOverviewVO.java
@@ -39,8 +39,8 @@ public class ClusterOverviewVO {
     private int proxies;
     private int topics;
     private int groups;
-    private int tpsIn;
-    private int tpsOut;
+    private long tpsIn;
+    private long tpsOut;
     private String version;
     private List<Integer> throughput;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardController.java
@@ -21,6 +21,7 @@ import org.apache.rocketmq.studio.common.domain.Result;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -31,7 +32,7 @@ public class DashboardController {
     private final DashboardService dashboardService;
 
     @GetMapping
-    public Result<DashboardDataVO> getDashboard() {
-        return Result.ok(dashboardService.getDashboard());
+    public Result<DashboardDataVO> getDashboard(@RequestParam(required = false) String instanceId) {
+        return Result.ok(dashboardService.getDashboard(instanceId));
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardProvider.java
@@ -20,4 +20,8 @@ package org.apache.rocketmq.studio.ops.dashboard;
 
 public interface DashboardProvider {
     DashboardDataVO getDashboardData();
+
+    default DashboardDataVO getDashboardData(String instanceId) {
+        return getDashboardData();
+    }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardService.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.studio.ops.dashboard;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Service
@@ -31,5 +32,13 @@ public class DashboardService {
     public DashboardDataVO getDashboard() {
         log.debug("Fetching dashboard data");
         return dashboardProvider.getDashboardData();
+    }
+
+    public DashboardDataVO getDashboard(String instanceId) {
+        if (!StringUtils.hasText(instanceId)) {
+            return getDashboard();
+        }
+        log.debug("Fetching dashboard data for instance={}", instanceId);
+        return dashboardProvider.getDashboardData(instanceId.trim());
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactory.java
@@ -65,6 +65,20 @@ public class AliyunClientFactory {
     }
 
     /**
+     * Releases all clients created with a credential so the next call observes rotated secrets.
+     */
+    public void invalidateCredential(String credentialId) {
+        String prefix = credentialId + "#";
+        clients.entrySet().removeIf(entry -> {
+            if (!entry.getKey().startsWith(prefix)) {
+                return false;
+            }
+            entry.getValue().close();
+            return true;
+        });
+    }
+
+    /**
      * Executes an SDK call with a bounded wait and unified exception mapping.
      */
     public <T> T call(String credentialId, String region, Function<AsyncClient, CompletableFuture<T>> action) {
@@ -106,7 +120,7 @@ public class AliyunClientFactory {
         return "rocketmq." + region + ".aliyuncs.com";
     }
 
-    private AsyncClient createClient(String credentialId, String region) {
+    protected AsyncClient createClient(String credentialId, String region) {
         CloudCredentialVO credential = credentialRepository.findById(credentialId)
                 .orElseThrow(() -> new BusinessException(404, "Cloud credential not found: " + credentialId));
         StaticCredentialProvider credentialProvider = StaticCredentialProvider.create(

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/AdminClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/AdminClient.java
@@ -27,7 +27,7 @@ public interface AdminClient {
     ConsumerGroupVO getConsumerGroup(String instanceId, String name);
     TopicVO createTopic(TopicVO topic);
     TopicVO updateTopic(TopicVO topic);
-    void deleteTopic(String name);
+    void deleteTopic(String instanceId, String name);
     SendMessageVO sendMessage(SendMessageDTO request);
     ConsumerGroupVO createConsumerGroup(ConsumerGroupVO group);
     void deleteConsumerGroup(String instanceId, String name);

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
@@ -80,7 +80,7 @@ public class ApacheInstanceProvider implements InstanceProvider {
 
     @Override
     public void deleteTopic(String instanceId, String topicName) {
-        adminClient.deleteTopic(topicName);
+        adminClient.deleteTopic(instanceId, topicName);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -135,7 +135,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
         int writeQueues = topic.getWriteQueues() > 0 ? topic.getWriteQueues() : 8;
         int readQueues = topic.getReadQueues() > 0 ? topic.getReadQueues() : 8;
 
-        return adminFactory.execute(namesrvAddr(), null, admin -> {
+        return executeForInstance(topic.getInstanceId(), admin -> {
             try {
                 String clusterName = getClusterName(admin);
                 // Match on the (cluster_id, name) key: the same topic name can exist in several
@@ -216,7 +216,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
         int writeQueues = topic.getWriteQueues() > 0 ? topic.getWriteQueues() : 8;
         int readQueues = topic.getReadQueues() > 0 ? topic.getReadQueues() : 8;
 
-        return adminFactory.execute(namesrvAddr(), null, admin -> {
+        return executeForInstance(topic.getInstanceId(), admin -> {
             try {
                 // Match on the (cluster_id, name) key to avoid ambiguity when several clusters share
                 // the same topic name (a name-only lookup would throw TooManyResultsException).
@@ -270,9 +270,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
     }
 
     @Override
-    public void deleteTopic(String name) {
-        String namesrvAddr = namesrvAddr();
-        adminFactory.execute(namesrvAddr, null, admin -> {
+    public void deleteTopic(String instanceId, String name) {
+        String namesrvAddr = namesrvAddr(instanceId);
+        executeForInstance(instanceId, admin -> {
             try {
                 Set<String> brokerAddrs = getAllMasterBrokerAddrs(admin);
 
@@ -291,8 +291,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 }
                 admin.deleteTopicInNameServer(nsAddrs, getClusterName(admin), name);
 
-                // Delete from DB, scoped to the current cluster so same-named topics in other
-                // clusters are not removed.
+                // Topic names may be shared by several clusters managed by this Studio instance.
                 topicMapper.delete(new LambdaQueryWrapper<RmqTopic>()
                         .eq(RmqTopic::getClusterId, getClusterName(admin))
                         .eq(RmqTopic::getName, name));
@@ -311,7 +310,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
 
     @Override
     public SendMessageVO sendMessage(SendMessageDTO request) {
-        String namesrvAddr = namesrvAddr();
+        String namesrvAddr = namesrvAddr(request.getInstanceId());
 
         DefaultMQProducer producer = new DefaultMQProducer(nextMessageSenderGroup());
         producer.setNamesrvAddr(namesrvAddr);
@@ -452,8 +451,10 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 admin.deleteSubscriptionGroup(addr, name, true);
             }
 
-            // Delete from DB
-            groupMapper.delete(new LambdaQueryWrapper<RmqGroup>().eq(RmqGroup::getName, name));
+            // Consumer group names may be shared by several clusters managed by this Studio instance.
+            groupMapper.delete(new LambdaQueryWrapper<RmqGroup>()
+                    .eq(RmqGroup::getClusterId, getClusterName(admin))
+                    .eq(RmqGroup::getName, name));
 
             recordAudit("DELETE_GROUP", name, "", "SUCCESS");
         } catch (BusinessException e) {
@@ -508,6 +509,19 @@ public class RocketMQAdminClientImpl implements AdminClient {
             throw new BusinessException(503, "RocketMQ admin not connected");
         }
         return namesrvAddr;
+    }
+
+    private String namesrvAddr(String instanceId) {
+        return StringUtils.hasText(instanceId)
+                ? runtimeAdminClientResolver.resolveEndpoint(instanceId)
+                : namesrvAddr();
+    }
+
+    private <T> T executeForInstance(String instanceId, MqAdminExtFactory.AdminAction<T> action) {
+        if (StringUtils.hasText(instanceId)) {
+            return runtimeAdminClientResolver.execute(instanceId, action);
+        }
+        return adminFactory.execute(namesrvAddr(), null, action);
     }
 
     private Set<String> getAllMasterBrokerAddrs(MQAdminExt admin) throws Exception {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -29,7 +29,6 @@ import org.apache.rocketmq.remoting.protocol.body.SubscriptionGroupWrapper;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.client.ClientConnectionVO;
 import org.apache.rocketmq.studio.cluster.client.ClientProvider;
-import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.ClientLanguage;
@@ -40,7 +39,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -64,9 +62,7 @@ public class RocketMQClientProvider implements ClientProvider {
 
     private static final long SUBSCRIPTION_GROUP_TIMEOUT_MILLIS = 5000L;
 
-    private final MqAdminExtFactory adminFactory;
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
-    private final RocketMQProperties properties;
 
     @Override
     public List<ClientConnectionVO> findConnections(String instanceId, String clusterId, String type) {
@@ -86,36 +82,35 @@ public class RocketMQClientProvider implements ClientProvider {
     }
 
     @Override
-    public List<ClientConnectionVO> findProducerConnections(String topic, String producerGroup) {
-        String namesrvAddr = properties.getNamesrvAddr();
-        if (!StringUtils.hasText(namesrvAddr)) {
-            throw new BusinessException(501, "Client connection provider is not configured");
-        }
-        return adminFactory.execute(namesrvAddr, null, admin -> {
-            try {
-                ProducerConnection producerConnection =
-                        admin.examineProducerConnectionInfo(producerGroup, topic);
-                if (producerConnection == null || producerConnection.getConnectionSet() == null) {
-                    return List.<ClientConnectionVO>of();
-                }
-                return producerConnection.getConnectionSet().stream()
-                        .filter(Objects::nonNull)
-                        .map(connection -> toConnectionVO(
-                                connection, ClientType.Producer, topic, producerGroup, null))
-                        .toList();
-            } catch (MQClientException e) {
-                if (isTopicNotExist(e)) {
-                    // A non-existent topic is a normal "nothing here" outcome — the client
-                    // page should show an empty list, not a 502 that looks like a failure.
-                    return List.<ClientConnectionVO>of();
-                }
-                throw new BusinessException(502,
-                        "Failed to query producer connections: " + rootMessage(e));
-            } catch (Exception e) {
-                throw new BusinessException(502,
-                        "Failed to query producer connections: " + rootMessage(e));
+    public List<ClientConnectionVO> findProducerConnections(String instanceId, String topic, String producerGroup) {
+        return runtimeAdminClientResolver.execute(instanceId,
+                adminExt -> findProducerConnections(adminExt, topic, producerGroup));
+    }
+
+    private List<ClientConnectionVO> findProducerConnections(MQAdminExt adminExt, String topic, String producerGroup) {
+        try {
+            ProducerConnection producerConnection =
+                    adminExt.examineProducerConnectionInfo(producerGroup, topic);
+            if (producerConnection == null || producerConnection.getConnectionSet() == null) {
+                return List.of();
             }
-        });
+            return producerConnection.getConnectionSet().stream()
+                    .filter(Objects::nonNull)
+                    .map(connection -> toConnectionVO(
+                            connection, ClientType.Producer, topic, producerGroup, null))
+                    .toList();
+        } catch (MQClientException e) {
+            if (isTopicNotExist(e)) {
+                // A non-existent topic is a normal "nothing here" outcome — the client
+                // page should show an empty list, not a 502 that looks like a failure.
+                return List.of();
+            }
+            throw new BusinessException(502,
+                    "Failed to query producer connections: " + rootMessage(e));
+        } catch (Exception e) {
+            throw new BusinessException(502,
+                    "Failed to query producer connections: " + rootMessage(e));
+        }
     }
 
     private boolean isTopicNotExist(MQClientException e) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -24,6 +24,7 @@ import org.apache.rocketmq.studio.cluster.broker.ClusterProvider;
 import org.apache.rocketmq.studio.cluster.broker.ClusterVO;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.nameserver.NameServerVO;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.BrokerStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
@@ -85,7 +86,8 @@ public class RocketMQClusterProvider implements ClusterProvider {
             });
         } catch (Exception e) {
             log.warn("Failed to discover clusters via NameServer: {}", e.getMessage());
-            return Collections.emptyList();
+            throw new BusinessException(502,
+                    "Failed to discover clusters via NameServer: " + rootMessage(e));
         }
     }
 
@@ -131,7 +133,7 @@ public class RocketMQClusterProvider implements ClusterProvider {
                                      List<NameServerVO> nameServers) {
         ClusterVO cluster = ClusterVO.builder()
                 .name(clusterName)
-                .status(ClusterStatus.healthy)
+                .status(hasUnavailableRuntimeStats(brokers) ? ClusterStatus.warning : ClusterStatus.healthy)
                 .brokers(brokers != null ? brokers : Collections.emptyList())
                 .proxies(Collections.emptyList())
                 .nameServers(nameServers != null ? nameServers : Collections.emptyList())
@@ -171,18 +173,29 @@ public class RocketMQClusterProvider implements ClusterProvider {
                     .status(BrokerStatus.running);
 
             // Try to get runtime info for version and TPS
-            enrichBrokerWithRuntimeInfo(admin, builder, masterAddr);
+            builder.runtimeStatsAvailable(enrichBrokerWithRuntimeInfo(admin, builder, masterAddr));
 
             brokers.add(builder.build());
         }
         return brokers;
     }
 
-    private void enrichBrokerWithRuntimeInfo(MQAdminExt admin, BrokerVO.BrokerVOBuilder builder, String brokerAddr) {
+    private String rootMessage(Throwable error) {
+        Throwable current = error;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        String message = current.getMessage();
+        return message == null || message.isBlank()
+                ? current.getClass().getSimpleName()
+                : message;
+    }
+
+    private boolean enrichBrokerWithRuntimeInfo(MQAdminExt admin, BrokerVO.BrokerVOBuilder builder, String brokerAddr) {
         try {
             KVTable runtimeInfo = admin.fetchBrokerRuntimeStats(brokerAddr);
             if (runtimeInfo == null || runtimeInfo.getTable() == null) {
-                return;
+                return false;
             }
 
             Map<String, String> table = runtimeInfo.getTable();
@@ -213,9 +226,15 @@ public class RocketMQClusterProvider implements ClusterProvider {
                     // keep default
                 }
             }
+            return true;
         } catch (Exception e) {
-            log.debug("Failed to get runtime info for broker at {}: {}", brokerAddr, e.getMessage());
+            log.warn("Failed to get runtime info for broker at {}: {}", brokerAddr, e.getMessage());
+            return false;
         }
+    }
+
+    private boolean hasUnavailableRuntimeStats(List<BrokerVO> brokers) {
+        return brokers != null && brokers.stream().anyMatch(broker -> !broker.isRuntimeStatsAvailable());
     }
 
     /**

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -21,6 +21,7 @@ import org.apache.rocketmq.client.consumer.PullResult;
 import org.apache.rocketmq.client.consumer.PullStatus;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendStatus;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageConst;
@@ -62,6 +63,8 @@ public class RocketMQDLQProvider implements DLQProvider {
 
     private static final long ONE_HOUR_MILLIS = 3600_000L;
     private static final int RESEND_HARD_CAP = 5000;
+    private static final String ORIGIN_MESSAGE_ID_PROPERTY = "studio_dlq_origin_message_id";
+    private static final String ORIGIN_TOPIC_PROPERTY = "studio_dlq_origin_topic";
 
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
     private final AuditService auditService;
@@ -93,6 +96,7 @@ public class RocketMQDLQProvider implements DLQProvider {
     private DLQGroupVO buildDLQGroup(MQAdminExt adminExt, String groupName, String dlqTopic) {
         long messageCount = 0L;
         LocalDateTime lastEnqueueTime = null;
+        boolean statsAvailable = true;
         try {
             TopicStatsTable statsTable = adminExt.examineTopicStats(dlqTopic);
             if (statsTable != null && statsTable.getOffsetTable() != null) {
@@ -113,6 +117,7 @@ public class RocketMQDLQProvider implements DLQProvider {
                 }
             }
         } catch (Exception e) {
+            statsAvailable = false;
             log.warn("Failed to examine stats for DLQ topic {}: {}", dlqTopic, e.getMessage());
         }
 
@@ -122,7 +127,8 @@ public class RocketMQDLQProvider implements DLQProvider {
                 .messageCount(messageCount)
                 .lastEnqueueTime(lastEnqueueTime)
                 .retryCount(0)
-                .status(messageCount > 0 ? "ACTIVE" : "EMPTY")
+                .status(statsAvailable ? (messageCount > 0 ? "ACTIVE" : "EMPTY") : "UNAVAILABLE")
+                .statsAvailable(statsAvailable)
                 .build();
     }
 
@@ -191,7 +197,17 @@ public class RocketMQDLQProvider implements DLQProvider {
                             break outer;
                         }
                         PullResult pullResult = consumer.pull(queue, "*", offset, 32);
-                        offset = pullResult.getNextBeginOffset();
+                        if (pullResult == null) {
+                            log.warn("Stop DLQ scan for {} because queue {} returned no pull result", dlqTopic, queue);
+                            break;
+                        }
+                        long nextOffset = pullResult.getNextBeginOffset();
+                        if (nextOffset <= offset) {
+                            log.warn("Stop DLQ scan for {} because queue {} did not advance offset {}",
+                                    dlqTopic, queue, offset);
+                            break;
+                        }
+                        offset = nextOffset;
                         if (pullResult.getPullStatus() != PullStatus.FOUND
                                 || pullResult.getMsgFoundList() == null) {
                             break;
@@ -232,9 +248,15 @@ public class RocketMQDLQProvider implements DLQProvider {
             if (StringUtils.hasText(deadLetter.getKeys())) {
                 message.setKeys(deadLetter.getKeys());
             }
-            message.putUserProperty("DLQ_ORIGIN_MESSAGE_ID", deadLetter.getMsgId());
-            message.putUserProperty("DLQ_ORIGIN_TOPIC", deadLetter.getTopic());
+            message.putUserProperty(ORIGIN_MESSAGE_ID_PROPERTY, deadLetter.getMsgId());
+            message.putUserProperty(ORIGIN_TOPIC_PROPERTY, deadLetter.getTopic());
             SendResult sendResult = producer.send(message);
+            if (sendResult == null || sendResult.getSendStatus() != SendStatus.SEND_OK) {
+                log.warn("DLQ resend was not accepted: msgId={} topic={} sendStatus={}",
+                        deadLetter.getMsgId(), destination,
+                        sendResult == null ? "<null>" : sendResult.getSendStatus());
+                return false;
+            }
             log.debug("Resent dead letter msgId={} to topic={}, sendStatus={}",
                     deadLetter.getMsgId(), destination, sendResult.getSendStatus());
             return true;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.provider.apache;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -29,8 +30,11 @@ import org.apache.rocketmq.remoting.protocol.body.TopicList;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.apache.rocketmq.studio.ops.dashboard.ClusterOverviewVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardProvider;
@@ -56,6 +60,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
 
     private final MqAdminExtFactory adminFactory;
     private final RocketMQProperties properties;
+    private final RuntimeAdminClientResolver runtimeAdminClientResolver;
 
     @Override
     public DashboardDataVO getDashboardData() {
@@ -64,10 +69,18 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             log.warn("NameServer address not configured, returning empty dashboard");
             return emptyDashboard();
         }
-        return adminFactory.execute(namesrvAddr, null, this::collectDashboardData);
+        return adminFactory.execute(namesrvAddr, null,
+                admin -> collectDashboardData(admin, ClusterType.V5_PROXY_CLUSTER));
     }
 
-    private DashboardDataVO collectDashboardData(MQAdminExt admin) {
+    @Override
+    public DashboardDataVO getDashboardData(String instanceId) {
+        InstanceVO instance = runtimeAdminClientResolver.resolveInstance(instanceId);
+        return runtimeAdminClientResolver.execute(instance,
+                admin -> collectDashboardData(admin, clusterTypeFor(instance)));
+    }
+
+    private DashboardDataVO collectDashboardData(MQAdminExt admin, ClusterType clusterType) {
         int totalClusters = 0;
         int totalBrokers = 0;
         int totalTopics = 0;
@@ -76,6 +89,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
         long tpsOut = 0;
         long messagesToday = 0;
         List<ClusterOverviewVO> clusters = new ArrayList<>();
+        Map<String, KVTable> runtimeStatsByBroker = new HashMap<>();
 
         try {
             ClusterInfo clusterInfo = admin.examineBrokerClusterInfo();
@@ -115,7 +129,8 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             // Count topics
             try {
                 TopicList topicList = admin.fetchAllTopicList();
-                Set<String> topics = topicList.getTopicList();
+                Set<String> topics = topicList == null || topicList.getTopicList() == null
+                        ? Set.of() : topicList.getTopicList();
                 totalTopics = (int) topics.stream()
                         .filter(t -> !isSystemTopic(t))
                         .count();
@@ -144,6 +159,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 // Get runtime stats for TPS
                 try {
                     KVTable runtimeInfo = admin.fetchBrokerRuntimeStats(brokerAddr);
+                    runtimeStatsByBroker.put(brokerAddr, runtimeInfo);
                     if (runtimeInfo != null && runtimeInfo.getTable() != null) {
                         Map<String, String> table = runtimeInfo.getTable();
                         tpsIn += parseTps(table.get("putTps"));
@@ -166,11 +182,12 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             // Build per-cluster overview
             for (Map.Entry<String, Set<String>> clusterEntry : clusterAddrTable.entrySet()) {
                 String clusterName = clusterEntry.getKey();
-                Set<String> brokerNames = clusterEntry.getValue();
+                Set<String> brokerNames = clusterEntry.getValue() == null ? Set.of() : clusterEntry.getValue();
                 int clusterBrokers = 0;
-                int clusterTpsIn = 0;
-                int clusterTpsOut = 0;
+                long clusterTpsIn = 0;
+                long clusterTpsOut = 0;
                 String version = "unknown";
+                boolean runtimeMetricsUnavailable = false;
 
                 for (String brokerName : brokerNames) {
                     BrokerData brokerData = brokerAddrTable.get(brokerName);
@@ -178,20 +195,19 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                         clusterBrokers++;
                         String masterAddr = brokerData.getBrokerAddrs().get(0L);
                         if (masterAddr != null) {
-                            try {
-                                KVTable rt = admin.fetchBrokerRuntimeStats(masterAddr);
-                                if (rt != null && rt.getTable() != null) {
-                                    clusterTpsIn += (int) parseTps(rt.getTable().get("putTps"));
-                                    clusterTpsOut += (int) parseTps(rt.getTable().get("getTransferredTps"));
-                                    String v = rt.getTable().get("brokerVersionDesc");
-                                    if (v != null && "unknown".equals(version)) {
-                                        String brokerVersion = v.trim();
-                                        if (!brokerVersion.isEmpty()) {
-                                            version = brokerVersion;
-                                        }
+                            KVTable runtimeInfo = runtimeStatsByBroker.get(masterAddr);
+                            if (runtimeInfo != null && runtimeInfo.getTable() != null) {
+                                clusterTpsIn += parseTps(runtimeInfo.getTable().get("putTps"));
+                                clusterTpsOut += parseTps(runtimeInfo.getTable().get("getTransferredTps"));
+                                String value = runtimeInfo.getTable().get("brokerVersionDesc");
+                                if (value != null && "unknown".equals(version)) {
+                                    String brokerVersion = value.trim();
+                                    if (!brokerVersion.isEmpty()) {
+                                        version = brokerVersion;
                                     }
                                 }
-                            } catch (Exception ignored) {
+                            } else {
+                                runtimeMetricsUnavailable = true;
                             }
                         }
                     }
@@ -200,8 +216,8 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 clusters.add(ClusterOverviewVO.builder()
                         .id(clusterName)
                         .name(clusterName)
-                        .type(ClusterType.V5_PROXY_CLUSTER)
-                        .status(ClusterStatus.healthy)
+                        .type(clusterType)
+                        .status(runtimeMetricsUnavailable ? ClusterStatus.warning : ClusterStatus.healthy)
                         .brokers(clusterBrokers)
                         .proxies(0)
                         .topics(0)
@@ -238,6 +254,11 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 .stats(stats)
                 .clusters(clusters)
                 .build();
+    }
+
+    private ClusterType clusterTypeFor(InstanceVO instance) {
+        return instance.getType() == InstanceType.DIRECT
+                ? ClusterType.V4_DIRECT : ClusterType.V5_PROXY_CLUSTER;
     }
 
     private DashboardDataVO emptyDashboard() {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageId;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.instance.message.ConsumerStatusVO;
 import org.apache.rocketmq.studio.instance.message.MessageProvider;
@@ -82,17 +83,18 @@ public class RocketMQMessageProvider implements MessageProvider {
 
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
     private final QueryHistoryService queryHistoryService;
-    private final RocketMQProperties properties;
 
     @Override
     public List<MessageRecordVO> queryMessages(String instanceId, String topic, String msgId, String tag, String key,
                                                Long startTime, Long endTime) {
         String endpoint = runtimeAdminClientResolver.resolveEndpoint(instanceId);
         return runtimeAdminClientResolver.execute(instanceId,
-                adminExt -> queryMessages((DefaultMQAdminExt) adminExt, endpoint, topic, msgId, tag, key, startTime, endTime));
+                adminExt -> queryMessages(instanceId, (DefaultMQAdminExt) adminExt, endpoint,
+                        topic, msgId, tag, key, startTime, endTime));
     }
 
-    private List<MessageRecordVO> queryMessages(DefaultMQAdminExt adminExt, String endpoint, String topic, String msgId, String tag, String key,
+    private List<MessageRecordVO> queryMessages(String instanceId, DefaultMQAdminExt adminExt, String endpoint,
+                                                 String topic, String msgId, String tag, String key,
                                                  Long startTime, Long endTime) {
 
         long end = endTime != null ? endTime : System.currentTimeMillis();
@@ -114,7 +116,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             return Collections.emptyList();
         }
 
-        recordMessageQuery(queryType, topic, msgId, tag, key, startTime, endTime, result.size());
+        recordMessageQuery(instanceId, queryType, topic, msgId, tag, key, startTime, endTime, result.size());
         return result;
     }
 
@@ -175,7 +177,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             return result;
         } catch (Exception e) {
             log.warn("queryMessage(topic={}, key={}) failed: {}", topic, key, e.getMessage());
-            return Collections.emptyList();
+            throw new BusinessException(502, "Failed to query messages by key: " + e.getMessage());
         }
     }
 
@@ -201,7 +203,16 @@ public class RocketMQMessageProvider implements MessageProvider {
                         break outer;
                     }
                     PullResult pullResult = consumer.pull(queue, "*", offset, 32);
-                    offset = pullResult.getNextBeginOffset();
+                    if (pullResult == null) {
+                        log.warn("Stop topic query for {} because queue {} returned no pull result", topic, queue);
+                        break;
+                    }
+                    long nextOffset = pullResult.getNextBeginOffset();
+                    if (nextOffset <= offset) {
+                        log.warn("Stop topic query for {} because queue {} did not advance offset {}", topic, queue, offset);
+                        break;
+                    }
+                    offset = nextOffset;
                     if (pullResult.getPullStatus() != PullStatus.FOUND
                             || pullResult.getMsgFoundList() == null) {
                         break;
@@ -223,6 +234,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             }
         } catch (Exception e) {
             log.warn("queryByTopic(topic={}) failed: {}", topic, e.getMessage());
+            throw new BusinessException(502, "Failed to query messages by topic: " + e.getMessage());
         } finally {
             consumer.shutdown();
         }
@@ -232,10 +244,10 @@ public class RocketMQMessageProvider implements MessageProvider {
     @Override
     public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
         return runtimeAdminClientResolver.execute(instanceId,
-                adminExt -> getMessageTrace((DefaultMQAdminExt) adminExt, msgId));
+                adminExt -> getMessageTrace(instanceId, (DefaultMQAdminExt) adminExt, msgId));
     }
 
-    private TraceRecordVO getMessageTrace(DefaultMQAdminExt adminExt, String msgId) {
+    private TraceRecordVO getMessageTrace(String instanceId, DefaultMQAdminExt adminExt, String msgId) {
 
         long now = System.currentTimeMillis();
         long begin = now - ONE_HOUR_MILLIS;
@@ -255,7 +267,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             log.warn("Trace query for msgId={} failed: {}", msgId, e.getMessage());
         }
 
-        recordTraceQuery(msgId, null, nodes.size(), consumerStatus.size());
+        recordTraceQuery(instanceId, msgId, null, nodes.size(), consumerStatus.size());
         return TraceRecordVO.builder()
                 .nodes(nodes)
                 .consumerStatus(consumerStatus)
@@ -478,26 +490,22 @@ public class RocketMQMessageProvider implements MessageProvider {
         return consumer;
     }
 
-    private void recordMessageQuery(String queryType, String topic, String msgId, String tag, String key,
+    private void recordMessageQuery(String instanceId, String queryType, String topic, String msgId, String tag, String key,
                                     Long startTime, Long endTime, int resultCount) {
         try {
-            queryHistoryService.recordMessageQuery(clusterContext(), queryType, topic, msgId, tag, key,
+            queryHistoryService.recordMessageQuery(instanceId, queryType, topic, msgId, tag, key,
                     startTime, endTime, resultCount);
         } catch (Exception e) {
             log.warn("Failed to record message query history: {}", e.getMessage());
         }
     }
 
-    private void recordTraceQuery(String msgId, String topic, int nodeCount, int consumerCount) {
+    private void recordTraceQuery(String instanceId, String msgId, String topic, int nodeCount, int consumerCount) {
         try {
-            queryHistoryService.recordTraceQuery(clusterContext(), msgId, topic, nodeCount, consumerCount);
+            queryHistoryService.recordTraceQuery(instanceId, msgId, topic, nodeCount, consumerCount);
         } catch (Exception e) {
             log.warn("Failed to record trace query history: {}", e.getMessage());
         }
-    }
-
-    private String clusterContext() {
-        return StringUtils.hasText(properties.getNamesrvAddr()) ? properties.getNamesrvAddr() : null;
     }
 
     private static TraceRecordVO emptyTrace() {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
@@ -21,6 +21,7 @@ import org.springframework.util.StringUtils;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.provider.alibaba.AliyunClientFactory;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,7 @@ public class CloudCredentialService {
 
     private final CloudCredentialRepository credentialRepository;
     private final InstanceRepository instanceRepository;
+    private final AliyunClientFactory aliyunClientFactory;
 
     public List<CloudCredentialVO> listMasked() {
         log.info("Listing cloud credentials (masked)");
@@ -90,7 +92,9 @@ public class CloudCredentialService {
             existing.setRemark(request.getRemark());
         }
         existing.setUpdatedAt(LocalDateTime.now());
-        return maskAccessKey(credentialRepository.save(existing));
+        CloudCredentialVO saved = credentialRepository.save(existing);
+        invalidateAliyunClients(saved);
+        return maskAccessKey(saved);
     }
 
     public void delete(String id) {
@@ -98,12 +102,13 @@ public class CloudCredentialService {
             throw new BusinessException(400, "Cloud credential id is required");
         }
         log.info("Deleting cloud credential id={}", id);
-        credentialRepository.findById(id)
+        CloudCredentialVO existing = credentialRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(404, "Cloud credential not found: " + id));
         if (instanceRepository.existsByCredentialId(id)) {
             throw new BusinessException(400, "Cloud credential is referenced by existing instances");
         }
         credentialRepository.deleteById(id);
+        invalidateAliyunClients(existing);
     }
 
     public CloudCredentialVO reveal(String id) {
@@ -125,5 +130,10 @@ public class CloudCredentialService {
         masked.setCreatedAt(credential.getCreatedAt());
         masked.setUpdatedAt(credential.getUpdatedAt());
         return masked;
+    }
+    private void invalidateAliyunClients(CloudCredentialVO credential) {
+        if (credential.getVendor() == org.apache.rocketmq.studio.common.domain.enums.InstanceVendor.ALIYUN) {
+            aliyunClientFactory.invalidateCredential(credential.getId());
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/DataSourceVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/DataSourceVO.java
@@ -22,6 +22,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -36,4 +38,6 @@ public class DataSourceVO {
     private String url;
     private String auth;
     private String status;
+    /** Instance IDs this source serves; an empty list keeps the source globally available. */
+    private List<String> instanceIds;
 }

--- a/server/src/main/resources/application-postgresql.yml
+++ b/server/src/main/resources/application-postgresql.yml
@@ -1,0 +1,23 @@
+# Opt-in PostgreSQL persistence profile
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/rocketmq}
+    username: ${SPRING_DATASOURCE_USERNAME:rocketmq}
+    password: ${SPRING_DATASOURCE_PASSWORD:rocketmq}
+    driver-class-name: org.postgresql.Driver
+  sql:
+    init:
+      mode: never
+  flyway:
+    enabled: true
+    locations: classpath:db/migration/postgresql
+    baseline-on-migrate: true
+    baseline-version: 0
+    validate-on-migrate: true
+
+mybatis-plus:
+  configuration:
+    database-id: postgresql
+  global-config:
+    db-config:
+      id-type: auto

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
     name: rocketmq-studio
   profiles:
     active: dev
+  flyway:
+    enabled: false
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/rocketmq?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC}
     username: ${SPRING_DATASOURCE_USERNAME:root}

--- a/server/src/main/resources/db/migration/postgresql/V1__baseline.sql
+++ b/server/src/main/resources/db/migration/postgresql/V1__baseline.sql
@@ -1,0 +1,222 @@
+-- Flyway V1: RocketMQ Studio PostgreSQL schema
+-- Equivalent to the Studio-owned MySQL schema; RocketMQ runtime data remains external.
+
+-- 1. NameServer / 集群地址注册表
+CREATE TABLE IF NOT EXISTS rmq_nameserver (
+  id VARCHAR(64) PRIMARY KEY,
+  name VARCHAR(128) NOT NULL,
+  namesrv_addr VARCHAR(512) NOT NULL,
+  cluster_type VARCHAR(32) DEFAULT 'V5_PROXY_CLUSTER',
+  status VARCHAR(32) DEFAULT 'healthy',
+  description TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+-- 2. 实例注册表（实例管理页的数据源，topic/group 按 instance_id 归属统计）
+CREATE TABLE IF NOT EXISTS rmq_instance (
+  id VARCHAR(64) PRIMARY KEY,
+  name VARCHAR(128) NOT NULL,
+  remark VARCHAR(255),
+  type VARCHAR(32) NOT NULL,
+  endpoint VARCHAR(512) NOT NULL,
+  vendor VARCHAR(32) NOT NULL DEFAULT 'APACHE',
+  cloud_instance_id VARCHAR(128),
+  credential_id VARCHAR(64),
+  region_id VARCHAR(64),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 3. Topic 管理记录（通过 Studio 创建/管理的 Topic 元数据）
+CREATE TABLE IF NOT EXISTS rmq_topic (
+  id BIGSERIAL PRIMARY KEY,
+  cluster_id VARCHAR(64) NOT NULL,
+  instance_id VARCHAR(64),
+  name VARCHAR(255) NOT NULL,
+  topic_type VARCHAR(32) DEFAULT 'NORMAL',
+  read_queue_nums INT DEFAULT 8,
+  write_queue_nums INT DEFAULT 8,
+  perm INT DEFAULT 6,
+  remark VARCHAR(255),
+  status VARCHAR(32) DEFAULT 'ACTIVE',
+  created_by VARCHAR(64),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT uk_cluster_topic UNIQUE (cluster_id, name)
+);
+
+-- 4. Consumer Group 管理记录
+CREATE TABLE IF NOT EXISTS rmq_group (
+  id BIGSERIAL PRIMARY KEY,
+  cluster_id VARCHAR(64) NOT NULL,
+  instance_id VARCHAR(64),
+  name VARCHAR(255) NOT NULL,
+  consume_type VARCHAR(32) DEFAULT 'CONCURRENTLY',
+  message_model VARCHAR(32) DEFAULT 'CLUSTERING',
+  max_retry INT DEFAULT 16,
+  status VARCHAR(32) DEFAULT 'ACTIVE',
+  created_by VARCHAR(64),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT uk_cluster_group UNIQUE (cluster_id, name)
+);
+
+-- 5. K8s 证书管理
+CREATE TABLE IF NOT EXISTS rmq_k8s_certificate (
+  id VARCHAR(64) PRIMARY KEY,
+  name VARCHAR(128) NOT NULL,
+  namespace VARCHAR(128),
+  cluster VARCHAR(128),
+  cert_type VARCHAR(32) DEFAULT 'TLS',
+  issuer VARCHAR(256),
+  not_before TIMESTAMP,
+  not_after TIMESTAMP,
+  status VARCHAR(32) DEFAULT 'valid',
+  days_remaining INT,
+  san TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 6. 消息查询记录
+CREATE TABLE IF NOT EXISTS rmq_message_query (
+  id BIGSERIAL PRIMARY KEY,
+  query_type VARCHAR(32) NOT NULL,
+  topic VARCHAR(255),
+  msg_id VARCHAR(128),
+  tag VARCHAR(128),
+  message_key VARCHAR(255),
+  start_time BIGINT,
+  end_time BIGINT,
+  result_count INT DEFAULT 0,
+  cluster_id VARCHAR(255),
+  queried_by VARCHAR(64),
+  queried_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 7. 消息轨迹查询记录
+CREATE TABLE IF NOT EXISTS rmq_trace_query (
+  id BIGSERIAL PRIMARY KEY,
+  msg_id VARCHAR(128) NOT NULL,
+  topic VARCHAR(255),
+  node_count INT DEFAULT 0,
+  consumer_count INT DEFAULT 0,
+  cluster_id VARCHAR(255),
+  queried_by VARCHAR(64),
+  queried_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 8. 操作审计日志（所有写操作）
+CREATE TABLE IF NOT EXISTS rmq_operation_audit (
+  id BIGSERIAL PRIMARY KEY,
+  operation VARCHAR(64) NOT NULL,
+  resource_type VARCHAR(64) NOT NULL,
+  resource_name VARCHAR(255),
+  cluster_id VARCHAR(64),
+  detail TEXT,
+  result VARCHAR(16) DEFAULT 'SUCCESS',
+  error_message TEXT,
+  operator VARCHAR(64),
+  operated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 9. 通用设置（单行）
+CREATE TABLE IF NOT EXISTS rmq_settings (
+  id VARCHAR(16) PRIMARY KEY DEFAULT 'singleton',
+  json TEXT NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 10. 数据源配置
+CREATE TABLE IF NOT EXISTS rmq_data_source (
+  ds_key VARCHAR(64) PRIMARY KEY,
+  json TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 11. ACL 规则
+CREATE TABLE IF NOT EXISTS rmq_acl_rule (
+  id VARCHAR(64) PRIMARY KEY,
+  principal VARCHAR(128) NOT NULL,
+  resource VARCHAR(255) NOT NULL,
+  resource_type VARCHAR(32),
+  resource_pattern VARCHAR(32),
+  actions VARCHAR(128),
+  decision VARCHAR(16),
+  scope VARCHAR(64),
+  acl_version VARCHAR(16),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 12. ACL 用户（secret_key 为 base64 编码后的密码，禁止明文存储）
+CREATE TABLE IF NOT EXISTS rmq_acl_user (
+  id VARCHAR(64) PRIMARY KEY,
+  username VARCHAR(128) NOT NULL,
+  access_key VARCHAR(255) NOT NULL,
+  secret_key VARCHAR(512) NOT NULL,
+  admin BOOLEAN DEFAULT FALSE,
+  clusters VARCHAR(1024),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT uk_username UNIQUE (username)
+);
+
+-- 13. 告警规则
+CREATE TABLE IF NOT EXISTS rmq_alert_rule (
+  id VARCHAR(64) PRIMARY KEY,
+  name VARCHAR(128) NOT NULL,
+  metric VARCHAR(128),
+  operator VARCHAR(16),
+  threshold DOUBLE PRECISION,
+  threshold_unit VARCHAR(32),
+  duration VARCHAR(32),
+  channels VARCHAR(512),
+  enabled BOOLEAN DEFAULT TRUE,
+  last_triggered VARCHAR(64),
+  description VARCHAR(512),
+  broker_name VARCHAR(128),
+  cluster_name VARCHAR(128),
+  severity VARCHAR(32),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 14. 系统告警事件
+CREATE TABLE IF NOT EXISTS rmq_system_alert (
+  id VARCHAR(64) PRIMARY KEY,
+  level VARCHAR(32),
+  title VARCHAR(255),
+  description TEXT,
+  time TIMESTAMP,
+  acknowledged BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 15. Cloud provider credentials (secret_key is base64-encoded and never seeded).
+CREATE TABLE IF NOT EXISTS rmq_cloud_credential (
+  id VARCHAR(64) PRIMARY KEY,
+  name VARCHAR(128) NOT NULL,
+  vendor VARCHAR(32) NOT NULL,
+  access_key VARCHAR(255) NOT NULL,
+  secret_key VARCHAR(512) NOT NULL,
+  remark VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT uk_vendor_access_key UNIQUE (vendor, access_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_instance_rmq_topic ON rmq_topic (instance_id);
+CREATE INDEX IF NOT EXISTS idx_instance_rmq_group ON rmq_group (instance_id);
+CREATE INDEX IF NOT EXISTS idx_queried_at_rmq_message_query ON rmq_message_query (queried_at);
+CREATE INDEX IF NOT EXISTS idx_topic_rmq_message_query ON rmq_message_query (topic);
+CREATE INDEX IF NOT EXISTS idx_msg_id_rmq_trace_query ON rmq_trace_query (msg_id);
+CREATE INDEX IF NOT EXISTS idx_queried_at_rmq_trace_query ON rmq_trace_query (queried_at);
+CREATE INDEX IF NOT EXISTS idx_operated_at_rmq_operation_audit ON rmq_operation_audit (operated_at);
+CREATE INDEX IF NOT EXISTS idx_resource_rmq_operation_audit ON rmq_operation_audit (resource_type, resource_name);
+CREATE INDEX IF NOT EXISTS idx_operation_rmq_operation_audit ON rmq_operation_audit (operation);
+CREATE INDEX IF NOT EXISTS idx_principal_rmq_acl_rule ON rmq_acl_rule (principal);
+CREATE INDEX IF NOT EXISTS idx_level_rmq_system_alert ON rmq_system_alert (level);
+CREATE INDEX IF NOT EXISTS idx_acknowledged_rmq_system_alert ON rmq_system_alert (acknowledged);

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -17,7 +17,6 @@ CREATE TABLE IF NOT EXISTS rmq_nameserver (
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
 -- 2. 实例注册表（实例管理页的数据源，topic/group 按 instance_id 归属统计）
 CREATE TABLE IF NOT EXISTS rmq_instance (
   id VARCHAR(64) PRIMARY KEY,
@@ -25,10 +24,6 @@ CREATE TABLE IF NOT EXISTS rmq_instance (
   remark VARCHAR(255),
   type VARCHAR(32) NOT NULL COMMENT 'PROXY/DIRECT',
   endpoint VARCHAR(512) NOT NULL,
-  vendor VARCHAR(32) NOT NULL DEFAULT 'APACHE' COMMENT 'APACHE/ALIYUN/TENCENT',
-  cloud_instance_id VARCHAR(128) COMMENT '云厂商实例 ID（vendor 非 APACHE 时必填）',
-  credential_id VARCHAR(64) COMMENT '引用 rmq_cloud_credential.id',
-  region_id VARCHAR(64) COMMENT '云 region',
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -213,161 +208,15 @@ CREATE TABLE IF NOT EXISTS rmq_system_alert (
   INDEX idx_acknowledged (acknowledged)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 15. 云厂商凭据（secret_key 为 base64 编码，禁止明文；access_key 明文用于唯一键与打码展示）
+-- 15. Cloud provider credentials (secret_key is base64-encoded and never seeded).
 CREATE TABLE IF NOT EXISTS rmq_cloud_credential (
   id VARCHAR(64) PRIMARY KEY,
-  name VARCHAR(128) NOT NULL COMMENT '凭据显示名',
+  name VARCHAR(128) NOT NULL COMMENT 'Credential display name',
   vendor VARCHAR(32) NOT NULL COMMENT 'ALIYUN/TENCENT',
   access_key VARCHAR(255) NOT NULL,
-  secret_key VARCHAR(512) NOT NULL COMMENT 'base64 编码的 SK',
+  secret_key VARCHAR(512) NOT NULL COMMENT 'Base64-encoded secret key',
   remark VARCHAR(255),
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   UNIQUE KEY uk_vendor_access_key (vendor, access_key)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- ============================================================
--- 样例数据（幂等）：instance / topic / group 列表以本库为准，创建时写库、读取时读库。
--- 实例管理页默认 5 个实例：2 个 DIRECT（instance-direct-1/2）+ 3 个 PROXY（instance-proxy-1/2/3）。
--- topic/group 通过 instance_id 归属实例，实例页的 topic/group 数量按 instance_id group by 实时统计。
--- cluster_id 需与 NameServer 上报的集群名一致，否则页面按集群过滤时查不到。
--- ============================================================
-
-INSERT IGNORE INTO rmq_instance (id, name, remark, type, endpoint) VALUES
-  ('instance-direct-1', 'instance-direct-1', '直连实例 1，交易核心链路（NameServer 直连）', 'DIRECT', '10.0.1.11:9876'),
-  ('instance-direct-2', 'instance-direct-2', '直连实例 2，风控与审计链路（NameServer 直连）', 'DIRECT', '10.0.1.12:9876'),
-  ('instance-proxy-1',  'instance-proxy-1',  'Proxy 实例 1，电商交易主链路', 'PROXY', '10.0.2.21:8080'),
-  ('instance-proxy-2',  'instance-proxy-2',  'Proxy 实例 2，营销与会员链路', 'PROXY', '10.0.2.22:8080'),
-  ('instance-proxy-3',  'instance-proxy-3',  'Proxy 实例 3，物流与大数据链路', 'PROXY', '10.0.2.23:8080');
-
-INSERT IGNORE INTO rmq_topic
-  (cluster_id, instance_id, name, topic_type, read_queue_nums, write_queue_nums, perm, remark, status, created_by)
-VALUES
-  -- instance-proxy-1：电商交易主链路
-  ('rocketmq-studio', 'instance-proxy-1', 'order_create_event',        'NORMAL',      8,  8, 6,
-   '下单成功事件，履约、营销、风控多方订阅', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'order_status_change',       'FIFO',        4,  4, 6,
-   '订单状态流转，按订单号分区保证同单有序', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'order_timeout_cancel',      'DELAY',       8,  8, 6,
-   '未支付订单超时关单，延迟 30 分钟投递', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'payment_result_notify',     'TRANSACTION', 8,  8, 6,
-   '支付结果通知，与支付流水落库同事务', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'inventory_deduct_command',  'NORMAL',     16, 16, 6,
-   '库存扣减指令，大促期间扩容至 16 队列', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'refund_apply_event',        'NORMAL',      4,  4, 6,
-   '退款申请事件，客服与财务系统订阅', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'cart_sync_event',           'NORMAL',      4,  4, 6,
-   '购物车多端同步事件', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'trade_close_archive',       'NORMAL',      2,  2, 4,
-   '交易关单归档，只读供对账回溯', 'ACTIVE', 'seed'),
-  -- instance-proxy-2：营销与会员链路
-  ('rocketmq-studio', 'instance-proxy-2', 'marketing_coupon_issue',    'NORMAL',      4,  4, 6,
-   '营销发券，活动期间异步发放优惠券', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'marketing_campaign_push',   'NORMAL',      8,  8, 6,
-   '大促活动 push 触达，按人群包分批投递', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'member_register_event',     'NORMAL',      4,  4, 6,
-   '新会员注册事件，积分与权益系统订阅', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'member_points_change',      'FIFO',        4,  4, 6,
-   '会员积分变动，按会员 ID 分区保序', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'member_level_upgrade',      'DELAY',       4,  4, 6,
-   '会员升级权益延迟发放', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'sms_send_command',          'NORMAL',      8,  8, 6,
-   '短信下发指令，网关限流后消费', 'ACTIVE', 'seed'),
-  -- instance-proxy-3：物流与大数据链路
-  ('rocketmq-studio', 'instance-proxy-3', 'logistics_tracking_update', 'NORMAL',      8,  8, 6,
-   '物流轨迹更新，承运商回调后投递', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'logistics_dispatch_order',  'FIFO',        8,  8, 6,
-   '运单调度指令，同单有序', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'settlement_daily_archive',  'NORMAL',      2,  2, 4,
-   '日结账单归档，已停止写入仅供回溯消费', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'bi_realtime_report',        'NORMAL',     16, 16, 6,
-   '实时报表数据流，BI 大屏消费', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'user_behavior_log',         'NORMAL',     16, 16, 6,
-   '用户行为埋点日志，离线分析入湖', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'click_stream_etl',          'NORMAL',      8,  8, 6,
-   '点击流 ETL 中间结果', 'ACTIVE', 'seed'),
-  -- instance-direct-1：交易核心直连链路
-  ('rocketmq-studio', 'instance-direct-1', 'trade_core_order_flow',    'FIFO',        8,  8, 6,
-   '交易核心订单流水，直连低延迟链路', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-1', 'payment_channel_callback', 'NORMAL',      8,  8, 6,
-   '支付渠道回调通知', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-1', 'account_ledger_entry',     'TRANSACTION', 8,  8, 6,
-   '账户记账分录，与账务落库同事务', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-1', 'ledger_reconcile_task',    'DELAY',       4,  4, 6,
-   '对账任务延迟触发，T+1 凌晨执行', 'ACTIVE', 'seed'),
-  -- instance-direct-2：风控与审计链路
-  ('rocketmq-studio', 'instance-direct-2', 'risk_control_audit',       'NORMAL',      4,  4, 2,
-   '风控审计流水，仅生产侧写入，消费方待接入', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-2', 'risk_event_alert',         'NORMAL',      4,  4, 6,
-   '风控命中事件告警，实时推送处置平台', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-2', 'audit_operation_log',      'NORMAL',      8,  8, 6,
-   '操作审计日志，合规留存 180 天', 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-2', 'compliance_report_daily',  'DELAY',       2,  2, 6,
-   '合规日报延迟生成任务', 'ACTIVE', 'seed');
-
-INSERT IGNORE INTO rmq_group
-  (cluster_id, instance_id, name, consume_type, message_model, max_retry, status, created_by)
-VALUES
-  -- instance-proxy-1
-  ('rocketmq-studio', 'instance-proxy-1', 'GID_fulfillment_order',  'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'GID_inventory_deduct',   'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'GID_payment_result',     'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'GID_refund_process',     'PUSH', 'CLUSTERING',    8, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'GID_cart_sync',          'PUSH', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-1', 'GID_trade_archive',      'PULL', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  -- instance-proxy-2
-  ('rocketmq-studio', 'instance-proxy-2', 'GID_marketing_coupon',   'PUSH', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'GID_campaign_push',      'PUSH', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'GID_member_points',      'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'GID_member_benefit',     'PUSH', 'CLUSTERING',    8, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-2', 'GID_sms_gateway',        'PUSH', 'CLUSTERING',    5, 'ACTIVE', 'seed'),
-  -- instance-proxy-3
-  ('rocketmq-studio', 'instance-proxy-3', 'GID_logistics_tracking', 'PUSH', 'CLUSTERING',    5, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'GID_logistics_dispatch', 'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'GID_settlement_archive', 'PULL', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'GID_bi_realtime_report', 'PUSH', 'BROADCASTING',  1, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'GID_behavior_ingest',    'PUSH', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-proxy-3', 'GID_click_stream_etl',   'PUSH', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  -- instance-direct-1
-  ('rocketmq-studio', 'instance-direct-1', 'GID_trade_core_flow',   'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-1', 'GID_pay_channel_cb',    'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-1', 'GID_ledger_entry',      'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-1', 'GID_reconcile_task',    'PULL', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  -- instance-direct-2
-  ('rocketmq-studio', 'instance-direct-2', 'GID_risk_alert',        'PUSH', 'CLUSTERING',    8, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-2', 'GID_audit_archive',     'PUSH', 'CLUSTERING',    3, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-2', 'GID_compliance_daily',  'PULL', 'CLUSTERING',    1, 'ACTIVE', 'seed'),
-  ('rocketmq-studio', 'instance-direct-2', 'studio-trace-consumer', 'PUSH', 'CLUSTERING',   16, 'ACTIVE', 'seed');
-
--- ACL 规则种子：principal 对应下方 ACL 用户，资源对齐上面的 seed topic/group，scope 为实例 id
-INSERT IGNORE INTO rmq_acl_rule
-  (id, principal, resource, resource_type, resource_pattern, actions, decision, scope, acl_version)
-VALUES
-  ('acl-001', 'user-order-service',         'order_*',                 'Topic',   'PREFIX',  'PUB,SUB', 'ALLOW', 'instance-proxy-1',  '2.0'),
-  ('acl-002', 'user-payment-service',       'payment_*',               'Topic',   'PREFIX',  'PUB,SUB', 'ALLOW', 'instance-proxy-1',  '2.0'),
-  ('acl-003', 'user-admin',                 '*',                       'Cluster', 'LITERAL', 'ALL',     'ALLOW', 'instance-proxy-1',  '2.0'),
-  ('acl-004', 'user-log-collector',         'audit_operation_log',     'Topic',   'LITERAL', 'SUB',     'ALLOW', 'instance-direct-2', '1.0'),
-  ('acl-005', 'user-order-service',         'GID_fulfillment_*',       'Group',   'PREFIX',  'SUB',     'ALLOW', 'instance-proxy-1',  '2.0'),
-  ('acl-006', 'user-inventory-service',     'inventory_deduct_command','Topic',   'LITERAL', 'PUB,SUB', 'ALLOW', 'instance-proxy-1',  '2.0'),
-  ('acl-007', 'user-guest',                 'payment_result_notify',   'Topic',   'LITERAL', 'PUB,SUB', 'DENY',  'instance-proxy-1',  '1.0'),
-  ('acl-008', 'user-notification-service',  'sms_send_command',        'Topic',   'LITERAL', 'PUB',     'ALLOW', 'instance-proxy-2',  '2.0'),
-  ('acl-009', 'user-risk-control',          'risk_event_alert',        'Topic',   'LITERAL', 'SUB',     'ALLOW', 'instance-direct-2', '1.0'),
-  ('acl-010', 'user-guest',                 '*',                       'Cluster', 'LITERAL', 'PUB',     'DENY',  'instance-proxy-2',  '2.0'),
-  ('acl-011', 'user-payment-service',       'GID_payment_*',           'Group',   'PREFIX',  'SUB',     'ALLOW', 'instance-proxy-1',  '2.0'),
-  ('acl-012', 'user-monitor',               'user_behavior_log',       'Topic',   'LITERAL', 'SUB',     'ALLOW', 'instance-proxy-3',  '1.0'),
-  ('acl-013', 'user-ai-service',            'click_stream_etl',        'Topic',   'LITERAL', 'PUB,SUB', 'ALLOW', 'instance-proxy-3',  '2.0');
-
--- ACL 用户种子：secret_key 为密码的 base64 编码（如 user-admin 明文 Admin@Studio#2026）
-INSERT IGNORE INTO rmq_acl_user
-  (id, username, access_key, secret_key, admin, clusters)
-VALUES
-  ('u-001', 'user-admin',                 'AKSTUDIOadmin0001', 'QWRtaW5AU3R1ZGlvIzIwMjY=',     1,
-   'instance-proxy-1,instance-proxy-2,instance-proxy-3,instance-direct-1,instance-direct-2'),
-  ('u-002', 'user-order-service',         'AKSTUDIOordr0002',  'T3JkZXJTdmNAMjAyNiNQcm9k',     0, 'instance-proxy-1'),
-  ('u-003', 'user-payment-service',       'AKSTUDIOpaym0003',  'UGF5U3ZjQDIwMjYjUHJvZA==',     0, 'instance-proxy-1'),
-  ('u-004', 'user-log-collector',         'AKSTUDIOlogs0004',  'TG9nQ29sbGVjdEAyMDI2I09wcw==', 0, 'instance-direct-2'),
-  ('u-005', 'user-guest',                 'AKSTUDIOgues0005',  'R3Vlc3RAMjAyNiNSZWFk',         0, 'instance-proxy-2'),
-  ('u-006', 'user-inventory-service',     'AKSTUDIOinvn0006',  'SW52U3ZjQDIwMjYjUHJvZA==',     0, 'instance-proxy-1'),
-  ('u-007', 'user-notification-service',  'AKSTUDIONtfy0007',  'Tm90aWZ5U3ZjQDIwMjYjTXNn',     0, 'instance-proxy-2'),
-  ('u-008', 'user-monitor',               'AKSTUDIOmonr0008',  'TW9uaXRvckAyMDI2I09icw==',     0,
-   'instance-proxy-3,instance-direct-2');

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
@@ -71,6 +71,54 @@ class MqAdminExtFactoryTest {
     }
 
     @Test
+    void releaseShouldShutdownAndEvictCachedClient() throws Exception {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+
+        factory.execute("10.0.0.1:9876", null, ignored -> "first");
+        factory.release(" 10.0.0.1:9876 ");
+        factory.execute("10.0.0.1:9876", null, ignored -> "second");
+
+        assertThat(factory.created.get()).isEqualTo(2);
+        verify(admin, times(2)).start();
+        verify(admin).shutdown();
+    }
+
+    @Test
+    void releaseShouldEvictClientUsingEquivalentNameServerAddressList() throws Exception {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+
+        factory.execute("10.0.0.2:9876,10.0.0.1:9876", null, ignored -> "first");
+        factory.release("10.0.0.1:9876;10.0.0.2:9876");
+        factory.execute("10.0.0.1:9876;10.0.0.2:9876", null, ignored -> "second");
+
+        assertThat(factory.created.get()).isEqualTo(2);
+        verify(admin).shutdown();
+    }
+
+    @Test
+    void executeShouldReuseClientForEquivalentNameServerAddressLists() throws Exception {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+
+        factory.execute("10.0.0.2:9876, 10.0.0.1:9876;10.0.0.2:9876", null, ignored -> null);
+        factory.execute("10.0.0.1:9876;10.0.0.2:9876", null, ignored -> null);
+
+        assertThat(factory.created.get()).isEqualTo(1);
+        verify(admin).setNamesrvAddr("10.0.0.1:9876;10.0.0.2:9876");
+    }
+
+    @Test
+    void executeShouldRejectAddressListsWithoutUsableEntries() {
+        MqAdminExtFactory factory = new MqAdminExtFactory();
+
+        assertThatThrownBy(() -> factory.execute(" ; , ", null, ignored -> null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("NameServer address is required");
+    }
+
+    @Test
     void executeShouldWrapConnectionFailure() throws Exception {
         DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
         doThrow(new RuntimeException("connection refused")).when(admin).start();

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientProviderStubTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientProviderStubTest.java
@@ -35,7 +35,7 @@ class ClientProviderStubTest {
 
     @Test
     void findProducerConnectionsShouldFailWhenRealProviderIsMissing() {
-        assertThatThrownBy(() -> provider.findProducerConnections("order-topic", "order-producer"))
+        assertThatThrownBy(() -> provider.findProducerConnections("instance-1", "order-topic", "order-producer"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Client connection provider is not configured")
                 .satisfies(ex -> assertThatBusinessExceptionCode(ex, 501));

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionServiceTest.java
@@ -53,22 +53,23 @@ class ProducerConnectionServiceTest {
                 .language(ClientLanguage.Java)
                 .version("5.1.0")
                 .build();
-        when(clientProvider.findProducerConnections("order-topic", "pg-order"))
+        when(clientProvider.findProducerConnections("instance-1", "order-topic", "pg-order"))
                 .thenReturn(List.of(producer));
 
-        List<ProducerConnectionVO> result = producerConnectionService.listConnections("order-topic", "pg-order");
+        List<ProducerConnectionVO> result = producerConnectionService.listConnections(
+                "instance-1", "order-topic", "pg-order");
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getClientId()).isEqualTo("producer-1");
         assertThat(result.get(0).getClientAddr()).isEqualTo("10.0.0.1:38888");
         assertThat(result.get(0).getLanguage()).isEqualTo("Java");
         assertThat(result.get(0).getVersionDesc()).isEqualTo("5.1.0");
-        verify(clientProvider).findProducerConnections("order-topic", "pg-order");
+        verify(clientProvider).findProducerConnections("instance-1", "order-topic", "pg-order");
     }
 
     @Test
     void listConnectionsShouldRejectMissingTopic() {
-        assertThatThrownBy(() -> producerConnectionService.listConnections(" ", "pg-order"))
+        assertThatThrownBy(() -> producerConnectionService.listConnections("instance-1", " ", "pg-order"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("topic is required")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
@@ -77,7 +78,7 @@ class ProducerConnectionServiceTest {
 
     @Test
     void listConnectionsShouldRejectMissingProducerGroup() {
-        assertThatThrownBy(() -> producerConnectionService.listConnections("order-topic", null))
+        assertThatThrownBy(() -> producerConnectionService.listConnections("instance-1", "order-topic", null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("producerGroup is required")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
@@ -86,18 +87,18 @@ class ProducerConnectionServiceTest {
 
     @Test
     void listConnectionsShouldTrimRequiredValues() {
-        when(clientProvider.findProducerConnections("order-topic", "pg-order"))
+        when(clientProvider.findProducerConnections("instance-1", "order-topic", "pg-order"))
                 .thenReturn(List.of());
 
         List<ProducerConnectionVO> result = producerConnectionService.listConnections(
-                " order-topic ", " pg-order ");
+                " instance-1 ", " order-topic ", " pg-order ");
         assertThat(result).isEmpty();
-        verify(clientProvider).findProducerConnections("order-topic", "pg-order");
+        verify(clientProvider).findProducerConnections("instance-1", "order-topic", "pg-order");
     }
 
     @Test
     void listProducerGroupsShouldReturnSortedUniqueActiveGroups() {
-        when(clientProvider.findConnections(null, null, ClientType.Producer.name()))
+        when(clientProvider.findConnections("instance-1", null, ClientType.Producer.name()))
                 .thenReturn(List.of(
                         ClientConnectionVO.builder().producerGroup(" pg-payment ").build(),
                         ClientConnectionVO.builder().producerGroup("pg-order").build(),
@@ -105,8 +106,17 @@ class ProducerConnectionServiceTest {
                         ClientConnectionVO.builder().producerGroup(" ").build(),
                         ClientConnectionVO.builder().build()));
 
-        assertThat(producerConnectionService.listProducerGroups())
+        assertThat(producerConnectionService.listProducerGroups("instance-1"))
                 .containsExactly("pg-order", "pg-payment");
-        verify(clientProvider).findConnections(null, null, ClientType.Producer.name());
+        verify(clientProvider).findConnections("instance-1", null, ClientType.Producer.name());
+    }
+
+    @Test
+    void listConnectionsShouldRejectMissingInstanceId() {
+        assertThatThrownBy(() -> producerConnectionService.listConnections(null, "order-topic", "pg-order"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("instanceId is required")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+        verifyNoInteractions(clientProvider);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerControllerTest.java
@@ -44,15 +44,15 @@ class ProducerControllerTest {
 
     @Test
     void listProducerGroupsShouldReturnSuggestions() throws Exception {
-        when(producerConnectionService.listProducerGroups())
+        when(producerConnectionService.listProducerGroups("instance-1"))
                 .thenReturn(List.of("pg-order", "pg-payment"));
 
-        mockMvc.perform(get("/api/producer/groups"))
+        mockMvc.perform(get("/api/producer/groups").param("instanceId", "instance-1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0]").value("pg-order"))
                 .andExpect(jsonPath("$.data[1]").value("pg-payment"));
 
-        verify(producerConnectionService).listProducerGroups();
+        verify(producerConnectionService).listProducerGroups("instance-1");
     }
 
     @Test
@@ -63,10 +63,11 @@ class ProducerControllerTest {
                 .language("Java")
                 .versionDesc("5.1.0")
                 .build();
-        when(producerConnectionService.listConnections("order-topic", "pg-order"))
+        when(producerConnectionService.listConnections("instance-1", "order-topic", "pg-order"))
                 .thenReturn(List.of(connection));
 
         mockMvc.perform(get("/api/producer/connection")
+                        .param("instanceId", "instance-1")
                         .param("topic", "order-topic")
                         .param("producerGroup", "pg-order"))
                 .andExpect(status().isOk())
@@ -76,12 +77,13 @@ class ProducerControllerTest {
                 .andExpect(jsonPath("$.connectionSet[0].language").value("Java"))
                 .andExpect(jsonPath("$.connectionSet[0].versionDesc").value("5.1.0"));
 
-        verify(producerConnectionService).listConnections("order-topic", "pg-order");
+        verify(producerConnectionService).listConnections("instance-1", "order-topic", "pg-order");
     }
 
     @Test
     void listConnectionsShouldRequireTopic() throws Exception {
         mockMvc.perform(get("/api/producer/connection")
+                        .param("instanceId", "instance-1")
                         .param("producerGroup", "pg-order"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
@@ -93,6 +95,7 @@ class ProducerControllerTest {
     @Test
     void listConnectionsShouldRequireProducerGroup() throws Exception {
         mockMvc.perform(get("/api/producer/connection")
+                        .param("instanceId", "instance-1")
                         .param("topic", "order-topic"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
@@ -104,10 +107,23 @@ class ProducerControllerTest {
     @Test
     void listConnectionsShouldRejectBlankParameters() throws Exception {
         mockMvc.perform(get("/api/producer/connection")
+                        .param("instanceId", "instance-1")
                         .param("topic", " ")
                         .param("producerGroup", "pg-order"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("topic is required"));
+
+        verifyNoInteractions(producerConnectionService);
+    }
+
+    @Test
+    void listConnectionsShouldRequireInstanceId() throws Exception {
+        mockMvc.perform(get("/api/producer/connection")
+                        .param("topic", "order-topic")
+                        .param("producerGroup", "pg-order"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("instanceId is required"));
 
         verifyNoInteractions(producerConnectionService);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusMetricsSourceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusMetricsSourceTest.java
@@ -252,6 +252,30 @@ class PrometheusMetricsSourceTest {
     }
 
     @Test
+    void queryShouldRejectResponseWithTooManyLabelsInOneSeries() {
+        server.createContext("/api/v1/query_range", exchange -> respond(exchange, 200, responseWithLabels(65)));
+
+        assertThatThrownBy(() -> source(Duration.ofSeconds(2)).query(query()))
+                .isInstanceOf(PrometheusException.class)
+                .satisfies(exception -> assertThat(((PrometheusException) exception).getStatusCode())
+                        .isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE.value()))
+                .hasMessage("Prometheus query returned too many labels in a time series; narrow the query");
+    }
+
+    @Test
+    void queryShouldRejectResponseWithOversizedLabelValue() {
+        server.createContext("/api/v1/query_range", exchange -> respond(exchange, 200,
+                "{\"status\":\"success\",\"data\":{\"resultType\":\"matrix\",\"result\":[{\"metric\":{\"topic\":\""
+                        + "x".repeat(4_097) + "\"},\"values\":[[1784107658,\"1\"]]}]}}"));
+
+        assertThatThrownBy(() -> source(Duration.ofSeconds(2)).query(query()))
+                .isInstanceOf(PrometheusException.class)
+                .satisfies(exception -> assertThat(((PrometheusException) exception).getStatusCode())
+                        .isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE.value()))
+                .hasMessage("Prometheus query returned an oversized time-series label; narrow the query");
+    }
+
+    @Test
     void queryShouldRejectResponseLargerThanFiveMebibytes() {
         server.createContext("/api/v1/query_range", exchange -> respond(exchange, 200,
                 "{\"status\":\"success\",\"padding\":\"" + "x".repeat(5 * 1024 * 1024) + "\"}"));
@@ -434,5 +458,17 @@ class PrometheusMetricsSourceTest {
         }
         return "{\"status\":\"success\",\"data\":{\"resultType\":\"matrix\",\"result\":[{\"metric\":{},\"values\":["
                 + values + "]}]}}";
+    }
+
+    private String responseWithLabels(int count) {
+        StringBuilder labels = new StringBuilder();
+        for (int index = 0; index < count; index++) {
+            if (index > 0) {
+                labels.append(',');
+            }
+            labels.append("\"label_").append(index).append("\":\"value\"");
+        }
+        return "{\"status\":\"success\",\"data\":{\"resultType\":\"matrix\",\"result\":[{\"metric\":{" + labels
+                + "},\"values\":[[1784107658,\"1\"]]}]}}";
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
@@ -19,7 +19,11 @@ package org.apache.rocketmq.studio.cluster.metrics.grafana;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -72,9 +76,50 @@ class GrafanaDashboardServiceTest {
     }
 
     @Test
+    void getDashboardJsonShouldDecodeBundledAssetAsUtf8() throws Exception {
+        try (InputStream input = getClass().getClassLoader()
+                .getResourceAsStream("grafana/rocketmq-broker.json")) {
+            assertTrue(input != null, "expected bundled dashboard resource");
+            String expected = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+
+            assertEquals(expected, service.getDashboardJson("rocketmq-broker"));
+        }
+    }
+
+    @Test
     void getDashboardJsonShouldThrowWhenUidUnknown() {
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> service.getDashboardJson("no-such-dashboard"));
         assertEquals(404, exception.getCode());
+    }
+
+    @Test
+    void listDashboardsShouldSkipEmptyAndNonObjectAssets() {
+        GrafanaDashboardService service = serviceWithResources(
+                resource("empty.json", ""),
+                resource("array.json", "[]"),
+                resource("valid.json", "{\"title\":\"Valid\",\"tags\":[\"rocketmq\"]}"));
+
+        List<GrafanaDashboardInfo> dashboards = service.listDashboards();
+
+        assertEquals(List.of(new GrafanaDashboardInfo("valid", "Valid", "", List.of("rocketmq"))), dashboards);
+    }
+
+    private static GrafanaDashboardService serviceWithResources(Resource... resources) {
+        return new GrafanaDashboardService(new ObjectMapper()) {
+            @Override
+            protected Resource[] resolveResources() {
+                return resources;
+            }
+        };
+    }
+
+    private static Resource resource(String filename, String content) {
+        return new ByteArrayResource(content.getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        };
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -19,13 +19,14 @@ package org.apache.rocketmq.studio.instance;
 
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialRepository;
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialVO;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.CloudCatalogProvider;
 import org.apache.rocketmq.studio.provider.CloudInstanceDetailVO;
-import org.apache.rocketmq.studio.provider.InstanceProvider;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
+import org.apache.rocketmq.studio.provider.InstanceProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -59,6 +60,9 @@ class InstanceServiceTest {
     @Mock
     private InstanceProvider instanceProvider;
 
+    @Mock
+    private MqAdminExtFactory adminFactory;
+
     @InjectMocks
     private InstanceService instanceService;
 
@@ -75,6 +79,37 @@ class InstanceServiceTest {
 
         assertThat(result).hasSize(2);
         verify(instanceRepository).findAll();
+    }
+
+    @Test
+    void listInstancesMarksCloudCountsUnavailableWhenProviderFails() {
+        InstanceVO instance = InstanceVO.builder().vendor(InstanceVendor.ALIYUN).build();
+        instance.setId("cloud-1");
+        InstanceProvider provider = org.mockito.Mockito.mock(InstanceProvider.class);
+        when(instanceRepository.findAll()).thenReturn(List.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(provider);
+        when(provider.countTopics("cloud-1")).thenThrow(new IllegalStateException("access denied"));
+
+        InstanceVO result = instanceService.listInstances(null, null).get(0);
+
+        assertThat(result.isResourceCountsAvailable()).isFalse();
+    }
+
+    @Test
+    void listInstancesKeepsCloudCountsAvailableWhenProviderReturnsEmptyLists() {
+        InstanceVO instance = InstanceVO.builder().vendor(InstanceVendor.ALIYUN).build();
+        instance.setId("cloud-1");
+        InstanceProvider provider = org.mockito.Mockito.mock(InstanceProvider.class);
+        when(instanceRepository.findAll()).thenReturn(List.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(provider);
+        when(provider.countTopics("cloud-1")).thenReturn(0);
+        when(provider.countGroups("cloud-1")).thenReturn(0);
+
+        InstanceVO result = instanceService.listInstances(null, null).get(0);
+
+        assertThat(result.isResourceCountsAvailable()).isTrue();
+        assertThat(result.getTopicCount()).isZero();
+        assertThat(result.getConsumerGroupCount()).isZero();
     }
 
     @Test
@@ -275,6 +310,24 @@ class InstanceServiceTest {
     }
 
     @Test
+    void createInstanceShouldRejectEndpointWithEmptyAddressSegment() {
+        InstanceVO input = InstanceVO.builder().name("valid-name").endpoint("namesrv:9876;").build();
+
+        assertThatThrownBy(() -> instanceService.createInstance(input))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO endpoint must not contain empty addresses");
+    }
+
+    @Test
+    void createInstanceShouldTrimEndpointBeforeSaving() {
+        InstanceVO input = InstanceVO.builder().name("valid-name").type(InstanceType.PROXY)
+                .endpoint("  namesrv:9876  ").build();
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThat(instanceService.createInstance(input).getEndpoint()).isEqualTo("namesrv:9876");
+    }
+
+    @Test
     void updateInstanceShouldMergeFieldsOntoExisting() {
         LocalDateTime originalCreatedAt = LocalDateTime.of(2025, 1, 2, 3, 4, 5);
         LocalDateTime originalUpdatedAt = LocalDateTime.of(2025, 2, 3, 4, 5, 6);
@@ -357,6 +410,73 @@ class InstanceServiceTest {
         assertThat(stored.getId()).isEqualTo("inst-1");
         assertThat(stored.getCreatedAt()).isEqualTo(originalCreatedAt);
         assertThat(stored.getUpdatedAt()).isEqualTo(originalUpdatedAt);
+    }
+
+    @Test
+    void updateInstanceShouldReleaseUnusedPreviousEndpoint() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("instance")
+                .endpoint("old-namesrv:9876")
+                .build();
+        existing.setId("inst-1");
+        InstanceVO update = InstanceVO.builder().endpoint("new-namesrv:9876").build();
+        update.setId("inst-1");
+
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(instanceRepository.findAll()).thenReturn(List.of());
+
+        instanceService.updateInstance(update);
+
+        verify(adminFactory).release("old-namesrv:9876");
+    }
+
+    @Test
+    void updateInstanceShouldKeepEndpointClientWhenAnotherInstanceReferencesIt() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("instance")
+                .endpoint("shared-namesrv:9876")
+                .build();
+        existing.setId("inst-1");
+        InstanceVO shared = InstanceVO.builder()
+                .name("shared-instance")
+                .endpoint(" shared-namesrv:9876 ")
+                .build();
+        shared.setId("inst-2");
+        InstanceVO update = InstanceVO.builder().endpoint("new-namesrv:9876").build();
+        update.setId("inst-1");
+
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(instanceRepository.findAll()).thenReturn(List.of(shared));
+
+        instanceService.updateInstance(update);
+
+        verify(adminFactory, never()).release("shared-namesrv:9876");
+    }
+
+    @Test
+    void updateInstanceShouldKeepEndpointClientWhenAnotherInstanceUsesEquivalentAddressList() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("instance")
+                .endpoint("namesrv-b:9876;namesrv-a:9876")
+                .build();
+        existing.setId("inst-1");
+        InstanceVO shared = InstanceVO.builder()
+                .name("shared-instance")
+                .endpoint(" namesrv-a:9876, namesrv-b:9876 ")
+                .build();
+        shared.setId("inst-2");
+        InstanceVO update = InstanceVO.builder().endpoint("new-namesrv:9876").build();
+        update.setId("inst-1");
+
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(instanceRepository.findAll()).thenReturn(List.of(shared));
+
+        instanceService.updateInstance(update);
+
+        verifyNoInteractions(adminFactory);
     }
 
     @Test
@@ -446,11 +566,28 @@ class InstanceServiceTest {
     }
 
     @Test
+    void updateInstanceShouldRejectEndpointWithEmptyAddressSegment() {
+        InstanceVO existing = InstanceVO.builder().name("instance").endpoint("namesrv:9876").build();
+        existing.setId("inst-1");
+        InstanceVO update = InstanceVO.builder().endpoint("; ;").build();
+        update.setId("inst-1");
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> instanceService.updateInstance(update))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO endpoint must not contain empty addresses");
+        verify(instanceRepository, never()).save(any(InstanceVO.class));
+    }
+
+    @Test
     void deleteInstanceShouldRemoveExistingInstance() {
         InstanceVO existing = InstanceVO.builder().name("to-delete").build();
         existing.setId("inst-1");
 
         when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("inst-1")).thenReturn(0);
+        when(instanceProvider.countGroups("inst-1")).thenReturn(0);
 
         instanceService.deleteInstance("inst-1");
 
@@ -461,10 +598,13 @@ class InstanceServiceTest {
     void deleteInstanceShouldRejectInstanceWithTopics() {
         InstanceVO existing = InstanceVO.builder()
                 .name("with-topics")
-                .topicCount(2)
+                .topicCount(0)
                 .build();
         existing.setId("inst-1");
         when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("inst-1")).thenReturn(2);
+        when(instanceProvider.countGroups("inst-1")).thenReturn(0);
 
         assertThatThrownBy(() -> instanceService.deleteInstance("inst-1"))
                 .isInstanceOf(BusinessException.class)
@@ -478,10 +618,13 @@ class InstanceServiceTest {
     void deleteInstanceShouldRejectInstanceWithConsumerGroups() {
         InstanceVO existing = InstanceVO.builder()
                 .name("with-consumer-groups")
-                .consumerGroupCount(3)
+                .consumerGroupCount(0)
                 .build();
         existing.setId("inst-1");
         when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("inst-1")).thenReturn(0);
+        when(instanceProvider.countGroups("inst-1")).thenReturn(3);
 
         assertThatThrownBy(() -> instanceService.deleteInstance("inst-1"))
                 .isInstanceOf(BusinessException.class)
@@ -489,6 +632,23 @@ class InstanceServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(409));
 
         verify(instanceRepository, never()).deleteById("inst-1");
+    }
+
+    @Test
+    void deleteInstanceShouldReleaseUnusedEndpoint() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("to-delete")
+                .endpoint("namesrv:9876")
+                .build();
+        existing.setId("inst-1");
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.findAll()).thenReturn(List.of());
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+
+        instanceService.deleteInstance("inst-1");
+
+        verify(instanceRepository).deleteById("inst-1");
+        verify(adminFactory).release("namesrv:9876");
     }
 
     @Test
@@ -516,13 +676,32 @@ class InstanceServiceTest {
 
     @Test
     void createInstanceShouldDefaultToApacheVendorTest() {
-        InstanceVO instance = InstanceVO.builder().name("inst").endpoint("10.0.0.1:8080").build();
+        InstanceVO instance = InstanceVO.builder()
+                .name("inst")
+                .endpoint("10.0.0.1:8080")
+                .type(InstanceType.PROXY)
+                .build();
         when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         InstanceVO created = instanceService.createInstance(instance);
 
         assertThat(created.getVendor()).isEqualTo(InstanceVendor.APACHE);
         verifyNoInteractions(cloudCredentialRepository, providerRegistry);
+    }
+
+    @Test
+    void createApacheInstanceShouldRequireTypeTest() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("inst")
+                .endpoint("10.0.0.1:8080")
+                .build();
+
+        assertThatThrownBy(() -> instanceService.createInstance(instance))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO type is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(instanceRepository, never()).save(any(InstanceVO.class));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -14,11 +14,41 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class MessageServiceTest {
+
+    @Test
+    void rejectsKeyQueryWithoutTopicBeforeCallingProvider() {
+        MessageProvider provider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(provider, registry);
+
+        assertThatThrownBy(() -> service.queryMessages(null, null, null, null, "order-1", null, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topic is required when key is specified");
+
+        verifyNoInteractions(provider);
+    }
+
+    @Test
+    void keepsMessageIdQueryWithoutTopicValid() {
+        MessageProvider provider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        when(provider.queryMessages(null, null, "msg-001", null, null, null, null))
+                .thenReturn(Collections.emptyList());
+        MessageService service = new MessageService(provider, registry);
+
+        service.queryMessages(null, null, "msg-001", null, null, null, null);
+
+        verify(provider).queryMessages(null, null, "msg-001", null, null, null, null);
+    }
 
     @Test
     void rejectsReversedTopicQueryWindowBeforeCallingProvider() {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicServiceTest.java
@@ -20,8 +20,6 @@ package org.apache.rocketmq.studio.instance.topic;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -30,10 +28,12 @@ class LiteTopicServiceTest {
     private final LiteTopicService liteTopicService = new LiteTopicService();
 
     @Test
-    void listLiteTopicsShouldNotReturnSampleData() {
-        List<LiteTopicItemVO> result = liteTopicService.listLiteTopics("hat", " DEFAULT ");
-
-        assertThat(result).isEmpty();
+    void listLiteTopicsShouldReturnUnsupportedWhenProviderIsUnavailable() {
+        assertThatThrownBy(() -> liteTopicService.listLiteTopics("hat", " DEFAULT "))
+                .isInstanceOfSatisfying(BusinessException.class, ex -> {
+                    assertThat(ex.getCode()).isEqualTo(501);
+                    assertThat(ex.getMessage()).isEqualTo("LiteTopic provider integration is not available");
+                });
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/OpsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/OpsServiceTest.java
@@ -28,12 +28,13 @@ class OpsServiceTest {
     private final OpsService opsService = new OpsService();
 
     @Test
-    void getHomePageShouldReturnDefaultSettings() {
+    void getHomePageShouldReportUnavailableConfiguration() {
         OpsHomeVO home = opsService.getHomePage();
 
-        assertThat(home.getNamesvrAddrList()).containsExactly("127.0.0.1:9876");
-        assertThat(home.getCurrentNamesrv()).isEqualTo("127.0.0.1:9876");
-        assertThat(home.isUseVIPChannel()).isTrue();
+        assertThat(home.isConfigurationAvailable()).isFalse();
+        assertThat(home.getNamesvrAddrList()).isEmpty();
+        assertThat(home.getCurrentNamesrv()).isEmpty();
+        assertThat(home.isUseVIPChannel()).isFalse();
         assertThat(home.isUseTLS()).isFalse();
     }
 
@@ -53,8 +54,8 @@ class OpsServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
 
         OpsHomeVO home = opsService.getHomePage();
-        assertThat(home.getNamesvrAddrList()).containsExactly("127.0.0.1:9876");
-        assertThat(home.getCurrentNamesrv()).isEqualTo("127.0.0.1:9876");
+        assertThat(home.getNamesvrAddrList()).isEmpty();
+        assertThat(home.getCurrentNamesrv()).isEmpty();
     }
 
     @Test
@@ -69,7 +70,7 @@ class OpsServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
 
         OpsHomeVO home = opsService.getHomePage();
-        assertThat(home.isUseVIPChannel()).isTrue();
+        assertThat(home.isUseVIPChannel()).isFalse();
         assertThat(home.isUseTLS()).isFalse();
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -265,8 +265,8 @@ class ToolGatewayServiceTest {
         assertThat(cluster).containsEntry("proxies", 1);
         assertThat(cluster).containsEntry("topics", 3);
         assertThat(cluster).containsEntry("groups", 4);
-        assertThat(cluster).containsEntry("tpsIn", 7);
-        assertThat(cluster).containsEntry("tpsOut", 8);
+        assertThat(cluster).containsEntry("tpsIn", 7L);
+        assertThat(cluster).containsEntry("tpsOut", 8L);
         assertThat(cluster).containsEntry("version", "5.2.0");
         assertThat(cluster).containsEntry("throughput", List.of(1, 2, 3));
         assertThat(cluster).doesNotContainKeys("endpoint");

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
@@ -18,7 +18,10 @@ package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -80,5 +83,53 @@ class AlertRuleAssetServiceTest {
         boolean hasBroker = rules.stream().anyMatch(r -> "broker".equals(r.team()));
         assertTrue(hasCritical, "expected at least one critical rule");
         assertTrue(hasBroker, "expected at least one broker rule");
+    }
+    @Test
+    void assetLoadingShouldSkipEmptyAndNonObjectYaml() {
+        AlertRuleAssetService service = serviceWithResources(
+                resource("empty.yaml", ""),
+                resource("array.yaml", "[]"),
+                resource("valid.yaml", "groups:\n  - name: broker\n    rules:\n      - alert: BrokerDown\n        expr: up == 0\n"));
+
+        assertEquals(List.of(new AlertRuleAssetInfo("valid", "broker", 1, List.of("warning"))),
+                service.listAssets());
+        assertEquals(List.of(new PrometheusAlertRule("broker", "BrokerDown", "up == 0", "5m",
+                "warning", "broker", "BrokerDown", "")), service.loadDefaultRules());
+    }
+
+    @Test
+    void assetLoadingShouldSkipRulesWithoutAlertOrExpression() {
+        AlertRuleAssetService service = serviceWithResources(resource("mixed.yaml", """
+                groups:
+                  - name: broker
+                    rules:
+                      - alert: MissingExpression
+                      - expr: up == 0
+                      - alert: BrokerDown
+                        expr: up == 0
+                """));
+
+        assertEquals(List.of(new AlertRuleAssetInfo("mixed", "broker", 1, List.of("warning"))),
+                service.listAssets());
+        assertEquals(List.of(new PrometheusAlertRule("broker", "BrokerDown", "up == 0", "5m",
+                "warning", "broker", "BrokerDown", "")), service.loadDefaultRules());
+    }
+
+    private static AlertRuleAssetService serviceWithResources(Resource... resources) {
+        return new AlertRuleAssetService() {
+            @Override
+            protected Resource[] resolveResources() {
+                return resources;
+            }
+        };
+    }
+
+    private static Resource resource(String filename, String content) {
+        return new ByteArrayResource(content.getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        };
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardControllerTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -80,7 +81,7 @@ class DashboardControllerTest {
                 .clusters(List.of(cluster))
                 .build();
 
-        when(dashboardService.getDashboard()).thenReturn(data);
+        when(dashboardService.getDashboard(isNull())).thenReturn(data);
 
         mockMvc.perform(get("/api/dashboard"))
                 .andExpect(status().isOk())
@@ -97,7 +98,7 @@ class DashboardControllerTest {
                 .andExpect(jsonPath("$.data.clusters[0].status").value("healthy"))
                 .andExpect(jsonPath("$.data.clusters[0].version").value("5.1.0"));
 
-        verify(dashboardService).getDashboard();
+        verify(dashboardService).getDashboard(isNull());
     }
 
     @Test
@@ -107,12 +108,27 @@ class DashboardControllerTest {
                 .clusters(List.of())
                 .build();
 
-        when(dashboardService.getDashboard()).thenReturn(data);
+        when(dashboardService.getDashboard(isNull())).thenReturn(data);
 
         mockMvc.perform(get("/api/dashboard"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.stats.totalClusters").value(0))
                 .andExpect(jsonPath("$.data.clusters").isArray())
                 .andExpect(jsonPath("$.data.clusters").isEmpty());
+    }
+
+    @Test
+    void getDashboardShouldForwardSelectedInstance() throws Exception {
+        DashboardDataVO data = DashboardDataVO.builder()
+                .stats(DashboardStatsVO.builder().totalClusters(1).build())
+                .clusters(List.of())
+                .build();
+        when(dashboardService.getDashboard("instance-prod")).thenReturn(data);
+
+        mockMvc.perform(get("/api/dashboard").param("instanceId", "instance-prod"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.stats.totalClusters").value(1));
+
+        verify(dashboardService).getDashboard("instance-prod");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardServiceTest.java
@@ -110,4 +110,32 @@ class DashboardServiceTest {
         assertThat(result.getClusters()).isEmpty();
         verify(dashboardProvider).getDashboardData();
     }
+
+    @Test
+    void getDashboardShouldUseSelectedInstanceWhenProvided() {
+        DashboardDataVO instanceData = DashboardDataVO.builder()
+                .stats(DashboardStatsVO.builder().totalClusters(1).build())
+                .clusters(List.of())
+                .build();
+        when(dashboardProvider.getDashboardData("instance-a")).thenReturn(instanceData);
+
+        DashboardDataVO result = dashboardService.getDashboard(" instance-a ");
+
+        assertThat(result).isSameAs(instanceData);
+        verify(dashboardProvider).getDashboardData("instance-a");
+    }
+
+    @Test
+    void getDashboardShouldKeepDefaultPathForBlankInstance() {
+        DashboardDataVO defaultData = DashboardDataVO.builder()
+                .stats(DashboardStatsVO.builder().build())
+                .clusters(List.of())
+                .build();
+        when(dashboardProvider.getDashboardData()).thenReturn(defaultData);
+
+        DashboardDataVO result = dashboardService.getDashboard(" ");
+
+        assertThat(result).isSameAs(defaultData);
+        verify(dashboardProvider).getDashboardData();
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/postgresql/PostgresqlPersistenceIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/postgresql/PostgresqlPersistenceIntegrationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.persistence.postgresql;
+
+import org.apache.rocketmq.studio.persistence.entity.RmqInstance;
+import org.apache.rocketmq.studio.persistence.mapper.RmqInstanceMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("postgresql")
+@Testcontainers(disabledWithoutDocker = true)
+class PostgresqlPersistenceIntegrationTest {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("rocketmq")
+            .withUsername("rocketmq")
+            .withPassword("rocketmq");
+
+    @DynamicPropertySource
+    static void configurePostgresql(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private RmqInstanceMapper instanceMapper;
+
+    @Test
+    void startsWithPostgresqlSchemaAndSupportsMybatisCrud() throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            assertThat(connection.getMetaData().getDatabaseProductName()).isEqualTo("PostgreSQL");
+        }
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM flyway_schema_history WHERE success", Integer.class))
+                .isEqualTo(1);
+
+        RmqInstance instance = new RmqInstance();
+        instance.setId("postgres-instance");
+        instance.setName("PostgreSQL-backed instance");
+        instance.setType("DIRECT");
+        instance.setEndpoint("127.0.0.1:9876");
+
+        assertThat(instanceMapper.insert(instance)).isEqualTo(1);
+        RmqInstance stored = instanceMapper.selectById("postgres-instance");
+        assertThat(stored).isNotNull();
+        assertThat(stored.getName()).isEqualTo("PostgreSQL-backed instance");
+        assertThat(stored.getVendor()).isEqualTo("APACHE");
+        assertThat(instanceMapper.deleteById("postgres-instance")).isEqualTo(1);
+        assertThat(instanceMapper.selectById("postgres-instance")).isNull();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactoryTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -90,6 +91,25 @@ class AliyunClientFactoryTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
                 .isEqualTo(404);
+    }
+
+    @Test
+    void invalidateCredentialShouldCloseAndRemoveClientsForEveryRegionTest() {
+        AsyncClient first = Mockito.mock(AsyncClient.class);
+        AsyncClient second = Mockito.mock(AsyncClient.class);
+        AtomicInteger created = new AtomicInteger();
+        factory = new AliyunClientFactory(credentialRepository) {
+            @Override
+            protected AsyncClient createClient(String credentialId, String region) {
+                return created.getAndIncrement() == 0 ? first : second;
+            }
+        };
+
+        assertThat(factory.client(CREDENTIAL_ID, REGION)).isSameAs(first);
+        factory.invalidateCredential(CREDENTIAL_ID);
+
+        Mockito.verify(first).close();
+        assertThat(factory.client(CREDENTIAL_ID, REGION)).isSameAs(second);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -181,6 +181,51 @@ class RocketMQAdminClientImplTest {
     }
 
     @Test
+    void topicWritesUseSelectedInstanceAdmin() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqTopic.class);
+        DefaultMQAdminExt selectedAdmin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        when(selectedAdmin.examineBrokerClusterInfo()).thenReturn(clusterInfoWithMaster());
+        when(topicMapper.selectOne(any())).thenReturn(null);
+        doNothing().when(selectedAdmin).createAndUpdateTopicConfig(anyString(), any(TopicConfig.class));
+        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("instance-a"), any()))
+                .thenAnswer(invocation -> invocation.<MqAdminExtFactory.AdminAction<Object>>getArgument(1)
+                        .apply(selectedAdmin));
+
+        TopicVO topic = new TopicVO();
+        topic.setName("topicA");
+        topic.setInstanceId("instance-a");
+
+        adminClient.createTopic(topic);
+        adminClient.updateTopic(topic);
+
+        verify(runtimeAdminClientResolver, times(2)).execute(org.mockito.ArgumentMatchers.eq("instance-a"), any());
+        verify(selectedAdmin, times(2)).createAndUpdateTopicConfig(
+                org.mockito.ArgumentMatchers.eq("10.0.0.1:10911"), any(TopicConfig.class));
+        verify(adminExt, never()).createAndUpdateTopicConfig(anyString(), any(TopicConfig.class));
+    }
+
+    @Test
+    void topicDeleteUsesSelectedInstanceAndScopesMetadataToCluster() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqTopic.class);
+        DefaultMQAdminExt selectedAdmin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        when(selectedAdmin.examineBrokerClusterInfo()).thenReturn(clusterInfoWithMaster());
+        doNothing().when(selectedAdmin).deleteTopicInBroker(any(), anyString());
+        doNothing().when(selectedAdmin).deleteTopicInNameServer(any(), anyString(), anyString());
+        when(runtimeAdminClientResolver.resolveEndpoint("instance-a")).thenReturn("10.0.0.2:9876");
+        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("instance-a"), any()))
+                .thenAnswer(invocation -> invocation.<MqAdminExtFactory.AdminAction<Object>>getArgument(1)
+                        .apply(selectedAdmin));
+
+        adminClient.deleteTopic("instance-a", "orders");
+
+        ArgumentCaptor<LambdaQueryWrapper<RmqTopic>> captor = ArgumentCaptor.forClass(LambdaQueryWrapper.class);
+        verify(topicMapper).delete(captor.capture());
+        assertThat(captor.getValue().getSqlSegment()).contains("cluster_id", "name");
+        verify(selectedAdmin).deleteTopicInBroker(Set.of("10.0.0.1:10911"), "orders");
+        verify(selectedAdmin).deleteTopicInNameServer(Set.of("10.0.0.2:9876"), "cluster-1", "orders");
+    }
+
+    @Test
     void createConsumerGroupUsesSelectedInstanceAdmin() throws Exception {
         TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqGroup.class);
         DefaultMQAdminExt selectedAdmin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
@@ -213,6 +258,7 @@ class RocketMQAdminClientImplTest {
 
     @Test
     void deleteConsumerGroupUsesSelectedInstanceAdmin() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqGroup.class);
         DefaultMQAdminExt selectedAdmin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
         ClusterInfo clusterInfo = new ClusterInfo();
         BrokerData brokerData = new BrokerData();
@@ -232,6 +278,9 @@ class RocketMQAdminClientImplTest {
         verify(runtimeAdminClientResolver).execute(org.mockito.ArgumentMatchers.eq("instance-a"), any());
         verify(selectedAdmin).deleteSubscriptionGroup("10.0.0.1:10911", "cg-orders", true);
         verify(adminExt, never()).deleteSubscriptionGroup(anyString(), anyString(), org.mockito.ArgumentMatchers.anyBoolean());
+        ArgumentCaptor<LambdaQueryWrapper<RmqGroup>> captor = ArgumentCaptor.forClass(LambdaQueryWrapper.class);
+        verify(groupMapper).delete(captor.capture());
+        assertThat(captor.getValue().getSqlSegment()).contains("cluster_id", "name");
     }
 
     @Test
@@ -300,6 +349,30 @@ class RocketMQAdminClientImplTest {
             SendMessageVO result = adminClient.sendMessage(request);
             // The message was already delivered; an audit failure must not turn this into an error.
             assertThat(result.getMsgId()).isEqualTo("msg-1");
+        }
+    }
+
+    @Test
+    void sendMessageUsesSelectedInstanceEndpoint() throws Exception {
+        when(runtimeAdminClientResolver.resolveEndpoint("instance-a")).thenReturn("10.0.0.2:9876");
+        try (MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class, (producer, context) -> {
+                         doNothing().when(producer).start();
+                         SendResult sendResult = new SendResult();
+                         sendResult.setMsgId("msg-1");
+                         sendResult.setOffsetMsgId("offset-1");
+                         when(producer.send(any(Message.class))).thenReturn(sendResult);
+                         doNothing().when(producer).shutdown();
+                     })) {
+            SendMessageDTO request = new SendMessageDTO();
+            request.setTopic("TopicA");
+            request.setBody("hello");
+            request.setInstanceId("instance-a");
+
+            adminClient.sendMessage(request);
+
+            DefaultMQProducer producer = mockedProducers.constructed().getFirst();
+            verify(producer).setNamesrvAddr("10.0.0.2:9876");
         }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
@@ -47,9 +47,10 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -57,9 +58,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RocketMQClientProviderTest {
-
-    @Mock
-    private MqAdminExtFactory adminFactory;
 
     @Mock
     private DefaultMQAdminExt adminExt;
@@ -71,11 +69,7 @@ class RocketMQClientProviderTest {
 
     @BeforeEach
     void setUp() {
-        lenient().when(adminFactory.execute(anyString(), any(), any())).thenAnswer(invocation ->
-                invocation.<MqAdminExtFactory.AdminAction<Object>>getArgument(2).apply(adminExt));
-        RocketMQProperties properties = new RocketMQProperties();
-        properties.setNamesrvAddr("10.0.0.1:9876");
-        provider = new RocketMQClientProvider(adminFactory, runtimeAdminClientResolver, properties);
+        provider = new RocketMQClientProvider(runtimeAdminClientResolver);
         lenient().when(runtimeAdminClientResolver.execute(anyString(), any())).thenAnswer(invocation ->
                 invocation.<MqAdminExtFactory.AdminAction<Object>>
                         getArgument(1).apply(adminExt));
@@ -159,7 +153,7 @@ class RocketMQClientProviderTest {
         when(adminExt.examineProducerConnectionInfo("pg-order", "TopicA"))
                 .thenReturn(producerConnection);
 
-        List<ClientConnectionVO> connections = provider.findProducerConnections("TopicA", "pg-order");
+        List<ClientConnectionVO> connections = provider.findProducerConnections("instance-a", "TopicA", "pg-order");
 
         assertThat(connections).singleElement().satisfies(connection -> {
             assertThat(connection.getClientId()).isEqualTo("producer-client");
@@ -167,6 +161,7 @@ class RocketMQClientProviderTest {
             assertThat(connection.getProducerGroup()).isEqualTo("pg-order");
         });
         verify(adminExt).examineProducerConnectionInfo("pg-order", "TopicA");
+        verify(runtimeAdminClientResolver).execute(eq("instance-a"), any());
     }
 
     @Test
@@ -174,7 +169,7 @@ class RocketMQClientProviderTest {
         when(adminExt.examineProducerConnectionInfo("pg-order", "TopicA"))
                 .thenThrow(new IllegalStateException("broker unavailable"));
 
-        assertThatThrownBy(() -> provider.findProducerConnections("TopicA", "pg-order"))
+        assertThatThrownBy(() -> provider.findProducerConnections("instance-a", "TopicA", "pg-order"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Failed to query producer connections: broker unavailable")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
@@ -186,7 +181,8 @@ class RocketMQClientProviderTest {
                 .thenThrow(new MQClientException(ResponseCode.TOPIC_NOT_EXIST,
                         "CAN'T FIND BROKER FOR TOPIC: NoSuchTopic"));
 
-        List<ClientConnectionVO> connections = provider.findProducerConnections("NoSuchTopic", "pg-order");
+        List<ClientConnectionVO> connections = provider.findProducerConnections(
+                "instance-a", "NoSuchTopic", "pg-order");
 
         assertThat(connections).isEmpty();
         verify(adminExt).examineProducerConnectionInfo("pg-order", "NoSuchTopic");
@@ -198,7 +194,8 @@ class RocketMQClientProviderTest {
                 .thenThrow(new MQClientException(ResponseCode.TOPIC_NOT_EXIST,
                         "connect to ns failed, route info of this topic not found"));
 
-        List<ClientConnectionVO> connections = provider.findProducerConnections("NoRouteTopic", "pg-order");
+        List<ClientConnectionVO> connections = provider.findProducerConnections(
+                "instance-a", "NoRouteTopic", "pg-order");
 
         assertThat(connections).isEmpty();
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
@@ -21,6 +21,8 @@ import org.apache.rocketmq.remoting.protocol.body.KVTable;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.ClusterVO;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -50,6 +53,8 @@ class RocketMQClusterProviderTest {
         assertThat(clusters.get(0).getBrokers()).hasSize(1);
         assertThat(clusters.get(0).getBrokers().get(0).getTpsIn()).isEqualTo(12);
         assertThat(clusters.get(0).getBrokers().get(0).getTpsOut()).isEqualTo(34);
+        assertThat(clusters.get(0).getBrokers().get(0).isRuntimeStatsAvailable()).isTrue();
+        assertThat(clusters.get(0).getStatus()).isEqualTo(ClusterStatus.healthy);
     }
 
     @Test
@@ -86,6 +91,22 @@ class RocketMQClusterProviderTest {
         assertThat(cluster.getTpsHistory()).isNotNull().isEmpty();
     }
 
+    @Test
+    void discoverClustersMarksWarningWhenBrokerRuntimeStatsAreUnavailable() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RocketMQClusterProvider provider = newProvider(adminExt);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911"))
+                .thenThrow(new IllegalStateException("broker unavailable"));
+
+        ClusterVO cluster = provider.discoverClusters().get(0);
+
+        assertThat(cluster.getStatus()).isEqualTo(ClusterStatus.warning);
+        assertThat(cluster.getBrokers()).singleElement()
+                .extracting(broker -> broker.isRuntimeStatsAvailable())
+                .isEqualTo(false);
+    }
+
     private RocketMQClusterProvider newProvider(DefaultMQAdminExt adminExt) {
         MqAdminExtFactory adminFactory = mock(MqAdminExtFactory.class);
         when(adminFactory.execute(anyString(), any(), any())).thenAnswer(invocation ->
@@ -93,6 +114,20 @@ class RocketMQClusterProviderTest {
         RocketMQProperties properties = new RocketMQProperties();
         properties.setNamesrvAddr("10.0.0.1:9876");
         return new RocketMQClusterProvider(adminFactory, properties);
+    }
+
+    @Test
+    void discoverClustersShouldExposeNameServerFailures() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RocketMQClusterProvider provider = newProvider(adminExt);
+
+        when(adminExt.examineBrokerClusterInfo()).thenThrow(new IllegalStateException("NameServer unavailable"));
+
+        assertThatThrownBy(provider::discoverClusters)
+                .isInstanceOfSatisfying(BusinessException.class, error -> {
+                    assertThat(error.getCode()).isEqualTo(502);
+                    assertThat(error.getMessage()).contains("NameServer unavailable");
+                });
     }
 
     private ClusterInfo clusterInfo() {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -17,17 +17,33 @@
 package org.apache.rocketmq.studio.provider.apache;
 
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.PullStatus;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendStatus;
 import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.protocol.admin.TopicStatsTable;
+import org.apache.rocketmq.remoting.protocol.body.TopicList;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.instance.dlq.DLQGroupVO;
 import org.apache.rocketmq.studio.ops.audit.AuditService;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,6 +56,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -52,12 +69,51 @@ class RocketMQDLQProviderTest {
     @Mock
     private AuditService auditService;
 
+    @Mock
+    private MQAdminExt adminExt;
+
     private RocketMQDLQProvider provider;
 
     @BeforeEach
     void setUp() {
         lenient().when(runtimeAdminClientResolver.resolveEndpoint("instance-a")).thenReturn("namesrv-a:9876");
+        lenient().when(runtimeAdminClientResolver.execute(anyString(), any())).thenAnswer(invocation -> {
+            MqAdminExtFactory.AdminAction<Object> action = invocation.getArgument(1);
+            return action.apply(adminExt);
+        });
         provider = new RocketMQDLQProvider(runtimeAdminClientResolver, auditService);
+    }
+
+    @Test
+    void marksStatsUnavailableWhenTopicStatsCannotBeRead() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        TopicList topicList = new TopicList();
+        topicList.setTopicList(Set.of(dlqTopic));
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList);
+        when(adminExt.examineTopicStats(dlqTopic)).thenThrow(new IllegalStateException("access denied"));
+
+        List<DLQGroupVO> groups = provider.listDLQGroups("instance-a");
+
+        assertThat(groups).singleElement().satisfies(group -> {
+            assertThat(group.isStatsAvailable()).isFalse();
+            assertThat(group.getStatus()).isEqualTo("UNAVAILABLE");
+        });
+    }
+
+    @Test
+    void keepsEmptyStatusWhenTopicStatsAreSuccessfullyRead() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        TopicList topicList = new TopicList();
+        topicList.setTopicList(Set.of(dlqTopic));
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList);
+        when(adminExt.examineTopicStats(dlqTopic)).thenReturn(new TopicStatsTable());
+
+        List<DLQGroupVO> groups = provider.listDLQGroups("instance-a");
+
+        assertThat(groups).singleElement().satisfies(group -> {
+            assertThat(group.isStatsAvailable()).isTrue();
+            assertThat(group.getStatus()).isEqualTo("EMPTY");
+        });
     }
 
     @Test
@@ -88,6 +144,72 @@ class RocketMQDLQProviderTest {
                 contains("matched=0, resent=0, failed=0"),
                 eq("SUCCESS"));
         verify(runtimeAdminClientResolver).resolveEndpoint("instance-a");
+    }
+
+    @Test
+    @Timeout(value = 1, unit = TimeUnit.SECONDS)
+    void resendMessagesStopsWhenPullOffsetDoesNotAdvance() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        MessageQueue queue = new MessageQueue(dlqTopic, "broker-a", 0);
+        PullResult stalledResult = new PullResult(PullStatus.FOUND, 10, 0, 10, List.of());
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(Set.of(queue));
+                         when(consumer.searchOffset(eq(queue), anyLong())).thenReturn(10L);
+                         when(consumer.pull(eq(queue), eq("*"), eq(10L), eq(32))).thenReturn(stalledResult);
+                         doNothing().when(consumer).shutdown();
+                     });
+             MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class)) {
+            provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic");
+
+            verify(mockedConsumers.constructed().get(0), times(1)).pull(queue, "*", 10L, 32);
+            assertThat(mockedProducers.constructed()).isEmpty();
+        }
+    }
+
+    @Test
+    void resendMessagesCountsNonSendOkResultsAsFailures() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        MessageQueue queue = new MessageQueue(dlqTopic, "broker-a", 0);
+        MessageExt deadLetter = new MessageExt();
+        deadLetter.setMsgId("msg-1");
+        deadLetter.setTopic(dlqTopic);
+        deadLetter.setBody(new byte[] {1});
+        deadLetter.setStoreTimestamp(150L);
+        PullResult pullResult = new PullResult(PullStatus.FOUND, 1L, 0L, 0L, List.of(deadLetter));
+        SendResult sendResult = new SendResult();
+        sendResult.setSendStatus(SendStatus.FLUSH_DISK_TIMEOUT);
+
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(Set.of(queue));
+                         when(consumer.searchOffset(queue, 100L)).thenReturn(0L);
+                         when(consumer.searchOffset(queue, 200L)).thenReturn(0L);
+                         when(consumer.pull(queue, "*", 0L, 32)).thenReturn(pullResult);
+                         doNothing().when(consumer).shutdown();
+                     });
+             MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class, (producer, context) -> {
+                         doNothing().when(producer).start();
+                         when(producer.send(any(Message.class))).thenReturn(sendResult);
+                         doNothing().when(producer).shutdown();
+                     })) {
+            assertThat(provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic"))
+                    .extracting("matched", "resent", "failed", "outcome")
+                    .containsExactly(1, 0, 1, "PARTIAL");
+
+            assertThat(mockedConsumers.constructed()).hasSize(1);
+            assertThat(mockedProducers.constructed()).hasSize(1);
+            verify(mockedProducers.constructed().get(0)).send(any(Message.class));
+        }
+        verify(auditService).record(
+                eq("RESEND_DLQ"),
+                eq("group-a"),
+                contains("matched=1, resent=0, failed=1"),
+                eq("PARTIAL"));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -26,6 +26,11 @@ import org.apache.rocketmq.remoting.protocol.body.KVTable;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
+import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.Test;
@@ -33,7 +38,10 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RocketMQDashboardProviderTest {
@@ -51,6 +59,8 @@ class RocketMQDashboardProviderTest {
 
         assertThat(dashboard.getClusters()).hasSize(1);
         assertThat(dashboard.getClusters().get(0).getVersion()).isEqualTo("V5_3_3");
+        assertThat(dashboard.getClusters().get(0).getType()).isEqualTo(ClusterType.V5_PROXY_CLUSTER);
+        verify(adminExt, times(1)).fetchBrokerRuntimeStats("10.0.0.11:10911");
     }
 
     @Test
@@ -116,15 +126,92 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getStats().getTotalBrokers()).isZero();
     }
 
+    @Test
+    void dashboardShouldUseSelectedDirectInstanceAndReportDirectType() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        InstanceVO instance = InstanceVO.builder()
+                .type(InstanceType.DIRECT)
+                .endpoint("namesrv-direct:9876")
+                .build();
+        instance.setId("instance-direct");
+        when(resolver.resolveInstance("instance-direct")).thenReturn(instance);
+        when(resolver.execute(eq(instance), any())).thenAnswer(invocation ->
+                invocation.<MqAdminExtFactory.AdminAction<DashboardDataVO>>getArgument(1).apply(adminExt));
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = newProvider(adminExt, resolver).getDashboardData("instance-direct");
+
+        assertThat(dashboard.getClusters()).hasSize(1);
+        assertThat(dashboard.getClusters().get(0).getType()).isEqualTo(ClusterType.V4_DIRECT);
+        verify(resolver).execute(eq(instance), any());
+    }
+
+    @Test
+    void dashboardShouldMarkClusterWarningWhenBrokerRuntimeStatsFail() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911"))
+                .thenThrow(new RuntimeException("broker unavailable"));
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getClusters()).singleElement()
+                .extracting(cluster -> cluster.getStatus())
+                .isEqualTo(ClusterStatus.warning);
+    }
+
+    @Test
+    void dashboardShouldKeepPerClusterTpsAboveIntegerRange() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911"))
+                .thenReturn(runtimeStats("3000000000.0", "4000000000.0"));
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getClusters()).singleElement().satisfies(cluster -> {
+            assertThat(cluster.getTpsIn()).isEqualTo(3_000_000_000L);
+            assertThat(cluster.getTpsOut()).isEqualTo(4_000_000_000L);
+        });
+    }
+
+    @Test
+    void dashboardShouldTolerateMissingTopicListAndClusterMembership() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        ClusterInfo info = new ClusterInfo();
+        info.setBrokerAddrTable(new HashMap<>());
+        HashMap<String, Set<String>> clusterAddrTable = new HashMap<>();
+        clusterAddrTable.put("cluster-without-members", null);
+        info.setClusterAddrTable(clusterAddrTable);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(info);
+        when(adminExt.fetchAllTopicList()).thenReturn(null);
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getStats().getTotalTopics()).isZero();
+        assertThat(dashboard.getClusters()).singleElement().satisfies(cluster -> {
+            assertThat(cluster.getName()).isEqualTo("cluster-without-members");
+            assertThat(cluster.getBrokers()).isZero();
+        });
+    }
+
     private RocketMQDashboardProvider newProvider(DefaultMQAdminExt adminExt) {
+        return newProvider(adminExt, mock(RuntimeAdminClientResolver.class));
+    }
+
+    private RocketMQDashboardProvider newProvider(DefaultMQAdminExt adminExt, RuntimeAdminClientResolver resolver) {
         MqAdminExtFactory adminFactory = mock(MqAdminExtFactory.class);
         when(adminFactory.execute(anyString(), any(), any())).thenAnswer(invocation ->
                 invocation.<MqAdminExtFactory.AdminAction<Object>>getArgument(2).apply(adminExt));
         RocketMQProperties properties = new RocketMQProperties();
         properties.setNamesrvAddr("10.0.0.1:9876");
-        return new RocketMQDashboardProvider(adminFactory, properties);
+        return new RocketMQDashboardProvider(adminFactory, properties, resolver);
     }
-
     private ClusterInfo clusterInfo() {
         ClusterInfo info = new ClusterInfo();
         HashMap<Long, String> addrs = new HashMap<>();
@@ -147,10 +234,14 @@ class RocketMQDashboardProviderTest {
     }
 
     private KVTable runtimeStats() {
+        return runtimeStats("2.0", "5.0");
+    }
+
+    private KVTable runtimeStats(String putTps, String getTransferredTps) {
         HashMap<String, String> table = new HashMap<>();
         table.put("brokerVersionDesc", "  V5_3_3  ");
-        table.put("putTps", "1.0 2.0 3.0");
-        table.put("getTransferredTps", "4.0 5.0 6.0");
+        table.put("putTps", "1.0 " + putTps + " 3.0");
+        table.put("getTransferredTps", "4.0 " + getTransferredTps + " 6.0");
         table.put("msgPutTotalTodayMorning", "42");
 
         KVTable kvTable = new KVTable();

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -18,10 +18,13 @@ package org.apache.rocketmq.studio.provider.apache;
 
 import org.apache.rocketmq.client.QueryResult;
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.PullStatus;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
 import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
@@ -30,6 +33,7 @@ import org.apache.rocketmq.studio.instance.message.QueryHistoryService;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
@@ -37,17 +41,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,8 +81,7 @@ class RocketMQMessageProviderTest {
             MqAdminExtFactory.AdminAction<Object> action = invocation.getArgument(1);
             return action == null ? null : action.apply(adminExt);
         });
-        provider = new RocketMQMessageProvider(runtimeAdminClientResolver, queryHistoryService,
-                new RocketMQProperties());
+        provider = new RocketMQMessageProvider(runtimeAdminClientResolver, queryHistoryService);
     }
 
     @Test
@@ -97,8 +105,56 @@ class RocketMQMessageProviderTest {
         }
         verify(runtimeAdminClientResolver).resolveEndpoint("instance-a");
         verify(runtimeAdminClientResolver).execute(eq("instance-a"), any());
-        verify(queryHistoryService).recordMessageQuery(null, "TOPIC", "TopicA", null, null, null,
+        verify(queryHistoryService).recordMessageQuery("instance-a", "TOPIC", "TopicA", null, null, null,
                 100L, 200L, 0);
+    }
+
+    @Test
+    void queryByKeySurfacesAdminFailure() throws Exception {
+        when(adminExt.queryMessage("TopicA", "order-1", 64, 100L, 200L))
+                .thenThrow(new IllegalStateException("broker unavailable"));
+
+        assertThatThrownBy(() -> provider.queryMessages(
+                "instance-a", "TopicA", null, null, "order-1", 100L, 200L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Failed to query messages by key: broker unavailable")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    @Test
+    void queryByTopicSurfacesPullConsumerFailure() throws Exception {
+        try (MockedConstruction<DefaultMQPullConsumer> ignored =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doThrow(new IllegalStateException("nameserver unavailable")).when(consumer).start();
+                         doNothing().when(consumer).shutdown();
+                     })) {
+            assertThatThrownBy(() -> provider.queryMessages(
+                    "instance-a", "TopicA", null, null, null, 100L, 200L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("Failed to query messages by topic: nameserver unavailable")
+                    .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+        }
+    }
+
+    @Test
+    @Timeout(value = 1, unit = TimeUnit.SECONDS)
+    void queryByTopicStopsWhenPullOffsetDoesNotAdvance() throws Exception {
+        MessageQueue queue = new MessageQueue("TopicA", "broker-a", 0);
+        PullResult stalledResult = new PullResult(PullStatus.FOUND, 10, 0, 10, List.of());
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues("TopicA")).thenReturn(Set.of(queue));
+                         when(consumer.searchOffset(eq(queue), anyLong())).thenReturn(10L);
+                         when(consumer.pull(eq(queue), eq("*"), eq(10L), eq(32))).thenReturn(stalledResult);
+                         doNothing().when(consumer).shutdown();
+                     })) {
+            List<MessageRecordVO> messages = provider.queryMessages(
+                    "instance-a", "TopicA", null, null, null, 100L, 200L);
+
+            assertThat(messages).isEmpty();
+            verify(mockedConsumers.constructed().get(0), times(1)).pull(queue, "*", 10L, 32);
+        }
     }
 
     @Test
@@ -161,6 +217,7 @@ class RocketMQMessageProviderTest {
         TraceRecordVO record = provider.getMessageTrace("instance-a", "msg-123");
 
         assertThat(record.getNodes()).hasSize(2);
+        verify(queryHistoryService).recordTraceQuery(eq("instance-a"), eq("msg-123"), eq(null), eq(2), eq(1));
         TraceNodeVO produce = record.getNodes().get(0);
         assertThat(produce.getTitle()).isEqualTo("produce");
         assertThat(produce.getStatus()).isEqualTo("finish");

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.provider.alibaba.AliyunClientFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -44,6 +45,9 @@ class CloudCredentialServiceTest {
 
     @Mock
     private InstanceRepository instanceRepository;
+
+    @Mock
+    private AliyunClientFactory aliyunClientFactory;
 
     @InjectMocks
     private CloudCredentialService service;
@@ -133,6 +137,40 @@ class CloudCredentialServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("referenced");
         verify(credentialRepository, never()).deleteById(any());
+    }
+
+    @Test
+    void updateShouldInvalidateAliyunClientsAfterSavingCredentialTest() {
+        CloudCredentialVO stored = new CloudCredentialVO();
+        stored.setId("cred-1");
+        stored.setVendor(InstanceVendor.ALIYUN);
+        stored.setAccessKey("LTAI5tUpdateKey000000001");
+        stored.setSecretKey("old-secret");
+        when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
+        when(credentialRepository.save(any(CloudCredentialVO.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UpdateCloudCredentialDTO request = new UpdateCloudCredentialDTO();
+        request.setId("cred-1");
+        request.setSecretKey("new-secret");
+
+        service.update(request);
+
+        verify(aliyunClientFactory).invalidateCredential("cred-1");
+    }
+
+    @Test
+    void deleteShouldInvalidateAliyunClientsAfterRemovingCredentialTest() {
+        CloudCredentialVO stored = new CloudCredentialVO();
+        stored.setId("cred-1");
+        stored.setVendor(InstanceVendor.ALIYUN);
+        when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
+        when(instanceRepository.existsByCredentialId("cred-1")).thenReturn(false);
+
+        service.delete("cred-1");
+
+        verify(credentialRepository).deleteById("cred-1");
+        verify(aliyunClientFactory).invalidateCredential("cred-1");
     }
 
     @Test

--- a/web/src/api/cluster.ts
+++ b/web/src/api/cluster.ts
@@ -44,7 +44,8 @@ export interface BrokerInfo {
   tpsIn: number;
   tpsOut: number;
   diskUsage: number;
-  version: string;
+  version?: string | null;
+  runtimeStatsAvailable?: boolean;
 }
 
 export interface ProxyInfo {

--- a/web/src/api/instance.ts
+++ b/web/src/api/instance.ts
@@ -32,6 +32,7 @@ export interface Instance {
   regionId?: string;
   topicCount: number;
   consumerGroupCount: number;
+  resourceCountsAvailable?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -59,9 +59,10 @@ export interface DLQGroup {
   groupName: string;
   dlqTopic: string;
   messageCount: number;
-  lastEnqueueTime: string;
+  lastEnqueueTime?: string | null;
   retryCount: number;
   status: string;
+  statsAvailable?: boolean;
 }
 
 export interface DLQResendResult {

--- a/web/src/api/metadata.test.ts
+++ b/web/src/api/metadata.test.ts
@@ -92,14 +92,18 @@ describe('topic metadata API', () => {
       return [200, { code: 200, data: null }];
     });
     mock.onPost('/topics/send').reply((config) => {
-      expect(JSON.parse(config.data)).toMatchObject({ topic: topic.name, body: '{"id":1}' });
+      expect(JSON.parse(config.data)).toMatchObject({
+        topic: topic.name,
+        instanceId: 'instance-a',
+        body: '{"id":1}',
+      });
       return [200, { code: 200, data: { msgId: 'msg-1', sendTime: 1, offsetMsgId: 'offset-1' } }];
     });
 
     await expect(createTopic(topic)).resolves.toEqual(topic);
     await expect(deleteTopic(topic.name, 'instance-a')).resolves.toBeUndefined();
-    await expect(sendTopicMessage({ topic: topic.name, body: '{"id":1}' })).resolves.toMatchObject({
-      msgId: 'msg-1',
-    });
+    await expect(
+      sendTopicMessage({ topic: topic.name, instanceId: 'instance-a', body: '{"id":1}' }),
+    ).resolves.toMatchObject({ msgId: 'msg-1' });
   });
 });

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -145,11 +145,11 @@ export async function getTopicConsumers(name: string, instanceId?: string) {
 
 export interface SendTopicMessageRequest {
   topic: string;
+  instanceId?: string;
   tag?: string;
   key?: string;
   body: string;
   properties?: Record<string, string>;
-  instanceId?: string;
 }
 
 export interface SendTopicMessageResult {

--- a/web/src/api/metrics.test.ts
+++ b/web/src/api/metrics.test.ts
@@ -63,6 +63,15 @@ describe('metrics API', () => {
     await expect(getDashboard()).resolves.toEqual(dashboard);
   });
 
+  it('forwards the selected instance to the dashboard endpoint', async () => {
+    mock.onGet('/dashboard').reply((config) => {
+      expect(config.params).toEqual({ instanceId: 'instance-prod' });
+      return [200, { code: 200, data: dashboard }];
+    });
+
+    await expect(getDashboard('instance-prod')).resolves.toEqual(dashboard);
+  });
+
   it('posts a metrics query and returns its result', async () => {
     const query = { metric: 'TPS_IN', start: 1, end: 2, step: '1m' };
     const result = {

--- a/web/src/api/metrics.ts
+++ b/web/src/api/metrics.ts
@@ -92,8 +92,10 @@ export interface MetricProfile {
 }
 
 // ─── Dashboard ──────────────────────────────────────────────────
-export async function getDashboard() {
-  const res = await client.get<{ data: DashboardData }>('/dashboard');
+export async function getDashboard(instanceId?: string) {
+  const res = await client.get<{ data: DashboardData }>('/dashboard', {
+    params: instanceId ? { instanceId } : undefined,
+  });
   return res.data.data;
 }
 

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -113,6 +113,8 @@ export async function cleanupAuditLogs(beforeDays: number) {
 
 // ─── NameServer Operations ──────────────────────────────────────
 export interface OpsHomeData {
+  configurationAvailable: boolean;
+  unavailableReason?: string;
   namesvrAddrList: string[];
   useVIPChannel: boolean;
   useTLS: boolean;

--- a/web/src/api/producer.test.ts
+++ b/web/src/api/producer.test.ts
@@ -65,7 +65,7 @@ describe('Producer API', () => {
       data: ['pg-order', 'pg-payment'],
     });
 
-    await expect(fetchProducerGroups()).resolves.toEqual(['pg-order', 'pg-payment']);
+    await expect(fetchProducerGroups('instance-1')).resolves.toEqual(['pg-order', 'pg-payment']);
   });
 
   it('queries producer connections by topic and group', async () => {
@@ -86,10 +86,11 @@ describe('Producer API', () => {
     mock.onGet('/producer/connection').reply((config) => {
       expect(config.params.topic).toBe('order-events');
       expect(config.params.producerGroup).toBe('order-producer');
+      expect(config.params.instanceId).toBe('instance-1');
       return [200, { connectionSet: connections }];
     });
 
-    const result = await queryProducerConnection('order-events', 'order-producer');
+    const result = await queryProducerConnection('instance-1', 'order-events', 'order-producer');
     expect(result).toHaveLength(2);
     expect(result[0].clientId).toBe('producer-1');
   });
@@ -97,7 +98,7 @@ describe('Producer API', () => {
   it('handles empty producer connections', async () => {
     mock.onGet('/producer/connection').reply(200, { connectionSet: [] });
 
-    const result = await queryProducerConnection('topic', 'group');
+    const result = await queryProducerConnection('instance-1', 'topic', 'group');
     expect(result).toEqual([]);
   });
 });

--- a/web/src/api/producer.ts
+++ b/web/src/api/producer.ts
@@ -44,18 +44,19 @@ export async function fetchTopicList(): Promise<string[]> {
 }
 
 /** Fetch active producer groups for query suggestions */
-export async function fetchProducerGroups(): Promise<string[]> {
-  const res = await client.get<{ data?: string[] }>('/producer/groups');
+export async function fetchProducerGroups(instanceId: string): Promise<string[]> {
+  const res = await client.get<{ data?: string[] }>('/producer/groups', { params: { instanceId } });
   return res.data.data ?? [];
 }
 
 /** Query producer connections by topic and producer group */
 export async function queryProducerConnection(
+  instanceId: string,
   topic: string,
   producerGroup: string,
 ): Promise<ProducerConnection[]> {
   const res = await client.get<{ connectionSet: ProducerConnection[] }>('/producer/connection', {
-    params: { topic, producerGroup },
+    params: { instanceId, topic, producerGroup },
   });
   return res.data?.connectionSet ?? [];
 }

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -46,6 +46,7 @@ export interface DataSource {
   password?: string;
   bearerToken?: string;
   status: string;
+  instanceIds?: string[];
 }
 
 // ─── General Settings ───────────────────────────────────────────

--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -252,6 +252,9 @@ const MetricsExplorer = () => {
   const [dataSourceKey, setDataSourceKey] = useState('');
   const [dataSourcesLoading, setDataSourcesLoading] = useState(true);
   const requestId = useRef(0);
+  // Keeps the latest data source readable from the stable loadMetrics callback so switching
+  // the source uses the new key instead of a stale closure value.
+  const dataSourceKeyRef = useRef(dataSourceKey);
 
   const selectedProfile = useMemo(
     () => profiles.find((profile) => profile.id === profileId),
@@ -277,8 +280,8 @@ const MetricsExplorer = () => {
       setQueryLoading(true);
       setQueryError(false);
       try {
-        const result = dataSourceKey
-          ? await queryByDataSource({ key: dataSourceKey, query })
+        const result = dataSourceKeyRef.current
+          ? await queryByDataSource({ key: dataSourceKeyRef.current, query })
           : await queryMetrics(query);
         if (currentRequest === requestId.current) setData(result);
       } catch {
@@ -290,7 +293,7 @@ const MetricsExplorer = () => {
         if (currentRequest === requestId.current) setQueryLoading(false);
       }
     },
-    [dataSourceKey],
+    [],
   );
 
   useEffect(() => {
@@ -343,6 +346,7 @@ const MetricsExplorer = () => {
   };
 
   const handleDataSourceChange = (nextKey: string) => {
+    dataSourceKeyRef.current = nextKey;
     setDataSourceKey(nextKey);
     setData(null);
     void loadMetrics(selectedMetric, selectedRange);

--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -211,7 +211,11 @@ const MetricChart = ({ data, metric, locale, noSamples }: MetricChartProps) => {
   );
 };
 
-const MetricsExplorer = () => {
+interface MetricsExplorerProps {
+  instanceId?: string;
+}
+
+const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
   const { lang } = useLang();
   const copy =
     lang === 'zh'
@@ -265,6 +269,15 @@ const MetricsExplorer = () => {
     [metricId, selectedProfile],
   );
   const selectedRange = RANGE_OPTIONS.find((range) => range.value === rangeId) ?? RANGE_OPTIONS[0];
+  const availableDataSources = useMemo(
+    () =>
+      dataSources.filter(
+        (source) =>
+          !source.instanceIds?.length ||
+          (instanceId !== undefined && source.instanceIds.includes(instanceId)),
+      ),
+    [dataSources, instanceId],
+  );
 
   const loadMetrics = useCallback(
     async (metric: MetricMapping | undefined, range: (typeof RANGE_OPTIONS)[number]) => {
@@ -369,6 +382,15 @@ const MetricsExplorer = () => {
     };
   }, []);
 
+  useEffect(() => {
+    if (dataSourceKey && !availableDataSources.some((source) => source.key === dataSourceKey)) {
+      window.setTimeout(() => {
+        setDataSourceKey('');
+        setData(null);
+      }, 0);
+    }
+  }, [availableDataSources, dataSourceKey]);
+
   return (
     <section aria-labelledby="metrics-explorer-title" style={{ marginTop: 24 }}>
       <Flex
@@ -393,7 +415,7 @@ const MetricsExplorer = () => {
             onChange={handleDataSourceChange}
             options={[
               { label: copy.defaultDataSource, value: '' },
-              ...dataSources.map((ds) => ({ label: ds.name, value: ds.key })),
+              ...availableDataSources.map((ds) => ({ label: ds.name, value: ds.key })),
             ]}
             style={{ width: 200, maxWidth: '100%' }}
           />

--- a/web/src/components/__tests__/MetricsExplorer.test.tsx
+++ b/web/src/components/__tests__/MetricsExplorer.test.tsx
@@ -269,4 +269,45 @@ describe('MetricsExplorer', () => {
     );
     expect(vi.mocked(queryMetrics).mock.calls.length).toBe(queryMetricsCallsBefore);
   });
+
+  it('only offers data sources bound to the selected instance or globally available', async () => {
+    vi.mocked(listDataSources).mockResolvedValue([
+      {
+        key: 'ds-global',
+        name: 'Global Prometheus',
+        type: 'Prometheus',
+        url: '',
+        auth: 'None',
+        status: 'healthy',
+      },
+      {
+        key: 'ds-instance-a',
+        name: 'Instance A Prometheus',
+        type: 'Prometheus',
+        url: '',
+        auth: 'None',
+        status: 'healthy',
+        instanceIds: ['instance-a'],
+      },
+      {
+        key: 'ds-instance-b',
+        name: 'Instance B Prometheus',
+        type: 'Prometheus',
+        url: '',
+        auth: 'None',
+        status: 'healthy',
+        instanceIds: ['instance-b'],
+      },
+    ]);
+
+    const user = userEvent.setup();
+    renderWithProviders(<MetricsExplorer instanceId="instance-a" />);
+
+    await screen.findByRole('combobox', { name: '数据源' });
+    await user.click(screen.getByRole('combobox', { name: '数据源' }));
+
+    expect(await screen.findByText('Global Prometheus')).toBeInTheDocument();
+    expect(screen.getByText('Instance A Prometheus')).toBeInTheDocument();
+    expect(screen.queryByText('Instance B Prometheus')).not.toBeInTheDocument();
+  });
 });

--- a/web/src/hooks/useInstanceFilter.test.tsx
+++ b/web/src/hooks/useInstanceFilter.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { useInstanceFilter } from './useInstanceFilter';
+
+const instanceServiceMocks = vi.hoisted(() => ({
+  listInstances: vi.fn(),
+}));
+
+vi.mock('../services/instanceService', () => instanceServiceMocks);
+
+function InstanceRouteProbe() {
+  const { pathname } = useLocation();
+  const { selectedInstanceId } = useInstanceFilter();
+  return <output>{`${pathname}|${selectedInstanceId}`}</output>;
+}
+
+describe('useInstanceFilter', () => {
+  it('replaces an unknown route instance with the first available instance', async () => {
+    instanceServiceMocks.listInstances.mockResolvedValue([
+      {
+        id: 'instance-a',
+        name: 'Instance A',
+        remark: '',
+        type: 'PROXY',
+        endpoint: '127.0.0.1:8080',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={['/instance/missing/topic']}>
+        <Routes>
+          <Route path="/instance/:instanceId/topic" element={<InstanceRouteProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('/instance/instance-a/topic|instance-a')).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/hooks/useInstanceFilter.ts
+++ b/web/src/hooks/useInstanceFilter.ts
@@ -44,7 +44,8 @@ export function useInstanceFilter() {
       .then((nextInstances) => {
         if (cancelled) return;
         setInstances(nextInstances);
-        if (!routeInstanceId && nextInstances.length > 0) {
+        const isKnownInstance = nextInstances.some((instance) => instance.id === routeInstanceId);
+        if (nextInstances.length > 0 && !isKnownInstance) {
           navigate(`/instance/${nextInstances[0].id}/${section}`, { replace: true });
         }
       })

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -574,6 +574,14 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Proxy 重启已提交: {addr}',
     en: 'Proxy restart submitted: {addr}',
   },
+  'cluster.restartBrokerConfirm': {
+    zh: '确定要重启 Broker "{name}" 吗？',
+    en: 'Are you sure to restart Broker "{name}"?',
+  },
+  'cluster.restartBrokerSubmitted': {
+    zh: 'Broker 重启已提交: {name}',
+    en: 'Broker restart submitted: {name}',
+  },
 
   // ─── Topic ───
   'topic.type': { zh: '类型', en: 'Type' },

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -201,7 +201,7 @@ const ClientsPage = () => {
     return clusterConnections.filter(
       (connection) =>
         connection.clientId.toLowerCase().includes(normalizedSearch) ||
-        connection.address.includes(search),
+        connection.address?.toLowerCase().includes(normalizedSearch),
     );
   }, [clusterConnections, search]);
 

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -403,8 +403,8 @@ const ClusterPage = () => {
         key: 'version',
         width: 80,
         align: 'right',
-        sorter: (a, b) => a.version.localeCompare(b.version),
-        render: (v: string) => <span style={{ fontSize: 13 }}>{v}</span>,
+        sorter: (a, b) => (a.version || '').localeCompare(b.version || ''),
+        render: (v?: string | null) => <span style={{ fontSize: 13 }}>{v || '-'}</span>,
       },
       {
         title: t('cluster.diskUsage'),

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -521,34 +521,38 @@ const ClusterPage = () => {
             onOk={() => {
               configForm.validateFields().then(async (values) => {
                 if (!selectedCluster) return;
-                const { maxMessageSizeMB, ...configValues } = values;
-                const nextConfig: ClusterConfig = {
-                  ...(selectedCluster.config ?? {}),
-                  ...configValues,
-                  maxMessageSize: maxMessageSizeMB * 1048576,
-                };
-                const result = await updateClusterConfig({
-                  id: selectedCluster.id,
-                  ...nextConfig,
-                });
-                if (result.status === 'SUCCESS') {
-                  await requestRefresh('operation');
-                  message.success(t('cluster.configUpdated'));
-                  setConfigModalOpen(false);
-                  return;
-                }
+                try {
+                  const { maxMessageSizeMB, ...configValues } = values;
+                  const nextConfig: ClusterConfig = {
+                    ...(selectedCluster.config ?? {}),
+                    ...configValues,
+                    maxMessageSize: maxMessageSizeMB * 1048576,
+                  };
+                  const result = await updateClusterConfig({
+                    id: selectedCluster.id,
+                    ...nextConfig,
+                  });
+                  if (result.status === 'SUCCESS') {
+                    await requestRefresh('operation');
+                    message.success(t('cluster.configUpdated'));
+                    setConfigModalOpen(false);
+                    return;
+                  }
 
-                const failedAddresses = result.failedBrokers
-                  .map((failure) => failure.address)
-                  .join(', ');
-                if (result.status === 'PARTIAL') {
-                  await requestRefresh('operation');
-                  message.warning(
-                    t('cluster.configPartiallyUpdated', { brokers: failedAddresses }),
-                  );
-                  return;
+                  const failedAddresses = result.failedBrokers
+                    .map((failure) => failure.address)
+                    .join(', ');
+                  if (result.status === 'PARTIAL') {
+                    await requestRefresh('operation');
+                    message.warning(
+                      t('cluster.configPartiallyUpdated', { brokers: failedAddresses }),
+                    );
+                    return;
+                  }
+                  message.error(t('cluster.configUpdateFailed', { brokers: failedAddresses }));
+                } catch {
+                  message.error(t('cluster.configUpdateFailed', { brokers: '' }));
                 }
-                message.error(t('cluster.configUpdateFailed', { brokers: failedAddresses }));
               });
             }}
             width={560}

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -1,6 +1,19 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Alert, Button, Card, Col, Row, Skeleton, Statistic, Table, Tag, Typography } from 'antd';
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Row,
+  Select,
+  Skeleton,
+  Space,
+  Statistic,
+  Table,
+  Tag,
+  Typography,
+} from 'antd';
 import { ClusterOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { ListDashes, ArrowDown } from '@phosphor-icons/react';
 import PageHeader from '../../components/PageHeader';
@@ -10,6 +23,8 @@ import MetricsExplorer from '../../components/MetricsExplorer';
 import { CLUSTER_TYPE_MAP } from '../../constants/theme';
 import { getDashboard } from '../../services/dashboardService';
 import type { DashboardData } from '../../api/metrics';
+import { listInstances } from '../../services/instanceService';
+import type { Instance } from '../../api/instance';
 import { useLang } from '../../i18n/LangContext';
 
 const { Text } = Typography;
@@ -18,6 +33,8 @@ const DashboardPage = () => {
   const navigate = useNavigate();
   const { t } = useLang();
   const [dashboard, setDashboard] = useState<DashboardData | null>(null);
+  const [instances, setInstances] = useState<Instance[]>([]);
+  const [selectedInstanceId, setSelectedInstanceId] = useState<string>();
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
 
@@ -25,22 +42,59 @@ const DashboardPage = () => {
     setLoading(true);
     setLoadError(false);
     try {
-      setDashboard(await getDashboard());
+      setDashboard(await getDashboard(selectedInstanceId));
     } catch {
       setLoadError(true);
     } finally {
       setLoading(false);
     }
+  }, [selectedInstanceId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void listInstances()
+      .then((nextInstances) => {
+        if (!cancelled) setInstances(nextInstances);
+      })
+      .catch(() => {
+        if (!cancelled) setInstances([]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
     void Promise.resolve().then(loadDashboard);
   }, [loadDashboard]);
 
+  const dashboardHeader = (
+    <PageHeader
+      title={t('dashboard.title')}
+      subtitle={t('dashboard.subtitle')}
+      extra={
+        <Space>
+          <Select
+            aria-label="Dashboard instance"
+            allowClear
+            placeholder="All configured instances"
+            value={selectedInstanceId}
+            onChange={setSelectedInstanceId}
+            options={instances.map((instance) => ({ value: instance.id, label: instance.name }))}
+            style={{ width: 220 }}
+          />
+          <Button onClick={() => void loadDashboard()} loading={loading}>
+            Refresh
+          </Button>
+        </Space>
+      }
+    />
+  );
+
   if (loading && !dashboard) {
     return (
       <div style={{ padding: 24 }}>
-        <PageHeader title={t('dashboard.title')} subtitle={t('dashboard.subtitle')} />
+        {dashboardHeader}
         <Skeleton active paragraph={{ rows: 8 }} />
       </div>
     );
@@ -49,7 +103,7 @@ const DashboardPage = () => {
   if (loadError || !dashboard) {
     return (
       <div style={{ padding: 24 }}>
-        <PageHeader title={t('dashboard.title')} subtitle={t('dashboard.subtitle')} />
+        {dashboardHeader}
         <Alert
           type="error"
           showIcon
@@ -203,7 +257,7 @@ const DashboardPage = () => {
 
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader title={t('dashboard.title')} subtitle={t('dashboard.subtitle')} />
+      {dashboardHeader}
 
       <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
         {statCards.map((card) => (
@@ -242,7 +296,7 @@ const DashboardPage = () => {
         />
       </Card>
 
-      <MetricsExplorer />
+      <MetricsExplorer instanceId={selectedInstanceId} />
     </div>
   );
 };

--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -55,6 +55,13 @@ const dlqGroup: DLQGroup = {
   status: 'ACTIVE',
 };
 
+const unavailableDlqGroup: DLQGroup = {
+  ...dlqGroup,
+  messageCount: 0,
+  statsAvailable: false,
+  status: 'UNAVAILABLE',
+};
+
 const secondDlqGroup: DLQGroup = {
   groupName: '-cg-"payment"',
   dlqTopic: '%DLQ%cg-payment',
@@ -129,6 +136,33 @@ describe('DLQ page', () => {
     renderWithProviders(<DLQPage />);
 
     expect(await screen.findByText('DLQ provider is not configured')).toBeInTheDocument();
+  });
+
+  it('does not present unavailable DLQ statistics as an empty queue', async () => {
+    vi.mocked(messageService.listDLQGroups).mockResolvedValue([unavailableDlqGroup]);
+    renderWithProviders(<DLQPage />);
+
+    const row = (await screen.findByText('cg-order')).closest('tr');
+    if (!row) throw new Error('DLQ group row not found');
+
+    expect(within(row).getByText('不可用')).toBeInTheDocument();
+    expect(within(row).getByRole('button', { name: '重投消息' })).toBeDisabled();
+    expect(within(row).getByRole('button', { name: '导出' })).toBeDisabled();
+    expect(within(row).getByRole('checkbox')).toBeDisabled();
+  });
+
+  it('sorts DLQ rows with missing enqueue timestamps', async () => {
+    vi.mocked(messageService.listDLQGroups).mockResolvedValue([
+      dlqGroup,
+      { ...secondDlqGroup, lastEnqueueTime: null },
+    ]);
+    const user = userEvent.setup();
+    renderWithProviders(<DLQPage />);
+
+    await screen.findByText('cg-order');
+    await user.click(screen.getByText('最近入队时间'));
+
+    expect(screen.getByText('-')).toBeInTheDocument();
   });
 
   it('opens a detail dialog with the selected group metadata', async () => {

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -806,10 +806,22 @@ const ConsumerPage = () => {
                   cancelText: '取消',
                   onOk: async () => {
                     const names = selectedRowKeys.map(String);
-                    await batchDeleteConsumerGroups(names, selectedInstanceId || undefined);
-                    setGroups((prev) => prev.filter((g) => !names.includes(g.name)));
-                    message.success(`已删除 ${selectedRowKeys.length} 个 Group`);
-                    setSelectedRowKeys([]);
+                    const { deleted, failed } = await batchDeleteConsumerGroups(
+                      names,
+                      selectedInstanceId || undefined,
+                    );
+                    setGroups((prev) => prev.filter((g) => !deleted.includes(g.name)));
+                    if (failed.length > 0) {
+                      message.warning(
+                        `已删除 ${deleted.length} 个，失败 ${failed.length} 个：${failed.join(', ')}`,
+                      );
+                      setSelectedRowKeys((prev) =>
+                        prev.filter((key) => !deleted.includes(String(key))),
+                      );
+                    } else {
+                      message.success(`已删除 ${deleted.length} 个 Group`);
+                      setSelectedRowKeys([]);
+                    }
                   },
                 });
               }}
@@ -1419,11 +1431,11 @@ const ConsumerPage = () => {
           if (resetGroup) {
             setResetSubmitting(true);
             try {
-                await resetConsumerOffset({
-                  name: resetGroup.name,
-                  instanceId: selectedInstanceId || undefined,
-                  timestamp: resetTime.valueOf(),
-                });
+              await resetConsumerOffset({
+                name: resetGroup.name,
+                instanceId: selectedInstanceId || undefined,
+                timestamp: resetTime.valueOf(),
+              });
               message.success(
                 `${resetGroup.name} 消费位点已重置到 ${resetTime.format('YYYY-MM-DD HH:mm:ss')}`,
               );

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -69,8 +69,10 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
   return fallback;
 };
 
-const formatDateTime = (iso: string): string => {
+const formatDateTime = (iso?: string | null): string => {
+  if (!iso) return '-';
   const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '-';
   const pad = (n: number) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 };
@@ -89,7 +91,7 @@ const exportDLQGroups = (groups: DLQGroup[], filename: string) => {
       String(group.messageCount),
       String(group.retryCount),
       group.status,
-      group.lastEnqueueTime,
+      group.lastEnqueueTime || '',
     ]),
   ];
   const csv = rows.map((row) => row.map(escapeCSVValue).join(',')).join('\n');
@@ -259,15 +261,22 @@ const DLQPage = () => {
       width: 100,
       align: 'right',
       sorter: (a, b) => a.messageCount - b.messageCount,
-      render: (count: number) => (
+      render: (count: number, record: DLQGroup) => (
         <Text
           style={{
             fontFamily: 'monospace',
             fontWeight: 600,
-            color: count > 50 ? '#ff4d4f' : count > 0 ? '#fa8c16' : undefined,
+            color:
+              record.statsAvailable === false
+                ? undefined
+                : count > 50
+                  ? '#ff4d4f'
+                  : count > 0
+                    ? '#fa8c16'
+                    : undefined,
           }}
         >
-          {count.toLocaleString()}
+          {record.statsAvailable === false ? '不可用' : count.toLocaleString()}
         </Text>
       ),
     },
@@ -276,8 +285,8 @@ const DLQPage = () => {
       dataIndex: 'lastEnqueueTime',
       key: 'lastEnqueueTime',
       width: 180,
-      sorter: (a, b) => a.lastEnqueueTime.localeCompare(b.lastEnqueueTime),
-      render: (time: string) => (
+      sorter: (a, b) => (a.lastEnqueueTime || '').localeCompare(b.lastEnqueueTime || ''),
+      render: (time?: string | null) => (
         <Text type="secondary" style={{ fontSize: 13 }}>
           {formatDateTime(time)}
         </Text>
@@ -302,7 +311,7 @@ const DLQPage = () => {
             icon={<ArrowsCounterClockwise size={14} />}
             style={{ borderColor: '#fa8c16', color: '#fa8c16' }}
             onClick={() => openRetryModal(record)}
-            disabled={record.messageCount === 0}
+            disabled={record.statsAvailable === false || record.messageCount === 0}
           >
             重投消息
           </Button>
@@ -311,7 +320,7 @@ const DLQPage = () => {
             icon={<Download size={14} />}
             style={{ borderColor: '#52c41a', color: '#52c41a' }}
             onClick={() => handleExport(record)}
-            disabled={record.messageCount === 0}
+            disabled={record.statsAvailable === false || record.messageCount === 0}
           >
             导出
           </Button>
@@ -373,7 +382,9 @@ const DLQPage = () => {
             selectedRowKeys: selectedGroupNames,
             preserveSelectedRowKeys: true,
             onChange: (keys) => setSelectedGroupNames(keys.map(String)),
-            getCheckboxProps: (record) => ({ disabled: record.messageCount === 0 }),
+            getCheckboxProps: (record) => ({
+              disabled: record.statsAvailable === false || record.messageCount === 0,
+            }),
           }}
           pagination={{
             pageSize: 20,
@@ -511,7 +522,9 @@ const DLQPage = () => {
                   strong
                   style={{ color: detailGroup.messageCount > 0 ? '#fa8c16' : undefined }}
                 >
-                  {detailGroup.messageCount.toLocaleString()}
+                  {detailGroup.statsAvailable === false
+                    ? '不可用'
+                    : detailGroup.messageCount.toLocaleString()}
                 </Text>
               </div>
               <div>
@@ -524,7 +537,9 @@ const DLQPage = () => {
                 <Text type="secondary" style={{ fontSize: 13, display: 'block', marginBottom: 4 }}>
                   状态
                 </Text>
-                <Text>{detailGroup.status}</Text>
+                <Text>
+                  {detailGroup.statsAvailable === false ? '统计不可用' : detailGroup.status}
+                </Text>
               </div>
             </Flex>
             <div style={{ marginTop: 16 }}>

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -312,6 +312,8 @@ const InstancePage = () => {
       width: 80,
       align: 'center' as const,
       sorter: (a, b) => a.topicCount - b.topicCount,
+      render: (count: number, record: Instance) =>
+        record.resourceCountsAvailable === false ? '不可用' : count,
     },
     {
       title: 'Group',
@@ -320,6 +322,8 @@ const InstancePage = () => {
       width: 80,
       align: 'center' as const,
       sorter: (a, b) => a.consumerGroupCount - b.consumerGroupCount,
+      render: (count: number, record: Instance) =>
+        record.resourceCountsAvailable === false ? '不可用' : count,
     },
     {
       title: '创建时间',

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -807,11 +807,11 @@ const TopicPage = () => {
       }
       const result = await sendTopicMessage({
         topic: values.topic,
+        instanceId: selectedInstanceId || undefined,
         tag: values.tag || undefined,
         key: values.key || undefined,
         body: values.body,
         properties: props,
-        instanceId: selectedInstanceId || undefined,
       });
       // Keep the modal open for consecutive sends
       message.success(`消息发送成功！MsgId: ${result.msgId}`);

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -61,6 +61,8 @@ import {
 } from '../../api/settings';
 import type { DataSource } from '../../api/settings';
 import { STATUS_MAP } from '../../constants/theme';
+import { listInstances } from '../../services/instanceService';
+import type { Instance } from '../../api/instance';
 
 const { Title, Text, Link: TypoLink } = Typography;
 
@@ -279,6 +281,7 @@ const GeneralSettingsTab = () => {
 
 export const DataSourceTab = () => {
   const [dataSources, setDataSources] = useState<DataSource[]>([]);
+  const [instances, setInstances] = useState<Instance[]>([]);
   const [loading, setLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
   const [editingDataSource, setEditingDataSource] = useState<DataSource | null>(null);
@@ -300,6 +303,20 @@ export const DataSourceTab = () => {
         if (!cancelled) setLoading(false);
       });
 
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void listInstances()
+      .then((nextInstances) => {
+        if (!cancelled) setInstances(nextInstances);
+      })
+      .catch(() => {
+        if (!cancelled) setInstances([]);
+      });
     return () => {
       cancelled = true;
     };
@@ -380,6 +397,20 @@ export const DataSourceTab = () => {
       render: (t: string) => <Tag color={typeTagColor[t]}>{t}</Tag>,
     },
     { title: 'URL', dataIndex: 'url', key: 'url' },
+    {
+      title: '适用实例',
+      dataIndex: 'instanceIds',
+      key: 'instanceIds',
+      render: (instanceIds: string[] | undefined) => {
+        if (!instanceIds?.length) return '全局';
+        return instanceIds
+          .map(
+            (instanceId) =>
+              instances.find((instance) => instance.id === instanceId)?.name ?? instanceId,
+          )
+          .join('、');
+      },
+    },
     { title: '认证方式', dataIndex: 'auth', key: 'auth' },
     {
       title: '状态',
@@ -479,6 +510,15 @@ export const DataSourceTab = () => {
             rules={[{ required: true, message: '请输入数据源 URL' }]}
           >
             <Input placeholder="http://localhost:9090" />
+          </Form.Item>
+
+          <Form.Item label="适用实例" name="instanceIds" extra="留空时可用于所有实例">
+            <Select
+              mode="multiple"
+              allowClear
+              placeholder="选择此数据源对应的实例"
+              options={instances.map((instance) => ({ value: instance.id, label: instance.name }))}
+            />
           </Form.Item>
 
           <Form.Item label="认证方式" name="auth" initialValue="None">

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Table, Button, Tag, Tabs, Card, Space, Switch, Progress, Tooltip, Spin, App } from 'antd';
 import {
   Plus,
@@ -157,6 +157,15 @@ const BrokerClusterPage = () => {
       setLoading(false);
     }
   }, [message, t]);
+
+  // Live refresh: poll while the auto-refresh switch is on.
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const timer = setInterval(() => {
+      void loadData();
+    }, 5000);
+    return () => clearInterval(timer);
+  }, [autoRefresh, loadData]);
 
   const initialized = useRef<boolean | null>(null);
   if (initialized.current == null) {

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -15,34 +15,48 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { Table, Button, Tag, Tabs, Card, Space, Switch, Progress, Tooltip, Spin, App } from 'antd';
+import { useCallback, useEffect, useState } from 'react';
 import {
-  Plus,
+  Table,
+  Button,
+  Tag,
+  Tabs,
+  Card,
+  Space,
+  Switch,
+  Progress,
+  Tooltip,
+  Spin,
+  App,
+  Modal,
+} from 'antd';
+import {
   ArrowClockwise,
-  GearSix,
   ArrowsClockwise,
   Cloud,
   ChartBar,
   PlugsConnected,
 } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
-import { listClusters } from '../../services/clusterService';
+import { listClusters, restartBroker } from '../../services/clusterService';
 import type { ClusterInfo } from '../../api/cluster';
 
 // ─── Types ──────────────────────────────────────────────────────
 type NodeStatus = 'running' | 'readonly' | 'maintenance';
 
+const REFRESH_INTERVAL_MS = 2000;
+
 interface BrokerRecord {
   key: string;
+  clusterId: string;
   k8sCluster: string;
   brokerName: string;
   status: NodeStatus;
   version: string;
-  diskUsage: number;
+  diskUsage: number | null;
   address: string;
-  tpsIn: number;
-  tpsOut: number;
+  tpsIn: number | null;
+  tpsOut: number | null;
 }
 
 interface NameServerRecord {
@@ -91,14 +105,15 @@ function mapClusters(clusters: ClusterInfo[]): {
     cluster.brokers.forEach((broker, index) => {
       brokers.push({
         key: `${cluster.id}-broker-${broker.addr || index}`,
+        clusterId: cluster.id,
         k8sCluster: clusterLabel,
         brokerName: broker.name || broker.addr,
         status: normalizeStatus(broker.status),
-        version: broker.version || cluster.version,
-        diskUsage: broker.diskUsage ?? 0,
+        version: broker.version || '-',
+        diskUsage: broker.runtimeStatsAvailable === false ? null : (broker.diskUsage ?? 0),
         address: broker.addr,
-        tpsIn: broker.tpsIn ?? 0,
-        tpsOut: broker.tpsOut ?? 0,
+        tpsIn: broker.runtimeStatsAvailable === false ? null : (broker.tpsIn ?? 0),
+        tpsOut: broker.runtimeStatsAvailable === false ? null : (broker.tpsOut ?? 0),
       });
     });
 
@@ -167,11 +182,37 @@ const BrokerClusterPage = () => {
     return () => clearInterval(timer);
   }, [autoRefresh, loadData]);
 
-  const initialized = useRef<boolean | null>(null);
-  if (initialized.current == null) {
-    initialized.current = true;
-    void loadData();
-  }
+  const handleRestartBroker = async (broker: BrokerRecord) => {
+    try {
+      const result = await restartBroker(broker.clusterId, broker.brokerName);
+      if (!result.success) {
+        message.error(result.message || t('common.failure'));
+        return;
+      }
+      await loadData();
+      message.success(
+        result.message || t('cluster.restartBrokerSubmitted', { name: broker.brokerName }),
+      );
+    } catch {
+      message.error(t('common.failure'));
+    }
+  };
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      void loadData();
+    });
+    return () => window.clearTimeout(timeoutId);
+  }, [loadData]);
+
+  useEffect(() => {
+    if (!autoRefresh) return;
+
+    const intervalId = window.setInterval(() => {
+      void loadData();
+    }, REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(intervalId);
+  }, [autoRefresh, loadData]);
 
   const renderStatus = (status: string) => {
     const config: Record<string, { color: string; label: string }> = {
@@ -186,7 +227,8 @@ const BrokerClusterPage = () => {
     return <Tag color={color}>{label}</Tag>;
   };
 
-  const renderDiskUsage = (percent: number) => {
+  const renderDiskUsage = (percent: number | null) => {
+    if (percent == null) return '-';
     let status: 'normal' | 'active' | 'exception' = 'normal';
     let color = '#52c41a';
     if (percent > 85) {
@@ -258,32 +300,42 @@ const BrokerClusterPage = () => {
       title: t('brokerCluster.tpsIn'),
       dataIndex: 'tpsIn',
       key: 'tpsIn',
-      render: (value: number) => <span style={{ fontWeight: 500 }}>{value.toLocaleString()}</span>,
-      sorter: (a: BrokerRecord, b: BrokerRecord) => a.tpsIn - b.tpsIn,
+      render: (value: number | null) => (
+        <span style={{ fontWeight: 500 }}>{value?.toLocaleString() ?? '-'}</span>
+      ),
+      sorter: (a: BrokerRecord, b: BrokerRecord) => (a.tpsIn ?? -1) - (b.tpsIn ?? -1),
     },
     {
       title: t('brokerCluster.tpsOut'),
       dataIndex: 'tpsOut',
       key: 'tpsOut',
-      render: (value: number) => <span style={{ fontWeight: 500 }}>{value.toLocaleString()}</span>,
-      sorter: (a: BrokerRecord, b: BrokerRecord) => a.tpsOut - b.tpsOut,
+      render: (value: number | null) => (
+        <span style={{ fontWeight: 500 }}>{value?.toLocaleString() ?? '-'}</span>
+      ),
+      sorter: (a: BrokerRecord, b: BrokerRecord) => (a.tpsOut ?? -1) - (b.tpsOut ?? -1),
     },
     {
       title: t('common.actions'),
       key: 'action',
-      render: () => (
-        <Space size="small">
-          <Tooltip title={t('brokerCluster.config')}>
-            <Button type="link" size="small" icon={<GearSix size={14} />}>
-              {t('brokerCluster.config')}
-            </Button>
-          </Tooltip>
-          <Tooltip title={t('brokerCluster.restart')}>
-            <Button type="link" size="small" icon={<ArrowsClockwise size={14} />}>
-              {t('brokerCluster.restart')}
-            </Button>
-          </Tooltip>
-        </Space>
+      render: (_: unknown, record: BrokerRecord) => (
+        <Tooltip title={t('brokerCluster.restart')}>
+          <Button
+            type="link"
+            size="small"
+            icon={<ArrowsClockwise size={14} />}
+            onClick={() => {
+              Modal.confirm({
+                title: t('cluster.confirmRestart'),
+                content: t('cluster.restartBrokerConfirm', { name: record.brokerName }),
+                okText: t('common.confirm'),
+                cancelText: t('common.cancel'),
+                onOk: () => handleRestartBroker(record),
+              });
+            }}
+          >
+            {t('brokerCluster.restart')}
+          </Button>
+        </Tooltip>
       ),
     },
   ];
@@ -330,20 +382,6 @@ const BrokerClusterPage = () => {
       dataIndex: 'connections',
       key: 'connections',
       render: (text: number) => <span style={{ fontWeight: 500 }}>{text.toLocaleString()}</span>,
-    },
-    {
-      title: t('common.actions'),
-      key: 'action',
-      render: () => (
-        <Space size="small">
-          <Button type="link" size="small" icon={<GearSix size={14} />}>
-            {t('brokerCluster.config')}
-          </Button>
-          <Button type="link" size="small" icon={<ArrowsClockwise size={14} />}>
-            {t('brokerCluster.restart')}
-          </Button>
-        </Space>
-      ),
     },
   ];
 
@@ -407,20 +445,6 @@ const BrokerClusterPage = () => {
       key: 'connections',
       render: (text: number) => <span style={{ fontWeight: 500 }}>{text.toLocaleString()}</span>,
     },
-    {
-      title: t('common.actions'),
-      key: 'action',
-      render: () => (
-        <Space size="small">
-          <Button type="link" size="small" icon={<GearSix size={14} />}>
-            {t('brokerCluster.config')}
-          </Button>
-          <Button type="link" size="small" icon={<ArrowsClockwise size={14} />}>
-            {t('brokerCluster.restart')}
-          </Button>
-        </Space>
-      ),
-    },
   ];
 
   return (
@@ -455,9 +479,6 @@ const BrokerClusterPage = () => {
           />
           <Button icon={<ArrowClockwise size={14} />} size="small" onClick={() => void loadData()}>
             {t('common.reset')}
-          </Button>
-          <Button type="primary" icon={<Plus size={14} />}>
-            {t('brokerCluster.createCluster')}
           </Button>
         </Space>
       </div>

--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Table,
   Button,
@@ -31,7 +31,7 @@ import {
   Switch,
   message,
 } from 'antd';
-import { MagnifyingGlass, Plus, ArrowClockwise, Users, Eye } from '@phosphor-icons/react';
+import { MagnifyingGlass, ArrowClockwise, Users } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
 import type { ConsumerGroup, QueueProgress, SubscriptionEntry } from '../../api/metadata';
 import {
@@ -44,6 +44,7 @@ import {
 type GroupStatus = 'running' | 'warning' | 'stopped';
 
 const BACKLOG_WARNING_THRESHOLD = 10000;
+const GROUP_REFRESH_INTERVAL_MS = 2000;
 
 const deriveStatus = (group: ConsumerGroup): GroupStatus => {
   if (group.onlineInstances <= 0) return 'stopped';
@@ -65,51 +66,50 @@ const GroupManagementPage = () => {
   const [subscriptions, setSubscriptions] = useState<SubscriptionEntry[]>([]);
   const [progress, setProgress] = useState<QueueProgress[]>([]);
   const [detailLoading, setDetailLoading] = useState(false);
+  const listRequestId = useRef(0);
+  const detailRequestId = useRef(0);
   const { t } = useLang();
 
-  useEffect(() => {
-    let cancelled = false;
-
-    const fetchGroups = async () => {
-      try {
-        const data = await listConsumerGroups();
-        if (!cancelled) setGroups(data);
-      } catch {
-        if (!cancelled) message.error(t('consumer.fetchListFailed'));
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-
-    void fetchGroups();
-    return () => {
-      cancelled = true;
-    };
-  }, [t]);
-
-  const handleRefresh = useCallback(async () => {
+  const loadGroups = useCallback(async () => {
+    const requestId = ++listRequestId.current;
     setLoading(true);
     try {
       const data = await listConsumerGroups();
+      if (requestId !== listRequestId.current) return;
       setGroups(data);
     } catch {
+      if (requestId !== listRequestId.current) return;
       message.error(t('consumer.fetchListFailed'));
     } finally {
-      setLoading(false);
+      if (requestId === listRequestId.current) {
+        setLoading(false);
+      }
     }
   }, [t]);
 
-  // Live refresh: poll while the auto-refresh switch is on.
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      void loadGroups();
+    });
+    return () => window.clearTimeout(timeoutId);
+  }, [loadGroups]);
+
   useEffect(() => {
     if (!autoRefresh) return;
-    const timer = setInterval(() => {
-      void handleRefresh();
-    }, 5000);
-    return () => clearInterval(timer);
-  }, [autoRefresh, handleRefresh]);
+
+    const intervalId = window.setInterval(() => {
+      void loadGroups();
+    }, GROUP_REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(intervalId);
+  }, [autoRefresh, loadGroups]);
+
+  const handleRefresh = useCallback(() => {
+    void loadGroups();
+  }, [loadGroups]);
 
   const handleViewDetail = useCallback(
     async (group: ConsumerGroup) => {
+      const requestId = ++detailRequestId.current;
       setSelectedGroup(group);
       setModalVisible(true);
       setSubscriptions([]);
@@ -120,12 +120,16 @@ const GroupManagementPage = () => {
           getConsumerSubscriptions(group.name),
           getConsumerProgress(group.name),
         ]);
+        if (requestId !== detailRequestId.current) return;
         setSubscriptions(subs);
         setProgress(prog);
       } catch {
+        if (requestId !== detailRequestId.current) return;
         message.error(t('consumer.fetchProgressFailed', { name: group.name }));
       } finally {
-        setDetailLoading(false);
+        if (requestId === detailRequestId.current) {
+          setDetailLoading(false);
+        }
       }
     },
     [t],
@@ -206,14 +210,9 @@ const GroupManagementPage = () => {
       title: t('common.actions'),
       key: 'action',
       render: (_: unknown, record: ConsumerGroup) => (
-        <Space size="small">
-          <Button type="link" size="small" onClick={() => void handleViewDetail(record)}>
-            {t('common.detail')}
-          </Button>
-          <Button type="link" size="small">
-            {t('brokerCluster.config')}
-          </Button>
-        </Space>
+        <Button type="link" size="small" onClick={() => void handleViewDetail(record)}>
+          {t('common.detail')}
+        </Button>
       ),
     },
   ];
@@ -244,15 +243,6 @@ const GroupManagementPage = () => {
         <code style={{ background: '#f5f5f5', padding: '2px 6px', borderRadius: 4, fontSize: 12 }}>
           {text}
         </code>
-      ),
-    },
-    {
-      title: t('common.actions'),
-      key: 'action',
-      render: () => (
-        <Button type="link" size="small" icon={<Eye size={14} />}>
-          {t('groupMgmt.viewDistribution')}
-        </Button>
       ),
     },
   ];
@@ -288,9 +278,6 @@ const GroupManagementPage = () => {
             style={{ width: 240 }}
             allowClear
           />
-          <Button type="primary" icon={<Plus size={14} />}>
-            {t('groupMgmt.createGroup')}
-          </Button>
           <Switch
             checked={autoRefresh}
             onChange={setAutoRefresh}
@@ -298,11 +285,7 @@ const GroupManagementPage = () => {
             unCheckedChildren={t('groupMgmt.manual')}
             size="small"
           />
-          <Button
-            icon={<ArrowClockwise size={14} />}
-            size="small"
-            onClick={() => void handleRefresh()}
-          >
+          <Button icon={<ArrowClockwise size={14} />} size="small" onClick={handleRefresh}>
             {t('common.reset')}
           </Button>
         </Space>
@@ -326,7 +309,10 @@ const GroupManagementPage = () => {
       <Modal
         title={null}
         open={modalVisible}
-        onCancel={() => setModalVisible(false)}
+        onCancel={() => {
+          ++detailRequestId.current;
+          setModalVisible(false);
+        }}
         footer={null}
         width={720}
         destroyOnClose

--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -99,6 +99,15 @@ const GroupManagementPage = () => {
     }
   }, [t]);
 
+  // Live refresh: poll while the auto-refresh switch is on.
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const timer = setInterval(() => {
+      void handleRefresh();
+    }, 5000);
+    return () => clearInterval(timer);
+  }, [autoRefresh, handleRefresh]);
+
   const handleViewDetail = useCallback(
     async (group: ConsumerGroup) => {
       setSelectedGroup(group);

--- a/web/src/pages/studio/LiteTopic.tsx
+++ b/web/src/pages/studio/LiteTopic.tsx
@@ -130,6 +130,7 @@ const LiteTopicPage: React.FC = () => {
   const mountedRef = useRef(false);
   const bootstrapRequestId = useRef(0);
   const displayRequestId = useRef(0);
+  const sessionRequestId = useRef(0);
 
   useEffect(() => {
     messageRef.current = message;
@@ -250,16 +251,22 @@ const LiteTopicPage: React.FC = () => {
   };
 
   const handleViewSessions = async (sessionId: string) => {
+    const requestId = ++sessionRequestId.current;
     setSessionDrawerOpen(true);
     setSessionLoading(true);
+    setSessionData(null);
     try {
       const data = await queryLiteTopicSession(sessionId);
+      if (requestId !== sessionRequestId.current) return;
       setSessionData(data);
     } catch {
+      if (requestId !== sessionRequestId.current) return;
       message.error(t('liteTopic.fetchSessionFailed'));
       setSessionData(null);
     } finally {
-      setSessionLoading(false);
+      if (requestId === sessionRequestId.current) {
+        setSessionLoading(false);
+      }
     }
   };
 

--- a/web/src/pages/studio/Ops.tsx
+++ b/web/src/pages/studio/Ops.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { App, Button, Input, Popconfirm, Select, Space, Switch, Tooltip, Typography } from 'antd';
+import { Alert, App, Button, Input, Popconfirm, Select, Space, Switch, Tooltip, Typography } from 'antd';
 import { FloppyDisk, Plus, Trash } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
 import useAuthStore from '../../stores/authStore';
@@ -42,7 +42,9 @@ const OpsPage: React.FC = () => {
   const [newNamesrvAddr, setNewNamesrvAddr] = useState('');
   const [useVIPChannel, setUseVIPChannel] = useState(false);
   const [useTLS, setUseTLS] = useState(false);
-  const writeOperationEnabled = !token || admin === true;
+  const [configurationAvailable, setConfigurationAvailable] = useState(false);
+  const [unavailableReason, setUnavailableReason] = useState('');
+  const writeOperationEnabled = configurationAvailable && (!token || admin === true);
   const deleteNameServerDisabled =
     !selectedNamesrv || selectedNamesrv === currentNamesrv || namesrvAddrList.length <= 1;
 
@@ -58,6 +60,8 @@ const OpsPage: React.FC = () => {
           setUseTLS(data.useTLS);
           setSelectedNamesrv(data.currentNamesrv);
           setCurrentNamesrv(data.currentNamesrv);
+          setConfigurationAvailable(data.configurationAvailable);
+          setUnavailableReason(data.unavailableReason || '');
         }
       } catch {
         if (!cancelled) {
@@ -140,6 +144,15 @@ const OpsPage: React.FC = () => {
 
   return (
     <div style={{ padding: 24 }}>
+      {!configurationAvailable && (
+        <Alert
+          type="info"
+          showIcon
+          message="运行时配置不可用"
+          description={unavailableReason || '当前集群不支持读取或更新 Ops 配置。'}
+          style={{ marginBottom: 24 }}
+        />
+      )}
       {/* NameServer Address List */}
       <div style={{ marginBottom: 24 }}>
         <Typography.Title level={4}>{t('ops.nameServerAddressList')}</Typography.Title>

--- a/web/src/pages/studio/Producer.tsx
+++ b/web/src/pages/studio/Producer.tsx
@@ -25,12 +25,16 @@ import {
   queryProducerConnection,
   type ProducerConnection,
 } from '../../api/producer';
+import type { Instance } from '../../api/instance';
+import { listInstances } from '../../services/instanceService';
 
 const ProducerPage = () => {
   const [form] = Form.useForm();
   const [topicList, setTopicList] = useState<string[]>([]);
   const [producerGroups, setProducerGroups] = useState<string[]>([]);
   const [connectionList, setConnectionList] = useState<ProducerConnection[]>([]);
+  const [instances, setInstances] = useState<Instance[]>([]);
+  const [selectedInstanceId, setSelectedInstanceId] = useState('');
   const [loading, setLoading] = useState(false);
   const { t } = useLang();
   const { message } = App.useApp();
@@ -39,44 +43,81 @@ const ProducerPage = () => {
   useEffect(() => {
     let cancelled = false;
 
-    const loadTopics = async () => {
-      try {
-        const topics = await fetchTopicList();
+    void listInstances()
+      .then((nextInstances) => {
+        if (cancelled) return;
+        setInstances(nextInstances);
+        setSelectedInstanceId((current) => current || nextInstances[0]?.id || '');
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setInstances([]);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void fetchTopicList()
+      .then((topics) => {
         if (!cancelled) {
           setTopicList(topics);
         }
-      } catch {
+      })
+      .catch(() => {
         if (!cancelled) {
           message.error(fetchTopicFailedMessage);
         }
-      }
-    };
-
-    const loadProducerGroups = async () => {
-      try {
-        const groups = await fetchProducerGroups();
-        if (!cancelled) {
-          setProducerGroups(groups);
-        }
-      } catch {
-        if (!cancelled) {
-          setProducerGroups([]);
-        }
-      }
-    };
-
-    void loadTopics();
-    void loadProducerGroups();
+      });
 
     return () => {
       cancelled = true;
     };
   }, [fetchTopicFailedMessage, message]);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!selectedInstanceId) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    void fetchProducerGroups(selectedInstanceId)
+      .then((groups) => {
+        if (!cancelled) {
+          setProducerGroups(groups);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setProducerGroups([]);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedInstanceId]);
+
   const onFinish = async (values: { selectedTopic: string; producerGroup: string }) => {
+    if (!selectedInstanceId) {
+      message.error('Select an instance before querying producer connections.');
+      return;
+    }
     setLoading(true);
     try {
-      const connections = await queryProducerConnection(values.selectedTopic, values.producerGroup);
+      const connections = await queryProducerConnection(
+        selectedInstanceId,
+        values.selectedTopic,
+        values.producerGroup,
+      );
       setConnectionList(connections);
       if (connections.length === 0) {
         message.info(t('producer.noConnections'));
@@ -125,6 +166,16 @@ const ProducerPage = () => {
 
       <Card bordered={false} style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}>
         <Form form={form} layout="inline" onFinish={onFinish} style={{ marginBottom: 20 }}>
+          <Form.Item label="INSTANCE">
+            <Select
+              aria-label="Instance"
+              value={selectedInstanceId || undefined}
+              onChange={setSelectedInstanceId}
+              placeholder="Select instance"
+              style={{ width: 220 }}
+              options={instances.map((instance) => ({ value: instance.id, label: instance.name }))}
+            />
+          </Form.Item>
           <Form.Item
             label="TOPIC"
             name="selectedTopic"
@@ -158,6 +209,7 @@ const ProducerPage = () => {
               type="primary"
               htmlType="submit"
               loading={loading}
+              disabled={!selectedInstanceId}
               icon={<MagnifyingGlass size={14} />}
             >
               {t('common.search')}

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -15,17 +15,18 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
-import { listClusters } from '../../../services/clusterService';
+import { listClusters, restartBroker } from '../../../services/clusterService';
 import type { ClusterInfo } from '../../../api/cluster';
 import BrokerCluster from '../BrokerCluster';
 
 vi.mock('../../../services/clusterService', () => ({
   listClusters: vi.fn(),
+  restartBroker: vi.fn(),
 }));
 
 // Mock matchMedia for antd responsive components
@@ -120,16 +121,16 @@ describe('BrokerCluster Page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(listClusters).mockResolvedValue(clusterFixture);
+    vi.mocked(restartBroker).mockResolvedValue({ success: true, message: 'restarted' });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should render the page title', () => {
     renderWithProviders(<BrokerCluster />);
     expect(screen.getByText('Broker 集群')).toBeInTheDocument();
-  });
-
-  it('should render create cluster button', () => {
-    renderWithProviders(<BrokerCluster />);
-    expect(screen.getByText('创建集群')).toBeInTheDocument();
   });
 
   it('should render reset button', () => {
@@ -176,13 +177,30 @@ describe('BrokerCluster Page', () => {
     expect(screen.getAllByText('10.0.1.30:8080').length).toBeGreaterThan(0);
   });
 
-  it('should render config and restart action buttons', async () => {
+  it('should render only supported broker restart actions', async () => {
     renderWithProviders(<BrokerCluster />);
     await screen.findByText('broker-api-a');
-    const configButtons = screen.getAllByText('配置');
-    expect(configButtons.length).toBeGreaterThan(0);
+    expect(screen.queryByText('创建集群')).not.toBeInTheDocument();
+    expect(screen.queryByText('配置')).not.toBeInTheDocument();
     const restartButtons = screen.getAllByText('重启');
-    expect(restartButtons.length).toBeGreaterThan(0);
+    expect(restartButtons).toHaveLength(2);
+  });
+
+  it('restarts a broker after confirmation and refreshes the cluster data', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<BrokerCluster />);
+    await screen.findByText('broker-api-a');
+
+    await user.click(screen.getAllByText('重启')[0]);
+    expect(await screen.findByText('确定要重启 Broker "broker-api-a" 吗？')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /确\s*认/ }));
+
+    await waitFor(() => {
+      expect(restartBroker).toHaveBeenCalledWith('cluster-1', 'broker-api-a');
+    });
+    await waitFor(() => {
+      expect(listClusters).toHaveBeenCalledTimes(2);
+    });
   });
 
   it('does not show mock infrastructure data when the API fails', async () => {
@@ -195,5 +213,28 @@ describe('BrokerCluster Page', () => {
     expect(screen.queryByText('broker-b')).not.toBeInTheDocument();
     expect(screen.queryByText('nameserver-a')).not.toBeInTheDocument();
     expect(screen.queryByText('proxy-a')).not.toBeInTheDocument();
+  });
+
+  it('polls only while live refresh is enabled', async () => {
+    vi.useFakeTimers();
+    renderWithProviders(<BrokerCluster />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(listClusters).toHaveBeenCalledTimes(1);
+
+    const liveRefreshSwitch = screen.getByRole('switch');
+    fireEvent.click(liveRefreshSwitch);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(listClusters).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(liveRefreshSwitch);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(listClusters).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
-import type { ConsumerGroup } from '../../../api/metadata';
+import type { ConsumerGroup, QueueProgress, SubscriptionEntry } from '../../../api/metadata';
 import * as consumerService from '../../../services/consumerService';
 import GroupManagement from '../GroupManagement';
 
@@ -84,11 +84,24 @@ const renderWithProviders = (ui: React.ReactElement) => {
   );
 };
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
 describe('GroupManagement Page', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(consumerService.listConsumerGroups).mockResolvedValue(groups);
     vi.mocked(consumerService.getConsumerProgress).mockResolvedValue([]);
     vi.mocked(consumerService.getConsumerSubscriptions).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should render the page title', () => {
@@ -101,9 +114,14 @@ describe('GroupManagement Page', () => {
     expect(screen.getByPlaceholderText('搜索消费组')).toBeInTheDocument();
   });
 
-  it('should render create group button', () => {
+  it('should not render unsupported mutation actions in the global view', async () => {
     renderWithProviders(<GroupManagement />);
-    expect(screen.getByText('创建消费组')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('order-consumer-group')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('创建消费组')).not.toBeInTheDocument();
+    expect(screen.queryByText('配置')).not.toBeInTheDocument();
+    expect(screen.queryByText('查看分布')).not.toBeInTheDocument();
   });
 
   it('should render reset button', () => {
@@ -126,6 +144,109 @@ describe('GroupManagement Page', () => {
     });
     const detailButtons = screen.getAllByText('详情');
     expect(detailButtons.length).toBeGreaterThan(0);
+  });
+
+  it('keeps the latest group detail when an earlier request resolves last', async () => {
+    const firstSubscriptions = createDeferred<SubscriptionEntry[]>();
+    const firstProgress = createDeferred<QueueProgress[]>();
+    const secondSubscriptions = createDeferred<SubscriptionEntry[]>();
+    const secondProgress = createDeferred<QueueProgress[]>();
+    vi.mocked(consumerService.getConsumerSubscriptions).mockImplementation((groupName) =>
+      groupName === 'order-consumer-group'
+        ? firstSubscriptions.promise
+        : secondSubscriptions.promise,
+    );
+    vi.mocked(consumerService.getConsumerProgress).mockImplementation((groupName) =>
+      groupName === 'order-consumer-group' ? firstProgress.promise : secondProgress.promise,
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<GroupManagement />);
+    await screen.findByText('order-consumer-group');
+
+    const detailButtons = screen.getAllByText('详情');
+    await user.click(detailButtons[0]);
+    await user.click(detailButtons[1]);
+
+    await act(async () => {
+      secondSubscriptions.resolve([
+        {
+          topic: 'SECOND_GROUP_TOPIC',
+          expression: '*',
+          type: 'TAG',
+          filterMode: 'TAG',
+          consistency: 'consistent',
+        },
+      ]);
+      secondProgress.resolve([]);
+    });
+    expect(await screen.findByText('SECOND_GROUP_TOPIC')).toBeInTheDocument();
+
+    await act(async () => {
+      firstSubscriptions.resolve([
+        {
+          topic: 'FIRST_GROUP_TOPIC',
+          expression: '*',
+          type: 'TAG',
+          filterMode: 'TAG',
+          consistency: 'consistent',
+        },
+      ]);
+      firstProgress.resolve([]);
+    });
+    expect(screen.getByText('SECOND_GROUP_TOPIC')).toBeInTheDocument();
+    expect(screen.queryByText('FIRST_GROUP_TOPIC')).not.toBeInTheDocument();
+  });
+
+  it('keeps the latest group list when an earlier refresh resolves last', async () => {
+    const initialGroups = createDeferred<ConsumerGroup[]>();
+    const refreshedGroups = createDeferred<ConsumerGroup[]>();
+    vi.mocked(consumerService.listConsumerGroups)
+      .mockReturnValueOnce(initialGroups.promise)
+      .mockReturnValueOnce(refreshedGroups.promise);
+    vi.useFakeTimers();
+    renderWithProviders(<GroupManagement />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    fireEvent.click(screen.getByText('重置'));
+
+    await act(async () => {
+      refreshedGroups.resolve([makeGroup({ name: 'fresh-group' })]);
+      await Promise.resolve();
+    });
+    expect(screen.getByText('fresh-group')).toBeInTheDocument();
+
+    await act(async () => {
+      initialGroups.resolve([makeGroup({ name: 'stale-group' })]);
+      await Promise.resolve();
+    });
+    expect(screen.getByText('fresh-group')).toBeInTheDocument();
+    expect(screen.queryByText('stale-group')).not.toBeInTheDocument();
+  });
+
+  it('polls only while auto refresh is enabled', async () => {
+    vi.useFakeTimers();
+    renderWithProviders(<GroupManagement />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(1);
+
+    const autoRefreshSwitch = screen.getByRole('switch');
+    fireEvent.click(autoRefreshSwitch);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(autoRefreshSwitch);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(2);
   });
 
   it('should filter groups by search text', async () => {

--- a/web/src/pages/studio/__tests__/LiteTopic.test.tsx
+++ b/web/src/pages/studio/__tests__/LiteTopic.test.tsx
@@ -114,6 +114,46 @@ describe('LiteTopic Page', () => {
     expect(within(popProgressLabel.parentElement!).getByText('96%')).toBeInTheDocument();
   });
 
+  it('keeps the latest session detail when an earlier request resolves last', async () => {
+    const firstSession = createDeferred<{
+      sessionId: string;
+      totalMessages: number;
+      consumedMessages: number;
+    }>();
+    const secondSession = createDeferred<{
+      sessionId: string;
+      totalMessages: number;
+      consumedMessages: number;
+    }>();
+    apiMocks.queryLiteTopicList.mockResolvedValue([
+      { namespace: 'default', topicPattern: 'first-*', sessionIds: ['session-1'] },
+      { namespace: 'default', topicPattern: 'second-*', sessionIds: ['session-2'] },
+    ]);
+    apiMocks.queryLiteTopicSession.mockImplementation((sessionId: string) =>
+      sessionId === 'session-1' ? firstSession.promise : secondSession.promise,
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    const viewSessionButtons = await screen.findAllByText('查看会话');
+    await user.click(viewSessionButtons[0]);
+    await user.click(viewSessionButtons[1]);
+
+    await act(async () => {
+      secondSession.resolve({ sessionId: 'session-2', totalMessages: 222, consumedMessages: 22 });
+    });
+    expect(await screen.findByText('session-2')).toBeInTheDocument();
+    expect(screen.getByText('222')).toBeInTheDocument();
+
+    await act(async () => {
+      firstSession.resolve({ sessionId: 'session-1', totalMessages: 111, consumedMessages: 11 });
+    });
+    expect(screen.getByText('session-2')).toBeInTheDocument();
+    expect(screen.getByText('222')).toBeInTheDocument();
+    expect(screen.queryByText('111')).not.toBeInTheDocument();
+  });
+
   it('keeps namespace identity in the table and builds stable options from the initial list', async () => {
     const initialItems: LiteTopicItem[] = [
       { namespace: 'zeta', topicPattern: 'shared-*' },

--- a/web/src/pages/studio/__tests__/Ops.test.tsx
+++ b/web/src/pages/studio/__tests__/Ops.test.tsx
@@ -66,6 +66,7 @@ describe('OpsPage', () => {
     useAuthStore.setState({ token: null, user: null, admin: null });
     vi.mocked(queryOpsHomePage).mockResolvedValue({
       namesvrAddrList: ['127.0.0.1:9876', '127.0.0.2:9876'],
+      configurationAvailable: true,
       useVIPChannel: true,
       useTLS: false,
       currentNamesrv: '127.0.0.1:9876',

--- a/web/src/pages/studio/__tests__/Producer.test.tsx
+++ b/web/src/pages/studio/__tests__/Producer.test.tsx
@@ -26,11 +26,16 @@ import {
   fetchTopicList,
   queryProducerConnection,
 } from '../../../api/producer';
+import { listInstances } from '../../../services/instanceService';
 
 vi.mock('../../../api/producer', () => ({
   fetchProducerGroups: vi.fn(),
   fetchTopicList: vi.fn(),
   queryProducerConnection: vi.fn(),
+}));
+
+vi.mock('../../../services/instanceService', () => ({
+  listInstances: vi.fn(),
 }));
 
 beforeAll(() => {
@@ -60,6 +65,19 @@ const renderWithProviders = (ui: React.ReactElement) => {
 describe('ProducerPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'instance-1',
+        name: 'Primary instance',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '127.0.0.1:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-08-01T00:00:00',
+        updatedAt: '2026-08-01T00:00:00',
+      },
+    ]);
     vi.mocked(fetchTopicList).mockResolvedValue(['order-events', 'payment-events']);
     vi.mocked(fetchProducerGroups).mockResolvedValue(['pg-order', 'pg-payment']);
     vi.mocked(queryProducerConnection).mockResolvedValue([]);
@@ -81,7 +99,7 @@ describe('ProducerPage', () => {
       expect(fetchTopicList).toHaveBeenCalledTimes(1);
     });
 
-    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(screen.getAllByRole('combobox')[1]);
     await screen.findByRole('option', { name: 'order-events' });
     expect(await screen.findByRole('option', { name: 'payment-events' })).toBeInTheDocument();
   });
@@ -91,7 +109,7 @@ describe('ProducerPage', () => {
     renderWithProviders(<ProducerPage />);
 
     await waitFor(() => expect(fetchProducerGroups).toHaveBeenCalledTimes(1));
-    const groupInput = screen.getAllByRole('combobox')[1];
+    const groupInput = screen.getAllByRole('combobox')[2];
     await user.type(groupInput, 'payment');
 
     expect(await screen.findByRole('option', { name: 'pg-payment' })).toBeInTheDocument();
@@ -110,7 +128,7 @@ describe('ProducerPage', () => {
     renderWithProviders(<ProducerPage />);
 
     await waitFor(() => expect(fetchTopicList).toHaveBeenCalledTimes(1));
-    const [topicSelect, groupInput] = screen.getAllByRole('combobox');
+    const [, topicSelect, groupInput] = screen.getAllByRole('combobox');
     fireEvent.mouseDown(topicSelect.parentElement!);
     await user.click(
       await screen.findByText('order-events', { selector: '.ant-select-item-option-content' }),
@@ -119,7 +137,11 @@ describe('ProducerPage', () => {
     await user.click(screen.getByRole('button', { name: /搜索/ }));
 
     await waitFor(() => {
-      expect(queryProducerConnection).toHaveBeenCalledWith('order-events', 'order-producer');
+      expect(queryProducerConnection).toHaveBeenCalledWith(
+        'instance-1',
+        'order-events',
+        'order-producer',
+      );
     });
     expect(await screen.findByText('producer-1')).toBeInTheDocument();
   });
@@ -129,7 +151,7 @@ describe('ProducerPage', () => {
     renderWithProviders(<ProducerPage />);
 
     await waitFor(() => expect(fetchTopicList).toHaveBeenCalledTimes(1));
-    const [topicSelect] = screen.getAllByRole('combobox');
+    const [, topicSelect] = screen.getAllByRole('combobox');
     fireEvent.mouseDown(topicSelect.parentElement!);
     await user.click(
       await screen.findByText('order-events', { selector: '.ant-select-item-option-content' }),
@@ -148,7 +170,7 @@ describe('ProducerPage', () => {
     renderWithProviders(<ProducerPage />);
 
     await waitFor(() => expect(fetchTopicList).toHaveBeenCalledTimes(1));
-    const [topicSelect, groupInput] = screen.getAllByRole('combobox');
+    const [, topicSelect, groupInput] = screen.getAllByRole('combobox');
     fireEvent.mouseDown(topicSelect.parentElement!);
     await user.click(
       await screen.findByText('order-events', { selector: '.ant-select-item-option-content' }),
@@ -157,7 +179,11 @@ describe('ProducerPage', () => {
     await user.click(screen.getByRole('button', { name: /搜索/ }));
 
     await waitFor(() => {
-      expect(queryProducerConnection).toHaveBeenCalledWith('order-events', 'manual-producer');
+      expect(queryProducerConnection).toHaveBeenCalledWith(
+        'instance-1',
+        'order-events',
+        'manual-producer',
+      );
     });
   });
 });

--- a/web/src/services/consumerService.ts
+++ b/web/src/services/consumerService.ts
@@ -121,12 +121,25 @@ export async function resetConsumerOffset(data: ResetConsumerOffsetRequest): Pro
   return metadataApi.resetConsumerOffset(data);
 }
 
-// Batch delete: loop through single delete calls
+export interface BatchDeleteConsumerGroupsResult {
+  deleted: string[];
+  failed: string[];
+}
+
+// Batch delete: attempt every selected group and report partial failures so a single
+// failing group cannot silently abort the whole batch.
 export async function batchDeleteConsumerGroups(
   names: string[],
   instanceId?: string,
-): Promise<void> {
+): Promise<BatchDeleteConsumerGroupsResult> {
+  const result: BatchDeleteConsumerGroupsResult = { deleted: [], failed: [] };
   for (const name of names) {
-    await deleteConsumerGroup(name, instanceId);
+    try {
+      await deleteConsumerGroup(name, instanceId);
+      result.deleted.push(name);
+    } catch {
+      result.failed.push(name);
+    }
   }
+  return result;
 }

--- a/web/src/services/dashboardService.ts
+++ b/web/src/services/dashboardService.ts
@@ -10,12 +10,12 @@ function copyClusterOverview(cluster: DashboardData['clusters'][number]) {
   };
 }
 
-export async function getDashboard(): Promise<DashboardData> {
+export async function getDashboard(instanceId?: string): Promise<DashboardData> {
   if (isMockMode()) {
     return {
       stats: { ...dashboardStats },
       clusters: (clusterOverview as DashboardData['clusters']).map(copyClusterOverview),
     };
   }
-  return metricsApi.getDashboard();
+  return metricsApi.getDashboard(instanceId);
 }


### PR DESCRIPTION
## Summary

- add an opt-in `postgresql` Spring profile while keeping the existing MySQL/H2 defaults unchanged
- add the PostgreSQL JDBC driver and Flyway PostgreSQL support
- provide a versioned PostgreSQL baseline covering all 15 Studio-owned persistence tables and indexes
- configure MyBatis Plus for the PostgreSQL database id and automatic schema migration
- document the PostgreSQL deployment environment variables
- add Testcontainers coverage that boots the Spring context and exercises MyBatis CRUD against PostgreSQL 16

## Why

Issue #956 asks for PostgreSQL persistence support. The current datasource configuration and schema are MySQL-oriented, so pointing Studio at PostgreSQL is not enough: startup schema initialization, data types, identity columns, booleans, and index naming all need a PostgreSQL-compatible path.

This change makes PostgreSQL explicit and opt-in. It does not change the default development or production datasource behavior.

## Validation

- `mvn -DskipTests=false -Dtest=PostgresqlPersistenceIntegrationTest test` (compilation and Checkstyle pass; Testcontainers is skipped locally because Testcontainers 1.21.2 cannot negotiate with Docker Desktop 29)
- `mvn -DskipTests=false -Dtest=StudioApplicationTest test`
- PostgreSQL 16 + Flyway 11.7.2 manual migration: all 15 Studio tables created, history version recorded, second migration is a no-op
- started the actual application with `SPRING_PROFILES_ACTIVE=postgresql`; `/actuator/health` returned `UP`
- verified instance create/list/delete through `/api/instances` against PostgreSQL and confirmed the final database row count returned to zero

Fixes #956
