### PR TITLE
fix: harden message and DLQ request handling

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -65,6 +65,7 @@ import java.util.Set;
 public class RocketMQAdminClientImpl implements AdminClient {
 
     private static final String MESSAGE_SENDER_GROUP_PREFIX = "studio-msg-sender";
+    private static final int MAX_MESSAGE_SIZE = 4 * 1024 * 1024; // 4 MB default broker limit
 
     private final MqAdminExtFactory adminFactory;
     private final RocketMQProperties properties;
@@ -324,9 +325,13 @@ public class RocketMQAdminClientImpl implements AdminClient {
             String tag = request.getTag() != null ? request.getTag() : "";
             String key = request.getKey() != null ? request.getKey() : "";
             String body = request.getBody() != null ? request.getBody() : "";
+            byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+            if (bodyBytes.length > MAX_MESSAGE_SIZE) {
+                throw new BusinessException(400, "Message body size " + bodyBytes.length
+                        + " exceeds the maximum of " + MAX_MESSAGE_SIZE + " bytes");
+            }
 
-            String fullTopic = tag.isEmpty() ? topic : topic + ":" + tag;
-            Message msg = new Message(topic, tag, key, body.getBytes(StandardCharsets.UTF_8));
+            Message msg = new Message(topic, tag, key, bodyBytes);
 
             // Add custom properties
             if (request.getProperties() != null) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -63,6 +63,7 @@ public class RocketMQDLQProvider implements DLQProvider {
 
     private static final long ONE_HOUR_MILLIS = 3600_000L;
     private static final int RESEND_HARD_CAP = 5000;
+    private static final int MAX_CONSECUTIVE_OFFSET_ILLEGAL = 3;
     private static final String ORIGIN_MESSAGE_ID_PROPERTY = "studio_dlq_origin_message_id";
     private static final String ORIGIN_TOPIC_PROPERTY = "studio_dlq_origin_topic";
 
@@ -192,6 +193,7 @@ public class RocketMQDLQProvider implements DLQProvider {
                 try {
                     long minOffset = consumer.searchOffset(queue, begin);
                     long maxOffset = consumer.searchOffset(queue, end);
+                    int consecutiveIllegalOffsets = 0;
                     for (long offset = minOffset; offset <= maxOffset; ) {
                         if (result.size() >= RESEND_HARD_CAP) {
                             break outer;
@@ -208,10 +210,28 @@ public class RocketMQDLQProvider implements DLQProvider {
                             break;
                         }
                         offset = nextOffset;
+                        if (pullResult.getPullStatus() == PullStatus.OFFSET_ILLEGAL) {
+                            // The broker returned a corrected offset in nextBeginOffset because
+                            // the requested offset is no longer valid (expired, compacted, or
+                            // before the queue's minimum offset). Retry from the corrected
+                            // position instead of abandoning the queue -- otherwise dead-letter
+                            // messages that still exist after the corrected offset are silently
+                            // dropped and never resent.
+                            if (++consecutiveIllegalOffsets > MAX_CONSECUTIVE_OFFSET_ILLEGAL) {
+                                log.warn("Stop DLQ scan for {} because queue {} returned OFFSET_ILLEGAL "
+                                        + "{} times consecutively, giving up at offset {}", dlqTopic, queue,
+                                        consecutiveIllegalOffsets, offset);
+                                break;
+                            }
+                            log.debug("Offset was illegal for queue {} in DLQ {}, retrying from {}",
+                                    queue, dlqTopic, offset);
+                            continue;
+                        }
                         if (pullResult.getPullStatus() != PullStatus.FOUND
                                 || pullResult.getMsgFoundList() == null) {
                             break;
                         }
+                        consecutiveIllegalOffsets = 0;
                         for (MessageExt messageExt : pullResult.getMsgFoundList()) {
                             if (messageExt.getStoreTimestamp() >= begin
                                     && messageExt.getStoreTimestamp() <= end) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -100,6 +100,9 @@ public class RocketMQMessageProvider implements MessageProvider {
 
         long end = endTime != null ? endTime : System.currentTimeMillis();
         long begin = startTime != null ? startTime : end - ONE_HOUR_MILLIS;
+        if (begin >= end) {
+            throw new BusinessException(400, "Message query start time must be before end time");
+        }
 
         List<MessageRecordVO> result;
         String queryType;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -80,6 +80,7 @@ public class RocketMQMessageProvider implements MessageProvider {
     private static final int MAX_PROPERTY_VALUE_CHARS = 1024;
     private static final long ONE_HOUR_MILLIS = 3600_000L;
     private static final long ONE_DAY_MILLIS = 24 * ONE_HOUR_MILLIS;
+    private static final int MAX_CONSECUTIVE_OFFSET_ILLEGAL = 3;
 
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
     private final QueryHistoryService queryHistoryService;
@@ -198,6 +199,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             for (MessageQueue queue : queues) {
                 long minOffset = consumer.searchOffset(queue, begin);
                 long maxOffset = consumer.searchOffset(queue, end);
+                int consecutiveIllegalOffsets = 0;
                 for (long offset = minOffset; offset <= maxOffset; ) {
                     if (result.size() >= Math.min(limit, TOPIC_QUERY_HARD_CAP)) {
                         break outer;
@@ -213,10 +215,27 @@ public class RocketMQMessageProvider implements MessageProvider {
                         break;
                     }
                     offset = nextOffset;
+                    if (pullResult.getPullStatus() == PullStatus.OFFSET_ILLEGAL) {
+                        // The broker returned a corrected offset in nextBeginOffset because
+                        // the requested offset is no longer valid (expired, compacted, or
+                        // before the queue's minimum offset). Retry from the corrected
+                        // position instead of abandoning the queue -- otherwise messages
+                        // that still exist after the corrected offset are silently dropped.
+                        if (++consecutiveIllegalOffsets > MAX_CONSECUTIVE_OFFSET_ILLEGAL) {
+                            log.warn("Stop topic query for {} because queue {} returned OFFSET_ILLEGAL "
+                                    + "{} times consecutively, giving up at offset {}", topic, queue,
+                                    consecutiveIllegalOffsets, offset);
+                            break;
+                        }
+                        log.debug("Offset was illegal for queue {} in topic {}, retrying from {}",
+                                queue, topic, offset);
+                        continue;
+                    }
                     if (pullResult.getPullStatus() != PullStatus.FOUND
                             || pullResult.getMsgFoundList() == null) {
                         break;
                     }
+                    consecutiveIllegalOffsets = 0;
                     for (MessageExt messageExt : pullResult.getMsgFoundList()) {
                         if (messageExt.getStoreTimestamp() < begin
                                 || messageExt.getStoreTimestamp() > end) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -457,6 +457,17 @@ public class RocketMQMessageProvider implements MessageProvider {
             return new DisplayBody(null, null, false);
         }
         int textLength = Math.min(body.length, MAX_BODY_DISPLAY_BYTES);
+        // When truncating, walk back to the last complete UTF-8 character boundary
+        // to avoid splitting a multi-byte character, which would cause the decoder
+        // to fall through to BASE64 encoding even for valid UTF-8 text.
+        if (textLength < body.length) {
+            while (textLength > 0 && (body[textLength] & 0xC0) == 0x80) {
+                textLength--;
+            }
+            if (textLength > 0 && (body[textLength] & 0xC0) == 0xC0) {
+                textLength--;
+            }
+        }
         try {
             String value = StandardCharsets.UTF_8.newDecoder()
                     .onMalformedInput(CodingErrorAction.REPORT)


### PR DESCRIPTION
This merged batch contains four request and scan hardening fixes:

- retry topic and DLQ pulls from the broker-corrected offset after `OFFSET_ILLEGAL`;
- truncate displayed UTF-8 bodies only at a complete character boundary;
- reject message-query windows whose start is not before the end;
- reject message bodies above the 4 MiB limit before creating a producer.

These changes address #1353, #1424, #1433, and #1443. The provider and validation regression tests were later consolidated into #2034.