### PR TITLE
fix(web): require an instance for message queries

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -27,10 +27,14 @@ const messageServiceMocks = vi.hoisted(() => ({
   getMessageTrace: vi.fn(),
   queryMessages: vi.fn(),
 }));
+const instanceFilterMocks = vi.hoisted(() => ({
+  useInstanceFilter: vi.fn(),
+}));
 
 const QUERY_HISTORY_STORAGE_KEY = 'rocketmq-studio-message-query-history';
 
 vi.mock('../../../services/messageService', () => messageServiceMocks);
+vi.mock('../../../hooks/useInstanceFilter', () => instanceFilterMocks);
 
 vi.mock('../../../services/instanceService', () => ({
   listInstances: vi.fn().mockResolvedValue([]),
@@ -94,6 +98,11 @@ describe('Message page query history', () => {
     localStorage.clear();
     messageServiceMocks.getMessageTrace.mockReset().mockResolvedValue(null);
     messageServiceMocks.queryMessages.mockReset().mockResolvedValue([]);
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
   });
 
   afterEach(() => {
@@ -115,7 +124,7 @@ describe('Message page query history', () => {
       expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
         topic: 'order-create',
         msgId: 'MID-001',
-        instanceId: '',
+        instanceId: 'instance-a',
       });
       expect(screen.getByRole('button', { name: /最近查询/ })).toBeEnabled();
     });
@@ -132,7 +141,7 @@ describe('Message page query history', () => {
       expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
         topic: 'order-create',
         msgId: 'MID-001',
-        instanceId: '',
+        instanceId: 'instance-a',
       });
     });
 
@@ -157,7 +166,7 @@ describe('Message page query history', () => {
       expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
         topic: 'order-create',
         msgId: 'MID-FAILED',
-        instanceId: '',
+        instanceId: 'instance-a',
       });
     });
     expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
@@ -237,7 +246,7 @@ describe('Message page query history', () => {
     await waitFor(() => {
       expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith({
         ...topicParams,
-        instanceId: '',
+        instanceId: 'instance-a',
       });
     });
 
@@ -246,7 +255,7 @@ describe('Message page query history', () => {
     await waitFor(() => {
       expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith({
         ...keyParams,
-        instanceId: '',
+        instanceId: 'instance-a',
       });
       expect(screen.getByPlaceholderText('输入 Message Key')).toHaveValue('ORDER-001');
     });
@@ -289,5 +298,22 @@ describe('Message page query history', () => {
       await screen.findByText('消费验证接口尚未接入，无法确认该消息的真实消费状态'),
     ).toBeInTheDocument();
     expect(screen.queryByText(/消费验证成功/)).not.toBeInTheDocument();
+  });
+
+  it('requires an instance before allowing a message query', async () => {
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: '',
+      selectInstance: vi.fn(),
+      instanceOptions: [],
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<MessagePage />);
+
+    await user.click(screen.getByText('按 Message ID'));
+    await user.type(screen.getByPlaceholderText('输入 Message ID'), 'MID-NO-INSTANCE');
+
+    expect(screen.getByRole('button', { name: /^search查询$/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
+    expect(messageServiceMocks.queryMessages).not.toHaveBeenCalled();
   });
 });

--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -28,8 +28,12 @@ const serviceMocks = vi.hoisted(() => ({
   getMessageTrace: vi.fn(),
   queryMessages: vi.fn(),
 }));
+const instanceFilterMocks = vi.hoisted(() => ({
+  useInstanceFilter: vi.fn(),
+}));
 
 vi.mock('../../../services/messageService', () => serviceMocks);
+vi.mock('../../../hooks/useInstanceFilter', () => instanceFilterMocks);
 
 vi.mock('../../../services/instanceService', () => ({
   listInstances: vi.fn().mockResolvedValue([]),
@@ -107,6 +111,11 @@ describe('MessagePage async request ownership', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     serviceMocks.getMessageTrace.mockResolvedValue(null);
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
     vi.spyOn(message, 'success').mockImplementation(vi.fn());
   });
 

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -289,6 +289,10 @@ const MessagePage = () => {
   };
 
   const executeQuery = async (mode: QueryMode, params: MessageQuery) => {
+    if (!selectedInstanceId) {
+      setQueryError('请先选择实例后再查询消息');
+      return;
+    }
     const requestGeneration = queryGenerationRef.current + 1;
     queryGenerationRef.current = requestGeneration;
     setQueryLoading(true);
@@ -777,6 +781,8 @@ const MessagePage = () => {
             <Button
               type="primary"
               icon={<SearchOutlined />}
+              disabled={!selectedInstanceId}
+              title={selectedInstanceId ? undefined : '请先选择实例'}
               onClick={() => {
                 void handleQuery();
               }}
@@ -786,9 +792,12 @@ const MessagePage = () => {
             <Dropdown
               menu={{ items: recentQueryMenuItems, onClick: handleRecentQueryMenuClick }}
               trigger={['click']}
-              disabled={recentQueries.length === 0}
+              disabled={recentQueries.length === 0 || !selectedInstanceId}
             >
-              <Button icon={<HistoryOutlined />} disabled={recentQueries.length === 0}>
+              <Button
+                icon={<HistoryOutlined />}
+                disabled={recentQueries.length === 0 || !selectedInstanceId}
+              >
                 最近查询
               </Button>
             </Dropdown>


### PR DESCRIPTION
Closes #1380

## Summary
- disable message queries and query-history replay until an instance is selected
- guard query execution so stale UI events cannot send an unscoped request
- update message-page tests to use explicit instance context and cover the no-instance state

## Verification
- npm test -- --run src/pages/instance/__tests__/MessagePage.test.tsx src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
- npm run build