### PR TITLE
fix(web): clear message state on instance change

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -28,8 +28,12 @@ const serviceMocks = vi.hoisted(() => ({
   getMessageTrace: vi.fn(),
   queryMessages: vi.fn(),
 }));
+const instanceFilterMocks = vi.hoisted(() => ({
+  useInstanceFilter: vi.fn(),
+}));
 
 vi.mock('../../../services/messageService', () => serviceMocks);
+vi.mock('../../../hooks/useInstanceFilter', () => instanceFilterMocks);
 
 vi.mock('../../../services/instanceService', () => ({
   listInstances: vi.fn().mockResolvedValue([]),
@@ -90,23 +94,29 @@ const createTrace = (title: string): TraceRecord => ({
   consumerStatus: [],
 });
 
-const renderPage = () =>
-  render(
-    <ConfigProvider theme={{ token: { motion: false } }}>
-      <App>
-        <LangProvider>
-          <MemoryRouter>
-            <MessagePage />
-          </MemoryRouter>
-        </LangProvider>
-      </App>
-    </ConfigProvider>,
-  );
+const MessagePageWithProviders = () => (
+  <ConfigProvider theme={{ token: { motion: false } }}>
+    <App>
+      <LangProvider>
+        <MemoryRouter>
+          <MessagePage />
+        </MemoryRouter>
+      </LangProvider>
+    </App>
+  </ConfigProvider>
+);
+
+const renderPage = () => render(<MessagePageWithProviders />);
 
 describe('MessagePage async request ownership', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     serviceMocks.getMessageTrace.mockResolvedValue(null);
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
     vi.spyOn(message, 'success').mockImplementation(vi.fn());
   });
 
@@ -129,6 +139,29 @@ describe('MessagePage async request ownership', () => {
     });
 
     expect(screen.queryByText('late-after-reset')).not.toBeInTheDocument();
+  });
+
+  it('clears query results and message details when the selected instance changes', async () => {
+    serviceMocks.queryMessages.mockResolvedValue([createMessage('message-from-instance-a')]);
+    const user = userEvent.setup();
+    const page = renderPage();
+
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+    const row = await screen.findByRole('row', { name: /message-from-instance-a/ });
+    await user.click(within(row).getByRole('button', { name: /详情/ }));
+    expect(await screen.findByRole('dialog', { name: '消息详情' })).toBeInTheDocument();
+
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-b',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-b', label: 'Instance B' }],
+    });
+    page.rerender(<MessagePageWithProviders />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('message-from-instance-a')).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog', { name: '消息详情' })).not.toBeInTheDocument();
+    });
   });
   it('surfaces unavailable message provider errors from query requests', async () => {
     serviceMocks.queryMessages.mockRejectedValue(

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -259,6 +259,19 @@ const MessagePage = () => {
     [],
   );
 
+  useEffect(() => {
+    queryGenerationRef.current += 1;
+    traceGenerationRef.current += 1;
+    setMessages([]);
+    setQueryLoading(false);
+    setQueryError(null);
+    setSelectedMsg(null);
+    setModalOpen(false);
+    setTraceData(null);
+    setTraceLoading(false);
+    setTraceError(null);
+  }, [selectedInstanceId]);
+
   /* ─── Handlers ─── */
   const handleReset = () => {
     queryGenerationRef.current += 1;


### PR DESCRIPTION
Closes #1383

## Summary
- treat a selected-instance change as a message query context boundary
- clear results, selected details, trace state, and query errors
- invalidate in-flight query and trace responses from the previous instance
- add a regression test for stale results and message detail dialogs

## Verification
- npm test -- --run src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
- npm run build