### PR TITLE
fix(web): scope message topics by instance

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -27,25 +27,22 @@ const messageServiceMocks = vi.hoisted(() => ({
   getMessageTrace: vi.fn(),
   queryMessages: vi.fn(),
 }));
+const topicServiceMocks = vi.hoisted(() => ({
+  listTopics: vi.fn(),
+}));
+const instanceFilterMocks = vi.hoisted(() => ({
+  useInstanceFilter: vi.fn(),
+}));
 
 const QUERY_HISTORY_STORAGE_KEY = 'rocketmq-studio-message-query-history';
 
 vi.mock('../../../services/messageService', () => messageServiceMocks);
+vi.mock('../../../hooks/useInstanceFilter', () => instanceFilterMocks);
 
 vi.mock('../../../services/instanceService', () => ({
   listInstances: vi.fn().mockResolvedValue([]),
 }));
-vi.mock('../../../services/topicService', () => ({
-  listTopics: vi
-    .fn()
-    .mockResolvedValue([
-      { name: 'order-create' },
-      { name: 'payment-callback' },
-      { name: 'user-activity-log' },
-      { name: 'notification-push' },
-      { name: 'inventory-sync' },
-    ]),
-}));
+vi.mock('../../../services/topicService', () => topicServiceMocks);
 
 import MessagePage from '../message';
 
@@ -94,6 +91,12 @@ describe('Message page query history', () => {
     localStorage.clear();
     messageServiceMocks.getMessageTrace.mockReset().mockResolvedValue(null);
     messageServiceMocks.queryMessages.mockReset().mockResolvedValue([]);
+    topicServiceMocks.listTopics.mockReset().mockResolvedValue([]);
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: '',
+      selectInstance: vi.fn(),
+      instanceOptions: [],
+    });
   });
 
   afterEach(() => {
@@ -102,6 +105,14 @@ describe('Message page query history', () => {
 
   it('persists successful queries for replay and allows clearing the history', async () => {
     const user = userEvent.setup();
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
+    topicServiceMocks.listTopics.mockResolvedValue([
+      { name: 'order-create', instanceId: 'instance-a' },
+    ]);
     const firstView = renderWithProviders(<MessagePage />);
     expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
 
@@ -115,7 +126,7 @@ describe('Message page query history', () => {
       expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
         topic: 'order-create',
         msgId: 'MID-001',
-        instanceId: '',
+        instanceId: 'instance-a',
       });
       expect(screen.getByRole('button', { name: /最近查询/ })).toBeEnabled();
     });
@@ -132,7 +143,7 @@ describe('Message page query history', () => {
       expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
         topic: 'order-create',
         msgId: 'MID-001',
-        instanceId: '',
+        instanceId: 'instance-a',
       });
     });
 
@@ -144,6 +155,14 @@ describe('Message page query history', () => {
 
   it('does not save failed queries', async () => {
     const user = userEvent.setup();
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
+    topicServiceMocks.listTopics.mockResolvedValue([
+      { name: 'order-create', instanceId: 'instance-a' },
+    ]);
     messageServiceMocks.queryMessages.mockRejectedValue(new Error('network error'));
     renderWithProviders(<MessagePage />);
 
@@ -157,7 +176,7 @@ describe('Message page query history', () => {
       expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
         topic: 'order-create',
         msgId: 'MID-FAILED',
-        instanceId: '',
+        instanceId: 'instance-a',
       });
     });
     expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
@@ -166,6 +185,14 @@ describe('Message page query history', () => {
 
   it('keeps five unique queries and moves a repeated query to the front', async () => {
     const user = userEvent.setup();
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
+    topicServiceMocks.listTopics.mockResolvedValue([
+      { name: 'order-create', instanceId: 'instance-a' },
+    ]);
     renderWithProviders(<MessagePage />);
     await user.click(screen.getByText('按 Message ID'));
     await user.click(lastElement(screen.getAllByRole('combobox')));
@@ -273,6 +300,14 @@ describe('Message page query history', () => {
 
   it('does not report consume verification success without a backend API', async () => {
     const user = userEvent.setup();
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
+    topicServiceMocks.listTopics.mockResolvedValue([
+      { name: 'order-create', instanceId: 'instance-a' },
+    ]);
     messageServiceMocks.queryMessages.mockResolvedValue([createMessage('MID-CONSUME-VERIFY-001')]);
     renderWithProviders(<MessagePage />);
 
@@ -289,5 +324,43 @@ describe('Message page query history', () => {
       await screen.findByText('消费验证接口尚未接入，无法确认该消息的真实消费状态'),
     ).toBeInTheDocument();
     expect(screen.queryByText(/消费验证成功/)).not.toBeInTheDocument();
+  });
+
+  it('loads topic options only for the selected instance', async () => {
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
+    topicServiceMocks.listTopics.mockResolvedValue([{ name: 'topic-on-instance-a' }]);
+    renderWithProviders(<MessagePage />);
+
+    await waitFor(() => {
+      expect(topicServiceMocks.listTopics).toHaveBeenCalledWith({ instanceId: 'instance-a' });
+    });
+  });
+
+  it('does not load static topic options without a selected instance', async () => {
+    renderWithProviders(<MessagePage />);
+
+    await waitFor(() => {
+      expect(topicServiceMocks.listTopics).not.toHaveBeenCalled();
+    });
+  });
+
+  it('clears topic options when loading the selected instance topics fails', async () => {
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
+    topicServiceMocks.listTopics.mockRejectedValue(new Error('topic lookup failed'));
+    const user = userEvent.setup();
+    renderWithProviders(<MessagePage />);
+
+    await waitFor(() => expect(topicServiceMocks.listTopics).toHaveBeenCalledTimes(1));
+    await user.click(screen.getAllByRole('combobox')[1]);
+
+    expect(screen.queryByText('order-create')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -92,14 +92,6 @@ const QUERY_OPTIONS = [
   { value: 'msgid' as const, label: '按 Message ID' },
 ];
 
-const TOPIC_OPTIONS = [
-  'order-create',
-  'payment-callback',
-  'user-activity-log',
-  'notification-push',
-  'inventory-sync',
-];
-
 const DELIVERY_STATUS_MAP: Record<string, { label: string; color: string }> = {
   success: { label: '成功', color: 'green' },
   failed: { label: '失败', color: 'red' },
@@ -212,11 +204,17 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
 const MessagePage = () => {
   const { t } = useLang();
   const { selectedInstanceId, selectInstance, instanceOptions } = useInstanceFilter();
-  const [topicOptions, setTopicOptions] = useState<string[]>(TOPIC_OPTIONS);
+  const [topicOptions, setTopicOptions] = useState<string[]>([]);
+  const [selectedTopic, setSelectedTopic] = useState<string | undefined>();
 
   useEffect(() => {
     let cancelled = false;
-    void listTopics()
+    if (!selectedInstanceId) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    void listTopics({ instanceId: selectedInstanceId })
       .then((nextTopics) => {
         if (cancelled) return;
         const scoped = selectedInstanceId
@@ -227,14 +225,18 @@ const MessagePage = () => {
         setTopicOptions(scoped.map((topic) => topic.name));
       })
       .catch(() => {
-        // 加载失败保持静态选项可用
+        if (!cancelled) setTopicOptions([]);
       });
     return () => {
       cancelled = true;
     };
   }, [selectedInstanceId]);
+  const handleInstanceChange = (id: string) => {
+    setTopicOptions([]);
+    setSelectedTopic(undefined);
+    selectInstance(id);
+  };
   const [queryMode, setQueryMode] = useState<QueryMode>('topic');
-  const [selectedTopic, setSelectedTopic] = useState<string | undefined>();
   const [dateRange, setDateRange] = useState<[Dayjs, Dayjs]>(getDefaultRange);
   const [keyInput, setKeyInput] = useState('');
   const [msgIdInput, setMsgIdInput] = useState('');
@@ -688,7 +690,7 @@ const MessagePage = () => {
             <Select
               placeholder="选择实例"
               value={selectedInstanceId || undefined}
-              onChange={selectInstance}
+              onChange={handleInstanceChange}
               options={instanceOptions}
               style={{ width: 220 }}
               notFoundContent="暂无实例"

--- a/web/src/services/topicService.test.ts
+++ b/web/src/services/topicService.test.ts
@@ -69,6 +69,13 @@ describe('topic service mock data', () => {
     expect(blankSearchTopics).toHaveLength(allTopics.length);
   });
 
+  it('filters mock topics by instance ID', async () => {
+    const topics = await listTopics({ instanceId: 'instance-proxy-1' });
+
+    expect(topics).not.toHaveLength(0);
+    expect(topics.every((topic) => topic.instanceId === 'instance-proxy-1')).toBe(true);
+  });
+
   it('rejects duplicate topic creates in the same cluster', async () => {
     const existing = (await listTopics({ search: 'order-create' }))[0];
     const before = await listTopics({ clusterId: existing.clusterId });

--- a/web/src/services/topicService.ts
+++ b/web/src/services/topicService.ts
@@ -24,6 +24,7 @@ export async function listTopics(params?: TopicQuery): Promise<Topic[]> {
     }
     if (params?.type) result = result.filter((t) => t.type === params.type);
     if (params?.clusterId) result = result.filter((t) => t.clusterId === params.clusterId);
+    if (params?.instanceId) result = result.filter((t) => t.instanceId === params.instanceId);
     return (result as unknown as Topic[]).map(cloneTopic);
   }
   return metadataApi.listTopics(params);


### PR DESCRIPTION
Closes #1385

## Summary
- request Message Explorer topics with the selected instance ID
- clear topic choices when there is no selected instance or topic loading fails
- apply the same instance filter in mock mode
- cover instance-scoped and failed topic loading

## Verification
- npm test -- --run src/pages/instance/__tests__/MessagePage.test.tsx src/services/topicService.test.ts
- npm run build