### PR TITLE
fix(settings): validate Metrics data source types

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/settings/DataSourceDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/DataSourceDTO.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.settings;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
 @Data
@@ -28,6 +29,9 @@ public class DataSourceDTO {
     private String name;
 
     @NotBlank(message = "type is required")
+    @Pattern(
+            regexp = "(?i)\\s*(?:prometheus|victoria[ _]?metrics|thanos|mimir|cortex|arms)?\\s*",
+            message = "Unsupported metrics data source type")
     private String type;
 
     @NotBlank(message = "url is required")
@@ -39,7 +43,7 @@ public class DataSourceDTO {
         return DataSourceVO.builder()
                 .key(key)
                 .name(name)
-                .type(type)
+                .type(type.trim())
                 .url(url)
                 .auth(auth)
                 .build();

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
@@ -160,9 +160,9 @@ class SettingsControllerTest {
 
     @Test
     void listDataSourcesShouldReturnAllSources() throws Exception {
-        DataSourceVO ds1 = DataSourceVO.builder().key("ds-1").name("Production").type("rocketmq")
+        DataSourceVO ds1 = DataSourceVO.builder().key("ds-1").name("Production").type("Prometheus")
                 .url("prod:9876").status("connected").build();
-        DataSourceVO ds2 = DataSourceVO.builder().key("ds-2").name("Staging").type("rocketmq")
+        DataSourceVO ds2 = DataSourceVO.builder().key("ds-2").name("Staging").type("Prometheus")
                 .url("staging:9876").status("disconnected").build();
         when(settingsService.listDataSources()).thenReturn(Arrays.asList(ds1, ds2));
 
@@ -189,9 +189,9 @@ class SettingsControllerTest {
 
     @Test
     void createDataSourceShouldReturnCreatedSource() throws Exception {
-        DataSourceVO input = DataSourceVO.builder().name("New DS").type("rocketmq")
+        DataSourceVO input = DataSourceVO.builder().name("New DS").type("Prometheus")
                 .url("new-host:9876").build();
-        DataSourceVO created = DataSourceVO.builder().key("ds-new").name("New DS").type("rocketmq")
+        DataSourceVO created = DataSourceVO.builder().key("ds-new").name("New DS").type("Prometheus")
                 .url("new-host:9876").status("connected").build();
         when(settingsService.createDataSource(any(DataSourceVO.class))).thenReturn(created);
 
@@ -223,6 +223,24 @@ class SettingsControllerTest {
     }
 
     @Test
+    void createDataSourceShouldRejectUnsupportedMetricsType() throws Exception {
+        mockMvc.perform(post("/api/settings/datasources/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "New DS",
+                                  "type": "unsupported",
+                                  "url": "http://metrics.example.test"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", is(400)))
+                .andExpect(jsonPath("$.message", is("Unsupported metrics data source type")));
+
+        verifyNoInteractions(settingsService);
+    }
+
+    @Test
     void createDataSourceShouldRejectNullRequestBody() throws Exception {
         mockMvc.perform(post("/api/settings/datasources/create")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -236,7 +254,7 @@ class SettingsControllerTest {
 
     @Test
     void updateDataSourceShouldReturnUpdatedSource() throws Exception {
-        DataSourceVO input = DataSourceVO.builder().key("ds-1").name("Updated DS").type("rocketmq")
+        DataSourceVO input = DataSourceVO.builder().key("ds-1").name("Updated DS").type("Prometheus")
                 .url("updated:9876").build();
         when(settingsService.updateDataSource(any(DataSourceVO.class))).thenReturn(input);
 
@@ -263,6 +281,25 @@ class SettingsControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code", is(400)))
                 .andExpect(jsonPath("$.message", is("name is required")));
+
+        verifyNoInteractions(settingsService);
+    }
+
+    @Test
+    void updateDataSourceShouldRejectUnsupportedMetricsType() throws Exception {
+        mockMvc.perform(post("/api/settings/datasources/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "key": "ds-1",
+                                  "name": "Updated DS",
+                                  "type": "unsupported",
+                                  "url": "http://metrics.example.test"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", is(400)))
+                .andExpect(jsonPath("$.message", is("Unsupported metrics data source type")));
 
         verifyNoInteractions(settingsService);
     }


### PR DESCRIPTION
Closes #1387

## Summary
- reject unsupported Metrics data-source types before persistence
- trim accepted types while retaining the display form used by the UI
- cover unsupported create and update requests

## Verification
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=SettingsControllerTest test