### PR TITLE
fix(settings): validate Metrics data source authentication

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/settings/DataSourceDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/DataSourceDTO.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.settings;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
 @Data
@@ -33,6 +34,9 @@ public class DataSourceDTO {
     @NotBlank(message = "url is required")
     private String url;
 
+    @Pattern(
+            regexp = "(?i)\\s*(?:none|basic auth|bearer token)?\\s*",
+            message = "Unsupported metrics data source authentication")
     private String auth;
 
     public DataSourceVO toDataSourceVO() {
@@ -41,7 +45,7 @@ public class DataSourceDTO {
                 .name(name)
                 .type(type)
                 .url(url)
-                .auth(auth)
+                .auth(auth == null ? null : auth.trim())
                 .build();
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
@@ -223,6 +223,25 @@ class SettingsControllerTest {
     }
 
     @Test
+    void createDataSourceShouldRejectUnsupportedAuthentication() throws Exception {
+        mockMvc.perform(post("/api/settings/datasources/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "New DS",
+                                  "type": "Prometheus",
+                                  "url": "http://metrics.example.test",
+                                  "auth": "API Key"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", is(400)))
+                .andExpect(jsonPath("$.message", is("Unsupported metrics data source authentication")));
+
+        verifyNoInteractions(settingsService);
+    }
+
+    @Test
     void createDataSourceShouldRejectNullRequestBody() throws Exception {
         mockMvc.perform(post("/api/settings/datasources/create")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -263,6 +282,26 @@ class SettingsControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code", is(400)))
                 .andExpect(jsonPath("$.message", is("name is required")));
+
+        verifyNoInteractions(settingsService);
+    }
+
+    @Test
+    void updateDataSourceShouldRejectUnsupportedAuthentication() throws Exception {
+        mockMvc.perform(post("/api/settings/datasources/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "key": "ds-1",
+                                  "name": "Updated DS",
+                                  "type": "Prometheus",
+                                  "url": "http://metrics.example.test",
+                                  "auth": "API Key"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", is(400)))
+                .andExpect(jsonPath("$.message", is("Unsupported metrics data source authentication")));
 
         verifyNoInteractions(settingsService);
     }


### PR DESCRIPTION
Closes #1389

## Summary
- reject unsupported Metrics data-source authentication modes before persistence
- preserve blank auth as no authentication and trim accepted values
- cover unsupported create and update requests

## Verification
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=SettingsControllerTest test