### PR TITLE
fix(settings): surface corrupt persisted data sources

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.studio.persistence.entity.RmqDataSource;
 import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
 import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqSettingsMapper;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.settings.DataSourceVO;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.apache.rocketmq.studio.settings.SettingsRepository;
@@ -162,7 +163,7 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
             return vo;
         } catch (JsonProcessingException e) {
             log.error("Failed to deserialize data source: {}", entity.getDsKey(), e);
-            return DataSourceVO.builder().key(entity.getDsKey()).build();
+            throw new BusinessException(500, "Persisted data source is invalid: " + entity.getDsKey());
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.persistence.entity.RmqDataSource;
+import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqSettingsMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MybatisPlusSettingsRepositoryTest {
+
+    private RmqDataSourceMapper dataSourceMapper;
+    private MybatisPlusSettingsRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        dataSourceMapper = mock(RmqDataSourceMapper.class);
+        repository = new MybatisPlusSettingsRepository(mock(RmqSettingsMapper.class), dataSourceMapper,
+                new ObjectMapper());
+    }
+
+    @Test
+    void shouldRejectCorruptPersistedDataSource() {
+        RmqDataSource dataSource = new RmqDataSource();
+        dataSource.setDsKey("metrics-prod");
+        dataSource.setJson("{not-json");
+        when(dataSourceMapper.selectById("metrics-prod")).thenReturn(dataSource);
+
+        assertThatThrownBy(() -> repository.findDataSourceByKey("metrics-prod"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Persisted data source is invalid: metrics-prod")
+                .extracting("code")
+                .isEqualTo(500);
+    }
+}


### PR DESCRIPTION
Closes #1395

## Summary
- reject malformed persisted data-source JSON instead of returning a key-only placeholder
- retain the data-source key in the structured error for operator diagnosis
- add a repository regression test

## Verification
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=MybatisPlusSettingsRepositoryTest test