### PR TITLE
fix(aliyun): cancel timed-out OpenAPI calls

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactory.java
@@ -92,6 +92,7 @@ public class AliyunClientFactory {
         try {
             return future.get(callTimeoutSeconds, TimeUnit.SECONDS);
         } catch (TimeoutException ex) {
+            future.cancel(true);
             throw new BusinessException(504,
                     "Aliyun OpenAPI request timed out after " + callTimeoutSeconds + " seconds");
         } catch (InterruptedException ex) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactoryTest.java
@@ -117,12 +117,14 @@ class AliyunClientFactoryTest {
         factory.setCallTimeoutSeconds(1L);
         AliyunClientFactory spy = Mockito.spy(factory);
         doReturn(asyncClient).when(spy).client(anyString(), anyString());
+        CompletableFuture<Object> future = new CompletableFuture<>();
 
         assertThatThrownBy(() -> spy.call(CREDENTIAL_ID, REGION,
-                client -> new CompletableFuture<>()))
+                client -> future))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
                 .isEqualTo(504);
+        assertThat(future).isCancelled();
     }
 
     @Test


### PR DESCRIPTION
Closes #1397

## Summary
- cancel an in-flight Aliyun SDK future when the bounded wait times out
- retain the existing 504 timeout response
- verify the timed-out future is cancelled

## Verification
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=AliyunClientFactoryTest test