### PR TITLE
fix: persist topic metadata during update

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -249,6 +249,12 @@ public class RocketMQAdminClientImpl implements AdminClient {
                     existing.setWriteQueueNums(writeQueues);
                     existing.setReadQueueNums(readQueues);
                     existing.setPerm(topicConfig.getPerm());
+                    if (topic.getType() != null) {
+                        existing.setTopicType(topic.getType().name());
+                    }
+                    if (StringUtils.hasText(topic.getRemark())) {
+                        existing.setRemark(topic.getRemark());
+                    }
                     existing.setUpdatedAt(LocalDateTime.now());
                     topicMapper.updateById(existing);
                 }
@@ -325,7 +331,6 @@ public class RocketMQAdminClientImpl implements AdminClient {
             String key = request.getKey() != null ? request.getKey() : "";
             String body = request.getBody() != null ? request.getBody() : "";
 
-            String fullTopic = tag.isEmpty() ? topic : topic + ":" + tag;
             Message msg = new Message(topic, tag, key, body.getBytes(StandardCharsets.UTF_8));
 
             // Add custom properties


### PR DESCRIPTION
This was the standalone implementation for #1392. It made `updateTopic(...)` persist `topicType` and `remark`, matching the create path, and removed an unused local variable from message sending.

The PR was closed after its commit was consolidated into merged PR #1429. The resulting topic-update fix is present in `rocketmq-studio` as commit `24715633`.