### PR TITLE
fix: share system consumer-group filtering

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/SystemGroupFilter.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/SystemGroupFilter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+/**
+ * Shared utility for identifying RocketMQ system consumer groups.
+ *
+ * <p>Consolidates the system group prefix list that was previously duplicated
+ * (with inconsistencies) across {@code RocketMQClientProvider},
+ * {@code RocketMQMetadataProvider}, and {@code RocketMQDashboardProvider}.
+ */
+public final class SystemGroupFilter {
+
+    private SystemGroupFilter() {
+    }
+
+    /**
+     * Returns {@code true} if the given group name is a RocketMQ system consumer group
+     * that should be hidden from user-facing lists and excluded from dashboard counts.
+     *
+     * @param group the consumer group name, may be {@code null}
+     * @return {@code true} if the group is a system group
+     */
+    public static boolean isSystem(String group) {
+        if (group == null || group.isEmpty()) {
+            return true;
+        }
+        return group.startsWith("CID_RMQ_SYS_")
+                || group.startsWith("CID_ONSAPI_")
+                || group.startsWith("CID_SYS_")
+                || group.startsWith("CID_HOUSEKEEPING")
+                || group.startsWith("rmq_sys_")
+                || group.startsWith("%RETRY%")
+                || group.startsWith("%DLQ%")
+                || group.startsWith("TOOLS_CONSUMER")
+                || group.startsWith("FILTERSRV_CONSUMER")
+                || group.startsWith("SELF_TEST_");
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -34,6 +34,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.ClientLanguage;
 import org.apache.rocketmq.studio.common.domain.enums.ClientType;
 import org.apache.rocketmq.studio.common.domain.enums.Protocol;
+import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -333,17 +334,7 @@ public class RocketMQClientProvider implements ClientProvider {
     }
 
     private boolean isSystemGroup(String group) {
-        if (group == null) {
-            return true;
-        }
-        return group.startsWith("CID_RMQ_SYS_")
-                || group.startsWith("CID_ONSAPI_")
-                || group.startsWith("TOOLS_CONSUMER")
-                || group.startsWith("FILTERSRV_CONSUMER")
-                || group.startsWith("CID_SYS_")
-                || group.startsWith("%RETRY%")
-                || group.startsWith("SELF_TEST_")
-                || group.startsWith("CID_HOUSEKEEPING");
+        return SystemGroupFilter.isSystem(group);
     }
 
     private String rootMessage(Throwable error) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -39,6 +39,7 @@ import org.apache.rocketmq.studio.ops.dashboard.ClusterOverviewVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardProvider;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardStatsVO;
+import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -312,13 +313,6 @@ public class RocketMQDashboardProvider implements DashboardProvider {
     }
 
     private boolean isSystemGroup(String group) {
-        return group.startsWith("CID_RMQ_SYS_")
-                || group.startsWith("rmq_sys_")
-                || group.equals("TOOLS_CONSUMER")
-                || group.equals("FILTERSRV_CONSUMER")
-                || group.equals("CID_ONSAPI_OWNER")
-                || group.equals("CID_ONSAPI_PERMISSION")
-                || group.equals("CID_ONSAPI_PULL")
-                || group.startsWith("SELF_TEST_");
+        return SystemGroupFilter.isSystem(group);
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -33,6 +33,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
+import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
@@ -334,15 +335,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
     }
 
     private boolean isSystemConsumerGroup(String group) {
-        if (group == null || group.isEmpty()) {
-            return true;
-        }
-        return group.startsWith("%RETRY%")
-                || group.startsWith("%DLQ%")
-                || group.startsWith("CID_RMQ_SYS_")
-                || group.startsWith("CID_ONS_")
-                || group.startsWith("TOOLS_CONSUMER")
-                || group.startsWith("FILTERSRV_CONSUMER");
+        return SystemGroupFilter.isSystem(group);
     }
 
     @Override


### PR DESCRIPTION
This was the standalone implementation for #1401. It replaced the duplicated provider-specific checks with `SystemGroupFilter`, including the missing `CID_ONSAPI_`, `CID_SYS_`, `%RETRY%`, `%DLQ%`, and housekeeping patterns.

The PR was closed after its commit was consolidated into merged PR #1408. Direct regression coverage for the shared filter later landed through #2034.