### PR TITLE
fix: reject invalid persisted instance enums

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.studio.instance;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.persistence.entity.RmqGroup;
 import org.apache.rocketmq.studio.persistence.entity.RmqInstance;
 import org.apache.rocketmq.studio.persistence.entity.RmqTopic;
@@ -135,9 +136,9 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
         InstanceVO vo = InstanceVO.builder()
                 .name(entity.getName())
                 .remark(entity.getRemark())
-                .type(parseType(entity.getType()))
+                .type(parseType(entity.getId(), entity.getType()))
                 .endpoint(entity.getEndpoint())
-                .vendor(parseVendor(entity.getVendor()))
+                .vendor(parseVendor(entity.getId(), entity.getVendor()))
                 .cloudInstanceId(entity.getCloudInstanceId())
                 .credentialId(entity.getCredentialId())
                 .regionId(entity.getRegionId())
@@ -148,20 +149,25 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
         return vo;
     }
 
-    private InstanceType parseType(String type) {
+    private InstanceType parseType(String instanceId, String type) {
         try {
             return InstanceType.valueOf(type);
         } catch (IllegalArgumentException | NullPointerException ex) {
-            return InstanceType.PROXY;
+            throw invalidPersistedValue(instanceId, "type", type);
         }
     }
 
-    private InstanceVendor parseVendor(String vendor) {
+    private InstanceVendor parseVendor(String instanceId, String vendor) {
         try {
             return InstanceVendor.valueOf(vendor);
         } catch (IllegalArgumentException | NullPointerException ex) {
-            return InstanceVendor.APACHE;
+            throw invalidPersistedValue(instanceId, "vendor", vendor);
         }
+    }
+
+    private BusinessException invalidPersistedValue(String instanceId, String field, String value) {
+        return new BusinessException(500, "Invalid persisted instance " + field
+                + " for instance " + instanceId + ": " + value);
     }
 
     private RmqInstance toEntity(InstanceVO vo) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
@@ -19,6 +19,8 @@ package org.apache.rocketmq.studio.instance;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.persistence.entity.RmqInstance;
 import org.apache.rocketmq.studio.persistence.mapper.RmqGroupMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqInstanceMapper;
@@ -34,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -111,6 +114,30 @@ class MybatisPlusInstanceRepositoryTest {
     }
 
     @Test
+    void findByIdShouldRejectInvalidPersistedInstanceType() {
+        RmqInstance entity = entity("instance-invalid-type", InstanceType.DIRECT);
+        entity.setType("UNKNOWN_TYPE");
+        when(instanceMapper.selectById(entity.getId())).thenReturn(entity);
+
+        assertThatThrownBy(() -> repository.findById(entity.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Invalid persisted instance type")
+                .hasMessageContaining(entity.getId());
+    }
+
+    @Test
+    void findByIdShouldRejectInvalidPersistedInstanceVendor() {
+        RmqInstance entity = entity("instance-invalid-vendor", InstanceType.DIRECT);
+        entity.setVendor("UNKNOWN_VENDOR");
+        when(instanceMapper.selectById(entity.getId())).thenReturn(entity);
+
+        assertThatThrownBy(() -> repository.findById(entity.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Invalid persisted instance vendor")
+                .hasMessageContaining(entity.getId());
+    }
+
+    @Test
     void countTopicsByInstanceShouldDelegateToTopicMapperTest() {
         when(topicMapper.selectCount(any(QueryWrapper.class))).thenReturn(5L);
 
@@ -161,6 +188,7 @@ class MybatisPlusInstanceRepositoryTest {
         entity.setName(id);
         entity.setType(type.name());
         entity.setEndpoint("10.0.0.1:9876");
+        entity.setVendor(InstanceVendor.APACHE.name());
         entity.setCreatedAt(LocalDateTime.of(2026, 8, 3, 0, 0));
         entity.setUpdatedAt(LocalDateTime.of(2026, 8, 3, 0, 0));
         return entity;


### PR DESCRIPTION
## Summary

Stops invalid persisted instance `type` and `vendor` values from silently changing an instance into `PROXY`/`APACHE`. The repository now returns a structured 500 response that identifies the affected instance and field.

## Validation

- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) mvn -Dtest=MybatisPlusInstanceRepositoryTest test`

Closes #1406