### PR TITLE
fix: reject invalid persisted credential vendors

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.provider.credential;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.persistence.entity.RmqCloudCredential;
 import org.apache.rocketmq.studio.persistence.mapper.RmqCloudCredentialMapper;
@@ -85,7 +86,7 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
         CloudCredentialVO vo = new CloudCredentialVO();
         vo.setId(entity.getId());
         vo.setName(entity.getName());
-        vo.setVendor(parseVendor(entity.getVendor()));
+        vo.setVendor(parseVendor(entity.getId(), entity.getVendor()));
         vo.setAccessKey(entity.getAccessKey());
         vo.setSecretKey(CredentialUtils.decodeBase64(entity.getSecretKey()));
         vo.setRemark(entity.getRemark());
@@ -107,11 +108,12 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
         return entity;
     }
 
-    private static InstanceVendor parseVendor(String vendor) {
+    private static InstanceVendor parseVendor(String credentialId, String vendor) {
         try {
             return InstanceVendor.valueOf(vendor);
         } catch (IllegalArgumentException | NullPointerException ex) {
-            return null;
+            throw new BusinessException(500, "Invalid persisted cloud credential vendor for credential "
+                    + credentialId + ": " + vendor);
         }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.studio.provider.credential;
+
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.persistence.entity.RmqCloudCredential;
+import org.apache.rocketmq.studio.persistence.mapper.RmqCloudCredentialMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MybatisPlusCloudCredentialRepositoryTest {
+
+    @Mock
+    private RmqCloudCredentialMapper credentialMapper;
+
+    @InjectMocks
+    private MybatisPlusCloudCredentialRepository repository;
+
+    @Test
+    void findByIdShouldMapValidPersistedVendor() {
+        when(credentialMapper.selectById("cred-valid")).thenReturn(entity("cred-valid", "ALIYUN"));
+
+        Optional<CloudCredentialVO> result = repository.findById("cred-valid");
+
+        assertThat(result).isPresent();
+        assertThat(result.orElseThrow().getVendor()).isEqualTo(InstanceVendor.ALIYUN);
+    }
+
+    @Test
+    void findByIdShouldRejectInvalidPersistedVendor() {
+        when(credentialMapper.selectById("cred-invalid")).thenReturn(entity("cred-invalid", "UNKNOWN"));
+
+        assertThatThrownBy(() -> repository.findById("cred-invalid"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Invalid persisted cloud credential vendor")
+                .hasMessageContaining("cred-invalid");
+    }
+
+    private RmqCloudCredential entity(String id, String vendor) {
+        RmqCloudCredential entity = new RmqCloudCredential();
+        entity.setId(id);
+        entity.setName(id);
+        entity.setVendor(vendor);
+        entity.setAccessKey("access-key");
+        entity.setSecretKey("c2VjcmV0");
+        return entity;
+    }
+}


### PR DESCRIPTION
## Summary

Rejects corrupt persisted cloud credential vendors rather than returning a `CloudCredentialVO` with a null vendor. The error identifies the credential record, while valid persisted records retain their current mapping.

## Validation

- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) mvn -Dtest=MybatisPlusCloudCredentialRepositoryTest test`

Closes #1410