### PR TITLE
fix: preserve user properties during DLQ resend

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -248,6 +248,17 @@ public class RocketMQDLQProvider implements DLQProvider {
             if (StringUtils.hasText(deadLetter.getKeys())) {
                 message.setKeys(deadLetter.getKeys());
             }
+            // Copy user properties from the original message, skipping system-reserved
+            // keys to avoid conflicts with broker-internal properties.
+            Map<String, String> userProperties = deadLetter.getUserProperties();
+            if (userProperties != null) {
+                for (Map.Entry<String, String> entry : userProperties.entrySet()) {
+                    String key = entry.getKey();
+                    if (!MessageConst.STRING_HASH_SET.contains(key)) {
+                        message.putUserProperty(key, entry.getValue());
+                    }
+                }
+            }
             message.putUserProperty(ORIGIN_MESSAGE_ID_PROPERTY, deadLetter.getMsgId());
             message.putUserProperty(ORIGIN_TOPIC_PROPERTY, deadLetter.getTopic());
             SendResult sendResult = producer.send(message);


### PR DESCRIPTION
This was the standalone implementation for #1415. It copied non-system properties from the dead-letter message before adding Studio resend provenance, preserving application metadata such as correlation and trace identifiers.

The PR was closed after its commit was consolidated into merged PR #1436. Reserved-property filtering and focused producer assertions were later tightened in #2034.