### PR TITLE
fix: report corrupt K8s certificate records

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.persistence.entity.RmqK8sCertificate;
 import org.apache.rocketmq.studio.persistence.mapper.RmqK8sCertificateMapper;
 import org.springframework.stereotype.Repository;
@@ -81,13 +82,13 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         vo.setName(entity.getName());
         vo.setNamespace(entity.getNamespace());
         vo.setCluster(entity.getCluster());
-        vo.setType(parseCertType(entity.getCertType()));
+        vo.setType(parseCertType(entity.getId(), entity.getCertType()));
         vo.setIssuer(entity.getIssuer());
         vo.setNotBefore(entity.getNotBefore());
         vo.setNotAfter(entity.getNotAfter());
-        vo.setStatus(parseCertStatus(entity.getStatus()));
+        vo.setStatus(parseCertStatus(entity.getId(), entity.getStatus()));
         vo.setDaysRemaining(entity.getDaysRemaining() == null ? 0 : entity.getDaysRemaining());
-        vo.setSan(parseSan(entity.getSan()));
+        vo.setSan(parseSan(entity.getId(), entity.getSan()));
         vo.setCreatedAt(entity.getCreatedAt());
         vo.setUpdatedAt(entity.getUpdatedAt());
         return vo;
@@ -111,29 +112,29 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         return entity;
     }
 
-    private CertType parseCertType(String value) {
+    private CertType parseCertType(String certificateId, String value) {
         if (!StringUtils.hasText(value)) {
             return null;
         }
         try {
             return CertType.valueOf(value);
         } catch (IllegalArgumentException exception) {
-            throw new IllegalStateException("Invalid persisted certificate type: " + value, exception);
+            throw invalidPersistedValue(certificateId, "type", value);
         }
     }
 
-    private CertStatus parseCertStatus(String value) {
+    private CertStatus parseCertStatus(String certificateId, String value) {
         if (!StringUtils.hasText(value)) {
             return null;
         }
         try {
             return CertStatus.valueOf(value);
         } catch (IllegalArgumentException exception) {
-            throw new IllegalStateException("Invalid persisted certificate status: " + value, exception);
+            throw invalidPersistedValue(certificateId, "status", value);
         }
     }
 
-    private List<String> parseSan(String json) {
+    private List<String> parseSan(String certificateId, String json) {
         if (!StringUtils.hasText(json)) {
             return List.of();
         }
@@ -141,8 +142,13 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
             return objectMapper.readValue(json, new TypeReference<List<String>>() {
             });
         } catch (JsonProcessingException exception) {
-            throw new IllegalStateException("Invalid persisted certificate SAN JSON", exception);
+            throw invalidPersistedValue(certificateId, "SAN JSON", json);
         }
+    }
+
+    private BusinessException invalidPersistedValue(String certificateId, String field, String value) {
+        return new BusinessException(500, "Invalid persisted certificate " + field
+                + " for certificate " + certificateId + ": " + value);
     }
 
     private String writeSan(List<String> san) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.cluster.k8s;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.persistence.entity.RmqK8sCertificate;
 import org.apache.rocketmq.studio.persistence.mapper.RmqK8sCertificateMapper;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,7 @@ class MybatisPlusK8sCertRepositoryTest {
         when(mapper.selectById("cert-1")).thenReturn(entity);
 
         assertThatThrownBy(() -> repository(mapper).findById("cert-1"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("certificate type");
     }
 
@@ -47,8 +48,20 @@ class MybatisPlusK8sCertRepositoryTest {
         when(mapper.selectById("cert-1")).thenReturn(entity);
 
         assertThatThrownBy(() -> repository(mapper).findById("cert-1"))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("SAN JSON");
+    }
+
+    @Test
+    void findByIdSurfacesInvalidPersistedCertificateStatus() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        RmqK8sCertificate entity = certificate();
+        entity.setStatus("unknown");
+        when(mapper.selectById("cert-1")).thenReturn(entity);
+
+        assertThatThrownBy(() -> repository(mapper).findById("cert-1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("certificate status");
     }
 
     private MybatisPlusK8sCertRepository repository(RmqK8sCertificateMapper mapper) {


### PR DESCRIPTION
## Summary

Maps corrupt persisted K8s certificate type, status, and SAN JSON values to structured `BusinessException` responses. The failure now identifies the affected certificate field rather than becoming an undifferentiated internal server error.

## Validation

- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) mvn -Dtest=MybatisPlusK8sCertRepositoryTest test`

Closes #1414