### PR TITLE
fix: harden Prometheus alert rule export

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -25,8 +25,10 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
@@ -64,9 +66,11 @@ public class AlertService {
         for (Map.Entry<String, List<PrometheusAlertRule>> group : rulesByGroup.entrySet()) {
             yaml.append("  - name: ").append(group.getKey()).append('\n');
             yaml.append("    rules:\n");
+            Set<String> usedAlertNames = new HashSet<>();
             for (PrometheusAlertRule rule : group.getValue()) {
-                yaml.append("      # Rule ").append(index++).append(": ").append(rule.alert()).append('\n');
-                yaml.append("      - alert: ").append(rule.alert()).append('\n');
+                String uniqueAlertName = ensureUniqueAlertName(rule.alert(), usedAlertNames);
+                yaml.append("      # Rule ").append(index++).append(": ").append(uniqueAlertName).append('\n');
+                yaml.append("      - alert: ").append(uniqueAlertName).append('\n');
                 yaml.append("        expr: ").append(rule.expr()).append('\n');
                 yaml.append("        for: ").append(rule.duration()).append('\n');
                 yaml.append("        labels:\n");
@@ -189,6 +193,15 @@ public class AlertService {
             return "rocketmq-topic.rules";
         }
         return "rocketmq-broker.rules";
+    }
+
+    private String ensureUniqueAlertName(String baseName, Set<String> usedAlertNames) {
+        String uniqueName = baseName;
+        int suffix = 2;
+        while (!usedAlertNames.add(uniqueName)) {
+            uniqueName = baseName + "_" + suffix++;
+        }
+        return uniqueName;
     }
 
     private String alertName(AlertRuleVO rule) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -264,6 +264,9 @@ public class AlertService {
     }
 
     private String formatThreshold(double threshold) {
+        if (!Double.isFinite(threshold)) {
+            return "0";
+        }
         if (threshold == Math.rint(threshold)) {
             return Long.toString((long) threshold);
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -210,7 +210,14 @@ public class AlertService {
 
     private String alertName(AlertRuleVO rule) {
         String alertName = hasText(rule.getName()) ? rule.getName().replaceAll("[^A-Za-z0-9_]", "") : "";
-        return alertName.isEmpty() ? "RocketMQAlert" : alertName;
+        if (alertName.isEmpty()) {
+            return "RocketMQAlert";
+        }
+        // Prometheus alert names must start with [a-zA-Z_], not a digit
+        if (Character.isDigit(alertName.charAt(0))) {
+            alertName = "A_" + alertName;
+        }
+        return alertName;
     }
 
     private String expression(AlertRuleVO rule) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -36,6 +36,10 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class AlertService {
 
+    private static final Set<String> VALID_OPERATORS = Set.of(">", ">=", "<", "<=", "==", "!=");
+    private static final Pattern METRIC_NAME_PATTERN = Pattern.compile("^[a-zA-Z_:][a-zA-Z0-9_:]*$");
+    private static final Pattern DURATION_PATTERN = Pattern.compile("^\\d+(ms|s|m|h|d|w|y)$");
+
     private final AlertRepository alertRepository;
     private final AlertRuleAssetService alertRuleAssetService;
     private final OperationAuditService operationAuditService;
@@ -210,9 +214,19 @@ public class AlertService {
     }
 
     private String expression(AlertRuleVO rule) {
-        String metric = hasText(rule.getMetric()) ? rule.getMetric() : "rocketmq_consumer_lag_messages";
-        String operator = hasText(rule.getOperator()) ? rule.getOperator() : ">";
+        String metric = validateMetric(rule.getMetric());
+        String operator = validateOperator(rule.getOperator());
         return metric + labelSelector(rule) + " " + operator + " " + formatThreshold(rule.getThreshold());
+    }
+
+    private String validateMetric(String metric) {
+        String normalized = hasText(metric) ? metric.trim() : "rocketmq_consumer_lag_messages";
+        return METRIC_NAME_PATTERN.matcher(normalized).matches() ? normalized : "rocketmq_consumer_lag_messages";
+    }
+
+    private String validateOperator(String operator) {
+        String normalized = hasText(operator) ? operator.trim() : ">";
+        return VALID_OPERATORS.contains(normalized) ? normalized : ">";
     }
 
     private String labelSelector(AlertRuleVO rule) {
@@ -257,7 +271,8 @@ public class AlertService {
     }
 
     private String duration(AlertRuleVO rule) {
-        return hasText(rule.getDuration()) ? rule.getDuration() : "5m";
+        String dur = hasText(rule.getDuration()) ? rule.getDuration().trim() : "5m";
+        return DURATION_PATTERN.matcher(dur).matches() ? dur : "5m";
     }
 
     private String inferTeam(String metric) {


### PR DESCRIPTION
This merged batch hardens four parts of Prometheus alert export:

- de-duplicate identifiers that collide after name normalization;
- validate operator, metric, and duration values before PromQL generation;
- replace non-finite thresholds with a safe numeric value;
- prefix normalized alert names that would otherwise start with a digit.

The changes address #1404, #1419, #1431, and #1439. Adjacent regression coverage was later consolidated into #2034.