### PR TITLE
fix: surface Grafana resource discovery failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
@@ -18,7 +18,6 @@ package org.apache.rocketmq.studio.cluster.metrics.grafana;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.springframework.core.io.Resource;
@@ -42,13 +41,21 @@ import java.util.zip.ZipOutputStream;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class GrafanaDashboardService {
 
     private static final String LOCATION_PATTERN = "classpath*:grafana/*.json";
 
     private final ObjectMapper objectMapper;
-    private final ResourcePatternResolver resourceResolver = new PathMatchingResourcePatternResolver();
+    private final ResourcePatternResolver resourceResolver;
+
+    public GrafanaDashboardService(ObjectMapper objectMapper) {
+        this(objectMapper, new PathMatchingResourcePatternResolver());
+    }
+
+    GrafanaDashboardService(ObjectMapper objectMapper, ResourcePatternResolver resourceResolver) {
+        this.objectMapper = objectMapper;
+        this.resourceResolver = resourceResolver;
+    }
 
     /**
      * Lists metadata for every bundled Grafana dashboard.
@@ -152,7 +159,7 @@ public class GrafanaDashboardService {
             return resourceResolver.getResources(LOCATION_PATTERN);
         } catch (IOException e) {
             log.warn("Unable to resolve Grafana dashboard resources: {}", e.getMessage());
-            return new Resource[0];
+            throw new BusinessException(500, "Failed to resolve bundled Grafana dashboards");
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
@@ -21,6 +21,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -34,6 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class GrafanaDashboardServiceTest {
 
@@ -133,6 +136,18 @@ class GrafanaDashboardServiceTest {
         List<GrafanaDashboardInfo> dashboards = service.listDashboards();
 
         assertEquals(List.of(new GrafanaDashboardInfo("valid", "Valid", "", List.of("rocketmq"))), dashboards);
+    }
+
+    @Test
+    void listDashboardsShouldSurfaceResourceDiscoveryFailure() throws Exception {
+        ResourcePatternResolver resolver = mock(ResourcePatternResolver.class);
+        when(resolver.getResources("classpath*:grafana/*.json")).thenThrow(new java.io.IOException("broken jar"));
+        GrafanaDashboardService service = new GrafanaDashboardService(new ObjectMapper(), resolver);
+
+        BusinessException exception = assertThrows(BusinessException.class, service::listDashboards);
+
+        assertEquals(500, exception.getCode());
+        assertTrue(exception.getMessage().contains("resolve bundled Grafana dashboards"));
     }
 
     private static GrafanaDashboardService serviceWithResources(Resource... resources) {


### PR DESCRIPTION
## Summary

Differentiates a failure to discover bundled Grafana dashboard resources from a valid empty dashboard catalog. Resource discovery I/O failures now return a structured `BusinessException`.

## Validation

- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) mvn -Dtest=GrafanaDashboardServiceTest test`

Closes #1418