### PR TITLE
fix: reject loopback data-source URLs

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -266,7 +266,9 @@ public class SettingsService {
         }
         try {
             InetAddress address = InetAddress.getByName(normalized);
-            return !address.isAnyLocalAddress() && !address.isLinkLocalAddress();
+            return !address.isAnyLocalAddress()
+                    && !address.isLinkLocalAddress()
+                    && !address.isLoopbackAddress();
         } catch (UnknownHostException exception) {
             // Unresolvable host: let the connection attempt surface the real connectivity error.
             return true;


### PR DESCRIPTION
Reject loopback destinations in the settings data-source URL guard by checking `InetAddress.isLoopbackAddress()`, rather than relying only on a string comparison with `localhost`.

This fixes #1422. A focused service test for `http://127.0.0.1:9090` was later consolidated into #2034.