### PR TITLE
fix: avoid splitting UTF-8 characters during truncation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -438,6 +438,17 @@ public class RocketMQMessageProvider implements MessageProvider {
             return new DisplayBody(null, null, false);
         }
         int textLength = Math.min(body.length, MAX_BODY_DISPLAY_BYTES);
+        // When truncating, walk back to the last complete UTF-8 character boundary
+        // to avoid splitting a multi-byte character, which would cause the decoder
+        // to fall through to BASE64 encoding even for valid UTF-8 text.
+        if (textLength < body.length) {
+            while (textLength > 0 && (body[textLength] & 0xC0) == 0x80) {
+                textLength--;
+            }
+            if (textLength > 0 && (body[textLength] & 0xC0) == 0xC0) {
+                textLength--;
+            }
+        }
         try {
             String value = StandardCharsets.UTF_8.newDecoder()
                     .onMalformedInput(CodingErrorAction.REPORT)


### PR DESCRIPTION
This was the initial implementation for #1424. It moved a truncated message-body boundary backward when the byte limit landed inside a UTF-8 character, avoiding an unnecessary Base64 fallback for many valid text messages.

The commit was consolidated into merged PR #1378, but consecutive multi-byte cases still exposed a gap. Merged PR #1496 supplied the complete implementation and superseded this partial fix.