### PR TITLE
fix: scope broker operations and persist topic metadata

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ResetConsumerOffsetDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ResetConsumerOffsetDTO.java
@@ -39,5 +39,6 @@ public class ResetConsumerOffsetDTO {
     @Positive(message = "timestamp must be positive")
     private Long timestamp;
 
+    @NotBlank(message = "topic is required")
     private String topic;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -149,7 +149,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 TopicPerm effectivePerm = topic.getPerm() != null
                         ? topic.getPerm()
                         : existing == null ? TopicPerm.RW : fromRocketMQPerm(existing.getPerm());
-                Set<String> brokerAddrs = getAllMasterBrokerAddrs(admin);
+                Set<String> brokerAddrs = getMasterBrokerAddrsForCluster(admin, clusterName);
                 if (brokerAddrs.isEmpty()) {
                     throw new BusinessException(500, "No broker available to create topic");
                 }
@@ -230,7 +230,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 TopicPerm effectivePerm = topic.getPerm() != null
                         ? topic.getPerm()
                         : existing == null ? TopicPerm.RW : fromRocketMQPerm(existing.getPerm());
-                Set<String> brokerAddrs = getAllMasterBrokerAddrs(admin);
+                Set<String> brokerAddrs = getMasterBrokerAddrsForCluster(admin, clusterName);
                 if (brokerAddrs.isEmpty()) {
                     throw new BusinessException(500, "No broker available to update topic");
                 }
@@ -390,7 +390,8 @@ public class RocketMQAdminClientImpl implements AdminClient {
         String groupName = group.getName();
 
         try {
-            Set<String> brokerAddrs = getAllMasterBrokerAddrs(admin);
+            String groupClusterName = getClusterName(admin);
+            Set<String> brokerAddrs = getMasterBrokerAddrsForCluster(admin, groupClusterName);
             if (brokerAddrs.isEmpty()) {
                 throw new BusinessException(500, "No broker available to create consumer group");
             }
@@ -408,7 +409,6 @@ public class RocketMQAdminClientImpl implements AdminClient {
 
             // Persist to DB, upserting so re-creating an existing group does not violate the
             // unique (cluster_id, name) key.
-            String groupClusterName = getClusterName(admin);
             RmqGroup entity = groupMapper.selectOne(new LambdaQueryWrapper<RmqGroup>()
                     .eq(RmqGroup::getClusterId, groupClusterName)
                     .eq(RmqGroup::getName, groupName));
@@ -564,6 +564,41 @@ public class RocketMQAdminClientImpl implements AdminClient {
             }
         }
         return addrs;
+    }
+
+    /**
+     * Returns master broker addresses for the specified cluster only, using the
+     * clusterAddrTable to map cluster name to broker names. Falls back to all
+     * brokers when the cluster name is unknown or the cluster table is missing.
+     */
+    private Set<String> getMasterBrokerAddrsForCluster(MQAdminExt admin, String clusterName) throws Exception {
+        if (!StringUtils.hasText(clusterName)) {
+            return getAllMasterBrokerAddrs(admin);
+        }
+        ClusterInfo clusterInfo = admin.examineBrokerClusterInfo();
+        if (clusterInfo == null || clusterInfo.getClusterAddrTable() == null
+                || clusterInfo.getBrokerAddrTable() == null) {
+            return getAllMasterBrokerAddrs(admin);
+        }
+        Set<String> brokerNames = clusterInfo.getClusterAddrTable().get(clusterName);
+        if (brokerNames == null || brokerNames.isEmpty()) {
+            return getAllMasterBrokerAddrs(admin);
+        }
+        Set<String> addrs = new HashSet<>();
+        for (String brokerName : brokerNames) {
+            BrokerData brokerData = clusterInfo.getBrokerAddrTable().get(brokerName);
+            if (brokerData == null || brokerData.getBrokerAddrs() == null) {
+                continue;
+            }
+            String masterAddr = brokerData.getBrokerAddrs().get(0L);
+            if (masterAddr == null && !brokerData.getBrokerAddrs().isEmpty()) {
+                masterAddr = brokerData.getBrokerAddrs().values().iterator().next();
+            }
+            if (masterAddr != null) {
+                addrs.add(masterAddr);
+            }
+        }
+        return addrs.isEmpty() ? getAllMasterBrokerAddrs(admin) : addrs;
     }
 
     private String getClusterName(MQAdminExt admin) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -487,6 +487,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
 
     @Override
     public void resetOffset(String instanceId, String name, long timestamp, String topic) {
+        if (!StringUtils.hasText(topic)) {
+            throw new BusinessException(400, "topic is required for offset reset");
+        }
         try {
             if (StringUtils.hasText(instanceId)) {
                 runtimeAdminClientResolver.execute(instanceId, admin -> {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -250,6 +250,12 @@ public class RocketMQAdminClientImpl implements AdminClient {
                     existing.setWriteQueueNums(writeQueues);
                     existing.setReadQueueNums(readQueues);
                     existing.setPerm(topicConfig.getPerm());
+                    if (topic.getType() != null) {
+                        existing.setTopicType(topic.getType().name());
+                    }
+                    if (StringUtils.hasText(topic.getRemark())) {
+                        existing.setRemark(topic.getRemark());
+                    }
                     existing.setUpdatedAt(LocalDateTime.now());
                     topicMapper.updateById(existing);
                 }


### PR DESCRIPTION
This merged batch contains three admin-path fixes:

- persist `topicType` and `remark` during topic updates;
- restrict topic create/update and consumer-group creation to master brokers in the selected cluster;
- reject a blank reset-offset topic at both the request and admin-client boundaries.

The changes address #1392, #1428, and #1441. Selected-cluster delete paths and their multi-cluster regression tests were completed later in #2034.