### PR TITLE
fix: replace non-finite alert thresholds

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -236,6 +236,9 @@ public class AlertService {
     }
 
     private String formatThreshold(double threshold) {
+        if (!Double.isFinite(threshold)) {
+            return "0";
+        }
         if (threshold == Math.rint(threshold)) {
             return Long.toString((long) threshold);
         }


### PR DESCRIPTION
This was the standalone implementation for #1431. It prevents `NaN` and infinite threshold values from being written into generated PromQL by substituting a finite fallback.

The PR was closed after its commit was consolidated into merged PR #1420. Direct YAML regression coverage later landed through #2034.