### PR TITLE
fix: reject invalid message query windows

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -99,6 +99,9 @@ public class RocketMQMessageProvider implements MessageProvider {
 
         long end = endTime != null ? endTime : System.currentTimeMillis();
         long begin = startTime != null ? startTime : end - ONE_HOUR_MILLIS;
+        if (begin >= end) {
+            throw new BusinessException(400, "Message query start time must be before end time");
+        }
 
         List<MessageRecordVO> result;
         String queryType;


### PR DESCRIPTION
This was the standalone implementation for #1433. It rejects `begin >= end` before the Apache message provider performs broker query work.

The PR was closed after its commit was consolidated into merged PR #1378. Inverted and equal-range regression tests later landed through #2034.