### PR TITLE
fix: preserve DLQ properties and classify resend outcomes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -248,6 +248,17 @@ public class RocketMQDLQProvider implements DLQProvider {
             if (StringUtils.hasText(deadLetter.getKeys())) {
                 message.setKeys(deadLetter.getKeys());
             }
+            // Copy user properties from the original message, skipping system-reserved
+            // keys to avoid conflicts with broker-internal properties.
+            Map<String, String> userProperties = deadLetter.getUserProperties();
+            if (userProperties != null) {
+                for (Map.Entry<String, String> entry : userProperties.entrySet()) {
+                    String key = entry.getKey();
+                    if (!MessageConst.STRING_HASH_SET.contains(key)) {
+                        message.putUserProperty(key, entry.getValue());
+                    }
+                }
+            }
             message.putUserProperty(ORIGIN_MESSAGE_ID_PROPERTY, deadLetter.getMsgId());
             message.putUserProperty(ORIGIN_TOPIC_PROPERTY, deadLetter.getTopic());
             SendResult sendResult = producer.send(message);

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -166,13 +166,13 @@ public class RocketMQDLQProvider implements DLQProvider {
         String detail = String.format("instanceId=%s, group=%s, dlqTopic=%s, targetTopic=%s, matched=%d, resent=%d, failed=%d",
                 instanceId, groupName, dlqTopic, StringUtils.hasText(targetTopic) ? targetTopic : "<original>",
                 deadLetters.size(), resent, failed);
-        recordAudit(groupName, detail, failed == 0 ? "SUCCESS" : "PARTIAL");
+        recordAudit(groupName, detail, classifyOutcome(deadLetters.size(), resent, failed));
         log.info("DLQ resend completed: {}", detail);
         return DLQResendResultVO.builder()
                 .matched(deadLetters.size())
                 .resent(resent)
                 .failed(failed)
-                .outcome(failed == 0 ? "SUCCESS" : "PARTIAL")
+                .outcome(classifyOutcome(deadLetters.size(), resent, failed))
                 .build();
     }
 
@@ -313,6 +313,19 @@ public class RocketMQDLQProvider implements DLQProvider {
 
     static String nextResendProducerGroup() {
         return ShortLivedClientName.next("studio-dlq-resend");
+    }
+
+    private String classifyOutcome(int matched, int resent, int failed) {
+        if (matched == 0) {
+            return "NO_MESSAGES";
+        }
+        if (resent == 0 && failed > 0) {
+            return "FAILED";
+        }
+        if (failed > 0) {
+            return "PARTIAL";
+        }
+        return "SUCCESS";
     }
 
     private void recordAudit(String groupName, String detail, String result) {


### PR DESCRIPTION
This merged PR contains two DLQ resend fixes:

- preserve non-system user properties from the original dead-letter message;
- classify results as `NO_MESSAGES`, `FAILED`, `PARTIAL`, or `SUCCESS` from the actual scan and send counts.

The changes address #1415 and #1435. Reserved-property filtering and the focused outcome tests were later strengthened in #2034.