### PR TITLE
fix: align cluster and dashboard TPS parsing

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -209,12 +209,12 @@ public class RocketMQClusterProvider implements ClusterProvider {
             // Parse TPS from runtime stats
             String putTps = table.get("putTps");
             if (putTps != null && !putTps.isEmpty()) {
-                builder.tpsIn(parseFirstTpsValue(putTps));
+                builder.tpsIn(parseTpsValue(putTps));
             }
 
             String getTransferredTps = table.get("getTransferredTps");
             if (getTransferredTps != null && !getTransferredTps.isEmpty()) {
-                builder.tpsOut(parseFirstTpsValue(getTransferredTps));
+                builder.tpsOut(parseTpsValue(getTransferredTps));
             }
 
             // Disk usage
@@ -241,7 +241,7 @@ public class RocketMQClusterProvider implements ClusterProvider {
      * TPS properties are space-separated values representing 10s/1min/10min averages.
      * Parse the first value (10s average).
      */
-    private int parseFirstTpsValue(String tpsStr) {
+    private int parseTpsValue(String tpsStr) {
         try {
             String[] parts = tpsStr.trim().split("\\s+");
             if (parts.length > 0) {


### PR DESCRIPTION
This was the initial implementation for #1437. It changed the cluster provider to read the same one-minute TPS field as the dashboard and widened the result to `long`.

The commit was consolidated into merged PR #1400, but the final robust implementation and its dedicated whitespace/large-value tests landed in #1656.