### PR TITLE
fix: prefix digit-leading Prometheus alert names

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -192,7 +192,14 @@ public class AlertService {
 
     private String alertName(AlertRuleVO rule) {
         String alertName = hasText(rule.getName()) ? rule.getName().replaceAll("[^A-Za-z0-9_]", "") : "";
-        return alertName.isEmpty() ? "RocketMQAlert" : alertName;
+        if (alertName.isEmpty()) {
+            return "RocketMQAlert";
+        }
+        // Prometheus alert names must start with [a-zA-Z_], not a digit
+        if (Character.isDigit(alertName.charAt(0))) {
+            alertName = "A_" + alertName;
+        }
+        return alertName;
     }
 
     private String expression(AlertRuleVO rule) {


### PR DESCRIPTION
This was the standalone implementation for #1439. It prefixes a normalized alert name with `A_` when the first character would otherwise be a digit.

The PR was closed after its commit was consolidated into merged PR #1420. Direct export regression coverage later landed through #2034.