### PR TITLE
fix: validate reset-offset topics

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ResetConsumerOffsetDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ResetConsumerOffsetDTO.java
@@ -39,5 +39,6 @@ public class ResetConsumerOffsetDTO {
     @Positive(message = "timestamp must be positive")
     private Long timestamp;
 
+    @NotBlank(message = "topic is required")
     private String topic;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -476,6 +476,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
 
     @Override
     public void resetOffset(String instanceId, String name, long timestamp, String topic) {
+        if (!StringUtils.hasText(topic)) {
+            throw new BusinessException(400, "topic is required for offset reset");
+        }
         try {
             if (StringUtils.hasText(instanceId)) {
                 runtimeAdminClientResolver.execute(instanceId, admin -> {


### PR DESCRIPTION
This was the standalone implementation for #1441. It adds request-DTO and admin-client validation so a blank topic fails with a 400 error before any broker work.

The PR was closed after its commit was consolidated into merged PR #1429. The fail-fast regression test later landed through #2034.