### PR TITLE
fix: validate message body size before sending

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -65,6 +65,7 @@ import java.util.Set;
 public class RocketMQAdminClientImpl implements AdminClient {
 
     private static final String MESSAGE_SENDER_GROUP_PREFIX = "studio-msg-sender";
+    private static final int MAX_MESSAGE_SIZE = 4 * 1024 * 1024; // 4 MB default broker limit
 
     private final MqAdminExtFactory adminFactory;
     private final RocketMQProperties properties;
@@ -324,9 +325,13 @@ public class RocketMQAdminClientImpl implements AdminClient {
             String tag = request.getTag() != null ? request.getTag() : "";
             String key = request.getKey() != null ? request.getKey() : "";
             String body = request.getBody() != null ? request.getBody() : "";
+            byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+            if (bodyBytes.length > MAX_MESSAGE_SIZE) {
+                throw new BusinessException(400, "Message body size " + bodyBytes.length
+                        + " exceeds the maximum of " + MAX_MESSAGE_SIZE + " bytes");
+            }
 
-            String fullTopic = tag.isEmpty() ? topic : topic + ":" + tag;
-            Message msg = new Message(topic, tag, key, body.getBytes(StandardCharsets.UTF_8));
+            Message msg = new Message(topic, tag, key, bodyBytes);
 
             // Add custom properties
             if (request.getProperties() != null) {


### PR DESCRIPTION
This was the standalone implementation for #1443. It measures the UTF-8 body size against the 4 MiB limit before resolving an endpoint or constructing a producer.

The PR was closed after its commit was consolidated into merged PR #1378. Oversized multi-byte and exact-limit tests later landed through #2034.