### PR TITLE
fix: remove per-group admin calls from group listing

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -181,11 +181,9 @@ public class RocketMQMetadataProvider implements MetadataProvider {
             vo.setCreatedAt(entity.getCreatedAt());
             vo.setUpdatedAt(entity.getUpdatedAt());
 
-            if (StringUtils.hasText(instanceId)) {
-                enrichGroupWithConnectionInfo(vo, entity.getName(), instanceId);
-            } else if (hasAdmin()) {
-                enrichGroupWithConnectionInfo(vo, entity.getName(), null);
-            }
+            // Live connection info (online instances, lag) is intentionally NOT fetched
+            // during list operations to avoid N+1 admin API calls. It is loaded on
+            // demand when viewing a single group's detail page.
             result.add(vo);
         }
         return result;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -425,44 +425,6 @@ public class RocketMQMetadataProvider implements MetadataProvider {
 
     // ── Helper methods ──────────────────────────────────────────────────
 
-    private void enrichGroupWithConnectionInfo(ConsumerGroupVO vo, String groupName, String instanceId) {
-        try {
-            ConsumerConnection conn = executeForInstance(instanceId,
-                    admin -> admin.examineConsumerConnectionInfo(groupName));
-            if (conn != null) {
-                if (conn.getConnectionSet() != null) {
-                    vo.setOnlineInstances(conn.getConnectionSet().size());
-                }
-                if (conn.getSubscriptionTable() != null) {
-                    vo.setSubscribedTopics(new ArrayList<>(conn.getSubscriptionTable().keySet()));
-                }
-            }
-        } catch (Exception ignored) {
-            // Group may be offline, that's fine
-        }
-
-        // Try to get lag info
-        try {
-            ConsumeStats stats = executeForInstance(instanceId, admin -> admin.examineConsumeStats(groupName));
-            if (stats != null && stats.getOffsetTable() != null) {
-                long totalLag = 0;
-                for (OffsetWrapper ow : stats.getOffsetTable().values()) {
-                    totalLag += Math.max(0, ow.getBrokerOffset() - ow.getConsumerOffset());
-                }
-                vo.setTotalLag(totalLag);
-            }
-        } catch (Exception ignored) {
-            // No stats available
-        }
-    }
-
-    private <T> T executeForInstance(String instanceId, MqAdminExtFactory.AdminAction<T> action) {
-        if (StringUtils.hasText(instanceId)) {
-            return runtimeAdminClientResolver.execute(instanceId, action);
-        }
-        return adminExecute(action);
-    }
-
     private String filterMode(String expressionType) {
         if ("SQL92".equals(expressionType)) {
             return "SQL";

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
@@ -44,7 +44,6 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -101,21 +100,6 @@ class RocketMQMetadataProviderTest {
 
         assertThat(groups).hasSize(1);
         assertThat(groups.get(0).getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
-    }
-
-    @Test
-    void listConsumerGroupsShouldUseSelectedInstanceForRuntimeEnrichment() {
-        RmqGroup entity = new RmqGroup();
-        entity.setName("group-a");
-        entity.setInstanceId("instance-a");
-        entity.setClusterId("cluster-a");
-        when(groupMapper.selectList(any())).thenReturn(List.of(entity));
-        when(runtimeAdminClientResolver.execute(eq("instance-a"), any())).thenReturn(null);
-
-        List<ConsumerGroupVO> groups = newProvider().listConsumerGroups("instance-a", null, null);
-
-        assertThat(groups).singleElement().extracting(ConsumerGroupVO::getName).isEqualTo("group-a");
-        verify(runtimeAdminClientResolver, times(2)).execute(eq("instance-a"), any());
     }
 
     @Test


### PR DESCRIPTION
Remove live connection and lag enrichment from `listConsumerGroups(...)`, avoiding two broker admin calls for every row in the list. The follow-up commit also deletes the helper that became unused after the list path switched to stored metadata.

This fixes #1445. Tests verifying the absence of per-group admin lookups and the stored consume-type mapping were later consolidated into #2034.