### PR TITLE
fix: metrics error bodies, DLQ search and small UI fixes (#1252, #1254, #1255, #1256, #1257)

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
@@ -100,11 +100,24 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
                     .headers(this::applyAuthentication)
                     .body(form)
                     .exchange((request, clientResponse) -> {
-                        JsonNode body = objectMapper.readTree(readResponseBody(clientResponse.getBody()));
+                        byte[] rawBody = readResponseBody(clientResponse.getBody());
+                        int upstreamStatus = responseStatus(clientResponse.getStatusCode());
                         if (clientResponse.getStatusCode().isError()) {
-                            throw responseBodyException(body, responseStatus(clientResponse.getStatusCode()));
+                            // Check the status before parsing so a non-JSON error body (e.g. a proxy
+                            // HTML/plain-text page) is not misreported as a connection failure.
+                            try {
+                                throw responseBodyException(objectMapper.readTree(rawBody), upstreamStatus);
+                            } catch (IOException nonJsonBody) {
+                                throw new PrometheusException(upstreamStatus,
+                                        backendLabel() + " query failed (HTTP " + upstreamStatus + ")");
+                            }
                         }
-                        return body;
+                        try {
+                            return objectMapper.readTree(rawBody);
+                        } catch (IOException malformedBody) {
+                            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                                    backendLabel() + " returned a non-JSON response");
+                        }
                     });
             return parseResponse(response);
         } catch (PrometheusException exception) {

--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -36,7 +36,15 @@ vi.mock('../../../services/instanceService', () => ({
   listInstances: vi.fn().mockResolvedValue([]),
 }));
 vi.mock('../../../services/topicService', () => ({
-  listTopics: vi.fn().mockResolvedValue([]),
+  listTopics: vi
+    .fn()
+    .mockResolvedValue([
+      { name: 'order-create' },
+      { name: 'payment-callback' },
+      { name: 'user-activity-log' },
+      { name: 'notification-push' },
+      { name: 'inventory-sync' },
+    ]),
 }));
 
 import MessagePage from '../message';

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -179,7 +179,8 @@ const DLQPage = () => {
     if (!search) return groups;
     return groups.filter(
       (g) =>
-        g.groupName.includes(search) || g.dlqTopic.toLowerCase().includes(search.toLowerCase()),
+        g.groupName.toLowerCase().includes(search.toLowerCase()) ||
+        g.dlqTopic.toLowerCase().includes(search.toLowerCase()),
     );
   }, [groups, search]);
 

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -215,7 +215,10 @@ const InstancePage = () => {
       setAddModalOpen(false);
       addForm.resetFields();
       setVendor(DEFAULT_VENDOR);
-    } catch {
+    } catch (error) {
+      if (error && typeof error === 'object' && 'errorFields' in error) {
+        return; // validation failure; antd already shows field-level errors
+      }
       message.error('添加实例失败，请稍后重试');
     } finally {
       setSubmitting(false);
@@ -232,7 +235,10 @@ const InstancePage = () => {
       message.success(`实例「${updated.name}」备注已更新`);
       setEditModalOpen(false);
       editForm.resetFields();
-    } catch {
+    } catch (error) {
+      if (error && typeof error === 'object' && 'errorFields' in error) {
+        return; // validation failure; antd already shows field-level errors
+      }
       message.error('更新实例失败，请稍后重试');
     } finally {
       setSubmitting(false);

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -222,9 +222,9 @@ const MessagePage = () => {
         const scoped = selectedInstanceId
           ? nextTopics.filter((topic) => topic.instanceId === selectedInstanceId)
           : nextTopics;
-        if (scoped.length > 0) {
-          setTopicOptions(scoped.map((topic) => topic.name));
-        }
+        // Always update so an instance with no topics empties the dropdown instead of showing
+        // topics from another instance or the static defaults.
+        setTopicOptions(scoped.map((topic) => topic.name));
       })
       .catch(() => {
         // 加载失败保持静态选项可用

--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -308,7 +308,10 @@ const AlertsPage = () => {
       }
       setModalVisible(false);
       form.resetFields();
-    } catch {
+    } catch (error) {
+      if (error && typeof error === 'object' && 'errorFields' in error) {
+        return; // validation failure; antd already shows field-level errors
+      }
       message.error('保存告警规则失败，请稍后重试');
     } finally {
       setSubmitting(false);

--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -361,8 +361,13 @@ const AuditPage: React.FC = () => {
             total,
             showSizeChanger: true,
             onChange: (nextPage, nextPageSize) => {
-              setPage(nextPage);
-              setPageSize(nextPageSize);
+              if (nextPageSize !== pageSize) {
+                // A larger page size can make the current page exceed the new total page count.
+                setPage(1);
+                setPageSize(nextPageSize);
+              } else {
+                setPage(nextPage);
+              }
             },
           }}
         />

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -371,7 +371,10 @@ export const DataSourceTab = () => {
       message.success(editingDataSource ? '数据源已更新' : '数据源已添加');
       setModalOpen(false);
       dsForm.resetFields();
-    } catch {
+    } catch (error) {
+      if (error && typeof error === 'object' && 'errorFields' in error) {
+        return; // validation failure; antd already shows field-level errors
+      }
       message.error('保存数据源失败，请稍后重试');
     } finally {
       setSubmitting(false);


### PR DESCRIPTION
Consolidates five small fixes from @yyqdbngt into a single PR (same approach as #1234 / #1379 / #1381). Each commit keeps the original author, plus one test-adaptation commit.

- #1252 fix(metrics): report non-JSON error bodies with their real status (a proxy HTML/plain-text page is no longer misreported as a connection failure)
- #1254 fix(ui): make DLQ group search case-insensitive
- #1255 fix(ui): do not report form validation failure as a save failure (instance add/update handlers)
- #1256 fix(ui): clear topic dropdown when the instance has no topics
- #1257 fix(ui): reset audit page when changing page size

Note: a sixth related PR (#1253, group brokers by owning cluster) is not included — that behavior already shipped via #1055.

Test adaptation: MessagePage query-history tests now mock `listTopics` with real topic names, because #1256 intentionally replaces the old fall-through to static defaults.

Verification: backend 850/850 green; frontend build + 87 files / 449 tests green; eslint clean.

The original PRs will be closed referencing this one once merged.