### PR TITLE
fix(topic): preserve instance context on rebuild

### DIFF
--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -239,6 +239,36 @@ describe('TopicPage', () => {
     expect(within(getTableBody()).queryByText('topic-01')).not.toBeInTheDocument();
   });
 
+  it('keeps the selected instance when rebuilding a topic without a broker route', async () => {
+    const user = userEvent.setup();
+    const topic = { ...buildTopics(1)[0], instanceId: 'instance-a' };
+    instanceServiceMocks.listInstances.mockResolvedValue([
+      {
+        ...selectedInstance,
+        id: 'instance-a',
+        name: 'Instance A',
+        type: 'DIRECT',
+      },
+    ]);
+    topicServiceMocks.listTopics.mockResolvedValue([topic]);
+    renderWithProviders('/instance/instance-a/topic');
+
+    expect(await screen.findByText('topic-01')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /详情/ }));
+    await user.click(await screen.findByRole('button', { name: '在 Broker 上重建' }));
+
+    await waitFor(() =>
+      expect(topicServiceMocks.createTopic).toHaveBeenCalledWith({
+        name: 'topic-01',
+        type: 'NORMAL',
+        writeQueues: 8,
+        readQueues: 8,
+        instanceId: 'instance-a',
+      }),
+    );
+    expect(topicServiceMocks.getTopicRoutes).toHaveBeenLastCalledWith('topic-01', 'instance-a');
+  });
+
   it('keeps failed topics selected after a partially successful batch deletion', async () => {
     const user = userEvent.setup();
     topicServiceMocks.listTopics.mockResolvedValue(buildTopics(3));

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -376,6 +376,7 @@ const TopicPage = () => {
 
   // Metadata lives in the database, so a record can exist without a broker route.
   const rebuildTopic = async (topic: Topic) => {
+    const instanceId = topic.instanceId || selectedInstanceId || undefined;
     setRebuilding(true);
     try {
       await createTopic({
@@ -383,8 +384,9 @@ const TopicPage = () => {
         type: topic.type,
         writeQueues: topic.writeQueues,
         readQueues: topic.readQueues,
+        instanceId,
       });
-      const routes = await getTopicRoutes(topic.name);
+      const routes = await getTopicRoutes(topic.name, instanceId);
       setRoutesByTopic((previous) => ({ ...previous, [topic.name]: routes }));
       message.success(`Topic「${topic.name}」已在 Broker 上重建`);
     } catch {


### PR DESCRIPTION
## What is the purpose of the change

Fixes #1450.

The Topic detail dialog's rebuild path dropped the managed-instance context. Since Topic writes now require `instanceId`, rebuilding a persisted Topic without a Broker route failed with HTTP 400; the follow-up route refresh was also unscoped.

## Brief change log

- derive the rebuild target from the Topic record's `instanceId`, with the current selection as a legacy fallback
- forward that same instance ID to both `createTopic` and `getTopicRoutes`
- add a focused Topic page regression test covering the complete rebuild flow

## Verification

- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/pages/instance/__tests__/TopicPage.test.tsx` — 9 tests passed
- targeted ESLint passed with the base branch's existing `react-hooks/set-state-in-effect` finding disabled
- `npm run build` passed
- `git diff --check` passed
