### PR TITLE
[Studio] feat: Fix/studio p0 frontend fixes

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -2,6 +2,14 @@ server {
     listen 80;
     server_name _;
 
+    # Compress text assets; the entry JS bundle is ~1MB uncompressed.
+    gzip on;
+    gzip_comp_level 5;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_vary on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+
     # RESOLVER is injected by 15-resolver.sh (podman network gateway only).
     # Variable proxy_pass re-resolves on every request, so a recreated
     # rocketmq-server container with a new IP is picked up without restarting

--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -31,6 +31,7 @@ import {
   Checkbox,
   Flex,
   message,
+  Popconfirm,
   theme,
 } from 'antd';
 import type { ColumnsType, TableRowSelection } from 'antd/es/table/interface';
@@ -274,17 +275,23 @@ const AlertsPage = () => {
           >
             {t('common.edit')}
           </Button>
-          <Button
-            size="small"
-            icon={<Trash size={14} />}
-            danger
-            loading={actionId === `delete-${record.id}`}
-            disabled={isActionRunning}
-            style={{ borderColor: '#ff4d4f', color: '#ff4d4f' }}
-            onClick={() => void handleDelete(record)}
+          <Popconfirm
+            title={t('common.areYouSureToDelete')}
+            onConfirm={() => void handleDelete(record)}
+            okText={t('common.confirm')}
+            cancelText={t('common.cancel')}
           >
-            {t('common.delete')}
-          </Button>
+            <Button
+              size="small"
+              icon={<Trash size={14} />}
+              danger
+              loading={actionId === `delete-${record.id}`}
+              disabled={isActionRunning}
+              style={{ borderColor: '#ff4d4f', color: '#ff4d4f' }}
+            >
+              {t('common.delete')}
+            </Button>
+          </Popconfirm>
         </Flex>
       ),
     },

--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -89,6 +89,7 @@ const AuditPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [refreshKey, setRefreshKey] = useState(0);
   const [searchText, setSearchText] = useState('');
+  const [debouncedSearchText, setDebouncedSearchText] = useState('');
   const [selectedType, setSelectedType] = useState<string | undefined>(undefined);
   const [selectedResourceType, setSelectedResourceType] = useState<string | undefined>(undefined);
   const [selectedClusterId, setSelectedClusterId] = useState<string | undefined>(undefined);
@@ -115,6 +116,13 @@ const AuditPage: React.FC = () => {
     };
   }, [refreshKey]);
 
+  // Debounce free-text search so the record list is not re-fetched on every
+  // keystroke; typing pauses for 300ms before the query hits the server.
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebouncedSearchText(searchText), 300);
+    return () => window.clearTimeout(timer);
+  }, [searchText]);
+
   useEffect(() => {
     let cancelled = false;
 
@@ -122,7 +130,7 @@ const AuditPage: React.FC = () => {
       page,
       pageSize,
       ...buildAuditFilter(
-        searchText,
+        debouncedSearchText,
         selectedType,
         selectedResourceType,
         selectedClusterId,
@@ -148,7 +156,7 @@ const AuditPage: React.FC = () => {
   }, [
     page,
     pageSize,
-    searchText,
+    debouncedSearchText,
     selectedType,
     selectedResourceType,
     selectedClusterId,

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -26,6 +26,7 @@ import {
   Input,
   InputNumber,
   Modal,
+  Popconfirm,
   Radio,
   Select,
   Space,
@@ -447,15 +448,16 @@ export const DataSourceTab = () => {
           >
             编辑
           </Button>
-          <Button
-            type="link"
-            size="small"
-            danger
-            icon={<DeleteOutlined />}
-            onClick={() => void handleDelete(record)}
+          <Popconfirm
+            title="确定要删除该数据源吗？"
+            onConfirm={() => void handleDelete(record)}
+            okText="确定"
+            cancelText="取消"
           >
-            删除
-          </Button>
+            <Button type="link" size="small" danger icon={<DeleteOutlined />}>
+              删除
+            </Button>
+          </Popconfirm>
         </Space>
       ),
     },

--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -106,6 +106,9 @@ const GroupManagementPage = () => {
   }, [t]);
 
   useEffect(() => {
+    // Reset on (re)mount: under StrictMode the previous cleanup has already
+    // cleared the flag, and without this the remounted load never applies.
+    mountedRef.current = true;
     const timeoutId = window.setTimeout(() => {
       void loadGroups();
     });


### PR DESCRIPTION
# fix(web): gzip serving, delete confirmations, audit search debounce, StrictMode remount fix

## Summary

Four P0 frontend fixes identified during a post-merge audit of `rocketmq-studio`.

**1. Enable gzip compression in nginx (`web/nginx.conf`)**
The Docker deployment serves static assets through nginx without any compression configuration, so the ~1 MB entry bundle was delivered uncompressed. Adds `gzip on` with a sensible `gzip_types` list to the server block.

**2. Fix GroupManagement remount bug under React StrictMode (`web/src/pages/studio/GroupManagement.tsx`)**
The effect cleanup set `mountedRef.current = false`, but nothing ever reset it to `true` on remount. Because `main.tsx` renders under `<React.StrictMode>`, the dev-mode double mount made every `loadGroups` callback bail out early, leaving the consumer-group list loading forever. The mount effect now resets the flag — the same pattern already used in `pages/cluster/index.tsx`. Production behavior is unchanged; this fixes incorrect logic.

**3. Require confirmation before destructive deletes (`web/src/pages/ops/alerts.tsx`, `web/src/pages/settings/index.tsx`)**
Deleting an alert rule and deleting a data source executed immediately on click, while every other destructive action in the app asks for confirmation. Both buttons are now wrapped in `Popconfirm`, matching the existing convention (`Proxy.tsx`, `AlertManagement.tsx`).

**4. Debounce the audit-log search (`web/src/pages/ops/audit.tsx`)**
The audit search box re-ran the paginated server query on every keystroke — typing an 8-character word meant 8 requests. The search text is now debounced by 300 ms, the same pattern already used in `pages/instance/index.tsx`, so the query fires only when the user pauses typing. The export handler intentionally keeps using the immediate input value.

## Test plan

- [x] Targeted suites: `AuditPage`, `AlertsPage`, `DataSourceTab`, `GroupManagement` — 27 tests pass
- [x] Full frontend suite: 87 files / 449 tests pass
- [x] `npm run build` (tsc + vite) passes
- [x] ESLint on all modified files: 0 errors
- [ ] Manual: verify `Content-Encoding: gzip` responses from the Docker image
- [ ] Manual: verify the confirmation popovers on the Alerts and Settings pages
