### PR TITLE
feat: add instance-scoped Apache ACL 2.0 read foundation

### DIFF
--- a/deploy/mysql/upgrade-cloud-vendor.sql
+++ b/deploy/mysql/upgrade-cloud-vendor.sql
@@ -72,10 +72,26 @@ PREPARE region_id_statement FROM @region_id_sql;
 EXECUTE region_id_statement;
 DEALLOCATE PREPARE region_id_statement;
 
--- 5. 存量实例兜底回填
+-- 5. rmq_instance.admin_credential_ref. The reference is non-secret; actual Apache admin
+-- credentials remain external Spring configuration and are never stored in this database.
+SET @admin_credential_ref_column_exists := (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = @schema_name
+      AND table_name = 'rmq_instance'
+      AND column_name = 'admin_credential_ref'
+);
+SET @admin_credential_ref_sql := IF(@admin_credential_ref_column_exists = 0,
+    "ALTER TABLE rmq_instance ADD COLUMN admin_credential_ref VARCHAR(128) COMMENT 'External Apache admin credential reference; no secret material' AFTER credential_id",
+    'SELECT 1');
+PREPARE admin_credential_ref_statement FROM @admin_credential_ref_sql;
+EXECUTE admin_credential_ref_statement;
+DEALLOCATE PREPARE admin_credential_ref_statement;
+
+-- 6. 存量实例兜底回填
 UPDATE rmq_instance SET vendor = 'APACHE' WHERE vendor IS NULL OR vendor = '';
 
--- 6. 云厂商凭据表（secret_key 为 base64 编码，禁止明文；access_key 明文用于唯一键与打码展示）
+-- 7. 云厂商凭据表（secret_key 为 base64 编码，禁止明文；access_key 明文用于唯一键与打码展示）
 CREATE TABLE IF NOT EXISTS rmq_cloud_credential (
   id VARCHAR(64) PRIMARY KEY,
   name VARCHAR(128) NOT NULL COMMENT '凭据显示名',

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -35,12 +36,12 @@ import java.util.stream.Collectors;
  * Central lifecycle owner for real {@link DefaultMQAdminExt} connections.
  *
  * <p>This is the single real-network entry point shared by every live cluster/metadata provider.
- * Admin clients are created lazily, started once and cached per NameServer address so subsequent
- * calls reuse the established connection. All cached clients are shut down on context destruction.
+ * Admin clients are created lazily, started once and cached per NameServer address and credential
+ * reference so subsequent calls reuse the established connection without crossing identities. All
+ * cached clients are shut down on context destruction.
  *
- * <p>The {@link RPCHook} parameter is reserved for the ACL / authentication work (AUTH-01); it is
- * currently always {@code null} but is threaded through so credentials can be injected later
- * without changing this contract.
+ * <p>The {@link RPCHook} parameter carries Remoting authentication when a selected instance has
+ * an externally configured admin credential.
  */
 @Slf4j
 @Component
@@ -49,7 +50,7 @@ public class MqAdminExtFactory {
     /** Default admin RPC timeout in milliseconds. */
     private static final long DEFAULT_TIMEOUT_MILLIS = 5000L;
 
-    private final Map<String, DefaultMQAdminExt> cache = new ConcurrentHashMap<>();
+    private final Map<AdminClientCacheKey, DefaultMQAdminExt> cache = new ConcurrentHashMap<>();
     private final AtomicInteger instanceCounter = new AtomicInteger();
     private volatile boolean closed = false;
 
@@ -64,6 +65,19 @@ public class MqAdminExtFactory {
      * @throws BusinessException if the connection cannot be established or the action fails
      */
     public <T> T execute(String namesrvAddr, RPCHook rpcHook, AdminAction<T> action) {
+        String authenticationIdentity = rpcHook == null ? "anonymous"
+                : "custom-hook-" + Integer.toUnsignedString(System.identityHashCode(rpcHook));
+        return execute(namesrvAddr, rpcHook, authenticationIdentity, action);
+    }
+
+    /**
+     * Runs an action with a cache entry isolated by a non-secret authentication identity.
+     *
+     * <p>The identity must be a stable reference, never an access key or secret key. Callers that
+     * do not use a configured credential should use the three-argument overload.
+     */
+    public <T> T execute(String namesrvAddr, RPCHook rpcHook, String authenticationIdentity,
+                         AdminAction<T> action) {
         if (namesrvAddr == null || namesrvAddr.isBlank()) {
             throw new BusinessException(400, "NameServer address is required");
         }
@@ -74,8 +88,10 @@ public class MqAdminExtFactory {
         if (normalizedNamesrvAddr.isEmpty()) {
             throw new BusinessException(400, "NameServer address is required");
         }
-        DefaultMQAdminExt admin = cache.computeIfAbsent(normalizedNamesrvAddr,
-                addr -> createAndStart(addr, rpcHook));
+        AdminClientCacheKey cacheKey = new AdminClientCacheKey(normalizedNamesrvAddr,
+                normalizeAuthenticationIdentity(authenticationIdentity));
+        DefaultMQAdminExt admin = cache.computeIfAbsent(cacheKey,
+                key -> createAndStart(key.namesrvAddr(), rpcHook));
         try {
             return action.apply(admin);
         } catch (BusinessException ex) {
@@ -99,11 +115,14 @@ public class MqAdminExtFactory {
         if (normalizedNamesrvAddr.isEmpty()) {
             return;
         }
-        DefaultMQAdminExt admin = cache.remove(normalizedNamesrvAddr);
-        if (admin != null) {
-            safeShutdown(admin);
-            log.info("Released RocketMQ admin client for namesrv {}", normalizedNamesrvAddr);
-        }
+        cache.entrySet().removeIf(entry -> {
+            if (!entry.getKey().namesrvAddr().equals(normalizedNamesrvAddr)) {
+                return false;
+            }
+            safeShutdown(entry.getValue());
+            return true;
+        });
+        log.info("Released RocketMQ admin clients for namesrv {}", normalizedNamesrvAddr);
     }
 
     private DefaultMQAdminExt createAndStart(String namesrvAddr, RPCHook rpcHook) {
@@ -143,6 +162,11 @@ public class MqAdminExtFactory {
                 .collect(Collectors.joining(";"));
     }
 
+    private String normalizeAuthenticationIdentity(String authenticationIdentity) {
+        return authenticationIdentity == null || authenticationIdentity.isBlank()
+                ? "anonymous" : authenticationIdentity.trim();
+    }
+
     private void safeShutdown(MQAdminExt admin) {
         try {
             admin.shutdown();
@@ -172,5 +196,12 @@ public class MqAdminExtFactory {
     @FunctionalInterface
     public interface AdminAction<T> {
         T apply(MQAdminExt admin) throws Exception;
+    }
+
+    private record AdminClientCacheKey(String namesrvAddr, String authenticationIdentity) {
+        private AdminClientCacheKey {
+            Objects.requireNonNull(namesrvAddr, "namesrvAddr");
+            Objects.requireNonNull(authenticationIdentity, "authenticationIdentity");
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminProperties.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminProperties.java
@@ -21,6 +21,9 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * Configuration for the default RocketMQ cluster the studio connects to.
  *
@@ -35,4 +38,20 @@ public class MqAdminProperties {
 
     /** NameServer address list, e.g. {@code host1:9876;host2:9876}; blank disables discovery. */
     private String namesrvAddr;
+
+    /**
+     * Externally supplied credentials for Apache RocketMQ admin calls.
+     *
+     * <p>Instances persist only a reference into this map. Access keys and secret keys must be
+     * supplied through externalized Spring configuration, such as environment variables or a
+     * Kubernetes Secret, and must never be persisted in the Studio database.
+     */
+    private Map<String, Credential> credentials = new LinkedHashMap<>();
+
+    @Getter
+    @Setter
+    public static class Credential {
+        private String accessKey;
+        private String secretKey;
+    }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolver.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolver.java
@@ -7,6 +7,9 @@
 package org.apache.rocketmq.studio.cluster.broker;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.acl.common.AclClientRPCHook;
+import org.apache.rocketmq.acl.common.SessionCredentials;
+import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
@@ -20,6 +23,7 @@ public class RuntimeAdminClientResolver {
 
     private final InstanceRepository instanceRepository;
     private final MqAdminExtFactory adminFactory;
+    private final MqAdminProperties adminProperties;
 
     public InstanceVO resolveInstance(String instanceId) {
         if (!StringUtils.hasText(instanceId)) {
@@ -46,7 +50,24 @@ public class RuntimeAdminClientResolver {
         if (instance == null || !StringUtils.hasText(instance.getEndpoint())) {
             throw new BusinessException(400, "Instance endpoint is required");
         }
-        return adminFactory.execute(instance.getEndpoint().trim(), null, action);
+        String credentialRef = StringUtils.hasText(instance.getAdminCredentialRef())
+                ? instance.getAdminCredentialRef().trim() : null;
+        return adminFactory.execute(instance.getEndpoint().trim(), resolveCredential(credentialRef),
+                credentialRef, action);
+    }
+
+    private RPCHook resolveCredential(String credentialRef) {
+        if (!StringUtils.hasText(credentialRef)) {
+            return null;
+        }
+        MqAdminProperties.Credential credential = adminProperties.getCredentials().get(credentialRef);
+        if (credential == null || !StringUtils.hasText(credential.getAccessKey())
+                || !StringUtils.hasText(credential.getSecretKey())) {
+            throw new BusinessException(422,
+                    "Admin credential reference is not configured: " + credentialRef);
+        }
+        return new AclClientRPCHook(new SessionCredentials(
+                credential.getAccessKey().trim(), credential.getSecretKey()));
     }
 
     private InstanceVO requireApacheInstance(InstanceVO instance) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/CreateInstanceDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/CreateInstanceDTO.java
@@ -37,6 +37,8 @@ public class CreateInstanceDTO {
 
     private String credentialId;
 
+    private String adminCredentialRef;
+
     private String regionId;
 
     public InstanceVO toInstanceVO() {
@@ -48,6 +50,7 @@ public class CreateInstanceDTO {
                 .vendor(vendor)
                 .cloudInstanceId(cloudInstanceId)
                 .credentialId(credentialId)
+                .adminCredentialRef(adminCredentialRef)
                 .regionId(regionId)
                 .build();
         return vo;

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -36,6 +36,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.UUID;
 
 @Slf4j
@@ -108,6 +109,7 @@ public class InstanceService {
         instance.setVendor(InstanceVendor.APACHE);
         instance.setName(requireInstanceName(instance.getName()));
         instance.setEndpoint(requireValidEndpoint(instance.getEndpoint()));
+        instance.setAdminCredentialRef(normalizeCredentialRef(instance.getAdminCredentialRef()));
         if (instance.getType() == null) {
             throw new BusinessException(400, "InstanceVO type is required");
         }
@@ -188,6 +190,10 @@ public class InstanceService {
         return name.trim();
     }
 
+    private String normalizeCredentialRef(String credentialRef) {
+        return StringUtils.hasText(credentialRef) ? credentialRef.trim() : null;
+    }
+
     public InstanceVO updateInstance(InstanceVO instance) {
         requireInstance(instance);
         log.info("Updating instance: {}", instance.getId());
@@ -219,10 +225,13 @@ public class InstanceService {
         if (instance.getRemark() != null) {
             updated.setRemark(instance.getRemark());
         }
+        if (!cloudInstance && instance.getAdminCredentialRef() != null) {
+            updated.setAdminCredentialRef(normalizeCredentialRef(instance.getAdminCredentialRef()));
+        }
         updated.setUpdatedAt(LocalDateTime.now());
 
         InstanceVO saved = instanceRepository.save(updated);
-        releaseApacheEndpointIfUnused(existing, saved.getEndpoint());
+        releaseApacheClientIfChanged(existing, saved);
         recordAudit("UPDATE_INSTANCE", "INSTANCE", saved.getId(), null,
                 instanceAuditDetail(saved));
         return saved;
@@ -273,6 +282,7 @@ public class InstanceService {
                 .vendor(instance.getVendor() == null ? InstanceVendor.APACHE : instance.getVendor())
                 .cloudInstanceId(instance.getCloudInstanceId())
                 .credentialId(instance.getCredentialId())
+                .adminCredentialRef(instance.getAdminCredentialRef())
                 .regionId(instance.getRegionId())
                 .topicCount(instance.getTopicCount())
                 .consumerGroupCount(instance.getConsumerGroupCount())
@@ -289,6 +299,20 @@ public class InstanceService {
             return;
         }
         releaseEndpointIfUnused(existing.getEndpoint(), currentEndpoint, existing.getId());
+    }
+
+    private void releaseApacheClientIfChanged(InstanceVO existing, InstanceVO saved) {
+        InstanceVendor vendor = existing.getVendor() == null ? InstanceVendor.APACHE : existing.getVendor();
+        if (vendor != InstanceVendor.APACHE) {
+            return;
+        }
+        if (!Objects.equals(normalizeCredentialRef(existing.getAdminCredentialRef()),
+                normalizeCredentialRef(saved.getAdminCredentialRef()))
+                && Objects.equals(normalizeEndpoint(existing.getEndpoint()), normalizeEndpoint(saved.getEndpoint()))) {
+            adminFactory.release(existing.getEndpoint());
+            return;
+        }
+        releaseEndpointIfUnused(existing.getEndpoint(), saved.getEndpoint(), existing.getId());
     }
 
     private void releaseEndpointIfUnused(String previousEndpoint, String currentEndpoint, String excludedInstanceId) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceVO.java
@@ -39,6 +39,7 @@ public class InstanceVO extends BaseEntity {
     private InstanceVendor vendor;
     private String cloudInstanceId;
     private String credentialId;
+    private String adminCredentialRef;
     private String regionId;
     private int topicCount;
     private int consumerGroupCount;

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
@@ -141,6 +141,7 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
                 .vendor(parseVendor(entity.getId(), entity.getVendor()))
                 .cloudInstanceId(entity.getCloudInstanceId())
                 .credentialId(entity.getCredentialId())
+                .adminCredentialRef(entity.getAdminCredentialRef())
                 .regionId(entity.getRegionId())
                 .build();
         vo.setId(entity.getId());
@@ -180,6 +181,7 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
         entity.setVendor(vo.getVendor() == null ? InstanceVendor.APACHE.name() : vo.getVendor().name());
         entity.setCloudInstanceId(vo.getCloudInstanceId());
         entity.setCredentialId(vo.getCredentialId());
+        entity.setAdminCredentialRef(vo.getAdminCredentialRef());
         entity.setRegionId(vo.getRegionId());
         entity.setCreatedAt(vo.getCreatedAt());
         entity.setUpdatedAt(vo.getUpdatedAt());

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/UpdateInstanceDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/UpdateInstanceDTO.java
@@ -34,12 +34,15 @@ public class UpdateInstanceDTO {
 
     private String remark;
 
+    private String adminCredentialRef;
+
     public InstanceVO toInstanceVO() {
         InstanceVO vo = InstanceVO.builder()
                 .name(name)
                 .type(type)
                 .endpoint(endpoint)
                 .remark(remark)
+                .adminCredentialRef(adminCredentialRef)
                 .build();
         vo.setId(id);
         return vo;

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclCapabilitiesVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclCapabilitiesVO.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.studio.instance.acl;
+
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+
+/**
+ * Describes whether ACL operations are backed by the selected instance.
+ */
+public record AclCapabilitiesVO(
+        String instanceId,
+        InstanceVendor vendor,
+        InstanceType instanceType,
+        String stateSource,
+        boolean remoteReadSupported,
+        boolean remoteWriteSupported) {
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclController.java
@@ -37,6 +37,15 @@ import java.util.List;
 public class AclController {
 
     private final AclService aclService;
+    private final ApacheAclReadService apacheAclReadService;
+
+    @GetMapping("/remote/rules")
+    public Result<RemoteAclReadResult> listRemoteRules(
+            @RequestParam String instanceId,
+            @RequestParam(required = false) String subject,
+            @RequestParam(required = false) String resource) {
+        return Result.ok(apacheAclReadService.listRules(instanceId, subject, resource));
+    }
 
     @GetMapping("/capabilities")
     public Result<AclCapabilitiesVO> capabilities(@RequestParam String instanceId) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclController.java
@@ -38,6 +38,11 @@ public class AclController {
 
     private final AclService aclService;
 
+    @GetMapping("/capabilities")
+    public Result<AclCapabilitiesVO> capabilities(@RequestParam String instanceId) {
+        return Result.ok(aclService.capabilities(instanceId));
+    }
+
     @GetMapping("/rules")
     public Result<List<AclRuleVO>> listRules(
             @RequestParam(required = false) String clusterId,

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.instance.acl;
 import org.springframework.util.StringUtils;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.model.Acl2PolicyContext;
@@ -47,8 +48,9 @@ public class AclService {
         }
         InstanceVO instance = instanceRepository.findById(instanceId)
                 .orElseThrow(() -> new BusinessException(404, "Instance not found: " + instanceId));
+        boolean apacheInstance = instance.getVendor() == null || instance.getVendor() == InstanceVendor.APACHE;
         return new AclCapabilitiesVO(instance.getId(), instance.getVendor(), instance.getType(),
-                "STUDIO_LOCAL", false, false);
+                apacheInstance ? "APACHE_ACL2" : "STUDIO_LOCAL", apacheInstance, false);
     }
 
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -22,6 +22,8 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.model.Acl2PolicyContext;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,6 +39,17 @@ public class AclService {
 
     private final AclRepository aclRepository;
     private final OperationAuditService operationAuditService;
+    private final InstanceRepository instanceRepository;
+
+    public AclCapabilitiesVO capabilities(String instanceId) {
+        if (!StringUtils.hasText(instanceId)) {
+            throw new BusinessException(400, "instanceId is required");
+        }
+        InstanceVO instance = instanceRepository.findById(instanceId)
+                .orElseThrow(() -> new BusinessException(404, "Instance not found: " + instanceId));
+        return new AclCapabilitiesVO(instance.getId(), instance.getVendor(), instance.getType(),
+                "STUDIO_LOCAL", false, false);
+    }
 
 
     public List<AclRuleVO> listRules(String clusterId, String principal) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadService.java
@@ -2,14 +2,23 @@
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.rocketmq.studio.instance.acl;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
-import org.apache.rocketmq.remoting.protocol.body.AclInfo;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.springframework.stereotype.Service;
@@ -25,7 +34,7 @@ public class ApacheAclReadService {
 
     public RemoteAclReadResult listRules(String instanceId, String subject, String resource) {
         return runtimeAdminClientResolver.execute(instanceId, admin -> {
-            Map<String, List<AclInfo>> policies = new LinkedHashMap<>();
+            Map<String, List<RemoteAclPolicyVO>> policies = new LinkedHashMap<>();
             Map<String, String> failures = new LinkedHashMap<>();
             ClusterInfo clusterInfo = admin.examineBrokerClusterInfo();
             if (clusterInfo == null || clusterInfo.getBrokerAddrTable() == null) {
@@ -37,7 +46,9 @@ public class ApacheAclReadService {
                     continue;
                 }
                 try {
-                    policies.put(address, List.copyOf(admin.listAcl(address, subject, resource)));
+                    policies.put(address, admin.listAcl(address, subject, resource).stream()
+                            .map(RemoteAclPolicyVO::from)
+                            .toList());
                 } catch (Exception ex) {
                     failures.put(address, rootMessage(ex));
                 }
@@ -46,7 +57,7 @@ public class ApacheAclReadService {
         });
     }
 
-    private RemoteAclReadResult result(Map<String, List<AclInfo>> policies,
+    private RemoteAclReadResult result(Map<String, List<RemoteAclPolicyVO>> policies,
                                        Map<String, String> failures) {
         return RemoteAclReadResult.builder().source("APACHE_ACL2")
                 .policiesByBroker(Map.copyOf(policies)).failuresByBroker(Map.copyOf(failures)).build();

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadService.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.acl;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.body.AclInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ApacheAclReadService {
+    private final RuntimeAdminClientResolver runtimeAdminClientResolver;
+
+    public RemoteAclReadResult listRules(String instanceId, String subject, String resource) {
+        return runtimeAdminClientResolver.execute(instanceId, admin -> {
+            Map<String, List<AclInfo>> policies = new LinkedHashMap<>();
+            Map<String, String> failures = new LinkedHashMap<>();
+            ClusterInfo clusterInfo = admin.examineBrokerClusterInfo();
+            if (clusterInfo == null || clusterInfo.getBrokerAddrTable() == null) {
+                return result(policies, failures);
+            }
+            for (BrokerData broker : clusterInfo.getBrokerAddrTable().values()) {
+                String address = masterAddress(broker);
+                if (address == null || policies.containsKey(address) || failures.containsKey(address)) {
+                    continue;
+                }
+                try {
+                    policies.put(address, List.copyOf(admin.listAcl(address, subject, resource)));
+                } catch (Exception ex) {
+                    failures.put(address, rootMessage(ex));
+                }
+            }
+            return result(policies, failures);
+        });
+    }
+
+    private RemoteAclReadResult result(Map<String, List<AclInfo>> policies,
+                                       Map<String, String> failures) {
+        return RemoteAclReadResult.builder().source("APACHE_ACL2")
+                .policiesByBroker(Map.copyOf(policies)).failuresByBroker(Map.copyOf(failures)).build();
+    }
+
+    private String masterAddress(BrokerData broker) {
+        if (broker == null || broker.getBrokerAddrs() == null) {
+            return null;
+        }
+        return broker.getBrokerAddrs().get(MixAll.MASTER_ID);
+    }
+
+    private String rootMessage(Exception ex) {
+        Throwable cause = ex;
+        while (cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        return cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage();
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/RemoteAclPolicyVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/RemoteAclPolicyVO.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.acl;
+
+import org.apache.rocketmq.remoting.protocol.body.AclInfo;
+
+import java.util.List;
+
+/** REST representation of an Apache ACL 2.0 policy. */
+public record RemoteAclPolicyVO(String subject, List<PolicyGroupVO> policies) {
+
+    public static RemoteAclPolicyVO from(AclInfo policy) {
+        List<PolicyGroupVO> groups = policy.getPolicies() == null ? List.of() : policy.getPolicies().stream()
+                .map(PolicyGroupVO::from)
+                .toList();
+        return new RemoteAclPolicyVO(policy.getSubject(), groups);
+    }
+
+    public record PolicyGroupVO(String policyType, List<PolicyEntryVO> entries) {
+        private static PolicyGroupVO from(AclInfo.PolicyInfo policy) {
+            List<PolicyEntryVO> policyEntries = policy.getEntries() == null ? List.of() : policy.getEntries().stream()
+                    .map(PolicyEntryVO::from)
+                    .toList();
+            return new PolicyGroupVO(policy.getPolicyType(), policyEntries);
+        }
+    }
+
+    public record PolicyEntryVO(String resource, List<String> actions, List<String> sourceIps, String decision) {
+        private static PolicyEntryVO from(AclInfo.PolicyEntryInfo entry) {
+            return new PolicyEntryVO(entry.getResource(), listOrEmpty(entry.getActions()),
+                    listOrEmpty(entry.getSourceIps()), entry.getDecision());
+        }
+
+        private static List<String> listOrEmpty(List<String> values) {
+            return values == null ? List.of() : List.copyOf(values);
+        }
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/RemoteAclReadResult.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/RemoteAclReadResult.java
@@ -2,14 +2,22 @@
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.rocketmq.studio.instance.acl;
 
 import lombok.Builder;
 import lombok.Value;
-import org.apache.rocketmq.remoting.protocol.body.AclInfo;
-
 import java.util.List;
 import java.util.Map;
 
@@ -18,7 +26,7 @@ import java.util.Map;
 @Builder
 public class RemoteAclReadResult {
     String source;
-    Map<String, List<AclInfo>> policiesByBroker;
+    Map<String, List<RemoteAclPolicyVO>> policiesByBroker;
     Map<String, String> failuresByBroker;
 
     public boolean isPartial() {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/RemoteAclReadResult.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/RemoteAclReadResult.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.acl;
+
+import lombok.Builder;
+import lombok.Value;
+import org.apache.rocketmq.remoting.protocol.body.AclInfo;
+
+import java.util.List;
+import java.util.Map;
+
+/** Provider-backed ACL 2.0 read result, retaining per-Broker provenance. */
+@Value
+@Builder
+public class RemoteAclReadResult {
+    String source;
+    Map<String, List<AclInfo>> policiesByBroker;
+    Map<String, String> failuresByBroker;
+
+    public boolean isPartial() {
+        return !failuresByBroker.isEmpty() && !policiesByBroker.isEmpty();
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqInstance.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqInstance.java
@@ -44,6 +44,8 @@ public class RmqInstance {
 
     private String credentialId;
 
+    private String adminCredentialRef;
+
     private String regionId;
 
     private LocalDateTime createdAt;

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS rmq_instance (
   vendor VARCHAR(32),
   cloud_instance_id VARCHAR(128),
   credential_id VARCHAR(64),
+  admin_credential_ref VARCHAR(128) COMMENT 'External Apache admin credential reference; no secret material',
   region_id VARCHAR(128),
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP

--- a/server/src/test/java/org/apache/rocketmq/studio/StudioApplicationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/StudioApplicationTest.java
@@ -18,6 +18,10 @@ package org.apache.rocketmq.studio;
 
 import org.apache.rocketmq.studio.ops.ai.tool.ToolCatalog;
 import org.apache.rocketmq.studio.ops.ai.tool.ToolGatewayService;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.instance.MybatisPlusInstanceRepository;
 import org.apache.rocketmq.studio.persistence.mapper.RmqInstanceMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +48,9 @@ class StudioApplicationTest {
     private RmqInstanceMapper instanceMapper;
 
     @Autowired
+    private MybatisPlusInstanceRepository instanceRepository;
+
+    @Autowired
     private MockMvc mockMvc;
 
     @Test
@@ -55,5 +62,28 @@ class StudioApplicationTest {
         mockMvc.perform(get("/api/instances"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void instanceRepositoryPersistsAdminCredentialReference() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("acl-admin-ref-roundtrip")
+                .type(InstanceType.DIRECT)
+                .vendor(InstanceVendor.APACHE)
+                .endpoint("127.0.0.1:9876")
+                .adminCredentialRef("production-admin")
+                .build();
+        instance.setId("acl-admin-ref-roundtrip");
+
+        instanceRepository.save(instance);
+
+        assertThat(instanceMapper.selectById(instance.getId()).getAdminCredentialRef())
+                .isEqualTo("production-admin");
+        assertThat(instanceRepository.findById(instance.getId()))
+                .get()
+                .extracting(InstanceVO::getAdminCredentialRef)
+                .isEqualTo("production-admin");
+
+        instanceRepository.deleteById(instance.getId());
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
@@ -110,6 +110,43 @@ class MqAdminExtFactoryTest {
     }
 
     @Test
+    void executeShouldNotShareClientsAcrossCredentialReferences() throws Exception {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+
+        factory.execute("10.0.0.1:9876", mock(RPCHook.class), "credential-a", ignored -> null);
+        factory.execute("10.0.0.1:9876", mock(RPCHook.class), "credential-b", ignored -> null);
+
+        assertThat(factory.created.get()).isEqualTo(2);
+        verify(admin, times(2)).start();
+    }
+
+    @Test
+    void executeShouldNotShareClientsAcrossLegacyHookInstances() throws Exception {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+
+        factory.execute("10.0.0.1:9876", mock(RPCHook.class), ignored -> null);
+        factory.execute("10.0.0.1:9876", mock(RPCHook.class), ignored -> null);
+
+        assertThat(factory.created.get()).isEqualTo(2);
+    }
+
+    @Test
+    void releaseShouldEvictEveryCredentialIdentityForAnEndpoint() throws Exception {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+
+        factory.execute("10.0.0.1:9876", mock(RPCHook.class), "credential-a", ignored -> null);
+        factory.execute("10.0.0.1:9876", mock(RPCHook.class), "credential-b", ignored -> null);
+        factory.release("10.0.0.1:9876");
+        factory.execute("10.0.0.1:9876", mock(RPCHook.class), "credential-a", ignored -> null);
+
+        assertThat(factory.created.get()).isEqualTo(3);
+        verify(admin, times(2)).shutdown();
+    }
+
+    @Test
     void executeShouldRejectAddressListsWithoutUsableEntries() {
         MqAdminExtFactory factory = new MqAdminExtFactory();
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolverTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolverTest.java
@@ -22,9 +22,14 @@ import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,14 +56,16 @@ class RuntimeAdminClientResolverTest {
         instance.setId("instance-a");
         when(instanceRepository.findById("instance-a")).thenReturn(Optional.of(instance));
 
-        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory);
+        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory,
+                new MqAdminProperties());
 
         assertThat(resolver.resolveEndpoint("instance-a")).isEqualTo("namesrv-a:9876");
     }
 
     @Test
     void rejectsUnknownOrUnconfiguredInstances() {
-        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory);
+        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory,
+                new MqAdminProperties());
         when(instanceRepository.findById("missing")).thenReturn(Optional.empty());
         InstanceVO noEndpoint = InstanceVO.builder().endpoint(" ").build();
         when(instanceRepository.findById("no-endpoint")).thenReturn(Optional.of(noEndpoint));
@@ -75,12 +82,13 @@ class RuntimeAdminClientResolverTest {
     void executesAgainstTheSelectedInstanceEndpoint() {
         InstanceVO instance = InstanceVO.builder().endpoint("namesrv-b:9876").build();
         when(instanceRepository.findById("instance-b")).thenReturn(Optional.of(instance));
-        when(adminFactory.execute(eq("namesrv-b:9876"), isNull(), any())).thenReturn("done");
-        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory);
+        when(adminFactory.execute(eq("namesrv-b:9876"), isNull(), isNull(), any())).thenReturn("done");
+        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory,
+                new MqAdminProperties());
 
         String result = resolver.execute("instance-b", admin -> "unused");
         assertThat(result).isEqualTo("done");
-        verify(adminFactory).execute(eq("namesrv-b:9876"), isNull(), any());
+        verify(adminFactory).execute(eq("namesrv-b:9876"), isNull(), isNull(), any());
     }
 
     @Test
@@ -91,7 +99,8 @@ class RuntimeAdminClientResolverTest {
                 .build();
         instance.setId("cloud-instance");
         when(instanceRepository.findById("cloud-instance")).thenReturn(Optional.of(instance));
-        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory);
+        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory,
+                new MqAdminProperties());
 
         assertThatThrownBy(() -> resolver.resolveEndpoint("cloud-instance"))
                 .isInstanceOf(BusinessException.class)
@@ -100,5 +109,76 @@ class RuntimeAdminClientResolverTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Runtime AdminClient only supports Apache instances: cloud-instance");
         verifyNoInteractions(adminFactory);
+    }
+
+    @Test
+    void executesWithTheSelectedInstanceCredentialReference() {
+        InstanceVO instance = InstanceVO.builder()
+                .endpoint("namesrv-b:9876")
+                .adminCredentialRef(" production-admin ")
+                .build();
+        instance.setId("instance-b");
+        MqAdminProperties properties = new MqAdminProperties();
+        MqAdminProperties.Credential credential = new MqAdminProperties.Credential();
+        credential.setAccessKey("admin-ak");
+        credential.setSecretKey("admin-sk");
+        properties.getCredentials().put("production-admin", credential);
+        when(instanceRepository.findById("instance-b")).thenReturn(Optional.of(instance));
+        when(adminFactory.execute(eq("namesrv-b:9876"), any(), eq("production-admin"), any()))
+                .thenReturn("done");
+        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory,
+                properties);
+
+        String result = resolver.execute("instance-b", ignored -> "unused");
+
+        assertThat(result).isEqualTo("done");
+        ArgumentCaptor<org.apache.rocketmq.remoting.RPCHook> hookCaptor = ArgumentCaptor.forClass(
+                org.apache.rocketmq.remoting.RPCHook.class);
+        verify(adminFactory).execute(eq("namesrv-b:9876"), hookCaptor.capture(), eq("production-admin"), any());
+        org.apache.rocketmq.acl.common.AclClientRPCHook resolvedHook =
+                (org.apache.rocketmq.acl.common.AclClientRPCHook) hookCaptor.getValue();
+        assertThat(resolvedHook.getSessionCredentials().getAccessKey()).isEqualTo("admin-ak");
+        assertThat(resolvedHook.getSessionCredentials().getSecretKey()).isEqualTo("admin-sk");
+    }
+
+    @Test
+    void rejectsUnknownOrIncompleteCredentialReferencesBeforeNetworkCalls() {
+        MqAdminProperties properties = new MqAdminProperties();
+        MqAdminProperties.Credential credential = new MqAdminProperties.Credential();
+        credential.setAccessKey("admin-ak");
+        credential.setSecretKey("admin-sk");
+        properties.getCredentials().put("production-admin", credential);
+        MqAdminProperties.Credential incomplete = new MqAdminProperties.Credential();
+        incomplete.setAccessKey("admin-ak");
+        properties.getCredentials().put("incomplete", incomplete);
+        InstanceVO instance = InstanceVO.builder().endpoint("namesrv-b:9876")
+                .adminCredentialRef("missing").build();
+        instance.setId("instance-b");
+        when(instanceRepository.findById("instance-b")).thenReturn(Optional.of(instance));
+        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory,
+                properties);
+
+        assertThatThrownBy(() -> resolver.execute("instance-b", ignored -> "unused"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Admin credential reference is not configured: missing")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(422));
+        instance.setAdminCredentialRef("incomplete");
+        assertThatThrownBy(() -> resolver.execute("instance-b", ignored -> "unused"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Admin credential reference is not configured: incomplete");
+        verifyNoInteractions(adminFactory);
+    }
+
+    @Test
+    void bindsReferencedCredentialsFromExternalizedConfiguration() {
+        MqAdminProperties properties = new Binder(new MapConfigurationPropertySource(Map.of(
+                        "studio.cluster.admin.credentials.production-admin.access-key", "admin-ak",
+                        "studio.cluster.admin.credentials.production-admin.secret-key", "admin-sk")))
+                .bind("studio.cluster.admin", Bindable.of(MqAdminProperties.class)).get();
+
+        MqAdminProperties.Credential credential = properties.getCredentials().get("production-admin");
+
+        assertThat(credential.getAccessKey()).isEqualTo("admin-ak");
+        assertThat(credential.getSecretKey()).isEqualTo("admin-sk");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -348,6 +348,33 @@ class InstanceServiceTest {
     }
 
     @Test
+    void createApacheInstanceShouldTrimAndPersistOnlyAdminCredentialReference() {
+        InstanceVO input = InstanceVO.builder().name("production").type(InstanceType.PROXY)
+                .endpoint("namesrv:9876").adminCredentialRef(" production-admin ").build();
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        InstanceVO saved = instanceService.createInstance(input);
+
+        assertThat(saved.getAdminCredentialRef()).isEqualTo("production-admin");
+    }
+
+    @Test
+    void updateApacheInstanceShouldReleaseCachedClientWhenCredentialReferenceChanges() {
+        InstanceVO existing = InstanceVO.builder().name("production").type(InstanceType.PROXY)
+                .endpoint("namesrv:9876").adminCredentialRef("credential-a").build();
+        existing.setId("inst-1");
+        InstanceVO update = InstanceVO.builder().adminCredentialRef("credential-b").build();
+        update.setId("inst-1");
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        InstanceVO saved = instanceService.updateInstance(update);
+
+        assertThat(saved.getAdminCredentialRef()).isEqualTo("credential-b");
+        verify(adminFactory).release("namesrv:9876");
+    }
+
+    @Test
     void updateInstanceShouldMergeFieldsOntoExisting() {
         LocalDateTime originalCreatedAt = LocalDateTime.of(2025, 1, 2, 3, 4, 5);
         LocalDateTime originalUpdatedAt = LocalDateTime.of(2025, 2, 3, 4, 5, 6);

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.studio.persistence.mapper.RmqInstanceMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqTopicMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -75,6 +76,7 @@ class MybatisPlusInstanceRepositoryTest {
         assertThat(direct.getConsumerGroupCount()).isZero();
         assertThat(proxy.getTopicCount()).isZero();
         assertThat(proxy.getConsumerGroupCount()).isZero();
+        assertThat(direct.getAdminCredentialRef()).isEqualTo("admin-instance-direct-1");
         verifyNoInteractions(topicMapper, groupMapper);
     }
 
@@ -160,7 +162,9 @@ class MybatisPlusInstanceRepositoryTest {
 
         repository.save(vo);
 
-        verify(instanceMapper).insert(any(RmqInstance.class));
+        ArgumentCaptor<RmqInstance> entity = ArgumentCaptor.forClass(RmqInstance.class);
+        verify(instanceMapper).insert(entity.capture());
+        assertThat(entity.getValue().getAdminCredentialRef()).isEqualTo("admin-instance-proxy-2");
         verify(instanceMapper, never()).updateById(any(RmqInstance.class));
     }
 
@@ -189,6 +193,7 @@ class MybatisPlusInstanceRepositoryTest {
         entity.setType(type.name());
         entity.setEndpoint("10.0.0.1:9876");
         entity.setVendor(InstanceVendor.APACHE.name());
+        entity.setAdminCredentialRef("admin-" + id);
         entity.setCreatedAt(LocalDateTime.of(2026, 8, 3, 0, 0));
         entity.setUpdatedAt(LocalDateTime.of(2026, 8, 3, 0, 0));
         return entity;
@@ -201,6 +206,7 @@ class MybatisPlusInstanceRepositoryTest {
                 .endpoint("10.0.0.1:9876")
                 .build();
         vo.setId(id);
+        vo.setAdminCredentialRef("admin-" + id);
         return vo;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
@@ -61,18 +61,18 @@ class AclControllerTest {
     private ObjectMapper objectMapper;
 
     @Test
-    void capabilitiesShouldReturnInstanceScopedLocalState() throws Exception {
+    void capabilitiesShouldReturnApacheRemoteReadState() throws Exception {
         when(aclService.capabilities("instance-1"))
                 .thenReturn(new AclCapabilitiesVO("instance-1",
                         org.apache.rocketmq.studio.common.domain.enums.InstanceVendor.APACHE,
                         org.apache.rocketmq.studio.common.domain.enums.InstanceType.DIRECT,
-                        "STUDIO_LOCAL", false, false));
+                        "APACHE_ACL2", true, false));
 
         mockMvc.perform(get("/api/acl/capabilities").param("instanceId", "instance-1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.instanceId").value("instance-1"))
-                .andExpect(jsonPath("$.data.stateSource").value("STUDIO_LOCAL"))
-                .andExpect(jsonPath("$.data.remoteReadSupported").value(false))
+                .andExpect(jsonPath("$.data.stateSource").value("APACHE_ACL2"))
+                .andExpect(jsonPath("$.data.remoteReadSupported").value(true))
                 .andExpect(jsonPath("$.data.remoteWriteSupported").value(false));
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
@@ -58,6 +58,22 @@ class AclControllerTest {
     private ObjectMapper objectMapper;
 
     @Test
+    void capabilitiesShouldReturnInstanceScopedLocalState() throws Exception {
+        when(aclService.capabilities("instance-1"))
+                .thenReturn(new AclCapabilitiesVO("instance-1",
+                        org.apache.rocketmq.studio.common.domain.enums.InstanceVendor.APACHE,
+                        org.apache.rocketmq.studio.common.domain.enums.InstanceType.DIRECT,
+                        "STUDIO_LOCAL", false, false));
+
+        mockMvc.perform(get("/api/acl/capabilities").param("instanceId", "instance-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.instanceId").value("instance-1"))
+                .andExpect(jsonPath("$.data.stateSource").value("STUDIO_LOCAL"))
+                .andExpect(jsonPath("$.data.remoteReadSupported").value(false))
+                .andExpect(jsonPath("$.data.remoteWriteSupported").value(false));
+    }
+
+    @Test
     void listRulesShouldReturnRules() throws Exception {
         AclRuleVO rule = AclRuleVO.builder()
                 .principal("user1")

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
@@ -54,6 +54,9 @@ class AclControllerTest {
     @MockBean
     private AclService aclService;
 
+    @MockBean
+    private ApacheAclReadService apacheAclReadService;
+
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -71,6 +74,19 @@ class AclControllerTest {
                 .andExpect(jsonPath("$.data.stateSource").value("STUDIO_LOCAL"))
                 .andExpect(jsonPath("$.data.remoteReadSupported").value(false))
                 .andExpect(jsonPath("$.data.remoteWriteSupported").value(false));
+    }
+
+    @Test
+    void listRemoteRulesShouldRequireInstanceAndDelegateToApacheProvider() throws Exception {
+        RemoteAclReadResult result = RemoteAclReadResult.builder()
+                .source("APACHE_ACL2").policiesByBroker(Map.of()).failuresByBroker(Map.of()).build();
+        when(apacheAclReadService.listRules("instance-1", null, null)).thenReturn(result);
+
+        mockMvc.perform(get("/api/acl/remote/rules").param("instanceId", "instance-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.source").value("APACHE_ACL2"));
+
+        verify(apacheAclReadService).listRules("instance-1", null, null);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -20,6 +20,10 @@ package org.apache.rocketmq.studio.instance.acl;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.model.Acl2PolicyContext;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,6 +58,9 @@ class AclServiceTest {
     @Mock
     private OperationAuditService operationAuditService;
 
+    @Mock
+    private InstanceRepository instanceRepository;
+
     @InjectMocks
     private AclService aclService;
 
@@ -84,6 +91,35 @@ class AclServiceTest {
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getPrincipal()).isEqualTo("user1");
         verify(aclRepository).findRules("cluster-1", "user1");
+    }
+
+    @Test
+    void capabilitiesShouldDescribeSelectedInstanceAsLocalUntilProviderIsConnected() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("instance-1")
+                .vendor(InstanceVendor.APACHE)
+                .type(InstanceType.DIRECT)
+                .build();
+        instance.setId("instance-1");
+        when(instanceRepository.findById("instance-1")).thenReturn(Optional.of(instance));
+
+        AclCapabilitiesVO capabilities = aclService.capabilities("instance-1");
+
+        assertThat(capabilities.instanceId()).isEqualTo("instance-1");
+        assertThat(capabilities.vendor()).isEqualTo(InstanceVendor.APACHE);
+        assertThat(capabilities.instanceType()).isEqualTo(InstanceType.DIRECT);
+        assertThat(capabilities.stateSource()).isEqualTo("STUDIO_LOCAL");
+        assertThat(capabilities.remoteReadSupported()).isFalse();
+        assertThat(capabilities.remoteWriteSupported()).isFalse();
+    }
+
+    @Test
+    void capabilitiesShouldRejectUnknownInstance() {
+        when(instanceRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> aclService.capabilities("missing"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Instance not found: missing");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -94,7 +94,7 @@ class AclServiceTest {
     }
 
     @Test
-    void capabilitiesShouldDescribeSelectedInstanceAsLocalUntilProviderIsConnected() {
+    void capabilitiesShouldDescribeApacheRemoteReadSupport() {
         InstanceVO instance = InstanceVO.builder()
                 .name("instance-1")
                 .vendor(InstanceVendor.APACHE)
@@ -108,8 +108,8 @@ class AclServiceTest {
         assertThat(capabilities.instanceId()).isEqualTo("instance-1");
         assertThat(capabilities.vendor()).isEqualTo(InstanceVendor.APACHE);
         assertThat(capabilities.instanceType()).isEqualTo(InstanceType.DIRECT);
-        assertThat(capabilities.stateSource()).isEqualTo("STUDIO_LOCAL");
-        assertThat(capabilities.remoteReadSupported()).isFalse();
+        assertThat(capabilities.stateSource()).isEqualTo("APACHE_ACL2");
+        assertThat(capabilities.remoteReadSupported()).isTrue();
         assertThat(capabilities.remoteWriteSupported()).isFalse();
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadServiceTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.acl;
+
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ApacheAclReadServiceTest {
+    @Test
+    void retainsSuccessfulBrokerDataWhenAnotherBrokerFails() throws Exception {
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        MQAdminExt admin = mock(MQAdminExt.class);
+        ClusterInfo clusterInfo = new ClusterInfo();
+        BrokerData healthy = new BrokerData();
+        healthy.setBrokerAddrs(new HashMap<>(Map.of(0L, "broker-a:10911")));
+        BrokerData failing = new BrokerData();
+        failing.setBrokerAddrs(new HashMap<>(Map.of(0L, "broker-b:10911")));
+        clusterInfo.setBrokerAddrTable(Map.of("a", healthy, "b", failing));
+        when(admin.examineBrokerClusterInfo()).thenReturn(clusterInfo);
+        when(admin.listAcl("broker-a:10911", null, null)).thenReturn(List.of());
+        when(admin.listAcl("broker-b:10911", null, null)).thenThrow(new IllegalStateException("unavailable"));
+        when(resolver.execute(eq("instance-1"), any())).thenAnswer(invocation -> {
+            MqAdminExtFactory.AdminAction<?> action = invocation.getArgument(1);
+            return action.apply(admin);
+        });
+
+        RemoteAclReadResult result = new ApacheAclReadService(resolver).listRules("instance-1", null, null);
+
+        assertThat(result.getPoliciesByBroker()).containsKey("broker-a:10911");
+        assertThat(result.getFailuresByBroker()).containsEntry("broker-b:10911", "unavailable");
+        assertThat(result.isPartial()).isTrue();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadServiceTest.java
@@ -2,7 +2,17 @@
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.rocketmq.studio.instance.acl;
 

--- a/web/src/api/instance.ts
+++ b/web/src/api/instance.ts
@@ -29,6 +29,7 @@ export interface Instance {
   vendor?: InstanceVendor;
   cloudInstanceId?: string;
   credentialId?: string;
+  adminCredentialRef?: string;
   regionId?: string;
   topicCount: number;
   consumerGroupCount: number;
@@ -45,6 +46,7 @@ export interface CreateInstanceRequest {
   vendor?: InstanceVendor;
   cloudInstanceId?: string;
   credentialId?: string;
+  adminCredentialRef?: string;
   regionId?: string;
 }
 
@@ -54,6 +56,7 @@ export interface UpdateInstanceRequest {
   type?: 'PROXY' | 'DIRECT';
   endpoint?: string;
   remark?: string;
+  adminCredentialRef?: string;
 }
 
 export interface InstanceQuery {

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -245,7 +245,11 @@ const InstancePage = () => {
     try {
       const values = await editForm.validateFields();
       setSubmitting(true);
-      const updated = await updateInstance({ id: editingInstance.id, remark: values.remark || '' });
+      const updated = await updateInstance({
+        id: editingInstance.id,
+        remark: values.remark || '',
+        adminCredentialRef: values.adminCredentialRef,
+      });
       await loadInstances();
       message.success(`实例「${updated.name}」备注已更新`);
       setEditModalOpen(false);
@@ -382,7 +386,10 @@ const InstancePage = () => {
             style={{ borderColor: '#1677ff', color: '#1677ff' }}
             onClick={() => {
               setEditingInstance(record);
-              editForm.setFieldsValue({ remark: record.remark });
+              editForm.setFieldsValue({
+                remark: record.remark,
+                adminCredentialRef: record.adminCredentialRef,
+              });
               setEditModalOpen(true);
             }}
           >
@@ -625,6 +632,13 @@ const InstancePage = () => {
               message="接入地址为客户端访问入口"
               description="接入地址会展示在 Topic 等页面供客户端配置使用。若客户端环境无法解析该地址（如 K8s 内部 Service 域名），可自行配置 DNS 解析或在客户端 hosts 中映射。"
             />
+            <Form.Item
+              label="管理凭据引用"
+              name="adminCredentialRef"
+              extra="可选。仅保存服务端配置中的凭据引用，不会保存或传输 AK/SK。"
+            >
+              <Input placeholder="例：production-admin" />
+            </Form.Item>
             <Form.Item label="备注" name="remark">
               <Input.TextArea rows={2} placeholder="可选，描述实例用途" />
             </Form.Item>
@@ -663,6 +677,15 @@ const InstancePage = () => {
           <Form.Item label="接入地址">
             <Input value={editingInstance?.endpoint} disabled />
           </Form.Item>
+          {editingInstance?.vendor !== 'ALIYUN' && (
+            <Form.Item
+              label="管理凭据引用"
+              name="adminCredentialRef"
+              extra="仅保存服务端配置中的引用，不会保存或传输 AK/SK。"
+            >
+              <Input placeholder="例：production-admin" />
+            </Form.Item>
+          )}
           <Form.Item label="备注" name="remark">
             <Input.TextArea rows={3} placeholder="描述实例用途" />
           </Form.Item>

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -677,7 +677,7 @@ const InstancePage = () => {
           <Form.Item label="接入地址">
             <Input value={editingInstance?.endpoint} disabled />
           </Form.Item>
-          {editingInstance?.vendor !== 'ALIYUN' && (
+          {editingInstance?.vendor === 'APACHE' && (
             <Form.Item
               label="管理凭据引用"
               name="adminCredentialRef"


### PR DESCRIPTION
## Summary
Consolidates the implementation portions of #1312 into one reviewable Apache ACL 2.0 read foundation:
- expose selected-instance ACL capabilities without claiming remote enforcement
- resolve optional external Apache admin credential references into authenticated runtime AdminClients
- cache clients by NameServer endpoint and non-secret credential reference
- expose `GET /api/acl/remote/rules?instanceId=...`, querying ACL 2.0 policies from every discovered master Broker
- preserve provider provenance and partial-failure details; remote failures never fall back to Studio-local ACL records

## Explicit non-goals
- no remote ACL mutations
- no ACL 1.0 policy CRUD claim (it needs a separate file/config provider)
- no cloud ACL provider

## Validation
- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) mvn -Dtest=AclServiceTest,AclControllerTest,ApacheAclReadServiceTest,RuntimeAdminClientResolverTest,MqAdminExtFactoryTest,InstanceServiceTest test` (116 tests)

Closes #1426
Closes #1430
Closes #1449
Part of #1312