### PR TITLE
fix(settings): track concurrent data source tests

### DIFF
--- a/web/src/pages/settings/__tests__/DataSourceTab.test.tsx
+++ b/web/src/pages/settings/__tests__/DataSourceTab.test.tsx
@@ -101,6 +101,53 @@ describe('DataSourceTab', () => {
     resolveTest({ success: true, message: 'ok' });
   });
 
+  it('keeps each row loading until its own connection test finishes', async () => {
+    vi.mocked(listDataSources).mockResolvedValue(
+      sources.map((source) => ({ ...source, auth: 'None' })),
+    );
+    let resolveFirst: (value: { success: boolean; message: string }) => void = () => undefined;
+    let resolveSecond: (value: { success: boolean; message: string }) => void = () => undefined;
+    vi.mocked(testDataSource)
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSecond = resolve;
+        }),
+      );
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <App>
+        <DataSourceTab />
+      </App>,
+    );
+
+    await screen.findByText('Prometheus prod');
+    const buttons = screen.getAllByRole('button', { name: /测试连接/ });
+    await user.click(buttons[0]);
+    await user.click(buttons[1]);
+
+    await waitFor(() => {
+      expect(buttons[0]).toHaveClass('ant-btn-loading');
+      expect(buttons[1]).toHaveClass('ant-btn-loading');
+    });
+
+    resolveFirst({ success: true, message: 'ok' });
+    await waitFor(() => {
+      expect(buttons[0]).not.toHaveClass('ant-btn-loading');
+      expect(buttons[1]).toHaveClass('ant-btn-loading');
+    });
+
+    resolveSecond({ success: true, message: 'ok' });
+    await waitFor(() => {
+      expect(buttons[1]).not.toHaveClass('ant-btn-loading');
+    });
+  });
+
   it('submits basic auth credentials when testing from the modal', async () => {
     vi.mocked(testDataSource).mockResolvedValue({ success: true, message: 'ok' });
 

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -288,7 +288,7 @@ export const DataSourceTab = () => {
   const [editingDataSource, setEditingDataSource] = useState<DataSource | null>(null);
   const [dsForm] = Form.useForm();
   const authValue = Form.useWatch('auth', dsForm);
-  const [testingKey, setTestingKey] = useState<string | null>(null);
+  const [testingKeys, setTestingKeys] = useState<Set<string>>(() => new Set());
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
@@ -331,7 +331,7 @@ export const DataSourceTab = () => {
       message.warning('认证数据源请编辑后输入凭据再测试连接');
       return;
     }
-    setTestingKey(key);
+    setTestingKeys((previous) => new Set(previous).add(key));
     try {
       const result = await testDataSource(data);
       if (result.success) message.success(result.message);
@@ -339,7 +339,11 @@ export const DataSourceTab = () => {
     } catch {
       message.error('连接测试失败，请稍后重试');
     } finally {
-      setTestingKey(null);
+      setTestingKeys((previous) => {
+        const next = new Set(previous);
+        next.delete(key);
+        return next;
+      });
     }
   };
 
@@ -431,7 +435,7 @@ export const DataSourceTab = () => {
             type="link"
             size="small"
             icon={<ApiOutlined />}
-            loading={testingKey === record.key}
+            loading={testingKeys.has(record.key)}
             disabled={authNeedsSecret(record.auth)}
             title={
               authNeedsSecret(record.auth) ? '认证数据源请编辑后输入凭据再测试连接' : undefined
@@ -575,7 +579,7 @@ export const DataSourceTab = () => {
 
           <Button
             icon={<ApiOutlined />}
-            loading={testingKey === 'modal'}
+            loading={testingKeys.has('modal')}
             onClick={() => {
               void dsForm
                 .validateFields(testFieldNames(authValue))


### PR DESCRIPTION
## Summary
- track in-flight data source connection tests by row/modal key instead of one global key
- keep each loading indicator active until its own request settles
- cover overlapping row tests with independently controlled promises

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/pages/settings/__tests__/DataSourceTab.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npx eslint src/pages/settings/index.tsx src/pages/settings/__tests__/DataSourceTab.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npm run build`

Fixes #1455
