### PR TITLE
fix(settings): isolate audit recording failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -90,8 +90,16 @@ public class SettingsService {
         }
         settings.setClearApiKey(false);
         settingsRepository.saveGeneralSettings(settings);
-        operationAuditService.record("UPDATE_SETTINGS", "SETTINGS", "general",
-                null, "General settings updated", "SUCCESS", null);
+        recordSettingsAudit();
+    }
+
+    private void recordSettingsAudit() {
+        try {
+            operationAuditService.record("UPDATE_SETTINGS", "SETTINGS", "general",
+                    null, "General settings updated", "SUCCESS", null);
+        } catch (Exception auditFailure) {
+            log.warn("Failed to record general settings audit: {}", auditFailure.getMessage());
+        }
     }
 
 

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -39,8 +39,10 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -161,6 +163,24 @@ class SettingsServiceTest {
         assertThat(update.getApiKey()).isEmpty();
         assertThat(update.isClearApiKey()).isFalse();
         verify(settingsRepository).saveGeneralSettings(update);
+    }
+
+    @Test
+    void saveGeneralSettingsShouldSucceedWhenAuditRecordingFails() {
+        GeneralSettingsVO update = GeneralSettingsVO.builder()
+                .theme("dark")
+                .build();
+        doThrow(new IllegalStateException("audit unavailable"))
+                .when(operationAuditService)
+                .record("UPDATE_SETTINGS", "SETTINGS", "general",
+                        null, "General settings updated", "SUCCESS", null);
+
+        assertThatCode(() -> settingsService.saveGeneralSettings(update))
+                .doesNotThrowAnyException();
+
+        verify(settingsRepository).saveGeneralSettings(update);
+        verify(operationAuditService).record("UPDATE_SETTINGS", "SETTINGS", "general",
+                null, "General settings updated", "SUCCESS", null);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- make general-settings audit recording best effort after the settings are persisted
- log audit storage failures without returning a false save failure to callers
- add a service regression test for an unavailable audit store

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=SettingsServiceTest test` (28 tests)

Fixes #1457
