### PR TITLE
fix(dlq): guard newline-prefixed CSV formulas

### DIFF
--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -228,6 +228,25 @@ describe('DLQ page', () => {
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:dlq');
   });
 
+  it('neutralizes formulas hidden behind a leading line feed in CSV exports', async () => {
+    vi.mocked(messageService.listDLQGroups).mockResolvedValue([
+      {
+        ...dlqGroup,
+        groupName: '\n=1+1',
+        dlqTopic: '%DLQ%formula',
+      },
+    ]);
+    const user = userEvent.setup();
+    renderWithProviders(<DLQPage />);
+
+    const row = (await screen.findByText('%DLQ%formula')).closest('tr');
+    if (!row) throw new Error('DLQ group row not found');
+    await user.click(within(row).getByRole('button', { name: '导出' }));
+
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    await expect(blob.text()).resolves.toContain('"\'\n=1+1","%DLQ%formula"');
+  });
+
   it('clears a selected group when refreshed data shows no dead-letter messages', async () => {
     vi.mocked(messageService.listDLQGroups)
       .mockResolvedValueOnce([dlqGroup])

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -78,7 +78,7 @@ const formatDateTime = (iso?: string | null): string => {
 };
 
 const escapeCSVValue = (value: string) => {
-  const safeValue = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+  const safeValue = /^[=+\-@\t\r\n]/.test(value) ? `'${value}` : value;
   return `"${safeValue.replace(/"/g, '""')}"`;
 };
 


### PR DESCRIPTION
## Summary
- include line feed in the DLQ CSV formula-prefix guard
- keep CSV quoting behavior unchanged while neutralizing the spreadsheet cell value
- add an export regression test for a line-feed-prefixed formula

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/pages/instance/__tests__/DLQPage.test.tsx` (11 tests)
- `NODE_OPTIONS=--no-experimental-webstorage npx eslint --rule 'react-hooks/set-state-in-effect: off' src/pages/instance/dlq.tsx src/pages/instance/__tests__/DLQPage.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npm run build`

Note: the targeted file already triggers the repository's existing `react-hooks/set-state-in-effect` finding at `dlq.tsx:132`; the focused lint run disables only that unrelated rule.

Fixes #1461
