### PR TITLE
[ISSUE #1463] Support Tencent Cloud RocketMQ 5.x instance onboarding

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -104,11 +104,17 @@
             <artifactId>alibabacloud-rocketmq20220801</artifactId>
             <version>5.0.8</version>
         </dependency>
-        <!-- Tencent Cloud TDMQ OpenAPI, reserved for provider/tencent (not implemented yet) -->
+        <!-- Tencent Cloud RocketMQ 5.x OpenAPI (Trocket v20230308), used by provider/tencent -->
         <dependency>
             <groupId>com.tencentcloudapi</groupId>
-            <artifactId>tencentcloud-sdk-java-tdmq</artifactId>
-            <version>3.1.1500</version>
+            <artifactId>tencentcloud-sdk-java-trocket</artifactId>
+            <version>3.1.1292</version>
+        </dependency>
+        <!-- rocketmq-common also brings Kotlin-based okio-jvm 3.x; keep its runtime available. -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>1.9.25</version>
         </dependency>
     </dependencies>
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -91,8 +91,7 @@ public class InstanceService {
 
         switch (vendor) {
             case APACHE -> createApacheInstance(instance);
-            case ALIYUN -> createAliyunInstance(instance);
-            case TENCENT -> throw new BusinessException(501, "Tencent Cloud instance is not supported yet");
+            case ALIYUN, TENCENT -> createCloudInstance(instance, vendor);
         }
 
         instance.setId(UUID.randomUUID().toString());
@@ -118,21 +117,22 @@ public class InstanceService {
      * one of the cloud instances returned by the vendor catalog; endpoint is resolved from the
      * cloud instance detail (VPC endpoint preferred).
      */
-    private void createAliyunInstance(InstanceVO instance) {
-        instance.setVendor(InstanceVendor.ALIYUN);
+    private void createCloudInstance(InstanceVO instance, InstanceVendor vendor) {
+        instance.setVendor(vendor);
         if (instance.getEndpoint() != null && !instance.getEndpoint().isBlank()) {
             throw new BusinessException(400, "Commercial instances must be selected from the cloud catalog, endpoint cannot be set manually");
         }
         if (!StringUtils.hasText(instance.getCredentialId()) || !StringUtils.hasText(instance.getCloudInstanceId())
                 || !StringUtils.hasText(instance.getRegionId())) {
-            throw new BusinessException(400, "credentialId, cloudInstanceId and regionId are required for Aliyun instances");
+            throw new BusinessException(400,
+                    "credentialId, cloudInstanceId and regionId are required for " + vendor + " instances");
         }
         CloudCredentialVO credential = cloudCredentialRepository.findById(instance.getCredentialId())
                 .orElseThrow(() -> new BusinessException(404, "Cloud credential not found: " + instance.getCredentialId()));
-        if (credential.getVendor() != InstanceVendor.ALIYUN) {
-            throw new BusinessException(400, "Cloud credential vendor does not match ALIYUN");
+        if (credential.getVendor() != vendor) {
+            throw new BusinessException(400, "Cloud credential vendor does not match " + vendor);
         }
-        CloudInstanceDetailVO detail = providerRegistry.catalogFor(InstanceVendor.ALIYUN)
+        CloudInstanceDetailVO detail = providerRegistry.catalogFor(vendor)
                 .getCloudInstance(instance.getCredentialId(), instance.getRegionId(), instance.getCloudInstanceId());
         if (!StringUtils.hasText(instance.getName())) {
             instance.setName(detail.getInstanceName() != null && !detail.getInstanceName().isBlank()

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.provider.alibaba.AliyunClientFactory;
+import org.apache.rocketmq.studio.provider.tencent.TencentClientFactory;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +40,7 @@ public class CloudCredentialService {
     private final CloudCredentialRepository credentialRepository;
     private final InstanceRepository instanceRepository;
     private final AliyunClientFactory aliyunClientFactory;
+    private final TencentClientFactory tencentClientFactory;
     private final OperationAuditService operationAuditService;
 
     public List<CloudCredentialVO> listMasked() {
@@ -98,7 +100,7 @@ public class CloudCredentialService {
         }
         existing.setUpdatedAt(LocalDateTime.now());
         CloudCredentialVO saved = credentialRepository.save(existing);
-        invalidateAliyunClients(saved);
+        invalidateCloudClients(saved);
         recordAudit("UPDATE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", saved.getId(), null,
                 credentialAuditDetail(saved));
         return maskAccessKey(saved);
@@ -115,7 +117,7 @@ public class CloudCredentialService {
             throw new BusinessException(400, "Cloud credential is referenced by existing instances");
         }
         credentialRepository.deleteById(id);
-        invalidateAliyunClients(existing);
+        invalidateCloudClients(existing);
         recordAudit("DELETE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", id, null,
                 credentialAuditDetail(existing));
     }
@@ -145,9 +147,11 @@ public class CloudCredentialService {
         return "name=" + credential.getName() + ", vendor=" + credential.getVendor();
     }
 
-    private void invalidateAliyunClients(CloudCredentialVO credential) {
+    private void invalidateCloudClients(CloudCredentialVO credential) {
         if (credential.getVendor() == org.apache.rocketmq.studio.common.domain.enums.InstanceVendor.ALIYUN) {
             aliyunClientFactory.invalidateCredential(credential.getId());
+        } else if (credential.getVendor() == org.apache.rocketmq.studio.common.domain.enums.InstanceVendor.TENCENT) {
+            tencentClientFactory.invalidateCredential(credential.getId());
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogController.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.tencent;
+
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.provider.CloudInstanceOptionVO;
+import org.apache.rocketmq.studio.provider.CloudRegionVO;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+/**
+ * REST endpoints for browsing Tencent Cloud RocketMQ 5.x instances with a stored credential.
+ */
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/cloud/tencent")
+public class TencentCatalogController {
+
+    private final TencentCatalogService catalogService;
+
+    @GetMapping("/regions")
+    public Result<List<CloudRegionVO>> listRegions(@RequestParam String credentialId) {
+        return Result.ok(catalogService.listRegions(credentialId));
+    }
+
+    @GetMapping("/instances")
+    public Result<List<CloudInstanceOptionVO>> listInstances(@RequestParam String credentialId,
+                                                             @RequestParam String regionId,
+                                                             @RequestParam(required = false) String search) {
+        return Result.ok(catalogService.listCloudInstances(credentialId, regionId, search));
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.tencent;
+
+import com.tencentcloudapi.trocket.v20230308.models.DescribeInstanceListRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeInstanceListResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeInstanceRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeInstanceResponse;
+import com.tencentcloudapi.trocket.v20230308.models.Endpoint;
+import com.tencentcloudapi.trocket.v20230308.models.InstanceItem;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.provider.CloudCatalogProvider;
+import org.apache.rocketmq.studio.provider.CloudInstanceDetailVO;
+import org.apache.rocketmq.studio.provider.CloudInstanceOptionVO;
+import org.apache.rocketmq.studio.provider.CloudRegionVO;
+import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Tencent Cloud RocketMQ 5.x catalog backed by Trocket v20230308 OpenAPI.
+ */
+@RequiredArgsConstructor
+@Component
+public class TencentCatalogService implements CloudCatalogProvider {
+
+    static final int PAGE_SIZE = 100;
+    static final int MAX_PAGES = 100;
+    static final List<CloudRegionVO> SUPPORTED_REGIONS = List.of(
+            region("ap-beijing", "Beijing"),
+            region("ap-chengdu", "Chengdu"),
+            region("ap-chongqing", "Chongqing"),
+            region("ap-guangzhou", "Guangzhou"),
+            region("ap-hongkong", "Hong Kong"),
+            region("ap-nanjing", "Nanjing"),
+            region("ap-shanghai", "Shanghai"),
+            region("ap-singapore", "Singapore"),
+            region("ap-tokyo", "Tokyo"),
+            region("na-siliconvalley", "Silicon Valley"));
+
+    private final TencentClientFactory clientFactory;
+
+    @Override
+    public InstanceVendor vendor() {
+        return InstanceVendor.TENCENT;
+    }
+
+    @Override
+    public List<CloudRegionVO> listRegions(String credentialId) {
+        requireNonBlank(credentialId, "credentialId");
+        return SUPPORTED_REGIONS;
+    }
+
+    @Override
+    public List<CloudInstanceOptionVO> listCloudInstances(String credentialId, String regionId, String search) {
+        requireNonBlank(credentialId, "credentialId");
+        requireNonBlank(regionId, "regionId");
+        List<CloudInstanceOptionVO> instances = new ArrayList<>();
+        for (int page = 0; page < MAX_PAGES; page++) {
+            DescribeInstanceListRequest request = new DescribeInstanceListRequest();
+            request.setOffset((long) page * PAGE_SIZE);
+            request.setLimit((long) PAGE_SIZE);
+            DescribeInstanceListResponse response = clientFactory.call(credentialId, regionId,
+                    client -> client.DescribeInstanceList(request));
+            InstanceItem[] data = response == null ? null : response.getData();
+            if (data == null || data.length == 0) {
+                break;
+            }
+            for (InstanceItem item : data) {
+                CloudInstanceOptionVO option = toInstanceOption(item, regionId);
+                if (matchesSearch(search, option)) {
+                    instances.add(option);
+                }
+            }
+            if (data.length < PAGE_SIZE) {
+                break;
+            }
+        }
+        return instances;
+    }
+
+    @Override
+    public CloudInstanceDetailVO getCloudInstance(String credentialId, String regionId, String cloudInstanceId) {
+        requireNonBlank(credentialId, "credentialId");
+        requireNonBlank(regionId, "regionId");
+        requireNonBlank(cloudInstanceId, "cloudInstanceId");
+        DescribeInstanceRequest request = new DescribeInstanceRequest();
+        request.setInstanceId(cloudInstanceId);
+        DescribeInstanceResponse response = clientFactory.call(credentialId, regionId,
+                client -> client.DescribeInstance(request));
+        if (response == null || response.getInstanceId() == null) {
+            throw new BusinessException(404, "Tencent Cloud RocketMQ 5.x instance not found: " + cloudInstanceId);
+        }
+        CloudInstanceDetailVO detail = new CloudInstanceDetailVO();
+        detail.setInstanceId(response.getInstanceId());
+        detail.setInstanceName(response.getInstanceName());
+        detail.setStatus(response.getInstanceStatus());
+        detail.setRegionId(regionId);
+        detail.setRemark(response.getRemark());
+        detail.setEndpoints(toEndpoints(response.getEndpointList()));
+        return detail;
+    }
+
+    private static CloudInstanceOptionVO toInstanceOption(InstanceItem item, String regionId) {
+        CloudInstanceOptionVO option = new CloudInstanceOptionVO();
+        option.setInstanceId(item.getInstanceId());
+        option.setInstanceName(item.getInstanceName());
+        option.setStatus(item.getInstanceStatus());
+        option.setRegionId(regionId);
+        option.setTopicCount(toInteger(item.getTopicNum()));
+        option.setGroupCount(toInteger(item.getGroupNum()));
+        option.setRemark(item.getRemark());
+        return option;
+    }
+
+    private static List<CloudInstanceDetailVO.CloudEndpoint> toEndpoints(Endpoint[] endpoints) {
+        List<CloudInstanceDetailVO.CloudEndpoint> result = new ArrayList<>();
+        if (endpoints == null) {
+            return result;
+        }
+        for (Endpoint endpoint : endpoints) {
+            if (endpoint != null && "OPEN".equalsIgnoreCase(endpoint.getStatus())) {
+                result.add(new CloudInstanceDetailVO.CloudEndpoint(
+                        endpointType(endpoint.getType()), endpoint.getEndpointUrl()));
+            }
+        }
+        return result;
+    }
+
+    private static String endpointType(String type) {
+        if ("VPC".equalsIgnoreCase(type)) {
+            return "TCP_VPC";
+        }
+        if ("PUBLIC".equalsIgnoreCase(type)) {
+            return "TCP_INTERNET";
+        }
+        return type;
+    }
+
+    private static Integer toInteger(Long value) {
+        return value == null ? null : Math.toIntExact(value);
+    }
+
+    private static boolean matchesSearch(String search, CloudInstanceOptionVO option) {
+        if (search == null || search.isBlank()) {
+            return true;
+        }
+        String needle = search.toLowerCase(Locale.ROOT);
+        return containsIgnoreCase(option.getInstanceId(), needle)
+                || containsIgnoreCase(option.getInstanceName(), needle);
+    }
+
+    private static boolean containsIgnoreCase(String value, String needle) {
+        return value != null && value.toLowerCase(Locale.ROOT).contains(needle);
+    }
+
+    private static CloudRegionVO region(String id, String name) {
+        CloudRegionVO region = new CloudRegionVO();
+        region.setRegionId(id);
+        region.setRegionName(name);
+        return region;
+    }
+
+    private static void requireNonBlank(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new BusinessException(400, name + " is required");
+        }
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentClientFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentClientFactory.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.tencent;
+
+import com.tencentcloudapi.common.Credential;
+import com.tencentcloudapi.common.exception.TencentCloudSDKException;
+import com.tencentcloudapi.common.profile.ClientProfile;
+import com.tencentcloudapi.common.profile.HttpProfile;
+import com.tencentcloudapi.trocket.v20230308.TrocketClient;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.provider.credential.CloudCredentialRepository;
+import org.apache.rocketmq.studio.provider.credential.CloudCredentialVO;
+import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Builds and caches Tencent Cloud RocketMQ 5.x (Trocket v20230308) clients per credential#region.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class TencentClientFactory {
+
+    static final int CONNECT_TIMEOUT_SECONDS = 10;
+    static final int READ_TIMEOUT_SECONDS = 20;
+    static final String ENDPOINT = "trocket.tencentcloudapi.com";
+
+    private final CloudCredentialRepository credentialRepository;
+    private final Map<String, TrocketClient> clients = new ConcurrentHashMap<>();
+
+    public TrocketClient client(String credentialId, String region) {
+        String key = cacheKey(credentialId, region);
+        return clients.computeIfAbsent(key, ignored -> createClient(credentialId, region));
+    }
+
+    public void invalidateCredential(String credentialId) {
+        String prefix = credentialId + "#";
+        clients.keySet().removeIf(key -> key.startsWith(prefix));
+    }
+
+    public <T> T call(String credentialId, String region, TencentCall<T> action) {
+        try {
+            return action.execute(client(credentialId, region));
+        } catch (TencentCloudSDKException ex) {
+            throw mapToBusinessException(ex);
+        } catch (RuntimeException ex) {
+            if (ex instanceof BusinessException businessException) {
+                throw businessException;
+            }
+            throw new BusinessException(502, "Tencent Cloud OpenAPI error: " + ex.getMessage());
+        }
+    }
+
+    static String cacheKey(String credentialId, String region) {
+        return credentialId + "#" + region;
+    }
+
+    protected TrocketClient createClient(String credentialId, String region) {
+        CloudCredentialVO credential = credentialRepository.findById(credentialId)
+                .orElseThrow(() -> new BusinessException(404, "Cloud credential not found: " + credentialId));
+        Credential sdkCredential = new Credential(credential.getAccessKey(), credential.getSecretKey());
+        HttpProfile httpProfile = new HttpProfile();
+        httpProfile.setEndpoint(ENDPOINT);
+        httpProfile.setConnTimeout(CONNECT_TIMEOUT_SECONDS);
+        httpProfile.setReadTimeout(READ_TIMEOUT_SECONDS);
+        ClientProfile clientProfile = new ClientProfile();
+        clientProfile.setHttpProfile(httpProfile);
+        return new TrocketClient(sdkCredential, region, clientProfile);
+    }
+
+    static BusinessException mapToBusinessException(TencentCloudSDKException ex) {
+        String code = ex.getErrorCode();
+        String message = ex.getMessage();
+        log.warn("Tencent Cloud OpenAPI failure: code={}, requestId={}, message={}",
+                code, ex.getRequestId(), message);
+        if (code != null && (code.contains("UnauthorizedOperation") || code.contains("AccessDenied"))) {
+            return new BusinessException(403, defaultIfBlank(message, "Tencent Cloud OpenAPI access denied"));
+        }
+        if (code != null && (code.contains("AuthFailure") || code.contains("InvalidCredential")
+                || code.contains("InvalidSecretId") || code.contains("SignatureFailure"))) {
+            return new BusinessException(401, "Cloud credential is invalid");
+        }
+        if (code != null && (code.contains("NotFound") || code.contains("ResourceNotFound"))) {
+            return new BusinessException(404, defaultIfBlank(message, "Tencent Cloud resource not found"));
+        }
+        return new BusinessException(502,
+                "Tencent Cloud OpenAPI error: " + defaultIfBlank(message, code));
+    }
+
+    private static String defaultIfBlank(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+
+    @FunctionalInterface
+    public interface TencentCall<T> {
+        T execute(TrocketClient client) throws TencentCloudSDKException;
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -792,12 +792,34 @@ class InstanceServiceTest {
     }
 
     @Test
-    void createInstanceShouldRejectTencentVendorTest() {
-        InstanceVO instance = InstanceVO.builder().vendor(InstanceVendor.TENCENT).build();
+    void createInstanceShouldResolveTencentEndpointFromCatalogTest() {
+        InstanceVO instance = InstanceVO.builder()
+                .vendor(InstanceVendor.TENCENT)
+                .credentialId("cred-tencent")
+                .cloudInstanceId("rmq-abc")
+                .regionId("ap-chengdu")
+                .build();
+        CloudCredentialVO credential = new CloudCredentialVO();
+        credential.setId("cred-tencent");
+        credential.setVendor(InstanceVendor.TENCENT);
+        when(cloudCredentialRepository.findById("cred-tencent")).thenReturn(Optional.of(credential));
+        CloudCatalogProvider catalog = org.mockito.Mockito.mock(CloudCatalogProvider.class);
+        CloudInstanceDetailVO detail = new CloudInstanceDetailVO();
+        detail.setInstanceId("rmq-abc");
+        detail.setInstanceName("chengdu-prod");
+        detail.setEndpoints(List.of(
+                new CloudInstanceDetailVO.CloudEndpoint("TCP_INTERNET", "public.tencent:8080"),
+                new CloudInstanceDetailVO.CloudEndpoint("TCP_VPC", "vpc.tencent:8080")));
+        when(providerRegistry.catalogFor(InstanceVendor.TENCENT)).thenReturn(catalog);
+        when(catalog.getCloudInstance("cred-tencent", "ap-chengdu", "rmq-abc")).thenReturn(detail);
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        assertThatThrownBy(() -> instanceService.createInstance(instance))
-                .isInstanceOf(BusinessException.class)
-                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
+        InstanceVO created = instanceService.createInstance(instance);
+
+        assertThat(created.getName()).isEqualTo("chengdu-prod");
+        assertThat(created.getEndpoint()).isEqualTo("vpc.tencent:8080");
+        assertThat(created.getType()).isEqualTo(InstanceType.PROXY);
+        assertThat(created.getVendor()).isEqualTo(InstanceVendor.TENCENT);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
@@ -22,6 +22,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.provider.alibaba.AliyunClientFactory;
+import org.apache.rocketmq.studio.provider.tencent.TencentClientFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -51,6 +52,9 @@ class CloudCredentialServiceTest {
 
     @Mock
     private AliyunClientFactory aliyunClientFactory;
+
+    @Mock
+    private TencentClientFactory tencentClientFactory;
 
     @Mock
     private OperationAuditService operationAuditService;

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.tencent;
+
+import com.tencentcloudapi.trocket.v20230308.models.DescribeInstanceListResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeInstanceResponse;
+import com.tencentcloudapi.trocket.v20230308.models.Endpoint;
+import com.tencentcloudapi.trocket.v20230308.models.InstanceItem;
+import org.apache.rocketmq.studio.provider.CloudInstanceDetailVO;
+import org.apache.rocketmq.studio.provider.CloudInstanceOptionVO;
+import org.apache.rocketmq.studio.provider.CloudRegionVO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TencentCatalogServiceTest {
+
+    private static final String CREDENTIAL_ID = "cred-1";
+    private static final String REGION = "ap-chengdu";
+
+    @Mock
+    private TencentClientFactory clientFactory;
+
+    private TencentCatalogService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TencentCatalogService(clientFactory);
+    }
+
+    @Test
+    void listRegionsShouldContainChengduTest() {
+        List<CloudRegionVO> regions = service.listRegions(CREDENTIAL_ID);
+
+        assertThat(regions).extracting(CloudRegionVO::getRegionId).contains("ap-chengdu");
+    }
+
+    @Test
+    void listCloudInstancesShouldMapRocketmq5ItemsTest() {
+        InstanceItem item = new InstanceItem();
+        item.setInstanceId("rmq-abc");
+        item.setInstanceName("chengdu-prod");
+        item.setInstanceStatus("RUNNING");
+        item.setTopicNum(3L);
+        item.setGroupNum(2L);
+        DescribeInstanceListResponse response = new DescribeInstanceListResponse();
+        response.setData(new InstanceItem[]{item});
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any())).thenReturn(response);
+
+        List<CloudInstanceOptionVO> instances = service.listCloudInstances(CREDENTIAL_ID, REGION, "PROD");
+
+        assertThat(instances).hasSize(1);
+        assertThat(instances.get(0).getInstanceId()).isEqualTo("rmq-abc");
+        assertThat(instances.get(0).getRegionId()).isEqualTo(REGION);
+        assertThat(instances.get(0).getTopicCount()).isEqualTo(3);
+    }
+
+    @Test
+    void getCloudInstanceShouldMapOnlyOpenEndpointsTest() {
+        Endpoint vpc = endpoint("VPC", "OPEN", "vpc.tencent:8080");
+        Endpoint publicEndpoint = endpoint("PUBLIC", "OPEN", "public.tencent:8080");
+        Endpoint closed = endpoint("PUBLIC", "CLOSE", "closed.tencent:8080");
+        DescribeInstanceResponse response = new DescribeInstanceResponse();
+        response.setInstanceId("rmq-abc");
+        response.setInstanceName("chengdu-prod");
+        response.setInstanceStatus("RUNNING");
+        response.setEndpointList(new Endpoint[]{vpc, publicEndpoint, closed});
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any())).thenReturn(response);
+
+        CloudInstanceDetailVO detail = service.getCloudInstance(CREDENTIAL_ID, REGION, "rmq-abc");
+
+        assertThat(detail.getEndpoints()).hasSize(2);
+        assertThat(detail.getEndpoints().get(0).getEndpointType()).isEqualTo("TCP_VPC");
+        assertThat(detail.getEndpoints().get(1).getEndpointType()).isEqualTo("TCP_INTERNET");
+    }
+
+    private static Endpoint endpoint(String type, String status, String url) {
+        Endpoint endpoint = new Endpoint();
+        endpoint.setType(type);
+        endpoint.setStatus(status);
+        endpoint.setEndpointUrl(url);
+        return endpoint;
+    }
+}

--- a/web/src/api/tencentCatalog.ts
+++ b/web/src/api/tencentCatalog.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.
+ */
+
+import client from './client';
+import type { CloudInstanceOption, CloudRegion } from './aliyunCatalog';
+
+export async function listTencentRegions(credentialId: string) {
+  const res = await client.get<{ data: CloudRegion[] }>('/cloud/tencent/regions', {
+    params: { credentialId },
+  });
+  return res.data.data;
+}
+
+export async function listTencentInstances(
+  credentialId: string,
+  regionId: string,
+  search?: string,
+) {
+  const res = await client.get<{ data: CloudInstanceOption[] }>('/cloud/tencent/instances', {
+    params: { credentialId, regionId, ...(search ? { search } : {}) },
+  });
+  return res.data.data;
+}

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -45,6 +45,7 @@ import {
   type CloudInstanceOption,
   type CloudRegion,
 } from '../../api/aliyunCatalog';
+import { listTencentInstances, listTencentRegions } from '../../api/tencentCatalog';
 import { formatDateTime } from '../../utils/format';
 import {
   createInstance,
@@ -56,7 +57,10 @@ import { DEFAULT_VENDOR, VENDOR_OPTIONS, type InstanceVendor } from './vendorOpt
 
 const { Text } = Typography;
 
-const DEFAULT_ALIYUN_REGION_ID = 'cn-hangzhou';
+const DEFAULT_CLOUD_REGION_IDS: Partial<Record<InstanceVendor, string>> = {
+  ALIYUN: 'cn-hangzhou',
+  TENCENT: 'ap-chengdu',
+};
 
 /* ─── Helpers ─── */
 const typeLabel: Record<string, { text: string; color: string }> = {
@@ -133,31 +137,39 @@ const InstancePage = () => {
     };
   }, [loadInstances]);
 
+  const cloudVendor = vendor === 'ALIYUN' || vendor === 'TENCENT';
+
   useEffect(() => {
-    if (vendor !== 'ALIYUN' || !addModalOpen) {
+    if (!cloudVendor || !addModalOpen) {
       return;
     }
     const timer = window.setTimeout(() => {
       setCredentialsLoading(true);
       listCloudCredentials()
-        .then((items) => setCredentials(items.filter((item) => item.vendor === 'ALIYUN')))
+        .then((items) => setCredentials(items.filter((item) => item.vendor === vendor)))
         .catch(() => message.error('云凭据列表加载失败'))
         .finally(() => setCredentialsLoading(false));
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [vendor, addModalOpen]);
+  }, [vendor, cloudVendor, addModalOpen]);
 
   useEffect(() => {
-    if (vendor !== 'ALIYUN' || !addCredentialId) {
+    if (!cloudVendor || !addCredentialId) {
       return;
     }
     const timer = window.setTimeout(() => {
       setRegionsLoading(true);
-      listAliyunRegions(addCredentialId)
+      const request =
+        vendor === 'ALIYUN'
+          ? listAliyunRegions(addCredentialId)
+          : listTencentRegions(addCredentialId);
+      request
         .then((items) => {
           setRegions(items);
           if (!addForm.getFieldValue('regionId')) {
-            const preferred = items.find((region) => region.regionId === DEFAULT_ALIYUN_REGION_ID);
+            const preferred = items.find(
+              (region) => region.regionId === DEFAULT_CLOUD_REGION_IDS[vendor],
+            );
             if (preferred) {
               addForm.setFieldsValue({ regionId: preferred.regionId });
             }
@@ -167,21 +179,25 @@ const InstancePage = () => {
         .finally(() => setRegionsLoading(false));
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [vendor, addCredentialId, addForm]);
+  }, [vendor, cloudVendor, addCredentialId, addForm]);
 
   useEffect(() => {
-    if (vendor !== 'ALIYUN' || !addCredentialId || !addRegionId) {
+    if (!cloudVendor || !addCredentialId || !addRegionId) {
       return;
     }
     const timer = window.setTimeout(() => {
       setCloudInstancesLoading(true);
-      listAliyunInstances(addCredentialId, addRegionId)
+      const request =
+        vendor === 'ALIYUN'
+          ? listAliyunInstances(addCredentialId, addRegionId)
+          : listTencentInstances(addCredentialId, addRegionId);
+      request
         .then(setCloudInstances)
         .catch(() => message.error('云实例列表加载失败'))
         .finally(() => setCloudInstancesLoading(false));
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [vendor, addCredentialId, addRegionId]);
+  }, [vendor, cloudVendor, addCredentialId, addRegionId]);
 
   const handleCredentialChange = () => {
     setRegions([]);
@@ -198,17 +214,16 @@ const InstancePage = () => {
     try {
       const values = await addForm.validateFields();
       setSubmitting(true);
-      const payload =
-        vendor === 'ALIYUN'
-          ? {
-              name: values.name,
-              vendor: 'ALIYUN' as const,
-              credentialId: values.credentialId,
-              cloudInstanceId: values.cloudInstanceId,
-              regionId: values.regionId,
-              remark: values.remark,
-            }
-          : values;
+      const payload = cloudVendor
+        ? {
+            name: values.name,
+            vendor,
+            credentialId: values.credentialId,
+            cloudInstanceId: values.cloudInstanceId,
+            regionId: values.regionId,
+            remark: values.remark,
+          }
+        : values;
       const created = await createInstance(payload);
       await loadInstances();
       message.success(`实例「${created.name}」添加成功`);
@@ -470,7 +485,6 @@ const InstancePage = () => {
         }}
         onOk={() => void handleCreate()}
         confirmLoading={submitting}
-        okButtonProps={{ disabled: vendor === 'TENCENT' }}
         okText="连接"
         cancelText="取消"
         width={520}
@@ -493,13 +507,13 @@ const InstancePage = () => {
         <Text type="secondary" style={{ display: 'block', fontSize: 12, marginBottom: 12 }}>
           {VENDOR_OPTIONS.find((option) => option.key === vendor)?.description}
         </Text>
-        {vendor === 'ALIYUN' ? (
+        {cloudVendor ? (
           <Form form={addForm} layout="vertical">
             <Form.Item
               label="云凭据"
               name="credentialId"
               rules={[{ required: true, message: '请选择云凭据' }]}
-              extra="凭据为阿里云账号的 AK/SK，在云凭据管理中录入"
+              extra={`凭据为${vendor === 'ALIYUN' ? '阿里云' : '腾讯云'}账号的 AK/SK，由后端录入`}
             >
               <Select
                 placeholder="选择已录入的 AK/SK 凭据"
@@ -562,13 +576,6 @@ const InstancePage = () => {
               <Input.TextArea rows={2} placeholder="可选，描述实例用途" />
             </Form.Item>
           </Form>
-        ) : vendor === 'TENCENT' ? (
-          <Alert
-            type="info"
-            showIcon
-            message="Tencent 版接入开发中"
-            description="腾讯云 TDMQ RocketMQ 版接入正在开发中，敬请期待。"
-          />
         ) : (
           <Form form={addForm} layout="vertical">
             <Form.Item


### PR DESCRIPTION
## Summary
- replace the legacy Tencent TDMQ dependency with the official RocketMQ 5.x Trocket v20230308 SDK
- add a Tencent cloud catalog client/service/controller for region, instance-list, and instance-detail discovery
- enable Tencent credential -> region -> RocketMQ 5.x instance selection in the add-instance modal
- resolve open endpoints from the selected cloud instance (VPC preferred, public fallback) and persist it as a `TENCENT` Studio instance
- invalidate cached Tencent SDK clients when stored credentials are updated or deleted

## Validation
- `cd server && mvn -B -ntp -Dtest=TencentCatalogServiceTest,InstanceServiceTest,CloudCredentialServiceTest test` (61 tests passed)
- `cd web && npm run build`
- deployed locally with Docker Compose: server/mysql healthy and web available on port 6789
- called `/api/cloud/tencent/instances` against a real credential in `ap-chengdu`; received HTTP 200 and three RUNNING RocketMQ 5.x instances
- verified stored credential responses mask SecretId and never expose SecretKey

## Scope
This PR covers Tencent Cloud RocketMQ 5.x catalog browsing, instance onboarding, and viewing in the Studio instance list. Credential-management UI and Tencent resource operations after onboarding are out of scope.

Closes #1463
