### PR TITLE
fix(alerts): normalize severity with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -227,7 +228,7 @@ public class AlertService {
     private String severity(AlertRuleVO rule) {
         String severity = rule.getSeverity();
         if (hasText(severity)) {
-            String normalized = severity.trim().toLowerCase();
+            String normalized = severity.trim().toLowerCase(Locale.ROOT);
             if ("critical".equals(normalized) || "warning".equals(normalized) || "info".equals(normalized)) {
                 return normalized;
             }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -196,6 +197,30 @@ class AlertServiceTest {
         assertThat(result)
                 .contains("expr: rocketmq_broker_replication_lag_bytes > 1024")
                 .contains("severity: warning");
+    }
+
+    @Test
+    void exportPrometheusRulesYamlShouldNormalizeSeverityIndependentlyOfDefaultLocale() {
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .name("Informational Alert")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(1)
+                .severity("INFO")
+                .enabled(true)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+        Locale originalLocale = Locale.getDefault();
+
+        String result;
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            result = alertService.exportPrometheusRulesYaml();
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+
+        assertThat(result).contains("severity: info");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- normalize alert severity identifiers with `Locale.ROOT`
- prevent Turkish JVM locales from turning `INFO` into an unrecognized dotless-i value
- add a locale-specific Prometheus export regression test

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=AlertServiceTest test` (32 tests)

Fixes #1465
