### PR TITLE
fix(credentials): parse vendor with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CreateCloudCredentialDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CreateCloudCredentialDTO.java
@@ -20,6 +20,8 @@ import jakarta.validation.constraints.NotBlank;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import lombok.Data;
 
+import java.util.Locale;
+
 @Data
 public class CreateCloudCredentialDTO {
 
@@ -52,7 +54,7 @@ public class CreateCloudCredentialDTO {
             return null;
         }
         try {
-            return InstanceVendor.valueOf(vendor.trim().toUpperCase());
+            return InstanceVendor.valueOf(vendor.trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException ex) {
             return null;
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CreateCloudCredentialDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CreateCloudCredentialDTOTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.credential;
+
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreateCloudCredentialDTOTest {
+
+    @Test
+    void parseVendorShouldBeIndependentOfDefaultLocale() {
+        Locale originalLocale = Locale.getDefault();
+
+        InstanceVendor vendor;
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            vendor = CreateCloudCredentialDTO.parseVendor("aliyun");
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+
+        assertThat(vendor).isEqualTo(InstanceVendor.ALIYUN);
+    }
+}


### PR DESCRIPTION
## Summary
- uppercase cloud credential vendor identifiers with `Locale.ROOT`
- keep valid `aliyun` input parseable on Turkish-locale JVMs
- add a focused DTO locale regression test

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=CreateCloudCredentialDTOTest test`

Fixes #1467
