### PR TITLE
[ISSUE #1470] Reuse host Maven cache for local deploy builds

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -4,6 +4,11 @@ REMOTE_HOST=your-server-ip
 REMOTE_USER=root
 REMOTE_PATH=/opt/rocketmq-studio
 
+# Optional local server build settings. deploy.sh mounts this directory into
+# the Maven build container, so downloaded dependencies persist across builds.
+# MAVEN_CACHE_DIR=/home/your-user/.m2
+# MAVEN_IMAGE=maven:3.9.9-eclipse-temurin-21
+
 # Frontend public port
 PUBLIC_PORT=6789
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,7 +8,8 @@
 ./deploy/deploy.sh web       # 仅部署前端
 ```
 
-脚本自动完成：本地构建 → 导出镜像 → SCP 传输 → 远程加载 → 重启容器 → 验证
+脚本自动完成：本地构建 → 导出镜像 → SCP 传输 → 远程加载 → 重启容器 → 验证。
+后端通过 Maven 容器构建，并默认挂载宿主机的 `~/.m2`，后续构建会复用已下载的依赖。
 
 ## 配置
 
@@ -19,7 +20,13 @@ REMOTE_HOST=your-server-ip
 REMOTE_USER=root
 REMOTE_PATH=/opt/rocketmq-studio
 PUBLIC_PORT=8080
+
+# 可选：自定义宿主机 Maven 缓存和构建镜像
+MAVEN_CACHE_DIR=/home/your-user/.m2
+MAVEN_IMAGE=maven:3.9.9-eclipse-temurin-21
 ```
+
+`MAVEN_CACHE_DIR` 默认为当前用户的 `~/.m2`。如果其中存在 `settings.xml`，构建容器也会自动使用该配置。
 
 ## 本地 Docker Compose
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -35,6 +35,8 @@ REMOTE="${REMOTE_USER:-root}@$REMOTE_HOST"
 REMOTE_PATH="${REMOTE_PATH:-/opt/rocketmq-studio}"
 NETWORK="${PODMAN_NETWORK:-rocketmq-studio}"
 TMP_DIR="/tmp/rocketmq-studio-deploy"
+MAVEN_IMAGE="${MAVEN_IMAGE:-maven:3.9.9-eclipse-temurin-21}"
+MAVEN_CACHE_DIR="${MAVEN_CACHE_DIR:-$HOME/.m2}"
 
 TARGET="${1:-all}"  # all | server | web
 
@@ -51,8 +53,30 @@ check_prereqs() {
 
 # ─── 构建镜像 ───
 build_server() {
+  info "在 Maven 容器中构建 server（复用宿主机缓存: $MAVEN_CACHE_DIR）..."
+  mkdir -p "$MAVEN_CACHE_DIR"
+
+  local maven_settings=()
+  if [[ -f "$MAVEN_CACHE_DIR/settings.xml" ]]; then
+    maven_settings=(-s /maven-cache/settings.xml)
+  fi
+
+  docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/tmp \
+    -v "$PROJECT_DIR/server:/app" \
+    -v "$MAVEN_CACHE_DIR:/maven-cache" \
+    -w /app \
+    "$MAVEN_IMAGE" \
+    mvn -B -ntp "${maven_settings[@]}" \
+      -Dmaven.repo.local=/maven-cache/repository \
+      package -DskipTests
+
   info "构建 rocketmq-server 镜像..."
-  docker build -t rocketmq-server:latest "$PROJECT_DIR/server"
+  docker build \
+    --target runtime-prebuilt \
+    -t rocketmq-server:latest \
+    "$PROJECT_DIR/server"
   log "rocketmq-server 镜像构建完成"
 }
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,16 +1,5 @@
-# Stage 1: Build
-FROM alibabadragonwell/dragonwell:21 AS build
-RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz | tar xz -C /opt \
-    && ln -s /opt/apache-maven-3.9.9/bin/mvn /usr/local/bin/mvn
-WORKDIR /app
-COPY pom.xml .
-RUN mvn dependency:go-offline
-COPY src ./src
-COPY style ./style
-RUN mvn package -DskipTests
-
-# Stage 2: Runtime
-FROM alibabadragonwell/dragonwell:21
+# Shared runtime dependencies
+FROM alibabadragonwell/dragonwell:21 AS runtime-base
 WORKDIR /app
 # Node.js + agent CLIs for the claude-code / qoder agent providers.
 RUN curl -fsSL https://npmmirror.com/mirrors/node/v20.19.2/node-v20.19.2-linux-x64.tar.gz | tar xz -C /opt \
@@ -21,6 +10,26 @@ RUN curl -fsSL https://npmmirror.com/mirrors/node/v20.19.2/node-v20.19.2-linux-x
     && npm install -g @anthropic-ai/claude-code @qoder-ai/qodercli \
     && ln -s /opt/node-v20.19.2-linux-x64/bin/claude /usr/local/bin/claude \
     && ln -s /opt/node-v20.19.2-linux-x64/bin/qodercli /usr/local/bin/qodercli
-COPY --from=build /app/target/*.jar app.jar
 EXPOSE 8888
 ENTRYPOINT ["java", "-jar", "app.jar"]
+
+# deploy.sh target: package with the JAR prebuilt by a Maven container that
+# mounts the host ~/.m2 cache, avoiding dependency downloads on every build.
+# Keep this before the build stage so Docker's legacy builder can stop here.
+FROM runtime-base AS runtime-prebuilt
+COPY target/*.jar app.jar
+
+# Maven build stage used by the default CI / docker compose target.
+FROM alibabadragonwell/dragonwell:21 AS build
+RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz | tar xz -C /opt \
+    && ln -s /opt/apache-maven-3.9.9/bin/mvn /usr/local/bin/mvn
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+COPY style ./style
+RUN mvn package -DskipTests
+
+# Default (last) target: build the JAR inside Docker for CI / docker compose.
+FROM runtime-base AS runtime
+COPY --from=build /app/target/*.jar app.jar


### PR DESCRIPTION
## What is the purpose of the change

Fixes #1470.

Repeated local Studio deployments are slow because the backend is built in a Docker build stage that cannot reuse the developer's host Maven repository. When that layer is invalidated, Maven downloads the same dependencies again.

This change keeps Maven containerized while mounting the host Maven cache, then packages the resulting JAR into the runtime image.

## Brief changelog

- Build the server with a temporary Maven container from `deploy/deploy.sh`.
- Mount `MAVEN_CACHE_DIR` (default: `~/.m2`) and set `maven.repo.local` to its `repository` directory.
- Reuse `settings.xml` from the mounted Maven directory when present.
- Run the build container with the host UID/GID to avoid root-owned build artifacts.
- Add a `runtime-prebuilt` Dockerfile target for packaging the generated JAR.
- Preserve the default Dockerfile build target for CI and Docker Compose compatibility.
- Document `MAVEN_CACHE_DIR` and `MAVEN_IMAGE` overrides.

## Verifying this change

- `bash -n deploy/deploy.sh`
- `git diff --check`
- Ran the Maven container build using an existing host `~/.m2` cache:
  - build succeeded;
  - no dependency downloads were reported;
  - Maven build completed in 18.812 seconds.
- Built `server/Dockerfile` with `--target runtime-prebuilt`:
  - image build succeeded;
  - the Maven build stage was not executed;
  - `/app/app.jar` exists in the resulting image;
  - image entrypoint remains `java -jar app.jar`.

- [x] A GitHub issue is filed for this change.
- [x] The pull request addresses one issue.
- [x] The commit has a meaningful subject and Signed-off-by line.
- [x] The change is documented.
- [x] Full deployment was not run because it requires configured remote SSH/Podman infrastructure.
