### PR TITLE
fix(settings): normalize identifiers with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -186,7 +186,8 @@ public class SettingsService {
 
     private boolean isPrometheusCompatible(String type) {
         return StringUtils.hasText(type)
-                && PROMETHEUS_COMPATIBLE_TYPES.contains(type.replaceAll("\\s+", "").toLowerCase());
+                && PROMETHEUS_COMPATIBLE_TYPES.contains(
+                        type.replaceAll("\\s+", "").toLowerCase(Locale.ROOT));
     }
 
     private String normalizeDataSourceKey(String key) {
@@ -222,7 +223,7 @@ public class SettingsService {
         if (!StringUtils.hasText(auth)) {
             return AUTH_NONE;
         }
-        return auth.trim().replaceAll("\\s+", " ").toLowerCase();
+        return auth.trim().replaceAll("\\s+", " ").toLowerCase(Locale.ROOT);
     }
 
     private URI prometheusQueryUri(String baseUrl) throws URISyntaxException {

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -367,6 +368,35 @@ class SettingsServiceTest {
                 .build();
 
         DataSourceTestResultVO result = settingsService.testDataSource(request);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(authorization.get()).isEqualTo("Basic "
+                + Base64.getEncoder().encodeToString("prom:secret".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void testConnectionShouldNormalizeIdentifiersIndependentlyOfDefaultLocale() {
+        AtomicReference<String> authorization = new AtomicReference<>();
+        prometheusServer.createContext("/api/v1/query", exchange -> {
+            authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            respond(exchange, 200, "{\"status\":\"success\",\"data\":{\"resultType\":\"vector\",\"result\":[]}}");
+        });
+        DataSourceTestDTO request = DataSourceTestDTO.builder()
+                .url(prometheusBaseUrl)
+                .type("MIMIR")
+                .auth("Basic Auth")
+                .username("prom")
+                .password("secret")
+                .build();
+        Locale originalLocale = Locale.getDefault();
+
+        DataSourceTestResultVO result;
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            result = settingsService.testDataSource(request);
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
 
         assertThat(result.isSuccess()).isTrue();
         assertThat(authorization.get()).isEqualTo("Basic "


### PR DESCRIPTION
## Summary
- normalize Metrics data-source types and authentication modes with `Locale.ROOT`
- keep uppercase MIMIR and Basic Auth valid on Turkish-locale JVMs
- add an end-to-end connection-test regression covering both identifiers

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=SettingsServiceTest test` (28 tests)

Fixes #1469
