### PR TITLE
fix(web): harden Message Explorer instance context

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -28,6 +28,9 @@ const messageServiceMocks = vi.hoisted(() => ({
   getMessageTrace: vi.fn(),
   queryMessages: vi.fn(),
 }));
+const topicServiceMocks = vi.hoisted(() => ({
+  listTopics: vi.fn(),
+}));
 const instanceFilterMocks = vi.hoisted(() => ({
   useInstanceFilter: vi.fn(),
 }));
@@ -40,17 +43,7 @@ vi.mock('../../../hooks/useInstanceFilter', () => instanceFilterMocks);
 vi.mock('../../../services/instanceService', () => ({
   listInstances: vi.fn().mockResolvedValue([]),
 }));
-vi.mock('../../../services/topicService', () => ({
-  listTopics: vi
-    .fn()
-    .mockResolvedValue([
-      { name: 'order-create' },
-      { name: 'payment-callback' },
-      { name: 'user-activity-log' },
-      { name: 'notification-push' },
-      { name: 'inventory-sync' },
-    ]),
-}));
+vi.mock('../../../services/topicService', () => topicServiceMocks);
 
 import MessagePage from '../message';
 
@@ -99,6 +92,13 @@ describe('Message page query history', () => {
     localStorage.clear();
     messageServiceMocks.getMessageTrace.mockReset().mockResolvedValue(null);
     messageServiceMocks.queryMessages.mockReset().mockResolvedValue([]);
+    topicServiceMocks.listTopics.mockReset().mockResolvedValue([
+      { name: 'order-create' },
+      { name: 'payment-callback' },
+      { name: 'user-activity-log' },
+      { name: 'notification-push' },
+      { name: 'inventory-sync' },
+    ]);
     instanceFilterMocks.useInstanceFilter.mockReturnValue({
       selectedInstanceId: 'instance-a',
       selectInstance: vi.fn(),
@@ -337,5 +337,43 @@ describe('Message page query history', () => {
     expect(screen.getByRole('button', { name: /^search查询$/ })).toBeDisabled();
     expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
     expect(messageServiceMocks.queryMessages).not.toHaveBeenCalled();
+  });
+
+  it('loads topic options only for the selected instance', async () => {
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
+    topicServiceMocks.listTopics.mockResolvedValue([{ name: 'topic-on-instance-a' }]);
+    renderWithProviders(<MessagePage />);
+
+    await waitFor(() => {
+      expect(topicServiceMocks.listTopics).toHaveBeenCalledWith({ instanceId: 'instance-a' });
+    });
+  });
+
+  it('does not load static topic options without a selected instance', async () => {
+    renderWithProviders(<MessagePage />);
+
+    await waitFor(() => {
+      expect(topicServiceMocks.listTopics).not.toHaveBeenCalled();
+    });
+  });
+
+  it('clears topic options when loading the selected instance topics fails', async () => {
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
+    topicServiceMocks.listTopics.mockRejectedValue(new Error('topic lookup failed'));
+    const user = userEvent.setup();
+    renderWithProviders(<MessagePage />);
+
+    await waitFor(() => expect(topicServiceMocks.listTopics).toHaveBeenCalledTimes(1));
+    await user.click(screen.getAllByRole('combobox')[1]);
+
+    expect(screen.queryByText('order-create')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -92,13 +92,15 @@ describe('Message page query history', () => {
     localStorage.clear();
     messageServiceMocks.getMessageTrace.mockReset().mockResolvedValue(null);
     messageServiceMocks.queryMessages.mockReset().mockResolvedValue([]);
-    topicServiceMocks.listTopics.mockReset().mockResolvedValue([
-      { name: 'order-create' },
-      { name: 'payment-callback' },
-      { name: 'user-activity-log' },
-      { name: 'notification-push' },
-      { name: 'inventory-sync' },
-    ]);
+    topicServiceMocks.listTopics
+      .mockReset()
+      .mockResolvedValue([
+        { name: 'order-create' },
+        { name: 'payment-callback' },
+        { name: 'user-activity-log' },
+        { name: 'notification-push' },
+        { name: 'inventory-sync' },
+      ]);
     instanceFilterMocks.useInstanceFilter.mockReturnValue({
       selectedInstanceId: 'instance-a',
       selectInstance: vi.fn(),
@@ -354,6 +356,11 @@ describe('Message page query history', () => {
   });
 
   it('does not load static topic options without a selected instance', async () => {
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: '',
+      selectInstance: vi.fn(),
+      instanceOptions: [],
+    });
     renderWithProviders(<MessagePage />);
 
     await waitFor(() => {

--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -323,6 +323,7 @@ describe('Message page query history', () => {
     expect(screen.getByText('MID-NULL-FIELDS')).toBeInTheDocument();
     await user.click(screen.getByRole('columnheader', { name: /Key/ }));
     expect(screen.getByText('MID-FULL-FIELDS')).toBeInTheDocument();
+  });
 
   it('requires an instance before allowing a message query', async () => {
     instanceFilterMocks.useInstanceFilter.mockReturnValue({

--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -28,10 +28,14 @@ const messageServiceMocks = vi.hoisted(() => ({
   getMessageTrace: vi.fn(),
   queryMessages: vi.fn(),
 }));
+const instanceFilterMocks = vi.hoisted(() => ({
+  useInstanceFilter: vi.fn(),
+}));
 
 const QUERY_HISTORY_STORAGE_KEY = 'rocketmq-studio-message-query-history';
 
 vi.mock('../../../services/messageService', () => messageServiceMocks);
+vi.mock('../../../hooks/useInstanceFilter', () => instanceFilterMocks);
 
 vi.mock('../../../services/instanceService', () => ({
   listInstances: vi.fn().mockResolvedValue([]),
@@ -95,6 +99,11 @@ describe('Message page query history', () => {
     localStorage.clear();
     messageServiceMocks.getMessageTrace.mockReset().mockResolvedValue(null);
     messageServiceMocks.queryMessages.mockReset().mockResolvedValue([]);
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
   });
 
   afterEach(() => {
@@ -116,7 +125,7 @@ describe('Message page query history', () => {
       expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
         topic: 'order-create',
         msgId: 'MID-001',
-        instanceId: '',
+        instanceId: 'instance-a',
       });
       expect(screen.getByRole('button', { name: /最近查询/ })).toBeEnabled();
     });
@@ -133,7 +142,7 @@ describe('Message page query history', () => {
       expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
         topic: 'order-create',
         msgId: 'MID-001',
-        instanceId: '',
+        instanceId: 'instance-a',
       });
     });
 
@@ -158,7 +167,7 @@ describe('Message page query history', () => {
       expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
         topic: 'order-create',
         msgId: 'MID-FAILED',
-        instanceId: '',
+        instanceId: 'instance-a',
       });
     });
     expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
@@ -238,7 +247,7 @@ describe('Message page query history', () => {
     await waitFor(() => {
       expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith({
         ...topicParams,
-        instanceId: '',
+        instanceId: 'instance-a',
       });
     });
 
@@ -247,7 +256,7 @@ describe('Message page query history', () => {
     await waitFor(() => {
       expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith({
         ...keyParams,
-        instanceId: '',
+        instanceId: 'instance-a',
       });
       expect(screen.getByPlaceholderText('输入 Message Key')).toHaveValue('ORDER-001');
     });
@@ -312,5 +321,21 @@ describe('Message page query history', () => {
     expect(screen.getByText('MID-NULL-FIELDS')).toBeInTheDocument();
     await user.click(screen.getByRole('columnheader', { name: /Key/ }));
     expect(screen.getByText('MID-FULL-FIELDS')).toBeInTheDocument();
+
+  it('requires an instance before allowing a message query', async () => {
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: '',
+      selectInstance: vi.fn(),
+      instanceOptions: [],
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<MessagePage />);
+
+    await user.click(screen.getByText('按 Message ID'));
+    await user.type(screen.getByPlaceholderText('输入 Message ID'), 'MID-NO-INSTANCE');
+
+    expect(screen.getByRole('button', { name: /^search查询$/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
+    expect(messageServiceMocks.queryMessages).not.toHaveBeenCalled();
   });
 });

--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -28,8 +28,12 @@ const serviceMocks = vi.hoisted(() => ({
   getMessageTrace: vi.fn(),
   queryMessages: vi.fn(),
 }));
+const instanceFilterMocks = vi.hoisted(() => ({
+  useInstanceFilter: vi.fn(),
+}));
 
 vi.mock('../../../services/messageService', () => serviceMocks);
+vi.mock('../../../hooks/useInstanceFilter', () => instanceFilterMocks);
 
 vi.mock('../../../services/instanceService', () => ({
   listInstances: vi.fn().mockResolvedValue([]),
@@ -107,6 +111,11 @@ describe('MessagePage async request ownership', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     serviceMocks.getMessageTrace.mockResolvedValue(null);
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-a',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-a', label: 'Instance A' }],
+    });
     vi.spyOn(message, 'success').mockImplementation(vi.fn());
   });
 

--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -94,18 +94,19 @@ const createTrace = (title: string): TraceRecord => ({
   consumerStatus: [],
 });
 
-const renderPage = () =>
-  render(
-    <ConfigProvider theme={{ token: { motion: false } }}>
-      <App>
-        <LangProvider>
-          <MemoryRouter>
-            <MessagePage />
-          </MemoryRouter>
-        </LangProvider>
-      </App>
-    </ConfigProvider>,
-  );
+const MessagePageWithProviders = () => (
+  <ConfigProvider theme={{ token: { motion: false } }}>
+    <App>
+      <LangProvider>
+        <MemoryRouter>
+          <MessagePage />
+        </MemoryRouter>
+      </LangProvider>
+    </App>
+  </ConfigProvider>
+);
+
+const renderPage = () => render(<MessagePageWithProviders />);
 
 describe('MessagePage async request ownership', () => {
   beforeEach(() => {
@@ -138,6 +139,29 @@ describe('MessagePage async request ownership', () => {
     });
 
     expect(screen.queryByText('late-after-reset')).not.toBeInTheDocument();
+  });
+
+  it('clears query results and message details when the selected instance changes', async () => {
+    serviceMocks.queryMessages.mockResolvedValue([createMessage('message-from-instance-a')]);
+    const user = userEvent.setup();
+    const page = renderPage();
+
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+    const row = await screen.findByRole('row', { name: /message-from-instance-a/ });
+    await user.click(within(row).getByRole('button', { name: /详情/ }));
+    expect(await screen.findByRole('dialog', { name: '消息详情' })).toBeInTheDocument();
+
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 'instance-b',
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 'instance-b', label: 'Instance B' }],
+    });
+    page.rerender(<MessagePageWithProviders />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('message-from-instance-a')).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog', { name: '消息详情' })).not.toBeInTheDocument();
+    });
   });
   it('surfaces unavailable message provider errors from query requests', async () => {
     serviceMocks.queryMessages.mockRejectedValue(

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -289,6 +289,10 @@ const MessagePage = () => {
   };
 
   const executeQuery = async (mode: QueryMode, params: MessageQuery) => {
+    if (!selectedInstanceId) {
+      setQueryError('请先选择实例后再查询消息');
+      return;
+    }
     const requestGeneration = queryGenerationRef.current + 1;
     queryGenerationRef.current = requestGeneration;
     setQueryLoading(true);
@@ -779,6 +783,8 @@ const MessagePage = () => {
             <Button
               type="primary"
               icon={<SearchOutlined />}
+              disabled={!selectedInstanceId}
+              title={selectedInstanceId ? undefined : '请先选择实例'}
               onClick={() => {
                 void handleQuery();
               }}
@@ -788,9 +794,12 @@ const MessagePage = () => {
             <Dropdown
               menu={{ items: recentQueryMenuItems, onClick: handleRecentQueryMenuClick }}
               trigger={['click']}
-              disabled={recentQueries.length === 0}
+              disabled={recentQueries.length === 0 || !selectedInstanceId}
             >
-              <Button icon={<HistoryOutlined />} disabled={recentQueries.length === 0}>
+              <Button
+                icon={<HistoryOutlined />}
+                disabled={recentQueries.length === 0 || !selectedInstanceId}
+              >
                 最近查询
               </Button>
             </Dropdown>

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -92,14 +92,6 @@ const QUERY_OPTIONS = [
   { value: 'msgid' as const, label: '按 Message ID' },
 ];
 
-const TOPIC_OPTIONS = [
-  'order-create',
-  'payment-callback',
-  'user-activity-log',
-  'notification-push',
-  'inventory-sync',
-];
-
 const DELIVERY_STATUS_MAP: Record<string, { label: string; color: string }> = {
   success: { label: '成功', color: 'green' },
   failed: { label: '失败', color: 'red' },
@@ -212,22 +204,24 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
 const MessagePage = () => {
   const { t } = useLang();
   const { selectedInstanceId, selectInstance, instanceOptions } = useInstanceFilter();
-  const [topicOptions, setTopicOptions] = useState<string[]>(TOPIC_OPTIONS);
+  const [topicOptions, setTopicOptions] = useState<string[]>([]);
 
   useEffect(() => {
     let cancelled = false;
-    void listTopics()
+    setTopicOptions([]);
+    setSelectedTopic(undefined);
+    if (!selectedInstanceId) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    void listTopics({ instanceId: selectedInstanceId })
       .then((nextTopics) => {
         if (cancelled) return;
-        const scoped = selectedInstanceId
-          ? nextTopics.filter((topic) => topic.instanceId === selectedInstanceId)
-          : nextTopics;
-        // Always update so an instance with no topics empties the dropdown instead of showing
-        // topics from another instance or the static defaults.
-        setTopicOptions(scoped.map((topic) => topic.name));
+        setTopicOptions(nextTopics.map((topic) => topic.name));
       })
       .catch(() => {
-        // 加载失败保持静态选项可用
+        if (!cancelled) setTopicOptions([]);
       });
     return () => {
       cancelled = true;

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -259,6 +259,19 @@ const MessagePage = () => {
     [],
   );
 
+  useEffect(() => {
+    queryGenerationRef.current += 1;
+    traceGenerationRef.current += 1;
+    setMessages([]);
+    setQueryLoading(false);
+    setQueryError(null);
+    setSelectedMsg(null);
+    setModalOpen(false);
+    setTraceData(null);
+    setTraceLoading(false);
+    setTraceError(null);
+  }, [selectedInstanceId]);
+
   /* ─── Handlers ─── */
   const handleReset = () => {
     queryGenerationRef.current += 1;

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -207,14 +207,10 @@ const MessagePage = () => {
   const [topicOptions, setTopicOptions] = useState<string[]>([]);
 
   useEffect(() => {
-    let cancelled = false;
-    setTopicOptions([]);
-    setSelectedTopic(undefined);
     if (!selectedInstanceId) {
-      return () => {
-        cancelled = true;
-      };
+      return;
     }
+    let cancelled = false;
     void listTopics({ instanceId: selectedInstanceId })
       .then((nextTopics) => {
         if (cancelled) return;
@@ -253,9 +249,12 @@ const MessagePage = () => {
     [],
   );
 
-  useEffect(() => {
+  /* ─── Handlers ─── */
+  const handleInstanceChange = (instanceId: string) => {
     queryGenerationRef.current += 1;
     traceGenerationRef.current += 1;
+    setTopicOptions([]);
+    setSelectedTopic(undefined);
     setMessages([]);
     setQueryLoading(false);
     setQueryError(null);
@@ -264,9 +263,9 @@ const MessagePage = () => {
     setTraceData(null);
     setTraceLoading(false);
     setTraceError(null);
-  }, [selectedInstanceId]);
+    selectInstance(instanceId);
+  };
 
-  /* ─── Handlers ─── */
   const handleReset = () => {
     queryGenerationRef.current += 1;
     setSelectedTopic(undefined);
@@ -701,7 +700,7 @@ const MessagePage = () => {
             <Select
               placeholder="选择实例"
               value={selectedInstanceId || undefined}
-              onChange={selectInstance}
+              onChange={handleInstanceChange}
               options={instanceOptions}
               style={{ width: 220 }}
               notFoundContent="暂无实例"

--- a/web/src/services/topicService.test.ts
+++ b/web/src/services/topicService.test.ts
@@ -69,6 +69,13 @@ describe('topic service mock data', () => {
     expect(blankSearchTopics).toHaveLength(allTopics.length);
   });
 
+  it('filters mock topics by instance ID', async () => {
+    const topics = await listTopics({ instanceId: 'instance-proxy-1' });
+
+    expect(topics).not.toHaveLength(0);
+    expect(topics.every((topic) => topic.instanceId === 'instance-proxy-1')).toBe(true);
+  });
+
   it('rejects duplicate topic creates in the same cluster', async () => {
     const existing = (await listTopics({ search: 'order-create' }))[0];
     const before = await listTopics({ clusterId: existing.clusterId });

--- a/web/src/services/topicService.ts
+++ b/web/src/services/topicService.ts
@@ -24,6 +24,7 @@ export async function listTopics(params?: TopicQuery): Promise<Topic[]> {
     }
     if (params?.type) result = result.filter((t) => t.type === params.type);
     if (params?.clusterId) result = result.filter((t) => t.clusterId === params.clusterId);
+    if (params?.instanceId) result = result.filter((t) => t.instanceId === params.instanceId);
     return (result as unknown as Topic[]).map(cloneTopic);
   }
   return metadataApi.listTopics(params);


### PR DESCRIPTION
## Summary
- Require a selected instance before Message Explorer queries or recent-query replay can run.
- Clear query, detail, and topic state whenever the selected instance changes.
- Load topic options only through the selected instance context and clear them on lookup failure.

## Validation
- `npm test -- --run src/pages/instance/__tests__/MessagePage.test.tsx src/pages/instance/__tests__/MessagePageAsyncState.test.tsx src/services/topicService.test.ts`
- `npm run build`

Closes #1380
Closes #1383
Closes #1385