### PR TITLE
fix(settings): harden persisted settings integrity

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -152,7 +152,7 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
             return vo;
         } catch (JsonProcessingException e) {
             log.error("Failed to deserialize data source: {}", entity.getDsKey(), e);
-            return DataSourceVO.builder().key(entity.getDsKey()).build();
+            throw new BusinessException(500, "Persisted data source is invalid: " + entity.getDsKey());
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.studio.persistence.entity.RmqDataSource;
 import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
 import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqSettingsMapper;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.settings.DataSourceVO;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.apache.rocketmq.studio.settings.SettingsRepository;
@@ -73,18 +74,7 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
             return objectMapper.readValue(entity.getJson(), GeneralSettingsVO.class);
         } catch (JsonProcessingException e) {
             log.error("Failed to deserialize general settings", e);
-            return GeneralSettingsVO.builder()
-                    .theme("system")
-                    .compact(false)
-                    .desktopNotify(true)
-                    .notifySound(false)
-                    .sessionTimeout(30)
-                    .requireLogin(false)
-                    .llmProvider("openai")
-                    .apiKey("")
-                    .model("gpt-4")
-                    .baseUrl("")
-                    .build();
+            throw new BusinessException(500, "Persisted general settings are invalid");
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
+import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqSettingsMapper;
+import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MybatisPlusSettingsRepositoryTest {
+
+    private RmqSettingsMapper settingsMapper;
+    private MybatisPlusSettingsRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        settingsMapper = mock(RmqSettingsMapper.class);
+        repository = new MybatisPlusSettingsRepository(settingsMapper, mock(RmqDataSourceMapper.class),
+                new ObjectMapper());
+    }
+
+    @Test
+    void shouldReturnDefaultsWhenGeneralSettingsDoNotExist() {
+        when(settingsMapper.selectById("singleton")).thenReturn(null);
+
+        GeneralSettingsVO settings = repository.loadGeneralSettings();
+
+        assertThat(settings.getTheme()).isEqualTo("system");
+        assertThat(settings.isRequireLogin()).isFalse();
+    }
+
+    @Test
+    void shouldRejectCorruptPersistedGeneralSettings() {
+        RmqSettings settings = new RmqSettings();
+        settings.setJson("{not-json");
+        when(settingsMapper.selectById("singleton")).thenReturn(settings);
+
+        assertThatThrownBy(repository::loadGeneralSettings)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Persisted general settings are invalid")
+                .extracting("code")
+                .isEqualTo(500);
+    }
+
+    @Test
+    void shouldReadValidPersistedGeneralSettings() {
+        RmqSettings settings = new RmqSettings();
+        settings.setJson("{\"theme\":\"dark\",\"requireLogin\":true}");
+        when(settingsMapper.selectById("singleton")).thenReturn(settings);
+
+        GeneralSettingsVO loaded = repository.loadGeneralSettings();
+
+        assertThat(loaded.getTheme()).isEqualTo("dark");
+        assertThat(loaded.isRequireLogin()).isTrue();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -8,6 +8,7 @@ package org.apache.rocketmq.studio.persistence;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.persistence.entity.RmqDataSource;
 import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
 import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqSettingsMapper;
@@ -23,12 +24,14 @@ import static org.mockito.Mockito.when;
 class MybatisPlusSettingsRepositoryTest {
 
     private RmqSettingsMapper settingsMapper;
+    private RmqDataSourceMapper dataSourceMapper;
     private MybatisPlusSettingsRepository repository;
 
     @BeforeEach
     void setUp() {
         settingsMapper = mock(RmqSettingsMapper.class);
-        repository = new MybatisPlusSettingsRepository(settingsMapper, mock(RmqDataSourceMapper.class),
+        dataSourceMapper = mock(RmqDataSourceMapper.class);
+        repository = new MybatisPlusSettingsRepository(settingsMapper, dataSourceMapper,
                 new ObjectMapper());
     }
 
@@ -65,5 +68,19 @@ class MybatisPlusSettingsRepositoryTest {
 
         assertThat(loaded.getTheme()).isEqualTo("dark");
         assertThat(loaded.isRequireLogin()).isTrue();
+    }
+
+    @Test
+    void shouldRejectCorruptPersistedDataSource() {
+        RmqDataSource dataSource = new RmqDataSource();
+        dataSource.setDsKey("metrics-prod");
+        dataSource.setJson("{not-json");
+        when(dataSourceMapper.selectById("metrics-prod")).thenReturn(dataSource);
+
+        assertThatThrownBy(() -> repository.findDataSourceByKey("metrics-prod"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Persisted data source is invalid: metrics-prod")
+                .extracting("code")
+                .isEqualTo(500);
     }
 }


### PR DESCRIPTION
## Summary
- Surface corrupt persisted general settings as a structured server-side failure instead of silently using defaults.
- Surface corrupt persisted data-source JSON with the affected data-source key.
- Add repository-level regression coverage for missing, valid, and corrupt persisted settings.

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=MybatisPlusSettingsRepositoryTest test`

Closes #1391
Closes #1395