### PR TITLE
fix: clear stale client connections after instance load failure

### DIFF
--- a/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
@@ -222,6 +222,48 @@ describe('Clients page', () => {
     expect(within(screen.getByTestId('connection-total')).getByText('0')).toBeInTheDocument();
   });
 
+  it('clears the previous instance data when the next instance connection request fails', async () => {
+    vi.mocked(instanceService.listInstances).mockResolvedValue([
+      {
+        id: 'instance-1',
+        name: 'Instance 1',
+        endpoint: 'namesrv-1:9876',
+        type: 'DIRECT',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+      {
+        id: 'instance-2',
+        name: 'Instance 2',
+        endpoint: 'namesrv-2:9876',
+        type: 'DIRECT',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
+    vi.mocked(connectionsService.listConnections).mockImplementation((query) =>
+      query?.instanceId === 'instance-1'
+        ? Promise.resolve([connection])
+        : Promise.reject(new Error('Instance 2 is unavailable')),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<ClientsPage />);
+
+    await screen.findByText('order-svc-0@10.0.1.12:49152');
+    await user.click(screen.getByRole('combobox', { name: 'Instance' }));
+    await user.click(await screen.findByText('Instance 2', { selector: '.ant-select-item-option-content' }));
+
+    expect(await screen.findByText('Instance 2 is unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('order-svc-0@10.0.1.12:49152')).not.toBeInTheDocument();
+    expect(within(screen.getByTestId('connection-total')).getByText('0')).toBeInTheDocument();
+  });
+
   it('surfaces instance discovery failures and allows retrying', async () => {
     vi.mocked(instanceService.listInstances)
       .mockRejectedValueOnce(new Error('Unable to load managed instances'))

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -116,6 +116,15 @@ const ClientsPage = () => {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [instanceLoadKey, setInstanceLoadKey] = useState(0);
 
+  const handleInstanceChange = (instanceId: string) => {
+    setSelectedInstanceId(instanceId);
+    setConnections([]);
+    setClusterFilter('ALL');
+    setSelectedConnection(null);
+    setLoadError(null);
+    setLoading(true);
+  };
+
   useEffect(() => {
     let cancelled = false;
 
@@ -159,6 +168,9 @@ const ClientsPage = () => {
       })
       .catch((error) => {
         if (!cancelled) {
+          setConnections([]);
+          setClusterFilter('ALL');
+          setSelectedConnection(null);
           setLoadError(getLoadErrorMessage(error));
         }
       })
@@ -403,7 +415,7 @@ const ClientsPage = () => {
           <Select
             aria-label="Instance"
             value={selectedInstanceId || undefined}
-            onChange={setSelectedInstanceId}
+            onChange={handleInstanceChange}
             placeholder="Select instance"
             style={{ width: 180 }}
             options={instances.map((instance) => ({ value: instance.id, label: instance.name }))}


### PR DESCRIPTION
Closes #1478

## Summary
- clear instance-derived client connection state before switching runtime endpoints
- keep failed instance requests from displaying the previous instance's connections or summary
- add regression coverage for a failed instance switch

## Validation
- `npm test -- --run src/pages/cluster/__tests__/ClientsPage.test.tsx`
- `npm run build`

`npm run lint` remains blocked by pre-existing React hook lint errors in unrelated pages.