### PR TITLE
fix: handle Cluster page instance bootstrap failures

### DIFF
--- a/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
@@ -32,7 +32,12 @@ const clusterServiceMocks = vi.hoisted(() => ({
   updateNameServer: vi.fn(),
 }));
 
+const instanceServiceMocks = vi.hoisted(() => ({
+  listInstances: vi.fn(),
+}));
+
 vi.mock('../../../services/clusterService', () => clusterServiceMocks);
+vi.mock('../../../services/instanceService', () => instanceServiceMocks);
 
 import ClusterPage from '../index';
 
@@ -132,6 +137,20 @@ const flushPromises = async () => {
 
 describe('Cluster page', () => {
   beforeEach(() => {
+    instanceServiceMocks.listInstances.mockReset().mockResolvedValue([
+      {
+        id: 'instance-1',
+        name: 'Instance 1',
+        endpoint: 'namesrv-1:9876',
+        type: 'DIRECT',
+        vendor: 'APACHE',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
     clusterServiceMocks.createNameServer.mockReset().mockResolvedValue(undefined);
     clusterServiceMocks.listClusters.mockReset().mockResolvedValue([buildCluster()]);
     clusterServiceMocks.restartProxy.mockReset().mockResolvedValue(undefined);
@@ -152,6 +171,34 @@ describe('Cluster page', () => {
     Modal.destroyAll();
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it('surfaces instance bootstrap failures and retries without querying a default cluster', async () => {
+    instanceServiceMocks.listInstances
+      .mockRejectedValueOnce(new Error('managed instances unavailable'))
+      .mockResolvedValueOnce([
+        {
+          id: 'instance-1',
+          name: 'Instance 1',
+          endpoint: 'namesrv-1:9876',
+          type: 'DIRECT',
+          vendor: 'APACHE',
+          remark: '',
+          topicCount: 0,
+          consumerGroupCount: 0,
+          createdAt: '',
+          updatedAt: '',
+        },
+      ]);
+    const user = userEvent.setup();
+    renderWithProviders(<ClusterPage />);
+
+    const alert = await screen.findByRole('alert');
+    expect(clusterServiceMocks.listClusters).not.toHaveBeenCalled();
+
+    await user.click(within(alert).getByRole('button', { name: /重\s*试/ }));
+    expect(await screen.findByText('rocketmq-prod-0')).toBeInTheDocument();
+    expect(clusterServiceMocks.listClusters).toHaveBeenCalledWith('instance-1');
   });
 
   it('opens proxy detail dialog from the proxy table', async () => {
@@ -331,6 +378,7 @@ describe('Cluster page', () => {
       .mockResolvedValueOnce([buildCluster({ tpsIn: 202 })]);
 
     renderWithProviders(<ClusterPage />);
+    await flushPromises();
     fireEvent.click(screen.getByRole('button', { name: '刷新' }));
     fireEvent.click(screen.getByRole('button', { name: '刷新' }));
 
@@ -474,6 +522,8 @@ describe('Cluster page', () => {
     const initialRequest = deferred<ClusterInfo[]>();
     clusterServiceMocks.listClusters.mockReturnValue(initialRequest.promise);
     const view = renderWithProviders(<ClusterPage />);
+
+    await flushPromises();
 
     view.unmount();
     await act(async () => {

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -34,6 +34,7 @@ import {
   Space,
   Typography,
   Card,
+  Alert,
   message,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
@@ -87,6 +88,8 @@ const ClusterPage = () => {
   const [clusters, setClusters] = useState<ClusterInfo[]>([]);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState('');
+  const [instanceLoadError, setInstanceLoadError] = useState<string | null>(null);
+  const [instanceLoadKey, setInstanceLoadKey] = useState(0);
   const [loading, setLoading] = useState(true);
   const [nsSearch, setNsSearch] = useState('');
   const [brokerSearch, setBrokerSearch] = useState('');
@@ -155,19 +158,34 @@ const ClusterPage = () => {
   const selectedInstanceIdRef = useRef('');
 
   useEffect(() => {
+    let cancelled = false;
     void listInstances()
       .then((nextInstances) => {
+        if (cancelled) return;
         const apacheInstances = nextInstances.filter((instance) => instance.vendor === 'APACHE');
         setInstances(apacheInstances);
         const initialInstanceId = apacheInstances[0]?.id ?? '';
         selectedInstanceIdRef.current = initialInstanceId;
         setSelectedInstanceId(initialInstanceId);
-        void requestRefreshRef.current('manual');
+        setInstanceLoadError(null);
+        if (initialInstanceId) void requestRefreshRef.current('manual');
       })
       .catch(() => {
-        // Keep the page usable without instance filtering when the instance list is unavailable.
+        if (cancelled) return;
+        selectedInstanceIdRef.current = '';
+        setInstances([]);
+        setSelectedInstanceId('');
+        setClusters([]);
+        setSelectedProxy(null);
+        setInstanceLoadError(tRef.current('common.fetchDataFailed'));
+        setLoading(false);
+        setAutoRefresh(false);
+        autoRefreshRef.current = false;
       });
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [instanceLoadKey]);
 
   const clearRefreshTimer = useCallback(() => {
     if (refreshTimerRef.current !== null) {
@@ -180,6 +198,12 @@ const ClusterPage = () => {
     (source: RefreshSource): Promise<void> => {
       clearRefreshTimer();
       if (!mountedRef.current) return Promise.resolve();
+
+      if (!selectedInstanceIdRef.current) {
+        setClusters([]);
+        setLoading(false);
+        return Promise.resolve();
+      }
 
       if (source !== 'background') setLoading(true);
 
@@ -1029,6 +1053,19 @@ const ClusterPage = () => {
           </Flex>
         }
       />
+      {instanceLoadError && (
+        <Alert
+          type="error"
+          showIcon
+          message={instanceLoadError}
+          action={
+            <Button size="small" onClick={() => setInstanceLoadKey((key) => key + 1)}>
+              {t('common.retry')}
+            </Button>
+          }
+          style={{ marginBottom: 16 }}
+        />
+      )}
       <style>{`
         @keyframes livePulse {
           0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(82, 196, 26, 0.4); }


### PR DESCRIPTION
Closes #1480

## Summary
- wait for Apache instance discovery before querying Cluster runtime data
- surface discovery failures with a retry action and clear stale runtime state
- stop automatic refresh when no selected instance is available
- add regression coverage for failed bootstrap and retry behavior

## Validation
- `npm test -- --run src/pages/cluster/__tests__/ClusterPage.test.tsx`
- `npm run build`

`npm run lint` reports only pre-existing hook errors in unrelated pages.