### PR TITLE
fix: preserve selected instance when rebuilding topics

### DIFF
--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -239,6 +239,35 @@ describe('TopicPage', () => {
     expect(within(getTableBody()).queryByText('topic-01')).not.toBeInTheDocument();
   });
 
+  it('rebuilds a topic and refreshes its route through the selected instance', async () => {
+    const user = userEvent.setup();
+    instanceServiceMocks.listInstances.mockResolvedValue([selectedInstance]);
+    topicServiceMocks.listTopics.mockResolvedValue([
+      { ...buildTopics(1)[0], name: 'orders-topic', instanceId: selectedInstance.id },
+    ]);
+    renderWithProviders('/instance/instance-proxy-1/topic');
+
+    expect(await screen.findByText('orders-topic')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /详情/ }));
+    expect(await screen.findByRole('button', { name: '在 Broker 上重建' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '在 Broker 上重建' }));
+
+    await waitFor(() =>
+      expect(topicServiceMocks.createTopic).toHaveBeenCalledWith({
+        name: 'orders-topic',
+        type: 'NORMAL',
+        writeQueues: 8,
+        readQueues: 8,
+        instanceId: 'instance-proxy-1',
+      }),
+    );
+    expect(topicServiceMocks.getTopicRoutes).toHaveBeenLastCalledWith(
+      'orders-topic',
+      'instance-proxy-1',
+    );
+  });
+
   it('keeps failed topics selected after a partially successful batch deletion', async () => {
     const user = userEvent.setup();
     topicServiceMocks.listTopics.mockResolvedValue(buildTopics(3));

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -376,6 +376,10 @@ const TopicPage = () => {
 
   // Metadata lives in the database, so a record can exist without a broker route.
   const rebuildTopic = async (topic: Topic) => {
+    if (!selectedInstanceId) {
+      message.warning('请先选择实例后再重建 Topic');
+      return;
+    }
     setRebuilding(true);
     try {
       await createTopic({
@@ -383,8 +387,9 @@ const TopicPage = () => {
         type: topic.type,
         writeQueues: topic.writeQueues,
         readQueues: topic.readQueues,
+        instanceId: selectedInstanceId,
       });
-      const routes = await getTopicRoutes(topic.name);
+      const routes = await getTopicRoutes(topic.name, selectedInstanceId);
       setRoutesByTopic((previous) => ({ ...previous, [topic.name]: routes }));
       message.success(`Topic「${topic.name}」已在 Broker 上重建`);
     } catch {


### PR DESCRIPTION
## Summary
- route Topic rebuild requests through the currently selected instance
- refresh Broker routes through that same instance endpoint
- add a regression test for the rebuild flow

Closes #1482

## Verification
- `npm test -- --run src/pages/instance/__tests__/TopicPage.test.tsx`
- `npm run build`