### PR TITLE
fix: preserve selected instance in cluster navigation

### DIFF
--- a/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
@@ -19,6 +19,7 @@ import { App, message, Modal } from 'antd';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClusterInfo } from '../../../api/cluster';
 import { LangProvider } from '../../../i18n/LangContext';
@@ -60,7 +61,18 @@ beforeAll(() => {
 const renderWithProviders = (ui: React.ReactElement) =>
   render(
     <App>
-      <LangProvider>{ui}</LangProvider>
+      <LangProvider>
+        <MemoryRouter>{ui}</MemoryRouter>
+      </LangProvider>
+    </App>,
+  );
+
+const renderWithRoute = (ui: React.ReactElement, route: string) =>
+  render(
+    <App>
+      <LangProvider>
+        <MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>
+      </LangProvider>
     </App>,
   );
 
@@ -136,6 +148,40 @@ const flushPromises = async () => {
 };
 
 describe('Cluster page', () => {
+  it('uses a valid instanceId from the route instead of the default instance', async () => {
+    instanceServiceMocks.listInstances.mockResolvedValue([
+      {
+        id: 'instance-a',
+        name: 'Instance A',
+        type: 'DIRECT',
+        vendor: 'APACHE',
+        endpoint: '127.0.0.1:9876',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'instance-b',
+        name: 'Instance B',
+        type: 'DIRECT',
+        vendor: 'APACHE',
+        endpoint: '127.0.0.2:9876',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ]);
+    renderWithRoute(<ClusterPage />, '/cluster?instanceId=instance-b');
+
+    await screen.findByText('rocketmq-prod');
+
+    expect(clusterServiceMocks.listClusters).toHaveBeenCalledWith('instance-b');
+  });
+
   beforeEach(() => {
     instanceServiceMocks.listInstances.mockReset().mockResolvedValue([
       {

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -16,6 +16,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   Table,
   Tabs,
@@ -85,6 +86,8 @@ const compareText = (left: string | null | undefined, right: string | null | und
 
 const ClusterPage = () => {
   const { t } = useLang();
+  const [searchParams] = useSearchParams();
+  const requestedInstanceId = searchParams.get('instanceId') ?? '';
   const [clusters, setClusters] = useState<ClusterInfo[]>([]);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState('');
@@ -164,7 +167,11 @@ const ClusterPage = () => {
         if (cancelled) return;
         const apacheInstances = nextInstances.filter((instance) => instance.vendor === 'APACHE');
         setInstances(apacheInstances);
-        const initialInstanceId = apacheInstances[0]?.id ?? '';
+        const initialInstanceId = apacheInstances.some(
+          (instance) => instance.id === requestedInstanceId,
+        )
+          ? requestedInstanceId
+          : (apacheInstances[0]?.id ?? '');
         selectedInstanceIdRef.current = initialInstanceId;
         setSelectedInstanceId(initialInstanceId);
         setInstanceLoadError(null);
@@ -185,7 +192,7 @@ const ClusterPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [instanceLoadKey]);
+  }, [instanceLoadKey, requestedInstanceId]);
 
   const clearRefreshTimer = useCallback(() => {
     if (refreshTimerRef.current !== null) {

--- a/web/src/pages/home/__tests__/DashboardPage.test.tsx
+++ b/web/src/pages/home/__tests__/DashboardPage.test.tsx
@@ -9,7 +9,7 @@ import { App } from 'antd';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DashboardData } from '../../../api/metrics';
 import { LangProvider } from '../../../i18n/LangContext';
@@ -68,6 +68,16 @@ const renderWithProviders = (ui: React.ReactElement) =>
       </LangProvider>
     </App>,
   );
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return (
+    <output data-testid="location">
+      {location.pathname}
+      {location.search}
+    </output>
+  );
+};
 
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
@@ -138,5 +148,26 @@ describe('DashboardPage', () => {
       expect(screen.queryByText('instance-a-cluster')).not.toBeInTheDocument();
     });
     expect(screen.getByText('instance-b-cluster')).toBeInTheDocument();
+  });
+
+  it('preserves the selected instance when navigating to the cluster page', async () => {
+    vi.mocked(dashboardService.getDashboard).mockResolvedValue(dashboard('instance-a-cluster'));
+    const user = userEvent.setup();
+    renderWithProviders(
+      <>
+        <DashboardPage />
+        <LocationProbe />
+      </>,
+    );
+
+    await screen.findByText('instance-a-cluster');
+    const selector = screen.getByRole('combobox', { name: 'Dashboard instance' });
+    await user.click(selector);
+    await user.click(
+      await screen.findByText('Instance B', { selector: '.ant-select-item-option-content' }),
+    );
+    await user.click(screen.getByText('查看全部'));
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/cluster?instanceId=instance-b');
   });
 });

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -38,6 +38,9 @@ const DashboardPage = () => {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const dashboardRequestIdRef = useRef(0);
+  const clusterPagePath = selectedInstanceId
+    ? `/cluster?instanceId=${encodeURIComponent(selectedInstanceId)}`
+    : '/cluster';
 
   const loadDashboard = useCallback(async () => {
     const requestId = ++dashboardRequestIdRef.current;
@@ -289,7 +292,7 @@ const DashboardPage = () => {
 
       <Card
         title={t('dashboard.clusterHealth')}
-        extra={<a onClick={() => navigate('/cluster')}>{t('common.viewAll')}</a>}
+        extra={<a onClick={() => navigate(clusterPagePath)}>{t('common.viewAll')}</a>}
         styles={{ body: { padding: '0 20px 16px' } }}
       >
         <Table
@@ -300,7 +303,7 @@ const DashboardPage = () => {
           pagination={false}
           onRow={() => ({
             style: { cursor: 'pointer' },
-            onClick: () => navigate('/cluster'),
+            onClick: () => navigate(clusterPagePath),
           })}
         />
       </Card>


### PR DESCRIPTION
## Summary
- preserve the Dashboard-selected instance in Cluster navigation
- use a valid `instanceId` URL parameter during Cluster page initialization
- retain the existing first-Apache-instance fallback for absent or invalid parameters
- add Dashboard and Cluster page regression coverage

Closes #1484

## Verification
- `npm test -- --run src/pages/home/__tests__/DashboardPage.test.tsx src/pages/cluster/__tests__/ClusterPage.test.tsx`
- `npm run build`