### PR TITLE
fix(instance): normalize endpoint types with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 @Slf4j
@@ -159,7 +160,7 @@ public class InstanceService {
         if (endpointType == null) {
             return 2;
         }
-        return switch (endpointType.toUpperCase()) {
+        return switch (endpointType.toUpperCase(Locale.ROOT)) {
             case "TCP_VPC" -> 0;
             case "TCP_INTERNET" -> 1;
             default -> 2;

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -36,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -789,6 +790,41 @@ class InstanceServiceTest {
         assertThat(created.getName()).isEqualTo("prod-mq");
         assertThat(created.getEndpoint()).isEqualTo("vpc:8080");
         assertThat(created.getType()).isEqualTo(InstanceType.PROXY);
+    }
+
+    @Test
+    void createInstanceShouldPrioritizeEndpointsIndependentlyOfDefaultLocaleTest() {
+        InstanceVO instance = InstanceVO.builder()
+                .vendor(InstanceVendor.ALIYUN)
+                .credentialId("cred-1")
+                .cloudInstanceId("rmq-cn-xxx")
+                .regionId("cn-hangzhou")
+                .build();
+        CloudCredentialVO credential = new CloudCredentialVO();
+        credential.setId("cred-1");
+        credential.setVendor(InstanceVendor.ALIYUN);
+        when(cloudCredentialRepository.findById("cred-1")).thenReturn(Optional.of(credential));
+        CloudCatalogProvider catalog = org.mockito.Mockito.mock(CloudCatalogProvider.class);
+        CloudInstanceDetailVO detail = new CloudInstanceDetailVO();
+        detail.setInstanceId("rmq-cn-xxx");
+        detail.setInstanceName("prod-mq");
+        detail.setEndpoints(List.of(
+                new CloudInstanceDetailVO.CloudEndpoint("unknown", "fallback:8080"),
+                new CloudInstanceDetailVO.CloudEndpoint("tcp_internet", "public:8080")));
+        when(providerRegistry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
+        when(catalog.getCloudInstance("cred-1", "cn-hangzhou", "rmq-cn-xxx")).thenReturn(detail);
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        Locale originalLocale = Locale.getDefault();
+
+        InstanceVO created;
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            created = instanceService.createInstance(instance);
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+
+        assertThat(created.getEndpoint()).isEqualTo("public:8080");
     }
 
     @Test


### PR DESCRIPTION
### Problem

Endpoint type ordering used the JVM default locale. Under Turkish locale, lowercase `tcp_internet` uppercased to a value containing a dotted capital I, so the public endpoint was treated as unknown and could lose priority to an unsupported fallback endpoint.

### Fix

Normalize endpoint type identifiers with `Locale.ROOT` before applying endpoint priority.

### Verification

`mvn -B -ntp -Dmaven.compiler.proc=full -Dtest=InstanceServiceTest test`

Tests run: 48, failures: 0, errors: 0.