### PR TITLE
fix(metrics): normalize backend types with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendType.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendType.java
@@ -16,6 +16,8 @@
  */
 package org.apache.rocketmq.studio.cluster.metrics;
 
+import java.util.Locale;
+
 /**
  * Prometheus-compatible metrics backend types supported by RocketMQ Studio.
  * <p>
@@ -53,7 +55,7 @@ public enum MetricsBackendType {
         if (providerType == null) {
             return PROMETHEUS;
         }
-        return switch (providerType.trim().toUpperCase()) {
+        return switch (providerType.trim().toUpperCase(Locale.ROOT)) {
             case "PROMETHEUS" -> PROMETHEUS;
             case "VICTORIAMETRICS", "VICTORIA_METRICS", "VICTORIA" -> VICTORIA_METRICS;
             case "THANOS" -> THANOS;

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendTypeTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendTypeTest.java
@@ -18,6 +18,8 @@ package org.apache.rocketmq.studio.cluster.metrics;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MetricsBackendTypeTest {
@@ -41,6 +43,21 @@ class MetricsBackendTypeTest {
         assertThat(MetricsBackendType.fromProviderType(null)).isEqualTo(MetricsBackendType.PROMETHEUS);
         assertThat(MetricsBackendType.fromProviderType("")).isEqualTo(MetricsBackendType.PROMETHEUS);
         assertThat(MetricsBackendType.fromProviderType("unknown-backend")).isEqualTo(MetricsBackendType.PROMETHEUS);
+    }
+
+    @Test
+    void shouldResolveProviderTypeIndependentlyOfDefaultLocale() {
+        Locale originalLocale = Locale.getDefault();
+
+        MetricsBackendType backendType;
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            backendType = MetricsBackendType.fromProviderType("mimir");
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+
+        assertThat(backendType).isEqualTo(MetricsBackendType.MIMIR);
     }
 
     @Test


### PR DESCRIPTION
### Problem

Metrics backend names were uppercased with the JVM default locale. Under Turkish locale, lowercase `mimir` becomes a value containing dotted capital I characters, so the configured Mimir backend silently falls back to Prometheus and uses the wrong query path.

### Fix

Normalize backend identifiers with `Locale.ROOT` before resolving the backend type.

### Verification

`mvn -B -ntp -Dmaven.compiler.proc=full -Dtest=MetricsBackendTypeTest test`

Tests run: 4, failures: 0, errors: 0.