### PR TITLE
fix(metrics): normalize auth modes with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
@@ -28,6 +28,7 @@ import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -119,7 +120,7 @@ public class MetricsService {
         if (!StringUtils.hasText(auth)) {
             return "none";
         }
-        return switch (auth.trim().toLowerCase()) {
+        return switch (auth.trim().toLowerCase(Locale.ROOT)) {
             case "basic auth", "basic" -> "basic";
             case "bearer token", "bearer" -> "bearer";
             default -> "none";

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
@@ -29,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -419,6 +420,42 @@ class MetricsServiceTest {
                 .isThrownBy(() -> metricsService.queryByDataSource("ds-1", request))
                 .satisfies(exception -> assertThat(exception.getStatusCode()).isEqualTo(400));
         verifyNoInteractions(metricsSourceFactory, metricsSource);
+    }
+
+    @Test
+    void queryByDataSourceShouldNormalizeAuthIndependentlyOfDefaultLocale() {
+        MetricQueryDTO query = MetricQueryDTO.builder()
+                .metric("cpu")
+                .start(1700000000L)
+                .end(1700003600L)
+                .step("1m")
+                .build();
+        MetricsDataSourceQueryRequest request = new MetricsDataSourceQueryRequest();
+        request.setQuery(query);
+        request.setUsername("prom");
+        request.setPassword("secret");
+        DataSourceVO dataSource = DataSourceVO.builder()
+                .key("ds-1")
+                .name("prometheus-prod")
+                .type("prometheus")
+                .url("http://prometheus:9090")
+                .auth("BASIC")
+                .build();
+        when(settingsService.getDataSource("ds-1")).thenReturn(dataSource);
+        when(metricsSourceFactory.create(any(MetricsDataSourceConfig.class))).thenReturn(metricsSource);
+        when(metricsSource.query(any(MetricQueryDTO.class))).thenReturn(metricData("cpu", List.of()));
+        Locale originalLocale = Locale.getDefault();
+
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            metricsService.queryByDataSource("ds-1", request);
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+
+        ArgumentCaptor<MetricsDataSourceConfig> configCaptor = ArgumentCaptor.forClass(MetricsDataSourceConfig.class);
+        verify(metricsSourceFactory).create(configCaptor.capture());
+        assertThat(configCaptor.getValue().getAuthType()).isEqualTo("basic");
     }
 
     @Test


### PR DESCRIPTION
### Problem

Metrics authentication modes were lowercased with the JVM default locale. Under Turkish locale, uppercase `BASIC` becomes `basıc`, so valid basic authentication silently falls back to `none` and the query is sent without credentials.

### Fix

Normalize authentication mode identifiers with `Locale.ROOT` before mapping them to the metrics source configuration.

### Verification

`mvn -B -ntp -Dmaven.compiler.proc=full -Dtest=MetricsServiceTest test`

Tests run: 16, failures: 0, errors: 0.