### PR TITLE
fix(ai): normalize provider names with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -37,6 +37,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -381,6 +382,6 @@ public class OpenAiCompatibleLlmClient {
     }
 
     private String normalize(String provider) {
-        return provider == null ? "" : provider.trim().toLowerCase();
+        return provider == null ? "" : provider.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -77,6 +78,21 @@ class OpenAiCompatibleLlmClientTest {
         assertThat(requestBody.get().path("messages").path(0).path("role").asText()).isEqualTo("user");
         assertThat(requestBody.get().path("messages").path(0).path("content").asText()).isEqualTo("hello");
         assertThat(requestBody.get().path("max_tokens").asInt()).isEqualTo(256);
+    }
+
+    @Test
+    void supportsShouldNormalizeProviderIndependentlyOfDefaultLocale() {
+        Locale originalLocale = Locale.getDefault();
+
+        boolean supported;
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            supported = client.supports(config("OPENAI", "sk-test"));
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+
+        assertThat(supported).isTrue();
     }
 
     @Test


### PR DESCRIPTION
### Problem

OpenAI-compatible provider names were lowercased with the JVM default locale. Under Turkish locale, uppercase `OPENAI` becomes `openaı`, so a supported provider is rejected before any request is sent.

### Fix

Normalize provider identifiers with `Locale.ROOT` when checking gateway support and provider-specific behavior.

### Verification

`mvn -B -ntp -Dmaven.compiler.proc=full -Dtest=OpenAiCompatibleLlmClientTest test`

Tests run: 13, failures: 0, errors: 0.