### PR TITLE
fix(lite-topic): handle unset quota counters

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicQuota.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicQuota.java
@@ -38,14 +38,14 @@ public class LiteTopicQuota {
     private Double maxCreationRate;
 
     public double getUsageRate() {
-        if (maxTopicCount == null || maxTopicCount == 0) {
+        if (maxTopicCount == null || maxTopicCount == 0 || currentTopicCount == null) {
             return 0.0;
         }
         return (double) currentTopicCount / maxTopicCount;
     }
 
     public double getSessionUsageRate() {
-        if (maxSessionCount == null || maxSessionCount == 0) {
+        if (maxSessionCount == null || maxSessionCount == 0 || currentSessionCount == null) {
             return 0.0;
         }
         return (double) currentSessionCount / maxSessionCount;
@@ -65,6 +65,6 @@ public class LiteTopicQuota {
         if (maxTopicCount == null) {
             return 0;
         }
-        return Math.max(0, maxTopicCount - currentTopicCount);
+        return Math.max(0, maxTopicCount - (currentTopicCount == null ? 0 : currentTopicCount));
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
@@ -32,4 +32,15 @@ class LiteTopicQuotaTest {
 
         assertThat(quota.isQuotaExceeded()).isTrue();
     }
+
+    @Test
+    void quotaCalculationsShouldHandleUnsetCurrentCounts() {
+        LiteTopicQuota quota = new LiteTopicQuota();
+        quota.setMaxTopicCount(10);
+        quota.setMaxSessionCount(5);
+
+        assertThat(quota.getUsageRate()).isZero();
+        assertThat(quota.getSessionUsageRate()).isZero();
+        assertThat(quota.getRemainingQuota()).isEqualTo(10);
+    }
 }


### PR DESCRIPTION
### Problem

A partially populated Lite Topic quota can have configured maximums while its current topic or session counters are still unset. The usage and remaining-quota accessors unboxed those null counters and threw `NullPointerException`, which can break API serialization.

### Fix

Treat unset current counters as zero when calculating topic usage, session usage, and remaining topic quota.

### Verification

`mvn -B -ntp -Dmaven.compiler.proc=full -Dtest=LiteTopicQuotaTest test`

Tests run: 3, failures: 0, errors: 0.