### PR TITLE
fix(lite-topic): handle unset consumed message count

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicSession.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicSession.java
@@ -72,7 +72,7 @@ public class LiteTopicSession {
     }
 
     public double getConsumptionProgress() {
-        if (totalMessages == null || totalMessages == 0) {
+        if (totalMessages == null || totalMessages == 0 || consumedMessages == null) {
             return 0.0;
         }
         return (double) consumedMessages / totalMessages * 100.0;

--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSessionTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSessionTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LiteTopicSessionTest {
+
+    @Test
+    void consumptionProgressShouldHandleUnsetConsumedMessages() {
+        LiteTopicSession session = new LiteTopicSession();
+        session.setTotalMessages(10L);
+
+        assertThat(session.getConsumptionProgress()).isZero();
+    }
+
+    @Test
+    void consumptionProgressShouldCalculatePercentage() {
+        LiteTopicSession session = new LiteTopicSession();
+        session.setTotalMessages(10L);
+        session.setConsumedMessages(4L);
+
+        assertThat(session.getConsumptionProgress()).isEqualTo(40.0);
+    }
+}


### PR DESCRIPTION
### Problem

A Lite Topic session may report a total message count before the consumed message count is populated. `getConsumptionProgress` unboxed the missing consumed count and threw `NullPointerException`, which can break session response serialization.

### Fix

Return zero progress until the consumed message count is available, matching the existing behavior for an unset or zero total count.

### Verification

`mvn -B -ntp -Dmaven.compiler.proc=full -Dtest=LiteTopicSessionTest test`

Tests run: 2, failures: 0, errors: 0.