### PR TITLE
fix(lite-topic): handle unset summary consumer count

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicSummary.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicSummary.java
@@ -67,13 +67,14 @@ public class LiteTopicSummary {
     }
 
     public double getConsumerDensity() {
-        if (topicCount == null || topicCount == 0) {
+        if (topicCount == null || topicCount == 0 || consumerCount == null) {
             return 0.0;
         }
         return (double) consumerCount / topicCount;
     }
 
     public boolean isEmptyAggregation() {
-        return consumerCount == 0 && (totalBacklog == null || totalBacklog == 0);
+        return (consumerCount == null || consumerCount == 0)
+                && (totalBacklog == null || totalBacklog == 0);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSummaryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSummaryTest.java
@@ -43,4 +43,13 @@ class LiteTopicSummaryTest {
 
         assertThat(summary.getTTLStatus()).isEqualTo("ACTIVE");
     }
+
+    @Test
+    void aggregationHelpersShouldHandleUnsetConsumerCount() {
+        LiteTopicSummary summary = new LiteTopicSummary();
+        summary.setTopicCount(5);
+
+        assertThat(summary.getConsumerDensity()).isZero();
+        assertThat(summary.isEmptyAggregation()).isTrue();
+    }
 }


### PR DESCRIPTION
### Problem

A Lite Topic summary can be returned before its consumer count is populated. Both consumer-density calculation and empty-aggregation detection unboxed the missing count and threw `NullPointerException`, which can break summary response serialization.

### Fix

Treat an unset consumer count as zero in both aggregation helpers.

### Verification

`mvn -B -ntp -Dmaven.compiler.proc=full -Dtest=LiteTopicSummaryTest test`

Tests run: 4, failures: 0, errors: 0.