### PR TITLE
fix: redirect legacy alert management route

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,7 +48,6 @@ const LiteTopicPage = lazy(() => import('./pages/studio/LiteTopic'));
 const GroupManagementPage = lazy(() => import('./pages/studio/GroupManagement'));
 const BrokerClusterPage = lazy(() => import('./pages/studio/BrokerCluster'));
 const SslSettingsPage = lazy(() => import('./pages/studio/SslSettings'));
-const AlertManagementPage = lazy(() => import('./pages/studio/AlertManagement'));
 const GrafanaDashboardsPage = lazy(() => import('./pages/studio/GrafanaDashboards'));
 const ProducerPage = lazy(() => import('./pages/studio/Producer'));
 const OpsPage = lazy(() => import('./pages/studio/Ops'));
@@ -174,7 +173,7 @@ function App() {
             <Route path="studio/group-management" element={<GroupManagementPage />} />
             <Route path="studio/broker-cluster" element={<BrokerClusterPage />} />
             <Route path="studio/ssl-settings" element={<SslSettingsPage />} />
-            <Route path="studio/alert-management" element={<AlertManagementPage />} />
+            <Route path="studio/alert-management" element={<Navigate to="/ops/alerts" replace />} />
             <Route path="studio/producer" element={<ProducerPage />} />
             <Route path="studio/ops" element={<OpsPage />} />
             <Route path="ops/alert-rule-templates" element={<AlertRuleAssetsPage />} />


### PR DESCRIPTION
## Summary
- redirect `/studio/alert-management` to the persisted `/ops/alerts` page
- remove the unused legacy alert-management lazy route dependency

Closes #1489

## Verification
- `npm run build`