### PR TITLE
[ISSUE #1424] Preserve UTF-8 message body truncation boundaries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -494,14 +494,8 @@ public class RocketMQMessageProvider implements MessageProvider {
             return new DisplayBody(null, null, false);
         }
         int textLength = Math.min(body.length, MAX_BODY_DISPLAY_BYTES);
-        // When truncating, walk back to the last complete UTF-8 character boundary
-        // to avoid splitting a multi-byte character, which would cause the decoder
-        // to fall through to BASE64 encoding even for valid UTF-8 text.
-        if (textLength < body.length) {
-            while (textLength > 0 && (body[textLength] & 0xC0) == 0x80) {
-                textLength--;
-            }
-            if (textLength > 0 && (body[textLength] & 0xC0) == 0xC0) {
+        if (textLength < body.length && isUtf8ContinuationByte(body[textLength])) {
+            while (textLength > 0 && isUtf8ContinuationByte(body[textLength])) {
                 textLength--;
             }
         }
@@ -517,6 +511,10 @@ public class RocketMQMessageProvider implements MessageProvider {
             return new DisplayBody(Base64.getEncoder().encodeToString(
                     java.util.Arrays.copyOf(body, binaryLength)), "BASE64", body.length > binaryLength);
         }
+    }
+
+    private boolean isUtf8ContinuationByte(byte value) {
+        return (value & 0xC0) == 0x80;
     }
 
     private Map<String, String> limitProperties(Map<String, String> properties) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -193,6 +193,20 @@ class RocketMQMessageProviderTest {
     }
 
     @Test
+    void toRecordVODoesNotSplitUtf8CharacterAtBodyLimit() {
+        MessageExt message = new MessageExt();
+        message.setMsgId("msg-utf8");
+        message.setTopic("TopicA");
+        message.setBody(("x".repeat(64 * 1024 - 1) + "\u4E2Dsuffix").getBytes(StandardCharsets.UTF_8));
+
+        MessageRecordVO record = provider.toRecordVO(message);
+
+        assertThat(record.getBodyEncoding()).isEqualTo("UTF-8");
+        assertThat(record.getBody()).isEqualTo("x".repeat(64 * 1024 - 1));
+        assertThat(record.isBodyTruncated()).isTrue();
+    }
+
+    @Test
     void getMessageTraceParsesPubAndSubAfterPerRocketMq533Layout() throws Exception {
         // Field order follows RocketMQ 5.3.3 TraceDataEncoder: Pub = type, time, region, group,
         // topic, msgId, tags, keys, storeHost, bodyLength, costTime, msgType, offsetMsgId, isSuccess.


### PR DESCRIPTION
## Summary
- avoid cutting a UTF-8 code point at the message body display limit
- keep valid multibyte text in UTF-8 instead of falling back to Base64
- add a regression test for a split CJK character

## Testing
- `mvn -Dtest=RocketMQMessageProviderTest -Dmaven.compiler.proc=full test`

Closes #1424