### PR TITLE
[ISSUE #1404] Generate unique Prometheus alert names

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -23,10 +23,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
@@ -64,9 +66,11 @@ public class AlertService {
         for (Map.Entry<String, List<PrometheusAlertRule>> group : rulesByGroup.entrySet()) {
             yaml.append("  - name: ").append(group.getKey()).append('\n');
             yaml.append("    rules:\n");
+            Set<String> alertNames = new HashSet<>();
             for (PrometheusAlertRule rule : group.getValue()) {
-                yaml.append("      # Rule ").append(index++).append(": ").append(rule.alert()).append('\n');
-                yaml.append("      - alert: ").append(rule.alert()).append('\n');
+                String alertName = uniqueAlertName(rule.alert(), alertNames);
+                yaml.append("      # Rule ").append(index++).append(": ").append(alertName).append('\n');
+                yaml.append("      - alert: ").append(alertName).append('\n');
                 yaml.append("        expr: ").append(rule.expr()).append('\n');
                 yaml.append("        for: ").append(rule.duration()).append('\n');
                 yaml.append("        labels:\n");
@@ -79,6 +83,18 @@ public class AlertService {
             }
         }
         return yaml.toString();
+    }
+
+    private String uniqueAlertName(String baseName, Set<String> usedNames) {
+        if (usedNames.add(baseName)) {
+            return baseName;
+        }
+        int suffix = 2;
+        String candidate;
+        do {
+            candidate = baseName + "_" + suffix++;
+        } while (!usedNames.add(candidate));
+        return candidate;
     }
 
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -154,6 +154,31 @@ class AlertServiceTest {
     }
 
     @Test
+    void exportPrometheusRulesYamlShouldDisambiguateDuplicateAlertNames() {
+        AlertRuleVO first = AlertRuleVO.builder()
+                .name("High Lag")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(1000)
+                .enabled(true)
+                .build();
+        AlertRuleVO second = AlertRuleVO.builder()
+                .name("High-Lag")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(2000)
+                .enabled(true)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(first, second));
+
+        String result = alertService.exportPrometheusRulesYaml();
+
+        assertThat(result)
+                .contains("- alert: HighLag\n")
+                .contains("- alert: HighLag_2\n");
+    }
+
+    @Test
     void exportPrometheusRulesYamlShouldRenderReplicationLagRuleWithScopeAndSeverity() {
         AlertRuleVO rule = AlertRuleVO.builder()
                 .name("Replication Lag High")


### PR DESCRIPTION
## Summary
- track emitted alert names within each Prometheus rule group
- append deterministic numeric suffixes when sanitized names collide
- add regression coverage for two names that normalize identically

## Testing
- `mvn -Dtest=AlertServiceTest -Dmaven.compiler.proc=full test`

Closes #1404