### PR TITLE
[Studio] fix: restore rocketmq-studio backend compilation

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1191,6 +1191,13 @@ GET /api/messages?topic={topic}&msgId={msgId}&key={key}&startTime={startTime}&en
 GET /api/messages/:msgId/trace
 ```
 
+**Query 参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `instanceId` | `string` | 是 | Studio 实例 ID |
+| `storeTime` | `number` | 否 | 消息存储时间（Unix 毫秒），作为轨迹时间窗口提示；仅接受最近 7 天内且不晚于当前时间 5 分钟的值，缺失或无效时回退到最近 1 小时 |
+
 **Response `data`:** `TraceRecord`
 
 ```json

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageController.java
@@ -46,7 +46,9 @@ public class MessageController {
     }
 
     @GetMapping("/{msgId}/trace")
-    public Result<TraceRecordVO> getMessageTrace(@PathVariable String msgId, @RequestParam String instanceId) {
-        return Result.ok(messageService.getMessageTrace(instanceId, msgId));
+    public Result<TraceRecordVO> getMessageTrace(@PathVariable String msgId,
+                                                  @RequestParam String instanceId,
+                                                  @RequestParam(required = false) Long storeTime) {
+        return Result.ok(messageService.getMessageTrace(instanceId, msgId, storeTime));
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProvider.java
@@ -24,4 +24,8 @@ public interface MessageProvider {
                                         Long endTime);
 
     TraceRecordVO getMessageTrace(String instanceId, String msgId);
+
+    default TraceRecordVO getMessageTrace(String instanceId, String msgId, Long storeTime) {
+        return getMessageTrace(instanceId, msgId);
+    }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -45,13 +45,17 @@ public class MessageService {
     }
 
     public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
+        return getMessageTrace(instanceId, msgId, null);
+    }
+
+    public TraceRecordVO getMessageTrace(String instanceId, String msgId, Long storeTime) {
         if (!StringUtils.hasText(msgId)) {
             throw new BusinessException(400, "msgId is required");
         }
-        log.info("Getting message trace: msgId={}", msgId);
+        log.info("Getting message trace: msgId={}, storeTime={}", msgId, storeTime);
         return providerRegistry.byInstanceId(instanceId)
-                .map(provider -> provider.getMessageTrace(instanceId, msgId))
-                .orElseGet(() -> messageProvider.getMessageTrace(instanceId, msgId));
+                .map(provider -> provider.getMessageTrace(instanceId, msgId, storeTime))
+                .orElseGet(() -> messageProvider.getMessageTrace(instanceId, msgId, storeTime));
     }
 
     private void validateTopicQueryWindow(String topic, String msgId, String key, Long startTime, Long endTime) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
@@ -66,4 +66,8 @@ public interface InstanceProvider {
                                         String tag, String key, Long startTime, Long endTime);
 
     TraceRecordVO getMessageTrace(String instanceId, String msgId);
+
+    default TraceRecordVO getMessageTrace(String instanceId, String msgId, Long storeTime) {
+        return getMessageTrace(instanceId, msgId);
+    }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
@@ -129,6 +129,11 @@ public class ApacheInstanceProvider implements InstanceProvider {
         return messageProvider.getMessageTrace(instanceId, msgId);
     }
 
+    @Override
+    public TraceRecordVO getMessageTrace(String instanceId, String msgId, Long storeTime) {
+        return messageProvider.getMessageTrace(instanceId, msgId, storeTime);
+    }
+
     private boolean matchesInstance(String topicInstanceId, String instanceId) {
         if (instanceId == null || instanceId.isBlank()) {
             return true;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -270,7 +270,7 @@ public class RocketMQDLQProvider implements DLQProvider {
             }
             // Copy user properties from the original message, skipping system-reserved
             // keys to avoid conflicts with broker-internal properties.
-            Map<String, String> userProperties = deadLetter.getUserProperties();
+            Map<String, String> userProperties = deadLetter.getProperties();
             if (userProperties != null) {
                 for (Map.Entry<String, String> entry : userProperties.entrySet()) {
                     String key = entry.getKey();

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -42,6 +42,7 @@ import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardProvider;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardStatsVO;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
+import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -79,6 +79,9 @@ public class RocketMQMessageProvider implements MessageProvider {
     private static final int MAX_PROPERTIES = 64;
     private static final int MAX_PROPERTY_VALUE_CHARS = 1024;
     private static final long ONE_HOUR_MILLIS = 3600_000L;
+    private static final long ONE_DAY_MILLIS = 24 * ONE_HOUR_MILLIS;
+    private static final long MAX_TRACE_LOOKBACK_MILLIS = 7 * ONE_DAY_MILLIS;
+    private static final long TRACE_TIME_SKEW_MILLIS = 5 * 60_000L;
     private static final int MAX_CONSECUTIVE_OFFSET_ILLEGAL = 3;
 
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
@@ -264,15 +267,32 @@ public class RocketMQMessageProvider implements MessageProvider {
 
     @Override
     public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
-        return runtimeAdminClientResolver.execute(instanceId,
-                adminExt -> getMessageTrace(instanceId, (DefaultMQAdminExt) adminExt, msgId));
+        return getMessageTrace(instanceId, msgId, null);
     }
 
-    private TraceRecordVO getMessageTrace(String instanceId, DefaultMQAdminExt adminExt, String msgId) {
+    @Override
+    public TraceRecordVO getMessageTrace(String instanceId, String msgId, Long storeTime) {
+        return runtimeAdminClientResolver.execute(instanceId,
+                adminExt -> getMessageTrace(instanceId, (DefaultMQAdminExt) adminExt, msgId, storeTime));
+    }
+
+    private TraceRecordVO getMessageTrace(String instanceId, DefaultMQAdminExt adminExt,
+                                          String msgId, Long storeTime) {
 
         long now = System.currentTimeMillis();
-        long begin = now - ONE_HOUR_MILLIS;
-        long end = now + 60_000L;
+        long begin;
+        long end;
+        long messageStoreTimestamp = normalizeTraceStoreTime(storeTime, now);
+        if (messageStoreTimestamp > 0) {
+            begin = messageStoreTimestamp - TRACE_TIME_SKEW_MILLIS;
+            end = Math.max(messageStoreTimestamp + ONE_DAY_MILLIS, now + 60_000L);
+        } else {
+            if (storeTime != null) {
+                log.warn("Invalid storeTime={} for msgId={}, falling back to 1h trace window", storeTime, msgId);
+            }
+            begin = now - ONE_HOUR_MILLIS;
+            end = now + 60_000L;
+        }
 
         List<TraceNodeVO> nodes = new ArrayList<>();
         List<ConsumerStatusVO> consumerStatus = new ArrayList<>();
@@ -296,6 +316,18 @@ public class RocketMQMessageProvider implements MessageProvider {
                 .nodes(nodes)
                 .consumerStatus(consumerStatus)
                 .build();
+    }
+
+    private long normalizeTraceStoreTime(Long storeTime, long now) {
+        // The value is a client-supplied query hint, so keep it bounded before building the range.
+        if (storeTime == null || storeTime <= 0) {
+            return 0L;
+        }
+        if (storeTime > now + TRACE_TIME_SKEW_MILLIS
+                || storeTime < now - MAX_TRACE_LOOKBACK_MILLIS) {
+            return 0L;
+        }
+        return storeTime;
     }
 
     /**

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -79,7 +79,6 @@ public class RocketMQMessageProvider implements MessageProvider {
     private static final int MAX_PROPERTIES = 64;
     private static final int MAX_PROPERTY_VALUE_CHARS = 1024;
     private static final long ONE_HOUR_MILLIS = 3600_000L;
-    private static final long ONE_DAY_MILLIS = 24 * ONE_HOUR_MILLIS;
     private static final int MAX_CONSECUTIVE_OFFSET_ILLEGAL = 3;
 
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
@@ -272,23 +271,8 @@ public class RocketMQMessageProvider implements MessageProvider {
     private TraceRecordVO getMessageTrace(String instanceId, DefaultMQAdminExt adminExt, String msgId) {
 
         long now = System.currentTimeMillis();
-        long begin;
-        long end;
-        long messageStoreTimestamp = resolveMessageStoreTimestamp(adminExt, msgId);
-        if (messageStoreTimestamp > 0) {
-            // Derive the trace query window from the message's own store timestamp
-            // instead of a hardcoded 1-hour lookback. This ensures traces for messages
-            // older than 1 hour are still found as long as the trace data is retained
-            // on the broker (default fileReservedTime = 72 hours).
-            long traceBuffer = 5 * 60_000L;
-            begin = messageStoreTimestamp - traceBuffer;
-            end = Math.max(messageStoreTimestamp + ONE_DAY_MILLIS, now + 60_000L);
-        } else {
-            // Fallback: use the existing 1-hour window if the message can't be located
-            log.warn("Could not resolve store timestamp for msgId={}, falling back to 1h trace window", msgId);
-            begin = now - ONE_HOUR_MILLIS;
-            end = now + 60_000L;
-        }
+        long begin = now - ONE_HOUR_MILLIS;
+        long end = now + 60_000L;
 
         List<TraceNodeVO> nodes = new ArrayList<>();
         List<ConsumerStatusVO> consumerStatus = new ArrayList<>();
@@ -312,23 +296,6 @@ public class RocketMQMessageProvider implements MessageProvider {
                 .nodes(nodes)
                 .consumerStatus(consumerStatus)
                 .build();
-    }
-
-    /**
-     * Attempts to resolve the store timestamp of the original message so the trace
-     * query window can be derived from the message's own timeline rather than the
-     * current time. Returns 0 if the message cannot be located.
-     */
-    private long resolveMessageStoreTimestamp(DefaultMQAdminExt adminExt, String msgId) {
-        try {
-            MessageExt messageExt = adminExt.viewMessage(msgId);
-            if (messageExt != null) {
-                return messageExt.getStoreTimestamp();
-            }
-        } catch (Exception e) {
-            log.debug("Could not view message {} for trace timestamp: {}", msgId, e.getMessage());
-        }
-        return 0L;
     }
 
     /**

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -34,6 +34,7 @@ import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
+import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageControllerTest.java
@@ -72,14 +72,28 @@ class MessageControllerTest {
     }
 
     @Test
-    void messageTraceShouldPassInstanceId() throws Exception {
+    void messageTraceShouldRemainCompatibleWithoutStoreTime() throws Exception {
         TraceRecordVO trace = TraceRecordVO.builder().nodes(List.of()).consumerStatus(List.of()).build();
-        when(messageService.getMessageTrace("instance-a", "msg-001")).thenReturn(trace);
+        when(messageService.getMessageTrace(eq("instance-a"), eq("msg-001"), isNull())).thenReturn(trace);
 
         mockMvc.perform(get("/api/messages/msg-001/trace").param("instanceId", "instance-a"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200));
 
-        verify(messageService).getMessageTrace("instance-a", "msg-001");
+        verify(messageService).getMessageTrace(eq("instance-a"), eq("msg-001"), isNull());
+    }
+
+    @Test
+    void messageTraceShouldPassStoreTime() throws Exception {
+        TraceRecordVO trace = TraceRecordVO.builder().nodes(List.of()).consumerStatus(List.of()).build();
+        when(messageService.getMessageTrace("instance-a", "msg-001", 1784246400000L)).thenReturn(trace);
+
+        mockMvc.perform(get("/api/messages/msg-001/trace")
+                        .param("instanceId", "instance-a")
+                        .param("storeTime", "1784246400000"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(messageService).getMessageTrace("instance-a", "msg-001", 1784246400000L);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -11,12 +11,18 @@
 package org.apache.rocketmq.studio.instance.message;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.provider.InstanceProvider;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class MessageServiceTest {
 
@@ -57,6 +63,36 @@ class MessageServiceTest {
                 .hasMessage("msgId is required");
 
         verifyNoInteractions(provider, registry);
+    }
+
+    @Test
+    void forwardsTraceStoreTimeToTheSelectedInstanceProvider() {
+        MessageProvider fallbackProvider = mock(MessageProvider.class);
+        InstanceProvider selectedProvider = mock(InstanceProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(fallbackProvider, registry);
+        TraceRecordVO trace = TraceRecordVO.builder().build();
+        when(registry.byInstanceId("instance-a")).thenReturn(Optional.of(selectedProvider));
+        when(selectedProvider.getMessageTrace("instance-a", "msg-001", 1784246400000L)).thenReturn(trace);
+
+        assertThat(service.getMessageTrace("instance-a", "msg-001", 1784246400000L)).isSameAs(trace);
+
+        verify(selectedProvider).getMessageTrace("instance-a", "msg-001", 1784246400000L);
+        verifyNoInteractions(fallbackProvider);
+    }
+
+    @Test
+    void forwardsTraceStoreTimeToTheFallbackProvider() {
+        MessageProvider fallbackProvider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(fallbackProvider, registry);
+        TraceRecordVO trace = TraceRecordVO.builder().build();
+        when(registry.byInstanceId("instance-a")).thenReturn(Optional.empty());
+        when(fallbackProvider.getMessageTrace("instance-a", "msg-001", 1784246400000L)).thenReturn(trace);
+
+        assertThat(service.getMessageTrace("instance-a", "msg-001", 1784246400000L)).isSameAs(trace);
+
+        verify(fallbackProvider).getMessageTrace("instance-a", "msg-001", 1784246400000L);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProviderTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.provider.apache;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.message.MessageProvider;
+import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -73,5 +74,15 @@ class ApacheInstanceProviderTest {
         assertThat(provider.listConsumerGroups("inst-1", "orders")).isEmpty();
 
         verify(metadataProvider).listConsumerGroups("inst-1", null, "orders");
+    }
+
+    @Test
+    void getMessageTraceShouldPassStoreTimeToMessageProvider() {
+        TraceRecordVO trace = TraceRecordVO.builder().build();
+        when(messageProvider.getMessageTrace("inst-1", "msg-1", 1784246400000L)).thenReturn(trace);
+
+        assertThat(provider.getMessageTrace("inst-1", "msg-1", 1784246400000L)).isSameAs(trace);
+
+        verify(messageProvider).getMessageTrace("inst-1", "msg-1", 1784246400000L);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -62,6 +63,9 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RocketMQMessageProviderTest {
+
+    private static final long ONE_HOUR_MILLIS = 60 * 60_000L;
+    private static final long ONE_DAY_MILLIS = 24 * ONE_HOUR_MILLIS;
 
     @Mock
     private DefaultMQAdminExt adminExt;
@@ -268,5 +272,71 @@ class RocketMQMessageProviderTest {
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
 
         verify(queryHistoryService, never()).recordTraceQuery(anyString(), anyString(), any(), anyInt(), anyInt());
+    }
+
+    @Test
+    void getMessageTraceUsesSuppliedStoreTimeForTheQueryWindow() throws Exception {
+        long storeTime = System.currentTimeMillis() - 2 * ONE_HOUR_MILLIS;
+        long expectedBegin = storeTime - 5 * 60_000L;
+        long expectedEnd = storeTime + ONE_DAY_MILLIS;
+        when(adminExt.queryMessage("RMQ_SYS_TRACE_TOPIC", "msg-old", 64, expectedBegin, expectedEnd))
+                .thenReturn(new QueryResult(0L, List.of()));
+
+        TraceRecordVO record = provider.getMessageTrace("instance-a", "msg-old", storeTime);
+
+        assertThat(record.getNodes()).isEmpty();
+        verify(adminExt).queryMessage("RMQ_SYS_TRACE_TOPIC", "msg-old", 64, expectedBegin, expectedEnd);
+        verify(queryHistoryService).recordTraceQuery("instance-a", "msg-old", null, 0, 0);
+    }
+
+    @Test
+    void getMessageTraceExtendsTheWindowToNowForOlderMessages() throws Exception {
+        long before = System.currentTimeMillis();
+        long storeTime = before - 2 * ONE_DAY_MILLIS;
+        long expectedBegin = storeTime - 5 * 60_000L;
+        when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
+                .thenReturn(new QueryResult(0L, List.of()));
+
+        provider.getMessageTrace("instance-a", "msg-two-days-old", storeTime);
+
+        long after = System.currentTimeMillis();
+        ArgumentCaptor<Long> end = ArgumentCaptor.forClass(Long.class);
+        verify(adminExt).queryMessage(eq("RMQ_SYS_TRACE_TOPIC"), eq("msg-two-days-old"), eq(64),
+                eq(expectedBegin), end.capture());
+        assertThat(end.getValue()).isBetween(before + 60_000L, after + 60_000L);
+    }
+
+    @Test
+    void getMessageTraceFallsBackToOneHourForAnInvalidStoreTime() throws Exception {
+        when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
+                .thenReturn(new QueryResult(0L, List.of()));
+        long before = System.currentTimeMillis();
+
+        provider.getMessageTrace("instance-a", "msg-future", Long.MAX_VALUE);
+
+        long after = System.currentTimeMillis();
+        ArgumentCaptor<Long> begin = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Long> end = ArgumentCaptor.forClass(Long.class);
+        verify(adminExt).queryMessage(eq("RMQ_SYS_TRACE_TOPIC"), eq("msg-future"), eq(64),
+                begin.capture(), end.capture());
+        assertThat(begin.getValue()).isBetween(before - ONE_HOUR_MILLIS, after - ONE_HOUR_MILLIS);
+        assertThat(end.getValue()).isBetween(before + 60_000L, after + 60_000L);
+    }
+
+    @Test
+    void getMessageTraceFallsBackToOneHourForStoreTimeOlderThanSevenDays() throws Exception {
+        when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
+                .thenReturn(new QueryResult(0L, List.of()));
+        long before = System.currentTimeMillis();
+
+        provider.getMessageTrace("instance-a", "msg-old", before - 8 * ONE_DAY_MILLIS);
+
+        long after = System.currentTimeMillis();
+        ArgumentCaptor<Long> begin = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Long> end = ArgumentCaptor.forClass(Long.class);
+        verify(adminExt).queryMessage(eq("RMQ_SYS_TRACE_TOPIC"), eq("msg-old"), eq(64),
+                begin.capture(), end.capture());
+        assertThat(begin.getValue()).isBetween(before - ONE_HOUR_MILLIS, after - ONE_HOUR_MILLIS);
+        assertThat(end.getValue()).isBetween(before + 60_000L, after + 60_000L);
     }
 }

--- a/web/src/api/message.test.ts
+++ b/web/src/api/message.test.ts
@@ -108,10 +108,12 @@ describe('message API', () => {
       ],
     };
     mock
-      .onGet('/messages/msg-1/trace', { params: { instanceId: 'instance-a' } })
+      .onGet('/messages/msg-1/trace', {
+        params: { instanceId: 'instance-a', storeTime: 1784246400000 },
+      })
       .reply(200, { code: 200, data: trace });
 
-    await expect(getMessageTrace('msg-1', 'instance-a')).resolves.toEqual(trace);
+    await expect(getMessageTrace('msg-1', 'instance-a', 1784246400000)).resolves.toEqual(trace);
   });
 
   it('encodes message IDs before requesting trace records', async () => {

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -78,10 +78,10 @@ export async function queryMessages(params: MessageQuery) {
   return sortMessagesByStoreTimeDesc(res.data.data);
 }
 
-export async function getMessageTrace(msgId: string, instanceId?: string) {
+export async function getMessageTrace(msgId: string, instanceId?: string, storeTime?: number) {
   const res = await client.get<{ data: TraceRecord }>(
     `/messages/${encodeURIComponent(msgId)}/trace`,
-    { params: { instanceId } },
+    { params: { instanceId, ...(storeTime !== undefined ? { storeTime } : {}) } },
   );
   return res.data.data;
 }

--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -188,6 +188,12 @@ describe('MessagePage async request ownership', () => {
     const row = await screen.findByRole('row', { name: /message-a/ });
     await user.click(within(row).getByRole('button', { name: /轨迹/ }));
 
+    expect(serviceMocks.getMessageTrace).toHaveBeenCalledWith(
+      'message-a',
+      'instance-a',
+      '2026-07-31T00:00:00Z',
+    );
+
     const dialog = await screen.findByRole('dialog', { name: '消息详情' });
     expect(
       await within(dialog).findByText('Message query provider is not configured'),

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -404,7 +404,7 @@ const MessagePage = () => {
     setTraceLoading(true);
     setTraceError(null);
     try {
-      const result = await getMessageTrace(record.msgId, selectedInstanceId);
+      const result = await getMessageTrace(record.msgId, selectedInstanceId, record.storeTime);
       if (traceGenerationRef.current !== requestGeneration) return;
       setTraceData(result);
       setTraceError(null);

--- a/web/src/services/messageService.test.ts
+++ b/web/src/services/messageService.test.ts
@@ -15,15 +15,27 @@
  * limitations under the License.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as messageApi from '../api/message';
 import { getMessageTrace, listDLQGroups, queryMessages } from './messageService';
 
-vi.mock('./dataMode', () => ({ isMockMode: () => true }));
+const { mode } = vi.hoisted(() => ({ mode: { mock: true } }));
+
+vi.mock('./dataMode', () => ({ isMockMode: () => mode.mock }));
 vi.mock('../config', () => ({
   API_BASE_URL: '/api',
 }));
+vi.mock('../api/message', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/message')>();
+  return { ...actual, getMessageTrace: vi.fn() };
+});
 
 describe('message service mock data', () => {
+  beforeEach(() => {
+    mode.mock = true;
+    vi.clearAllMocks();
+  });
+
   it('returns copied message rows and properties', async () => {
     const first = await queryMessages({ msgId: 'AC1E0A6400002A9F0000000001A3F2B1' });
     expect(first[0].topic).toBe('order-create');
@@ -62,6 +74,28 @@ describe('message service mock data', () => {
     expect(second?.consumerStatus[0].group).toBe('cg-order-processor');
     expect(second?.nodes[0]).not.toBe(first?.nodes[0]);
     expect(second?.consumerStatus[0]).not.toBe(first?.consumerStatus[0]);
+  });
+
+  it('converts an ISO store time before requesting a trace in API mode', async () => {
+    mode.mock = false;
+    vi.mocked(messageApi.getMessageTrace).mockResolvedValue({ nodes: [], consumerStatus: [] });
+
+    await getMessageTrace('msg-1', 'instance-a', '2026-07-31T00:00:00Z');
+
+    expect(messageApi.getMessageTrace).toHaveBeenCalledWith(
+      'msg-1',
+      'instance-a',
+      Date.parse('2026-07-31T00:00:00Z'),
+    );
+  });
+
+  it('omits an invalid store time when requesting a trace in API mode', async () => {
+    mode.mock = false;
+    vi.mocked(messageApi.getMessageTrace).mockResolvedValue({ nodes: [], consumerStatus: [] });
+
+    await getMessageTrace('msg-1', 'instance-a', 'not-a-time');
+
+    expect(messageApi.getMessageTrace).toHaveBeenCalledWith('msg-1', 'instance-a', undefined);
   });
 
   it('returns copied DLQ group rows', async () => {

--- a/web/src/services/messageService.ts
+++ b/web/src/services/messageService.ts
@@ -51,12 +51,20 @@ export async function queryMessages(params: MessageQuery): Promise<MessageRecord
 export async function getMessageTrace(
   msgId: string,
   instanceId?: string,
+  storeTime?: MessageRecord['storeTime'],
 ): Promise<TraceRecord | null> {
   if (isMockMode()) {
     const trace = mockMessageTraces[msgId] as unknown as TraceRecord | undefined;
     return trace ? cloneTrace(trace) : null;
   }
-  return messageApi.getMessageTrace(msgId, instanceId);
+  const storeTimestamp = storeTime === undefined ? undefined : toStoreTimestamp(storeTime);
+  const validStoreTimestamp =
+    storeTimestamp !== undefined && Number.isFinite(storeTimestamp) && storeTimestamp > 0;
+  return messageApi.getMessageTrace(
+    msgId,
+    instanceId,
+    validStoreTimestamp ? storeTimestamp : undefined,
+  );
 }
 
 export async function listDLQGroups(instanceId: string): Promise<DLQGroup[]> {


### PR DESCRIPTION
## What is the purpose of the change

Restore the `rocketmq-studio` backend build after recent compilation regressions.

## Brief changelog

- Add missing imports.
- Use RocketMQ 5.5-compatible APIs.
- Revert the unsupported single-argument `viewMessage` call.

## Verifying this change

- `mvn -B -ntp clean package -DskipTests`