### PR TITLE
[Studio] fix(web): initialize data mode from VITE_USE_MOCK

### DIFF
--- a/web/.env.test
+++ b/web/.env.test
@@ -1,0 +1,2 @@
+# Keep tests in real-API mode unless a test explicitly selects mock data.
+VITE_USE_MOCK=false

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -28,8 +28,10 @@ vi.mock('./api/auth', async (importOriginal) => {
   return { ...actual, getAuthStatus: vi.fn() };
 });
 
+const dataModeMocks = vi.hoisted(() => ({ isMockMode: vi.fn(() => false) }));
+
 vi.mock('./config', () => ({ API_BASE_URL: '/api', USE_MOCK: false }));
-vi.mock('./services/dataMode', () => ({ isMockMode: () => false }));
+vi.mock('./services/dataMode', () => dataModeMocks);
 
 const mockedGetAuthStatus = vi.mocked(getAuthStatus);
 
@@ -85,6 +87,7 @@ function renderGate() {
 describe('AuthGate', () => {
   beforeEach(() => {
     mockedGetAuthStatus.mockReset();
+    dataModeMocks.isMockMode.mockReturnValue(false);
     localStorage.setItem('token', 'stale-token');
     localStorage.setItem('rocketmq-studio-user', 'admin');
   });
@@ -92,6 +95,15 @@ describe('AuthGate', () => {
   afterEach(() => {
     cleanup();
     localStorage.clear();
+  });
+
+  it('skips the authentication status request in mock mode', async () => {
+    dataModeMocks.isMockMode.mockReturnValue(true);
+
+    renderGate();
+
+    expect(await screen.findByText('protected content')).toBeInTheDocument();
+    expect(mockedGetAuthStatus).not.toHaveBeenCalled();
   });
 
   it('allows protected routes when login protection is disabled', async () => {

--- a/web/src/stores/dataModeStore.test.ts
+++ b/web/src/stores/dataModeStore.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const STORAGE_KEY = 'rocketmq-studio-data-mode';
+
+async function loadStore(envValue: string, persistedValue?: boolean) {
+  vi.stubEnv('VITE_USE_MOCK', envValue);
+  vi.resetModules();
+  if (persistedValue !== undefined) {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ state: { useMock: persistedValue }, version: 0 }),
+    );
+  }
+  return (await import('./dataModeStore')).useDataModeStore;
+}
+
+describe('dataModeStore', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  it.each([
+    ['true', true],
+    ['false', false],
+  ])('uses VITE_USE_MOCK=%s as the initial mode', async (envValue, expected) => {
+    const store = await loadStore(envValue);
+
+    expect(store.getState().useMock).toBe(expected);
+  });
+
+  it.each([
+    ['true', false],
+    ['false', true],
+  ])('prefers a persisted mode over VITE_USE_MOCK=%s', async (envValue, persistedValue) => {
+    const store = await loadStore(envValue, persistedValue);
+
+    expect(store.getState().useMock).toBe(persistedValue);
+  });
+});

--- a/web/src/stores/dataModeStore.ts
+++ b/web/src/stores/dataModeStore.ts
@@ -23,10 +23,12 @@ interface DataModeState {
   toggle: () => void;
 }
 
+const DEFAULT_USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true';
+
 export const useDataModeStore = create<DataModeState>()(
   persist(
     (set) => ({
-      useMock: false,
+      useMock: DEFAULT_USE_MOCK,
       toggle: () => set((state) => ({ useMock: !state.useMock })),
     }),
     {


### PR DESCRIPTION
## What is the purpose of the change

Honor `VITE_USE_MOCK` when initializing the data mode store, while preserving the user's persisted preference.

## Brief changelog

- Initialize the default data mode from `VITE_USE_MOCK`.
- Add test environment configuration and regression tests.

## Verifying this change

```bash
cd web
npm test -- src/stores/dataModeStore.test.ts src/App.test.tsx
npm run build