### PR TITLE
fix(cluster): hide unsupported NameServer and Proxy actions

### DIFF
--- a/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
@@ -24,15 +24,17 @@ import type { ClusterInfo } from '../../../api/cluster';
 import { LangProvider } from '../../../i18n/LangContext';
 
 const clusterServiceMocks = vi.hoisted(() => ({
-  createNameServer: vi.fn(),
   listClusters: vi.fn(),
-  restartProxy: vi.fn(),
   testClusterConnection: vi.fn(),
   updateClusterConfig: vi.fn(),
-  updateNameServer: vi.fn(),
+}));
+
+const instanceServiceMocks = vi.hoisted(() => ({
+  listInstances: vi.fn(),
 }));
 
 vi.mock('../../../services/clusterService', () => clusterServiceMocks);
+vi.mock('../../../services/instanceService', () => instanceServiceMocks);
 
 import ClusterPage from '../index';
 
@@ -132,9 +134,10 @@ const flushPromises = async () => {
 
 describe('Cluster page', () => {
   beforeEach(() => {
-    clusterServiceMocks.createNameServer.mockReset().mockResolvedValue(undefined);
     clusterServiceMocks.listClusters.mockReset().mockResolvedValue([buildCluster()]);
-    clusterServiceMocks.restartProxy.mockReset().mockResolvedValue(undefined);
+    // Keep instance bootstrap pending so these Cluster-page tests control only
+    // the cluster request lifecycle under test.
+    instanceServiceMocks.listInstances.mockReset().mockReturnValue(new Promise(() => {}));
     clusterServiceMocks.testClusterConnection.mockReset();
     clusterServiceMocks.updateClusterConfig.mockReset().mockImplementation(async () => {
       const cluster = buildCluster();
@@ -145,7 +148,6 @@ describe('Cluster page', () => {
         failedBrokers: [],
       };
     });
-    clusterServiceMocks.updateNameServer.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -169,6 +171,20 @@ describe('Cluster page', () => {
     expect(within(dialog).getByText('1,842')).toBeInTheDocument();
     expect(within(dialog).getByText('8081')).toBeInTheDocument();
     expect(within(dialog).getByText('8080')).toBeInTheDocument();
+  });
+
+  it('keeps topology read-only when runtime actions are unsupported', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ClusterPage />);
+
+    await user.click(screen.getByRole('tab', { name: /NameServer 管理/ }));
+    expect(screen.getAllByText('rocketmq-prod').length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: /新建 NameServer|编辑/ })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: /Proxy 管理/ }));
+    const proxyRow = await screen.findByRole('row', { name: /10\.101\.2\.21:8081/ });
+    expect(within(proxyRow).getByRole('button', { name: /详情/ })).toBeInTheDocument();
+    expect(within(proxyRow).queryByRole('button', { name: /重启/ })).not.toBeInTheDocument();
   });
 
   it('keeps cluster tabs usable when address fields are missing', async () => {
@@ -343,72 +359,6 @@ describe('Cluster page', () => {
 
     expect(clusterServiceMocks.listClusters).toHaveBeenCalledTimes(2);
     expect(screen.getByRole('row', { name: /10\.101\.2\.11:10911/ })).toHaveTextContent('202');
-  });
-
-  it('queues an operation refresh behind an in-flight background request', async () => {
-    vi.useFakeTimers();
-    const successSpy = vi.spyOn(message, 'success').mockImplementation(vi.fn());
-    const backgroundRequest = deferred<ClusterInfo[]>();
-    const operationRequest = deferred<void>();
-    let backgroundSettled = false;
-    void backgroundRequest.promise.then(() => {
-      backgroundSettled = true;
-    });
-    clusterServiceMocks.restartProxy.mockReturnValueOnce(operationRequest.promise);
-    clusterServiceMocks.listClusters
-      .mockResolvedValueOnce([buildCluster({ connections: 601 })])
-      .mockReturnValueOnce(backgroundRequest.promise)
-      .mockResolvedValueOnce([buildCluster({ connections: 603 })]);
-
-    renderWithProviders(<ClusterPage />);
-    await flushPromises();
-    fireEvent.click(screen.getByRole('tab', { name: /Proxy 管理/ }));
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
-
-    const proxyRow = screen.getByRole('row', { name: /10\.101\.2\.21:8081/ });
-    fireEvent.click(within(proxyRow).getByRole('button', { name: /重启/ }));
-    await flushPromises();
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
-    });
-    const dialog = screen.getAllByText('确认重启')[0].closest('.ant-modal');
-    expect(dialog).not.toBeNull();
-    fireEvent.click(within(dialog as HTMLElement).getByRole('button', { name: /确\s*认/ }));
-    await flushPromises();
-
-    expect(clusterServiceMocks.restartProxy).toHaveBeenCalledWith({
-      clusterId: 'cluster-prod',
-      addr: '10.101.2.21:8081',
-    });
-    expect(clusterServiceMocks.listClusters).toHaveBeenCalledTimes(2);
-
-    await act(async () => {
-      operationRequest.resolve();
-      await operationRequest.promise;
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    expect(backgroundSettled).toBe(false);
-    expect(clusterServiceMocks.listClusters).toHaveBeenCalledTimes(2);
-    expect(successSpy).not.toHaveBeenCalled();
-
-    await act(async () => {
-      backgroundRequest.resolve([buildCluster({ connections: 602 })]);
-      await backgroundRequest.promise;
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    await flushPromises();
-
-    expect(clusterServiceMocks.listClusters).toHaveBeenCalledTimes(3);
-    const proxyTabPanel = screen.getByRole('tabpanel', { name: /Proxy 管理/ });
-    const proxyTable = within(proxyTabPanel).getByRole('table');
-    expect(within(proxyTable).getByRole('row', { name: /10\.101\.2\.21:8081/ })).toHaveTextContent(
-      '603',
-    );
-    expect(successSpy).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the last snapshot and silently retries after a background failure', async () => {

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -41,7 +41,6 @@ import {
   ReloadOutlined,
   SettingOutlined,
   EyeOutlined,
-  EditOutlined,
   PlusOutlined,
 } from '@ant-design/icons';
 import { Cpu, HardDrives, Globe } from '@phosphor-icons/react';
@@ -57,12 +56,9 @@ import type {
   ClusterProbeResult,
 } from '../../api/cluster';
 import {
-  createNameServer,
   listClusters,
-  restartProxy,
   testClusterConnection,
   updateClusterConfig,
-  updateNameServer,
 } from '../../services/clusterService';
 import { listInstances } from '../../services/instanceService';
 import type { Instance } from '../../api/instance';
@@ -95,10 +91,7 @@ const ClusterPage = () => {
 
   const [configModalOpen, setConfigModalOpen] = useState(false);
   const [selectedCluster, setSelectedCluster] = useState<ClusterInfo | null>(null);
-  const [nsModalOpen, setNsModalOpen] = useState(false);
-  const [nsModalMode, setNsModalMode] = useState<'create' | 'edit'>('create');
   const [selectedProxy, setSelectedProxy] = useState<ProxyDetail | null>(null);
-  const [nsForm] = Form.useForm();
   const [configForm] = Form.useForm();
 
   // ─── Connection test ──────────────────────────────────────────────────────
@@ -635,7 +628,7 @@ const ClusterPage = () => {
       })
       .filter((c) => c.filteredNameServers.length > 0);
 
-    const getNsSubColumns = (clusterId: string): ColumnsType<NameServerInfo> => [
+    const getNsSubColumns = (): ColumnsType<NameServerInfo> => [
       {
         title: t('common.address'),
         dataIndex: 'addr',
@@ -663,27 +656,6 @@ const ClusterPage = () => {
           const cfg = map[status] ?? { color: 'default', label: status };
           return <Tag color={cfg.color}>{cfg.label}</Tag>;
         },
-      },
-      {
-        title: t('common.actions'),
-        key: 'action',
-        width: 100,
-        render: (_: unknown, record: NameServerInfo) => (
-          <Flex gap={6}>
-            <Button
-              size="small"
-              icon={<EditOutlined />}
-              style={{ borderColor: '#722ed1', color: '#722ed1' }}
-              onClick={() => {
-                setNsModalMode('edit');
-                nsForm.setFieldsValue({ clusterId, addr: record.addr, newAddr: '' });
-                setNsModalOpen(true);
-              }}
-            >
-              {t('common.edit')}
-            </Button>
-          </Flex>
-        ),
       },
     ];
 
@@ -766,17 +738,6 @@ const ClusterPage = () => {
               style={{ width: 240 }}
             />
           </Space>
-          <Button
-            type="primary"
-            icon={<PlusOutlined />}
-            onClick={() => {
-              setNsModalMode('create');
-              nsForm.resetFields();
-              setNsModalOpen(true);
-            }}
-          >
-            {t('cluster.createNameServer')}
-          </Button>
         </Flex>
         <Card bodyStyle={{ padding: 0 }}>
           <Table
@@ -790,7 +751,7 @@ const ClusterPage = () => {
               expandedRowRender: (record) => (
                 <div style={{ padding: '8px 0' }}>
                   <Table
-                    columns={getNsSubColumns(record.id)}
+                    columns={getNsSubColumns()}
                     dataSource={record.filteredNameServers}
                     rowKey="addr"
                     pagination={false}
@@ -832,7 +793,7 @@ const ClusterPage = () => {
         title: t('cluster.k8sName'),
         dataIndex: 'clusterName',
         key: 'clusterName',
-        width: 160,
+        width: 100,
         sorter: (a, b) => a.clusterName.localeCompare(b.clusterName),
         render: (name: string) => (
           <Text strong style={{ fontSize: 13 }}>
@@ -907,26 +868,6 @@ const ClusterPage = () => {
               onClick={() => setSelectedProxy(record)}
             >
               {t('common.detail')}
-            </Button>
-            <Button
-              size="small"
-              icon={<ReloadOutlined />}
-              style={{ borderColor: '#faad14', color: '#faad14' }}
-              onClick={() => {
-                Modal.confirm({
-                  title: t('cluster.confirmRestart'),
-                  content: t('cluster.restartProxyConfirm', { addr: record.addr }),
-                  okText: t('common.confirm'),
-                  cancelText: t('common.cancel'),
-                  onOk: async () => {
-                    await restartProxy({ clusterId: record.clusterId, addr: record.addr });
-                    await requestRefresh('operation');
-                    message.success(t('cluster.restartProxySubmitted', { addr: record.addr }));
-                  },
-                });
-              }}
-            >
-              {t('cluster.restart')}
             </Button>
           </Flex>
         ),
@@ -1031,63 +972,6 @@ const ClusterPage = () => {
           50% { opacity: 0.6; box-shadow: 0 0 0 4px rgba(82, 196, 26, 0); }
         }
       `}</style>
-      {/* ─── NameServer Create/Edit Modal ─── */}
-      <Modal
-        title={
-          nsModalMode === 'create' ? t('cluster.createNameServer') : t('cluster.editNameServer')
-        }
-        open={nsModalOpen}
-        onCancel={() => setNsModalOpen(false)}
-        onOk={() => {
-          nsForm.validateFields().then(async (values: Record<string, string>) => {
-            if (nsModalMode === 'create') {
-              await createNameServer({ clusterId: values.clusterId, addr: values.addr });
-              message.success(`${t('cluster.nsCreated')}: ${values.addr}`);
-            } else {
-              await updateNameServer({
-                clusterId: values.clusterId,
-                addr: values.addr,
-                newAddr: values.newAddr,
-              });
-              message.success(
-                `${t('cluster.nsUpdated')}: ${values.addr}${values.newAddr ? ` → ${values.newAddr}` : ''}`,
-              );
-            }
-            await requestRefresh('operation');
-            setNsModalOpen(false);
-          });
-        }}
-        okText={t('common.confirm')}
-        cancelText={t('common.cancel')}
-        destroyOnClose
-      >
-        <Form form={nsForm} layout="vertical" style={{ marginTop: 16 }}>
-          {nsModalMode === 'create' && (
-            <Form.Item
-              name="clusterId"
-              label={t('cluster.selectCluster')}
-              rules={[{ required: true, message: t('cluster.selectCluster') }]}
-            >
-              <Select
-                placeholder={t('cluster.selectCluster')}
-                options={clusters.map((c) => ({ label: c.name, value: c.id }))}
-              />
-            </Form.Item>
-          )}
-          <Form.Item
-            name="addr"
-            label={t('cluster.nsAddr')}
-            rules={[{ required: true, message: t('cluster.nsAddr') }]}
-          >
-            <Input placeholder={t('cluster.nsAddrPlaceholder')} disabled={nsModalMode === 'edit'} />
-          </Form.Item>
-          {nsModalMode === 'edit' && (
-            <Form.Item name="newAddr" label={t('cluster.newAddr')}>
-              <Input placeholder={t('cluster.newAddrPlaceholder')} />
-            </Form.Item>
-          )}
-        </Form>
-      </Modal>
       <Tabs items={tabItems} defaultActiveKey="broker" />
       <Modal
         title={t('cluster.proxyDetailTitle', { addr: selectedProxy?.addr ?? '' })}


### PR DESCRIPTION
Closes #1524

The Cluster page exposed NameServer create/edit and Proxy restart controls even though the corresponding backend operations explicitly return HTTP 501.

This change keeps the topology views and Proxy details available, while removing the nonfunctional mutation controls and their unreachable client calls.

Validation:
- `npm test -- --run src/pages/cluster/__tests__/ClusterPage.test.tsx`
- `npm run build`
- `npm run lint` (blocked by five pre-existing errors in unrelated files; this change introduces no lint errors)