### PR TITLE
fix(server): restore RocketMQ 5.5 compilation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -270,9 +270,9 @@ public class RocketMQDLQProvider implements DLQProvider {
             }
             // Copy user properties from the original message, skipping system-reserved
             // keys to avoid conflicts with broker-internal properties.
-            Map<String, String> userProperties = deadLetter.getUserProperties();
-            if (userProperties != null) {
-                for (Map.Entry<String, String> entry : userProperties.entrySet()) {
+            Map<String, String> properties = deadLetter.getProperties();
+            if (properties != null) {
+                for (Map.Entry<String, String> entry : properties.entrySet()) {
                     String key = entry.getKey();
                     if (!MessageConst.STRING_HASH_SET.contains(key)) {
                         message.putUserProperty(key, entry.getValue());

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -42,6 +42,7 @@ import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardProvider;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardStatsVO;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
+import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -321,7 +321,7 @@ public class RocketMQMessageProvider implements MessageProvider {
      */
     private long resolveMessageStoreTimestamp(DefaultMQAdminExt adminExt, String msgId) {
         try {
-            MessageExt messageExt = adminExt.viewMessage(msgId);
+            MessageExt messageExt = viewMessageByOffsetId(adminExt, msgId);
             if (messageExt != null) {
                 return messageExt.getStoreTimestamp();
             }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -34,6 +34,7 @@ import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
+import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;


### PR DESCRIPTION
Closes #1529

Restores compilation against the configured RocketMQ 5.5 API by:
- importing the shared system-topic filter and `Pattern`;
- copying message properties through the supported API;
- resolving trace message timestamps through the existing offset-ID lookup helper.

Validation:
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=AlertServiceTest test` (32 tests passed; compiles all main and test sources)