### PR TITLE
fix(cluster): isolate configuration snapshots

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
@@ -94,7 +94,7 @@ public class ClusterRepositoryImpl implements ClusterRepository {
                 .brokers(cluster.getBrokers() == null ? null : new ArrayList<>(cluster.getBrokers()))
                 .proxies(cluster.getProxies() == null ? null : new ArrayList<>(cluster.getProxies()))
                 .nameServers(cluster.getNameServers() == null ? null : new ArrayList<>(cluster.getNameServers()))
-                .config(cluster.getConfig())
+                .config(copyConfig(cluster.getConfig()))
                 .topicCount(cluster.getTopicCount())
                 .groupCount(cluster.getGroupCount())
                 .tpsHistory(cluster.getTpsHistory() == null ? null : new ArrayList<>(cluster.getTpsHistory()))
@@ -103,6 +103,24 @@ public class ClusterRepositoryImpl implements ClusterRepository {
         copy.setCreatedAt(cluster.getCreatedAt());
         copy.setUpdatedAt(cluster.getUpdatedAt());
         return copy;
+    }
+
+    private ClusterConfigVO copyConfig(ClusterConfigVO config) {
+        if (config == null) {
+            return null;
+        }
+        return ClusterConfigVO.builder()
+                .writeQueueNums(config.getWriteQueueNums())
+                .readQueueNums(config.getReadQueueNums())
+                .maxMessageSize(config.getMaxMessageSize())
+                .msgTraceTopicName(config.getMsgTraceTopicName())
+                .autoCreateTopicEnable(config.isAutoCreateTopicEnable())
+                .autoCreateSubscriptionGroup(config.isAutoCreateSubscriptionGroup())
+                .deleteWhen(config.getDeleteWhen())
+                .fileReservedTime(config.getFileReservedTime())
+                .flushDiskType(config.getFlushDiskType())
+                .brokerPermission(config.getBrokerPermission())
+                .build();
     }
 
     private void initStubData() {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
@@ -47,11 +47,14 @@ class ClusterRepositoryImplTest {
 
         ClusterVO first = repository.findById("cluster-001").orElseThrow();
         first.setName("mutated");
+        first.getConfig().setFileReservedTime(1);
 
         ClusterVO second = repository.findById("cluster-001").orElseThrow();
 
         // Mutating the returned copy must not affect the cached cluster.
         assertThat(second.getName()).isEqualTo("rmq-cluster-prod");
         assertThat(first.getBrokers()).isNotSameAs(second.getBrokers());
+        assertThat(second.getConfig()).isNotSameAs(first.getConfig());
+        assertThat(second.getConfig().getFileReservedTime()).isEqualTo(72);
     }
 }


### PR DESCRIPTION
Closes #1528

`ClusterRepositoryImpl.findById` promised an independent snapshot but shared the mutable `ClusterConfigVO` reference. This change deep-copies the configuration so callers cannot mutate repository state through a read result.

Validation:
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=ClusterRepositoryImplTest test` (3 tests passed)

The test was executed with the compilation fixes from #1530 present; this PR remains independent and contains only the snapshot-isolation change.