### PR TITLE
fix(nameserver): scope config drift by selected instance

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffService.java
@@ -72,8 +72,14 @@ public class NameServerConfigDiffService {
     private final MqAdminExtFactory adminFactory;
 
     public NameServerConfigDiffVO compare(String clusterId) {
+        return compare(clusterId, null);
+    }
+
+    public NameServerConfigDiffVO compare(String clusterId, String instanceId) {
         String normalizedClusterId = requireClusterId(clusterId);
-        ClusterVO cluster = clusterService.getCluster(normalizedClusterId);
+        ClusterVO cluster = instanceId == null || instanceId.isBlank()
+                ? clusterService.getCluster(normalizedClusterId)
+                : clusterService.getCluster(normalizedClusterId, instanceId);
         List<String> addresses = collectNameServerAddresses(cluster);
         if (addresses.isEmpty()) {
             throw new BusinessException(409,

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerController.java
@@ -39,8 +39,9 @@ public class NameServerController {
 
     @GetMapping("/config-diff")
     public Result<NameServerConfigDiffVO> compareConfiguration(
-            @RequestParam(required = false) String clusterId) {
-        return Result.ok(configDiffService.compare(clusterId));
+            @RequestParam(required = false) String clusterId,
+            @RequestParam(required = false) String instanceId) {
+        return Result.ok(configDiffService.compare(clusterId, instanceId));
     }
 
     @PostMapping("/create")

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerControllerTest.java
@@ -64,21 +64,22 @@ class NameServerControllerTest {
                 .nodes(java.util.List.of())
                 .differences(java.util.List.of())
                 .build();
-        when(configDiffService.compare("cluster-1")).thenReturn(result);
+        when(configDiffService.compare("cluster-1", "instance-1")).thenReturn(result);
 
         mockMvc.perform(get("/api/nameservers/config-diff")
-                        .param("clusterId", "cluster-1"))
+                        .param("clusterId", "cluster-1")
+                        .param("instanceId", "instance-1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.cluster").value("cluster-1"))
                 .andExpect(jsonPath("$.data.driftDetected").value(true));
 
-        verify(configDiffService).compare("cluster-1");
+        verify(configDiffService).compare("cluster-1", "instance-1");
     }
 
     @Test
     void compareConfigurationShouldRejectMissingClusterId() throws Exception {
-        when(configDiffService.compare(null)).thenThrow(
+        when(configDiffService.compare(null, null)).thenThrow(
                 new org.apache.rocketmq.studio.common.exception.BusinessException(
                         400, "cluster is required"));
 
@@ -87,7 +88,7 @@ class NameServerControllerTest {
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("cluster is required"));
 
-        verify(configDiffService).compare(null);
+        verify(configDiffService).compare(null, null);
     }
 
     @Test

--- a/web/src/api/cluster.ts
+++ b/web/src/api/cluster.ts
@@ -202,9 +202,9 @@ export async function updateNameServer(data: {
   await client.post('/nameservers/update', data);
 }
 
-export async function getNameServerConfigDiff(clusterId: string) {
+export async function getNameServerConfigDiff(clusterId: string, instanceId?: string) {
   const res = await client.get<{ data: NameServerConfigDiffResult }>('/nameservers/config-diff', {
-    params: { clusterId },
+    params: { clusterId, ...(instanceId ? { instanceId } : {}) },
   });
   return res.data.data;
 }

--- a/web/src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx
@@ -23,12 +23,14 @@ import { App } from 'antd';
 import { type ClusterInfo, type NameServerConfigDiffResult } from '../../../api/cluster';
 import { LangProvider } from '../../../i18n/LangContext';
 import { getNameServerConfigDiff, listClusters } from '../../../services/clusterService';
+import { listInstances } from '../../../services/instanceService';
 import NameServerConfigDriftPage from '../nameServerConfigDrift';
 
 vi.mock('../../../services/clusterService', () => ({
   getNameServerConfigDiff: vi.fn(),
   listClusters: vi.fn(),
 }));
+vi.mock('../../../services/instanceService', () => ({ listInstances: vi.fn() }));
 
 const createObjectURL = vi.fn(() => 'blob:nameserver-config-drift');
 const revokeObjectURL = vi.fn();
@@ -91,6 +93,20 @@ describe('NameServerConfigDriftPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(listClusters).mockResolvedValue([cluster]);
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'instance-1',
+        name: 'Instance 1',
+        remark: null,
+        type: 'DIRECT',
+        endpoint: '127.0.0.1:9876',
+        vendor: 'APACHE',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ]);
     vi.mocked(getNameServerConfigDiff).mockResolvedValue(driftResult);
   });
 
@@ -98,7 +114,8 @@ describe('NameServerConfigDriftPage', () => {
     renderWithProviders(<NameServerConfigDriftPage />);
 
     await waitFor(() => {
-      expect(getNameServerConfigDiff).toHaveBeenCalledWith('cluster-a');
+      expect(listClusters).toHaveBeenCalledWith('instance-1');
+      expect(getNameServerConfigDiff).toHaveBeenCalledWith('cluster-a', 'instance-1');
     });
     expect(await screen.findByText('检测到配置漂移')).toBeInTheDocument();
     expect(screen.getByText('listenPort')).toBeInTheDocument();

--- a/web/src/pages/ops/nameServerConfigDrift.tsx
+++ b/web/src/pages/ops/nameServerConfigDrift.tsx
@@ -27,6 +27,8 @@ import {
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
 import { getNameServerConfigDiff, listClusters } from '../../services/clusterService';
+import { listInstances } from '../../services/instanceService';
+import type { Instance } from '../../api/instance';
 
 const { Text, Title } = Typography;
 
@@ -34,6 +36,8 @@ const NameServerConfigDriftPage = () => {
   const { t } = useLang();
   const { message } = App.useApp();
   const requestSequence = useRef(0);
+  const [instances, setInstances] = useState<Instance[]>([]);
+  const [selectedInstanceId, setSelectedInstanceId] = useState<string>();
   const [clusters, setClusters] = useState<ClusterInfo[]>([]);
   const [selectedClusterId, setSelectedClusterId] = useState<string>();
   const [clustersLoading, setClustersLoading] = useState(true);
@@ -41,11 +45,11 @@ const NameServerConfigDriftPage = () => {
   const [result, setResult] = useState<NameServerConfigDiffResult>();
 
   const runCheck = useCallback(
-    async (clusterId: string) => {
+    async (clusterId: string, instanceId?: string) => {
       const sequence = ++requestSequence.current;
       setChecking(true);
       try {
-        const nextResult = await getNameServerConfigDiff(clusterId);
+        const nextResult = await getNameServerConfigDiff(clusterId, instanceId);
         if (sequence === requestSequence.current) setResult(nextResult);
       } catch {
         if (sequence === requestSequence.current) {
@@ -61,13 +65,19 @@ const NameServerConfigDriftPage = () => {
 
   useEffect(() => {
     let cancelled = false;
-    void listClusters()
-      .then((items) => {
+    void listInstances()
+      .then(async (nextInstances) => {
+        if (cancelled) return;
+        const apacheInstances = nextInstances.filter((instance) => instance.vendor === 'APACHE');
+        setInstances(apacheInstances);
+        const instanceId = apacheInstances[0]?.id;
+        setSelectedInstanceId(instanceId);
+        const items = await listClusters(instanceId);
         if (cancelled) return;
         setClusters(items);
         const firstClusterId = items[0]?.id;
         setSelectedClusterId(firstClusterId);
-        if (firstClusterId) void runCheck(firstClusterId);
+        if (firstClusterId) void runCheck(firstClusterId, instanceId);
       })
       .catch(() => {
         if (!cancelled) message.error(t('nameServerDrift.loadClustersFailed'));
@@ -84,7 +94,24 @@ const NameServerConfigDriftPage = () => {
   const selectCluster = (clusterId: string) => {
     setSelectedClusterId(clusterId);
     setResult(undefined);
-    void runCheck(clusterId);
+    void runCheck(clusterId, selectedInstanceId);
+  };
+
+  const selectInstance = (instanceId: string) => {
+    setSelectedInstanceId(instanceId);
+    setClusters([]);
+    setSelectedClusterId(undefined);
+    setResult(undefined);
+    setClustersLoading(true);
+    void listClusters(instanceId)
+      .then((items) => {
+        setClusters(items);
+        const firstClusterId = items[0]?.id;
+        setSelectedClusterId(firstClusterId);
+        if (firstClusterId) void runCheck(firstClusterId, instanceId);
+      })
+      .catch(() => message.error(t('nameServerDrift.loadClustersFailed')))
+      .finally(() => setClustersLoading(false));
   };
 
   const columns = useMemo<TableColumnsType<NameServerConfigDifference>>(() => {
@@ -159,6 +186,15 @@ const NameServerConfigDriftPage = () => {
 
       <Flex wrap gap={8} align="center" style={{ marginBottom: 20 }}>
         <Select
+          aria-label="实例"
+          loading={clustersLoading}
+          value={selectedInstanceId}
+          onChange={selectInstance}
+          placeholder="选择实例"
+          options={instances.map((instance) => ({ label: instance.name, value: instance.id }))}
+          style={{ width: 'min(100%, 280px)' }}
+        />
+        <Select
           aria-label={t('nameServerDrift.cluster')}
           loading={clustersLoading}
           value={selectedClusterId}
@@ -176,7 +212,7 @@ const NameServerConfigDriftPage = () => {
             icon={<ArrowsClockwise size={16} />}
             loading={checking}
             disabled={!selectedClusterId}
-            onClick={() => selectedClusterId && void runCheck(selectedClusterId)}
+            onClick={() => selectedClusterId && void runCheck(selectedClusterId, selectedInstanceId)}
           />
         </Tooltip>
         <Tooltip title={t('nameServerDrift.export')}>

--- a/web/src/services/clusterService.ts
+++ b/web/src/services/clusterService.ts
@@ -70,8 +70,9 @@ export async function getCluster(id: string, instanceId?: string): Promise<Clust
 
 export async function getNameServerConfigDiff(
   clusterId: string,
+  instanceId?: string,
 ): Promise<NameServerConfigDiffResult> {
-  if (!isMockMode()) return clusterApi.getNameServerConfigDiff(clusterId);
+  if (!isMockMode()) return clusterApi.getNameServerConfigDiff(clusterId, instanceId);
 
   const cluster = getMockCluster(clusterId);
   const nodes = cluster.nameServers.map((nameServer) => ({


### PR DESCRIPTION
Closes #1476

Routes NameServer configuration drift checks through the selected Apache instance:
- the page selects an instance before loading its clusters;
- drift requests carry `instanceId`;
- the controller and service resolve the cluster through that instance context.

Validation:
- `npm test -- --run src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx` (6 passed)
- `npm run build`

Server compilation currently depends on #1530, which restores the baseline RocketMQ 5.5 API compatibility.