### PR TITLE
fix(cluster): hide unsupported legacy Broker restart

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -25,20 +25,17 @@ import {
   Space,
   Switch,
   Progress,
-  Tooltip,
   Spin,
   App,
-  Modal,
 } from 'antd';
 import {
   ArrowClockwise,
-  ArrowsClockwise,
   Cloud,
   ChartBar,
   PlugsConnected,
 } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
-import { listClusters, restartBroker } from '../../services/clusterService';
+import { listClusters } from '../../services/clusterService';
 import type { ClusterInfo } from '../../api/cluster';
 
 // ─── Types ──────────────────────────────────────────────────────
@@ -189,22 +186,6 @@ const BrokerClusterPage = () => {
     }
   }, [message, t]);
 
-  const handleRestartBroker = async (broker: BrokerRecord) => {
-    try {
-      const result = await restartBroker(broker.clusterId, broker.brokerName);
-      if (!result.success) {
-        message.error(result.message || t('common.failure'));
-        return;
-      }
-      await loadData();
-      message.success(
-        result.message || t('cluster.restartBrokerSubmitted', { name: broker.brokerName }),
-      );
-    } catch {
-      message.error(t('common.failure'));
-    }
-  };
-
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
       void loadData();
@@ -324,30 +305,6 @@ const BrokerClusterPage = () => {
         <span style={{ fontWeight: 500 }}>{value?.toLocaleString() ?? '-'}</span>
       ),
       sorter: (a: BrokerRecord, b: BrokerRecord) => (a.tpsOut ?? -1) - (b.tpsOut ?? -1),
-    },
-    {
-      title: t('common.actions'),
-      key: 'action',
-      render: (_: unknown, record: BrokerRecord) => (
-        <Tooltip title={t('brokerCluster.restart')}>
-          <Button
-            type="link"
-            size="small"
-            icon={<ArrowsClockwise size={14} />}
-            onClick={() => {
-              Modal.confirm({
-                title: t('cluster.confirmRestart'),
-                content: t('cluster.restartBrokerConfirm', { name: record.brokerName }),
-                okText: t('common.confirm'),
-                cancelText: t('common.cancel'),
-                onOk: () => handleRestartBroker(record),
-              });
-            }}
-          >
-            {t('brokerCluster.restart')}
-          </Button>
-        </Tooltip>
-      ),
     },
   ];
 

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -20,13 +20,12 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
-import { listClusters, restartBroker } from '../../../services/clusterService';
+import { listClusters } from '../../../services/clusterService';
 import type { ClusterInfo } from '../../../api/cluster';
 import BrokerCluster from '../BrokerCluster';
 
 vi.mock('../../../services/clusterService', () => ({
   listClusters: vi.fn(),
-  restartBroker: vi.fn(),
 }));
 
 // Mock matchMedia for antd responsive components
@@ -129,7 +128,6 @@ describe('BrokerCluster Page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(listClusters).mockResolvedValue(clusterFixture);
-    vi.mocked(restartBroker).mockResolvedValue({ success: true, message: 'restarted' });
   });
 
   afterEach(() => {
@@ -185,30 +183,12 @@ describe('BrokerCluster Page', () => {
     expect(screen.getAllByText('10.0.1.30:8080').length).toBeGreaterThan(0);
   });
 
-  it('should render only supported broker restart actions', async () => {
+  it('renders Broker runtime data without unavailable mutation actions', async () => {
     renderWithProviders(<BrokerCluster />);
     await screen.findByText('broker-api-a');
     expect(screen.queryByText('创建集群')).not.toBeInTheDocument();
     expect(screen.queryByText('配置')).not.toBeInTheDocument();
-    const restartButtons = screen.getAllByText('重启');
-    expect(restartButtons).toHaveLength(2);
-  });
-
-  it('restarts a broker after confirmation and refreshes the cluster data', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<BrokerCluster />);
-    await screen.findByText('broker-api-a');
-
-    await user.click(screen.getAllByText('重启')[0]);
-    expect(await screen.findByText('确定要重启 Broker "broker-api-a" 吗？')).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: /确\s*认/ }));
-
-    await waitFor(() => {
-      expect(restartBroker).toHaveBeenCalledWith('cluster-1', 'broker-api-a');
-    });
-    await waitFor(() => {
-      expect(listClusters).toHaveBeenCalledTimes(2);
-    });
+    expect(screen.queryByText('重启')).not.toBeInTheDocument();
   });
 
   it('does not show mock infrastructure data when the API fails', async () => {


### PR DESCRIPTION
Closes #1526

The legacy Broker Cluster page invokes the Broker restart endpoint, but the current server implementation always rejects that operation as unsupported. Keep runtime diagnostics and refresh behavior while removing the unavailable mutation control and its unreachable client call.

Validation:
- `npm test -- --run src/pages/studio/__tests__/BrokerCluster.test.tsx`
- `npm run build`