### PR TITLE
fix(cluster): scope legacy Broker diagnostics and hide unavailable actions

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -29,6 +29,7 @@ import {
   Spin,
   App,
   Modal,
+  Select,
 } from 'antd';
 import {
   ArrowClockwise,
@@ -40,6 +41,8 @@ import {
 import { useLang } from '../../i18n/LangContext';
 import { listClusters, restartBroker } from '../../services/clusterService';
 import type { ClusterInfo } from '../../api/cluster';
+import { listInstances } from '../../services/instanceService';
+import type { Instance } from '../../api/instance';
 
 // ─── Types ──────────────────────────────────────────────────────
 type NodeStatus = 'running' | 'readonly' | 'maintenance' | 'unknown';
@@ -165,15 +168,27 @@ const BrokerClusterPage = () => {
   const [brokerData, setBrokerData] = useState<BrokerRecord[]>([]);
   const [nameServerData, setNameServerData] = useState<NameServerRecord[]>([]);
   const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
+  const [instances, setInstances] = useState<Instance[]>([]);
+  const [selectedInstanceId, setSelectedInstanceId] = useState('');
   const loadRequestId = useRef(0);
   const { t } = useLang();
   const { message } = App.useApp();
 
+  const clearData = useCallback(() => {
+    setBrokerData([]);
+    setNameServerData([]);
+    setProxyData([]);
+  }, []);
+
   const loadData = useCallback(async () => {
+    if (!selectedInstanceId) {
+      clearData();
+      return;
+    }
     const requestId = ++loadRequestId.current;
     setLoading(true);
     try {
-      const clusters = await listClusters();
+      const clusters = await listClusters(selectedInstanceId);
       if (requestId !== loadRequestId.current) return;
       const mapped = mapClusters(clusters);
       setBrokerData(mapped.brokers);
@@ -187,7 +202,7 @@ const BrokerClusterPage = () => {
         setLoading(false);
       }
     }
-  }, [message, t]);
+  }, [clearData, message, selectedInstanceId, t]);
 
   const handleRestartBroker = async (broker: BrokerRecord) => {
     try {
@@ -206,11 +221,26 @@ const BrokerClusterPage = () => {
   };
 
   useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      void loadData();
-    });
+    let active = true;
+    void listInstances()
+      .then((nextInstances) => {
+        if (!active) return;
+        setInstances(nextInstances);
+        setSelectedInstanceId(nextInstances[0]?.id ?? '');
+      })
+      .catch(() => {
+        if (!active) return;
+        clearData();
+        message.error(t('common.fetchDataFailed'));
+      });
     return () => {
-      window.clearTimeout(timeoutId);
+      active = false;
+    };
+  }, [clearData, message, t]);
+
+  useEffect(() => {
+    void loadData();
+    return () => {
       ++loadRequestId.current;
     };
   }, [loadData]);
@@ -481,6 +511,14 @@ const BrokerClusterPage = () => {
           {t('brokerCluster.title')}
         </h2>
         <Space size="middle">
+          <Select
+            aria-label="选择实例"
+            value={selectedInstanceId || undefined}
+            onChange={setSelectedInstanceId}
+            placeholder="选择实例"
+            style={{ minWidth: 180 }}
+            options={instances.map((instance) => ({ value: instance.id, label: instance.name }))}
+          />
           <Switch
             checked={autoRefresh}
             onChange={setAutoRefresh}

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -25,21 +25,18 @@ import {
   Space,
   Switch,
   Progress,
-  Tooltip,
   Spin,
   App,
-  Modal,
   Select,
 } from 'antd';
 import {
   ArrowClockwise,
-  ArrowsClockwise,
   Cloud,
   ChartBar,
   PlugsConnected,
 } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
-import { listClusters, restartBroker } from '../../services/clusterService';
+import { listClusters } from '../../services/clusterService';
 import type { ClusterInfo } from '../../api/cluster';
 import { listInstances } from '../../services/instanceService';
 import type { Instance } from '../../api/instance';
@@ -204,22 +201,6 @@ const BrokerClusterPage = () => {
     }
   }, [clearData, message, selectedInstanceId, t]);
 
-  const handleRestartBroker = async (broker: BrokerRecord) => {
-    try {
-      const result = await restartBroker(broker.clusterId, broker.brokerName);
-      if (!result.success) {
-        message.error(result.message || t('common.failure'));
-        return;
-      }
-      await loadData();
-      message.success(
-        result.message || t('cluster.restartBrokerSubmitted', { name: broker.brokerName }),
-      );
-    } catch {
-      message.error(t('common.failure'));
-    }
-  };
-
   useEffect(() => {
     let active = true;
     void listInstances()
@@ -354,30 +335,6 @@ const BrokerClusterPage = () => {
         <span style={{ fontWeight: 500 }}>{value?.toLocaleString() ?? '-'}</span>
       ),
       sorter: (a: BrokerRecord, b: BrokerRecord) => (a.tpsOut ?? -1) - (b.tpsOut ?? -1),
-    },
-    {
-      title: t('common.actions'),
-      key: 'action',
-      render: (_: unknown, record: BrokerRecord) => (
-        <Tooltip title={t('brokerCluster.restart')}>
-          <Button
-            type="link"
-            size="small"
-            icon={<ArrowsClockwise size={14} />}
-            onClick={() => {
-              Modal.confirm({
-                title: t('cluster.confirmRestart'),
-                content: t('cluster.restartBrokerConfirm', { name: record.brokerName }),
-                okText: t('common.confirm'),
-                cancelText: t('common.cancel'),
-                onOk: () => handleRestartBroker(record),
-              });
-            }}
-          >
-            {t('brokerCluster.restart')}
-          </Button>
-        </Tooltip>
-      ),
     },
   ];
 

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -20,14 +20,13 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
-import { listClusters, restartBroker } from '../../../services/clusterService';
+import { listClusters } from '../../../services/clusterService';
 import { listInstances } from '../../../services/instanceService';
 import type { ClusterInfo } from '../../../api/cluster';
 import BrokerCluster from '../BrokerCluster';
 
 vi.mock('../../../services/clusterService', () => ({
   listClusters: vi.fn(),
-  restartBroker: vi.fn(),
 }));
 
 vi.mock('../../../services/instanceService', () => ({
@@ -147,7 +146,6 @@ describe('BrokerCluster Page', () => {
       },
     ]);
     vi.mocked(listClusters).mockResolvedValue(clusterFixture);
-    vi.mocked(restartBroker).mockResolvedValue({ success: true, message: 'restarted' });
   });
 
   afterEach(() => {
@@ -213,30 +211,12 @@ describe('BrokerCluster Page', () => {
     expect(screen.getAllByText('10.0.1.30:8080').length).toBeGreaterThan(0);
   });
 
-  it('should render only supported broker restart actions', async () => {
+  it('renders Broker runtime data without unavailable mutation actions', async () => {
     renderWithProviders(<BrokerCluster />);
     await screen.findByText('broker-api-a');
     expect(screen.queryByText('创建集群')).not.toBeInTheDocument();
     expect(screen.queryByText('配置')).not.toBeInTheDocument();
-    const restartButtons = screen.getAllByText('重启');
-    expect(restartButtons).toHaveLength(2);
-  });
-
-  it('restarts a broker after confirmation and refreshes the cluster data', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<BrokerCluster />);
-    await screen.findByText('broker-api-a');
-
-    await user.click(screen.getAllByText('重启')[0]);
-    expect(await screen.findByText('确定要重启 Broker "broker-api-a" 吗？')).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: /确\s*认/ }));
-
-    await waitFor(() => {
-      expect(restartBroker).toHaveBeenCalledWith('cluster-1', 'broker-api-a');
-    });
-    await waitFor(() => {
-      expect(listClusters).toHaveBeenCalledTimes(2);
-    });
+    expect(screen.queryByText('重启')).not.toBeInTheDocument();
   });
 
   it('does not show mock infrastructure data when the API fails', async () => {

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -174,6 +174,15 @@ describe('BrokerCluster Page', () => {
     expect(listClusters).toHaveBeenCalledWith('instance-1');
   });
 
+  it('does not fall back to an unscoped cluster query when instance discovery fails', async () => {
+    vi.mocked(listInstances).mockRejectedValueOnce(new Error('instance discovery failed'));
+    renderWithProviders(<BrokerCluster />);
+
+    await waitFor(() => expect(listInstances).toHaveBeenCalledTimes(1));
+    expect(listClusters).not.toHaveBeenCalled();
+    expect(screen.queryByText('broker-api-a')).not.toBeInTheDocument();
+  });
+
   it('should display broker status tags', async () => {
     renderWithProviders(<BrokerCluster />);
     await screen.findAllByText('broker-api-a');

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -21,12 +21,17 @@ import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
 import { listClusters, restartBroker } from '../../../services/clusterService';
+import { listInstances } from '../../../services/instanceService';
 import type { ClusterInfo } from '../../../api/cluster';
 import BrokerCluster from '../BrokerCluster';
 
 vi.mock('../../../services/clusterService', () => ({
   listClusters: vi.fn(),
   restartBroker: vi.fn(),
+}));
+
+vi.mock('../../../services/instanceService', () => ({
+  listInstances: vi.fn(),
 }));
 
 // Mock matchMedia for antd responsive components
@@ -128,6 +133,19 @@ const createDeferred = <T,>() => {
 describe('BrokerCluster Page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'instance-1',
+        name: 'prod-cn',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '10.0.1.20:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
     vi.mocked(listClusters).mockResolvedValue(clusterFixture);
     vi.mocked(restartBroker).mockResolvedValue({ success: true, message: 'restarted' });
   });
@@ -153,6 +171,7 @@ describe('BrokerCluster Page', () => {
     expect(brokerA.length).toBeGreaterThan(0);
     expect(screen.getAllByText('broker-api-b').length).toBeGreaterThan(0);
     expect(screen.queryByText('broker-a')).not.toBeInTheDocument();
+    expect(listClusters).toHaveBeenCalledWith('instance-1');
   });
 
   it('should display broker status tags', async () => {


### PR DESCRIPTION
Closes #1540
Closes #1526

The legacy Broker Cluster page now loads managed instances before diagnostics and passes the selected `instanceId` to `listClusters(instanceId)`. It clears stale runtime tables when instance discovery fails or returns no instance.

The same page previously exposed Broker restart even though the server rejects it as unsupported. The mutation control and unreachable client path are removed while read-only runtime diagnostics and refresh remain available.

Absorbs #1537.

Validation:
- `npm test -- --run src/pages/studio/__tests__/BrokerCluster.test.tsx`
- `npm run build`