### PR TITLE
fix(metrics): normalize backend types locale-independently

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendType.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendType.java
@@ -16,6 +16,8 @@
  */
 package org.apache.rocketmq.studio.cluster.metrics;
 
+import java.util.Locale;
+
 /**
  * Prometheus-compatible metrics backend types supported by RocketMQ Studio.
  * <p>
@@ -53,7 +55,7 @@ public enum MetricsBackendType {
         if (providerType == null) {
             return PROMETHEUS;
         }
-        return switch (providerType.trim().toUpperCase()) {
+        return switch (providerType.trim().toUpperCase(Locale.ROOT)) {
             case "PROMETHEUS" -> PROMETHEUS;
             case "VICTORIAMETRICS", "VICTORIA_METRICS", "VICTORIA" -> VICTORIA_METRICS;
             case "THANOS" -> THANOS;

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendTypeTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendTypeTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.rocketmq.studio.cluster.metrics;
 
+import java.util.Locale;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +43,19 @@ class MetricsBackendTypeTest {
         assertThat(MetricsBackendType.fromProviderType(null)).isEqualTo(MetricsBackendType.PROMETHEUS);
         assertThat(MetricsBackendType.fromProviderType("")).isEqualTo(MetricsBackendType.PROMETHEUS);
         assertThat(MetricsBackendType.fromProviderType("unknown-backend")).isEqualTo(MetricsBackendType.PROMETHEUS);
+    }
+
+    @Test
+    void shouldResolveProviderTypeIndependentlyOfDefaultLocale() {
+        Locale originalLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertThat(MetricsBackendType.fromProviderType("mimir")).isEqualTo(MetricsBackendType.MIMIR);
+            assertThat(MetricsBackendType.fromProviderType("victoria_metrics"))
+                    .isEqualTo(MetricsBackendType.VICTORIA_METRICS);
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- normalize metrics backend provider names with `Locale.ROOT`
- cover Turkish-locale resolution for Mimir and VictoriaMetrics

## Testing
- `mvn -B -ntp -Dtest=MetricsBackendTypeTest test` — passes when applied with the base compilation fix in #1548

> CI note: the current backend check stops on the pre-existing base compilation failure fixed by #1548; both frontend checks pass.

Fixes #1544
