### PR TITLE
fix(build): restore server compilation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -270,7 +270,7 @@ public class RocketMQDLQProvider implements DLQProvider {
             }
             // Copy user properties from the original message, skipping system-reserved
             // keys to avoid conflicts with broker-internal properties.
-            Map<String, String> userProperties = deadLetter.getUserProperties();
+            Map<String, String> userProperties = deadLetter.getProperties();
             if (userProperties != null) {
                 for (Map.Entry<String, String> entry : userProperties.entrySet()) {
                     String key = entry.getKey();

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -42,6 +42,7 @@ import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardProvider;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardStatsVO;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
+import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -321,7 +321,7 @@ public class RocketMQMessageProvider implements MessageProvider {
      */
     private long resolveMessageStoreTimestamp(DefaultMQAdminExt adminExt, String msgId) {
         try {
-            MessageExt messageExt = adminExt.viewMessage(msgId);
+            MessageExt messageExt = viewMessageByOffsetId(adminExt, msgId);
             if (messageExt != null) {
                 return messageExt.getStoreTimestamp();
             }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -34,6 +34,7 @@ import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
+import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;


### PR DESCRIPTION
## Summary
- restore the missing alert validation and shared system-topic imports
- copy DLQ user properties through the RocketMQ 5.5 `getProperties()` API while retaining the reserved-key filter
- resolve trace timestamps through the existing offset-message lookup instead of the unavailable one-argument `viewMessage`
- restore a clean server package build against the declared dependencies

## Testing
- `mvn -B -ntp clean package -DskipTests` — passes
- `mvn -B -ntp -Dtest=RocketMQMessageProviderTest test` — passes
- the broader targeted run also exposes two pre-existing `RocketMQDLQProviderTest` expectations that no longer match the base implementation's `FAILED` / `NO_MESSAGES` outcomes

Fixes #1547
