### PR TITLE
fix(instance): rank cloud endpoints locale-independently

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 @Slf4j
@@ -159,7 +160,7 @@ public class InstanceService {
         if (endpointType == null) {
             return 2;
         }
-        return switch (endpointType.toUpperCase()) {
+        return switch (endpointType.toUpperCase(Locale.ROOT)) {
             case "TCP_VPC" -> 0;
             case "TCP_INTERNET" -> 1;
             default -> 2;

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -36,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -789,6 +790,38 @@ class InstanceServiceTest {
         assertThat(created.getName()).isEqualTo("prod-mq");
         assertThat(created.getEndpoint()).isEqualTo("vpc:8080");
         assertThat(created.getType()).isEqualTo(InstanceType.PROXY);
+    }
+
+    @Test
+    void createInstanceShouldResolveEndpointIndependentlyOfDefaultLocaleTest() {
+        InstanceVO instance = InstanceVO.builder()
+                .vendor(InstanceVendor.ALIYUN)
+                .credentialId("cred-1")
+                .cloudInstanceId("rmq-cn-xxx")
+                .regionId("cn-hangzhou")
+                .build();
+        CloudCredentialVO credential = new CloudCredentialVO();
+        credential.setId("cred-1");
+        credential.setVendor(InstanceVendor.ALIYUN);
+        when(cloudCredentialRepository.findById("cred-1")).thenReturn(Optional.of(credential));
+        CloudCatalogProvider catalog = org.mockito.Mockito.mock(CloudCatalogProvider.class);
+        CloudInstanceDetailVO detail = new CloudInstanceDetailVO();
+        detail.setInstanceId("rmq-cn-xxx");
+        detail.setInstanceName("prod-mq");
+        detail.setEndpoints(List.of(
+                new CloudInstanceDetailVO.CloudEndpoint("tcp_internet", "public:8080"),
+                new CloudInstanceDetailVO.CloudEndpoint("tcp_vpc", "vpc:8080")));
+        when(providerRegistry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
+        when(catalog.getCloudInstance("cred-1", "cn-hangzhou", "rmq-cn-xxx")).thenReturn(detail);
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Locale originalLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertThat(instanceService.createInstance(instance).getEndpoint()).isEqualTo("vpc:8080");
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- normalize cloud endpoint type identifiers with `Locale.ROOT`
- keep VPC endpoint priority stable under Turkish JVM locales
- add a regression test using lower-case cloud catalog endpoint types

## Testing
- `mvn -B -ntp -Dtest=InstanceServiceTest test` — 48 tests pass when applied with #1548

> CI note: the current backend check stops on the pre-existing base compilation failure fixed by #1548; both frontend checks pass.

Fixes #1549
