### PR TITLE
fix(metrics): normalize auth types locale-independently

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -105,7 +106,7 @@ public class MetricsService {
         if (!StringUtils.hasText(auth)) {
             return "none";
         }
-        return switch (auth.trim().toLowerCase()) {
+        return switch (auth.trim().toLowerCase(Locale.ROOT)) {
             case "basic auth", "basic" -> "basic";
             case "bearer token", "bearer" -> "bearer";
             default -> "none";

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
@@ -29,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -347,6 +348,32 @@ class MetricsServiceTest {
         verify(settingsService).getDataSource("ds-1");
         verify(metricsSourceFactory).create(any(MetricsDataSourceConfig.class));
         verify(metricsSource).query(any(MetricQueryDTO.class));
+    }
+
+    @Test
+    void queryByDataSourceShouldNormalizeAuthIndependentlyOfDefaultLocale() {
+        MetricQueryDTO query = MetricQueryDTO.builder()
+                .metric("cpu").start(1700000000L).end(1700003600L).step("1m").build();
+        MetricsDataSourceQueryRequest request = new MetricsDataSourceQueryRequest();
+        request.setQuery(query);
+        DataSourceVO dataSource = DataSourceVO.builder()
+                .key("ds-1").name("prometheus").type("prometheus")
+                .url("http://prometheus:9090").auth("BASIC AUTH").build();
+        when(settingsService.getDataSource("ds-1")).thenReturn(dataSource);
+        when(metricsSourceFactory.create(any(MetricsDataSourceConfig.class))).thenReturn(metricsSource);
+        when(metricsSource.query(any(MetricQueryDTO.class))).thenReturn(metricData("cpu", List.of()));
+
+        Locale originalLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            metricsService.queryByDataSource("ds-1", request);
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+
+        ArgumentCaptor<MetricsDataSourceConfig> configCaptor = ArgumentCaptor.forClass(MetricsDataSourceConfig.class);
+        verify(metricsSourceFactory).create(configCaptor.capture());
+        assertThat(configCaptor.getValue().getAuthType()).isEqualTo("basic");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- normalize persisted metrics auth labels with `Locale.ROOT`
- prevent `BASIC AUTH` from falling back to unauthenticated requests under Turkish locales
- capture and assert the generated metrics source configuration in a regression test

## Testing
- `mvn -B -ntp -Dtest=MetricsServiceTest test` — 16 tests pass when applied with #1548

> CI note: the current backend check stops on the pre-existing base compilation failure fixed by #1548; both frontend checks pass.

Fixes #1551
