### PR TITLE
fix(ai): normalize LLM providers locale-independently

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -37,6 +37,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -381,6 +382,6 @@ public class OpenAiCompatibleLlmClient {
     }
 
     private String normalize(String provider) {
-        return provider == null ? "" : provider.trim().toLowerCase();
+        return provider == null ? "" : provider.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -214,6 +215,17 @@ class OpenAiCompatibleLlmClientTest {
                     assertThat(gatewayException.getCode()).isEqualTo("llm.config.unsupported_provider");
                     assertThat(gatewayException.getHint()).contains("openai");
                 });
+    }
+
+    @Test
+    void supportsShouldNormalizeProviderIndependentlyOfDefaultLocale() {
+        Locale originalLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertThat(client.supports(config("TONGYI", "key"))).isTrue();
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- normalize LLM provider identifiers with `Locale.ROOT`
- keep supported providers such as Tongyi available under Turkish JVM locales
- add a focused regression test

## Testing
- `mvn -B -ntp -Dtest=OpenAiCompatibleLlmClientTest test` — 13 tests pass when applied with #1548

> CI note: the current backend check stops on the pre-existing base compilation failure fixed by #1548; both frontend checks pass.

Fixes #1553
