### PR TITLE
fix(alerts): normalize level filters locale-independently

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -30,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 /**
@@ -78,7 +79,7 @@ public class MybatisPlusAlertRepository implements AlertRepository {
     @Override
     public List<SystemAlertVO> findAlerts(String level) {
         QueryWrapper<RmqSystemAlert> query = new QueryWrapper<RmqSystemAlert>()
-                .eq(StringUtils.hasText(level), "level", level == null ? null : level.toLowerCase())
+                .eq(StringUtils.hasText(level), "level", level == null ? null : level.toLowerCase(Locale.ROOT))
                 .orderByDesc("time");
         return alertMapper.selectList(query).stream()
                 .map(MybatisPlusAlertRepository::toAlertVO)

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import org.apache.rocketmq.studio.persistence.entity.RmqSystemAlert;
+import org.apache.rocketmq.studio.persistence.mapper.RmqAlertRuleMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqSystemAlertMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MybatisPlusAlertRepositoryTest {
+
+    @Mock
+    private RmqAlertRuleMapper ruleMapper;
+
+    @Mock
+    private RmqSystemAlertMapper alertMapper;
+
+    @InjectMocks
+    private MybatisPlusAlertRepository repository;
+
+    @Test
+    void findAlertsShouldNormalizeLevelIndependentlyOfDefaultLocale() {
+        when(alertMapper.selectList(any(Wrapper.class))).thenReturn(List.of());
+
+        Locale originalLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            repository.findAlerts("INFO");
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+
+        ArgumentCaptor<Wrapper<RmqSystemAlert>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(alertMapper).selectList(queryCaptor.capture());
+        QueryWrapper<RmqSystemAlert> query = (QueryWrapper<RmqSystemAlert>) queryCaptor.getValue();
+        assertThat(query.getSqlSegment()).contains("level");
+        assertThat(query.getParamNameValuePairs()).containsValue("info");
+    }
+}


### PR DESCRIPTION
## Summary
- normalize system-alert level filters with `Locale.ROOT`
- prevent `INFO` filters from becoming an unmatched dotless-i value under Turkish locales
- add a repository test that verifies the bound MyBatis parameter

## Testing
- `mvn -B -ntp -Dtest=MybatisPlusAlertRepositoryTest test` — passes when applied with #1548

> CI note: the current backend check stops on the pre-existing base compilation failure fixed by #1548; frontend checks are unaffected.

Fixes #1555
