### PR TITLE
fix(consumer): guard control-prefixed CSV formulas

### DIFF
--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -195,7 +195,7 @@ describe('Consumer page', () => {
       {
         ...group,
         name: 'orders-cg',
-        namespace: 'trade',
+        namespace: '\r=formula-risk',
         subscribedTopics: ['orders-topic', 'payments,topic'],
       },
       {
@@ -222,6 +222,7 @@ describe('Consumer page', () => {
     expect(exportedBlob).toBeDefined();
     const csv = await exportedBlob!.text();
     expect(csv).toContain('"orders-cg"');
+    expect(csv).toContain('"\'\r=formula-risk"');
     expect(csv).toContain('"orders-topic;payments,topic"');
     expect(csv).not.toContain('users-cg');
     clickSpy.mockRestore();

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -139,7 +139,7 @@ const GROUP_EXPORT_COLUMNS: Array<{ header: string; value: (group: ConsumerGroup
 
 const escapeCsvCell = (value: unknown) => {
   const text = value == null ? '' : String(value);
-  const formulaSafeText = /^[=+\-@]/.test(text) ? `'${text}` : text;
+  const formulaSafeText = /^[=+\-@\t\r\n]/.test(text) ? `'${text}` : text;
   return `"${formulaSafeText.replace(/"/g, '""')}"`;
 };
 
@@ -232,6 +232,7 @@ const ConsumerPage = () => {
   const groupRequestIdRef = useRef(0);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- clear state owned by the previous instance
     setSelectedGroup(null);
     setModalOpen(false);
     setResetGroup(null);
@@ -241,6 +242,7 @@ const ConsumerPage = () => {
   useEffect(() => {
     if (!selectedInstanceId) {
       groupRequestIdRef.current += 1;
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- clear state when the instance scope is removed
       setGroups([]);
       setSelectedRowKeys([]);
       setLoading(false);


### PR DESCRIPTION
## Summary
- neutralize Consumer Group CSV cells starting with tab, CR, or LF
- preserve normal quote escaping and filter behavior
- add a regression assertion for a CR-prefixed formula payload
- document two existing instance-scope state resets for the targeted ESLint rule

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx`
- `NODE_OPTIONS=--no-experimental-webstorage npx eslint src/pages/instance/consumer.tsx src/pages/instance/__tests__/ConsumerPage.test.tsx` (passes with one existing Fast Refresh warning)

Fixes #1560
