### PR TITLE
[studio][ISSUE #1570] Prevent duplicate audit cleanup requests

### DIFF
--- a/web/src/pages/ops/__tests__/AuditPage.test.tsx
+++ b/web/src/pages/ops/__tests__/AuditPage.test.tsx
@@ -190,4 +190,28 @@ describe('Audit page', () => {
 
     await waitFor(() => expect(opsService.getAuditFilterOptions).toHaveBeenCalledTimes(2));
   });
+
+  it('submits audit cleanup only once while the request is pending', async () => {
+    const user = userEvent.setup();
+    let resolveCleanup: (deleted: number) => void = () => undefined;
+    vi.mocked(opsService.cleanupAuditLogs).mockImplementation(
+      () =>
+        new Promise<number>((resolve) => {
+          resolveCleanup = resolve;
+        }),
+    );
+
+    renderWithProviders(<AuditPage />);
+
+    expect(await screen.findByText('topic-a')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: '清理日志' }));
+    const confirmButton = await screen.findByRole('button', { name: '确认清理' });
+    await user.dblClick(confirmButton);
+
+    expect(opsService.cleanupAuditLogs).toHaveBeenCalledTimes(1);
+    expect(confirmButton).toHaveClass('ant-btn-loading');
+
+    resolveCleanup(3);
+    await waitFor(() => expect(opsService.getAuditFilterOptions).toHaveBeenCalledTimes(2));
+  });
 });

--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Card,
   Table,
@@ -98,7 +98,9 @@ const AuditPage: React.FC = () => {
   const [filterOptions, setFilterOptions] = useState<AuditFilterOptions>(emptyFilterOptions);
   const [cleanupModalOpen, setCleanupModalOpen] = useState(false);
   const [cleanupDays, setCleanupDays] = useState(30);
+  const [cleaning, setCleaning] = useState(false);
   const [exporting, setExporting] = useState(false);
+  const cleanupInFlightRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -168,6 +170,9 @@ const AuditPage: React.FC = () => {
   const { Text } = Typography;
 
   const handleCleanup = async () => {
+    if (cleanupInFlightRef.current) return;
+    cleanupInFlightRef.current = true;
+    setCleaning(true);
     try {
       await cleanupAuditLogs(cleanupDays);
       setPage(1);
@@ -176,6 +181,9 @@ const AuditPage: React.FC = () => {
       setCleanupModalOpen(false);
     } catch {
       message.error('清理审计日志失败，请稍后重试');
+    } finally {
+      cleanupInFlightRef.current = false;
+      setCleaning(false);
     }
   };
 
@@ -386,9 +394,16 @@ const AuditPage: React.FC = () => {
         title={t('audit.cleanupTitle')}
         open={cleanupModalOpen}
         onOk={handleCleanup}
-        onCancel={() => setCleanupModalOpen(false)}
+        onCancel={() => {
+          if (!cleanupInFlightRef.current) setCleanupModalOpen(false);
+        }}
         okText={t('audit.cleanupConfirm')}
         cancelText={t('common.cancel')}
+        confirmLoading={cleaning}
+        closable={!cleaning}
+        keyboard={!cleaning}
+        maskClosable={!cleaning}
+        cancelButtonProps={{ disabled: cleaning }}
         okButtonProps={{ danger: true }}
       >
         <Flex vertical gap={12}>


### PR DESCRIPTION
## What changed

- guard audit cleanup with an in-flight ref so repeated confirmation starts only one request
- show the modal confirmation button in a loading state
- disable cancel, close, keyboard, and mask-close paths while cleanup is pending
- restore all controls after success or failure
- add a regression test that double-clicks confirmation and asserts one service call

## Why

The Audit page previously allowed repeated confirmation while the destructive cleanup request was pending. On a slow connection this could issue multiple concurrent deletion requests for the same retention window, and the modal could be closed while cleanup still continued.

## Impact

The change is limited to the Audit Logs page and its test. The backend API contract and successful refresh behavior are unchanged.

Fixes #1570

## Validation

- npx vitest run src/pages/ops/__tests__/AuditPage.test.tsx
  - 5 tests passed
- npx eslint src/pages/ops/audit.tsx src/pages/ops/__tests__/AuditPage.test.tsx
- npm run build
  - TypeScript and Vite production build passed
- Husky pre-commit ESLint and Prettier checks passed