### PR TITLE
[studio][ISSUE #1573] Deduplicate system alert acknowledgements

### DIFF
--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -103,4 +103,26 @@ describe('SystemAlertsPage', () => {
       expect(acknowledgeButtons[1]).toHaveClass('ant-btn-loading');
     });
   });
+
+  it('submits only one acknowledgement for the same alert while pending', async () => {
+    let resolveAcknowledgement: () => void = () => undefined;
+    vi.mocked(acknowledgeAlert).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAcknowledgement = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('Broker unavailable');
+    const acknowledgeButton = screen.getAllByRole('button', { name: /^确认$/ })[0];
+    await user.dblClick(acknowledgeButton);
+
+    expect(acknowledgeAlert).toHaveBeenCalledTimes(1);
+    expect(acknowledgeButton).toHaveClass('ant-btn-loading');
+
+    resolveAcknowledgement();
+    await waitFor(() => expect(acknowledgeButton).not.toBeInTheDocument());
+  });
 });

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Card, Tag, Flex, Typography, Badge, Button, message } from 'antd';
 import { CheckCircle, Trash } from '@phosphor-icons/react';
 import PageHeader from '../../components/PageHeader';
@@ -43,6 +43,7 @@ const SystemAlertsPage = () => {
   const [loading, setLoading] = useState(true);
   const [acknowledgingIds, setAcknowledgingIds] = useState<Set<string>>(() => new Set());
   const [clearing, setClearing] = useState(false);
+  const acknowledgingIdsRef = useRef(new Set<string>());
 
   useEffect(() => {
     let cancelled = false;
@@ -68,6 +69,8 @@ const SystemAlertsPage = () => {
   const unackCount = alerts.filter((a) => !a.acknowledged).length;
 
   const handleAck = async (id: string) => {
+    if (acknowledgingIdsRef.current.has(id)) return;
+    acknowledgingIdsRef.current.add(id);
     setAcknowledgingIds((current) => new Set(current).add(id));
     try {
       await acknowledgeAlert(id);
@@ -76,6 +79,7 @@ const SystemAlertsPage = () => {
     } catch {
       message.error('确认告警失败，请稍后重试');
     } finally {
+      acknowledgingIdsRef.current.delete(id);
       setAcknowledgingIds((current) => {
         const next = new Set(current);
         next.delete(id);


### PR DESCRIPTION
## What changed

- add a synchronous in-flight set keyed by system-alert ID
- ignore duplicate acknowledgement attempts for an ID that is already pending
- remove the ID guard after success or failure so retry remains possible
- preserve concurrent acknowledgement of different alert IDs
- add a regression test that double-clicks one alert and asserts one API call

## Why

React state drives the existing per-row spinner, but it is not a synchronous lock. A rapid double click can enter handleAck twice before the loading state disables the row action, producing duplicate acknowledgement requests.

## Impact

Only duplicate requests for the same alert are suppressed. Different alerts can still be acknowledged concurrently, and the backend API contract is unchanged.

Fixes #1573

## Validation

- npx vitest run src/pages/ops/__tests__/SystemAlertsPage.test.tsx
  - 3 tests passed
- npx eslint src/pages/ops/systemAlerts.tsx src/pages/ops/__tests__/SystemAlertsPage.test.tsx
- npm run build
  - TypeScript and Vite production build passed
- Husky pre-commit ESLint and Prettier checks passed