### PR TITLE
[studio][ISSUE #1575] Prevent duplicate alert rule saves

### DIFF
--- a/web/src/pages/ops/__tests__/AlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/AlertsPage.test.tsx
@@ -22,7 +22,7 @@ import { App } from 'antd';
 import type { AlertRule } from '../../../api/ops';
 import { LangProvider } from '../../../i18n/LangContext';
 import AlertsPage from '../alerts';
-import { listAlertRules, toggleAlertRule } from '../../../services/opsService';
+import { listAlertRules, toggleAlertRule, updateAlertRule } from '../../../services/opsService';
 
 vi.mock('../../../services/opsService', () => ({
   createAlertRule: vi.fn(),
@@ -229,5 +229,28 @@ describe('AlertsPage', () => {
 
     resolveToggle?.({ ...cloneRule(alertRules[0]), enabled: true });
     expect(await screen.findByText('已启用 1 条告警规则')).toBeInTheDocument();
+  });
+
+  it('submits an alert rule edit only once while the request is pending', async () => {
+    let resolveUpdate: ((rule: AlertRule) => void) | undefined;
+    vi.mocked(updateAlertRule).mockReturnValue(
+      new Promise<AlertRule>((resolve) => {
+        resolveUpdate = resolve;
+      }),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('Broker disk usage');
+    await user.click(within(getRuleRow('Broker disk usage')).getByRole('button', { name: '编辑' }));
+    const dialog = await screen.findByRole('dialog');
+    const confirmButton = within(dialog).getByRole('button', { name: /编\s*辑/ });
+    await user.dblClick(confirmButton);
+
+    expect(updateAlertRule).toHaveBeenCalledTimes(1);
+    expect(confirmButton).toHaveClass('ant-btn-loading');
+
+    resolveUpdate?.(cloneRule(alertRules[0]));
+    expect(await screen.findByText('告警规则已更新')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState, type Key } from 'react';
+import { useEffect, useRef, useState, type Key } from 'react';
 import { Plus, Pencil, Trash } from '@phosphor-icons/react';
 import {
   Button,
@@ -71,6 +71,7 @@ const AlertsPage = () => {
   const [selectedRuleIds, setSelectedRuleIds] = useState<Key[]>([]);
   const [bulkAction, setBulkAction] = useState<'enable' | 'disable' | null>(null);
   const [form] = Form.useForm();
+  const submitInFlightRef = useRef(false);
 
   const channelLabels: Record<string, string> = {
     dingtalk: 'DingTalk',
@@ -298,10 +299,12 @@ const AlertsPage = () => {
   ];
 
   const handleSubmit = async () => {
+    if (submitInFlightRef.current) return;
+    submitInFlightRef.current = true;
+    setSubmitting(true);
     try {
       const values = await form.validateFields();
       const payload = attachThresholdUnit(values);
-      setSubmitting(true);
       if (editingRule) {
         const updated = await updateAlertRule({ ...editingRule, ...payload });
         setRules((previous) =>
@@ -321,6 +324,7 @@ const AlertsPage = () => {
       }
       message.error('保存告警规则失败，请稍后重试');
     } finally {
+      submitInFlightRef.current = false;
       setSubmitting(false);
     }
   };
@@ -412,10 +416,15 @@ const AlertsPage = () => {
         onOk={handleSubmit}
         confirmLoading={submitting}
         onCancel={() => {
+          if (submitInFlightRef.current) return;
           setModalVisible(false);
           setEditingRule(null);
           form.resetFields();
         }}
+        closable={!submitting}
+        keyboard={!submitting}
+        maskClosable={!submitting}
+        cancelButtonProps={{ disabled: submitting }}
         okText={editingRule ? t('common.edit') : t('common.create')}
         cancelText={t('common.cancel')}
       >


### PR DESCRIPTION
## What changed

- lock alert-rule submission synchronously before form validation begins
- ignore duplicate create/edit confirmations while a submission is pending
- keep the existing confirmation loading state active from validation through API completion
- prevent cancel, close, keyboard, and mask-close actions during submission
- release the guard after validation failure, API success, or API failure
- add a regression test that double-clicks edit confirmation and asserts one update request

## Why

AlertsPage previously set submitting only after validateFields completed. A rapid double click could enter handleSubmit twice and start duplicate create or update requests before React disabled the confirmation button. The modal also remained closable while the request continued.

## Impact

The change is limited to the Alert Rules modal and its test. Form validation, API contracts, successful list updates, and bulk actions are unchanged.

Fixes #1575

## Validation

- npx vitest run src/pages/ops/__tests__/AlertsPage.test.tsx
  - 5 tests passed
- npx eslint src/pages/ops/alerts.tsx src/pages/ops/__tests__/AlertsPage.test.tsx
- npm run build
  - TypeScript and Vite production build passed
- Husky pre-commit ESLint and Prettier checks passed