### PR TITLE
[studio][ISSUE #1580] Ignore stale resource plan previews

### DIFF
--- a/web/src/pages/instance/__tests__/ResourcePlanPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ResourcePlanPage.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { App } from 'antd';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -143,5 +143,88 @@ describe('ResourcePlanPage', () => {
       within(screen.getByText('总资源').closest('.ant-card')!).getByText('2'),
     ).toBeInTheDocument();
     expect(screen.getByText('writeQueues: 16 → 8')).toBeInTheDocument();
+  });
+
+  it('ignores an obsolete preview after the resource bundle changes', async () => {
+    let resolveFirstPreview: (value: unknown) => void = () => undefined;
+    const firstPreview = new Promise((resolve) => {
+      resolveFirstPreview = resolve;
+    });
+    const latestPlan = {
+      instanceId: 'instance-proxy-1',
+      summary: {
+        total: 1,
+        creates: 1,
+        updates: 0,
+        skips: 0,
+        conflicts: 0,
+        invalids: 0,
+        applicable: 1,
+      },
+      entries: [
+        {
+          resourceType: 'TOPIC',
+          name: 'payments',
+          rowIndex: 1,
+          action: 'CREATE',
+          applicable: true,
+          reason: 'Topic does not exist in the selected instance',
+          changes: [],
+        },
+      ],
+    };
+    resourcePlanServiceMocks.previewResourcePlan
+      .mockImplementationOnce(() => firstPreview)
+      .mockResolvedValueOnce(latestPlan);
+
+    const user = userEvent.setup();
+    renderWithProviders();
+    await screen.findByText('资源变更计划');
+
+    await user.click(screen.getByRole('button', { name: /生成计划/ }));
+    await waitFor(() =>
+      expect(resourcePlanServiceMocks.previewResourcePlan).toHaveBeenCalledTimes(1),
+    );
+
+    resourcePlanServiceMocks.parseResourceBundle.mockReturnValue({
+      topics: [{ name: 'payments' }],
+      consumerGroups: [],
+    });
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '{"topics":[{"name":"payments"}]}' },
+    });
+    await user.click(screen.getByRole('button', { name: /生成计划/ }));
+
+    expect(await screen.findByText('payments')).toBeInTheDocument();
+
+    resolveFirstPreview({
+      instanceId: 'instance-proxy-1',
+      summary: {
+        total: 1,
+        creates: 0,
+        updates: 1,
+        skips: 0,
+        conflicts: 0,
+        invalids: 0,
+        applicable: 1,
+      },
+      entries: [
+        {
+          resourceType: 'TOPIC',
+          name: 'orders',
+          rowIndex: 1,
+          action: 'UPDATE',
+          applicable: true,
+          reason: 'Topic exists with different configuration',
+          changes: [],
+        },
+      ],
+    });
+
+    await waitFor(() =>
+      expect(resourcePlanServiceMocks.previewResourcePlan).toHaveBeenCalledTimes(2),
+    );
+    expect(screen.getByText('payments')).toBeInTheDocument();
+    expect(screen.queryByText('orders')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/instance/resourcePlan.tsx
+++ b/web/src/pages/instance/resourcePlan.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import {
   Alert,
   App,
@@ -65,6 +65,8 @@ const ResourcePlanPage = () => {
   const [bundleText, setBundleText] = useState(RESOURCE_PLAN_SAMPLE);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [plan, setPlan] = useState<Awaited<ReturnType<typeof previewResourcePlan>> | null>(null);
+  const previewGenerationRef = useRef(0);
+  const currentPlan = plan?.instanceId === selectedInstanceId ? plan : null;
 
   const columns = useMemo<ColumnsType<ResourcePlanEntry>>(
     () => [
@@ -130,18 +132,32 @@ const ResourcePlanPage = () => {
       message.warning('请先选择实例');
       return;
     }
+    const requestGeneration = previewGenerationRef.current + 1;
+    previewGenerationRef.current = requestGeneration;
     setPreviewLoading(true);
     try {
       const bundle = parseResourceBundle(bundleText);
       const request = { instanceId: selectedInstanceId, ...bundle };
       const nextPlan = await previewResourcePlan(request);
+      if (previewGenerationRef.current !== requestGeneration) return;
       setPlan(nextPlan);
       message.success('资源变更计划已生成');
     } catch (error) {
-      message.error(error instanceof Error ? error.message : '资源变更计划生成失败');
+      if (previewGenerationRef.current === requestGeneration) {
+        message.error(error instanceof Error ? error.message : '资源变更计划生成失败');
+      }
     } finally {
-      setPreviewLoading(false);
+      if (previewGenerationRef.current === requestGeneration) {
+        setPreviewLoading(false);
+      }
     }
+  };
+
+  const handleBundleChange = (value: string) => {
+    previewGenerationRef.current += 1;
+    setBundleText(value);
+    setPlan(null);
+    setPreviewLoading(false);
   };
 
   return (
@@ -156,9 +172,14 @@ const ResourcePlanPage = () => {
               placeholder="选择实例"
               style={{ width: 220 }}
               options={instanceOptions}
-              onChange={selectInstance}
+              onChange={(instanceId) => {
+                previewGenerationRef.current += 1;
+                setPlan(null);
+                setPreviewLoading(false);
+                selectInstance(instanceId);
+              }}
             />
-            <Button onClick={() => setBundleText(RESOURCE_PLAN_SAMPLE)}>填充示例</Button>
+            <Button onClick={() => handleBundleChange(RESOURCE_PLAN_SAMPLE)}>填充示例</Button>
             <Button
               type="primary"
               icon={<PlayCircleOutlined />}
@@ -199,7 +220,7 @@ const ResourcePlanPage = () => {
           >
             <TextArea
               value={bundleText}
-              onChange={(event) => setBundleText(event.target.value)}
+              onChange={(event) => handleBundleChange(event.target.value)}
               autoSize={{ minRows: 20, maxRows: 30 }}
               spellCheck={false}
               style={{ fontFamily: 'Menlo, Monaco, Consolas, monospace', fontSize: 12 }}
@@ -207,18 +228,18 @@ const ResourcePlanPage = () => {
           </Card>
         </Col>
         <Col xs={24} lg={15}>
-          {plan && (
+          {currentPlan && (
             <Row gutter={[12, 12]} style={{ marginBottom: 16 }}>
               <Col xs={12} md={6}>
                 <Card size="small">
-                  <Statistic title="总资源" value={plan.summary.total} />
+                  <Statistic title="总资源" value={currentPlan.summary.total} />
                 </Card>
               </Col>
               <Col xs={12} md={6}>
                 <Card size="small">
                   <Statistic
                     title="可应用"
-                    value={plan.summary.applicable}
+                    value={currentPlan.summary.applicable}
                     valueStyle={{ color: '#389e0d' }}
                   />
                 </Card>
@@ -227,7 +248,7 @@ const ResourcePlanPage = () => {
                 <Card size="small">
                   <Statistic
                     title="冲突"
-                    value={plan.summary.conflicts}
+                    value={currentPlan.summary.conflicts}
                     valueStyle={{ color: '#d46b08' }}
                   />
                 </Card>
@@ -236,7 +257,7 @@ const ResourcePlanPage = () => {
                 <Card size="small">
                   <Statistic
                     title="无效"
-                    value={plan.summary.invalids}
+                    value={currentPlan.summary.invalids}
                     valueStyle={{ color: '#cf1322' }}
                   />
                 </Card>
@@ -248,7 +269,7 @@ const ResourcePlanPage = () => {
               rowKey={(record) => `${record.resourceType}-${record.name}-${record.rowIndex}`}
               loading={previewLoading}
               columns={columns}
-              dataSource={plan?.entries ?? []}
+              dataSource={currentPlan?.entries ?? []}
               pagination={{ pageSize: 10, showSizeChanger: true }}
               scroll={{ x: 1080 }}
               locale={{


### PR DESCRIPTION
## Summary

- invalidate an in-flight Resource Plan preview when the selected instance or resource bundle changes
- let only the latest preview request update results, notifications, and loading state
- hide plans whose instance no longer matches the active instance
- add a regression test that completes an obsolete request after the latest request

## Root cause

`ResourcePlanPage` used a single loading flag and accepted every asynchronous preview completion. A slower request for an older instance or bundle could therefore overwrite newer results and clear the latest request's loading state.

## User impact

The page now keeps preview results aligned with the currently selected instance and current JSON bundle, even when requests finish out of order.

Closes #1580

## Validation

- `npm test -- --run src/pages/instance/__tests__/ResourcePlanPage.test.tsx` (2 tests passed)
- `npx eslint src/pages/instance/resourcePlan.tsx src/pages/instance/__tests__/ResourcePlanPage.test.tsx --max-warnings=0`
- `npx prettier --check src/pages/instance/resourcePlan.tsx src/pages/instance/__tests__/ResourcePlanPage.test.tsx`
- `npm run build`