### PR TITLE
[studio][ISSUE #1585] Restore frontend lint

### DIFF
--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -119,27 +119,30 @@ const ClientsPage = () => {
   useEffect(() => {
     let cancelled = false;
 
-    setLoading(true);
-    void listInstances()
-      .then((nextInstances) => {
-        if (cancelled) return;
-        setInstances(nextInstances);
-        setSelectedInstanceId((current) => current || nextInstances[0]?.id || '');
-        setLoadError(null);
-      })
-      .catch((error) => {
-        if (cancelled) return;
-        setInstances([]);
-        setSelectedInstanceId('');
-        setConnections([]);
-        setLoadError(getLoadErrorMessage(error));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
+    const timer = window.setTimeout(() => {
+      setLoading(true);
+      void listInstances()
+        .then((nextInstances) => {
+          if (cancelled) return;
+          setInstances(nextInstances);
+          setSelectedInstanceId((current) => current || nextInstances[0]?.id || '');
+          setLoadError(null);
+        })
+        .catch((error) => {
+          if (cancelled) return;
+          setInstances([]);
+          setSelectedInstanceId('');
+          setConnections([]);
+          setLoadError(getLoadErrorMessage(error));
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, 0);
 
     return () => {
       cancelled = true;
+      window.clearTimeout(timer);
     };
   }, [instanceLoadKey]);
 

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -232,22 +232,24 @@ const ConsumerPage = () => {
   const groupRequestIdRef = useRef(0);
 
   useEffect(() => {
-    setSelectedGroup(null);
-    setModalOpen(false);
-    setResetGroup(null);
-    setResetModalOpen(false);
+    const timer = window.setTimeout(() => {
+      setSelectedGroup(null);
+      setModalOpen(false);
+      setResetGroup(null);
+      setResetModalOpen(false);
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [selectedInstanceId]);
 
   useEffect(() => {
-    if (!selectedInstanceId) {
-      groupRequestIdRef.current += 1;
-      setGroups([]);
-      setSelectedRowKeys([]);
-      setLoading(false);
-      return;
-    }
     const requestId = ++groupRequestIdRef.current;
     const timer = window.setTimeout(() => {
+      if (!selectedInstanceId) {
+        setGroups([]);
+        setSelectedRowKeys([]);
+        setLoading(false);
+        return;
+      }
       setLoading(true);
       void listConsumerGroups({ instanceId: selectedInstanceId })
         .then((nextGroups) => {
@@ -934,7 +936,7 @@ const ConsumerPage = () => {
         <Table
           columns={columns}
           dataSource={filtered}
-          loading={loading}
+          loading={Boolean(selectedInstanceId) && loading}
           rowKey="name"
           rowSelection={{
             selectedRowKeys,
@@ -958,7 +960,9 @@ const ConsumerPage = () => {
                     subscriptionsByGroup[diagnosticCacheKey(selectedInstanceId, record.name)] ?? []
                   }
                   rowKey="topic"
-                  loading={subscriptionLoadingByGroup[diagnosticCacheKey(selectedInstanceId, record.name)]}
+                  loading={
+                    subscriptionLoadingByGroup[diagnosticCacheKey(selectedInstanceId, record.name)]
+                  }
                   pagination={false}
                   size="small"
                 />

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -125,52 +125,50 @@ const DLQPage = () => {
   useEffect(() => {
     let cancelled = false;
 
-    // The retry dialog owns a group name that is meaningful only for the
-    // currently selected instance. Clear all instance-scoped state before
-    // starting the next request so an old group cannot be retried on a new
-    // instance while that request is in flight.
-    setGroups([]);
-    setSelectedGroupNames([]);
-    setDetailGroup(null);
-    setRetryModalOpen(false);
-    setRetryGroup(null);
-    setRetryTargetTopic('');
-    setRetryError(null);
-    setLoadError(null);
+    const timer = window.setTimeout(() => {
+      // The retry dialog owns a group name that is meaningful only for the
+      // currently selected instance. Clear all instance-scoped state before
+      // starting the next request so an old group cannot be retried on a new
+      // instance while that request is in flight.
+      setGroups([]);
+      setSelectedGroupNames([]);
+      setDetailGroup(null);
+      setRetryModalOpen(false);
+      setRetryGroup(null);
+      setRetryTargetTopic('');
+      setRetryError(null);
+      setLoadError(null);
 
-    if (!selectedInstanceId) {
-      void Promise.resolve().then(() => {
-        if (cancelled) return;
+      if (!selectedInstanceId) {
         setLoading(false);
-      });
-      return () => {
-        cancelled = true;
-      };
-    }
+        return;
+      }
 
-    setLoading(true);
-    void listDLQGroups(selectedInstanceId)
-      .then((nextGroups) => {
-        if (!cancelled) {
-          setGroups(nextGroups);
-          setLoadError(null);
-          const availableGroups = new Set(
-            nextGroups.filter((group) => group.messageCount > 0).map((group) => group.groupName),
-          );
-          setSelectedGroupNames((selected) =>
-            selected.filter((groupName) => availableGroups.has(groupName)),
-          );
-        }
-      })
-      .catch((error) => {
-        if (!cancelled) setLoadError(getErrorMessage(error, DEFAULT_LOAD_ERROR));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
+      setLoading(true);
+      void listDLQGroups(selectedInstanceId)
+        .then((nextGroups) => {
+          if (!cancelled) {
+            setGroups(nextGroups);
+            setLoadError(null);
+            const availableGroups = new Set(
+              nextGroups.filter((group) => group.messageCount > 0).map((group) => group.groupName),
+            );
+            setSelectedGroupNames((selected) =>
+              selected.filter((groupName) => availableGroups.has(groupName)),
+            );
+          }
+        })
+        .catch((error) => {
+          if (!cancelled) setLoadError(getErrorMessage(error, DEFAULT_LOAD_ERROR));
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, 0);
 
     return () => {
       cancelled = true;
+      window.clearTimeout(timer);
     };
   }, [refreshKey, selectedInstanceId]);
 


### PR DESCRIPTION
## Summary

- defer Clients instance loading state changes to a cancellable scheduled effect task
- defer Consumer instance-scoped modal/list resets while preserving request-generation invalidation
- defer DLQ instance-scoped cleanup and loading through the same cancellable lifecycle
- suppress the Consumer table spinner when no instance is available

## Root cause

The pages synchronously called React state setters from effect bodies. The current React hooks lint rules reject that pattern with five `react-hooks/set-state-in-effect` errors, so `npm run lint` failed on `rocketmq-studio`.

## User and developer impact

The frontend lint gate passes again. Existing cancellation and stale-response guards remain intact, and the no-instance Consumer state no longer briefly exposes a loading spinner.

Closes #1585

## Validation

- `npm run lint` (0 errors; existing non-blocking warnings remain)
- `npm test -- --run src/pages/cluster/__tests__/ClientsPage.test.tsx src/pages/instance/__tests__/ConsumerPage.test.tsx src/pages/instance/__tests__/DLQPage.test.tsx` (30 tests passed)
- `npm run build`