### PR TITLE
[studio][ISSUE #1587] Tolerate unavailable browser storage

### DIFF
--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -120,6 +120,24 @@ describe('API client response contract', () => {
     await client.get('/clusters');
   });
 
+  it('sends requests without authorization when browser storage is unavailable', async () => {
+    const getItem = vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage is unavailable', 'SecurityError');
+    });
+    mock.onGet('/clusters').reply((config) => {
+      expect(config.headers?.Authorization).toBeUndefined();
+      return [200, { code: 200, message: 'success', data: [] }];
+    });
+
+    try {
+      await expect(client.get('/clusters')).resolves.toMatchObject({
+        data: { code: 200, data: [] },
+      });
+    } finally {
+      getItem.mockRestore();
+    }
+  });
+
   it.each(['/auth/login', '/auth/status'])(
     'does not clear the current session when public auth request %s returns 401',
     async (path) => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -55,6 +55,14 @@ function isPublicAuthRequest(url?: string): boolean {
   return PUBLIC_AUTH_PATHS.has(relativePath);
 }
 
+function readStoredToken(): string | null {
+  try {
+    return localStorage.getItem(TOKEN_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
 const client = axios.create({
   baseURL: API_BASE_URL,
   timeout: 30000,
@@ -63,7 +71,7 @@ const client = axios.create({
 // Request interceptor: attach Authorization header
 client.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem(TOKEN_STORAGE_KEY);
+    const token = readStoredToken();
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }


### PR DESCRIPTION
## Summary

- read the persisted bearer token through a storage-safe helper
- treat Web Storage access failures as an absent token instead of rejecting the request
- add a regression test that throws `SecurityError` from `localStorage.getItem`

## Root cause

The authentication storage module already catches browser storage failures, but the Axios request interceptor bypassed it and accessed `localStorage` directly. A browser `SecurityError` therefore aborted all API calls before they reached the network.

## User impact

Studio can continue issuing unauthenticated or public requests in restricted-storage environments. Normal bearer-token attachment remains unchanged when storage is available.

Closes #1587

## Validation

- `npm test -- --run src/api/client.test.ts` (11 tests passed)
- `npx eslint src/api/client.ts src/api/client.test.ts --max-warnings=0`
- `npx prettier --check src/api/client.ts src/api/client.test.ts`
- `npm run build`