### PR TITLE
feat(tencent): support consumer group management on Tencent Cloud RocketMQ 5.x instances

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>com.tencentcloudapi</groupId>
             <artifactId>tencentcloud-sdk-java-trocket</artifactId>
-            <version>3.1.1292</version>
+            <version>3.1.1498</version>
         </dependency>
         <!-- rocketmq-common also brings Kotlin-based okio-jvm 3.x; keep its runtime available. -->
         <dependency>

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -16,13 +16,23 @@
  */
 package org.apache.rocketmq.studio.provider.tencent;
 
+import com.tencentcloudapi.trocket.v20230308.models.ConsumeGroupItem;
+import com.tencentcloudapi.trocket.v20230308.models.CreateConsumerGroupRequest;
 import com.tencentcloudapi.trocket.v20230308.models.CreateTopicRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DeleteConsumerGroupRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DeleteTopicRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupListRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupListResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicResponse;
 import com.tencentcloudapi.trocket.v20230308.models.ModifyTopicRequest;
+import com.tencentcloudapi.trocket.v20230308.models.ResetConsumerGroupOffsetRequest;
 import com.tencentcloudapi.trocket.v20230308.models.SubscriptionData;
 import com.tencentcloudapi.trocket.v20230308.models.TopicItem;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
@@ -48,6 +58,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -66,6 +77,7 @@ public class TencentInstanceProvider implements InstanceProvider {
     static final int MAX_PAGES = 100;
     static final int CONSUMER_PAGE_SIZE = 100;
     static final int DEFAULT_QUEUE_NUM = 8;
+    static final int DEFAULT_MAX_RETRY_TIMES = 16;
     private static final String NOT_IMPLEMENTED = "Tencent Cloud operation is not implemented yet";
 
     private final TencentClientFactory clientFactory;
@@ -83,7 +95,7 @@ public class TencentInstanceProvider implements InstanceProvider {
 
     @Override
     public int countGroups(String instanceId) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        return listConsumerGroups(instanceId, null, false).size();
     }
 
     @Override
@@ -229,32 +241,148 @@ public class TencentInstanceProvider implements InstanceProvider {
 
     @Override
     public List<ConsumerGroupVO> listConsumerGroups(String instanceId, String search) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        return listConsumerGroups(instanceId, search, true);
+    }
+
+    private List<ConsumerGroupVO> listConsumerGroups(String instanceId, String search, boolean enrichTimes) {
+        Context context = resolve(instanceId);
+        List<ConsumerGroupVO> groups = new ArrayList<>();
+        for (int page = 0; page < MAX_PAGES; page++) {
+            DescribeConsumerGroupListRequest request = new DescribeConsumerGroupListRequest();
+            request.setInstanceId(context.cloudInstanceId());
+            request.setOffset((long) page * PAGE_SIZE);
+            request.setLimit((long) PAGE_SIZE);
+            DescribeConsumerGroupListResponse response = clientFactory.call(context.credentialId(), context.regionId(),
+                    client -> client.DescribeConsumerGroupList(request));
+            ConsumeGroupItem[] data = response == null ? null : response.getData();
+            if (data == null || data.length == 0) {
+                break;
+            }
+            for (ConsumeGroupItem item : data) {
+                if (item == null) {
+                    continue;
+                }
+                ConsumerGroupVO group = toConsumerGroup(item, instanceId);
+                if (matchesSearch(search, group.getName())) {
+                    if (enrichTimes) {
+                        enrichConsumerGroupDetail(context, group);
+                    }
+                    groups.add(group);
+                }
+            }
+            if (data.length < PAGE_SIZE) {
+                break;
+            }
+        }
+        return groups;
+    }
+
+    /**
+     * DescribeConsumerGroupList exposes limited fields, so resolve the creation timestamp and the
+     * real consume model from DescribeConsumerGroup. Kept off the cheap count path to avoid N+1
+     * calls for instance listings.
+     */
+    private void enrichConsumerGroupDetail(Context context, ConsumerGroupVO group) {
+        try {
+            DescribeConsumerGroupRequest request = new DescribeConsumerGroupRequest();
+            request.setInstanceId(context.cloudInstanceId());
+            request.setConsumerGroup(group.getName());
+            DescribeConsumerGroupResponse response = clientFactory.call(context.credentialId(), context.regionId(),
+                    client -> client.DescribeConsumerGroup(request));
+            if (response == null) {
+                return;
+            }
+            group.setCreatedAt(toLocalDateTime(response.getCreatedTime()));
+            if (StringUtils.hasText(response.getConsumeModel())) {
+                group.setConsumeType(toConsumeType(response.getConsumeModel()));
+            }
+        } catch (BusinessException ignored) {
+            // A single group detail lookup failure should not fail the whole list.
+        }
     }
 
     @Override
     public ConsumerGroupVO createConsumerGroup(String instanceId, ConsumerGroupVO group) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        Context context = resolve(instanceId);
+        validateConsumerGroup(group);
+        CreateConsumerGroupRequest request = new CreateConsumerGroupRequest();
+        request.setInstanceId(context.cloudInstanceId());
+        request.setConsumerGroup(group.getName());
+        request.setMaxRetryTimes((long) retryMaxTimes(group));
+        request.setConsumeEnable(true);
+        request.setConsumeMessageOrderly(isOrderly(group));
+        clientFactory.call(context.credentialId(), context.regionId(), client -> client.CreateConsumerGroup(request));
+        group.setInstanceId(instanceId);
+        group.setRetryMaxTimes(retryMaxTimes(group));
+        group.setSubscribedTopics(java.util.List.of());
+        group.setCreatedAt(LocalDateTime.now());
+        group.setUpdatedAt(LocalDateTime.now());
+        return group;
     }
 
     @Override
     public void deleteConsumerGroup(String instanceId, String groupName) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        Context context = resolve(instanceId);
+        requireGroupName(groupName);
+        DeleteConsumerGroupRequest request = new DeleteConsumerGroupRequest();
+        request.setInstanceId(context.cloudInstanceId());
+        request.setConsumerGroup(groupName);
+        clientFactory.call(context.credentialId(), context.regionId(), client -> client.DeleteConsumerGroup(request));
     }
 
     @Override
     public List<QueueProgressVO> getGroupProgress(String instanceId, String groupName) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        Context context = resolve(instanceId);
+        requireGroupName(groupName);
+        List<SubscriptionData> subscriptions = listTopicSubscriptionsByGroup(context, groupName);
+        List<QueueProgressVO> rows = new ArrayList<>();
+        for (SubscriptionData subscription : subscriptions) {
+            if (subscription == null) {
+                continue;
+            }
+            rows.add(QueueProgressVO.builder()
+                    .broker("topic:" + subscription.getTopic())
+                    .queueId(0)
+                    .brokerOffset(0L)
+                    .consumerOffset(0L)
+                    .diffTotal(subscription.getConsumerLag() == null ? 0L : subscription.getConsumerLag())
+                    .build());
+        }
+        return rows;
     }
 
     @Override
     public List<SubscriptionEntryVO> getGroupSubscriptions(String instanceId, String groupName) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        Context context = resolve(instanceId);
+        requireGroupName(groupName);
+        List<SubscriptionData> subscriptions = listTopicSubscriptionsByGroup(context, groupName);
+        List<SubscriptionEntryVO> entries = new ArrayList<>();
+        for (SubscriptionData subscription : subscriptions) {
+            if (subscription == null) {
+                continue;
+            }
+            entries.add(toSubscriptionEntry(subscription));
+        }
+        return entries;
     }
 
     @Override
     public void resetOffset(String instanceId, String groupName, long timestamp, String topic) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        Context context = resolve(instanceId);
+        requireGroupName(groupName);
+        if (!StringUtils.hasText(topic)) {
+            throw new BusinessException(400, "Topic is required to reset consumer group offset");
+        }
+        ResetConsumerGroupOffsetRequest request = new ResetConsumerGroupOffsetRequest();
+        request.setInstanceId(context.cloudInstanceId());
+        request.setConsumerGroup(groupName);
+        request.setTopic(topic);
+        if (timestamp > 0L) {
+            request.setResetTimestamp(timestamp);
+        } else {
+            request.setResetTimestamp(System.currentTimeMillis());
+        }
+        clientFactory.call(context.credentialId(), context.regionId(), client -> client.ResetConsumerGroupOffset(request));
     }
 
     @Override
@@ -308,6 +436,98 @@ public class TencentInstanceProvider implements InstanceProvider {
                 .build();
     }
 
+    private static ConsumerGroupVO toConsumerGroup(ConsumeGroupItem item, String instanceId) {
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName(item.getConsumerGroup());
+        group.setInstanceId(instanceId);
+        group.setClusterId(item.getClusterIdV4());
+        group.setNamespace(item.getNamespaceV4());
+        group.setConsumeType(toConsumeType(item.getConsumeMessageOrderly()));
+        group.setDeliveryOrderType(item.getConsumeMessageOrderly() == null || !item.getConsumeMessageOrderly()
+                ? "Concurrently" : "Orderly");
+        group.setRetryMaxTimes(toInt(item.getMaxRetryTimes()));
+        group.setSubscribedTopics(java.util.List.of());
+        group.setInstances(java.util.List.of());
+        return group;
+    }
+
+    private List<SubscriptionData> listTopicSubscriptionsByGroup(Context context, String groupName) {
+        List<SubscriptionData> all = new ArrayList<>();
+        for (int page = 0; page < MAX_PAGES; page++) {
+            DescribeTopicListByGroupRequest request = new DescribeTopicListByGroupRequest();
+            request.setInstanceId(context.cloudInstanceId());
+            request.setConsumerGroup(groupName);
+            request.setOffset((long) page * PAGE_SIZE);
+            request.setLimit((long) PAGE_SIZE);
+            DescribeTopicListByGroupResponse response = clientFactory.call(context.credentialId(), context.regionId(),
+                    client -> client.DescribeTopicListByGroup(request));
+            SubscriptionData[] data = response == null ? null : response.getData();
+            if (data == null || data.length == 0) {
+                break;
+            }
+            all.addAll(Arrays.asList(data));
+            if (data.length < PAGE_SIZE) {
+                break;
+            }
+        }
+        return all;
+    }
+
+    private static SubscriptionEntryVO toSubscriptionEntry(SubscriptionData subscription) {
+        return SubscriptionEntryVO.builder()
+                .topic(subscription.getTopic())
+                .expression(subscription.getSubString())
+                .type(subscription.getExpressionType())
+                .filterMode(subscription.getExpressionType())
+                .consistency(subscription.getConsistency() == null ? null : String.valueOf(subscription.getConsistency()))
+                .build();
+    }
+
+    private static void validateConsumerGroup(ConsumerGroupVO group) {
+        if (group == null || !StringUtils.hasText(group.getName())) {
+            throw new BusinessException(400, "Consumer group name is required");
+        }
+    }
+
+    private static void requireGroupName(String groupName) {
+        if (!StringUtils.hasText(groupName)) {
+            throw new BusinessException(400, "Consumer group name is required");
+        }
+    }
+
+    private static int retryMaxTimes(ConsumerGroupVO group) {
+        return group.getRetryMaxTimes() > 0 ? group.getRetryMaxTimes() : DEFAULT_MAX_RETRY_TIMES;
+    }
+
+    private static boolean isOrderly(ConsumerGroupVO group) {
+        String deliveryOrderType = group.getDeliveryOrderType();
+        return deliveryOrderType != null
+                && (deliveryOrderType.toUpperCase(Locale.ROOT).contains("FIFO")
+                || deliveryOrderType.toUpperCase(Locale.ROOT).contains("ORDER"));
+    }
+
+    private static int toInt(Long value) {
+        return value == null ? 0 : Math.toIntExact(value);
+    }
+
+    private static ConsumeType toConsumeType(Boolean consumeMessageOrderly) {
+        // Tencent consumer groups use clustering consumption; orderly only affects delivery order.
+        return ConsumeType.CLUSTERING;
+    }
+
+    private static ConsumeType toConsumeType(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return null;
+        }
+        if (raw.toUpperCase(Locale.ROOT).contains("BROADCAST")) {
+            return ConsumeType.BROADCASTING;
+        }
+        if (raw.toUpperCase(Locale.ROOT).contains("CLUSTER")) {
+            return ConsumeType.CLUSTERING;
+        }
+        return null;
+    }
+
     private static TopicType toTopicType(String raw) {
         if (!StringUtils.hasText(raw)) {
             return null;
@@ -344,6 +564,13 @@ public class TencentInstanceProvider implements InstanceProvider {
         }
         String needle = search.trim().toLowerCase(Locale.ROOT);
         return contains(topic.getName(), needle) || contains(topic.getRemark(), needle);
+    }
+
+    private static boolean matchesSearch(String search, String value) {
+        if (!StringUtils.hasText(search)) {
+            return true;
+        }
+        return contains(value, search.trim().toLowerCase(Locale.ROOT));
     }
 
     private static boolean contains(String value, String needle) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -16,17 +16,28 @@
  */
 package org.apache.rocketmq.studio.provider.tencent;
 
+import com.tencentcloudapi.trocket.v20230308.models.ConsumeGroupItem;
+import com.tencentcloudapi.trocket.v20230308.models.CreateConsumerGroupRequest;
 import com.tencentcloudapi.trocket.v20230308.models.CreateTopicRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DeleteConsumerGroupRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupListResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicResponse;
 import com.tencentcloudapi.trocket.v20230308.models.ModifyTopicRequest;
+import com.tencentcloudapi.trocket.v20230308.models.ResetConsumerGroupOffsetRequest;
 import com.tencentcloudapi.trocket.v20230308.models.SubscriptionData;
 import com.tencentcloudapi.trocket.v20230308.models.TopicItem;
 import com.tencentcloudapi.trocket.v20230308.TrocketClient;
+import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
+import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
+import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.junit.jupiter.api.BeforeEach;
@@ -163,6 +174,103 @@ class TencentInstanceProviderTest {
         assertThat(consumers).hasSize(1);
         assertThat(consumers.get(0).getGroup()).isEqualTo("GID_orders");
         assertThat(consumers.get(0).getDiffTotal()).isEqualTo(42L);
+    }
+
+    @Test
+    void listConsumerGroupsShouldMapAndFilterTest() throws Exception {
+        ConsumeGroupItem one = new ConsumeGroupItem();
+        one.setConsumerGroup("GID_test");
+        one.setMaxRetryTimes(10L);
+        one.setConsumeMessageOrderly(false);
+        ConsumeGroupItem two = new ConsumeGroupItem();
+        two.setConsumerGroup("GID_orders");
+        two.setMaxRetryTimes(16L);
+        DescribeConsumerGroupListResponse response = new DescribeConsumerGroupListResponse();
+        response.setData(new ConsumeGroupItem[]{one, two});
+        when(client.DescribeConsumerGroupList(any())).thenReturn(response);
+        DescribeConsumerGroupResponse detail = new DescribeConsumerGroupResponse();
+        detail.setCreatedTime(1600000000000L);
+        detail.setConsumeModel("CLUSTERING");
+        when(client.DescribeConsumerGroup(any())).thenReturn(detail);
+
+        List<ConsumerGroupVO> groups = provider.listConsumerGroups(STUDIO_INSTANCE_ID, "orders");
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0).getName()).isEqualTo("GID_orders");
+        assertThat(groups.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_ID);
+        assertThat(groups.get(0).getRetryMaxTimes()).isEqualTo(16);
+        assertThat(groups.get(0).getCreatedAt()).isNotNull();
+        assertThat(groups.get(0).getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
+        assertThat(groups.get(0).getInstances()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void createConsumerGroupShouldCallTencentOpenApiTest() throws Exception {
+        when(client.CreateConsumerGroup(any())).thenReturn(null);
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName("GID_new");
+        group.setRetryMaxTimes(20);
+
+        ConsumerGroupVO created = provider.createConsumerGroup(STUDIO_INSTANCE_ID, group);
+
+        ArgumentCaptor<CreateConsumerGroupRequest> captor = ArgumentCaptor.forClass(CreateConsumerGroupRequest.class);
+        verify(client).CreateConsumerGroup(captor.capture());
+        assertThat(captor.getValue().getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
+        assertThat(captor.getValue().getConsumerGroup()).isEqualTo("GID_new");
+        assertThat(captor.getValue().getMaxRetryTimes()).isEqualTo(20L);
+        assertThat(created.getInstanceId()).isEqualTo(STUDIO_INSTANCE_ID);
+        assertThat(created.getRetryMaxTimes()).isEqualTo(20);
+    }
+
+    @Test
+    void deleteConsumerGroupShouldCallTencentOpenApiTest() throws Exception {
+        when(client.DeleteConsumerGroup(any())).thenReturn(null);
+
+        provider.deleteConsumerGroup(STUDIO_INSTANCE_ID, "GID_test");
+
+        ArgumentCaptor<DeleteConsumerGroupRequest> captor = ArgumentCaptor.forClass(DeleteConsumerGroupRequest.class);
+        verify(client).DeleteConsumerGroup(captor.capture());
+        assertThat(captor.getValue().getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
+        assertThat(captor.getValue().getConsumerGroup()).isEqualTo("GID_test");
+    }
+
+    @Test
+    void getGroupProgressAndSubscriptionsShouldMapSubscriptionDataTest() throws Exception {
+        SubscriptionData subscription = new SubscriptionData();
+        subscription.setTopic("orders");
+        subscription.setSubString("*");
+        subscription.setExpressionType("TAG");
+        subscription.setConsumerLag(42L);
+        subscription.setConsistency(0L);
+        DescribeTopicListByGroupResponse response = new DescribeTopicListByGroupResponse();
+        response.setData(new SubscriptionData[]{subscription});
+        when(client.DescribeTopicListByGroup(any())).thenReturn(response);
+
+        List<QueueProgressVO> progress = provider.getGroupProgress(STUDIO_INSTANCE_ID, "GID_test");
+        assertThat(progress).hasSize(1);
+        assertThat(progress.get(0).getBroker()).isEqualTo("topic:orders");
+        assertThat(progress.get(0).getDiffTotal()).isEqualTo(42L);
+
+        List<SubscriptionEntryVO> subscriptions = provider.getGroupSubscriptions(STUDIO_INSTANCE_ID, "GID_test");
+        assertThat(subscriptions).hasSize(1);
+        assertThat(subscriptions.get(0).getTopic()).isEqualTo("orders");
+        assertThat(subscriptions.get(0).getExpression()).isEqualTo("*");
+        assertThat(subscriptions.get(0).getType()).isEqualTo("TAG");
+    }
+
+    @Test
+    void resetOffsetShouldCallTencentOpenApiTest() throws Exception {
+        when(client.ResetConsumerGroupOffset(any())).thenReturn(null);
+
+        provider.resetOffset(STUDIO_INSTANCE_ID, "GID_test", 1600000000000L, "orders");
+
+        ArgumentCaptor<ResetConsumerGroupOffsetRequest> captor =
+                ArgumentCaptor.forClass(ResetConsumerGroupOffsetRequest.class);
+        verify(client).ResetConsumerGroupOffset(captor.capture());
+        assertThat(captor.getValue().getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
+        assertThat(captor.getValue().getConsumerGroup()).isEqualTo("GID_test");
+        assertThat(captor.getValue().getTopic()).isEqualTo("orders");
+        assertThat(captor.getValue().getResetTimestamp()).isEqualTo(1600000000000L);
     }
 
     private static TopicItem topicItem(String name, String type, long queueNum) {


### PR DESCRIPTION
## Summary

Adds consumer group management support for Tencent Cloud RocketMQ 5.x instances on the
`rocketmq-studio` branch, mapping the Tencent `provider/tencent` (Trocket v20230308 OpenAPI) to
the instance-scoped consumer group CRUD surface. Fixes #1590.

## Changes

**Consumer group management (Tencent provider)**
- `listConsumerGroups` - `DescribeConsumerGroupList` pagination + name filter; enriches per-group
  `createdAt` and the real `ConsumeModel` via `DescribeConsumerGroup` (off the cheap count path).
- `createConsumerGroup` / `deleteConsumerGroup` - `CreateConsumerGroup` / `DeleteConsumerGroup`
  with retry times and orderly-delivery defaults.
- `getGroupProgress` / `getGroupSubscriptions` - `DescribeTopicListByGroup` mapping per-topic
  consumer lag and subscription entries.
- `resetOffset` - `ResetConsumerGroupOffset` by timestamp (topic required).
- `countGroups` - cheap list path without N+1 detail lookups.

**Fix: blank group detail modal**
- `instances` and `subscribedTopics` are now set to empty lists instead of `null`, so the detail
  modal no longer throws `Cannot read properties of null (reading 'length')` when opened.

**SDK bump**
- `tencentcloud-sdk-java-trocket` `3.1.1292` -> `3.1.1498`, which adds
  `DescribeConsumerGroupResponse#getConsumeModel()` to map `ConsumeModel` (CLUSTERING /
  BROADCASTING) to `ConsumeType`. The older model could not read this field.

## Testing
- Unit tests added for the Tencent provider: list (mapping + consume model + timestamps + empty
  instances), create, delete, progress/subscriptions, and reset offset.
- Backend: `mvn test` passes (893+ tests, 0 failures); checkstyle clean.
- Manually verified against a real Tencent Cloud RocketMQ 5.x instance: group list shows real
  `createdAt` and `consumeType`, create/delete/reset work, and opening group detail no longer
  blanks the page.

## Notes
- Scoped to `rocketmq-studio`; message query and trace ops for Tencent remain unsupported.
- `subscriptionMode` (Push/Pop) and `subscriptionDataType` are not exposed by the Tencent API and
  remain empty, consistent with the Aliyun provider.
