### PR TITLE
[studio][ISSUE #1595] Preserve routed instance fallback

### DIFF
--- a/web/src/hooks/useInstanceFilter.test.tsx
+++ b/web/src/hooks/useInstanceFilter.test.tsx
@@ -33,6 +33,24 @@ function InstanceRouteProbe() {
 }
 
 describe('useInstanceFilter', () => {
+  it('preserves the routed instance when instance discovery fails', async () => {
+    instanceServiceMocks.listInstances.mockRejectedValue(new Error('instance service unavailable'));
+
+    render(
+      <MemoryRouter initialEntries={['/instance/instance-route-1/topic']}>
+        <Routes>
+          <Route path="/instance/:instanceId/topic" element={<InstanceRouteProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('/instance/instance-route-1/topic|instance-route-1'),
+      ).toBeInTheDocument();
+    });
+  });
+
   it('replaces an unknown route instance with the first available instance', async () => {
     instanceServiceMocks.listInstances.mockResolvedValue([
       {

--- a/web/src/hooks/useInstanceFilter.ts
+++ b/web/src/hooks/useInstanceFilter.ts
@@ -38,6 +38,7 @@ export function useInstanceFilter() {
   const section = scopedMatch?.[2] ?? staticMatch?.[1] ?? 'topic';
 
   const [instances, setInstances] = useState<Instance[]>([]);
+  const [instanceDiscoveryFailed, setInstanceDiscoveryFailed] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -45,6 +46,7 @@ export function useInstanceFilter() {
       .then((nextInstances) => {
         if (cancelled) return;
         setInstances(nextInstances);
+        setInstanceDiscoveryFailed(false);
         const isKnownInstance = nextInstances.some((instance) => instance.id === routeInstanceId);
         if (nextInstances.length > 0 && !isKnownInstance) {
           navigate(`/instance/${nextInstances[0].id}/${section}`, { replace: true });
@@ -52,6 +54,7 @@ export function useInstanceFilter() {
       })
       .catch(() => {
         // 实例列表加载失败时不做实例过滤，保持页面数据可用
+        if (!cancelled) setInstanceDiscoveryFailed(true);
       });
     return () => {
       cancelled = true;
@@ -59,7 +62,8 @@ export function useInstanceFilter() {
   }, [navigate, routeInstanceId, section]);
 
   const selectedInstanceId =
-    routeInstanceId && instances.some((instance) => instance.id === routeInstanceId)
+    routeInstanceId &&
+    (instanceDiscoveryFailed || instances.some((instance) => instance.id === routeInstanceId))
       ? routeInstanceId
       : (instances[0]?.id ?? '');
   const selectedInstance = instances.find((instance) => instance.id === selectedInstanceId);


### PR DESCRIPTION
## Summary

- track whether shared instance discovery failed
- preserve the instance ID from an instance-scoped route when discovery is unavailable
- retain successful-discovery validation and unknown-route fallback behavior
- add a focused regression test for the failed-discovery path

## Root cause

`useInstanceFilter` only accepted a routed instance ID when it appeared in the discovered instance list. A failed `listInstances()` call left that list empty, so the hook discarded the explicit route context despite its documented fallback behavior.

## User impact

Instance-scoped Topic, Consumer, Message, ACL, DLQ, and Resource Plan pages can continue using their routed instance when the shared discovery endpoint is temporarily unavailable.

Closes #1595

## Validation

- `npm test -- --run src/hooks/useInstanceFilter.test.tsx` (3 tests passed)
- `npx eslint src/hooks/useInstanceFilter.ts src/hooks/useInstanceFilter.test.tsx --max-warnings=0`
- `npx prettier --check src/hooks/useInstanceFilter.ts src/hooks/useInstanceFilter.test.tsx`
- `npm run build`