### PR TITLE
fix: use Tencent topic count metadata

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -78,7 +78,19 @@ public class TencentInstanceProvider implements InstanceProvider {
 
     @Override
     public int countTopics(String instanceId) {
-        return listTopics(instanceId, null, null, false).size();
+        Context context = resolve(instanceId);
+        DescribeTopicListRequest request = new DescribeTopicListRequest();
+        request.setInstanceId(context.cloudInstanceId());
+        request.setOffset(0L);
+        request.setLimit(1L);
+        DescribeTopicListResponse response = clientFactory.call(context.credentialId(), context.regionId(),
+                client -> client.DescribeTopicList(request));
+        if (response == null || response.getData() == null || response.getData().length == 0) {
+            return 0;
+        }
+        // Use the response total count if available; otherwise fall back to full scan
+        Long total = response.getTotalCount();
+        return total != null ? Math.toIntExact(total) : listTopics(instanceId, null, null, false).size();
     }
 
     @Override


### PR DESCRIPTION
Avoid listing every Tencent topic only to calculate a count. `countTopics(...)` now requests a minimal page and uses the OpenAPI `TotalCount` value when it is available, with a safe fallback for missing metadata.

This fixes #1599. The empty-data response edge case and oversized-count behavior were later completed and tested in merged PR #2041.