### PR TITLE
[studio][ISSUE #1598] Roll back partial auth sessions

### DIFF
--- a/web/src/stores/authStorage.test.ts
+++ b/web/src/stores/authStorage.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   clearAuthSession,
   persistAuthSession,
@@ -34,6 +34,33 @@ describe('auth session storage', () => {
     persistAuthSession('token-1', 'studio-admin', true);
 
     expect(readAuthSession()).toEqual({ token: 'token-1', user: 'studio-admin', admin: true });
+  });
+
+  it('rolls back every session key when a later storage write fails', () => {
+    persistAuthSession('old-token', 'old-user', false);
+    const originalSetItem = Storage.prototype.setItem;
+    let writeCount = 0;
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+      this: Storage,
+      key: string,
+      value: string,
+    ) {
+      writeCount += 1;
+      if (writeCount === 2) {
+        throw new DOMException('Storage quota exceeded', 'QuotaExceededError');
+      }
+      originalSetItem.call(this, key, value);
+    });
+
+    try {
+      persistAuthSession('new-token', 'new-user', true);
+    } finally {
+      setItem.mockRestore();
+    }
+
+    expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(USER_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(USER_ADMIN_STORAGE_KEY)).toBeNull();
   });
 
   it('does not restore an orphaned user without a token', () => {

--- a/web/src/stores/authStorage.ts
+++ b/web/src/stores/authStorage.ts
@@ -45,7 +45,8 @@ export function persistAuthSession(token: string, user: string, admin: boolean):
     localStorage.setItem(USER_STORAGE_KEY, user);
     localStorage.setItem(USER_ADMIN_STORAGE_KEY, String(admin));
   } catch {
-    // The in-memory store remains usable when browser storage is unavailable.
+    // Roll back a partially written browser session. The in-memory store remains usable.
+    clearAuthSession();
   }
 }
 


### PR DESCRIPTION
## Summary
- clear every persisted authentication key if a later localStorage write fails
- prevent a new token from being paired with stale user or admin metadata
- cover partial-write rollback with a quota failure regression test

## Root cause and impact
The session was persisted through three independent localStorage writes, but failures after the first write were swallowed. A quota or browser-storage failure could therefore leave a partial session that was restored on the next page load. The rollback keeps the in-memory login usable while ensuring no inconsistent browser session survives.

Closes #1598

## Validation
- npm test -- --run src/stores/authStorage.test.ts (5 passed)
- npm run lint -- src/stores/authStorage.ts src/stores/authStorage.test.ts
- npm run build
- git diff --check