### PR TITLE
[studio][ISSUE #1603] Reset unavailable metrics sources

### DIFF
--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -384,12 +384,15 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
 
   useEffect(() => {
     if (dataSourceKey && !availableDataSources.some((source) => source.key === dataSourceKey)) {
-      window.setTimeout(() => {
+      const timeoutId = window.setTimeout(() => {
+        dataSourceKeyRef.current = '';
         setDataSourceKey('');
         setData(null);
+        void loadMetrics(selectedMetric, selectedRange);
       }, 0);
+      return () => window.clearTimeout(timeoutId);
     }
-  }, [availableDataSources, dataSourceKey]);
+  }, [availableDataSources, dataSourceKey, loadMetrics, selectedMetric, selectedRange]);
 
   return (
     <section aria-labelledby="metrics-explorer-title" style={{ marginTop: 24 }}>

--- a/web/src/components/__tests__/MetricsExplorer.test.tsx
+++ b/web/src/components/__tests__/MetricsExplorer.test.tsx
@@ -310,4 +310,44 @@ describe('MetricsExplorer', () => {
     expect(screen.getByText('Instance A Prometheus')).toBeInTheDocument();
     expect(screen.queryByText('Instance B Prometheus')).not.toBeInTheDocument();
   });
+
+  it('falls back to the default source when the selected source is unavailable for a new instance', async () => {
+    vi.mocked(listDataSources).mockResolvedValue([
+      {
+        key: 'ds-instance-a',
+        name: 'Instance A Prometheus',
+        type: 'Prometheus',
+        url: '',
+        auth: 'None',
+        status: 'healthy',
+        instanceIds: ['instance-a'],
+      },
+    ]);
+
+    const user = userEvent.setup();
+    const { rerender } = renderWithProviders(<MetricsExplorer instanceId="instance-a" />);
+
+    await user.click(await screen.findByRole('combobox', { name: '数据源' }));
+    await user.click(
+      await screen.findByText('Instance A Prometheus', {
+        selector: '.ant-select-item-option-content',
+      }),
+    );
+    await waitFor(() => expect(queryByDataSource).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <App>
+        <LangProvider>
+          <MetricsExplorer instanceId="instance-b" />
+        </LangProvider>
+      </App>,
+    );
+
+    await waitFor(() => expect(queryMetrics).toHaveBeenCalledTimes(2));
+    expect(queryByDataSource).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: '刷新指标' }));
+    await waitFor(() => expect(queryMetrics).toHaveBeenCalledTimes(3));
+    expect(queryByDataSource).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- reset the Metrics Explorer internal data-source reference when an instance switch makes the selected source unavailable
- reload the selected metric through the default source immediately after fallback
- cancel the scheduled fallback during effect cleanup
- cover instance-scoped source fallback and subsequent refreshes with a regression test

## Root cause and impact
The availability effect cleared only the rendered `dataSourceKey` state. The stable ref used by the query callback retained the previous instance's source key, so the selector appeared to use the default source while refreshes continued querying the unavailable source. Keeping the state and ref synchronized prevents cross-instance metrics requests.

Closes #1603

## Validation
- npm test -- --run src/components/__tests__/MetricsExplorer.test.tsx (9 passed)
- npx eslint src/components/MetricsExplorer.tsx src/components/__tests__/MetricsExplorer.test.tsx
- npm run build
- git diff --check