### PR TITLE
fix: paginate Tencent topic subscriptions

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -206,23 +206,27 @@ public class TencentInstanceProvider implements InstanceProvider {
     public List<TopicConsumerVO> getTopicConsumers(String instanceId, String topicName) {
         Context context = resolve(instanceId);
         requireTopicName(topicName);
-        DescribeTopicRequest request = new DescribeTopicRequest();
-        request.setInstanceId(context.cloudInstanceId());
-        request.setTopic(topicName);
-        request.setOffset(0L);
-        request.setLimit((long) CONSUMER_PAGE_SIZE);
-        DescribeTopicResponse response = clientFactory.call(context.credentialId(), context.regionId(),
-                client -> client.DescribeTopic(request));
-        SubscriptionData[] data = response == null ? null : response.getSubscriptionData();
         List<TopicConsumerVO> consumers = new ArrayList<>();
-        if (data == null) {
-            return consumers;
-        }
-        for (SubscriptionData subscription : data) {
-            if (subscription == null) {
-                continue;
+        for (int page = 0; page < MAX_PAGES; page++) {
+            DescribeTopicRequest request = new DescribeTopicRequest();
+            request.setInstanceId(context.cloudInstanceId());
+            request.setTopic(topicName);
+            request.setOffset((long) page * CONSUMER_PAGE_SIZE);
+            request.setLimit((long) CONSUMER_PAGE_SIZE);
+            DescribeTopicResponse response = clientFactory.call(context.credentialId(), context.regionId(),
+                    client -> client.DescribeTopic(request));
+            SubscriptionData[] data = response == null ? null : response.getSubscriptionData();
+            if (data == null || data.length == 0) {
+                break;
             }
-            consumers.add(toTopicConsumer(subscription));
+            for (SubscriptionData subscription : data) {
+                if (subscription != null) {
+                    consumers.add(toTopicConsumer(subscription));
+                }
+            }
+            if (data.length < CONSUMER_PAGE_SIZE) {
+                break;
+            }
         }
         return consumers;
     }


### PR DESCRIPTION
This PR attempted to paginate `getTopicConsumers(...)`, but the same fix had already landed in merged PR #1584 with a stronger stop condition based on `SubscriptionCount` as well as short pages.

It was closed as a duplicate instead of being rebased. The full-final-page edge case was later added to the merged regression coverage in #2041.