### PR TITLE
[ISSUE #1613] Tolerate unavailable storage in AI chat

### DIFF
--- a/web/src/api/ai.test.ts
+++ b/web/src/api/ai.test.ts
@@ -57,6 +57,25 @@ describe('AI API', () => {
   });
 
   describe('chatStream (SSE)', () => {
+    it('continues without auth when browser storage is unavailable', async () => {
+      vi.mocked(localStorage.getItem).mockImplementation(() => {
+        throw new DOMException('storage disabled', 'SecurityError');
+      });
+      const fetchMock = vi.fn().mockResolvedValue(streamResponse(['data: [DONE]\n\n']));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        chatStream({ message: 'hello', mode: 'chat', model: 'stub' }, vi.fn()),
+      ).resolves.toBeUndefined();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/ai/chat',
+        expect.objectContaining({
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
     it('reassembles an event split across network chunks', async () => {
       vi.stubGlobal(
         'fetch',

--- a/web/src/api/ai.ts
+++ b/web/src/api/ai.ts
@@ -16,6 +16,7 @@
  */
 
 import client from './client';
+import { readAuthSession } from '../stores/authStorage';
 
 // ─── Types ──────────────────────────────────────────────────────
 export interface McpTool {
@@ -158,11 +159,12 @@ export async function chatStream(
   signal?: AbortSignal,
   onEnhance?: (prompt: string) => void,
 ) {
+  const token = readAuthSession().token;
   const response = await fetch('/api/ai/chat', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${localStorage.getItem('token') || ''}`,
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     body: JSON.stringify(data),
     signal,


### PR DESCRIPTION
## Summary
- read the chat token through the safe auth-session helper
- omit Authorization when storage cannot provide a token
- cover a storage `SecurityError` while SSE still proceeds

## Validation
- `npm test -- --run src/api/ai.test.ts`
- combined frontend build: `npm run build`

Fixes #1613