### PR TITLE
[ISSUE #1614] Keep Proxy discovery independent of browser storage

### DIFF
--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -53,6 +53,15 @@ import { queryProxyHomePage, addProxyAddr, removeProxyAddr, type ProxyNode } fro
 
 const { Text } = Typography;
 
+const persistProxyAddress = (address?: string) => {
+  if (!address) return;
+  try {
+    localStorage.setItem('proxyAddr', address);
+  } catch {
+    // Proxy discovery remains usable when browser storage is unavailable.
+  }
+};
+
 const ProxyPage: React.FC = () => {
   const { t } = useLang();
   const { message } = App.useApp();
@@ -99,11 +108,7 @@ const ProxyPage: React.FC = () => {
         totalTPS: null,
       });
 
-      if (currentProxyAddr) {
-        localStorage.setItem('proxyAddr', currentProxyAddr);
-      } else if (proxyAddrList && proxyAddrList.length > 0) {
-        localStorage.setItem('proxyAddr', proxyAddrList[0]);
-      }
+      persistProxyAddress(currentProxyAddr || proxyAddrList?.[0]);
       return true;
     } catch {
       if (requestId !== loadRequestId.current) return false;

--- a/web/src/pages/studio/__tests__/Proxy.test.tsx
+++ b/web/src/pages/studio/__tests__/Proxy.test.tsx
@@ -74,6 +74,19 @@ describe('ProxyPage', () => {
     vi.mocked(queryProxyHomePage).mockResolvedValue(proxyHome);
   });
 
+  it('keeps discovered nodes when browser storage is unavailable', async () => {
+    const storageSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('storage disabled', 'SecurityError');
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('127.0.0.1:8081')).toBeInTheDocument();
+    expect(screen.queryByText('获取代理列表失败')).not.toBeInTheDocument();
+    expect(queryProxyHomePage).toHaveBeenCalledTimes(1);
+    storageSpy.mockRestore();
+  });
+
   it('loads Proxy nodes once after the page mounts', async () => {
     renderPage();
 


### PR DESCRIPTION
## Summary
- move Proxy address persistence behind a best-effort helper
- keep successful discovery and refresh results when storage throws
- add a restricted-storage regression test

## Validation
- `npm test -- --run src/pages/studio/__tests__/Proxy.test.tsx`
- combined frontend build: `npm run build`

Fixes #1614