### PR TITLE
[ISSUE #1616] Prevent duplicate instance submissions

### DIFF
--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -157,6 +157,30 @@ describe('InstancePage', () => {
     expect(screen.getByText('latest-instance')).toBeInTheDocument();
   });
 
+  it('ignores duplicate create submissions while the first request is pending', async () => {
+    const user = userEvent.setup();
+    vi.mocked(instanceService.createInstance).mockImplementation(() => new Promise(() => {}));
+    renderPage();
+
+    expect(await screen.findByText('production-proxy')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /添加实例/ }));
+    const dialog = await screen.findByRole('dialog');
+    await user.type(within(dialog).getByLabelText('实例名称'), 'new-proxy');
+    const createTypeSelect = within(dialog).getByRole('combobox');
+    fireEvent.mouseDown(createTypeSelect.parentElement!);
+    const proxyOptions = await screen.findAllByText('Proxy 模式', {
+      selector: '.ant-select-item-option-content',
+    });
+    await user.click(proxyOptions[proxyOptions.length - 1]);
+    await user.type(within(dialog).getByLabelText('接入地址'), 'proxy-new:8080');
+    const connect = within(dialog).getByRole('button', { name: /连\s*接/ });
+
+    fireEvent.click(connect);
+    fireEvent.click(connect);
+
+    await waitFor(() => expect(instanceService.createInstance).toHaveBeenCalledTimes(1));
+  });
+
   it('reloads the current filters after creating an instance', async () => {
     const user = userEvent.setup();
     vi.mocked(instanceService.createInstance).mockResolvedValue(instance('created', 'new-proxy'));

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -98,6 +98,7 @@ const InstancePage = () => {
   const [editForm] = Form.useForm();
   const [submitting, setSubmitting] = useState(false);
   const requestIdRef = useRef(0);
+  const mutationInFlightRef = useRef(false);
 
   useEffect(() => {
     const timer = window.setTimeout(() => setDebouncedSearch(search.trim()), 300);
@@ -211,6 +212,8 @@ const InstancePage = () => {
   };
 
   const handleCreate = async () => {
+    if (mutationInFlightRef.current) return;
+    mutationInFlightRef.current = true;
     try {
       const values = await addForm.validateFields();
       setSubmitting(true);
@@ -236,12 +239,14 @@ const InstancePage = () => {
       }
       message.error('添加实例失败，请稍后重试');
     } finally {
+      mutationInFlightRef.current = false;
       setSubmitting(false);
     }
   };
 
   const handleUpdate = async () => {
-    if (!editingInstance) return;
+    if (!editingInstance || mutationInFlightRef.current) return;
+    mutationInFlightRef.current = true;
     try {
       const values = await editForm.validateFields();
       setSubmitting(true);
@@ -256,6 +261,7 @@ const InstancePage = () => {
       }
       message.error('更新实例失败，请稍后重试');
     } finally {
+      mutationInFlightRef.current = false;
       setSubmitting(false);
     }
   };


### PR DESCRIPTION
## Summary
- serialize instance create and update modal mutations
- acquire the guard before asynchronous form validation
- verify rapid create confirmations issue one request

## Validation
- `npm test -- --run src/pages/instance/__tests__/InstancePage.test.tsx`
- combined frontend build: `npm run build`

Fixes #1616