### PR TITLE
[ISSUE #1617] Prevent duplicate K8s certificate saves

### DIFF
--- a/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
@@ -16,11 +16,11 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App, Modal } from 'antd';
 import type { K8sCertInfo } from '../../../api/cluster';
-import { listK8sCerts, renewK8sCert } from '../../../services/clusterService';
+import { createK8sCert, listK8sCerts, renewK8sCert } from '../../../services/clusterService';
 import K8sCertsPage from '../certs';
 
 vi.mock('../../../services/clusterService', () => ({
@@ -89,6 +89,26 @@ describe('K8sCertsPage', () => {
         <K8sCertsPage />
       </App>,
     );
+
+  it('ignores duplicate certificate saves while the first request is pending', async () => {
+    vi.mocked(createK8sCert).mockImplementation(() => new Promise(() => {}));
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('rocketmq-prod-tls');
+    await user.click(screen.getByRole('button', { name: /添加证书/ }));
+    const dialog = await screen.findByRole('dialog');
+    await user.type(within(dialog).getByLabelText('证书名称'), 'new-cert');
+    await user.type(within(dialog).getByLabelText('K8s 集群名称'), 'prod');
+    await user.type(within(dialog).getByLabelText('签发者'), 'test-ca');
+    const save = within(dialog).getByRole('button', { name: /保\s*存/ });
+
+    fireEvent.click(save);
+    fireEvent.click(save);
+
+    await waitFor(() => expect(createK8sCert).toHaveBeenCalledTimes(1));
+    expect(dialog).toBeInTheDocument();
+  });
 
   it('displays certificate namespace and SAN metadata', async () => {
     renderPage();

--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Table,
   Tag,
@@ -58,6 +58,7 @@ const K8sCertsPage = () => {
   const [certs, setCerts] = useState<K8sCertInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
+  const saveInFlightRef = useRef(false);
   const [renewingIds, setRenewingIds] = useState<Set<string>>(() => new Set());
   const [certSearch, setCertSearch] = useState('');
   const [certTypeFilter, setCertTypeFilter] = useState<string>('');
@@ -97,23 +98,25 @@ const K8sCertsPage = () => {
   };
 
   const saveCert = async () => {
-    const values = await editForm.validateFields();
-    const data = {
-      name: values.name,
-      namespace: values.namespace,
-      cluster: values.cluster,
-      type: values.type,
-      issuer: values.issuer,
-      san: values.san
-        ? String(values.san)
-            .split(',')
-            .map((value) => value.trim())
-            .filter(Boolean)
-        : [],
-    };
-
-    setSubmitting(true);
+    if (saveInFlightRef.current) return;
+    saveInFlightRef.current = true;
     try {
+      const values = await editForm.validateFields();
+      const data = {
+        name: values.name,
+        namespace: values.namespace,
+        cluster: values.cluster,
+        type: values.type,
+        issuer: values.issuer,
+        san: values.san
+          ? String(values.san)
+              .split(',')
+              .map((value) => value.trim())
+              .filter(Boolean)
+          : [],
+      };
+
+      setSubmitting(true);
       if (editingCert) {
         const updated = await updateK8sCert({ id: editingCert.id, ...data });
         setCerts((prev) => prev.map((cert) => (cert.id === updated.id ? updated : cert)));
@@ -127,6 +130,7 @@ const K8sCertsPage = () => {
     } catch (error) {
       message.error(getErrorMessage(error));
     } finally {
+      saveInFlightRef.current = false;
       setSubmitting(false);
     }
   };


### PR DESCRIPTION
## Summary
- acquire a certificate save guard before validation
- release the guard consistently after create, update, validation, or failure
- add a pending-request double-confirm regression test

## Validation
- `npm test -- --run src/pages/cluster/__tests__/K8sCertsPage.test.tsx`
- combined frontend build: `npm run build`

Fixes #1617