### PR TITLE
[ISSUE #1618] Serialize NameServer mutations

### DIFF
--- a/web/src/pages/studio/Ops.tsx
+++ b/web/src/pages/studio/Ops.tsx
@@ -42,8 +42,10 @@ const OpsPage: React.FC = () => {
   const [newNamesrvAddr, setNewNamesrvAddr] = useState('');
   const [useVIPChannel, setUseVIPChannel] = useState(false);
   const [useTLS, setUseTLS] = useState(false);
+  const [namesrvUpdating, setNamesrvUpdating] = useState(false);
   const [vipUpdating, setVipUpdating] = useState(false);
   const [tlsUpdating, setTlsUpdating] = useState(false);
+  const namesrvMutationInFlight = useRef(false);
   const vipUpdateInFlight = useRef(false);
   const tlsUpdateInFlight = useRef(false);
   const [configurationAvailable, setConfigurationAvailable] = useState(false);
@@ -82,20 +84,29 @@ const OpsPage: React.FC = () => {
   }, [fetchFailedMessage, message]);
 
   const handleUpdateNameSvrAddr = async () => {
+    if (namesrvMutationInFlight.current) return;
     if (!selectedNamesrv) {
       message.warning(t('ops.selectNamesrv'));
       return;
     }
+    namesrvMutationInFlight.current = true;
+    setNamesrvUpdating(true);
     try {
       await updateNameSvrAddr(selectedNamesrv);
       setCurrentNamesrv(selectedNamesrv);
       message.success(t('common.success'));
     } catch {
       message.error(t('common.failure'));
+    } finally {
+      namesrvMutationInFlight.current = false;
+      setNamesrvUpdating(false);
     }
   };
 
   const handleDeleteNameSvrAddr = async () => {
+    if (namesrvMutationInFlight.current) return;
+    namesrvMutationInFlight.current = true;
+    setNamesrvUpdating(true);
     try {
       await deleteNameSvrAddr(selectedNamesrv);
       setNamesrvAddrList((addresses) => addresses.filter((addr) => addr !== selectedNamesrv));
@@ -103,15 +114,21 @@ const OpsPage: React.FC = () => {
       message.success(t('common.success'));
     } catch {
       message.error(t('common.failure'));
+    } finally {
+      namesrvMutationInFlight.current = false;
+      setNamesrvUpdating(false);
     }
   };
 
   const handleAddNameSvrAddr = async () => {
+    if (namesrvMutationInFlight.current) return;
     const addr = newNamesrvAddr.trim();
     if (!addr) {
       message.warning(t('ops.inputNamesrvAddr'));
       return;
     }
+    namesrvMutationInFlight.current = true;
+    setNamesrvUpdating(true);
     try {
       await addNameSvrAddr(addr);
       if (!namesrvAddrList.includes(addr)) {
@@ -121,6 +138,9 @@ const OpsPage: React.FC = () => {
       message.success(t('common.success'));
     } catch {
       message.error(t('common.failure'));
+    } finally {
+      namesrvMutationInFlight.current = false;
+      setNamesrvUpdating(false);
     }
   };
 
@@ -177,7 +197,7 @@ const OpsPage: React.FC = () => {
             style={{ minWidth: 400, maxWidth: 500 }}
             value={selectedNamesrv || undefined}
             onChange={setSelectedNamesrv}
-            disabled={!writeOperationEnabled}
+            disabled={!writeOperationEnabled || namesrvUpdating}
             placeholder={t('ops.selectNamesrv')}
             options={namesrvAddrList.map((addr) => ({ label: addr, value: addr }))}
           />
@@ -186,6 +206,8 @@ const OpsPage: React.FC = () => {
               type="primary"
               icon={<FloppyDisk size={16} />}
               onClick={handleUpdateNameSvrAddr}
+              loading={namesrvUpdating}
+              disabled={namesrvUpdating}
             >
               {t('common.update')}
             </Button>
@@ -196,14 +218,14 @@ const OpsPage: React.FC = () => {
               onConfirm={handleDeleteNameSvrAddr}
               okText={t('common.confirm')}
               cancelText={t('common.cancel')}
-              disabled={deleteNameServerDisabled}
+              disabled={deleteNameServerDisabled || namesrvUpdating}
             >
               <Tooltip title={t('common.delete')}>
                 <Button
                   danger
                   aria-label={t('common.delete')}
                   icon={<Trash size={16} />}
-                  disabled={deleteNameServerDisabled}
+                  disabled={deleteNameServerDisabled || namesrvUpdating}
                 />
               </Tooltip>
             </Popconfirm>
@@ -215,8 +237,15 @@ const OpsPage: React.FC = () => {
                 placeholder="NamesrvAddr"
                 value={newNamesrvAddr}
                 onChange={(e) => setNewNamesrvAddr(e.target.value)}
+                disabled={namesrvUpdating}
               />
-              <Button type="primary" icon={<Plus size={16} />} onClick={handleAddNameSvrAddr}>
+              <Button
+                type="primary"
+                icon={<Plus size={16} />}
+                onClick={handleAddNameSvrAddr}
+                loading={namesrvUpdating}
+                disabled={namesrvUpdating}
+              >
                 {t('common.add')}
               </Button>
             </Space.Compact>

--- a/web/src/pages/studio/__tests__/Ops.test.tsx
+++ b/web/src/pages/studio/__tests__/Ops.test.tsx
@@ -22,7 +22,7 @@ import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
 import OpsPage from '../Ops';
-import { deleteNameSvrAddr, queryOpsHomePage, updateIsVIPChannel } from '../../../api/ops';
+import { addNameSvrAddr, deleteNameSvrAddr, queryOpsHomePage, updateIsVIPChannel } from '../../../api/ops';
 import useAuthStore from '../../../stores/authStore';
 
 vi.mock('../../../api/ops', () => ({
@@ -83,6 +83,20 @@ describe('OpsPage', () => {
     expect(await screen.findByText('127.0.0.1:9876')).toBeInTheDocument();
     expect(screen.getAllByRole('switch')[0]).toBeChecked();
     expect(screen.getAllByRole('switch')[1]).not.toBeChecked();
+  });
+
+  it('prevents overlapping NameServer mutations', async () => {
+    vi.mocked(addNameSvrAddr).mockImplementation(() => new Promise(() => {}));
+    renderWithProviders(<OpsPage />);
+
+    const input = await screen.findByPlaceholderText('NamesrvAddr');
+    fireEvent.change(input, { target: { value: '127.0.0.3:9876' } });
+    const addButton = screen.getByRole('button', { name: /新增|添加/ });
+    fireEvent.click(addButton);
+    fireEvent.click(addButton);
+
+    await waitFor(() => expect(addNameSvrAddr).toHaveBeenCalledTimes(1));
+    expect(addButton).toBeDisabled();
   });
 
   it('prevents overlapping VIP channel updates', async () => {


### PR DESCRIPTION
## Summary
- share an immediate guard across NameServer add, update, and delete
- disable related controls while a mutation is active
- retain independent VIP and TLS update handling

## Validation
- `npm test -- --run src/pages/studio/__tests__/Ops.test.tsx`
- combined frontend build: `npm run build`

Fixes #1618