### PR TITLE
[ISSUE #1622] Guard concurrent ACL admin toggles

### DIFF
--- a/web/src/pages/instance/__tests__/AclPage.test.tsx
+++ b/web/src/pages/instance/__tests__/AclPage.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { App } from 'antd';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -209,6 +209,21 @@ describe('ACL page', () => {
     });
     expect(payload).not.toHaveProperty('accessKey');
     expect(payload).not.toHaveProperty('secretKey');
+  });
+
+  it('ignores duplicate admin toggles while an update is pending', async () => {
+    vi.mocked(aclService.updateAclUser).mockImplementation(() => new Promise(() => {}));
+    const user = userEvent.setup();
+    renderWithProviders(<AclPage />);
+
+    await user.click(await screen.findByText('用户管理'));
+    expect(await screen.findByText('remote-admin')).toBeInTheDocument();
+    const adminSwitch = screen.getByRole('switch');
+    fireEvent.click(adminSwitch);
+    fireEvent.click(adminSwitch);
+
+    await waitFor(() => expect(aclService.updateAclUser).toHaveBeenCalledTimes(1));
+    expect(adminSwitch).toBeDisabled();
   });
 
   it('does not submit masked credentials when toggling admin', async () => {

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Table,
   Card,
@@ -122,6 +122,8 @@ const AclPage = () => {
 
   // Secret key reveal
   const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set());
+  const [adminUpdatingIds, setAdminUpdatingIds] = useState<Set<string>>(() => new Set());
+  const adminUpdateInFlightRef = useRef<Set<string>>(new Set());
   const [credentialsByUser, setCredentialsByUser] = useState<
     Record<string, { accessKey: string; secretKey: string }>
   >({});
@@ -338,6 +340,9 @@ const AclPage = () => {
   };
 
   const handleToggleAdmin = async (user: AclUser, checked: boolean) => {
+    if (adminUpdateInFlightRef.current.has(user.id)) return;
+    adminUpdateInFlightRef.current.add(user.id);
+    setAdminUpdatingIds((current) => new Set(current).add(user.id));
     try {
       const updated = await updateAclUser({
         id: user.id,
@@ -350,6 +355,13 @@ const AclPage = () => {
       message.success(checked ? t('acl.adminSet') : t('acl.adminRemoved'));
     } catch {
       message.error(t('common.operationFailed'));
+    } finally {
+      adminUpdateInFlightRef.current.delete(user.id);
+      setAdminUpdatingIds((current) => {
+        const next = new Set(current);
+        next.delete(user.id);
+        return next;
+      });
     }
   };
 
@@ -574,6 +586,8 @@ const AclPage = () => {
         <Switch
           checked={val}
           size="small"
+          loading={adminUpdatingIds.has(record.id)}
+          disabled={adminUpdatingIds.has(record.id)}
           onChange={(checked) => handleToggleAdmin(record, checked)}
         />
       ),


### PR DESCRIPTION
## Summary
- track in-flight admin updates per ACL user
- block duplicate writes for one row without blocking other users
- expose row-local loading and disabled feedback

## Validation
- `npm test -- --run src/pages/instance/__tests__/AclPage.test.tsx`
- combined frontend build: `npm run build`

Fixes #1622