### PR TITLE
[studio][ISSUE #1607] Ignore stale alert rule refreshes

### DIFF
--- a/web/src/pages/studio/AlertManagement.tsx
+++ b/web/src/pages/studio/AlertManagement.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   App,
   Badge,
@@ -288,17 +288,24 @@ const AlertManagementPage: React.FC = () => {
   const [filterSeverity, setFilterSeverity] = useState('all');
   const [filterStatus, setFilterStatus] = useState('all');
   const [selectedRuleKeys, setSelectedRuleKeys] = useState<React.Key[]>([]);
+  const loadRequestId = useRef(0);
+
+  const invalidateRuleLoads = () => {
+    loadRequestId.current += 1;
+    setLoading(false);
+  };
 
   useEffect(() => {
     let cancelled = false;
 
     const loadRules = async () => {
-      if (!cancelled) {
+      const requestId = ++loadRequestId.current;
+      if (!cancelled && requestId === loadRequestId.current) {
         setLoading(true);
       }
       try {
         const loadedRules = await loadAlertRuleRows();
-        if (!cancelled) {
+        if (!cancelled && requestId === loadRequestId.current) {
           const enabledRuleKeys = new Set<React.Key>(
             loadedRules.filter((rule) => rule.enabled).map((rule) => rule.key),
           );
@@ -308,11 +315,11 @@ const AlertManagementPage: React.FC = () => {
           );
         }
       } catch {
-        if (!cancelled) {
+        if (!cancelled && requestId === loadRequestId.current) {
           message.error(fetchFailedMessage);
         }
       } finally {
-        if (!cancelled) {
+        if (!cancelled && requestId === loadRequestId.current) {
           setLoading(false);
         }
       }
@@ -322,22 +329,25 @@ const AlertManagementPage: React.FC = () => {
 
     return () => {
       cancelled = true;
+      loadRequestId.current += 1;
     };
   }, [fetchFailedMessage, message]);
 
   const fetchAlertRules = async () => {
+    const requestId = ++loadRequestId.current;
     setLoading(true);
     try {
       const loadedRules = await loadAlertRuleRows();
+      if (requestId !== loadRequestId.current) return;
       const enabledRuleKeys = new Set<React.Key>(
         loadedRules.filter((rule) => rule.enabled).map((rule) => rule.key),
       );
       setAlertRules(loadedRules);
       setSelectedRuleKeys((currentKeys) => currentKeys.filter((key) => enabledRuleKeys.has(key)));
     } catch {
-      message.error(t('alertMgmt.fetchFailed'));
+      if (requestId === loadRequestId.current) message.error(t('alertMgmt.fetchFailed'));
     } finally {
-      setLoading(false);
+      if (requestId === loadRequestId.current) setLoading(false);
     }
   };
 
@@ -348,6 +358,7 @@ const AlertManagementPage: React.FC = () => {
     }
     try {
       const updated = await toggleAlertRule(rule.id, enabled);
+      invalidateRuleLoads();
       const nextRule = toUiRule(updated, rule.index - 1);
       setAlertRules((rules) => rules.map((item) => (item.key === rule.key ? nextRule : item)));
       setSelectedRuleKeys((keys) => (enabled ? keys : keys.filter((key) => key !== rule.key)));
@@ -389,6 +400,7 @@ const AlertManagementPage: React.FC = () => {
     }
     try {
       await deleteAlertRule(rule.id);
+      invalidateRuleLoads();
       setAlertRules((rules) =>
         rules
           .filter((item) => item.key !== rule.key)
@@ -411,6 +423,7 @@ const AlertManagementPage: React.FC = () => {
           return;
         }
         const updated = await updateAlertRule(request);
+        invalidateRuleLoads();
         const nextRule = toUiRule(updated, editingRule.index - 1);
         setAlertRules((rules) =>
           rules.map((rule) => (rule.key === editingRule.key ? nextRule : rule)),
@@ -418,6 +431,7 @@ const AlertManagementPage: React.FC = () => {
         message.success(t('alertMgmt.updateSuccess'));
       } else {
         const created = await createAlertRule(request);
+        invalidateRuleLoads();
         setAlertRules((rules) =>
           [toUiRule(created, 0), ...rules].map((rule, index) => ({ ...rule, index: index + 1 })),
         );

--- a/web/src/pages/studio/__tests__/AlertManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/AlertManagement.test.tsx
@@ -17,7 +17,7 @@
 
 import type { ReactElement } from 'react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
@@ -115,6 +115,14 @@ const renderWithProviders = (ui: ReactElement) => {
       <LangProvider>{ui}</LangProvider>
     </App>,
   );
+};
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 };
 
 describe('AlertManagementPage', () => {
@@ -233,6 +241,30 @@ describe('AlertManagementPage', () => {
       expect(toggleAlertRule).toHaveBeenCalledWith('rule-broker-down', false);
     });
     expect(await screen.findByText('告警规则已更新')).toBeInTheDocument();
+  });
+
+  it('does not let a stale refresh overwrite a completed rule toggle', async () => {
+    const staleRefresh = createDeferred<typeof alertRules>();
+    vi.mocked(listAlertRules)
+      .mockResolvedValueOnce(alertRules)
+      .mockReturnValueOnce(staleRefresh.promise);
+    renderWithProviders(<AlertManagementPage />);
+
+    const brokerRule = await screen.findByText('BrokerDown');
+    const brokerRow = brokerRule.closest('tr');
+    expect(brokerRow).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /刷新/ }));
+    await waitFor(() => expect(listAlertRules).toHaveBeenCalledTimes(2));
+    fireEvent.click(within(brokerRow!).getByRole('switch'));
+
+    await waitFor(() => expect(within(brokerRow!).getByRole('switch')).not.toBeChecked());
+
+    await act(async () => {
+      staleRefresh.resolve(alertRules);
+      await staleRefresh.promise;
+    });
+    expect(within(brokerRow!).getByRole('switch')).not.toBeChecked();
   });
 
   it('creates a persisted alert rule from the editor modal', async () => {


### PR DESCRIPTION
## Summary
- version both mount-time and manual alert-rule loads
- ignore list responses that were superseded by a completed mutation
- invalidate older snapshots after successful toggle, create, update, and delete operations
- cover an out-of-order refresh and toggle with a regression test

## Root cause and impact
Alert-rule list requests applied their response unconditionally. Because mutations remain available while a refresh is pending, an older server snapshot could arrive after a successful mutation and visually restore the previous rule state. Request generations ensure a completed mutation remains authoritative until a newer explicit refresh.

Closes #1607

## Validation
- npm test -- --run src/pages/studio/__tests__/AlertManagement.test.tsx (10 passed)
- npx eslint src/pages/studio/AlertManagement.tsx src/pages/studio/__tests__/AlertManagement.test.tsx
- npm run build
- git diff --check