### PR TITLE
feat(tencent): support message query and trace on Tencent Cloud RocketMQ 5.x instances

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>com.tencentcloudapi</groupId>
             <artifactId>tencentcloud-sdk-java-trocket</artifactId>
-            <version>3.1.1292</version>
+            <version>3.1.1498</version>
         </dependency>
         <!-- rocketmq-common also brings Kotlin-based okio-jvm 3.x; keep its runtime available. -->
         <dependency>

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageController.java
@@ -46,7 +46,8 @@ public class MessageController {
     }
 
     @GetMapping("/{msgId}/trace")
-    public Result<TraceRecordVO> getMessageTrace(@PathVariable String msgId, @RequestParam String instanceId) {
-        return Result.ok(messageService.getMessageTrace(instanceId, msgId));
+    public Result<TraceRecordVO> getMessageTrace(@PathVariable String msgId, @RequestParam String instanceId,
+                                                 @RequestParam(required = false) String topic) {
+        return Result.ok(messageService.getMessageTrace(instanceId, msgId, topic));
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageController.java
@@ -47,6 +47,8 @@ public class MessageController {
 
     @GetMapping("/{msgId}/trace")
     public Result<TraceRecordVO> getMessageTrace(@PathVariable String msgId, @RequestParam String instanceId,
+                                                 // Optional for the Apache/Aliyun providers; the Tencent
+                                                 // provider requires a non-empty topic (DescribeMessageTrace).
                                                  @RequestParam(required = false) String topic) {
         return Result.ok(messageService.getMessageTrace(instanceId, msgId, topic));
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProvider.java
@@ -23,5 +23,5 @@ public interface MessageProvider {
     List<MessageRecordVO> queryMessages(String instanceId, String topic, String msgId, String tag, String key, Long startTime,
                                         Long endTime);
 
-    TraceRecordVO getMessageTrace(String instanceId, String msgId);
+    TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProviderStub.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProviderStub.java
@@ -36,7 +36,7 @@ public class MessageProviderStub implements MessageProvider {
     }
 
     @Override
-    public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
+    public TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic) {
         log.warn("MessageProviderStub.getMessageTrace called but no real message provider is configured");
         throw unsupported();
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -44,14 +44,14 @@ public class MessageService {
                 .orElseGet(() -> messageProvider.queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime));
     }
 
-    public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
+    public TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic) {
         if (!StringUtils.hasText(msgId)) {
             throw new BusinessException(400, "msgId is required");
         }
-        log.info("Getting message trace: msgId={}", msgId);
+        log.info("Getting message trace: msgId={}, topic={}", msgId, topic);
         return providerRegistry.byInstanceId(instanceId)
-                .map(provider -> provider.getMessageTrace(instanceId, msgId))
-                .orElseGet(() -> messageProvider.getMessageTrace(instanceId, msgId));
+                .map(provider -> provider.getMessageTrace(instanceId, msgId, topic))
+                .orElseGet(() -> messageProvider.getMessageTrace(instanceId, msgId, topic));
     }
 
     private void validateTopicQueryWindow(String topic, String msgId, String key, Long startTime, Long endTime) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
@@ -79,5 +79,5 @@ public interface InstanceProvider {
     List<MessageRecordVO> queryMessages(String instanceId, String topic, String msgId,
                                         String tag, String key, Long startTime, Long endTime);
 
-    TraceRecordVO getMessageTrace(String instanceId, String msgId);
+    TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
@@ -430,7 +430,7 @@ public class AliyunInstanceProvider implements InstanceProvider {
     }
 
     @Override
-    public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
+    public TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic) {
         Context ctx = resolve(instanceId);
         GetTraceRequest request = GetTraceRequest.builder()
                 .instanceId(ctx.cloudInstanceId())

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
@@ -131,8 +131,8 @@ public class ApacheInstanceProvider implements InstanceProvider {
     }
 
     @Override
-    public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
-        return messageProvider.getMessageTrace(instanceId, msgId);
+    public TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic) {
+        return messageProvider.getMessageTrace(instanceId, msgId, topic);
     }
 
     private boolean matchesInstance(String topicInstanceId, String instanceId) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -264,7 +264,7 @@ public class RocketMQMessageProvider implements MessageProvider {
     }
 
     @Override
-    public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
+    public TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic) {
         return runtimeAdminClientResolver.execute(instanceId,
                 adminExt -> getMessageTrace(instanceId, (DefaultMQAdminExt) adminExt, msgId));
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -500,7 +500,10 @@ public class TencentInstanceProvider implements InstanceProvider {
             // been collected. Like the Aliyun provider, the short-page check is the primary signal
             // so we do not rely on TotalCount, which may not be populated for every query.
             int returned = data == null ? 0 : data.length;
-            if (returned == 0 || returned < MESSAGE_LIMIT || total > 0 && result.size() >= total) {
+            // Stop on the last page (returned fewer rows than requested) or once all results have
+            // been collected. Like the Aliyun provider, the short-page check is the primary signal
+            // so we do not rely on TotalCount, which may not be populated for every query.
+            if (isLastPage(returned, total, result.size())) {
                 break;
             }
         }
@@ -675,6 +678,14 @@ public class TencentInstanceProvider implements InstanceProvider {
         } catch (Exception e) {
             return Collections.emptyMap();
         }
+    }
+
+    private static boolean isLastPage(int returned, long total, int collected) {
+        // The last page is one that returned no rows or fewer rows than requested. When the API
+        // reports a TotalCount, also stop once all expected results have been collected.
+        boolean shortPage = returned == 0 || returned < MESSAGE_LIMIT;
+        boolean allCollected = total > 0 && collected >= total;
+        return shortPage || allCollected;
     }
 
     private static long parseTraceTime(String value) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -494,16 +494,15 @@ public class TencentInstanceProvider implements InstanceProvider {
     }
 
     @Override
-    public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
+    public TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic) {
         Context context = resolve(instanceId);
         requireMsgId(msgId);
+        requireTopic(topic);
 
         DescribeMessageTraceRequest request = new DescribeMessageTraceRequest();
         request.setInstanceId(context.cloudInstanceId());
+        request.setTopic(topic);
         request.setMsgId(msgId);
-        // Topic is resolved by the service from the message ID; it may be left empty for
-        // delay/dead-letter messages, but passing it when known improves resolution.
-        request.setTopic("");
         DescribeMessageTraceResponse response = clientFactory.call(context.credentialId(), context.regionId(),
                 client -> client.DescribeMessageTrace(request));
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -64,6 +64,7 @@ import org.apache.rocketmq.studio.provider.InstanceProvider;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -87,6 +88,7 @@ import java.util.Map;
  * DescribeMessageList (list), DescribeMessage (detail) and DescribeMessageTrace (trace).</p>
  */
 @RequiredArgsConstructor
+@Slf4j
 @Component
 public class TencentInstanceProvider implements InstanceProvider {
 
@@ -99,6 +101,12 @@ public class TencentInstanceProvider implements InstanceProvider {
     static final int DEFAULT_MAX_RETRY_TIMES = 16;
     static final int MESSAGE_LIMIT = 100;
     private static final DateTimeFormatter TENCENT_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[,SSS][,SS]");
+    private static final DateTimeFormatter[] TENCENT_TIME_FORMATTERS = {
+        TENCENT_TIME_FORMATTER,
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"),
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"),
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    };
     private static final long ONE_HOUR_MILLIS = 60L * 60L * 1000L;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -656,18 +664,24 @@ public class TencentInstanceProvider implements InstanceProvider {
 
     private static long parseTraceTime(String value) {
         if (!StringUtils.hasText(value)) {
+            log.warn("Tencent message query: empty ProduceTime, storeTime=0");
             return 0L;
         }
-        try {
-            LocalDateTime parsed = LocalDateTime.parse(value, TENCENT_TIME_FORMATTER);
-            return parsed.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-        } catch (Exception e) {
+        String trimmed = value.trim();
+        for (DateTimeFormatter formatter : TENCENT_TIME_FORMATTERS) {
             try {
-                return Long.parseLong(value.trim());
-            } catch (NumberFormatException ignored) {
-                return 0L;
+                return LocalDateTime.parse(trimmed, formatter)
+                        .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            } catch (Exception ignored) {
+                // try next format
             }
         }
+        try {
+            return Long.parseLong(trimmed);
+        } catch (NumberFormatException ignored) {
+            log.warn("Tencent message query: unparseable ProduceTime={}, storeTime=0", value);
+        }
+        return 0L;
     }
 
     private static String toTraceStatus(int status) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -609,11 +609,13 @@ public class TencentInstanceProvider implements InstanceProvider {
             return null;
         }
         Map<String, String> properties = parseProperties(response.getProperties());
+        // DescribeMessage carries the tag and key inside Properties (TAGS / KEYS), not as
+        // top-level fields, so surface them onto the record for the message list/detail page.
         return MessageRecordVO.builder()
                 .msgId(defaultIfBlank(response.getMessageId(), ""))
                 .topic(defaultIfBlank(response.getShowTopicName(), ""))
-                .tag(null)
-                .key(null)
+                .tag(properties.get("TAGS"))
+                .key(properties.get("KEYS"))
                 .body(response.getBody())
                 .bodyEncoding("UTF-8")
                 .bodyTruncated(false)

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -496,8 +496,11 @@ public class TencentInstanceProvider implements InstanceProvider {
                     }
                 }
             }
-            // Stop when the last page returned no rows or we have collected everything.
-            if (data == null || data.length == 0 || result.size() >= total) {
+            // Stop on the last page (returned fewer rows than requested) or once all results have
+            // been collected. Like the Aliyun provider, the short-page check is the primary signal
+            // so we do not rely on TotalCount, which may not be populated for every query.
+            int returned = data == null ? 0 : data.length;
+            if (returned == 0 || returned < MESSAGE_LIMIT || total > 0 && result.size() >= total) {
                 break;
             }
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -25,6 +25,14 @@ import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupRequest
 import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupListRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupListResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageListRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageListResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageTraceRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageTraceResponse;
+import com.tencentcloudapi.trocket.v20230308.models.MessageItem;
+import com.tencentcloudapi.trocket.v20230308.models.MessageTraceItem;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListRequest;
@@ -36,6 +44,7 @@ import com.tencentcloudapi.trocket.v20230308.models.ResetConsumerGroupOffsetRequ
 import com.tencentcloudapi.trocket.v20230308.models.SubscriptionData;
 import com.tencentcloudapi.trocket.v20230308.models.TopicItem;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
+import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
@@ -45,7 +54,9 @@ import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
 import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
+import org.apache.rocketmq.studio.instance.message.ConsumerStatusVO;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
+import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
 import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
@@ -54,20 +65,26 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Tencent Cloud TDMQ RocketMQ 5.x topic operations backed by Trocket v20230308 OpenAPI.
  *
- * <p>Topic management is supported independently from the other instance-scoped operations. The
- * remaining operations intentionally retain the provider's unsupported-operation behavior until
- * their corresponding Tencent Cloud APIs are mapped to Studio's common models.</p>
+ * <p>In addition to topic/consumer-group management, message query is supported via
+ * DescribeMessageList (list), DescribeMessage (detail) and DescribeMessageTrace (trace).</p>
  */
 @RequiredArgsConstructor
 @Component
@@ -80,7 +97,14 @@ public class TencentInstanceProvider implements InstanceProvider {
     static final int MIN_QUEUE_NUM = 3;
     static final int MAX_QUEUE_NUM = 16;
     static final int DEFAULT_MAX_RETRY_TIMES = 16;
-    private static final String NOT_IMPLEMENTED = "Tencent Cloud operation is not implemented yet";
+    static final int MESSAGE_LIMIT = 100;
+    private static final DateTimeFormatter TENCENT_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[,SSS][,SS]");
+    private static final long ONE_HOUR_MILLIS = 60L * 60L * 1000L;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final String STAGE_PRODUCE = "produce";
+    private static final String STAGE_PERSIST = "persist";
+    private static final String STAGE_CONSUME = "consume";
 
     private final TencentClientFactory clientFactory;
     private final InstanceRepository instanceRepository;
@@ -416,12 +440,268 @@ public class TencentInstanceProvider implements InstanceProvider {
     @Override
     public List<MessageRecordVO> queryMessages(String instanceId, String topic, String msgId,
                                                String tag, String key, Long startTime, Long endTime) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        Context context = resolve(instanceId);
+        requireTopic(topic);
+        // Querying by message ID returns the full detail (body, properties and tracks) via
+        // DescribeMessage, mirroring the msgId path of the base provider.
+        if (StringUtils.hasText(msgId)) {
+            MessageRecordVO record = toRecordVO(describeMessage(context, topic, msgId));
+            return record == null ? Collections.emptyList() : Collections.singletonList(record);
+        }
+
+        long end = endTime != null ? endTime : System.currentTimeMillis();
+        long begin = startTime != null ? startTime : end - ONE_HOUR_MILLIS;
+        if (begin >= end) {
+            throw new BusinessException(400, "Message query start time must be before end time");
+        }
+
+        DescribeMessageListRequest request = new DescribeMessageListRequest();
+        request.setInstanceId(context.cloudInstanceId());
+        request.setTopic(topic);
+        request.setStartTime(begin);
+        request.setEndTime(end);
+        if (StringUtils.hasText(key)) {
+            request.setMsgKey(key);
+        }
+        if (StringUtils.hasText(tag)) {
+            request.setTag(tag);
+        }
+        request.setOffset(0L);
+        request.setLimit((long) MESSAGE_LIMIT);
+        DescribeMessageListResponse response = clientFactory.call(context.credentialId(), context.regionId(),
+                client -> client.DescribeMessageList(request));
+        MessageItem[] data = response == null ? null : response.getData();
+        if (data == null || data.length == 0) {
+            return Collections.emptyList();
+        }
+        List<MessageRecordVO> result = new ArrayList<>(data.length);
+        for (MessageItem item : data) {
+            result.add(toRecordVO(item, topic));
+        }
+        return result;
     }
 
     @Override
     public TraceRecordVO getMessageTrace(String instanceId, String msgId) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        Context context = resolve(instanceId);
+        requireMsgId(msgId);
+
+        DescribeMessageTraceRequest request = new DescribeMessageTraceRequest();
+        request.setInstanceId(context.cloudInstanceId());
+        request.setMsgId(msgId);
+        // Topic is resolved by the service from the message ID; it may be left empty for
+        // delay/dead-letter messages, but passing it when known improves resolution.
+        request.setTopic("");
+        DescribeMessageTraceResponse response = clientFactory.call(context.credentialId(), context.regionId(),
+                client -> client.DescribeMessageTrace(request));
+
+        List<TraceNodeVO> nodes = new ArrayList<>();
+        List<ConsumerStatusVO> consumerStatus = new ArrayList<>();
+        MessageTraceItem[] items = response == null ? null : response.getData();
+        if (items != null) {
+            for (MessageTraceItem item : items) {
+                buildTraceStage(item, nodes, consumerStatus);
+            }
+        }
+        return TraceRecordVO.builder()
+                .nodes(nodes)
+                .consumerStatus(consumerStatus)
+                .build();
+    }
+
+    private DescribeMessageResponse describeMessage(Context context, String topic, String msgId) {
+        DescribeMessageRequest request = new DescribeMessageRequest();
+        request.setInstanceId(context.cloudInstanceId());
+        request.setTopic(topic);
+        request.setMsgId(msgId);
+        return clientFactory.call(context.credentialId(), context.regionId(),
+                client -> client.DescribeMessage(request));
+    }
+
+    private static void buildTraceStage(MessageTraceItem item, List<TraceNodeVO> nodes,
+                                        List<ConsumerStatusVO> consumerStatus) {
+        String stage = item == null ? null : item.getStage();
+        String data = item == null ? null : item.getData();
+        if (!StringUtils.hasText(stage) || !StringUtils.hasText(data)) {
+            return;
+        }
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(data);
+            switch (stage) {
+                case STAGE_PRODUCE:
+                    nodes.add(buildProduceNode(root));
+                    break;
+                case STAGE_PERSIST:
+                    nodes.add(buildPersistNode(root));
+                    break;
+                case STAGE_CONSUME:
+                    buildConsumeNodes(root, nodes, consumerStatus);
+                    break;
+                default:
+                    break;
+            }
+        } catch (Exception e) {
+            // Unparseable trace payloads are skipped rather than failing the whole trace.
+        }
+    }
+
+    private static TraceNodeVO buildProduceNode(JsonNode root) {
+        return TraceNodeVO.builder()
+                .title(STAGE_PRODUCE)
+                .timestamp(parseTraceTime(root.path("ProduceTime").asText(null)))
+                .status(toTraceStatus(root.path("Status").asInt(0)))
+                .costTime(root.path("Duration").asLong(0L))
+                .description("producer=" + root.path("ProducerAddr").asText(""))
+                .build();
+    }
+
+    private static TraceNodeVO buildPersistNode(JsonNode root) {
+        return TraceNodeVO.builder()
+                .title(STAGE_PERSIST)
+                .timestamp(parseTraceTime(root.path("PersistTime").asText(null)))
+                .status(toTraceStatus(root.path("Status").asInt(0)))
+                .costTime(0L)
+                .description("store persist")
+                .build();
+    }
+
+    private static void buildConsumeNodes(JsonNode root, List<TraceNodeVO> nodes,
+                                          List<ConsumerStatusVO> consumerStatus) {
+        JsonNode logs = root.path("RocketMqConsumeLogs");
+        if (!logs.isArray()) {
+            return;
+        }
+        for (JsonNode log : logs) {
+            String group = log.path("ConsumerGroup").asText("");
+            long pushTime = parseTraceTime(log.path("PushTime").asText(null));
+            int status = log.path("Status").asInt(0);
+            int retryTimes = log.path("RetryTimes").asInt(0);
+            nodes.add(TraceNodeVO.builder()
+                    .title(STAGE_CONSUME)
+                    .timestamp(pushTime)
+                    .status(toConsumeTraceStatus(status))
+                    .costTime(0L)
+                    .description("group=" + group + ", consumer=" + log.path("ConsumerAddr").asText(""))
+                    .build());
+            consumerStatus.add(ConsumerStatusVO.builder()
+                    .group(group)
+                    .deliveryStatus(toDeliveryStatus(status))
+                    .consumeTime(pushTime)
+                    .retryCount(retryTimes)
+                    .build());
+        }
+    }
+
+    private static MessageRecordVO toRecordVO(DescribeMessageResponse response) {
+        if (response == null) {
+            return null;
+        }
+        Map<String, String> properties = parseProperties(response.getProperties());
+        return MessageRecordVO.builder()
+                .msgId(defaultIfBlank(response.getMessageId(), ""))
+                .topic(defaultIfBlank(response.getShowTopicName(), ""))
+                .tag(null)
+                .key(null)
+                .body(response.getBody())
+                .bodyEncoding("UTF-8")
+                .bodyTruncated(false)
+                .storeTime(parseTraceTime(response.getProduceTime()))
+                .bornHost(response.getProducerAddr())
+                .properties(properties)
+                .propertiesTruncated(false)
+                .size(0)
+                .build();
+    }
+
+    private static MessageRecordVO toRecordVO(MessageItem item, String topic) {
+        if (item == null) {
+            return null;
+        }
+        return MessageRecordVO.builder()
+                .msgId(defaultIfBlank(item.getMsgId(), ""))
+                .topic(topic)
+                .tag(item.getTags())
+                .key(item.getKeys())
+                .body(null)
+                .bodyEncoding(null)
+                .bodyTruncated(false)
+                .storeTime(parseTraceTime(item.getProduceTime()))
+                .bornHost(item.getProducerAddr())
+                .properties(Collections.emptyMap())
+                .propertiesTruncated(false)
+                .size(0)
+                .build();
+    }
+
+    private static Map<String, String> parseProperties(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return Collections.emptyMap();
+        }
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(raw);
+            if (root == null || !root.isObject()) {
+                return Collections.emptyMap();
+            }
+            Map<String, String> properties = new LinkedHashMap<>();
+            root.fields().forEachRemaining(entry -> properties.put(entry.getKey(), entry.getValue().asText("")));
+            return properties;
+        } catch (Exception e) {
+            return Collections.emptyMap();
+        }
+    }
+
+    private static long parseTraceTime(String value) {
+        if (!StringUtils.hasText(value)) {
+            return 0L;
+        }
+        try {
+            LocalDateTime parsed = LocalDateTime.parse(value, TENCENT_TIME_FORMATTER);
+            return parsed.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        } catch (Exception e) {
+            try {
+                return Long.parseLong(value.trim());
+            } catch (NumberFormatException ignored) {
+                return 0L;
+            }
+        }
+    }
+
+    private static String toTraceStatus(int status) {
+        return status == 0 ? "finish" : "failed";
+    }
+
+    private static String toConsumeTraceStatus(int status) {
+        // Tencent consume log Status uses the RocketMQ convention where 2 means consumed.
+        return status == 2 ? "finish" : "failed";
+    }
+
+    private static DeliveryStatus toDeliveryStatus(int status) {
+        // Tencent consume log status: 0/1 in-flight, 2 consumed, others failed.
+        switch (status) {
+            case 2:
+                return DeliveryStatus.success;
+            case 0:
+            case 1:
+                return DeliveryStatus.pending;
+            default:
+                return DeliveryStatus.failed;
+        }
+    }
+
+    private static String defaultIfBlank(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+
+    private static void requireTopic(String topic) {
+        if (!StringUtils.hasText(topic)) {
+            throw new BusinessException(400, "topic is required for Tencent Cloud message query");
+        }
+    }
+
+    private static void requireMsgId(String msgId) {
+        if (!StringUtils.hasText(msgId)) {
+            throw new BusinessException(400, "msgId is required for message trace query");
+        }
     }
 
     private Context resolve(String instanceId) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -16,13 +16,23 @@
  */
 package org.apache.rocketmq.studio.provider.tencent;
 
+import com.tencentcloudapi.trocket.v20230308.models.ConsumeGroupItem;
+import com.tencentcloudapi.trocket.v20230308.models.CreateConsumerGroupRequest;
 import com.tencentcloudapi.trocket.v20230308.models.CreateTopicRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DeleteConsumerGroupRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DeleteTopicRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupListRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupListResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicResponse;
 import com.tencentcloudapi.trocket.v20230308.models.ModifyTopicRequest;
+import com.tencentcloudapi.trocket.v20230308.models.ResetConsumerGroupOffsetRequest;
 import com.tencentcloudapi.trocket.v20230308.models.SubscriptionData;
 import com.tencentcloudapi.trocket.v20230308.models.TopicItem;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
@@ -48,6 +58,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -68,6 +79,7 @@ public class TencentInstanceProvider implements InstanceProvider {
     static final int DEFAULT_QUEUE_NUM = 8;
     static final int MIN_QUEUE_NUM = 3;
     static final int MAX_QUEUE_NUM = 16;
+    static final int DEFAULT_MAX_RETRY_TIMES = 16;
     private static final String NOT_IMPLEMENTED = "Tencent Cloud operation is not implemented yet";
 
     private final TencentClientFactory clientFactory;
@@ -97,7 +109,7 @@ public class TencentInstanceProvider implements InstanceProvider {
 
     @Override
     public int countGroups(String instanceId) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        return listConsumerGroups(instanceId, null, false).size();
     }
 
     @Override
@@ -257,32 +269,148 @@ public class TencentInstanceProvider implements InstanceProvider {
 
     @Override
     public List<ConsumerGroupVO> listConsumerGroups(String instanceId, String search) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        return listConsumerGroups(instanceId, search, true);
+    }
+
+    private List<ConsumerGroupVO> listConsumerGroups(String instanceId, String search, boolean enrichTimes) {
+        Context context = resolve(instanceId);
+        List<ConsumerGroupVO> groups = new ArrayList<>();
+        for (int page = 0; page < MAX_PAGES; page++) {
+            DescribeConsumerGroupListRequest request = new DescribeConsumerGroupListRequest();
+            request.setInstanceId(context.cloudInstanceId());
+            request.setOffset((long) page * PAGE_SIZE);
+            request.setLimit((long) PAGE_SIZE);
+            DescribeConsumerGroupListResponse response = clientFactory.call(context.credentialId(), context.regionId(),
+                    client -> client.DescribeConsumerGroupList(request));
+            ConsumeGroupItem[] data = response == null ? null : response.getData();
+            if (data == null || data.length == 0) {
+                break;
+            }
+            for (ConsumeGroupItem item : data) {
+                if (item == null) {
+                    continue;
+                }
+                ConsumerGroupVO group = toConsumerGroup(item, instanceId);
+                if (matchesSearch(search, group.getName())) {
+                    if (enrichTimes) {
+                        enrichConsumerGroupDetail(context, group);
+                    }
+                    groups.add(group);
+                }
+            }
+            if (data.length < PAGE_SIZE) {
+                break;
+            }
+        }
+        return groups;
+    }
+
+    /**
+     * DescribeConsumerGroupList exposes limited fields, so resolve the creation timestamp and the
+     * real consume model from DescribeConsumerGroup. Kept off the cheap count path to avoid N+1
+     * calls for instance listings.
+     */
+    private void enrichConsumerGroupDetail(Context context, ConsumerGroupVO group) {
+        try {
+            DescribeConsumerGroupRequest request = new DescribeConsumerGroupRequest();
+            request.setInstanceId(context.cloudInstanceId());
+            request.setConsumerGroup(group.getName());
+            DescribeConsumerGroupResponse response = clientFactory.call(context.credentialId(), context.regionId(),
+                    client -> client.DescribeConsumerGroup(request));
+            if (response == null) {
+                return;
+            }
+            group.setCreatedAt(toLocalDateTime(response.getCreatedTime()));
+            if (StringUtils.hasText(response.getConsumeModel())) {
+                group.setConsumeType(toConsumeType(response.getConsumeModel()));
+            }
+        } catch (BusinessException ignored) {
+            // A single group detail lookup failure should not fail the whole list.
+        }
     }
 
     @Override
     public ConsumerGroupVO createConsumerGroup(String instanceId, ConsumerGroupVO group) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        Context context = resolve(instanceId);
+        validateConsumerGroup(group);
+        CreateConsumerGroupRequest request = new CreateConsumerGroupRequest();
+        request.setInstanceId(context.cloudInstanceId());
+        request.setConsumerGroup(group.getName());
+        request.setMaxRetryTimes((long) retryMaxTimes(group));
+        request.setConsumeEnable(true);
+        request.setConsumeMessageOrderly(isOrderly(group));
+        clientFactory.call(context.credentialId(), context.regionId(), client -> client.CreateConsumerGroup(request));
+        group.setInstanceId(instanceId);
+        group.setRetryMaxTimes(retryMaxTimes(group));
+        group.setSubscribedTopics(java.util.List.of());
+        group.setCreatedAt(LocalDateTime.now());
+        group.setUpdatedAt(LocalDateTime.now());
+        return group;
     }
 
     @Override
     public void deleteConsumerGroup(String instanceId, String groupName) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        Context context = resolve(instanceId);
+        requireGroupName(groupName);
+        DeleteConsumerGroupRequest request = new DeleteConsumerGroupRequest();
+        request.setInstanceId(context.cloudInstanceId());
+        request.setConsumerGroup(groupName);
+        clientFactory.call(context.credentialId(), context.regionId(), client -> client.DeleteConsumerGroup(request));
     }
 
     @Override
     public List<QueueProgressVO> getGroupProgress(String instanceId, String groupName) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        Context context = resolve(instanceId);
+        requireGroupName(groupName);
+        List<SubscriptionData> subscriptions = listTopicSubscriptionsByGroup(context, groupName);
+        List<QueueProgressVO> rows = new ArrayList<>();
+        for (SubscriptionData subscription : subscriptions) {
+            if (subscription == null) {
+                continue;
+            }
+            rows.add(QueueProgressVO.builder()
+                    .broker("topic:" + subscription.getTopic())
+                    .queueId(0)
+                    .brokerOffset(0L)
+                    .consumerOffset(0L)
+                    .diffTotal(subscription.getConsumerLag() == null ? 0L : subscription.getConsumerLag())
+                    .build());
+        }
+        return rows;
     }
 
     @Override
     public List<SubscriptionEntryVO> getGroupSubscriptions(String instanceId, String groupName) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        Context context = resolve(instanceId);
+        requireGroupName(groupName);
+        List<SubscriptionData> subscriptions = listTopicSubscriptionsByGroup(context, groupName);
+        List<SubscriptionEntryVO> entries = new ArrayList<>();
+        for (SubscriptionData subscription : subscriptions) {
+            if (subscription == null) {
+                continue;
+            }
+            entries.add(toSubscriptionEntry(subscription));
+        }
+        return entries;
     }
 
     @Override
     public void resetOffset(String instanceId, String groupName, long timestamp, String topic) {
-        throw new UnsupportedOperationException(NOT_IMPLEMENTED);
+        Context context = resolve(instanceId);
+        requireGroupName(groupName);
+        if (!StringUtils.hasText(topic)) {
+            throw new BusinessException(400, "Topic is required to reset consumer group offset");
+        }
+        ResetConsumerGroupOffsetRequest request = new ResetConsumerGroupOffsetRequest();
+        request.setInstanceId(context.cloudInstanceId());
+        request.setConsumerGroup(groupName);
+        request.setTopic(topic);
+        if (timestamp > 0L) {
+            request.setResetTimestamp(timestamp);
+        } else {
+            request.setResetTimestamp(System.currentTimeMillis());
+        }
+        clientFactory.call(context.credentialId(), context.regionId(), client -> client.ResetConsumerGroupOffset(request));
     }
 
     @Override
@@ -336,6 +464,98 @@ public class TencentInstanceProvider implements InstanceProvider {
                 .build();
     }
 
+    private static ConsumerGroupVO toConsumerGroup(ConsumeGroupItem item, String instanceId) {
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName(item.getConsumerGroup());
+        group.setInstanceId(instanceId);
+        group.setClusterId(item.getClusterIdV4());
+        group.setNamespace(item.getNamespaceV4());
+        group.setConsumeType(toConsumeType(item.getConsumeMessageOrderly()));
+        group.setDeliveryOrderType(item.getConsumeMessageOrderly() == null || !item.getConsumeMessageOrderly()
+                ? "Concurrently" : "Orderly");
+        group.setRetryMaxTimes(toInt(item.getMaxRetryTimes()));
+        group.setSubscribedTopics(java.util.List.of());
+        group.setInstances(java.util.List.of());
+        return group;
+    }
+
+    private List<SubscriptionData> listTopicSubscriptionsByGroup(Context context, String groupName) {
+        List<SubscriptionData> all = new ArrayList<>();
+        for (int page = 0; page < MAX_PAGES; page++) {
+            DescribeTopicListByGroupRequest request = new DescribeTopicListByGroupRequest();
+            request.setInstanceId(context.cloudInstanceId());
+            request.setConsumerGroup(groupName);
+            request.setOffset((long) page * PAGE_SIZE);
+            request.setLimit((long) PAGE_SIZE);
+            DescribeTopicListByGroupResponse response = clientFactory.call(context.credentialId(), context.regionId(),
+                    client -> client.DescribeTopicListByGroup(request));
+            SubscriptionData[] data = response == null ? null : response.getData();
+            if (data == null || data.length == 0) {
+                break;
+            }
+            all.addAll(Arrays.asList(data));
+            if (data.length < PAGE_SIZE) {
+                break;
+            }
+        }
+        return all;
+    }
+
+    private static SubscriptionEntryVO toSubscriptionEntry(SubscriptionData subscription) {
+        return SubscriptionEntryVO.builder()
+                .topic(subscription.getTopic())
+                .expression(subscription.getSubString())
+                .type(subscription.getExpressionType())
+                .filterMode(subscription.getExpressionType())
+                .consistency(subscription.getConsistency() == null ? null : String.valueOf(subscription.getConsistency()))
+                .build();
+    }
+
+    private static void validateConsumerGroup(ConsumerGroupVO group) {
+        if (group == null || !StringUtils.hasText(group.getName())) {
+            throw new BusinessException(400, "Consumer group name is required");
+        }
+    }
+
+    private static void requireGroupName(String groupName) {
+        if (!StringUtils.hasText(groupName)) {
+            throw new BusinessException(400, "Consumer group name is required");
+        }
+    }
+
+    private static int retryMaxTimes(ConsumerGroupVO group) {
+        return group.getRetryMaxTimes() > 0 ? group.getRetryMaxTimes() : DEFAULT_MAX_RETRY_TIMES;
+    }
+
+    private static boolean isOrderly(ConsumerGroupVO group) {
+        String deliveryOrderType = group.getDeliveryOrderType();
+        return deliveryOrderType != null
+                && (deliveryOrderType.toUpperCase(Locale.ROOT).contains("FIFO")
+                || deliveryOrderType.toUpperCase(Locale.ROOT).contains("ORDER"));
+    }
+
+    private static int toInt(Long value) {
+        return value == null ? 0 : Math.toIntExact(value);
+    }
+
+    private static ConsumeType toConsumeType(Boolean consumeMessageOrderly) {
+        // Tencent consumer groups use clustering consumption; orderly only affects delivery order.
+        return ConsumeType.CLUSTERING;
+    }
+
+    private static ConsumeType toConsumeType(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return null;
+        }
+        if (raw.toUpperCase(Locale.ROOT).contains("BROADCAST")) {
+            return ConsumeType.BROADCASTING;
+        }
+        if (raw.toUpperCase(Locale.ROOT).contains("CLUSTER")) {
+            return ConsumeType.CLUSTERING;
+        }
+        return null;
+    }
+
     private static TopicType toTopicType(String raw) {
         if (!StringUtils.hasText(raw)) {
             return null;
@@ -372,6 +592,13 @@ public class TencentInstanceProvider implements InstanceProvider {
         }
         String needle = search.trim().toLowerCase(Locale.ROOT);
         return contains(topic.getName(), needle) || contains(topic.getRemark(), needle);
+    }
+
+    private static boolean matchesSearch(String search, String value) {
+        if (!StringUtils.hasText(search)) {
+            return true;
+        }
+        return contains(value, search.trim().toLowerCase(Locale.ROOT));
     }
 
     private static boolean contains(String value, String needle) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -460,6 +460,10 @@ public class TencentInstanceProvider implements InstanceProvider {
         request.setTopic(topic);
         request.setStartTime(begin);
         request.setEndTime(end);
+        // DescribeMessageList is an async, task-based query: the first call uses an empty
+        // TaskRequestId to start the query, and later pages reuse the id returned by the
+        // previous response. We only fetch the first page here.
+        request.setTaskRequestId("");
         if (StringUtils.hasText(key)) {
             request.setMsgKey(key);
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -80,6 +80,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Tencent Cloud TDMQ RocketMQ 5.x topic operations backed by Trocket v20230308 OpenAPI.
@@ -463,32 +464,42 @@ public class TencentInstanceProvider implements InstanceProvider {
             throw new BusinessException(400, "Message query start time must be before end time");
         }
 
-        DescribeMessageListRequest request = new DescribeMessageListRequest();
-        request.setInstanceId(context.cloudInstanceId());
-        request.setTopic(topic);
-        request.setStartTime(begin);
-        request.setEndTime(end);
-        // DescribeMessageList is an async, task-based query: the first call uses an empty
-        // TaskRequestId to start the query, and later pages reuse the id returned by the
-        // previous response. We only fetch the first page here.
-        request.setTaskRequestId("");
-        if (StringUtils.hasText(key)) {
-            request.setMsgKey(key);
-        }
-        if (StringUtils.hasText(tag)) {
-            request.setTag(tag);
-        }
-        request.setOffset(0L);
-        request.setLimit((long) MESSAGE_LIMIT);
-        DescribeMessageListResponse response = clientFactory.call(context.credentialId(), context.regionId(),
-                client -> client.DescribeMessageList(request));
-        MessageItem[] data = response == null ? null : response.getData();
-        if (data == null || data.length == 0) {
-            return Collections.emptyList();
-        }
-        List<MessageRecordVO> result = new ArrayList<>(data.length);
-        for (MessageItem item : data) {
-            result.add(toRecordVO(item, topic));
+        // DescribeMessageList is an async, task-based query: each logical query is identified by a
+        // TaskRequestId, and paging through that query reuses the same id (the response returns it
+        // for the next page). A fresh random id starts a brand-new query. The frontend message table
+        // is not server-paginated (pagination=false), so page through the whole result set here.
+        String taskRequestId = UUID.randomUUID().toString();
+        List<MessageRecordVO> result = new ArrayList<>();
+        for (int page = 0; page < MAX_PAGES; page++) {
+            DescribeMessageListRequest request = new DescribeMessageListRequest();
+            request.setInstanceId(context.cloudInstanceId());
+            request.setTopic(topic);
+            request.setStartTime(begin);
+            request.setEndTime(end);
+            request.setTaskRequestId(taskRequestId);
+            if (StringUtils.hasText(key)) {
+                request.setMsgKey(key);
+            }
+            if (StringUtils.hasText(tag)) {
+                request.setTag(tag);
+            }
+            request.setOffset((long) result.size());
+            request.setLimit((long) MESSAGE_LIMIT);
+            DescribeMessageListResponse response = clientFactory.call(context.credentialId(), context.regionId(),
+                    client -> client.DescribeMessageList(request));
+            MessageItem[] data = response == null ? null : response.getData();
+            long total = response == null ? 0L : (response.getTotalCount() == null ? 0L : response.getTotalCount());
+            if (data != null) {
+                for (MessageItem item : data) {
+                    if (item != null) {
+                        result.add(toRecordVO(item, topic));
+                    }
+                }
+            }
+            // Stop when the last page returned no rows or we have collected everything.
+            if (data == null || data.length == 0 || result.size() >= total) {
+                break;
+            }
         }
         return result;
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageControllerTest.java
@@ -74,12 +74,13 @@ class MessageControllerTest {
     @Test
     void messageTraceShouldPassInstanceId() throws Exception {
         TraceRecordVO trace = TraceRecordVO.builder().nodes(List.of()).consumerStatus(List.of()).build();
-        when(messageService.getMessageTrace("instance-a", "msg-001")).thenReturn(trace);
+        when(messageService.getMessageTrace("instance-a", "msg-001", "orders")).thenReturn(trace);
 
-        mockMvc.perform(get("/api/messages/msg-001/trace").param("instanceId", "instance-a"))
+        mockMvc.perform(get("/api/messages/msg-001/trace").param("instanceId", "instance-a")
+                .param("topic", "orders"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200));
 
-        verify(messageService).getMessageTrace("instance-a", "msg-001");
+        verify(messageService).getMessageTrace("instance-a", "msg-001", "orders");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageProviderStubTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageProviderStubTest.java
@@ -37,7 +37,7 @@ class MessageProviderStubTest {
 
     @Test
     void getMessageTraceShouldFailExplicitlyWhenRealProviderIsMissing() {
-        assertThatThrownBy(() -> provider.getMessageTrace("instance-a", "msg-001"))
+        assertThatThrownBy(() -> provider.getMessageTrace("instance-a", "msg-001", "orders"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Message query provider is not configured")
                 .extracting("code")

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -52,7 +52,7 @@ class MessageServiceTest {
         InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
         MessageService service = new MessageService(provider, registry);
 
-        assertThatThrownBy(() -> service.getMessageTrace("instance-a", "  "))
+        assertThatThrownBy(() -> service.getMessageTrace("instance-a", "  ", null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("msgId is required");
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -345,7 +345,7 @@ class AliyunInstanceProviderTest {
                 .build();
         when(asyncClient.getTrace(any())).thenReturn(CompletableFuture.completedFuture(response));
 
-        TraceRecordVO trace = provider.getMessageTrace(STUDIO_INSTANCE_ID, "msg-1");
+        TraceRecordVO trace = provider.getMessageTrace(STUDIO_INSTANCE_ID, "msg-1", "orders");
 
         assertThat(trace.getNodes()).hasSize(3);
         TraceNodeVO producer = trace.getNodes().get(0);

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -225,7 +225,7 @@ class RocketMQMessageProviderTest {
         when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
                 .thenReturn(queryResult);
 
-        TraceRecordVO record = provider.getMessageTrace("instance-a", "msg-123");
+        TraceRecordVO record = provider.getMessageTrace("instance-a", "msg-123", "orders");
 
         assertThat(record.getNodes()).hasSize(2);
         verify(queryHistoryService).recordTraceQuery(eq("instance-a"), eq("msg-123"), eq(null), eq(2), eq(1));
@@ -257,7 +257,7 @@ class RocketMQMessageProviderTest {
         when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
                 .thenReturn(queryResult);
 
-        TraceRecordVO record = provider.getMessageTrace("instance-a", "msg-tx");
+        TraceRecordVO record = provider.getMessageTrace("instance-a", "msg-tx", "orders");
 
         assertThat(record.getNodes()).hasSize(1);
         TraceNodeVO transaction = record.getNodes().get(0);
@@ -274,7 +274,7 @@ class RocketMQMessageProviderTest {
         when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
                 .thenThrow(new IllegalStateException("broker unavailable"));
 
-        assertThatThrownBy(() -> provider.getMessageTrace("instance-a", "msg-123"))
+        assertThatThrownBy(() -> provider.getMessageTrace("instance-a", "msg-123", "orders"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Failed to query message trace: broker unavailable")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
@@ -32,7 +32,6 @@ import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.persistence.entity.RmqGroup;
 import org.apache.rocketmq.studio.persistence.mapper.RmqGroupMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqTopicMapper;
-import org.apache.rocketmq.remoting.protocol.body.GroupList;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -40,7 +39,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -481,7 +481,7 @@ class TencentInstanceProviderTest {
         response.setData(new MessageTraceItem[]{produce, consume});
         when(client.DescribeMessageTrace(any())).thenReturn(response);
 
-        TraceRecordVO trace = provider.getMessageTrace(STUDIO_INSTANCE_ID, "MSG-1");
+        TraceRecordVO trace = provider.getMessageTrace(STUDIO_INSTANCE_ID, "MSG-1", "orders");
 
         assertThat(trace.getNodes()).hasSize(2);
         TraceNodeVO produceNode = trace.getNodes().get(0);
@@ -499,6 +499,7 @@ class TencentInstanceProviderTest {
         ArgumentCaptor<DescribeMessageTraceRequest> captor = ArgumentCaptor.forClass(DescribeMessageTraceRequest.class);
         verify(client).DescribeMessageTrace(captor.capture());
         assertThat(captor.getValue().getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
+        assertThat(captor.getValue().getTopic()).isEqualTo("orders");
         assertThat(captor.getValue().getMsgId()).isEqualTo("MSG-1");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -446,6 +446,7 @@ class TencentInstanceProviderTest {
         one.setProduceTime("2024-09-12 14:06:55,591");
         DescribeMessageListResponse response = new DescribeMessageListResponse();
         response.setData(new MessageItem[]{one});
+        response.setTotalCount(1L);
         when(client.DescribeMessageList(any())).thenReturn(response);
 
         List<MessageRecordVO> messages = provider.queryMessages(STUDIO_INSTANCE_ID, "orders", null,
@@ -464,7 +465,48 @@ class TencentInstanceProviderTest {
         assertThat(captor.getValue().getTopic()).isEqualTo("orders");
         assertThat(captor.getValue().getMsgKey()).isEqualTo("keyA");
         assertThat(captor.getValue().getTag()).isEqualTo("tagA");
-        assertThat(captor.getValue().getTaskRequestId()).isEqualTo("");
+        assertThat(captor.getValue().getTaskRequestId()).isNotBlank();
+        assertThat(captor.getValue().getOffset()).isEqualTo(0L);
+    }
+
+    @Test
+    void queryMessagesByTopicShouldPageWithSameTaskRequestIdTest() throws Exception {
+        MessageItem first = new MessageItem();
+        first.setMsgId("MSG-1");
+        first.setProduceTime("2024-09-12 14:06:55,591");
+        MessageItem second = new MessageItem();
+        second.setMsgId("MSG-2");
+        second.setProduceTime("2024-09-12 14:06:56,591");
+        MessageItem third = new MessageItem();
+        third.setMsgId("MSG-3");
+        third.setProduceTime("2024-09-12 14:06:57,591");
+        DescribeMessageListResponse page1 = new DescribeMessageListResponse();
+        page1.setData(new MessageItem[]{first, second});
+        page1.setTotalCount(3L);
+        DescribeMessageListResponse page2 = new DescribeMessageListResponse();
+        page2.setData(new MessageItem[]{third});
+        page2.setTotalCount(3L);
+        when(client.DescribeMessageList(any()))
+                .thenReturn(page1)
+                .thenReturn(page2);
+
+        List<MessageRecordVO> messages = provider.queryMessages(STUDIO_INSTANCE_ID, "orders", null,
+                null, null, 1600000000000L, 1600001000000L);
+
+        assertThat(messages).hasSize(3);
+        assertThat(messages.get(0).getMsgId()).isEqualTo("MSG-1");
+        assertThat(messages.get(1).getMsgId()).isEqualTo("MSG-2");
+        assertThat(messages.get(2).getMsgId()).isEqualTo("MSG-3");
+        ArgumentCaptor<DescribeMessageListRequest> captor = ArgumentCaptor.forClass(DescribeMessageListRequest.class);
+        verify(client, org.mockito.Mockito.times(2)).DescribeMessageList(captor.capture());
+        java.util.List<DescribeMessageListRequest> requests = captor.getAllValues();
+        assertThat(requests).hasSize(2);
+        assertThat(requests.get(0).getOffset()).isEqualTo(0L);
+        assertThat(requests.get(1).getOffset()).isEqualTo(2L);
+        // A single logical query reuses the same TaskRequestId across pages; only offset advances.
+        assertThat(requests.get(1).getTaskRequestId())
+                .isEqualTo(requests.get(0).getTaskRequestId())
+                .isNotBlank();
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -16,19 +16,30 @@
  */
 package org.apache.rocketmq.studio.provider.tencent;
 
+import com.tencentcloudapi.trocket.v20230308.models.ConsumeGroupItem;
+import com.tencentcloudapi.trocket.v20230308.models.CreateConsumerGroupRequest;
 import com.tencentcloudapi.trocket.v20230308.models.CreateTopicRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DeleteConsumerGroupRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupListResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicResponse;
 import com.tencentcloudapi.trocket.v20230308.models.ModifyTopicRequest;
+import com.tencentcloudapi.trocket.v20230308.models.ResetConsumerGroupOffsetRequest;
 import com.tencentcloudapi.trocket.v20230308.models.SubscriptionData;
 import com.tencentcloudapi.trocket.v20230308.models.TopicItem;
 import com.tencentcloudapi.trocket.v20230308.TrocketClient;
+import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
+import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
+import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.junit.jupiter.api.BeforeEach;
@@ -268,6 +279,103 @@ class TencentInstanceProviderTest {
         assertThat(captor.getAllValues())
                 .extracting(DescribeTopicRequest::getLimit)
                 .containsOnly(100L);
+    }
+
+    @Test
+    void listConsumerGroupsShouldMapAndFilterTest() throws Exception {
+        ConsumeGroupItem one = new ConsumeGroupItem();
+        one.setConsumerGroup("GID_test");
+        one.setMaxRetryTimes(10L);
+        one.setConsumeMessageOrderly(false);
+        ConsumeGroupItem two = new ConsumeGroupItem();
+        two.setConsumerGroup("GID_orders");
+        two.setMaxRetryTimes(16L);
+        DescribeConsumerGroupListResponse response = new DescribeConsumerGroupListResponse();
+        response.setData(new ConsumeGroupItem[]{one, two});
+        when(client.DescribeConsumerGroupList(any())).thenReturn(response);
+        DescribeConsumerGroupResponse detail = new DescribeConsumerGroupResponse();
+        detail.setCreatedTime(1600000000000L);
+        detail.setConsumeModel("CLUSTERING");
+        when(client.DescribeConsumerGroup(any())).thenReturn(detail);
+
+        List<ConsumerGroupVO> groups = provider.listConsumerGroups(STUDIO_INSTANCE_ID, "orders");
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0).getName()).isEqualTo("GID_orders");
+        assertThat(groups.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_ID);
+        assertThat(groups.get(0).getRetryMaxTimes()).isEqualTo(16);
+        assertThat(groups.get(0).getCreatedAt()).isNotNull();
+        assertThat(groups.get(0).getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
+        assertThat(groups.get(0).getInstances()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void createConsumerGroupShouldCallTencentOpenApiTest() throws Exception {
+        when(client.CreateConsumerGroup(any())).thenReturn(null);
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName("GID_new");
+        group.setRetryMaxTimes(20);
+
+        ConsumerGroupVO created = provider.createConsumerGroup(STUDIO_INSTANCE_ID, group);
+
+        ArgumentCaptor<CreateConsumerGroupRequest> captor = ArgumentCaptor.forClass(CreateConsumerGroupRequest.class);
+        verify(client).CreateConsumerGroup(captor.capture());
+        assertThat(captor.getValue().getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
+        assertThat(captor.getValue().getConsumerGroup()).isEqualTo("GID_new");
+        assertThat(captor.getValue().getMaxRetryTimes()).isEqualTo(20L);
+        assertThat(created.getInstanceId()).isEqualTo(STUDIO_INSTANCE_ID);
+        assertThat(created.getRetryMaxTimes()).isEqualTo(20);
+    }
+
+    @Test
+    void deleteConsumerGroupShouldCallTencentOpenApiTest() throws Exception {
+        when(client.DeleteConsumerGroup(any())).thenReturn(null);
+
+        provider.deleteConsumerGroup(STUDIO_INSTANCE_ID, "GID_test");
+
+        ArgumentCaptor<DeleteConsumerGroupRequest> captor = ArgumentCaptor.forClass(DeleteConsumerGroupRequest.class);
+        verify(client).DeleteConsumerGroup(captor.capture());
+        assertThat(captor.getValue().getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
+        assertThat(captor.getValue().getConsumerGroup()).isEqualTo("GID_test");
+    }
+
+    @Test
+    void getGroupProgressAndSubscriptionsShouldMapSubscriptionDataTest() throws Exception {
+        SubscriptionData subscription = new SubscriptionData();
+        subscription.setTopic("orders");
+        subscription.setSubString("*");
+        subscription.setExpressionType("TAG");
+        subscription.setConsumerLag(42L);
+        subscription.setConsistency(0L);
+        DescribeTopicListByGroupResponse response = new DescribeTopicListByGroupResponse();
+        response.setData(new SubscriptionData[]{subscription});
+        when(client.DescribeTopicListByGroup(any())).thenReturn(response);
+
+        List<QueueProgressVO> progress = provider.getGroupProgress(STUDIO_INSTANCE_ID, "GID_test");
+        assertThat(progress).hasSize(1);
+        assertThat(progress.get(0).getBroker()).isEqualTo("topic:orders");
+        assertThat(progress.get(0).getDiffTotal()).isEqualTo(42L);
+
+        List<SubscriptionEntryVO> subscriptions = provider.getGroupSubscriptions(STUDIO_INSTANCE_ID, "GID_test");
+        assertThat(subscriptions).hasSize(1);
+        assertThat(subscriptions.get(0).getTopic()).isEqualTo("orders");
+        assertThat(subscriptions.get(0).getExpression()).isEqualTo("*");
+        assertThat(subscriptions.get(0).getType()).isEqualTo("TAG");
+    }
+
+    @Test
+    void resetOffsetShouldCallTencentOpenApiTest() throws Exception {
+        when(client.ResetConsumerGroupOffset(any())).thenReturn(null);
+
+        provider.resetOffset(STUDIO_INSTANCE_ID, "GID_test", 1600000000000L, "orders");
+
+        ArgumentCaptor<ResetConsumerGroupOffsetRequest> captor =
+                ArgumentCaptor.forClass(ResetConsumerGroupOffsetRequest.class);
+        verify(client).ResetConsumerGroupOffset(captor.capture());
+        assertThat(captor.getValue().getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
+        assertThat(captor.getValue().getConsumerGroup()).isEqualTo("GID_test");
+        assertThat(captor.getValue().getTopic()).isEqualTo("orders");
+        assertThat(captor.getValue().getResetTimestamp()).isEqualTo(1600000000000L);
     }
 
     private static TopicItem topicItem(String name, String type, long queueNum) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -414,7 +414,7 @@ class TencentInstanceProviderTest {
         detail.setBody("hello body");
         detail.setProducerAddr("1.2.3.4:5000");
         detail.setProduceTime("2024-09-12 14:06:55,591");
-        detail.setProperties("{\"UNIQ_KEY\":\"MSG-1\",\"__CLIENT_HOST\":\"1.2.3.4\"}");
+        detail.setProperties("{\"UNIQ_KEY\":\"MSG-1\",\"TAGS\":\"tagA\",\"KEYS\":\"keyA\",\"__CLIENT_HOST\":\"1.2.3.4\"}");
         when(client.DescribeMessage(any())).thenReturn(detail);
 
         List<MessageRecordVO> messages =
@@ -426,6 +426,8 @@ class TencentInstanceProviderTest {
         assertThat(record.getTopic()).isEqualTo("orders");
         assertThat(record.getBody()).isEqualTo("hello body");
         assertThat(record.getBornHost()).isEqualTo("1.2.3.4:5000");
+        assertThat(record.getTag()).isEqualTo("tagA");
+        assertThat(record.getKey()).isEqualTo("keyA");
         assertThat(record.getProperties()).containsEntry("UNIQ_KEY", "MSG-1");
         ArgumentCaptor<DescribeMessageRequest> captor = ArgumentCaptor.forClass(DescribeMessageRequest.class);
         verify(client).DescribeMessage(captor.capture());

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -22,6 +22,14 @@ import com.tencentcloudapi.trocket.v20230308.models.CreateTopicRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DeleteConsumerGroupRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupListResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageListRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageListResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageTraceRequest;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageTraceResponse;
+import com.tencentcloudapi.trocket.v20230308.models.MessageItem;
+import com.tencentcloudapi.trocket.v20230308.models.MessageTraceItem;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicRequest;
@@ -32,6 +40,7 @@ import com.tencentcloudapi.trocket.v20230308.models.SubscriptionData;
 import com.tencentcloudapi.trocket.v20230308.models.TopicItem;
 import com.tencentcloudapi.trocket.v20230308.TrocketClient;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
+import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -40,6 +49,9 @@ import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
 import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
+import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
+import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
+import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.junit.jupiter.api.BeforeEach;
@@ -392,5 +404,98 @@ class TencentInstanceProviderTest {
         subscription.setConsumeType("CLUSTERING");
         subscription.setMessageModel("CLUSTERING");
         return subscription;
+    }
+
+    @Test
+    void queryMessagesByMsgIdShouldReturnDetailWithBodyTest() throws Exception {
+        DescribeMessageResponse detail = new DescribeMessageResponse();
+        detail.setMessageId("MSG-1");
+        detail.setShowTopicName("orders");
+        detail.setBody("hello body");
+        detail.setProducerAddr("1.2.3.4:5000");
+        detail.setProduceTime("2024-09-12 14:06:55,591");
+        detail.setProperties("{\"UNIQ_KEY\":\"MSG-1\",\"__CLIENT_HOST\":\"1.2.3.4\"}");
+        when(client.DescribeMessage(any())).thenReturn(detail);
+
+        List<MessageRecordVO> messages =
+                provider.queryMessages(STUDIO_INSTANCE_ID, "orders", "MSG-1", null, null, null, null);
+
+        assertThat(messages).hasSize(1);
+        MessageRecordVO record = messages.get(0);
+        assertThat(record.getMsgId()).isEqualTo("MSG-1");
+        assertThat(record.getTopic()).isEqualTo("orders");
+        assertThat(record.getBody()).isEqualTo("hello body");
+        assertThat(record.getBornHost()).isEqualTo("1.2.3.4:5000");
+        assertThat(record.getProperties()).containsEntry("UNIQ_KEY", "MSG-1");
+        ArgumentCaptor<DescribeMessageRequest> captor = ArgumentCaptor.forClass(DescribeMessageRequest.class);
+        verify(client).DescribeMessage(captor.capture());
+        assertThat(captor.getValue().getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
+        assertThat(captor.getValue().getTopic()).isEqualTo("orders");
+        assertThat(captor.getValue().getMsgId()).isEqualTo("MSG-1");
+    }
+
+    @Test
+    void queryMessagesByTopicShouldUseMessageListTest() throws Exception {
+        MessageItem one = new MessageItem();
+        one.setMsgId("MSG-A");
+        one.setTags("tagA");
+        one.setKeys("keyA");
+        one.setProducerAddr("1.2.3.4:5000");
+        one.setProduceTime("2024-09-12 14:06:55,591");
+        DescribeMessageListResponse response = new DescribeMessageListResponse();
+        response.setData(new MessageItem[]{one});
+        when(client.DescribeMessageList(any())).thenReturn(response);
+
+        List<MessageRecordVO> messages = provider.queryMessages(STUDIO_INSTANCE_ID, "orders", null,
+                "tagA", "keyA", 1600000000000L, 1600001000000L);
+
+        assertThat(messages).hasSize(1);
+        MessageRecordVO record = messages.get(0);
+        assertThat(record.getMsgId()).isEqualTo("MSG-A");
+        assertThat(record.getTag()).isEqualTo("tagA");
+        assertThat(record.getKey()).isEqualTo("keyA");
+        assertThat(record.getBornHost()).isEqualTo("1.2.3.4:5000");
+        assertThat(record.getStoreTime()).isGreaterThan(0L);
+        ArgumentCaptor<DescribeMessageListRequest> captor = ArgumentCaptor.forClass(DescribeMessageListRequest.class);
+        verify(client).DescribeMessageList(captor.capture());
+        assertThat(captor.getValue().getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
+        assertThat(captor.getValue().getTopic()).isEqualTo("orders");
+        assertThat(captor.getValue().getMsgKey()).isEqualTo("keyA");
+        assertThat(captor.getValue().getTag()).isEqualTo("tagA");
+    }
+
+    @Test
+    void getMessageTraceShouldMapStagesTest() throws Exception {
+        MessageTraceItem produce = new MessageTraceItem();
+        produce.setStage("produce");
+        produce.setData("{\"MsgId\":\"MSG-1\",\"Status\":0,\"ProduceTime\":\"2024-09-12 14:06:55,591\","
+                + "\"ProducerAddr\":\"1.2.3.4:5000\",\"Duration\":2}");
+        MessageTraceItem consume = new MessageTraceItem();
+        consume.setStage("consume");
+        consume.setData("{\"TotalCount\":1,\"RocketMqConsumeLogs\":[{\"MsgId\":\"MSG-1\",\"Status\":2,"
+                + "\"PushTime\":\"2024-09-12 14:06:55,600\",\"ConsumerGroup\":\"GID_test\",\"RetryTimes\":1}]}");
+        DescribeMessageTraceResponse response = new DescribeMessageTraceResponse();
+        response.setData(new MessageTraceItem[]{produce, consume});
+        when(client.DescribeMessageTrace(any())).thenReturn(response);
+
+        TraceRecordVO trace = provider.getMessageTrace(STUDIO_INSTANCE_ID, "MSG-1");
+
+        assertThat(trace.getNodes()).hasSize(2);
+        TraceNodeVO produceNode = trace.getNodes().get(0);
+        assertThat(produceNode.getTitle()).isEqualTo("produce");
+        assertThat(produceNode.getStatus()).isEqualTo("finish");
+        assertThat(produceNode.getCostTime()).isEqualTo(2L);
+        assertThat(produceNode.getTimestamp()).isGreaterThan(0L);
+        TraceNodeVO consumeNode = trace.getNodes().get(1);
+        assertThat(consumeNode.getTitle()).isEqualTo("consume");
+        assertThat(consumeNode.getStatus()).isEqualTo("finish");
+        assertThat(trace.getConsumerStatus()).hasSize(1);
+        assertThat(trace.getConsumerStatus().get(0).getGroup()).isEqualTo("GID_test");
+        assertThat(trace.getConsumerStatus().get(0).getDeliveryStatus()).isEqualTo(DeliveryStatus.success);
+        assertThat(trace.getConsumerStatus().get(0).getRetryCount()).isEqualTo(1);
+        ArgumentCaptor<DescribeMessageTraceRequest> captor = ArgumentCaptor.forClass(DescribeMessageTraceRequest.class);
+        verify(client).DescribeMessageTrace(captor.capture());
+        assertThat(captor.getValue().getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
+        assertThat(captor.getValue().getMsgId()).isEqualTo("MSG-1");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -462,6 +462,7 @@ class TencentInstanceProviderTest {
         assertThat(captor.getValue().getTopic()).isEqualTo("orders");
         assertThat(captor.getValue().getMsgKey()).isEqualTo("keyA");
         assertThat(captor.getValue().getTag()).isEqualTo("tagA");
+        assertThat(captor.getValue().getTaskRequestId()).isEqualTo("");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -471,21 +471,22 @@ class TencentInstanceProviderTest {
 
     @Test
     void queryMessagesByTopicShouldPageWithSameTaskRequestIdTest() throws Exception {
-        MessageItem first = new MessageItem();
-        first.setMsgId("MSG-1");
-        first.setProduceTime("2024-09-12 14:06:55,591");
-        MessageItem second = new MessageItem();
-        second.setMsgId("MSG-2");
-        second.setProduceTime("2024-09-12 14:06:56,591");
-        MessageItem third = new MessageItem();
-        third.setMsgId("MSG-3");
-        third.setProduceTime("2024-09-12 14:06:57,591");
+        // Page 1 returns a full page (MESSAGE_LIMIT), forcing a second page; page 2 is a short
+        // page, which terminates the loop.
+        MessageItem[] page1Items = new MessageItem[TencentInstanceProvider.MESSAGE_LIMIT];
+        for (int i = 0; i < page1Items.length; i++) {
+            MessageItem item = new MessageItem();
+            item.setMsgId("MSG-" + (i + 1));
+            item.setProduceTime("2024-09-12 14:06:55,591");
+            page1Items[i] = item;
+        }
+        MessageItem last = new MessageItem();
+        last.setMsgId("MSG-LAST");
+        last.setProduceTime("2024-09-12 14:06:56,591");
         DescribeMessageListResponse page1 = new DescribeMessageListResponse();
-        page1.setData(new MessageItem[]{first, second});
-        page1.setTotalCount(3L);
+        page1.setData(page1Items);
         DescribeMessageListResponse page2 = new DescribeMessageListResponse();
-        page2.setData(new MessageItem[]{third});
-        page2.setTotalCount(3L);
+        page2.setData(new MessageItem[]{last});
         when(client.DescribeMessageList(any()))
                 .thenReturn(page1)
                 .thenReturn(page2);
@@ -493,16 +494,17 @@ class TencentInstanceProviderTest {
         List<MessageRecordVO> messages = provider.queryMessages(STUDIO_INSTANCE_ID, "orders", null,
                 null, null, 1600000000000L, 1600001000000L);
 
-        assertThat(messages).hasSize(3);
+        assertThat(messages).hasSize(TencentInstanceProvider.MESSAGE_LIMIT + 1);
         assertThat(messages.get(0).getMsgId()).isEqualTo("MSG-1");
-        assertThat(messages.get(1).getMsgId()).isEqualTo("MSG-2");
-        assertThat(messages.get(2).getMsgId()).isEqualTo("MSG-3");
+        assertThat(messages.get(TencentInstanceProvider.MESSAGE_LIMIT - 1).getMsgId())
+                .isEqualTo("MSG-" + TencentInstanceProvider.MESSAGE_LIMIT);
+        assertThat(messages.get(TencentInstanceProvider.MESSAGE_LIMIT).getMsgId()).isEqualTo("MSG-LAST");
         ArgumentCaptor<DescribeMessageListRequest> captor = ArgumentCaptor.forClass(DescribeMessageListRequest.class);
         verify(client, org.mockito.Mockito.times(2)).DescribeMessageList(captor.capture());
         java.util.List<DescribeMessageListRequest> requests = captor.getAllValues();
         assertThat(requests).hasSize(2);
         assertThat(requests.get(0).getOffset()).isEqualTo(0L);
-        assertThat(requests.get(1).getOffset()).isEqualTo(2L);
+        assertThat(requests.get(1).getOffset()).isEqualTo((long) TencentInstanceProvider.MESSAGE_LIMIT);
         // A single logical query reuses the same TaskRequestId across pages; only offset advances.
         assertThat(requests.get(1).getTaskRequestId())
                 .isEqualTo(requests.get(0).getTaskRequestId())

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -80,10 +80,10 @@ export async function queryMessages(params: MessageQuery) {
   return sortMessagesByStoreTimeDesc(res.data.data);
 }
 
-export async function getMessageTrace(msgId: string, instanceId?: string) {
+export async function getMessageTrace(msgId: string, instanceId?: string, topic?: string) {
   const res = await client.get<{ data: TraceRecord }>(
     `/messages/${encodeURIComponent(msgId)}/trace`,
-    { params: { instanceId } },
+    { params: { instanceId, topic } },
   );
   return res.data.data;
 }

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -458,7 +458,7 @@ const MessagePageContent = ({
     setTraceLoading(true);
     setTraceError(null);
     try {
-      const result = await getMessageTrace(record.msgId, selectedInstanceId);
+      const result = await getMessageTrace(record.msgId, selectedInstanceId, record.topic);
       if (traceGenerationRef.current !== requestGeneration) return;
       setTraceData(result);
       setTraceError(null);

--- a/web/src/services/messageService.ts
+++ b/web/src/services/messageService.ts
@@ -51,12 +51,13 @@ export async function queryMessages(params: MessageQuery): Promise<MessageRecord
 export async function getMessageTrace(
   msgId: string,
   instanceId?: string,
+  topic?: string,
 ): Promise<TraceRecord | null> {
   if (isMockMode()) {
     const trace = mockMessageTraces[msgId] as unknown as TraceRecord | undefined;
     return trace ? cloneTrace(trace) : null;
   }
-  return messageApi.getMessageTrace(msgId, instanceId);
+  return messageApi.getMessageTrace(msgId, instanceId, topic);
 }
 
 export async function listDLQGroups(instanceId: string): Promise<DLQGroup[]> {


### PR DESCRIPTION
## Summary

Adds message query and trace support for Tencent Cloud RocketMQ 5.x instances on the
`rocketmq-studio` branch, mapping the Tencent `provider/tencent` (Trocket v20230308 OpenAPI) to the
message query surface. Fixes #1639.

## Changes

**Message query & trace (Tencent provider)**
- `queryMessages` - by message ID via `DescribeMessage` (full detail with body, properties,
  producer, store time); by topic / time / key / tag via `DescribeMessageList`, paging through the
  whole result set with a stable `TaskRequestId` per logical query (a fresh random id starts a new
  query; subsequent pages reuse it while `Offset` advances until `TotalCount` is reached).
- `getMessageTrace` - `DescribeMessageTrace` parses the per-stage JSON payload
  (`produce` / `persist` / `consume`) into `TraceNodeVO` nodes and `ConsumerStatusVO` entries
  (consumer group, delivery status, retry count). The `topic` is threaded through the trace call
  chain (`MessageController` / `MessageService` / `InstanceProvider` / `MessageProvider`) because
  the API rejects an empty `Topic`.

**Time parsing**
- Tencent returns `ProduceTime` in several shapes (`yyyy-MM-dd HH:mm:ss`, `.SSS`, `,SSS`). The
  parser accepts the common formats and falls back to epoch-millis for numeric values.

**Tag / key surfacing**
- `DescribeMessage` carries tag and key inside `Properties` as `TAGS` / `KEYS`; they are extracted
  onto the record so the message detail/list page shows them.

## Testing
- Unit tests added for the Tencent provider: msgId detail query (body + tag + key extraction),
  topic/key list query (page aggregation with a stable `TaskRequestId`), and trace stage mapping
  (produce/persist/consume, delivery status + retry count). Signatures for `getMessageTrace` were
  updated across providers and their tests.
- Backend: `mvn test` passes (896+ tests, 0 failures); checkstyle clean.
- Frontend: lint/prettier clean; the trace tab now passes `record.topic`.
- Manually verified against a real Tencent Cloud RocketMQ 5.x instance: message list by topic shows
  real store times, msgId detail shows body/tag/key, and the trace tab renders produce/persist/
  consume nodes and consumer status.

## Notes
- Scoped to `rocketmq-studio`; this PR stacks on the still-open consumer-group PR #1591, so until
  that merges the diff also contains the consumer-group changes.
- Dead-letter (DLQ) message operations for Tencent remain unsupported.
