### PR TITLE
fix(proxy): resolve endpoints by selected instance

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
@@ -21,65 +21,42 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import lombok.RequiredArgsConstructor;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class ProxyAddressService {
 
-    private static final Pattern PROXY_ADDR_PATTERN =
-            Pattern.compile("^(\\[[0-9a-fA-F:.]+]|[A-Za-z0-9._-]+):(\\d{1,5})$");
-    private static final int MIN_PORT = 1;
-    private static final int MAX_PORT = 65535;
+    private final InstanceRepository instanceRepository;
 
-    private final Set<String> proxyAddrs = new LinkedHashSet<>(List.of("127.0.0.1:8081"));
-    private String currentProxyAddr = "127.0.0.1:8081";
-
-    public synchronized ProxyHomeVO getHomePage() {
+    /**
+     * A managed Proxy instance has one durable access endpoint. Multi-address discovery and
+     * failover require a Proxy Admin contract and are intentionally not inferred here.
+     */
+    public ProxyHomeVO getHomePage(String instanceId) {
+        if (instanceId == null || instanceId.isBlank()) {
+            throw new BusinessException(400, "instanceId is required");
+        }
+        InstanceVO instance = instanceRepository.findById(instanceId)
+                .orElseThrow(() -> new BusinessException(404, "Instance not found: " + instanceId));
+        if (instance.getType() != InstanceType.PROXY) {
+            throw new BusinessException(400, "Instance is not a Proxy instance: " + instanceId);
+        }
+        String endpoint = instance.getEndpoint();
+        if (endpoint == null || endpoint.isBlank()) {
+            throw new BusinessException(409, "Proxy instance has no configured endpoint: " + instanceId);
+        }
+        String normalizedEndpoint = endpoint.trim();
+        log.debug("Resolved Proxy endpoint for instance {}", instanceId);
         return ProxyHomeVO.builder()
-                .proxyAddrList(new ArrayList<>(proxyAddrs))
-                .currentProxyAddr(currentProxyAddr)
+                .proxyAddrList(List.of(normalizedEndpoint))
+                .currentProxyAddr(normalizedEndpoint)
                 .build();
     }
 
-    public synchronized void addProxyAddr(String newProxyAddr) {
-        String normalized = normalizeProxyAddr(newProxyAddr, "newProxyAddr");
-        proxyAddrs.add(normalized);
-        if (currentProxyAddr == null || currentProxyAddr.isBlank()) {
-            currentProxyAddr = normalized;
-        }
-        log.info("Added Proxy address {}", normalized);
-    }
-
-    public synchronized void removeProxyAddr(String proxyAddr) {
-        String normalized = normalizeProxyAddr(proxyAddr, "proxyAddr");
-        if (!proxyAddrs.remove(normalized)) {
-            throw new BusinessException(404, "Proxy address not found: " + normalized);
-        }
-        if (normalized.equals(currentProxyAddr)) {
-            currentProxyAddr = proxyAddrs.stream().findFirst().orElse("");
-        }
-        log.info("Removed Proxy address {}", normalized);
-    }
-
-    private String normalizeProxyAddr(String proxyAddr, String fieldName) {
-        if (proxyAddr == null || proxyAddr.trim().isEmpty()) {
-            throw new BusinessException(400, fieldName + " is required");
-        }
-        String normalized = proxyAddr.trim();
-        Matcher matcher = PROXY_ADDR_PATTERN.matcher(normalized);
-        if (!matcher.matches()) {
-            throw new BusinessException(400, fieldName + " must be in host:port or [ipv6]:port format");
-        }
-        int port = Integer.parseInt(matcher.group(2));
-        if (port < MIN_PORT || port > MAX_PORT) {
-            throw new BusinessException(400, fieldName + " port must be between 1 and 65535");
-        }
-        return normalized;
-    }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyCompatController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyCompatController.java
@@ -19,7 +19,6 @@ package org.apache.rocketmq.studio.cluster.proxy;
 
 import org.apache.rocketmq.studio.common.domain.Result;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,19 +33,22 @@ public class ProxyCompatController {
     private final ProxyAddressService proxyAddressService;
 
     @GetMapping("/homePage.query")
-    public Result<ProxyHomeVO> homePage() {
-        return Result.ok(proxyAddressService.getHomePage());
+    public Result<ProxyHomeVO> homePage(@RequestParam String instanceId) {
+        return Result.ok(proxyAddressService.getHomePage(instanceId));
     }
 
-    @PostMapping(value = "/addProxyAddr.do", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    public Result<Void> addProxyAddr(@RequestParam String newProxyAddr) {
-        proxyAddressService.addProxyAddr(newProxyAddr);
-        return Result.ok();
+    /**
+     * Kept for legacy Dashboard clients. Proxy endpoint changes belong to managed-instance
+     * configuration; this page must not mutate a process-local address list.
+     */
+    @PostMapping("/addProxyAddr.do")
+    public Result<Void> addProxyAddr() {
+        throw new UnsupportedOperationException("Update the managed instance endpoint instead");
     }
 
-    @PostMapping(value = "/removeProxyAddr.do", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    public Result<Void> removeProxyAddr(@RequestParam String proxyAddr) {
-        proxyAddressService.removeProxyAddr(proxyAddr);
-        return Result.ok();
+    @PostMapping("/removeProxyAddr.do")
+    public Result<Void> removeProxyAddr() {
+        throw new UnsupportedOperationException("Update the managed instance endpoint instead");
     }
+
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
@@ -18,111 +18,77 @@
 package org.apache.rocketmq.studio.cluster.proxy;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class ProxyAddressServiceTest {
 
-    private final ProxyAddressService proxyAddressService = new ProxyAddressService();
+    @Mock
+    private InstanceRepository instanceRepository;
 
-    @Test
-    void homePageShouldReturnDefaultProxyAddress() {
-        ProxyHomeVO home = proxyAddressService.getHomePage();
+    private ProxyAddressService proxyAddressService;
 
-        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081");
-        assertThat(home.getCurrentProxyAddr()).isEqualTo("127.0.0.1:8081");
+    @BeforeEach
+    void setUp() {
+        proxyAddressService = new ProxyAddressService(instanceRepository);
     }
 
     @Test
-    void addProxyAddrShouldTrimAndKeepUniqueAddresses() {
-        proxyAddressService.addProxyAddr(" 10.0.0.1:8081 ");
-        proxyAddressService.addProxyAddr("10.0.0.1:8081");
+    void homePageShouldReturnSelectedProxyInstanceEndpoint() {
+        when(instanceRepository.findById("proxy-a")).thenReturn(Optional.of(proxyInstance("proxy-a", "10.0.0.1:8081")));
 
-        ProxyHomeVO home = proxyAddressService.getHomePage();
-        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081", "10.0.0.1:8081");
-        assertThat(home.getCurrentProxyAddr()).isEqualTo("127.0.0.1:8081");
+        ProxyHomeVO home = proxyAddressService.getHomePage("proxy-a");
+
+        assertThat(home.getProxyAddrList()).containsExactly("10.0.0.1:8081");
+        assertThat(home.getCurrentProxyAddr()).isEqualTo("10.0.0.1:8081");
     }
 
     @Test
-    void addProxyAddrShouldRejectBlankAddress() {
-        assertThatThrownBy(() -> proxyAddressService.addProxyAddr(" "))
+    void homePageShouldRequireInstanceId() {
+        assertThatThrownBy(() -> proxyAddressService.getHomePage(" "))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("newProxyAddr is required")
+                .hasMessage("instanceId is required")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
     }
 
     @Test
-    void addProxyAddrShouldAcceptBracketedIpv6Address() {
-        proxyAddressService.addProxyAddr(" [::1]:8081 ");
+    void homePageShouldRejectDirectInstance() {
+        InstanceVO direct = proxyInstance("direct-a", "127.0.0.1:9876");
+        direct.setType(InstanceType.DIRECT);
+        when(instanceRepository.findById("direct-a")).thenReturn(Optional.of(direct));
 
-        ProxyHomeVO home = proxyAddressService.getHomePage();
-        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081", "[::1]:8081");
-    }
-
-    @Test
-    void addProxyAddrShouldRejectInvalidAddressFormats() {
-        List<String> invalidProxyAddrs = List.of(
-                "10.0.0.1",
-                "10.0.0.1:abc",
-                "10.0.0.1:0",
-                "10.0.0.1:65536",
-                "http://10.0.0.1:8081",
-                "10.0.0.1:8081/path"
-        );
-
-        for (String invalidProxyAddr : invalidProxyAddrs) {
-            assertThatThrownBy(() -> proxyAddressService.addProxyAddr(invalidProxyAddr))
-                    .as("invalid proxy address %s", invalidProxyAddr)
-                    .isInstanceOf(BusinessException.class)
-                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
-        }
-    }
-
-    @Test
-    void removeProxyAddrShouldTrimAndRemoveAddress() {
-        proxyAddressService.addProxyAddr("10.0.0.1:8081");
-
-        proxyAddressService.removeProxyAddr(" 10.0.0.1:8081 ");
-
-        ProxyHomeVO home = proxyAddressService.getHomePage();
-        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081");
-        assertThat(home.getCurrentProxyAddr()).isEqualTo("127.0.0.1:8081");
-    }
-
-    @Test
-    void removeProxyAddrShouldSelectNextProxyWhenCurrentIsRemoved() {
-        proxyAddressService.removeProxyAddr("127.0.0.1:8081");
-
-        ProxyHomeVO emptyHome = proxyAddressService.getHomePage();
-        assertThat(emptyHome.getProxyAddrList()).isEmpty();
-        assertThat(emptyHome.getCurrentProxyAddr()).isEmpty();
-
-        proxyAddressService.addProxyAddr("10.0.0.1:8081");
-        proxyAddressService.addProxyAddr("10.0.0.2:8081");
-        proxyAddressService.removeProxyAddr("10.0.0.1:8081");
-
-        ProxyHomeVO home = proxyAddressService.getHomePage();
-        assertThat(home.getProxyAddrList()).containsExactly("10.0.0.2:8081");
-        assertThat(home.getCurrentProxyAddr()).isEqualTo("10.0.0.2:8081");
-    }
-
-    @Test
-    void removeProxyAddrShouldRejectBlankAddress() {
-        assertThatThrownBy(() -> proxyAddressService.removeProxyAddr(" "))
+        assertThatThrownBy(() -> proxyAddressService.getHomePage("direct-a"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("proxyAddr is required")
+                .hasMessage("Instance is not a Proxy instance: direct-a")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
     }
 
     @Test
-    void removeProxyAddrShouldRejectUnknownAddress() {
-        assertThatThrownBy(() -> proxyAddressService.removeProxyAddr("10.0.0.1:8081"))
+    void homePageShouldRejectMissingInstance() {
+        when(instanceRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> proxyAddressService.getHomePage("missing"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("Proxy address not found: 10.0.0.1:8081")
+                .hasMessage("Instance not found: missing")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
+    }
+
+    private InstanceVO proxyInstance(String id, String endpoint) {
+        InstanceVO instance = InstanceVO.builder().type(InstanceType.PROXY).endpoint(endpoint).build();
+        instance.setId(id);
+        return instance;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyCompatControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyCompatControllerTest.java
@@ -22,12 +22,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -51,34 +49,22 @@ class ProxyCompatControllerTest {
                 .proxyAddrList(List.of("127.0.0.1:8081", "10.0.0.1:8081"))
                 .currentProxyAddr("127.0.0.1:8081")
                 .build();
-        when(proxyAddressService.getHomePage()).thenReturn(home);
+        when(proxyAddressService.getHomePage("proxy-a")).thenReturn(home);
 
-        mockMvc.perform(get("/api/proxy/homePage.query"))
+        mockMvc.perform(get("/api/proxy/homePage.query").param("instanceId", "proxy-a"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.proxyAddrList[0]").value("127.0.0.1:8081"))
                 .andExpect(jsonPath("$.data.currentProxyAddr").value("127.0.0.1:8081"));
+
+        verify(proxyAddressService).getHomePage("proxy-a");
     }
 
     @Test
-    void addProxyAddrShouldAcceptFormEncodedPayload() throws Exception {
-        mockMvc.perform(post("/api/proxy/addProxyAddr.do")
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("newProxyAddr", "10.0.0.1:8081"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(200));
-
-        verify(proxyAddressService).addProxyAddr(eq("10.0.0.1:8081"));
-    }
-
-    @Test
-    void removeProxyAddrShouldAcceptFormEncodedPayload() throws Exception {
-        mockMvc.perform(post("/api/proxy/removeProxyAddr.do")
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("proxyAddr", "10.0.0.1:8081"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(200));
-
-        verify(proxyAddressService).removeProxyAddr(eq("10.0.0.1:8081"));
+    void legacyProxyAddressMutationsShouldReportUnsupported() throws Exception {
+        mockMvc.perform(post("/api/proxy/addProxyAddr.do"))
+                .andExpect(status().isNotImplemented())
+                .andExpect(jsonPath("$.code").value(501))
+                .andExpect(jsonPath("$.message").value("Update the managed instance endpoint instead"));
     }
 }

--- a/web/src/api/proxy.test.ts
+++ b/web/src/api/proxy.test.ts
@@ -38,19 +38,19 @@ describe('Proxy API', () => {
       proxyAddrList: ['192.168.1.1:8081', '192.168.1.2:8081'],
       currentProxyAddr: '192.168.1.1:8081',
     };
-    mock.onGet('/proxy/homePage.query').reply(200, { code: 200, data });
+    mock.onGet('/proxy/homePage.query', { params: { instanceId: 'instance-a' } }).reply(200, { code: 200, data });
 
-    const result = await queryProxyHomePage();
+    const result = await queryProxyHomePage('instance-a');
     expect(result.proxyAddrList).toHaveLength(2);
     expect(result.currentProxyAddr).toBe('192.168.1.1:8081');
   });
 
   it('handles empty proxy address list', async () => {
     mock
-      .onGet('/proxy/homePage.query')
+      .onGet('/proxy/homePage.query', { params: { instanceId: 'instance-a' } })
       .reply(200, { code: 200, data: { proxyAddrList: [], currentProxyAddr: '' } });
 
-    const result = await queryProxyHomePage();
+    const result = await queryProxyHomePage('instance-a');
     expect(result.proxyAddrList).toHaveLength(0);
     expect(result.currentProxyAddr).toBe('');
   });

--- a/web/src/api/proxy.ts
+++ b/web/src/api/proxy.ts
@@ -39,7 +39,9 @@ export interface ProxyNode {
 
 // ─── API Functions ───────────────────────────────────────────────
 
-export async function queryProxyHomePage(): Promise<ProxyHomePageData> {
-  const res = await client.get<{ data: ProxyHomePageData }>('/proxy/homePage.query');
+export async function queryProxyHomePage(instanceId: string): Promise<ProxyHomePageData> {
+  const res = await client.get<{ data: ProxyHomePageData }>('/proxy/homePage.query', {
+    params: { instanceId },
+  });
   return res.data.data;
 }

--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -31,6 +31,7 @@ import {
   Descriptions,
   Tooltip,
   App,
+  Select,
   Typography,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
@@ -45,6 +46,8 @@ import {
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
 import { queryProxyHomePage, type ProxyNode } from '../../api/proxy';
+import { listInstances } from '../../services/instanceService';
+import type { Instance } from '../../api/instance';
 
 const { Text } = Typography;
 
@@ -56,6 +59,8 @@ const ProxyPage: React.FC = () => {
   const [proxyNodes, setProxyNodes] = useState<ProxyNode[]>([]);
   const [selectedNode, setSelectedNode] = useState<ProxyNode | null>(null);
   const [configModalOpen, setConfigModalOpen] = useState(false);
+  const [instances, setInstances] = useState<Instance[]>([]);
+  const [selectedInstanceId, setSelectedInstanceId] = useState('');
   const loadRequestId = useRef(0);
 
   const [clusterStats, setClusterStats] = useState({
@@ -65,11 +70,36 @@ const ProxyPage: React.FC = () => {
     totalTPS: null as number | null,
   });
 
+  useEffect(() => {
+    let cancelled = false;
+    void listInstances({ type: 'PROXY' })
+      .then((nextInstances) => {
+        if (cancelled) return;
+        setInstances(nextInstances);
+        setSelectedInstanceId((current) =>
+          nextInstances.some((instance) => instance.id === current) ? current : (nextInstances[0]?.id ?? ''),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) {
+          message.error(t('proxy.fetchListFailed'));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [message, t]);
+
   const loadProxyNodes = useCallback(async () => {
+    if (!selectedInstanceId) {
+      setProxyNodes([]);
+      setClusterStats({ totalNodes: 0, healthyNodes: null, totalConnections: null, totalTPS: null });
+      return false;
+    }
     const requestId = ++loadRequestId.current;
     setLoading(true);
     try {
-      const { proxyAddrList, currentProxyAddr } = await queryProxyHomePage();
+      const { proxyAddrList, currentProxyAddr } = await queryProxyHomePage(selectedInstanceId);
       if (requestId !== loadRequestId.current) return false;
       const nodes: ProxyNode[] = (proxyAddrList || []).map((addr) => ({
         key: addr,
@@ -92,11 +122,6 @@ const ProxyPage: React.FC = () => {
         totalTPS: null,
       });
 
-      if (currentProxyAddr) {
-        localStorage.setItem('proxyAddr', currentProxyAddr);
-      } else if (proxyAddrList && proxyAddrList.length > 0) {
-        localStorage.setItem('proxyAddr', proxyAddrList[0]);
-      }
       return true;
     } catch {
       if (requestId !== loadRequestId.current) return false;
@@ -107,7 +132,7 @@ const ProxyPage: React.FC = () => {
         setLoading(false);
       }
     }
-  }, [message, t]);
+  }, [message, selectedInstanceId, t]);
 
   useEffect(() => {
     // The state updates are performed by the asynchronous Proxy API request, not by this effect itself.
@@ -276,6 +301,15 @@ const ProxyPage: React.FC = () => {
 
         extra={
           <Space>
+            <Select
+              aria-label="Proxy instance"
+              placeholder="选择 Proxy 实例"
+              value={selectedInstanceId || undefined}
+              onChange={setSelectedInstanceId}
+              options={instances.map((instance) => ({ value: instance.id, label: instance.name }))}
+              style={{ width: 220 }}
+              notFoundContent="暂无 Proxy 实例"
+            />
             <Button type="primary" icon={<ArrowClockwise size={14} />} onClick={handleRefresh}>
               {t('common.refresh')}
             </Button>

--- a/web/src/pages/studio/__tests__/Proxy.test.tsx
+++ b/web/src/pages/studio/__tests__/Proxy.test.tsx
@@ -20,11 +20,16 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { queryProxyHomePage } from '../../../api/proxy';
+import { listInstances } from '../../../services/instanceService';
 import { LangProvider } from '../../../i18n/LangContext';
 import ProxyPage from '../Proxy';
 
 vi.mock('../../../api/proxy', () => ({
   queryProxyHomePage: vi.fn(),
+}));
+
+vi.mock('../../../services/instanceService', () => ({
+  listInstances: vi.fn(),
 }));
 
 beforeAll(() => {
@@ -69,6 +74,19 @@ const createDeferred = <T,>() => {
 describe('ProxyPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'proxy-a',
+        name: 'Proxy A',
+        remark: null,
+        type: 'PROXY',
+        endpoint: '127.0.0.1:8081',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
     vi.mocked(queryProxyHomePage).mockResolvedValue(proxyHome);
   });
 
@@ -76,6 +94,7 @@ describe('ProxyPage', () => {
     renderPage();
 
     await screen.findByText('127.0.0.1:8081');
+    expect(queryProxyHomePage).toHaveBeenCalledWith('proxy-a');
     expect(queryProxyHomePage).toHaveBeenCalledTimes(1);
   });
 
@@ -150,5 +169,26 @@ describe('ProxyPage', () => {
     await act(async () => older.resolve(proxyHome));
     expect(screen.getByText('127.0.0.2:8081')).toBeInTheDocument();
     expect(screen.queryByText('127.0.0.1:8081')).not.toBeInTheDocument();
+  });
+
+  it('loads the selected Proxy instance endpoint instead of a process-global address', async () => {
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'proxy-a', name: 'Proxy A', remark: null, type: 'PROXY', endpoint: '127.0.0.1:8081',
+        topicCount: 0, consumerGroupCount: 0, createdAt: '', updatedAt: '',
+      },
+      {
+        id: 'proxy-b', name: 'Proxy B', remark: null, type: 'PROXY', endpoint: '127.0.0.2:8081',
+        topicCount: 0, consumerGroupCount: 0, createdAt: '', updatedAt: '',
+      },
+    ]);
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText('127.0.0.1:8081');
+
+    await user.click(screen.getByRole('combobox', { name: 'Proxy instance' }));
+    await user.click(await screen.findByText('Proxy B'));
+
+    await waitFor(() => expect(queryProxyHomePage).toHaveBeenLastCalledWith('proxy-b'));
   });
 });


### PR DESCRIPTION
Closes #1113

## Summary
- resolve Proxy home-page addresses from the selected managed `PROXY` instance
- remove process-local default address state and client-side `localStorage` writes
- keep legacy mutation routes explicit but unavailable, directing users to managed instance configuration
- add instance selection and regression coverage for instance-scoped requests

## Verification
- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) mvn -f server/pom.xml -Dtest=ProxyAddressServiceTest,ProxyCompatControllerTest test`
- `npm test -- --run src/api/proxy.test.ts src/pages/studio/__tests__/Proxy.test.tsx`
- `npm run build`