### PR TITLE
fix: disable redirects for metrics requests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
@@ -68,7 +68,14 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
     protected AbstractPrometheusCompatibleMetricsSource(RestClient.Builder restClientBuilder,
                                                          ObjectMapper objectMapper,
                                                          MetricsSourceSettings settings) {
-        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        // Disable redirect following to prevent SSRF bypass via HTTP redirect
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory() {
+            @Override
+            protected void prepareConnection(java.net.HttpURLConnection connection, String httpMethod) throws IOException {
+                super.prepareConnection(connection, httpMethod);
+                connection.setInstanceFollowRedirects(false);
+            }
+        };
         requestFactory.setConnectTimeout(settings.getConnectTimeout());
         requestFactory.setReadTimeout(settings.getReadTimeout());
         this.restClient = restClientBuilder.requestFactory(requestFactory).build();


### PR DESCRIPTION
Disable redirect following on each HTTP connection created by `AbstractPrometheusCompatibleMetricsSource`, so a validated metrics endpoint cannot silently redirect the request to another destination.

This fixes #1647. The implementation was later moved into the shared no-redirect request factory and covered directly in #2034.