### PR TITLE
fix: distinguish unavailable Topic consumer metrics

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/TopicConsumerVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/TopicConsumerVO.java
@@ -32,4 +32,6 @@ public class TopicConsumerVO {
     private String messageModel;
     private double consumeTps;
     private long diffTotal;
+    @Builder.Default
+    private boolean metricsAvailable = true;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -329,6 +329,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                             .messageModel("CLUSTERING")
                             .consumeTps(0)
                             .diffTotal(0)
+                            .metricsAvailable(false)
                             .build());
                 }
             }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
@@ -30,11 +30,13 @@ import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.persistence.entity.RmqGroup;
 import org.apache.rocketmq.studio.persistence.mapper.RmqGroupMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqTopicMapper;
+import org.apache.rocketmq.remoting.protocol.body.GroupList;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashSet;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -156,6 +158,23 @@ class RocketMQMetadataProviderTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Failed to get consumers for topic TopicA: broker unavailable")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    @Test
+    void getTopicConsumersMarksMetricsUnavailableWhenGroupStatsCannotBeRead() throws Exception {
+        DefaultMQAdminExt admin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        GroupList groupList = new GroupList();
+        groupList.setGroupList(new HashSet<>(List.of("cg-orders")));
+        when(admin.queryTopicConsumeByWho("TopicA")).thenReturn(groupList);
+        when(admin.examineConsumeStats("cg-orders", "TopicA"))
+                .thenThrow(new IllegalStateException("broker unavailable"));
+
+        List<TopicConsumerVO> consumers = newLiveProvider(admin).getTopicConsumers(null, "TopicA");
+
+        assertThat(consumers).singleElement().satisfies(consumer -> {
+            assertThat(consumer.getGroup()).isEqualTo("cg-orders");
+            assertThat(consumer.isMetricsAvailable()).isFalse();
+        });
     }
 
     @Test

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -44,6 +44,7 @@ export interface ConsumerGroupInfo {
   messageModel: string;
   consumeTps: number;
   diffTotal: number;
+  metricsAvailable?: boolean;
 }
 
 // ─── Consumer Group (matches mock/consumers.ts) ─────────────────

--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -426,4 +426,24 @@ describe('TopicPage', () => {
     expect(screen.getByRole('button', { name: /导入/ })).toBeDisabled();
     expect(screen.getByRole('button', { name: /创建 Topic/ })).toBeDisabled();
   });
+
+  it('renders unavailable Topic consumer metrics distinctly from zero', async () => {
+    const user = userEvent.setup();
+    topicServiceMocks.listTopics.mockResolvedValue([buildTopics(1)[0]]);
+    topicServiceMocks.getTopicConsumers.mockResolvedValue([
+      {
+        group: 'cg-orders',
+        consumeType: 'CLUSTERING',
+        messageModel: 'CLUSTERING',
+        consumeTps: 0,
+        diffTotal: 0,
+        metricsAvailable: false,
+      },
+    ]);
+    renderWithProviders();
+
+    await user.click(await screen.findByRole('button', { name: /详情/ }));
+
+    expect(await screen.findAllByText('不可用')).not.toHaveLength(0);
+  });
 });

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -563,13 +563,19 @@ const TopicPage = () => {
       title: '消费 TPS',
       dataIndex: 'consumeTps',
       key: 'consumeTps',
-      render: (n: number) => formatNumber(n),
+      render: (n: number, record) =>
+        record.metricsAvailable === false ? <Text type="secondary">不可用</Text> : formatNumber(n),
     },
     {
       title: '堆积量',
       dataIndex: 'diffTotal',
       key: 'diffTotal',
-      render: (n: number) => <Text type={n > 100 ? 'warning' : undefined}>{formatNumber(n)}</Text>,
+      render: (n: number, record) =>
+        record.metricsAvailable === false ? (
+          <Text type="secondary">不可用</Text>
+        ) : (
+          <Text type={n > 100 ? 'warning' : undefined}>{formatNumber(n)}</Text>
+        ),
     },
   ];
 


### PR DESCRIPTION
## Summary

- add a `metricsAvailable` contract field for Topic consumer diagnostics
- mark per-group stats failures unavailable instead of reporting zero TPS and lag
- render unavailable metrics distinctly in the Topic detail table

## Validation

- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) PATH="$JAVA_HOME/bin:$PATH" mvn -f server/pom.xml -Dtest=RocketMQMetadataProviderTest test`
- `npm test -- --run src/pages/instance/__tests__/TopicPage.test.tsx -t "renders unavailable Topic consumer metrics distinctly from zero"`
- `npm run build`

The full TopicPage suite still has a pre-existing asynchronous loading assertion failure in `disables Topic writes until an instance is available`; the new focused test passes.

Closes #1207