### PR TITLE
fix: surface dashboard runtime collection failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -33,6 +33,7 @@ import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
@@ -98,8 +99,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
         try {
             ClusterInfo clusterInfo = admin.examineBrokerClusterInfo();
             if (clusterInfo == null) {
-                log.warn("NameServer returned no cluster topology, returning empty dashboard");
-                return emptyDashboard();
+                throw new BusinessException(502, "Failed to collect dashboard data: NameServer returned no cluster topology");
             }
             // The NameServer topology is decoded from JSON; a payload missing either
             // table yields null here. Treat it as empty so a partial topology degrades
@@ -283,8 +283,11 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             }
 
         } catch (Exception e) {
+            if (e instanceof BusinessException businessException) {
+                throw businessException;
+            }
             log.error("Failed to collect dashboard data from RocketMQ cluster", e);
-            return emptyDashboard();
+            throw new BusinessException(502, "Failed to collect dashboard data: " + e.getMessage());
         }
 
         long messagesPerSecond = tpsIn + tpsOut;

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.remoting.protocol.body.TopicList;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
@@ -36,6 +37,7 @@ import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -79,6 +81,32 @@ class RocketMQDashboardProviderTest {
         // A partial NameServer payload must not throw and zero the page.
         assertThat(dashboard.getStats()).isNotNull();
         assertThat(dashboard.getClusters()).isEmpty();
+    }
+
+    @Test
+    void dashboardShouldRejectAnUnavailableTopologyInsteadOfReturningAnEmptyOverview() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(null);
+
+        RocketMQDashboardProvider provider = newProvider(adminExt);
+
+        assertThatThrownBy(provider::getDashboardData)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502))
+                .hasMessageContaining("Failed to collect dashboard data");
+    }
+
+    @Test
+    void dashboardShouldRejectAdminFailuresInsteadOfReturningAnEmptyOverview() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenThrow(new IllegalStateException("access denied"));
+
+        RocketMQDashboardProvider provider = newProvider(adminExt);
+
+        assertThatThrownBy(provider::getDashboardData)
+                .isInstanceOf(BusinessException.class)
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502))
+                .hasMessageContaining("access denied");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- retain the empty overview for a valid empty topology
- return a structured 502 when topology is unavailable or top-level Admin collection fails
- cover both failure paths and valid empty topology

Closes #1654

## Verification
- `mvn -f server/pom.xml -Dtest=RocketMQDashboardProviderTest test`