### PR TITLE
feat: audit metrics data source mutations

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -102,6 +102,28 @@ public class SettingsService {
         }
     }
 
+    private void recordDataSourceAudit(String operation, DataSourceVO dataSource) {
+        if (dataSource == null) {
+            return;
+        }
+        String detail = String.format("name=%s, type=%s, instanceCount=%d", dataSource.getName(),
+                dataSource.getType(), dataSource.getInstanceIds() == null ? 0 : dataSource.getInstanceIds().size());
+        recordDataSourceAudit(operation, dataSource.getKey(), detail);
+    }
+
+    private void recordDataSourceDeleteAudit(String key) {
+        recordDataSourceAudit("DELETE_DATA_SOURCE", key, "key=" + key);
+    }
+
+    private void recordDataSourceAudit(String operation, String key, String detail) {
+        try {
+            operationAuditService.record(operation, "METRICS_DATA_SOURCE", key, null, detail, "SUCCESS", null);
+        } catch (Exception auditFailure) {
+            log.warn("Failed to record data source audit operation={} key={}: {}", operation, key,
+                    auditFailure.getMessage());
+        }
+    }
+
 
     public List<DataSourceVO> listDataSources() {
         log.debug("Listing all data sources");
@@ -115,7 +137,9 @@ public class SettingsService {
         }
         log.info("Creating data source: {}", dataSource.getName());
         dataSource.setKey(UUID.randomUUID().toString());
-        return settingsRepository.saveDataSource(dataSource);
+        DataSourceVO saved = settingsRepository.saveDataSource(dataSource);
+        recordDataSourceAudit("CREATE_DATA_SOURCE", saved);
+        return saved;
     }
 
 
@@ -129,6 +153,7 @@ public class SettingsService {
         if (!settingsRepository.replaceDataSource(dataSource)) {
             throw new BusinessException(404, "Data source not found: " + key);
         }
+        recordDataSourceAudit("UPDATE_DATA_SOURCE", dataSource);
         return dataSource;
     }
 
@@ -139,6 +164,7 @@ public class SettingsService {
         if (!settingsRepository.deleteDataSource(normalizedKey)) {
             throw new BusinessException(404, "Data source not found: " + normalizedKey);
         }
+        recordDataSourceDeleteAudit(normalizedKey);
     }
 
 

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -233,6 +233,8 @@ class SettingsServiceTest {
         assertThat(result.getKey()).isNotBlank();
         assertThat(result.getName()).isEqualTo("New DS");
         verify(settingsRepository).saveDataSource(input);
+        verify(operationAuditService).record("CREATE_DATA_SOURCE", "METRICS_DATA_SOURCE", result.getKey(),
+                null, "name=New DS, type=rocketmq, instanceCount=0", "SUCCESS", null);
     }
 
     @Test
@@ -269,6 +271,8 @@ class SettingsServiceTest {
         assertThat(result.getKey()).isEqualTo("ds-1");
         assertThat(result.getName()).isEqualTo("Updated DS");
         verify(settingsRepository).replaceDataSource(input);
+        verify(operationAuditService).record("UPDATE_DATA_SOURCE", "METRICS_DATA_SOURCE", "ds-1",
+                null, "name=Updated DS, type=rocketmq, instanceCount=0", "SUCCESS", null);
     }
 
     @Test
@@ -318,6 +322,8 @@ class SettingsServiceTest {
         settingsService.deleteDataSource("ds-1");
 
         verify(settingsRepository).deleteDataSource("ds-1");
+        verify(operationAuditService).record("DELETE_DATA_SOURCE", "METRICS_DATA_SOURCE", "ds-1",
+                null, "key=ds-1", "SUCCESS", null);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- audit successful Prometheus-compatible data source creation, update, and deletion
- record only non-sensitive identifiers and metadata; URLs and credentials are excluded
- isolate audit persistence failures from completed configuration changes

Closes #1300

## Verification
- `mvn -f server/pom.xml -Dtest=SettingsServiceTest test`