### PR TITLE
fix: normalize ACL bound types with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 @Slf4j
@@ -210,7 +211,7 @@ public class AclService {
     }
 
     private boolean isValidAcl2BoundType(String boundType) {
-        return switch (boundType.trim().toUpperCase()) {
+        return switch (boundType.trim().toUpperCase(Locale.ROOT)) {
             case "TOPIC", "GROUP", "*", "USER", "SERVICE_ACCOUNT" -> true;
             default -> false;
         };

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -573,6 +574,22 @@ class AclServiceTest {
         policy.setWhiteSet(List.of("192.168.1.0/24", "10.0.0.1"));
 
         aclService.validateAcl2Policy(policy);
+    }
+
+    @Test
+    void validateAcl2PolicyShouldIgnoreTheJvmDefaultLocaleWhenNormalizingBoundType() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            Acl2PolicyContext policy = new Acl2PolicyContext();
+            policy.setPolicyName("orders-policy");
+            policy.setBoundType("topic");
+            policy.setRules(List.of(Acl2PolicyContext.AuthorizationRule.defaultAllowRule("orders-*")));
+
+            aclService.validateAcl2Policy(policy);
+        } finally {
+            Locale.setDefault(previous);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- normalize ACL 2.0 bound type protocol tokens with `Locale.ROOT`
- cover a Turkish JVM default locale regression

Closes #1661

## Verification
- `mvn -f server/pom.xml -Dtest=AclServiceTest test`