### PR TITLE
fix: surface failed cluster detail refreshes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -132,8 +132,12 @@ public class RocketMQClusterProvider implements ClusterProvider {
                 return buildClusterVO(clusterId, brokers, nameServers);
             });
         } catch (Exception e) {
+            if (e instanceof BusinessException businessException) {
+                throw businessException;
+            }
             log.warn("Failed to refresh cluster detail for {}: {}", clusterId, e.getMessage());
-            return null;
+            throw new BusinessException(502,
+                    "Failed to refresh cluster detail for " + clusterId + ": " + rootMessage(e));
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -380,6 +380,23 @@ class ClusterServiceTest {
     }
 
     @Test
+    void updateConfigShouldNotFallBackToPersistedClusterWhenLiveRefreshFails() {
+        when(clusterProvider.refreshClusterDetail("cluster-1"))
+                .thenThrow(new BusinessException(502, "NameServer unavailable"));
+
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .flushDiskType("SYNC_FLUSH")
+                .build();
+
+        assertThatThrownBy(() -> clusterService.updateClusterConfig(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("NameServer unavailable")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(502));
+        verify(clusterRepository, never()).findById("cluster-1");
+    }
+
+    @Test
     void updateConfigShouldRejectInvalidFlushDiskType() {
         when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
@@ -93,6 +93,19 @@ class RocketMQClusterProviderTest {
     }
 
     @Test
+    void refreshClusterDetailShouldSurfaceNameServerFailuresInsteadOfReturningNull() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RocketMQClusterProvider provider = newProvider(adminExt);
+        when(adminExt.examineBrokerClusterInfo()).thenThrow(new IllegalStateException("NameServer unavailable"));
+
+        assertThatThrownBy(() -> provider.refreshClusterDetail("DefaultCluster"))
+                .isInstanceOfSatisfying(BusinessException.class, error -> {
+                    assertThat(error.getCode()).isEqualTo(502);
+                    assertThat(error.getMessage()).contains("NameServer unavailable");
+                });
+    }
+
+    @Test
     void discoverClustersMarksWarningWhenBrokerRuntimeStatsAreUnavailable() throws Exception {
         DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
         RocketMQClusterProvider provider = newProvider(adminExt);


### PR DESCRIPTION
## Summary
- return a structured 502 for failed live Cluster detail refreshes
- retain `null` only for absent topology/cluster cases
- prevent configuration updates from falling back to persisted cluster metadata after a failed refresh

Closes #1663

## Verification
- `mvn -f server/pom.xml -Dtest=RocketMQClusterProviderTest,ClusterServiceTest test`