### PR TITLE
refactor: make the LLM redirect policy explicit

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -56,6 +56,7 @@ public class OpenAiCompatibleLlmClient {
     public OpenAiCompatibleLlmClient(ObjectMapper objectMapper) {
         this(objectMapper, HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
+                .followRedirects(HttpClient.Redirect.NEVER)
                 .build(), Duration.ofSeconds(60));
     }
 


### PR DESCRIPTION
Set `HttpClient.Redirect.NEVER` explicitly on the OpenAI-compatible LLM client.

The original issue #1669 incorrectly assumed that Java's `HttpClient` follows redirects by default. Java 21 already defaults to `NEVER`, so this merged change documents and locks in the existing safe behavior rather than fixing an actual redirect-following vulnerability.