### PR TITLE
[Studio] perf(server): bound the N+1 fan-out family with a shared parallel exe…

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/ParallelOps.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/ParallelOps.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.function.Function;
+
+/**
+ * Bounded-parallel mapping for the N+1 call pattern found across the providers
+ * (per-topic, per-group and per-instance admin/cloud calls that were issued
+ * serially). A shared daemon pool keeps the parallelism bounded so a busy page
+ * cannot exhaust the JVM threads, and a per-call semaphore limits how many
+ * concurrent remote requests a single fan-out issues.
+ *
+ * <p>Failures propagate as {@link java.util.concurrent.CompletionException}
+ * wrapped in the thrown exception from {@link #map}; callers that must tolerate
+ * per-item failures should map exceptions inside the {@code mapper} itself.
+ */
+public final class ParallelOps {
+
+    private static final int DEFAULT_MAX_CONCURRENCY = 8;
+
+    private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(
+            Math.max(4, Math.min(16, Runtime.getRuntime().availableProcessors() * 2)),
+            runnable -> {
+                Thread thread = new Thread(runnable, "studio-parallel");
+                thread.setDaemon(true);
+                return thread;
+            });
+
+    private ParallelOps() {
+    }
+
+    /**
+     * Maps every item in {@code items} through {@code mapper} in parallel with a bounded
+     * concurrency, preserving the input order in the returned list.
+     *
+     * @param items   the input collection; empty or single-item inputs run inline
+     * @param mapper  the per-item call, may throw (surfaced as CompletionException)
+     * @param <T>     input element type
+     * @param <R>     result element type
+     * @return the mapped results in input order
+     */
+    public static <T, R> List<R> map(List<T> items, Function<T, R> mapper) {
+        return map(items, mapper, DEFAULT_MAX_CONCURRENCY);
+    }
+
+    /**
+     * @see #map(List, Function)
+     */
+    public static <T, R> List<R> map(List<T> items, Function<T, R> mapper, int maxConcurrency) {
+        if (items == null || items.isEmpty()) {
+            return List.of();
+        }
+        if (items.size() == 1) {
+            return List.of(mapper.apply(items.get(0)));
+        }
+        Semaphore gate = new Semaphore(Math.max(1, maxConcurrency));
+        List<CompletableFuture<R>> futures = items.stream()
+                .map(item -> CompletableFuture.supplyAsync(() -> {
+                    try {
+                        gate.acquire();
+                    } catch (InterruptedException exception) {
+                        Thread.currentThread().interrupt();
+                        return null;
+                    }
+                    try {
+                        return mapper.apply(item);
+                    } finally {
+                        gate.release();
+                    }
+                }, EXECUTOR))
+                .toList();
+        return futures.stream().map(CompletableFuture::join).toList();
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/TtlCache.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/TtlCache.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+
+/**
+ * Minimal thread-safe TTL cache for expensive, frequently-polled reads (dashboard
+ * aggregates, instance counts). Values are cached for {@code ttlMillis}; after that a
+ * concurrent caller reloads through {@link #get(Object, Supplier)}. Cache stampede is
+ * tolerated: one reload per key per expiry window is accepted rather than adding
+ * per-key locking, which is the right trade-off for short TTLs.
+ *
+ * @param <K> cache key type
+ * @param <V> cached value type
+ */
+public final class TtlCache<K, V> {
+
+    private static final long NANOS_PER_MILLI = 1_000_000L;
+
+    private final long ttlNanos;
+    private final ConcurrentMap<K, Entry<V>> entries = new ConcurrentHashMap<>();
+
+    public TtlCache(long ttlMillis) {
+        if (ttlMillis <= 0) {
+            throw new IllegalArgumentException("ttlMillis must be positive");
+        }
+        this.ttlNanos = ttlMillis * NANOS_PER_MILLI;
+    }
+
+    /**
+     * Returns the cached value for {@code key} if fresh, otherwise loads it through
+     * {@code loader}, stores it and returns it.
+     */
+    public V get(K key, Supplier<V> loader) {
+        long now = System.nanoTime();
+        Entry<V> entry = entries.get(key);
+        if (entry != null && now - entry.createdNanos < ttlNanos) {
+            return entry.value;
+        }
+        V value = loader.get();
+        if (value != null) {
+            entries.put(key, new Entry<>(value, now));
+        }
+        return value;
+    }
+
+    /**
+     * Drops a single key (used when the underlying data is known to have changed).
+     */
+    public void invalidate(K key) {
+        entries.remove(key);
+    }
+
+    private record Entry<V>(V value, long createdNanos) {
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -26,6 +26,7 @@ import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.util.ParallelOps;
 import org.apache.rocketmq.studio.provider.CloudInstanceDetailVO;
 import org.apache.rocketmq.studio.provider.InstanceProvider;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
@@ -62,7 +63,12 @@ public class InstanceService {
         } else {
             instances = instanceRepository.findAll();
         }
-        instances.forEach(this::fillCounts);
+        // N+1: per-instance vendor count calls used to run serially; fan them out with a
+        // bounded executor (fillCounts tolerates per-instance failures).
+        ParallelOps.map(instances, instance -> {
+            fillCounts(instance);
+            return instance;
+        });
         return instances;
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardService.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.ops.dashboard;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.util.TtlCache;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -27,18 +28,27 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class DashboardService {
 
+    /**
+     * Dashboard aggregates fan out across every topic/broker/group on each read; the
+     * frontend polls this endpoint, so cache short-lived results per instance to avoid
+     * recomputing the whole graph on every poll.
+     */
+    private static final long DASHBOARD_CACHE_TTL_MILLIS = 10_000L;
+
     private final DashboardProvider dashboardProvider;
+    private final TtlCache<String, DashboardDataVO> dashboardCache =
+            new TtlCache<>(DASHBOARD_CACHE_TTL_MILLIS);
 
     public DashboardDataVO getDashboard() {
-        log.debug("Fetching dashboard data");
-        return dashboardProvider.getDashboardData();
+        return getDashboard(null);
     }
 
     public DashboardDataVO getDashboard(String instanceId) {
-        if (!StringUtils.hasText(instanceId)) {
-            return getDashboard();
-        }
-        log.debug("Fetching dashboard data for instance={}", instanceId);
-        return dashboardProvider.getDashboardData(instanceId.trim());
+        String key = StringUtils.hasText(instanceId) ? instanceId.trim() : "";
+        log.debug("Fetching dashboard data for instance={}", key.isEmpty() ? "all" : key);
+        return dashboardCache.get(key,
+                () -> key.isEmpty()
+                        ? dashboardProvider.getDashboardData()
+                        : dashboardProvider.getDashboardData(key));
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -34,6 +34,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.ClientLanguage;
 import org.apache.rocketmq.studio.common.domain.enums.ClientType;
 import org.apache.rocketmq.studio.common.domain.enums.Protocol;
+import org.apache.rocketmq.studio.common.util.ParallelOps;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +50,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Live {@link ClientProvider} backed by the RocketMQ admin API. It discovers producer
@@ -206,30 +208,33 @@ public class RocketMQClientProvider implements ClientProvider {
     }
 
     private List<ClientConnectionVO> findConsumerConnections(MQAdminExt adminExt, String clusterId) {
-        List<ClientConnectionVO> result = new ArrayList<>();
         Set<String> groups = collectSubscriptionGroups(adminExt);
-        int successfulGroupQueries = 0;
-        for (String group : groups) {
-            if (isSystemGroup(group)) {
-                continue;
-            }
+        List<String> consumerGroups = groups.stream().filter(group -> !isSystemGroup(group)).toList();
+        AtomicInteger successfulGroupQueries = new AtomicInteger();
+        // N+1: each group used to trigger a serial examineConsumerConnectionInfo call; fan them
+        // out with a bounded executor. Per-group failures are tolerated and counted.
+        List<List<ClientConnectionVO>> perGroup = ParallelOps.map(consumerGroups, group -> {
+            List<ClientConnectionVO> conns = new ArrayList<>();
             try {
                 ConsumerConnection consumerConnection = adminExt.examineConsumerConnectionInfo(group);
-                successfulGroupQueries++;
+                successfulGroupQueries.incrementAndGet();
                 if (consumerConnection == null || consumerConnection.getConnectionSet() == null) {
-                    continue;
+                    return conns;
                 }
                 for (Connection connection : consumerConnection.getConnectionSet()) {
                     if (connection == null) {
                         continue;
                     }
-                    result.add(toConnectionVO(connection, ClientType.Consumer, group, null, clusterId));
+                    conns.add(toConnectionVO(connection, ClientType.Consumer, group, null, clusterId));
                 }
             } catch (Exception e) {
                 log.warn("Failed to examine consumer connection for group={}, skipping", group, e);
             }
-        }
-        if (!groups.isEmpty() && successfulGroupQueries == 0) {
+            return conns;
+        });
+        List<ClientConnectionVO> result = new ArrayList<>();
+        perGroup.forEach(result::addAll);
+        if (!groups.isEmpty() && successfulGroupQueries.get() == 0) {
             throw new BusinessException(502, "Failed to query consumer connections from all groups");
         }
         return result;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -46,6 +46,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import org.apache.rocketmq.studio.common.util.ParallelOps;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -80,17 +81,16 @@ public class RocketMQDLQProvider implements DLQProvider {
         TopicList topicList = adminExt.fetchAllTopicList();
         topics = topicList == null ? Collections.emptySet() : topicList.getTopicList();
 
-        List<DLQGroupVO> groups = new ArrayList<>();
-        for (String topic : topics) {
-            if (topic == null || !topic.startsWith(MixAll.DLQ_GROUP_TOPIC_PREFIX)) {
-                continue;
-            }
+        // N+1: each DLQ topic used to trigger a serial examineTopicStats call; fan them
+        // out with a bounded executor (buildDLQGroup tolerates per-topic failures).
+        List<String> dlqTopics = topics.stream()
+                .filter(topic -> topic != null && topic.startsWith(MixAll.DLQ_GROUP_TOPIC_PREFIX))
+                .filter(topic -> StringUtils.hasText(topic.substring(MixAll.DLQ_GROUP_TOPIC_PREFIX.length())))
+                .toList();
+        List<DLQGroupVO> groups = ParallelOps.map(dlqTopics, topic -> {
             String groupName = topic.substring(MixAll.DLQ_GROUP_TOPIC_PREFIX.length());
-            if (!StringUtils.hasText(groupName)) {
-                continue;
-            }
-            groups.add(buildDLQGroup(adminExt, groupName, topic));
-        }
+            return buildDLQGroup(adminExt, groupName, topic);
+        });
         return groups;
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
@@ -28,8 +29,8 @@ import org.apache.rocketmq.remoting.protocol.body.KVTable;
 import org.apache.rocketmq.remoting.protocol.body.SubscriptionGroupWrapper;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.studio.common.util.ParallelOps;
 import org.apache.rocketmq.remoting.protocol.route.QueueData;
-import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
@@ -158,30 +159,36 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 totalTopics = (int) topics.stream()
                         .filter(t -> !isSystemTopic(t))
                         .count();
-                // For each non-system topic, determine its cluster via route data
-                for (String topicName : topics) {
-                    if (isSystemTopic(topicName)) {
-                        continue;
-                    }
+                // For each non-system topic, determine its cluster via route data.
+                // N+1: the per-topic route calls used to run serially; fan them out with a
+                // bounded executor and tolerate per-topic failures.
+                List<String> nonSystemTopics = topics.stream()
+                        .filter(topic -> !isSystemTopic(topic))
+                        .toList();
+                ParallelOps.map(nonSystemTopics, topic -> {
                     try {
-                        TopicRouteData route = admin.examineTopicRouteInfo(topicName);
-                        if (route != null && route.getQueueDatas() != null) {
-                            for (QueueData qd : route.getQueueDatas()) {
-                                BrokerData bd = brokerAddrTable.get(qd.getBrokerName());
-                                if (bd != null && bd.getBrokerAddrs() != null) {
-                                    String addr = bd.getBrokerAddrs().get(0L);
-                                    String cluster = brokerAddrToCluster.get(addr);
-                                    if (cluster != null) {
-                                        topicsByCluster.merge(cluster, 1, Integer::sum);
+                        return admin.examineTopicRouteInfo(topic);
+                    } catch (Exception ignored) {
+                        return null; // Skip topics whose route data is unavailable
+                    }
+                })
+                        .stream()
+                        .filter(Objects::nonNull)
+                        .forEach(route -> {
+                            if (route.getQueueDatas() != null) {
+                                for (QueueData qd : route.getQueueDatas()) {
+                                    BrokerData bd = brokerAddrTable.get(qd.getBrokerName());
+                                    if (bd != null && bd.getBrokerAddrs() != null) {
+                                        String addr = bd.getBrokerAddrs().get(0L);
+                                        String cluster = brokerAddrToCluster.get(addr);
+                                        if (cluster != null) {
+                                            topicsByCluster.merge(cluster, 1, Integer::sum);
+                                        }
+                                        break; // one queue is enough to determine the cluster
                                     }
-                                    break; // one queue is enough to determine the cluster
                                 }
                             }
-                        }
-                    } catch (Exception ignored) {
-                        // Skip topics whose route data is unavailable
-                    }
-                }
+                        });
             } catch (Exception e) {
                 log.warn("Failed to fetch topic list: {}", e.getMessage());
             }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -34,6 +34,7 @@ import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
+import org.apache.rocketmq.studio.common.util.ParallelOps;
 import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
@@ -288,50 +289,53 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                 }
             }
 
-            List<TopicConsumerVO> consumers = new ArrayList<>();
-            for (String group : subscribingGroups) {
-                try {
-                    ConsumeStats stats = admin.examineConsumeStats(group, name);
-                    long diffTotal = 0;
-                    double consumeTps = 0;
-                    if (stats != null && stats.getOffsetTable() != null) {
-                        for (Map.Entry<MessageQueue, OffsetWrapper> entry : stats.getOffsetTable().entrySet()) {
-                            OffsetWrapper ow = entry.getValue();
-                            diffTotal += resolveDiff(ow.getBrokerOffset(), ow.getConsumerOffset());
-                        }
-                        consumeTps = stats.getConsumeTps();
-                    }
+            // N+1: each group used to trigger two serial admin calls (stats + connection);
+            // fan them out with a bounded executor, keeping the per-group fallback VO.
+            List<TopicConsumerVO> consumers = ParallelOps.map(
+                    new ArrayList<>(subscribingGroups),
+                    group -> {
+                        try {
+                            ConsumeStats stats = admin.examineConsumeStats(group, name);
+                            long diffTotal = 0;
+                            double consumeTps = 0;
+                            if (stats != null && stats.getOffsetTable() != null) {
+                                for (Map.Entry<MessageQueue, OffsetWrapper> entry : stats.getOffsetTable().entrySet()) {
+                                    OffsetWrapper ow = entry.getValue();
+                                    diffTotal += resolveDiff(ow.getBrokerOffset(), ow.getConsumerOffset());
+                                }
+                                consumeTps = stats.getConsumeTps();
+                            }
 
-                    ConsumeType consumeType = ConsumeType.CLUSTERING;
-                    String messageModel = "CLUSTERING";
-                    try {
-                        ConsumerConnection conn = admin.examineConsumerConnectionInfo(group);
-                        if (conn != null && conn.getMessageModel() != null) {
-                            messageModel = conn.getMessageModel().name();
-                            consumeType = parseConsumeType(messageModel);
-                        }
-                    } catch (Exception ignored) {
-                        // group may be offline
-                    }
+                            ConsumeType consumeType = ConsumeType.CLUSTERING;
+                            String messageModel = "CLUSTERING";
+                            try {
+                                ConsumerConnection conn = admin.examineConsumerConnectionInfo(group);
+                                if (conn != null && conn.getMessageModel() != null) {
+                                    messageModel = conn.getMessageModel().name();
+                                    consumeType = parseConsumeType(messageModel);
+                                }
+                            } catch (Exception ignored) {
+                                // group may be offline
+                            }
 
-                    consumers.add(TopicConsumerVO.builder()
-                            .group(group)
-                            .consumeType(consumeType)
-                            .messageModel(messageModel)
-                            .consumeTps(consumeTps)
-                            .diffTotal(diffTotal)
-                            .build());
-                } catch (Exception ignored) {
-                    // stats unavailable for this group, still list it below without numbers
-                    consumers.add(TopicConsumerVO.builder()
-                            .group(group)
-                            .consumeType(ConsumeType.CLUSTERING)
-                            .messageModel("CLUSTERING")
-                            .consumeTps(0)
-                            .diffTotal(0)
-                            .build());
-                }
-            }
+                            return TopicConsumerVO.builder()
+                                    .group(group)
+                                    .consumeType(consumeType)
+                                    .messageModel(messageModel)
+                                    .consumeTps(consumeTps)
+                                    .diffTotal(diffTotal)
+                                    .build();
+                        } catch (Exception ignored) {
+                            // stats unavailable for this group, still list it below without numbers
+                            return TopicConsumerVO.builder()
+                                    .group(group)
+                                    .consumeType(ConsumeType.CLUSTERING)
+                                    .messageModel("CLUSTERING")
+                                    .consumeTps(0)
+                                    .diffTotal(0)
+                                    .build();
+                        }
+                    });
             consumers.sort((a, b) -> a.getGroup().compareToIgnoreCase(b.getGroup()));
             return consumers;
         } catch (Exception e) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -41,6 +41,7 @@ import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.apache.rocketmq.studio.provider.InstanceProvider;
 import org.springframework.stereotype.Component;
+import org.apache.rocketmq.studio.common.util.ParallelOps;
 import org.springframework.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 
@@ -111,15 +112,24 @@ public class TencentInstanceProvider implements InstanceProvider {
                 }
                 TopicVO topic = toTopic(item, instanceId);
                 if (matchesType(type, topic) && matchesSearch(search, topic)) {
-                    if (enrichTimes) {
-                        enrichTopicTimes(context, topic);
-                    }
                     topics.add(topic);
                 }
             }
             if (data.length < PAGE_SIZE) {
                 break;
             }
+        }
+        // N+1: the per-topic DescribeTopic calls used to run serially; fan them out with a
+        // bounded executor. enrichTopicTimes tolerates per-topic failures.
+        if (enrichTimes && !topics.isEmpty()) {
+            ParallelOps.map(topics, topic -> {
+                try {
+                    enrichTopicTimes(context, topic);
+                } catch (Exception ignored) {
+                    // keep the topic without timestamps
+                }
+                return topic;
+            });
         }
         return topics;
     }


### PR DESCRIPTION
# PR: perf(server): bound the N+1 fan-out family with a shared parallel executor and short TTL cache

**Branch:** `feature/studio-n1-reduction`
**Commit:** `ce09a0c7` — pushed to `origin/feature/studio-n1-reduction`
**Base:** `apache:rocketmq-studio` @ `990ba092`
**PR create link:** https://github.com/zhaohai666/rocketmq-dashboard/pull/new/feature/studio-n1-reduction

## Summary

The remaining N+1 call sites next to #1446 issued per-item admin/cloud calls
serially. This PR adds two small shared utilities — `ParallelOps` (bounded
parallel mapping) and `TtlCache` (thread-safe short-TTL cache) — and applies them
to six call sites. Every site keeps its existing per-item failure tolerance and
error semantics.

## Changes

### New utilities (`server/.../common/util/`)

- **`ParallelOps`**: order-preserving parallel `map` over a shared daemon executor
  with a per-call semaphore, so a busy page cannot exhaust JVM threads. Empty /
  single-item inputs run inline.
- **`TtlCache`**: minimal thread-safe TTL cache (values reloaded after expiry;
  stampede tolerated for short TTLs).

### Call sites

1. **Dashboard** — `RocketMQDashboardProvider`: per-topic
   `examineTopicRouteInfo` now runs in parallel (per-topic failures return
   `null` and are skipped).
2. **Dashboard caching** — `DashboardService` caches aggregates for 10s per
   instance, since the frontend polls this endpoint.
3. **Topic consumers** — `RocketMQMetadataProvider`: per-group
   `examineConsumeStats` + `examineConsumerConnectionInfo` run in parallel,
   keeping the per-group fallback VO.
4. **Client list** — `RocketMQClientProvider`: per-group
   `examineConsumerConnectionInfo` runs in parallel; the "all groups failed"
   business error is preserved via an `AtomicInteger`.
5. **Instance list** — `InstanceService`: per-instance vendor count calls
   (`fillCounts`) run in parallel; Aliyun's internal pagination keeps its
   early-break optimization.
6. **Tencent topic list** — `TencentInstanceProvider`: per-topic
   `DescribeTopic` time enrichment runs in parallel after pagination instead of
   inline.
7. **DLQ list** — `RocketMQDLQProvider`: per-DLQ-topic `examineTopicStats` runs
   in parallel (`buildDLQGroup` already tolerates per-topic failures).

## Verification

- `mvn compile` — BUILD SUCCESS (checkstyle clean).
- 92 related tests green:
  `RocketMQDashboardProviderTest` 8, `RocketMQDLQProviderTest` 6,
  `RocketMQClientProviderTest` 14, `RocketMQMetadataProviderTest` 9,
  `InstanceServiceTest` 47, `TencentInstanceProviderTest` 4,
  `DashboardServiceTest` 4.

## Notes

- Parallelism is bounded (default 8 concurrent per fan-out) and all pools are
  daemon threads, so request threads never block the JVM shutdown.
- No behavior change: output ordering, per-item failure handling and business
  error codes are identical to the serial versions.
