### PR TITLE
[studio][ISSUE #1642] Validate resource plan numeric fields

### DIFF
--- a/web/src/services/resourcePlanService.test.ts
+++ b/web/src/services/resourcePlanService.test.ts
@@ -115,4 +115,35 @@ describe('resource plan service', () => {
       { field: 'writeQueues', currentValue: '16', desiredValue: '32' },
     ]);
   });
+
+  it('rejects numeric fields that are not non-negative integers at runtime', async () => {
+    topicServiceMocks.listTopics.mockResolvedValue([]);
+    consumerServiceMocks.listConsumerGroups.mockResolvedValue([]);
+    const bundle = parseResourceBundle(`{
+      "topics": [
+        { "name": "string-queues", "writeQueues": "8" },
+        { "name": "fractional-queues", "readQueues": 1.5 }
+      ],
+      "consumerGroups": [
+        { "name": "negative-retries", "retryMaxTimes": -1 },
+        { "name": "null-delay", "delaySeconds": null }
+      ]
+    }`);
+
+    const plan = await previewResourcePlan({ instanceId: 'instance-proxy-1', ...bundle });
+
+    expect(plan.summary).toMatchObject({
+      total: 4,
+      invalids: 4,
+      applicable: 0,
+    });
+    expect(plan.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'string-queues', action: 'INVALID' }),
+        expect.objectContaining({ name: 'fractional-queues', action: 'INVALID' }),
+        expect.objectContaining({ name: 'negative-retries', action: 'INVALID' }),
+        expect.objectContaining({ name: 'null-delay', action: 'INVALID' }),
+      ]),
+    );
+  });
 });

--- a/web/src/services/resourcePlanService.ts
+++ b/web/src/services/resourcePlanService.ts
@@ -188,11 +188,11 @@ function planTopicEntries(
     if (seen.has(name))
       return invalidEntry('TOPIC', name, index, 'Duplicate topic in resource plan');
     seen.add(name);
-    if (topic.writeQueues !== undefined && topic.writeQueues < 0) {
-      return invalidEntry('TOPIC', name, index, 'Topic writeQueues must be zero or positive');
+    if (topic.writeQueues !== undefined && !isNonNegativeInteger(topic.writeQueues)) {
+      return invalidEntry('TOPIC', name, index, 'Topic writeQueues must be a non-negative integer');
     }
-    if (topic.readQueues !== undefined && topic.readQueues < 0) {
-      return invalidEntry('TOPIC', name, index, 'Topic readQueues must be zero or positive');
+    if (topic.readQueues !== undefined && !isNonNegativeInteger(topic.readQueues)) {
+      return invalidEntry('TOPIC', name, index, 'Topic readQueues must be a non-negative integer');
     }
 
     const existing = existingTopics.get(name);
@@ -255,20 +255,20 @@ function planConsumerGroupEntries(
       );
     }
     seen.add(name);
-    if (group.retryMaxTimes !== undefined && group.retryMaxTimes < 0) {
+    if (group.retryMaxTimes !== undefined && !isNonNegativeInteger(group.retryMaxTimes)) {
       return invalidEntry(
         'CONSUMER_GROUP',
         name,
         index,
-        'Consumer group retryMaxTimes must be zero or positive',
+        'Consumer group retryMaxTimes must be a non-negative integer',
       );
     }
-    if (group.delaySeconds !== undefined && group.delaySeconds < 0) {
+    if (group.delaySeconds !== undefined && !isNonNegativeInteger(group.delaySeconds)) {
       return invalidEntry(
         'CONSUMER_GROUP',
         name,
         index,
-        'Consumer group delaySeconds must be zero or positive',
+        'Consumer group delaySeconds must be a non-negative integer',
       );
     }
 
@@ -380,6 +380,10 @@ function entry(
 
 function normalizeName(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
 }
 
 function comparable(value: unknown): string | null {


### PR DESCRIPTION
## Summary
- validate resource-plan numeric fields at runtime instead of relying on TypeScript types
- require queue, retry, and delay counts to be non-negative integers
- mark malformed JSON rows as INVALID and non-applicable
- cover string, fractional, negative, and null values parsed from JSON

## Root cause and impact
The JSON parser only validated the top-level arrays, while entry validation rejected numeric values only when they compared below zero. Runtime values such as strings and fractions therefore bypassed the check and could be reported as actionable CREATE or UPDATE entries. A shared integer predicate keeps preview results aligned with RocketMQ resource constraints.

Closes #1642

## Validation
- npm test -- --run src/services/resourcePlanService.test.ts (3 passed)
- npx eslint src/services/resourcePlanService.ts src/services/resourcePlanService.test.ts
- npm run build
- git diff --check