### PR TITLE
[studio][ISSUE #1680] Sanitize throughput sparkline samples

### DIFF
--- a/web/src/components/MiniBar.tsx
+++ b/web/src/components/MiniBar.tsx
@@ -32,13 +32,14 @@ const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: M
     );
   }
 
-  const max = Math.max(...data, 1);
+  const normalizedData = data.map((value) => (Number.isFinite(value) ? Math.max(0, value) : 0));
+  const max = Math.max(...normalizedData, 1);
   const barWidth = Math.max(2, (width - (data.length - 1) * 2) / data.length);
 
   return (
     <div
       role="img"
-      aria-label={label || `趋势数据：${data.join('、')}`}
+      aria-label={label || `趋势数据：${normalizedData.join('、')}`}
       style={{
         display: 'inline-flex',
         alignItems: 'flex-end',
@@ -47,7 +48,7 @@ const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: M
         width,
       }}
     >
-      {data.map((value, i) => (
+      {normalizedData.map((value, i) => (
         <div
           key={i}
           style={{

--- a/web/src/components/__tests__/MiniBar.test.tsx
+++ b/web/src/components/__tests__/MiniBar.test.tsx
@@ -34,4 +34,16 @@ describe('MiniBar', () => {
 
     expect(getBarHeights()).toEqual(['0px', '4px', '20px']);
   });
+
+  it('treats negative and non-finite throughput samples as zero', () => {
+    render(
+      <MiniBar
+        data={[-5, Number.NaN, Number.POSITIVE_INFINITY, 10]}
+        height={20}
+        label="Throughput trend"
+      />,
+    );
+
+    expect(getBarHeights()).toEqual(['0px', '0px', '0px', '20px']);
+  });
 });


### PR DESCRIPTION
## Summary
- normalize negative throughput samples to zero before rendering dashboard sparklines
- treat NaN and infinite samples as zero so they cannot poison the chart maximum or CSS heights
- use normalized samples in the default accessible label
- cover invalid samples alongside the existing zero and positive-value behavior

## Root cause and impact
The sparkline assigned every nonzero sample a minimum visible height. Counter resets can yield negative throughput deltas, which were therefore shown as positive traffic, while non-finite values produced invalid height calculations. Normalization preserves existing positive trends and prevents misleading bars.

Closes #1680

## Validation
- npm test -- --run src/components/__tests__/MiniBar.test.tsx (3 passed)
- npx eslint src/components/MiniBar.tsx src/components/__tests__/MiniBar.test.tsx
- npm run build
- git diff --check