### PR TITLE
fix: collect dashboard topic and group counts by broker

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -154,7 +154,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             Map<String, Set<String>> topicsByCluster = new HashMap<>();
             Set<String> topicCountsUnavailableClusters = new HashSet<>();
             Set<String> allGroups = new HashSet<>();
-            Map<String, Integer> groupsByCluster = new HashMap<>();
+            Map<String, Set<String>> groupsByCluster = new HashMap<>();
             for (String brokerAddr : masterAddrs) {
                 String clusterName = brokerAddrToCluster.get(brokerAddr);
                 try {
@@ -185,7 +185,8 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                             if (!isSystemGroup(groupName)) {
                                 allGroups.add(groupName);
                                 if (clusterName != null) {
-                                    groupsByCluster.merge(clusterName, 1, Integer::sum);
+                                    groupsByCluster.computeIfAbsent(clusterName, ignored -> new HashSet<>())
+                                            .add(groupName);
                                 }
                             }
                         }
@@ -260,7 +261,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                         .brokers(clusterBrokers)
                         .proxies(0)
                         .topics(topicsByCluster.getOrDefault(clusterName, Set.of()).size())
-                        .groups(groupsByCluster.getOrDefault(clusterName, 0))
+                        .groups(groupsByCluster.getOrDefault(clusterName, Set.of()).size())
                         .tpsIn(clusterTpsIn)
                         .tpsOut(clusterTpsOut)
                         .version(version)

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -26,10 +26,8 @@ import java.util.Set;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.KVTable;
 import org.apache.rocketmq.remoting.protocol.body.SubscriptionGroupWrapper;
-import org.apache.rocketmq.remoting.protocol.body.TopicList;
+import org.apache.rocketmq.remoting.protocol.body.TopicConfigSerializeWrapper;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
-import org.apache.rocketmq.remoting.protocol.route.QueueData;
-import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
@@ -149,48 +147,35 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 }
             }
 
-            // Count topics globally and per-cluster
-            Map<String, Integer> topicsByCluster = new HashMap<>();
-            try {
-                TopicList topicList = admin.fetchAllTopicList();
-                Set<String> topics = topicList == null || topicList.getTopicList() == null
-                        ? Set.of() : topicList.getTopicList();
-                totalTopics = (int) topics.stream()
-                        .filter(t -> !isSystemTopic(t))
-                        .count();
-                // For each non-system topic, determine its cluster via route data
-                for (String topicName : topics) {
-                    if (isSystemTopic(topicName)) {
-                        continue;
-                    }
-                    try {
-                        TopicRouteData route = admin.examineTopicRouteInfo(topicName);
-                        if (route != null && route.getQueueDatas() != null) {
-                            for (QueueData qd : route.getQueueDatas()) {
-                                BrokerData bd = brokerAddrTable.get(qd.getBrokerName());
-                                if (bd != null && bd.getBrokerAddrs() != null) {
-                                    String addr = bd.getBrokerAddrs().get(0L);
-                                    String cluster = brokerAddrToCluster.get(addr);
-                                    if (cluster != null) {
-                                        topicsByCluster.merge(cluster, 1, Integer::sum);
-                                    }
-                                    break; // one queue is enough to determine the cluster
-                                }
-                            }
-                        }
-                    } catch (Exception ignored) {
-                        // Skip topics whose route data is unavailable
-                    }
-                }
-            } catch (Exception e) {
-                log.warn("Failed to fetch topic list: {}", e.getMessage());
-            }
-
-            // Count subscription groups globally and per-cluster, and collect TPS from each master broker
+            // Count topics and subscription groups from each master broker. Topic metadata is
+            // available in the broker config response, so this remains bounded by broker count
+            // instead of resolving a NameServer route for every Topic.
+            Set<String> allTopics = new HashSet<>();
+            Map<String, Set<String>> topicsByCluster = new HashMap<>();
+            Set<String> topicCountsUnavailableClusters = new HashSet<>();
             Set<String> allGroups = new HashSet<>();
             Map<String, Integer> groupsByCluster = new HashMap<>();
             for (String brokerAddr : masterAddrs) {
                 String clusterName = brokerAddrToCluster.get(brokerAddr);
+                try {
+                    TopicConfigSerializeWrapper topicConfig = admin.getAllTopicConfig(brokerAddr, 5000);
+                    if (topicConfig == null || topicConfig.getTopicConfigTable() == null) {
+                        markTopicCountUnavailable(topicCountsUnavailableClusters, clusterName);
+                    } else {
+                        Set<String> clusterTopics = topicsByCluster.computeIfAbsent(
+                                clusterName, ignored -> new HashSet<>());
+                        topicConfig.getTopicConfigTable().keySet().stream()
+                                .filter(topic -> !isSystemTopic(topic))
+                                .forEach(topic -> {
+                                    allTopics.add(topic);
+                                    clusterTopics.add(topic);
+                                });
+                    }
+                } catch (Exception e) {
+                    markTopicCountUnavailable(topicCountsUnavailableClusters, clusterName);
+                    log.warn("Failed to get topic config from broker {}: {}", brokerAddr, e.getMessage());
+                }
+
                 try {
                     SubscriptionGroupWrapper subscriptionGroupWrapper = admin.getAllSubscriptionGroup(brokerAddr, 5000);
                     if (subscriptionGroupWrapper != null && subscriptionGroupWrapper.getSubscriptionGroupTable() != null) {
@@ -230,6 +215,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                     log.warn("Failed to get runtime info from broker {}: {}", brokerAddr, e.getMessage());
                 }
             }
+            totalTopics = allTopics.size();
             totalGroups = allGroups.size();
 
             // Build per-cluster overview
@@ -240,7 +226,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 long clusterTpsIn = 0;
                 long clusterTpsOut = 0;
                 String version = "unknown";
-                boolean runtimeMetricsUnavailable = false;
+                boolean runtimeMetricsUnavailable = topicCountsUnavailableClusters.contains(clusterName);
 
                 for (String brokerName : brokerNames) {
                     BrokerData brokerData = brokerAddrTable.get(brokerName);
@@ -273,7 +259,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                         .status(runtimeMetricsUnavailable ? ClusterStatus.warning : ClusterStatus.healthy)
                         .brokers(clusterBrokers)
                         .proxies(0)
-                        .topics(topicsByCluster.getOrDefault(clusterName, 0))
+                        .topics(topicsByCluster.getOrDefault(clusterName, Set.of()).size())
                         .groups(groupsByCluster.getOrDefault(clusterName, 0))
                         .tpsIn(clusterTpsIn)
                         .tpsOut(clusterTpsOut)
@@ -368,5 +354,11 @@ public class RocketMQDashboardProvider implements DashboardProvider {
 
     private boolean isSystemGroup(String group) {
         return SystemGroupFilter.isSystem(group);
+    }
+
+    private void markTopicCountUnavailable(Set<String> unavailableClusters, String clusterName) {
+        if (clusterName != null) {
+            unavailableClusters.add(clusterName);
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -155,12 +155,13 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             Set<String> topicCountsUnavailableClusters = new HashSet<>();
             Set<String> allGroups = new HashSet<>();
             Map<String, Set<String>> groupsByCluster = new HashMap<>();
+            Set<String> groupCountsUnavailableClusters = new HashSet<>();
             for (String brokerAddr : masterAddrs) {
                 String clusterName = brokerAddrToCluster.get(brokerAddr);
                 try {
                     TopicConfigSerializeWrapper topicConfig = admin.getAllTopicConfig(brokerAddr, 5000);
                     if (topicConfig == null || topicConfig.getTopicConfigTable() == null) {
-                        markTopicCountUnavailable(topicCountsUnavailableClusters, clusterName);
+                        markCountUnavailable(topicCountsUnavailableClusters, clusterName);
                     } else {
                         Set<String> clusterTopics = topicsByCluster.computeIfAbsent(
                                 clusterName, ignored -> new HashSet<>());
@@ -172,7 +173,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                                 });
                     }
                 } catch (Exception e) {
-                    markTopicCountUnavailable(topicCountsUnavailableClusters, clusterName);
+                    markCountUnavailable(topicCountsUnavailableClusters, clusterName);
                     log.warn("Failed to get topic config from broker {}: {}", brokerAddr, e.getMessage());
                 }
 
@@ -192,6 +193,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                         }
                     }
                 } catch (Exception e) {
+                    markCountUnavailable(groupCountsUnavailableClusters, clusterName);
                     log.warn("Failed to get subscription groups from broker {}: {}", brokerAddr, e.getMessage());
                 }
 
@@ -227,7 +229,8 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 long clusterTpsIn = 0;
                 long clusterTpsOut = 0;
                 String version = "unknown";
-                boolean runtimeMetricsUnavailable = topicCountsUnavailableClusters.contains(clusterName);
+                boolean runtimeMetricsUnavailable = topicCountsUnavailableClusters.contains(clusterName)
+                        || groupCountsUnavailableClusters.contains(clusterName);
 
                 for (String brokerName : brokerNames) {
                     BrokerData brokerData = brokerAddrTable.get(brokerName);
@@ -357,7 +360,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
         return SystemGroupFilter.isSystem(group);
     }
 
-    private void markTopicCountUnavailable(Set<String> unavailableClusters, String clusterName) {
+    private void markCountUnavailable(Set<String> unavailableClusters, String clusterName) {
         if (clusterName != null) {
             unavailableClusters.add(clusterName);
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -91,6 +91,26 @@ class RocketMQDashboardProviderTest {
     }
 
     @Test
+    void dashboardShouldDeduplicateTopicsReportedByMultipleClusterBrokers() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithTwoMasters());
+        when(adminExt.getAllTopicConfig("10.0.0.11:10911", 5000))
+                .thenReturn(topicConfig("orders", "payments"));
+        when(adminExt.getAllTopicConfig("10.0.0.12:10911", 5000))
+                .thenReturn(topicConfig("orders", "inventory"));
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.12:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getStats().getTotalTopics()).isEqualTo(3);
+        assertThat(dashboard.getClusters()).singleElement()
+                .extracting(cluster -> cluster.getTopics())
+                .isEqualTo(3);
+        verify(adminExt, never()).examineTopicRouteInfo(anyString());
+    }
+
+    @Test
     void dashboardShouldMarkClusterWarningWhenTopicCountsAreUnavailable() throws Exception {
         DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
         when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
@@ -296,6 +316,25 @@ class RocketMQDashboardProviderTest {
         clusterAddrTable.put("DefaultCluster", Set.of("broker-a"));
         info.setClusterAddrTable(clusterAddrTable);
         return info;
+    }
+
+    private ClusterInfo clusterInfoWithTwoMasters() {
+        ClusterInfo info = new ClusterInfo();
+        HashMap<String, BrokerData> brokerAddrTable = new HashMap<>();
+        brokerAddrTable.put("broker-a", brokerData("broker-a", "10.0.0.11:10911"));
+        brokerAddrTable.put("broker-b", brokerData("broker-b", "10.0.0.12:10911"));
+        info.setBrokerAddrTable(brokerAddrTable);
+
+        HashMap<String, Set<String>> clusterAddrTable = new HashMap<>();
+        clusterAddrTable.put("DefaultCluster", Set.of("broker-a", "broker-b"));
+        info.setClusterAddrTable(clusterAddrTable);
+        return info;
+    }
+
+    private BrokerData brokerData(String name, String address) {
+        HashMap<Long, String> addresses = new HashMap<>();
+        addresses.put(0L, address);
+        return new BrokerData("DefaultCluster", name, addresses);
     }
 
     private TopicList topicList() {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -148,6 +148,23 @@ class RocketMQDashboardProviderTest {
     }
 
     @Test
+    void dashboardShouldMarkClusterWarningWhenGroupCountsAreUnavailable() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.getAllTopicConfig("10.0.0.11:10911", 5000)).thenReturn(topicConfig("orders"));
+        when(adminExt.getAllSubscriptionGroup("10.0.0.11:10911", 5000))
+                .thenThrow(new RuntimeException("broker unavailable"));
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getClusters()).singleElement()
+                .extracting(cluster -> cluster.getStatus())
+                .isEqualTo(ClusterStatus.warning);
+        assertThat(dashboard.getStats().getHealthyClusters()).isZero();
+    }
+
+    @Test
     void dashboardShouldSurviveNullTopologyTables() throws Exception {
         DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
         ClusterInfo bare = new ClusterInfo();

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -20,10 +20,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.KVTable;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
+import org.apache.rocketmq.remoting.protocol.body.TopicConfigSerializeWrapper;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
@@ -42,6 +45,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,6 +57,7 @@ class RocketMQDashboardProviderTest {
         DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
         when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
         when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+        when(adminExt.getAllTopicConfig("10.0.0.11:10911", 5000)).thenReturn(topicConfig("order-topic"));
         when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
 
         RocketMQDashboardProvider provider = newProvider(adminExt);
@@ -64,6 +69,41 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getClusters().get(0).getType()).isEqualTo(ClusterType.V5_PROXY_CLUSTER);
         assertThat(dashboard.getStats().getHealthyClusters()).isEqualTo(1);
         verify(adminExt, times(1)).fetchBrokerRuntimeStats("10.0.0.11:10911");
+    }
+
+    @Test
+    void dashboardShouldCountTopicsFromBrokerConfigWithoutPerTopicRouteRequests() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.getAllTopicConfig("10.0.0.11:10911", 5000))
+                .thenReturn(topicConfig("order-topic", "payments", "SCHEDULE_TOPIC_XXXX"));
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getStats().getTotalTopics()).isEqualTo(2);
+        assertThat(dashboard.getClusters()).singleElement().satisfies(cluster -> {
+            assertThat(cluster.getTopics()).isEqualTo(2);
+            assertThat(cluster.getStatus()).isEqualTo(ClusterStatus.healthy);
+        });
+        verify(adminExt).getAllTopicConfig("10.0.0.11:10911", 5000);
+        verify(adminExt, never()).examineTopicRouteInfo(anyString());
+    }
+
+    @Test
+    void dashboardShouldMarkClusterWarningWhenTopicCountsAreUnavailable() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.getAllTopicConfig("10.0.0.11:10911", 5000))
+                .thenThrow(new RuntimeException("broker unavailable"));
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getClusters()).singleElement()
+                .extracting(cluster -> cluster.getStatus())
+                .isEqualTo(ClusterStatus.warning);
+        assertThat(dashboard.getStats().getHealthyClusters()).isZero();
     }
 
     @Test
@@ -262,6 +302,16 @@ class RocketMQDashboardProviderTest {
         TopicList topicList = new TopicList();
         topicList.setTopicList(Set.of("order-topic"));
         return topicList;
+    }
+
+    private TopicConfigSerializeWrapper topicConfig(String... names) {
+        TopicConfigSerializeWrapper wrapper = new TopicConfigSerializeWrapper();
+        ConcurrentHashMap<String, TopicConfig> configs = new ConcurrentHashMap<>();
+        for (String name : names) {
+            configs.put(name, new TopicConfig(name));
+        }
+        wrapper.setTopicConfigTable(configs);
+        return wrapper;
     }
 
     private KVTable runtimeStats() {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -25,9 +25,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.KVTable;
+import org.apache.rocketmq.remoting.protocol.body.SubscriptionGroupWrapper;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
 import org.apache.rocketmq.remoting.protocol.body.TopicConfigSerializeWrapper;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -108,6 +110,25 @@ class RocketMQDashboardProviderTest {
                 .extracting(cluster -> cluster.getTopics())
                 .isEqualTo(3);
         verify(adminExt, never()).examineTopicRouteInfo(anyString());
+    }
+
+    @Test
+    void dashboardShouldDeduplicateGroupsReportedByMultipleClusterBrokers() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithTwoMasters());
+        when(adminExt.getAllSubscriptionGroup("10.0.0.11:10911", 5000))
+                .thenReturn(subscriptionGroups("cg-orders", "cg-payments"));
+        when(adminExt.getAllSubscriptionGroup("10.0.0.12:10911", 5000))
+                .thenReturn(subscriptionGroups("cg-orders", "cg-inventory"));
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.12:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getStats().getTotalConsumerGroups()).isEqualTo(3);
+        assertThat(dashboard.getClusters()).singleElement()
+                .extracting(cluster -> cluster.getGroups())
+                .isEqualTo(3);
     }
 
     @Test
@@ -350,6 +371,16 @@ class RocketMQDashboardProviderTest {
             configs.put(name, new TopicConfig(name));
         }
         wrapper.setTopicConfigTable(configs);
+        return wrapper;
+    }
+
+    private SubscriptionGroupWrapper subscriptionGroups(String... names) {
+        SubscriptionGroupWrapper wrapper = new SubscriptionGroupWrapper();
+        ConcurrentHashMap<String, SubscriptionGroupConfig> groups = new ConcurrentHashMap<>();
+        for (String name : names) {
+            groups.put(name, new SubscriptionGroupConfig());
+        }
+        wrapper.setSubscriptionGroupTable(groups);
         return wrapper;
     }
 


### PR DESCRIPTION
## Summary
- derive per-cluster Topic counts from each master Broker's topic-config response
- collect per-cluster Consumer Group counts as sets so a group replicated to multiple Brokers is counted once
- remove the per-Topic `examineTopicRouteInfo` loop from Dashboard collection
- mark a Cluster warning when Topic or Consumer Group counts cannot be read, and keep the healthy-cluster summary consistent with warning status

Closes #1660
Fixes #1394

## Verification
- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) PATH="$JAVA_HOME/bin:$PATH" mvn -f server/pom.xml -Dtest=RocketMQDashboardProviderTest test`

The regression tests verify exact Topic and Consumer Group counts across multiple master Brokers, system-topic filtering, zero calls to `examineTopicRouteInfo`, and warning behavior when Broker Topic or Consumer Group config is unavailable.