### PR TITLE
[studio][ISSUE #1686] Clean up failed browser downloads

### DIFF
--- a/web/src/utils/download.test.ts
+++ b/web/src/utils/download.test.ts
@@ -52,4 +52,26 @@ describe('downloadBlob', () => {
     expect(document.querySelector('a[download="export.csv"]')).not.toBeInTheDocument();
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:download');
   });
+
+  it('removes the anchor and revokes the URL when download activation throws', () => {
+    const createObjectURL = vi.fn(() => 'blob:failed-download');
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      writable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      writable: true,
+      value: revokeObjectURL,
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {
+      throw new Error('Download blocked');
+    });
+
+    const blob = new Blob(['content'], { type: 'text/csv' });
+
+    expect(() => downloadBlob(blob, 'failed.csv')).toThrow('Download blocked');
+    expect(document.querySelector('a[download="failed.csv"]')).not.toBeInTheDocument();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:failed-download');
+  });
 });

--- a/web/src/utils/download.ts
+++ b/web/src/utils/download.ts
@@ -21,8 +21,11 @@ export const downloadBlob = (blob: Blob, filename: string) => {
   anchor.href = url;
   anchor.download = filename;
   anchor.style.display = 'none';
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  URL.revokeObjectURL(url);
+  try {
+    document.body.appendChild(anchor);
+    anchor.click();
+  } finally {
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  }
 };


### PR DESCRIPTION
## Summary
- always remove the temporary download anchor after activation attempts
- always revoke the Blob URL even when browser download activation throws
- continue propagating the original error so existing callers can report export failure
- cover the exceptional cleanup path with a regression test

## Root cause and impact
Cleanup followed `anchor.click()` without a `finally` block. A blocked or failed browser activation therefore skipped both cleanup operations, leaving a hidden DOM node and Blob-backed URL allocated after every failed export. The shared helper now preserves the same success path and guarantees cleanup.

Closes #1686

## Validation
- npm test -- --run src/utils/download.test.ts (2 passed)
- npx eslint src/utils/download.ts src/utils/download.test.ts
- npm run build
- git diff --check