### PR TITLE
[studio][ISSUE #1690] Support legacy system theme listeners

### DIFF
--- a/web/src/theme/ThemeProvider.tsx
+++ b/web/src/theme/ThemeProvider.tsx
@@ -48,8 +48,14 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
         current.followsSystem ? { ...current, darkMode: event.matches } : current,
       );
     };
-    mediaQuery.addEventListener('change', updateTheme);
-    return () => mediaQuery.removeEventListener('change', updateTheme);
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', updateTheme);
+      return () => mediaQuery.removeEventListener('change', updateTheme);
+    }
+    if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(updateTheme);
+      return () => mediaQuery.removeListener(updateTheme);
+    }
   }, [themeState.followsSystem]);
 
   return (

--- a/web/src/theme/__tests__/ThemeContext.test.tsx
+++ b/web/src/theme/__tests__/ThemeContext.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '../ThemeProvider';
 import { useTheme } from '../useTheme';
@@ -153,5 +153,35 @@ describe('ThemeContext', () => {
 
     await user.click(screen.getByText('set-light'));
     expect(screen.getByTestId('mode')).toHaveTextContent('light');
+  });
+
+  it('follows system changes through legacy matchMedia listeners', () => {
+    let changeListener: ((event: MediaQueryListEvent) => void) | undefined;
+    const addListener = vi.fn((listener: (event: MediaQueryListEvent) => void) => {
+      changeListener = listener;
+    });
+    const removeListener = vi.fn();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockReturnValue({
+        matches: false,
+        media: '(prefers-color-scheme: dark)',
+        addListener,
+        removeListener,
+      }),
+    });
+
+    const { unmount } = render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('mode')).toHaveTextContent('light');
+
+    act(() => changeListener?.({ matches: true } as MediaQueryListEvent));
+    expect(screen.getByTestId('mode')).toHaveTextContent('dark');
+
+    unmount();
+    expect(removeListener).toHaveBeenCalledWith(changeListener);
   });
 });


### PR DESCRIPTION
## Summary
- subscribe to system theme changes through MediaQueryList event listeners when available
- fall back to legacy addListener/removeListener in older Safari and embedded WebViews
- clean up through the same API used for subscription
- cover legacy rendering, theme updates, and listener removal

## Root cause and impact
ThemeProvider checked that `matchMedia` existed but assumed its result implemented EventTarget. Legacy MediaQueryList implementations expose only addListener/removeListener, causing the provider effect to throw when the application follows the system theme. Feature detection keeps modern behavior and restores compatibility.

Closes #1690

## Validation
- npm test -- --run src/theme/__tests__/ThemeContext.test.tsx (9 passed)
- npx eslint src/theme/ThemeProvider.tsx src/theme/__tests__/ThemeContext.test.tsx
- npm run build
- git diff --check