### PR TITLE
fix: scope group management to selected instance

### DIFF
--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -25,6 +25,7 @@ import {
   Tabs,
   Card,
   Row,
+  Select,
   Col,
   Descriptions,
   Space,
@@ -39,6 +40,8 @@ import {
   getConsumerSubscriptions,
   listConsumerGroups,
 } from '../../services/consumerService';
+import { listInstances } from '../../services/instanceService';
+import type { Instance } from '../../api/instance';
 
 // ─── Helpers ────────────────────────────────────────────────────
 type GroupStatus = 'running' | 'warning' | 'stopped';
@@ -62,6 +65,8 @@ const GroupManagementPage = () => {
   const [selectedGroup, setSelectedGroup] = useState<ConsumerGroup | null>(null);
   const [autoRefresh, setAutoRefresh] = useState(false);
   const [groups, setGroups] = useState<ConsumerGroup[]>([]);
+  const [instances, setInstances] = useState<Instance[]>([]);
+  const [selectedInstanceId, setSelectedInstanceId] = useState('');
   const [loading, setLoading] = useState(true);
   const [subscriptions, setSubscriptions] = useState<SubscriptionEntry[]>([]);
   const [progress, setProgress] = useState<QueueProgress[]>([]);
@@ -74,6 +79,9 @@ const GroupManagementPage = () => {
   const { t } = useLang();
 
   const loadGroups = useCallback((): Promise<void> => {
+    if (!selectedInstanceId) {
+      return Promise.resolve();
+    }
     if (listInFlight.current) {
       listRefreshQueued.current = true;
       return listInFlight.current;
@@ -85,7 +93,7 @@ const GroupManagementPage = () => {
         listRefreshQueued.current = false;
         const requestId = ++listRequestId.current;
         try {
-          const data = await listConsumerGroups();
+          const data = await listConsumerGroups({ instanceId: selectedInstanceId });
           if (!mountedRef.current || requestId !== listRequestId.current) return;
           setGroups(data);
         } catch {
@@ -95,14 +103,47 @@ const GroupManagementPage = () => {
       } while (mountedRef.current && listRefreshQueued.current);
     };
 
-    const cycle = run().finally(() => {
-      listInFlight.current = null;
-      if (mountedRef.current) {
-        setLoading(false);
+    let cycle: Promise<void>;
+    cycle = run().finally(() => {
+      if (listInFlight.current === cycle) {
+        listInFlight.current = null;
+        if (mountedRef.current) {
+          setLoading(false);
+        }
       }
     });
     listInFlight.current = cycle;
     return cycle;
+  }, [selectedInstanceId, t]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void listInstances()
+      .then((nextInstances) => {
+        if (cancelled) return;
+        setInstances(nextInstances);
+        setSelectedInstanceId((current) =>
+          nextInstances.some((instance) => instance.id === current)
+            ? current
+            : nextInstances[0]?.id || '',
+        );
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setInstances([]);
+        setSelectedInstanceId('');
+        setGroups([]);
+        setSelectedGroup(null);
+        setSubscriptions([]);
+        setProgress([]);
+        setLoading(false);
+        message.error(t('consumer.fetchListFailed'));
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [t]);
 
   useEffect(() => {
@@ -132,6 +173,18 @@ const GroupManagementPage = () => {
   const handleRefresh = useCallback(() => {
     void loadGroups();
   }, [loadGroups]);
+
+  const handleInstanceChange = (instanceId: string) => {
+    ++detailRequestId.current;
+    ++listRequestId.current;
+    listInFlight.current = null;
+    listRefreshQueued.current = false;
+    setSelectedInstanceId(instanceId);
+    setGroups([]);
+    setSelectedGroup(null);
+    setSubscriptions([]);
+    setProgress([]);
+  };
 
   const handleViewDetail = useCallback(
     async (group: ConsumerGroup) => {
@@ -303,6 +356,15 @@ const GroupManagementPage = () => {
             onChange={(e) => setSearchText(e.target.value)}
             style={{ width: 240 }}
             allowClear
+          />
+          <Select
+            aria-label={t('common.selectInstance')}
+            value={selectedInstanceId || undefined}
+            onChange={handleInstanceChange}
+            placeholder={t('common.selectInstance')}
+            options={instances.map((instance) => ({ value: instance.id, label: instance.name }))}
+            style={{ width: 220 }}
+            disabled={instances.length === 0}
           />
           <Switch
             checked={autoRefresh}

--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -123,6 +123,15 @@ const GroupManagementPage = () => {
       .then((nextInstances) => {
         if (cancelled) return;
         setInstances(nextInstances);
+        if (nextInstances.length === 0) {
+          setSelectedInstanceId('');
+          setGroups([]);
+          setSelectedGroup(null);
+          setSubscriptions([]);
+          setProgress([]);
+          setLoading(false);
+          return;
+        }
         setSelectedInstanceId((current) =>
           nextInstances.some((instance) => instance.id === current)
             ? current

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -189,6 +189,17 @@ describe('GroupManagement Page', () => {
     expect(consumerService.listConsumerGroups).not.toHaveBeenCalled();
   });
 
+  it('stops loading when no managed instances are available', async () => {
+    vi.mocked(instanceService.listInstances).mockResolvedValueOnce([]);
+    const { container } = renderWithProviders(<GroupManagement />);
+
+    await waitFor(() => {
+      expect(instanceService.listInstances).toHaveBeenCalledOnce();
+      expect(container.querySelector('.ant-table-wrapper .ant-spin-spinning')).toBeNull();
+    });
+    expect(consumerService.listConsumerGroups).not.toHaveBeenCalled();
+  });
+
   it('should render search input with placeholder', () => {
     renderWithProviders(<GroupManagement />);
     expect(screen.getByPlaceholderText('搜索消费组')).toBeInTheDocument();

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -22,12 +22,17 @@ import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
 import type { ConsumerGroup, QueueProgress, SubscriptionEntry } from '../../../api/metadata';
 import * as consumerService from '../../../services/consumerService';
+import * as instanceService from '../../../services/instanceService';
 import GroupManagement from '../GroupManagement';
 
 vi.mock('../../../services/consumerService', () => ({
   listConsumerGroups: vi.fn(),
   getConsumerProgress: vi.fn(),
   getConsumerSubscriptions: vi.fn(),
+}));
+
+vi.mock('../../../services/instanceService', () => ({
+  listInstances: vi.fn(),
 }));
 
 // Mock matchMedia for antd responsive components
@@ -95,6 +100,19 @@ const createDeferred = <T,>() => {
 describe('GroupManagement Page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(instanceService.listInstances).mockResolvedValue([
+      {
+        id: 'instance-a',
+        name: 'Instance A',
+        remark: null,
+        type: 'DIRECT',
+        endpoint: 'namesrv-a:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
     vi.mocked(consumerService.listConsumerGroups).mockResolvedValue(groups);
     vi.mocked(consumerService.getConsumerProgress).mockResolvedValue([]);
     vi.mocked(consumerService.getConsumerSubscriptions).mockResolvedValue([]);
@@ -107,6 +125,68 @@ describe('GroupManagement Page', () => {
   it('should render the page title', () => {
     renderWithProviders(<GroupManagement />);
     expect(screen.getByText('消费组管理')).toBeInTheDocument();
+  });
+
+  it('loads consumer groups for the selected managed instance', async () => {
+    renderWithProviders(<GroupManagement />);
+
+    await waitFor(() => {
+      expect(instanceService.listInstances).toHaveBeenCalledOnce();
+      expect(consumerService.listConsumerGroups).toHaveBeenCalledWith({ instanceId: 'instance-a' });
+    });
+  });
+
+  it('reloads consumer groups after selecting another managed instance', async () => {
+    vi.mocked(instanceService.listInstances).mockResolvedValue([
+      {
+        id: 'instance-a',
+        name: 'Instance A',
+        remark: null,
+        type: 'DIRECT',
+        endpoint: 'namesrv-a:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+      {
+        id: 'instance-b',
+        name: 'Instance B',
+        remark: null,
+        type: 'DIRECT',
+        endpoint: 'namesrv-b:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
+    const user = userEvent.setup();
+    renderWithProviders(<GroupManagement />);
+
+    await waitFor(() => {
+      expect(consumerService.listConsumerGroups).toHaveBeenCalledWith({ instanceId: 'instance-a' });
+    });
+
+    await user.click(screen.getByRole('combobox', { name: '选择实例' }));
+    await user.click(
+      await screen.findByText('Instance B', { selector: '.ant-select-item-option-content' }),
+    );
+
+    await waitFor(() => {
+      expect(consumerService.listConsumerGroups).toHaveBeenLastCalledWith({ instanceId: 'instance-b' });
+    });
+  });
+
+  it('does not fall back to the legacy global group list when instance loading fails', async () => {
+    vi.mocked(instanceService.listInstances).mockRejectedValueOnce(new Error('instance API unavailable'));
+
+    renderWithProviders(<GroupManagement />);
+
+    await waitFor(() => {
+      expect(instanceService.listInstances).toHaveBeenCalledOnce();
+    });
+    expect(consumerService.listConsumerGroups).not.toHaveBeenCalled();
   });
 
   it('should render search input with placeholder', () => {
@@ -219,13 +299,13 @@ describe('GroupManagement Page', () => {
   });
 
   it('polls only while auto refresh is enabled', async () => {
-    vi.useFakeTimers();
     renderWithProviders(<GroupManagement />);
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
+    await waitFor(() => {
+      expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(1);
     });
-    expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(1);
+
+    vi.useFakeTimers();
 
     const autoRefreshSwitch = screen.getByRole('switch');
     fireEvent.click(autoRefreshSwitch);


### PR DESCRIPTION
## Summary
- load managed instances before requesting the global consumer group view
- require the selected instance ID for consumer group list requests
- clear stale group and detail state when the instance changes or loading instances fails
- prevent an in-flight request for an old instance from blocking the newly selected instance

Closes #1700

## Verification
- `npm test -- --run src/pages/studio/__tests__/GroupManagement.test.tsx`
- `npm run build`

`npm run lint` remains blocked by existing `react-hooks/set-state-in-effect` errors in `web/src/pages/instance/consumer.tsx`.