### PR TITLE
fix: reset consumer state by selected instance

### DIFF
--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -364,6 +364,7 @@ describe('Consumer page', () => {
     await waitFor(() =>
       expect(consumerService.listConsumerGroups).toHaveBeenCalledWith({ instanceId: 'instance-b' }),
     );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     await user.click(await screen.findByRole('button', { name: /详情/ }));
 
     await waitFor(() =>

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -184,15 +184,20 @@ export const diagnosticCacheKey = (instanceId: string, groupName: string) =>
 /* ═══════════════════════════════════════════
    ConsumerPage
    ═══════════════════════════════════════════ */
-const ConsumerPage = () => {
+type ConsumerPageContentProps = ReturnType<typeof useInstanceFilter>;
+
+const ConsumerPageContent = ({
+  selectedInstanceId,
+  selectedInstance,
+  selectInstance,
+  instanceOptions,
+}: ConsumerPageContentProps) => {
   const { t } = useLang();
-  const { selectedInstanceId, selectedInstance, selectInstance, instanceOptions } =
-    useInstanceFilter();
   const isCloudInstance =
     selectedInstance?.vendor === 'ALIYUN' || selectedInstance?.vendor === 'TENCENT';
   const hasSelectedInstance = Boolean(selectedInstanceId);
   const [groups, setGroups] = useState<ConsumerGroup[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(hasSelectedInstance);
   const [submitting, setSubmitting] = useState(false);
   const [resetSubmitting, setResetSubmitting] = useState(false);
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
@@ -234,22 +239,8 @@ const ConsumerPage = () => {
   const stackRequestIdRef = useRef(0);
 
   useEffect(() => {
-    stackRequestIdRef.current += 1;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- clear state owned by the previous instance
-    setSelectedGroup(null);
-    setModalOpen(false);
-    setResetGroup(null);
-    setResetTopic(undefined);
-    setResetModalOpen(false);
-  }, [selectedInstanceId]);
-
-  useEffect(() => {
     if (!selectedInstanceId) {
       groupRequestIdRef.current += 1;
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- clear state when the instance scope is removed
-      setGroups([]);
-      setSelectedRowKeys([]);
-      setLoading(false);
       return;
     }
     const requestId = ++groupRequestIdRef.current;
@@ -1719,6 +1710,16 @@ const ConsumerPage = () => {
         )}
       </Modal>
     </div>
+  );
+};
+
+const ConsumerPage = () => {
+  const instanceFilter = useInstanceFilter();
+  return (
+    <ConsumerPageContent
+      key={instanceFilter.selectedInstanceId || 'no-selected-instance'}
+      {...instanceFilter}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary
- remount Consumer page content at selected-instance lifecycle boundaries
- discard prior instance detail and selection state before loading a new instance
- keep an unresolved instance idle rather than synchronously resetting state in effects
- add a regression assertion that switching instances closes the old detail dialog

Closes #1706

## Verification
- `npm test -- --run src/pages/instance/__tests__/ConsumerPage.test.tsx`
- `npm run build`
- `npm run lint` (0 errors; existing warnings remain)