### PR TITLE
fix: retry client connection queries

### DIFF
--- a/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
@@ -222,6 +222,25 @@ describe('Clients page', () => {
     expect(within(screen.getByTestId('connection-total')).getByText('0')).toBeInTheDocument();
   });
 
+  it('retries the current instance connection query after a runtime failure', async () => {
+    vi.mocked(connectionsService.listConnections)
+      .mockRejectedValueOnce(new Error('Client connection provider is not configured'))
+      .mockResolvedValueOnce([connection]);
+    const user = userEvent.setup();
+    renderWithProviders(<ClientsPage />);
+
+    expect(
+      await screen.findByText('Client connection provider is not configured'),
+    ).toBeInTheDocument();
+    expect(connectionsService.listConnections).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: /重\s*试/ }));
+
+    expect(await screen.findByText('order-svc-0@10.0.1.12:49152')).toBeInTheDocument();
+    expect(connectionsService.listConnections).toHaveBeenCalledTimes(2);
+    expect(connectionsService.listConnections).toHaveBeenLastCalledWith({ instanceId: 'instance-1' });
+  });
+
   it('clears the previous instance data when the next instance connection request fails', async () => {
     vi.mocked(instanceService.listInstances).mockResolvedValue([
       {

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -115,6 +115,7 @@ const ClientsPage = () => {
   const [selectedConnection, setSelectedConnection] = useState<ClientConnection | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [instanceLoadKey, setInstanceLoadKey] = useState(0);
+  const [connectionLoadKey, setConnectionLoadKey] = useState(0);
 
   const handleInstanceChange = (instanceId: string) => {
     setSelectedInstanceId(instanceId);
@@ -181,7 +182,7 @@ const ClientsPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [selectedInstanceId]);
+  }, [connectionLoadKey, selectedInstanceId]);
 
   /* ─── Cluster options using nsClusterName ─── */
   const clusterOptions = useMemo(() => {
@@ -392,7 +393,9 @@ const ClientsPage = () => {
               size="small"
               onClick={() => {
                 setLoading(true);
+                setLoadError(null);
                 setInstanceLoadKey((key) => key + 1);
+                setConnectionLoadKey((key) => key + 1);
               }}
             >
               重试


### PR DESCRIPTION
## Summary
- add a refresh generation for runtime client-connection queries
- make the existing retry action re-request connections for the currently selected instance
- retain instance discovery retry and stale-response cancellation behavior
- cover recovery from a transient runtime query failure

Closes #1708

## Verification
- `npm test -- --run src/pages/cluster/__tests__/ClientsPage.test.tsx`
- `npm run build`

`npm run lint` is blocked by the Consumer lifecycle errors addressed by pending #1707; this PR introduces no lint errors.