### PR TITLE
test: add regression coverage from closed duplicates (#1497, #1498, #1499)

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -154,6 +154,31 @@ class AlertServiceTest {
     }
 
     @Test
+    void exportPrometheusRulesYamlShouldDisambiguateDuplicateAlertNames() {
+        AlertRuleVO first = AlertRuleVO.builder()
+                .name("High Lag")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(1000)
+                .enabled(true)
+                .build();
+        AlertRuleVO second = AlertRuleVO.builder()
+                .name("High-Lag")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(2000)
+                .enabled(true)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(first, second));
+
+        String result = alertService.exportPrometheusRulesYaml();
+
+        assertThat(result)
+                .contains("- alert: HighLag\n")
+                .contains("- alert: HighLag_2\n");
+    }
+
+    @Test
     void exportPrometheusRulesYamlShouldRenderReplicationLagRuleWithScopeAndSeverity() {
         AlertRuleVO rule = AlertRuleVO.builder()
                 .name("Replication Lag High")
@@ -197,6 +222,26 @@ class AlertServiceTest {
         assertThat(result)
                 .contains("expr: rocketmq_broker_replication_lag_bytes > 1024")
                 .contains("severity: warning");
+    }
+
+    @Test
+    void exportPrometheusRulesYamlShouldReplaceInvalidPrometheusFields() {
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .name("Malformed rule")
+                .metric("up) or vector(1")
+                .operator("> 0 or")
+                .threshold(10)
+                .duration("5xyz")
+                .enabled(true)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+
+        String result = alertService.exportPrometheusRulesYaml();
+
+        assertThat(result)
+                .contains("expr: rocketmq_consumer_lag_messages > 10")
+                .contains("for: 5m")
+                .doesNotContain("vector(1", "> 0 or", "5xyz");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
@@ -203,6 +204,27 @@ class RocketMQAdminClientImplTest {
         verify(selectedAdmin, times(2)).createAndUpdateTopicConfig(
                 org.mockito.ArgumentMatchers.eq("10.0.0.1:10911"), any(TopicConfig.class));
         verify(adminExt, never()).createAndUpdateTopicConfig(anyString(), any(TopicConfig.class));
+    }
+
+    @Test
+    void updateTopicPersistsTypeAndRemark() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqTopic.class);
+        RmqTopic existing = new RmqTopic();
+        existing.setTopicType(TopicType.NORMAL.name());
+        existing.setRemark("old remark");
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithMaster());
+        when(topicMapper.selectOne(any())).thenReturn(existing);
+
+        TopicVO topic = new TopicVO();
+        topic.setName("orders");
+        topic.setType(TopicType.FIFO);
+        topic.setRemark("updated remark");
+
+        adminClient.updateTopic(topic);
+
+        assertThat(existing.getTopicType()).isEqualTo(TopicType.FIFO.name());
+        assertThat(existing.getRemark()).isEqualTo("updated remark");
+        verify(topicMapper).updateById(existing);
     }
 
     @Test


### PR DESCRIPTION
Salvages the test increments from three closed duplicate PRs (all authored by @yyqdbngt, commits keep original authorship):

- #1497: updateTopicPersistsTypeAndRemark (main code already covered by 24715633)
- #1498: exportPrometheusRulesYamlShouldReplaceInvalidPrometheusFields (covered by be5265a8)
- #1499: exportPrometheusRulesYamlShouldDisambiguateDuplicateAlertNames (covered by be5265a8)

Verified: AlertServiceTest 34/34, RocketMQAdminClientImplTest 17/17.