### PR TITLE
fix: reset topic state by selected instance

### DIFF
--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -361,6 +361,50 @@ describe('TopicPage', () => {
     expect(screen.getByText('10.0.2.21:8080')).toBeInTheDocument();
   });
 
+  it('closes Topic details when switching to another instance', async () => {
+    const user = userEvent.setup();
+    const base = buildTopics(1)[0];
+    instanceServiceMocks.listInstances.mockResolvedValue([
+      {
+        ...selectedInstance,
+        id: 'instance-a',
+        name: 'Instance A',
+        type: 'DIRECT',
+      },
+      {
+        ...selectedInstance,
+        id: 'instance-b',
+        name: 'Instance B',
+        type: 'DIRECT',
+        endpoint: '127.0.0.2:9876',
+      },
+    ]);
+    topicServiceMocks.listTopics.mockImplementation(async (params) => [
+      {
+        ...base,
+        name: params?.instanceId === 'instance-b' ? 'topic-b' : 'topic-a',
+        instanceId: params?.instanceId ?? 'instance-a',
+      },
+    ]);
+    renderWithProviders('/instance/instance-a/topic');
+
+    expect(await screen.findByText('topic-a')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /详情/ }));
+    const findTopicDetailDialog = () =>
+      screen
+        .getAllByRole('dialog')
+        .find((dialog) => within(dialog).queryByText('基本信息'));
+    await waitFor(() => expect(findTopicDetailDialog()).toBeDefined());
+
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(
+      await screen.findByText('Instance B', { selector: '.ant-select-item-option-content' }),
+    );
+
+    expect(await screen.findByText('topic-b')).toBeInTheDocument();
+    await waitFor(() => expect(findTopicDetailDialog()).toBeUndefined());
+  });
+
   it('imports valid topic CSV rows through the create service with the selected instance', async () => {
     const user = userEvent.setup();
     topicServiceMocks.listTopics.mockResolvedValue([]);

--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -405,6 +405,69 @@ describe('TopicPage', () => {
     await waitFor(() => expect(findTopicDetailDialog()).toBeUndefined());
   });
 
+  it('clears pending Topic writes when switching instances', async () => {
+    const user = userEvent.setup();
+    const base = buildTopics(1)[0];
+    instanceServiceMocks.listInstances.mockResolvedValue([
+      {
+        ...selectedInstance,
+        id: 'instance-a',
+        name: 'Instance A',
+        type: 'DIRECT',
+      },
+      {
+        ...selectedInstance,
+        id: 'instance-b',
+        name: 'Instance B',
+        type: 'DIRECT',
+        endpoint: '127.0.0.2:9876',
+      },
+    ]);
+    topicServiceMocks.listTopics.mockImplementation(async (params) => [
+      {
+        ...base,
+        name: params?.instanceId === 'instance-b' ? 'topic-b' : 'topic-a',
+        instanceId: params?.instanceId ?? 'instance-a',
+      },
+    ]);
+    renderWithProviders('/instance/instance-a/topic');
+
+    expect(await screen.findByText('topic-a')).toBeInTheDocument();
+    await user.click(screen.getAllByRole('checkbox')[1]);
+    expect(screen.getByRole('button', { name: /删除 \(1\)$/ })).toBeInTheDocument();
+
+    const csv = [
+      '"Name","Type","Write Queues","Read Queues","Permission"',
+      '"imported-topic","NORMAL","8","8","RW"',
+    ].join('\n');
+    await user.upload(screen.getByTestId('topic-import-file'), new File([csv], 'topics.csv'));
+    expect(await screen.findByText('检测到 1 个 Topic，将按顺序调用创建接口')).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(
+      await screen.findByText('Instance B', { selector: '.ant-select-item-option-content' }),
+    );
+
+    expect(await screen.findByText('topic-b')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('检测到 1 个 Topic，将按顺序调用创建接口')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /删除 \(1\)$/ })).not.toBeInTheDocument();
+    });
+    expect(topicServiceMocks.batchDeleteTopics).not.toHaveBeenCalled();
+    expect(topicServiceMocks.createTopic).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /发送/ }));
+    expect(await screen.findByText('发送消息到 topic-b')).toBeInTheDocument();
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(
+      await screen.findByText('Instance A', { selector: '.ant-select-item-option-content' }),
+    );
+
+    expect(await screen.findByText('topic-a')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('发送消息到 topic-b')).not.toBeInTheDocument());
+    expect(topicServiceMocks.sendTopicMessage).not.toHaveBeenCalled();
+  });
+
   it('imports valid topic CSV rows through the create service with the selected instance', async () => {
     const user = userEvent.setup();
     topicServiceMocks.listTopics.mockResolvedValue([]);

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -267,10 +267,15 @@ const formatDateTime = (iso?: string): string => {
 };
 
 // ═══════════════════════════════════════════════════════════════════
-const TopicPage = () => {
+type TopicPageContentProps = ReturnType<typeof useInstanceFilter>;
+
+const TopicPageContent = ({
+  selectedInstanceId,
+  selectedInstance,
+  selectInstance,
+  instanceOptions,
+}: TopicPageContentProps) => {
   const { t } = useLang();
-  const { selectedInstanceId, selectedInstance, selectInstance, instanceOptions } =
-    useInstanceFilter();
   const isCloudInstance =
     selectedInstance?.vendor === 'ALIYUN' || selectedInstance?.vendor === 'TENCENT';
   const hasSelectedInstance = Boolean(selectedInstanceId);
@@ -1423,6 +1428,16 @@ const TopicPage = () => {
         </Form>
       </Modal>
     </div>
+  );
+};
+
+const TopicPage = () => {
+  const instanceFilter = useInstanceFilter();
+  return (
+    <TopicPageContent
+      key={instanceFilter.selectedInstanceId || 'no-selected-instance'}
+      {...instanceFilter}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary
- remount Topic page content at selected-instance lifecycle boundaries
- discard prior-instance details, batch selections, CSV imports, send-message state, and diagnostics before loading a new instance
- keep the no-instance state idle
- add regression coverage for pending Topic writes and detail state across instance switches

Closes #1720

## Verification
- `npm test -- --run src/pages/instance/__tests__/TopicPage.test.tsx` (13 tests passed)
- `npm run build`
- `git diff --check`

`npm run lint` remains blocked by unrelated baseline errors outside this PR.