### PR TITLE
fix: reject deletion when cloud counts are unavailable

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -239,8 +239,16 @@ public class InstanceService {
 
         InstanceProvider provider = providerRegistry.forVendor(
                 existing.getVendor() == null ? InstanceVendor.APACHE : existing.getVendor());
-        int topicCount = provider.countTopics(id);
-        int consumerGroupCount = provider.countGroups(id);
+        int topicCount;
+        int consumerGroupCount;
+        try {
+            topicCount = provider.countTopics(id);
+            consumerGroupCount = provider.countGroups(id);
+        } catch (UnsupportedOperationException ex) {
+            throw new BusinessException(501,
+                    "Cannot delete instance because managed resource counts are unavailable for "
+                            + provider.vendor());
+        }
         if (topicCount > 0 || consumerGroupCount > 0) {
             throw new BusinessException(409, String.format(
                     "Cannot delete instance with managed resources: topics=%d, consumerGroups=%d",

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -670,6 +670,28 @@ class InstanceServiceTest {
     }
 
     @Test
+    void deleteInstanceShouldRejectWhenProviderCannotCountManagedResources() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("tencent-instance")
+                .vendor(InstanceVendor.TENCENT)
+                .build();
+        existing.setId("inst-tencent");
+        when(instanceRepository.findById("inst-tencent")).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.TENCENT)).thenReturn(instanceProvider);
+        when(instanceProvider.vendor()).thenReturn(InstanceVendor.TENCENT);
+        when(instanceProvider.countTopics("inst-tencent")).thenReturn(0);
+        when(instanceProvider.countGroups("inst-tencent"))
+                .thenThrow(new UnsupportedOperationException("Tencent groups are unavailable"));
+
+        assertThatThrownBy(() -> instanceService.deleteInstance("inst-tencent"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Cannot delete instance because managed resource counts are unavailable for TENCENT")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
+
+        verify(instanceRepository, never()).deleteById("inst-tencent");
+    }
+
+    @Test
     void deleteInstanceShouldReleaseUnusedEndpoint() {
         InstanceVO existing = InstanceVO.builder()
                 .name("to-delete")


### PR DESCRIPTION
## Summary
- convert unsupported cloud resource-count capabilities during instance deletion into a structured 501 response
- prevent deleting an instance when Studio cannot verify that Topics and Consumer Groups are absent
- preserve existing successful deletion and managed-resource conflict behavior
- add Tencent capability regression coverage

Closes #1726

## Verification
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=InstanceServiceTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -DskipTests compile`