### PR TITLE
fix(web): normalize navigation search without locale

### DIFF
--- a/web/src/layouts/navigationSearch.test.ts
+++ b/web/src/layouts/navigationSearch.test.ts
@@ -15,10 +15,14 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { filterNavigationEntries, isNavigationSearchShortcut } from './navigationSearch';
 
 describe('navigation search helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   const entries = [
     { key: '/cluster', label: 'RocketMQ 集群' },
     { key: '/settings', label: 'Settings' },
@@ -28,6 +32,15 @@ describe('navigation search helpers', () => {
   it('filters labels case-insensitively and ignores query whitespace', () => {
     expect(filterNavigationEntries(entries, ' SETTINGS ')).toEqual([entries[1]]);
     expect(filterNavigationEntries(entries, '集群')).toEqual([entries[0]]);
+  });
+
+  it('normalizes searches independently of the browser locale', () => {
+    const localeLowerCase = String.prototype.toLocaleLowerCase;
+    vi.spyOn(String.prototype, 'toLocaleLowerCase').mockImplementation(function () {
+      return localeLowerCase.call(this, 'tr');
+    });
+
+    expect(filterNavigationEntries(entries, 'SETTINGS')).toEqual([entries[1]]);
   });
 
   it('filters by route keys case-insensitively', () => {

--- a/web/src/layouts/navigationSearch.ts
+++ b/web/src/layouts/navigationSearch.ts
@@ -26,7 +26,7 @@ export interface NavigationSearchEntry {
 function normalizeSearchText(value: string): string {
   return value
     .normalize('NFKC')
-    .toLocaleLowerCase()
+    .toLowerCase()
     .replace(/[^\p{L}\p{N}]+/gu, ' ')
     .trim();
 }
@@ -78,7 +78,7 @@ export function isNavigationSearchShortcut(event: {
     ) !== null;
 
   return (
-    event.key.toLocaleLowerCase() === 'k' &&
+    event.key.toLowerCase() === 'k' &&
     (event.metaKey || event.ctrlKey) &&
     !event.altKey &&
     !isEditableTarget


### PR DESCRIPTION
## Summary
- normalize navigation search text with locale-independent casing
- keep the Command/Control-K shortcut independent of the browser locale
- add a Turkish-locale regression test

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/layouts/navigationSearch.test.ts --reporter=dot`
