### PR TITLE
fix(ai): normalize LLM engines with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVO.java
@@ -25,6 +25,8 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.util.StringUtils;
 
+import java.util.Locale;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -67,6 +69,6 @@ public class LlmConfigVO {
     }
 
     public String normalizeEngine() {
-        return StringUtils.hasText(engine) ? engine.trim().toLowerCase() : ENGINE_HTTP;
+        return StringUtils.hasText(engine) ? engine.trim().toLowerCase(Locale.ROOT) : ENGINE_HTTP;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVOTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmConfigVOTest {
+
+    @Test
+    void shouldNormalizeEngineIndependentlyOfDefaultLocale() {
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            LlmConfigVO config = LlmConfigVO.builder().engine(" CLI ").build();
+
+            assertThat(config.normalizeEngine()).isEqualTo("cli");
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- normalize configured LLM engines with `Locale.ROOT`
- avoid default-locale casing changing engine identifiers
- cover Turkish-default-locale behavior

## Testing
- `mvn -q -Dtest=LlmConfigVOTest test`
