### PR TITLE
fix(ai): resolve agent engines with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistry.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistry.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.ops.ai;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -37,7 +38,7 @@ public class AgentProviderRegistry {
     }
 
     public AgentProvider forEngine(String engine) {
-        AgentProvider provider = providers.get(engine == null ? "" : engine.trim().toLowerCase());
+        AgentProvider provider = providers.get(engine == null ? "" : engine.trim().toLowerCase(Locale.ROOT));
         if (provider == null) {
             throw new LlmGatewayException(400, "llm.config.unsupported_engine",
                     "Agent engine is not supported: " + engine,

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AgentProviderRegistryTest {
+
+    @Test
+    void shouldResolveEngineIndependentlyOfDefaultLocale() {
+        AgentProvider provider = mock(AgentProvider.class);
+        when(provider.engine()).thenReturn("cli");
+        AgentProviderRegistry registry = new AgentProviderRegistry(List.of(provider));
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+            assertThat(registry.forEngine(" CLI ")).isSameAs(provider);
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- resolve agent-provider engine names with `Locale.ROOT`
- prevent the host default locale from changing stable engine identifiers
- add Turkish-locale regression coverage

## Testing
- `mvn -q -Dtest=AgentProviderRegistryTest test`
