### PR TITLE
fix(audit): bound cleanup retention

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditCleanupDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditCleanupDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.audit;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,5 +29,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AuditCleanupDTO {
     @Positive(message = "beforeDays must be greater than 0")
+    @Max(value = 365, message = "beforeDays must not exceed 365")
     private Integer beforeDays;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditService.java
@@ -106,6 +106,9 @@ public class AuditService {
         if (beforeDays <= 0) {
             throw new BusinessException(400, "beforeDays must be greater than 0");
         }
+        if (beforeDays > 365) {
+            throw new BusinessException(400, "beforeDays must not exceed 365");
+        }
         log.info("Cleaning up audit logs older than {} days", beforeDays);
         LocalDateTime cutoff = LocalDateTime.now().minusDays(beforeDays);
         return auditRepository.deleteBefore(cutoff);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditControllerTest.java
@@ -135,6 +135,18 @@ class AuditControllerTest {
     }
 
     @Test
+    void cleanupLogsShouldRejectRetentionBeyondMaximum() throws Exception {
+        mockMvc.perform(post("/api/audit-logs/cleanup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("beforeDays", 366))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("beforeDays must not exceed 365"));
+
+        verifyNoInteractions(auditService);
+    }
+
+    @Test
     void cleanupLogsShouldRejectInvalidRetentionType() throws Exception {
         mockMvc.perform(post("/api/audit-logs/cleanup")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
@@ -182,4 +182,11 @@ class AuditServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("beforeDays must be greater than 0");
     }
+
+    @Test
+    void cleanupLogsRejectsRetentionBeyondMaximum() {
+        assertThatThrownBy(() -> auditService.cleanupLogs(366))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("beforeDays must not exceed 365");
+    }
 }


### PR DESCRIPTION
## Summary
- reject audit cleanup retention beyond the UI-supported 365-day maximum
- enforce the bound at both request-validation and service layers
- cover controller and direct-service callers

## Testing
- `mvn -q -Dtest=AuditControllerTest,AuditServiceTest test`
