### PR TITLE
fix(settings): reject null persisted JSON

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -71,7 +71,11 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
                     .build();
         }
         try {
-            return objectMapper.readValue(entity.getJson(), GeneralSettingsVO.class);
+            GeneralSettingsVO settings = objectMapper.readValue(entity.getJson(), GeneralSettingsVO.class);
+            if (settings == null) {
+                throw new BusinessException(500, "Persisted general settings are invalid");
+            }
+            return settings;
         } catch (JsonProcessingException e) {
             log.error("Failed to deserialize general settings", e);
             throw new BusinessException(500, "Persisted general settings are invalid");
@@ -148,9 +152,12 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
     private DataSourceVO toDataSourceVO(RmqDataSource entity) {
         try {
             DataSourceVO vo = objectMapper.readValue(entity.getJson(), DataSourceVO.class);
+            if (vo == null) {
+                throw new BusinessException(500, "Persisted data source is invalid: " + entity.getDsKey());
+            }
             vo.setKey(entity.getDsKey());
             return vo;
-        } catch (JsonProcessingException e) {
+        } catch (JsonProcessingException | IllegalArgumentException e) {
             log.error("Failed to deserialize data source: {}", entity.getDsKey(), e);
             throw new BusinessException(500, "Persisted data source is invalid: " + entity.getDsKey());
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -59,6 +59,19 @@ class MybatisPlusSettingsRepositoryTest {
     }
 
     @Test
+    void shouldRejectNullPersistedGeneralSettings() {
+        RmqSettings settings = new RmqSettings();
+        settings.setJson("null");
+        when(settingsMapper.selectById("singleton")).thenReturn(settings);
+
+        assertThatThrownBy(repository::loadGeneralSettings)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Persisted general settings are invalid")
+                .extracting("code")
+                .isEqualTo(500);
+    }
+
+    @Test
     void shouldReadValidPersistedGeneralSettings() {
         RmqSettings settings = new RmqSettings();
         settings.setJson("{\"theme\":\"dark\",\"requireLogin\":true}");
@@ -68,6 +81,20 @@ class MybatisPlusSettingsRepositoryTest {
 
         assertThat(loaded.getTheme()).isEqualTo("dark");
         assertThat(loaded.isRequireLogin()).isTrue();
+    }
+
+    @Test
+    void shouldRejectNullPersistedDataSource() {
+        RmqDataSource dataSource = new RmqDataSource();
+        dataSource.setDsKey("metrics-prod");
+        dataSource.setJson("null");
+        when(dataSourceMapper.selectById("metrics-prod")).thenReturn(dataSource);
+
+        assertThatThrownBy(() -> repository.findDataSourceByKey("metrics-prod"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Persisted data source is invalid: metrics-prod")
+                .extracting("code")
+                .isEqualTo(500);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- reject JSON `null` in persisted general settings
- reject JSON `null` and null JSON values in persisted data sources
- return the existing structured persistence error instead of leaking a null-pointer failure

## Testing
- `mvn -q -Dtest=MybatisPlusSettingsRepositoryTest test`
