### PR TITLE
fix(alerts): surface asset discovery failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetService.java
@@ -46,7 +46,15 @@ public class AlertRuleAssetService {
     private static final String LOCATION_PATTERN = "classpath*:alerts/*.yaml";
 
     private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
-    private final ResourcePatternResolver resourceResolver = new PathMatchingResourcePatternResolver();
+    private final ResourcePatternResolver resourceResolver;
+
+    public AlertRuleAssetService() {
+        this(new PathMatchingResourcePatternResolver());
+    }
+
+    AlertRuleAssetService(ResourcePatternResolver resourceResolver) {
+        this.resourceResolver = resourceResolver;
+    }
 
     /**
      * Lists metadata for every bundled alert rule asset.
@@ -166,8 +174,8 @@ public class AlertRuleAssetService {
         try {
             return resourceResolver.getResources(LOCATION_PATTERN);
         } catch (IOException e) {
-            log.warn("Unable to resolve alert rule assets: {}", e.getMessage());
-            return new Resource[0];
+            log.error("Unable to resolve alert rule assets", e);
+            throw new BusinessException(500, "Failed to resolve bundled alert rule assets");
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
@@ -20,7 +20,9 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -28,6 +30,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class AlertRuleAssetServiceTest {
 
@@ -74,6 +79,18 @@ class AlertRuleAssetServiceTest {
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> service.getAssetYaml("no-such-asset"));
         assertEquals(404, exception.getCode());
+    }
+
+    @Test
+    void listAssetsShouldSurfaceResourceDiscoveryFailures() throws IOException {
+        ResourcePatternResolver resolver = mock(ResourcePatternResolver.class);
+        when(resolver.getResources(anyString())).thenThrow(new IOException("classpath unavailable"));
+        AlertRuleAssetService failingService = new AlertRuleAssetService(resolver);
+
+        BusinessException exception = assertThrows(BusinessException.class, failingService::listAssets);
+
+        assertEquals(500, exception.getCode());
+        assertEquals("Failed to resolve bundled alert rule assets", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- distinguish alert-rule classpath discovery failures from a valid empty asset set
- return a structured server error instead of silently disabling bundled rules
- add resolver-failure regression coverage

## Testing
- `mvn -q -Dtest=AlertRuleAssetServiceTest test`
