### PR TITLE
fix(metrics): validate Prometheus value types

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
@@ -249,6 +249,10 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
         Iterator<Map.Entry<String, JsonNode>> fields = metric.fields();
         fields.forEachRemaining(entry -> {
             String key = entry.getKey();
+            if (!entry.getValue().isTextual()) {
+                throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                        backendLabel() + " returned a malformed time-series label");
+            }
             String value = entry.getValue().asText();
             if (key.length() > MAX_LABEL_KEY_LENGTH || value.length() > MAX_LABEL_VALUE_LENGTH) {
                 throw new PrometheusException(HttpStatus.PAYLOAD_TOO_LARGE.value(),
@@ -272,12 +276,17 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
 
     private MetricDataVO.MetricSampleVO parseSample(JsonNode sampleNode) {
         if (sampleNode == null || !sampleNode.isArray() || sampleNode.size() != 2
-                || !sampleNode.get(0).isNumber()) {
+                || !sampleNode.get(0).isNumber() || !sampleNode.get(1).isTextual()) {
+            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                    backendLabel() + " returned a malformed sample");
+        }
+        double timestamp = sampleNode.get(0).asDouble();
+        if (!Double.isFinite(timestamp)) {
             throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
                     backendLabel() + " returned a malformed sample");
         }
         return MetricDataVO.MetricSampleVO.builder()
-                .timestamp(sampleNode.get(0).asDouble())
+                .timestamp(timestamp)
                 .value(sampleNode.get(1).asText())
                 .build();
     }
@@ -288,8 +297,13 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
             throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
                     backendLabel() + " returned a malformed histogram sample");
         }
+        double timestamp = sampleNode.get(0).asDouble();
+        if (!Double.isFinite(timestamp)) {
+            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                    backendLabel() + " returned a malformed histogram sample");
+        }
         return MetricDataVO.MetricHistogramSampleVO.builder()
-                .timestamp(sampleNode.get(0).asDouble())
+                .timestamp(timestamp)
                 .histogram(sampleNode.get(1))
                 .build();
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusMetricsSourceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusMetricsSourceTest.java
@@ -230,6 +230,32 @@ class PrometheusMetricsSourceTest {
     }
 
     @Test
+    void queryShouldRejectNonTextSampleValues() {
+        server.createContext("/api/v1/query_range", exchange -> respond(exchange, 200, """
+                {"status":"success","data":{"resultType":"matrix","result":[
+                  {"metric":{"topic":"orders"},"values":[[1784107658,1.25]]}
+                ]}}
+                """));
+
+        assertThatThrownBy(() -> source(Duration.ofSeconds(2)).query(query()))
+                .isInstanceOf(PrometheusException.class)
+                .hasMessage("Prometheus returned a malformed sample");
+    }
+
+    @Test
+    void queryShouldRejectNonTextSeriesLabels() {
+        server.createContext("/api/v1/query_range", exchange -> respond(exchange, 200, """
+                {"status":"success","data":{"resultType":"matrix","result":[
+                  {"metric":{"topic":{"name":"orders"}},"values":[[1784107658,"1.25"]]}
+                ]}}
+                """));
+
+        assertThatThrownBy(() -> source(Duration.ofSeconds(2)).query(query()))
+                .isInstanceOf(PrometheusException.class)
+                .hasMessage("Prometheus returned a malformed time-series label");
+    }
+
+    @Test
     void queryShouldRejectResponseWithTooManySeries() {
         server.createContext("/api/v1/query_range", exchange -> respond(exchange, 200, responseWithSeries(1_001)));
 


### PR DESCRIPTION
## Summary
- reject non-text Prometheus sample values instead of coercing them
- reject structured/null label values instead of silently converting them
- reject non-finite sample and histogram timestamps

## Testing
- `mvn -q -Dtest=PrometheusMetricsSourceTest test`
