### PR TITLE
fix(ai): preserve selected home prompt mode

### DIFF
--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -21,7 +21,7 @@ import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { MemoryRouter } from 'react-router-dom';
 import { LangProvider } from '../../../i18n/LangContext';
-import { executeTool, listTools } from '../../../api/ai';
+import { chatStream, executeTool, listTools } from '../../../api/ai';
 import { listClusters, type ClusterInfo } from '../../../api/cluster';
 import { getLlmConfig, getLlmModels } from '../../../api/llm';
 import AiPage from '../index';
@@ -59,11 +59,11 @@ beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn();
 });
 
-const renderPage = () =>
+const renderPage = (state?: unknown) =>
   render(
     <App>
       <LangProvider>
-        <MemoryRouter initialEntries={['/ai']}>
+        <MemoryRouter initialEntries={[state === undefined ? '/ai' : { pathname: '/ai', state }]}>
           <AiPage />
         </MemoryRouter>
       </LangProvider>
@@ -103,6 +103,20 @@ describe('AiPage tool runner', () => {
         permission: 'cluster:read',
       },
     ]);
+  });
+
+  it('uses the mode carried from the home-page draft', async () => {
+    vi.mocked(chatStream).mockResolvedValue(undefined);
+    renderPage({ prompt: '检查集群状态', mode: 'diagnose' });
+
+    await waitFor(() => {
+      expect(chatStream).toHaveBeenCalledWith(
+        expect.objectContaining({ message: '检查集群状态', mode: 'diagnose' }),
+        expect.any(Function),
+        expect.any(AbortSignal),
+        expect.any(Function),
+      );
+    });
   });
 
   it('loads the catalog, creates a schema template, and renders structured output', async () => {

--- a/web/src/pages/ai/chatDraft.test.ts
+++ b/web/src/pages/ai/chatDraft.test.ts
@@ -26,6 +26,16 @@ describe('AI chat draft navigation state', () => {
     });
   });
 
+  it('preserves supported home modes and drops unknown modes', () => {
+    expect(getChatDraft({ prompt: '检查集群状态', mode: 'diagnose' })).toEqual({
+      prompt: '检查集群状态',
+      mode: 'diagnose',
+    });
+    expect(getChatDraft({ prompt: '检查集群状态', mode: 'unknown' })).toEqual({
+      prompt: '检查集群状态',
+    });
+  });
+
   it('rejects invalid or empty navigation state', () => {
     expect(getChatDraft(null)).toBeNull();
     expect(getChatDraft({ prompt: '   ' })).toBeNull();

--- a/web/src/pages/ai/chatDraft.ts
+++ b/web/src/pages/ai/chatDraft.ts
@@ -15,9 +15,14 @@
  * limitations under the License.
  */
 
+export type ChatMode = 'chat' | 'diagnose' | 'manage' | 'query';
+
+const CHAT_MODES = new Set<ChatMode>(['chat', 'diagnose', 'manage', 'query']);
+
 export interface ChatDraft {
   prompt: string;
   model?: string;
+  mode?: ChatMode;
   enhance?: boolean;
 }
 
@@ -26,10 +31,15 @@ export function getChatDraft(state: unknown): ChatDraft | null {
   const candidate = state as Record<string, unknown>;
   if (typeof candidate.prompt !== 'string' || !candidate.prompt.trim()) return null;
   const model = typeof candidate.model === 'string' ? candidate.model.trim() : '';
+  const mode =
+    typeof candidate.mode === 'string' && CHAT_MODES.has(candidate.mode as ChatMode)
+      ? (candidate.mode as ChatMode)
+      : undefined;
 
   return {
     prompt: candidate.prompt.trim(),
     ...(model ? { model } : {}),
+    ...(mode ? { mode } : {}),
     ...(candidate.enhance === true ? { enhance: true } : {}),
   };
 }

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -46,7 +46,7 @@ import { AiStreamError, chatStream, executeTool, listTools, type McpTool } from 
 import { listClusters } from '../../api/cluster';
 import { getLlmConfig, getLlmModels, type LlmConfig } from '../../api/llm';
 import { useEngineStore } from '../../stores/engineStore';
-import { getChatDraft } from './chatDraft';
+import { getChatDraft, type ChatMode } from './chatDraft';
 
 const { Text } = Typography;
 
@@ -403,9 +403,12 @@ const AiPage = () => {
   const abortControllerRef = useRef<AbortController | null>(null);
   const conversationIdRef = useRef<string | null>(null);
   const consumedDraftRef = useRef(false);
-  const pendingAutoSendRef = useRef<{ prompt: string; model?: string; enhance?: boolean } | null>(
-    null,
-  );
+  const pendingAutoSendRef = useRef<{
+    prompt: string;
+    model?: string;
+    mode?: ChatMode;
+    enhance?: boolean;
+  } | null>(null);
 
   const scrollToBottom = useCallback(() => {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -465,6 +468,7 @@ const AiPage = () => {
       pendingAutoSendRef.current = {
         prompt: draft.prompt,
         model: draft.model,
+        mode: draft.mode,
         enhance: draft.enhance,
       };
       navigate('/ai', { replace: true, state: null });
@@ -490,7 +494,12 @@ const AiPage = () => {
   const llmReady = Boolean((llmConfig?.ready ?? llmConfig?.enabled) && selectedModel);
 
   const handleSend = useCallback(
-    async (textOverride?: string, modelOverride?: string, enhance?: boolean) => {
+    async (
+      textOverride?: string,
+      modelOverride?: string,
+      enhance?: boolean,
+      modeOverride: ChatMode = 'chat',
+    ) => {
       const text = (textOverride ?? inputValue).trim();
       const model = modelOverride ?? selectedModel;
       if (!text || loading) return;
@@ -527,7 +536,7 @@ const AiPage = () => {
         await chatStream(
           {
             message: text,
-            mode: 'chat',
+            mode: modeOverride,
             model,
             engine: useEngineStore.getState().engine,
             enhance,
@@ -585,7 +594,7 @@ const AiPage = () => {
     const pending = pendingAutoSendRef.current;
     if (!pending || loading || !llmReady) return;
     pendingAutoSendRef.current = null;
-    void handleSend(pending.prompt, pending.model, pending.enhance);
+    void handleSend(pending.prompt, pending.model, pending.enhance, pending.mode);
   }, [llmReady, loading, handleSend]);
 
   const handleStop = useCallback(() => {

--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -94,6 +94,7 @@ describe('HomePage LLM models', () => {
           prompt: '查看集群状态',
           model: 'qwen3.8-max',
           engine: 'claude-code',
+          mode: 'chat',
         },
       });
     });

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -192,6 +192,7 @@ const HomePage = () => {
             prompt,
             ...(selectedModel ? { model: selectedModel } : {}),
             engine,
+            mode: activeMode,
             ...(promoteOn ? { enhance: true } : {}),
           }
         : null,


### PR DESCRIPTION
## Summary
- include the selected home-page AI mode in navigation state
- validate and consume supported draft modes on the AI page
- send the preserved mode instead of always forcing `chat`

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/pages/ai/chatDraft.test.ts src/pages/home/__tests__/HomePage.test.tsx src/pages/ai/__tests__/AiPage.test.tsx --reporter=dot`
