### PR TITLE
fix(grafana): reject null dashboard assets

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
@@ -100,6 +100,9 @@ public class GrafanaDashboardService {
         try (InputStream in = resource.getInputStream()) {
             @SuppressWarnings("unchecked")
             Map<String, Object> model = objectMapper.readValue(in, Map.class);
+            if (model == null) {
+                throw new BusinessException(500, "Failed to read Grafana dashboard: " + uid);
+            }
             return model;
         } catch (IOException e) {
             throw new BusinessException(500, "Failed to read Grafana dashboard: " + uid);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
@@ -66,6 +66,17 @@ class GrafanaDashboardServiceTest {
     }
 
     @Test
+    void getDashboardShouldRejectNullJsonAsset() {
+        GrafanaDashboardService service = serviceWithResources(resource("null.json", "null"));
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> service.getDashboard("null"));
+
+        assertEquals(500, exception.getCode());
+        assertEquals("Failed to read Grafana dashboard: null", exception.getMessage());
+    }
+
+    @Test
     void getDashboardShouldThrowWhenUidUnknown() {
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> service.getDashboard("no-such-dashboard"));


### PR DESCRIPTION
## Summary
- reject a bundled Grafana asset whose JSON root is `null`
- return the existing structured dashboard-read error instead of a null model
- add direct dashboard lookup regression coverage

## Testing
- `mvn -q -Dtest=GrafanaDashboardServiceTest test`
