### PR TITLE
fix(credentials): verify delete result

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
@@ -116,7 +116,9 @@ public class CloudCredentialService {
         if (instanceRepository.existsByCredentialId(id)) {
             throw new BusinessException(400, "Cloud credential is referenced by existing instances");
         }
-        credentialRepository.deleteById(id);
+        if (!credentialRepository.deleteById(id)) {
+            throw new BusinessException(404, "Cloud credential not found: " + id);
+        }
         invalidateCloudClients(existing);
         recordAudit("DELETE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", id, null,
                 credentialAuditDetail(existing));

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
@@ -182,6 +182,7 @@ class CloudCredentialServiceTest {
         stored.setVendor(InstanceVendor.ALIYUN);
         when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
         when(instanceRepository.existsByCredentialId("cred-1")).thenReturn(false);
+        when(credentialRepository.deleteById("cred-1")).thenReturn(true);
 
         service.delete("cred-1");
 
@@ -189,6 +190,22 @@ class CloudCredentialServiceTest {
         verify(aliyunClientFactory).invalidateCredential("cred-1");
         verify(operationAuditService).record(eq("DELETE_CLOUD_CREDENTIAL"), eq("CLOUD_CREDENTIAL"),
                 eq("cred-1"), eq(null), eq("name=null, vendor=ALIYUN"), eq("SUCCESS"), eq(null));
+    }
+
+    @Test
+    void deleteShouldRejectConcurrentRemovalBeforeInvalidatingClientsTest() {
+        CloudCredentialVO stored = new CloudCredentialVO();
+        stored.setId("cred-1");
+        stored.setVendor(InstanceVendor.ALIYUN);
+        when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
+        when(instanceRepository.existsByCredentialId("cred-1")).thenReturn(false);
+        when(credentialRepository.deleteById("cred-1")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.delete("cred-1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Cloud credential not found: cred-1");
+
+        verify(aliyunClientFactory, never()).invalidateCredential(any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- check the credential repository delete result
- report a concurrent removal as not found
- avoid client invalidation and success auditing when no row was deleted

## Testing
- `mvn -q -Dtest=CloudCredentialServiceTest test`
