### PR TITLE
fix: align Proxy diagnostics with managed instances

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
@@ -18,6 +18,9 @@
 package org.apache.rocketmq.studio.cluster.proxy;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -29,11 +32,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.time.Duration;
-
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -48,11 +47,11 @@ public class ProxyAddressService {
 
     private static final String RELOAD_PATH = "/admin/reloadConfig";
 
-    private final Set<String> proxyAddrs = new LinkedHashSet<>(List.of("127.0.0.1:8081"));
-    private String currentProxyAddr = "127.0.0.1:8081";
+    private final InstanceRepository instanceRepository;
     private final RestTemplate restTemplate;
 
-    public ProxyAddressService() {
+    public ProxyAddressService(InstanceRepository instanceRepository) {
+        this.instanceRepository = instanceRepository;
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory() {
             @Override
             protected void prepareConnection(java.net.HttpURLConnection connection, String httpMethod) throws IOException {
@@ -65,31 +64,40 @@ public class ProxyAddressService {
         this.restTemplate = new RestTemplate(factory);
     }
 
-    public synchronized ProxyHomeVO getHomePage() {
+    public ProxyHomeVO getHomePage() {
+        List<String> proxyAddrs = listConfiguredProxyEndpoints();
         return ProxyHomeVO.builder()
-                .proxyAddrList(new ArrayList<>(proxyAddrs))
-                .currentProxyAddr(currentProxyAddr)
+                .proxyAddrList(proxyAddrs)
+                .currentProxyAddr(proxyAddrs.isEmpty() ? "" : proxyAddrs.get(0))
                 .build();
     }
 
-    public synchronized void addProxyAddr(String newProxyAddr) {
-        String normalized = normalizeProxyAddr(newProxyAddr, "newProxyAddr");
-        proxyAddrs.add(normalized);
-        if (currentProxyAddr == null || currentProxyAddr.isBlank()) {
-            currentProxyAddr = normalized;
+    /**
+     * A managed Proxy instance owns its access endpoint. This compat surface returns the selected
+     * instance endpoint without inventing additional cluster-global proxy addresses.
+     */
+    public ProxyHomeVO getHomePage(String instanceId) {
+        if (instanceId == null || instanceId.isBlank()) {
+            throw new BusinessException(400, "instanceId is required");
         }
-        log.info("Added Proxy address {}", normalized);
+        InstanceVO instance = instanceRepository.findById(instanceId)
+                .orElseThrow(() -> new BusinessException(404, "Instance not found: " + instanceId));
+        if (instance.getType() != InstanceType.PROXY) {
+            throw new BusinessException(400, "Instance is not a Proxy instance: " + instanceId);
+        }
+        String endpoint = normalizeConfiguredEndpoint(instance.getEndpoint(), instanceId);
+        return ProxyHomeVO.builder()
+                .proxyAddrList(List.of(endpoint))
+                .currentProxyAddr(endpoint)
+                .build();
     }
 
-    public synchronized void removeProxyAddr(String proxyAddr) {
-        String normalized = normalizeProxyAddr(proxyAddr, "proxyAddr");
-        if (!proxyAddrs.remove(normalized)) {
-            throw new BusinessException(404, "Proxy address not found: " + normalized);
-        }
-        if (normalized.equals(currentProxyAddr)) {
-            currentProxyAddr = proxyAddrs.stream().findFirst().orElse("");
-        }
-        log.info("Removed Proxy address {}", normalized);
+    public void addProxyAddr(String newProxyAddr) {
+        throw new UnsupportedOperationException("Update the managed instance endpoint instead");
+    }
+
+    public void removeProxyAddr(String proxyAddr) {
+        throw new UnsupportedOperationException("Update the managed instance endpoint instead");
     }
 
     /**
@@ -99,10 +107,8 @@ public class ProxyAddressService {
      */
     public void reloadConfig(String addr) {
         String normalized = normalizeProxyAddr(addr, "addr");
-        synchronized (this) {
-            if (!proxyAddrs.contains(normalized)) {
-                throw new BusinessException(400, "addr is not a registered proxy address");
-            }
+        if (listConfiguredProxyEndpoints().stream().noneMatch(normalized::equals)) {
+            throw new BusinessException(400, "addr is not a configured proxy endpoint");
         }
         String url = "http://" + normalized + RELOAD_PATH;
         try {
@@ -123,6 +129,22 @@ public class ProxyAddressService {
             log.warn("Proxy config reload via {} failed: {}", url, ex.getMessage());
             throw new BusinessException(500, "Config reload failed: " + ex.getMessage());
         }
+    }
+
+    private List<String> listConfiguredProxyEndpoints() {
+        return instanceRepository.findByType(InstanceType.PROXY).stream()
+                .map(InstanceVO::getEndpoint)
+                .filter(endpoint -> endpoint != null && !endpoint.isBlank())
+                .map(String::trim)
+                .distinct()
+                .toList();
+    }
+
+    private String normalizeConfiguredEndpoint(String endpoint, String instanceId) {
+        if (endpoint == null || endpoint.isBlank()) {
+            throw new BusinessException(409, "Proxy instance has no configured endpoint: " + instanceId);
+        }
+        return normalizeProxyAddr(endpoint, "endpoint");
     }
 
     private String normalizeProxyAddr(String proxyAddr, String fieldName) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyCompatController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyCompatController.java
@@ -19,7 +19,6 @@ package org.apache.rocketmq.studio.cluster.proxy;
 
 import org.apache.rocketmq.studio.common.domain.Result;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,19 +33,17 @@ public class ProxyCompatController {
     private final ProxyAddressService proxyAddressService;
 
     @GetMapping("/homePage.query")
-    public Result<ProxyHomeVO> homePage() {
-        return Result.ok(proxyAddressService.getHomePage());
+    public Result<ProxyHomeVO> homePage(@RequestParam String instanceId) {
+        return Result.ok(proxyAddressService.getHomePage(instanceId));
     }
 
-    @PostMapping(value = "/addProxyAddr.do", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    public Result<Void> addProxyAddr(@RequestParam String newProxyAddr) {
-        proxyAddressService.addProxyAddr(newProxyAddr);
-        return Result.ok();
+    @PostMapping("/addProxyAddr.do")
+    public Result<Void> addProxyAddr() {
+        throw new UnsupportedOperationException("Update the managed instance endpoint instead");
     }
 
-    @PostMapping(value = "/removeProxyAddr.do", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    public Result<Void> removeProxyAddr(@RequestParam String proxyAddr) {
-        proxyAddressService.removeProxyAddr(proxyAddr);
-        return Result.ok();
+    @PostMapping("/removeProxyAddr.do")
+    public Result<Void> removeProxyAddr() {
+        throw new UnsupportedOperationException("Update the managed instance endpoint instead");
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyConfigReloadDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyConfigReloadDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.proxy;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProxyConfigReloadDTO {
+    @NotBlank(message = "addr is required")
+    private String addr;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyController.java
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -40,8 +39,7 @@ public class ProxyController {
     private final ProxyAddressService proxyAddressService;
 
     @GetMapping
-    public Result<List<ProxyVO>> listProxies(@RequestParam(required = false) String clusterId) {
-        requireClusterId(clusterId);
+    public Result<List<ProxyVO>> listProxies() {
         List<ProxyVO> proxies = proxyAddressService.getHomePage().getProxyAddrList().stream()
                 .map(addr -> ProxyVO.builder().addr(addr).build())
                 .toList();
@@ -49,7 +47,7 @@ public class ProxyController {
     }
 
     @PostMapping("/config/reload")
-    public Result<Map<String, Boolean>> reloadProxyConfig(@Valid @RequestBody RestartProxyDTO command) {
+    public Result<Map<String, Boolean>> reloadProxyConfig(@Valid @RequestBody ProxyConfigReloadDTO command) {
         proxyAddressService.reloadConfig(command.getAddr());
         return Result.ok(Map.of("success", true));
     }
@@ -61,11 +59,5 @@ public class ProxyController {
             throw new BusinessException(500, "Failed to restart proxy");
         }
         return Result.ok();
-    }
-
-    private void requireClusterId(String clusterId) {
-        if (clusterId == null || clusterId.isBlank()) {
-            throw new BusinessException(400, "clusterId is required");
-        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
@@ -17,120 +17,130 @@
 
 package org.apache.rocketmq.studio.cluster.proxy;
 
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class ProxyAddressServiceTest {
 
-    private final ProxyAddressService proxyAddressService = new ProxyAddressService();
+    @Mock
+    private InstanceRepository instanceRepository;
 
-    @Test
-    void homePageShouldReturnDefaultProxyAddress() {
-        ProxyHomeVO home = proxyAddressService.getHomePage();
+    private ProxyAddressService proxyAddressService;
 
-        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081");
-        assertThat(home.getCurrentProxyAddr()).isEqualTo("127.0.0.1:8081");
+    @BeforeEach
+    void setUp() {
+        proxyAddressService = new ProxyAddressService(instanceRepository);
     }
 
     @Test
-    void addProxyAddrShouldTrimAndKeepUniqueAddresses() {
-        proxyAddressService.addProxyAddr(" 10.0.0.1:8081 ");
-        proxyAddressService.addProxyAddr("10.0.0.1:8081");
+    void homePageShouldReturnConfiguredProxyEndpoints() {
+        when(instanceRepository.findByType(InstanceType.PROXY)).thenReturn(List.of(
+                proxyInstance("proxy-a", "10.0.0.1:8081"),
+                proxyInstance("proxy-b", "10.0.0.2:8081")
+        ));
 
         ProxyHomeVO home = proxyAddressService.getHomePage();
-        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081", "10.0.0.1:8081");
-        assertThat(home.getCurrentProxyAddr()).isEqualTo("127.0.0.1:8081");
+
+        assertThat(home.getProxyAddrList()).containsExactly("10.0.0.1:8081", "10.0.0.2:8081");
+        assertThat(home.getCurrentProxyAddr()).isEqualTo("10.0.0.1:8081");
     }
 
     @Test
-    void addProxyAddrShouldRejectBlankAddress() {
-        assertThatThrownBy(() -> proxyAddressService.addProxyAddr(" "))
+    void homePageShouldReturnSelectedProxyInstanceEndpoint() {
+        when(instanceRepository.findById("proxy-a")).thenReturn(Optional.of(proxyInstance("proxy-a", "10.0.0.1:8081")));
+
+        ProxyHomeVO home = proxyAddressService.getHomePage("proxy-a");
+
+        assertThat(home.getProxyAddrList()).containsExactly("10.0.0.1:8081");
+        assertThat(home.getCurrentProxyAddr()).isEqualTo("10.0.0.1:8081");
+    }
+
+    @Test
+    void homePageShouldRequireInstanceId() {
+        assertThatThrownBy(() -> proxyAddressService.getHomePage(" "))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("newProxyAddr is required")
+                .hasMessage("instanceId is required")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
     }
 
     @Test
-    void addProxyAddrShouldAcceptBracketedIpv6Address() {
-        proxyAddressService.addProxyAddr(" [::1]:8081 ");
+    void homePageShouldRejectDirectInstance() {
+        InstanceVO direct = proxyInstance("direct-a", "127.0.0.1:9876");
+        direct.setType(InstanceType.DIRECT);
+        when(instanceRepository.findById("direct-a")).thenReturn(Optional.of(direct));
 
-        ProxyHomeVO home = proxyAddressService.getHomePage();
-        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081", "[::1]:8081");
-    }
-
-    @Test
-    void addProxyAddrShouldRejectInvalidAddressFormats() {
-        List<String> invalidProxyAddrs = List.of(
-                "10.0.0.1",
-                "10.0.0.1:abc",
-                "10.0.0.1:0",
-                "10.0.0.1:65536",
-                "http://10.0.0.1:8081",
-                "10.0.0.1:8081/path"
-        );
-
-        for (String invalidProxyAddr : invalidProxyAddrs) {
-            assertThatThrownBy(() -> proxyAddressService.addProxyAddr(invalidProxyAddr))
-                    .as("invalid proxy address %s", invalidProxyAddr)
-                    .isInstanceOf(BusinessException.class)
-                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
-        }
-    }
-
-    @Test
-    void removeProxyAddrShouldTrimAndRemoveAddress() {
-        proxyAddressService.addProxyAddr("10.0.0.1:8081");
-
-        proxyAddressService.removeProxyAddr(" 10.0.0.1:8081 ");
-
-        ProxyHomeVO home = proxyAddressService.getHomePage();
-        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081");
-        assertThat(home.getCurrentProxyAddr()).isEqualTo("127.0.0.1:8081");
-    }
-
-    @Test
-    void removeProxyAddrShouldSelectNextProxyWhenCurrentIsRemoved() {
-        proxyAddressService.removeProxyAddr("127.0.0.1:8081");
-
-        ProxyHomeVO emptyHome = proxyAddressService.getHomePage();
-        assertThat(emptyHome.getProxyAddrList()).isEmpty();
-        assertThat(emptyHome.getCurrentProxyAddr()).isEmpty();
-
-        proxyAddressService.addProxyAddr("10.0.0.1:8081");
-        proxyAddressService.addProxyAddr("10.0.0.2:8081");
-        proxyAddressService.removeProxyAddr("10.0.0.1:8081");
-
-        ProxyHomeVO home = proxyAddressService.getHomePage();
-        assertThat(home.getProxyAddrList()).containsExactly("10.0.0.2:8081");
-        assertThat(home.getCurrentProxyAddr()).isEqualTo("10.0.0.2:8081");
-    }
-
-    @Test
-    void removeProxyAddrShouldRejectBlankAddress() {
-        assertThatThrownBy(() -> proxyAddressService.removeProxyAddr(" "))
+        assertThatThrownBy(() -> proxyAddressService.getHomePage("direct-a"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("proxyAddr is required")
+                .hasMessage("Instance is not a Proxy instance: direct-a")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
     }
 
     @Test
-    void removeProxyAddrShouldRejectUnknownAddress() {
-        assertThatThrownBy(() -> proxyAddressService.removeProxyAddr("10.0.0.1:8081"))
+    void homePageShouldRejectMissingInstance() {
+        when(instanceRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> proxyAddressService.getHomePage("missing"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("Proxy address not found: 10.0.0.1:8081")
+                .hasMessage("Instance not found: missing")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
     }
 
     @Test
-    void reloadConfigShouldRejectUnregisteredAddressTest() {
+    void homePageShouldRejectProxyInstanceWithoutEndpoint() {
+        when(instanceRepository.findById("proxy-a")).thenReturn(Optional.of(proxyInstance("proxy-a", " ")));
+
+        assertThatThrownBy(() -> proxyAddressService.getHomePage("proxy-a"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Proxy instance has no configured endpoint: proxy-a")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(409));
+    }
+
+    @Test
+    void legacyProxyAddressMutationsShouldBeUnsupported() {
+        assertThatThrownBy(() -> proxyAddressService.addProxyAddr("10.0.0.1:8081"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Update the managed instance endpoint instead");
+        assertThatThrownBy(() -> proxyAddressService.removeProxyAddr("10.0.0.1:8081"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Update the managed instance endpoint instead");
+    }
+
+    @Test
+    void reloadConfigShouldRejectAddressOutsideConfiguredProxyInstances() {
+        when(instanceRepository.findByType(InstanceType.PROXY)).thenReturn(List.of(proxyInstance("proxy-a", "10.0.0.2:8081")));
+
         assertThatThrownBy(() -> proxyAddressService.reloadConfig("10.0.0.1:8081"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("addr is not a registered proxy address")
+                .hasMessage("addr is not a configured proxy endpoint")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+    }
+
+    @Test
+    void reloadConfigShouldRejectInvalidAddressFormat() {
+        assertThatThrownBy(() -> proxyAddressService.reloadConfig("bad"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("addr must be in host:port or [ipv6]:port format")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+    }
+
+    private InstanceVO proxyInstance(String id, String endpoint) {
+        InstanceVO instance = InstanceVO.builder().type(InstanceType.PROXY).endpoint(endpoint).build();
+        instance.setId(id);
+        return instance;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyCompatControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyCompatControllerTest.java
@@ -22,12 +22,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -48,37 +46,25 @@ class ProxyCompatControllerTest {
     @Test
     void homePageShouldReturnProxyAddressState() throws Exception {
         ProxyHomeVO home = ProxyHomeVO.builder()
-                .proxyAddrList(List.of("127.0.0.1:8081", "10.0.0.1:8081"))
-                .currentProxyAddr("127.0.0.1:8081")
+                .proxyAddrList(List.of("10.0.0.1:8081"))
+                .currentProxyAddr("10.0.0.1:8081")
                 .build();
-        when(proxyAddressService.getHomePage()).thenReturn(home);
+        when(proxyAddressService.getHomePage("proxy-a")).thenReturn(home);
 
-        mockMvc.perform(get("/api/proxy/homePage.query"))
+        mockMvc.perform(get("/api/proxy/homePage.query").param("instanceId", "proxy-a"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.proxyAddrList[0]").value("127.0.0.1:8081"))
-                .andExpect(jsonPath("$.data.currentProxyAddr").value("127.0.0.1:8081"));
+                .andExpect(jsonPath("$.data.proxyAddrList[0]").value("10.0.0.1:8081"))
+                .andExpect(jsonPath("$.data.currentProxyAddr").value("10.0.0.1:8081"));
+
+        verify(proxyAddressService).getHomePage("proxy-a");
     }
 
     @Test
-    void addProxyAddrShouldAcceptFormEncodedPayload() throws Exception {
-        mockMvc.perform(post("/api/proxy/addProxyAddr.do")
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("newProxyAddr", "10.0.0.1:8081"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(200));
-
-        verify(proxyAddressService).addProxyAddr(eq("10.0.0.1:8081"));
-    }
-
-    @Test
-    void removeProxyAddrShouldAcceptFormEncodedPayload() throws Exception {
-        mockMvc.perform(post("/api/proxy/removeProxyAddr.do")
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("proxyAddr", "10.0.0.1:8081"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(200));
-
-        verify(proxyAddressService).removeProxyAddr(eq("10.0.0.1:8081"));
+    void legacyProxyAddressMutationsShouldReportUnsupported() throws Exception {
+        mockMvc.perform(post("/api/proxy/addProxyAddr.do"))
+                .andExpect(status().isNotImplemented())
+                .andExpect(jsonPath("$.code").value(501))
+                .andExpect(jsonPath("$.message").value("Update the managed instance endpoint instead"));
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyControllerTest.java
@@ -104,14 +104,14 @@ class ProxyControllerTest {
     }
 
     @Test
-    void listProxiesShouldReturnProxiesForCluster() throws Exception {
+    void listProxiesShouldReturnRegisteredProxies() throws Exception {
         when(proxyAddressService.getHomePage())
                 .thenReturn(ProxyHomeVO.builder()
                         .proxyAddrList(List.of("127.0.0.1:8081"))
                         .currentProxyAddr("127.0.0.1:8081")
                         .build());
 
-        mockMvc.perform(get("/api/proxies").param("clusterId", "cluster-1"))
+        mockMvc.perform(get("/api/proxies"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data[0].addr").value("127.0.0.1:8081"));
@@ -120,17 +120,8 @@ class ProxyControllerTest {
     }
 
     @Test
-    void listProxiesShouldRejectMissingClusterId() throws Exception {
-        mockMvc.perform(get("/api/proxies"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(400))
-                .andExpect(jsonPath("$.message").value("clusterId is required"));
-    }
-
-    @Test
     void reloadProxyConfigShouldReturnSuccess() throws Exception {
-        RestartProxyDTO request = RestartProxyDTO.builder()
-                .clusterId("cluster-1")
+        ProxyConfigReloadDTO request = ProxyConfigReloadDTO.builder()
                 .addr("127.0.0.1:8081")
                 .build();
 
@@ -146,9 +137,7 @@ class ProxyControllerTest {
 
     @Test
     void reloadProxyConfigShouldRejectMissingAddr() throws Exception {
-        RestartProxyDTO request = RestartProxyDTO.builder()
-                .clusterId("cluster-1")
-                .build();
+        ProxyConfigReloadDTO request = ProxyConfigReloadDTO.builder().build();
 
         mockMvc.perform(post("/api/proxies/config/reload")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/web/src/api/proxy.test.ts
+++ b/web/src/api/proxy.test.ts
@@ -18,7 +18,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { queryProxyHomePage } from './proxy';
+import { queryProxyHomePage, reloadProxyConfig } from './proxy';
 
 const mock = new MockAdapter(client);
 
@@ -38,20 +38,32 @@ describe('Proxy API', () => {
       proxyAddrList: ['192.168.1.1:8081', '192.168.1.2:8081'],
       currentProxyAddr: '192.168.1.1:8081',
     };
-    mock.onGet('/proxy/homePage.query').reply(200, { code: 200, data });
+    mock.onGet('/proxy/homePage.query', { params: { instanceId: 'instance-a' } }).reply(200, {
+      code: 200,
+      data,
+    });
 
-    const result = await queryProxyHomePage();
+    const result = await queryProxyHomePage('instance-a');
     expect(result.proxyAddrList).toHaveLength(2);
     expect(result.currentProxyAddr).toBe('192.168.1.1:8081');
   });
 
   it('handles empty proxy address list', async () => {
     mock
-      .onGet('/proxy/homePage.query')
+      .onGet('/proxy/homePage.query', { params: { instanceId: 'instance-a' } })
       .reply(200, { code: 200, data: { proxyAddrList: [], currentProxyAddr: '' } });
 
-    const result = await queryProxyHomePage();
+    const result = await queryProxyHomePage('instance-a');
     expect(result.proxyAddrList).toHaveLength(0);
     expect(result.currentProxyAddr).toBe('');
+  });
+
+  it('reloads proxy configuration without an unused cluster identifier', async () => {
+    mock.onPost('/proxies/config/reload').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ addr: '192.168.1.1:8081' });
+      return [200, { code: 200, data: { success: true } }];
+    });
+
+    await expect(reloadProxyConfig('192.168.1.1:8081')).resolves.toEqual({ success: true });
   });
 });

--- a/web/src/api/proxy.ts
+++ b/web/src/api/proxy.ts
@@ -39,21 +39,16 @@ export interface ProxyNode {
 
 // ─── API Functions ───────────────────────────────────────────────
 
-export async function queryProxyHomePage(): Promise<ProxyHomePageData> {
-  const res = await client.get<{ data: ProxyHomePageData }>('/proxy/homePage.query');
+export async function queryProxyHomePage(instanceId: string): Promise<ProxyHomePageData> {
+  const res = await client.get<{ data: ProxyHomePageData }>('/proxy/homePage.query', {
+    params: { instanceId },
+  });
   return res.data.data;
 }
 
-/**
- * Trigger a configuration hot-reload for a proxy.
- * Uses the same DTO as restartProxy ({ clusterId, addr }).
- */
-export async function reloadProxyConfig(
-  clusterId: string,
-  addr: string,
-): Promise<{ success: boolean }> {
+/** Trigger a configuration hot-reload for a registered proxy address. */
+export async function reloadProxyConfig(addr: string): Promise<{ success: boolean }> {
   const res = await client.post<{ data: { success: boolean } }>('/proxies/config/reload', {
-    clusterId,
     addr,
   });
   return res.data.data;

--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -31,8 +31,8 @@ import {
   Descriptions,
   Tooltip,
   App,
+  Select,
   Typography,
-  Input,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import {
@@ -46,6 +46,8 @@ import {
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
 import { queryProxyHomePage, reloadProxyConfig, type ProxyNode } from '../../api/proxy';
+import type { Instance } from '../../api/instance';
+import { listInstances } from '../../services/instanceService';
 
 const { Text } = Typography;
 
@@ -57,9 +59,8 @@ const ProxyPage: React.FC = () => {
   const [proxyNodes, setProxyNodes] = useState<ProxyNode[]>([]);
   const [selectedNode, setSelectedNode] = useState<ProxyNode | null>(null);
   const [configModalOpen, setConfigModalOpen] = useState(false);
-  const [clusterId, setClusterId] = useState<string>(
-    localStorage.getItem('clusterId') || 'DefaultCluster',
-  );
+  const [instances, setInstances] = useState<Instance[]>([]);
+  const [selectedInstanceId, setSelectedInstanceId] = useState('');
   const loadRequestId = useRef(0);
 
   const [clusterStats, setClusterStats] = useState({
@@ -69,11 +70,43 @@ const ProxyPage: React.FC = () => {
     totalTPS: null as number | null,
   });
 
+  useEffect(() => {
+    let cancelled = false;
+    void listInstances({ type: 'PROXY' })
+      .then((nextInstances) => {
+        if (cancelled) return;
+        setInstances(nextInstances);
+        setSelectedInstanceId((current) =>
+          nextInstances.some((instance) => instance.id === current)
+            ? current
+            : (nextInstances[0]?.id ?? ''),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) {
+          message.error(t('proxy.fetchListFailed'));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [message, t]);
+
   const loadProxyNodes = useCallback(async () => {
+    if (!selectedInstanceId) {
+      setProxyNodes([]);
+      setClusterStats({
+        totalNodes: 0,
+        healthyNodes: null,
+        totalConnections: null,
+        totalTPS: null,
+      });
+      return false;
+    }
     const requestId = ++loadRequestId.current;
     setLoading(true);
     try {
-      const { proxyAddrList, currentProxyAddr } = await queryProxyHomePage();
+      const { proxyAddrList, currentProxyAddr } = await queryProxyHomePage(selectedInstanceId);
       if (requestId !== loadRequestId.current) return false;
       const nodes: ProxyNode[] = (proxyAddrList || []).map((addr) => ({
         key: addr,
@@ -96,12 +129,6 @@ const ProxyPage: React.FC = () => {
         totalTPS: null,
       });
 
-      if (currentProxyAddr) {
-        localStorage.setItem('proxyAddr', currentProxyAddr);
-      } else if (proxyAddrList && proxyAddrList.length > 0) {
-        localStorage.setItem('proxyAddr', proxyAddrList[0]);
-      }
-
       return true;
     } catch {
       if (requestId !== loadRequestId.current) return false;
@@ -112,7 +139,7 @@ const ProxyPage: React.FC = () => {
         setLoading(false);
       }
     }
-  }, [message, t]);
+  }, [message, selectedInstanceId, t]);
 
   useEffect(() => {
     const requestId = loadRequestId.current;
@@ -135,16 +162,9 @@ const ProxyPage: React.FC = () => {
     }
   };
 
-  const handleClusterIdChange = (value: string) => {
-    setClusterId(value);
-    if (value) {
-      localStorage.setItem('clusterId', value);
-    }
-  };
-
   const handleReloadConfig = async (node: ProxyNode) => {
     try {
-      const result = await reloadProxyConfig(clusterId, node.address);
+      const result = await reloadProxyConfig(node.address);
       if (result.success) {
         message.success(t('proxy.reloadSuccess'));
       } else {
@@ -318,15 +338,16 @@ const ProxyPage: React.FC = () => {
     <div style={{ padding: 0 }}>
       <PageHeader
         title={t('proxy.title')}
-
         extra={
           <Space>
-            <Input
-              placeholder={t('proxy.clusterIdPlaceholder')}
-              value={clusterId}
-              onChange={(e) => handleClusterIdChange(e.target.value)}
-              style={{ width: 200 }}
-              aria-label={t('proxy.clusterId')}
+            <Select
+              aria-label="Proxy instance"
+              placeholder="选择 Proxy 实例"
+              value={selectedInstanceId || undefined}
+              onChange={setSelectedInstanceId}
+              options={instances.map((instance) => ({ value: instance.id, label: instance.name }))}
+              style={{ width: 220 }}
+              notFoundContent="暂无 Proxy 实例"
             />
             <Button type="primary" icon={<ArrowClockwise size={14} />} onClick={handleRefresh}>
               {t('common.refresh')}

--- a/web/src/pages/studio/__tests__/Proxy.test.tsx
+++ b/web/src/pages/studio/__tests__/Proxy.test.tsx
@@ -20,12 +20,17 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { queryProxyHomePage, reloadProxyConfig } from '../../../api/proxy';
+import { listInstances } from '../../../services/instanceService';
 import { LangProvider } from '../../../i18n/LangContext';
 import ProxyPage from '../Proxy';
 
 vi.mock('../../../api/proxy', () => ({
   queryProxyHomePage: vi.fn(),
   reloadProxyConfig: vi.fn(),
+}));
+
+vi.mock('../../../services/instanceService', () => ({
+  listInstances: vi.fn(),
 }));
 
 beforeAll(() => {
@@ -70,6 +75,19 @@ const createDeferred = <T,>() => {
 describe('ProxyPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'proxy-a',
+        name: 'Proxy A',
+        remark: null,
+        type: 'PROXY',
+        endpoint: '127.0.0.1:8081',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
     vi.mocked(queryProxyHomePage).mockResolvedValue(proxyHome);
     vi.mocked(reloadProxyConfig).mockResolvedValue({
       success: true,
@@ -80,6 +98,7 @@ describe('ProxyPage', () => {
     renderPage();
 
     await screen.findByText('127.0.0.1:8081');
+    expect(queryProxyHomePage).toHaveBeenCalledWith('proxy-a');
     expect(queryProxyHomePage).toHaveBeenCalledTimes(1);
   });
 
@@ -136,9 +155,7 @@ describe('ProxyPage', () => {
 
     await user.click(screen.getByRole('button', { name: '重载配置' }));
 
-    await waitFor(() =>
-      expect(reloadProxyConfig).toHaveBeenCalledWith('DefaultCluster', '127.0.0.1:8081'),
-    );
+    await waitFor(() => expect(reloadProxyConfig).toHaveBeenCalledWith('127.0.0.1:8081'));
     expect(await screen.findByText('配置重载成功')).toBeInTheDocument();
   });
 
@@ -167,5 +184,40 @@ describe('ProxyPage', () => {
     await act(async () => older.resolve(proxyHome));
     expect(screen.getByText('127.0.0.2:8081')).toBeInTheDocument();
     expect(screen.queryByText('127.0.0.1:8081')).not.toBeInTheDocument();
+  });
+
+  it('loads the selected Proxy instance endpoint instead of a process-global address', async () => {
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'proxy-a',
+        name: 'Proxy A',
+        remark: null,
+        type: 'PROXY',
+        endpoint: '127.0.0.1:8081',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+      {
+        id: 'proxy-b',
+        name: 'Proxy B',
+        remark: null,
+        type: 'PROXY',
+        endpoint: '127.0.0.2:8081',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText('127.0.0.1:8081');
+
+    await user.click(screen.getByRole('combobox', { name: 'Proxy instance' }));
+    await user.click(await screen.findByText('Proxy B'));
+
+    await waitFor(() => expect(queryProxyHomePage).toHaveBeenLastCalledWith('proxy-b'));
   });
 });


### PR DESCRIPTION
## Summary

- resolve Proxy dashboard endpoints from the selected managed `PROXY` instance
- remove misleading cluster-global and process-local Proxy address state
- keep configuration reload scoped to configured managed endpoints
- return explicit unsupported behavior for legacy add/remove address routes instead of mutating simulated state
- preserve read-only Proxy topology and configuration views

Closes #1113
Closes #1740

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=ProxyAddressServiceTest,ProxyCompatControllerTest,ProxyControllerTest test` (17 tests passed)
- `npx vitest run src/api/proxy.test.ts src/pages/studio/__tests__/Proxy.test.tsx` (11 tests passed)
- targeted ESLint on changed frontend files
- `npm run build`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -DskipTests package`
- `git diff --check origin/rocketmq-studio...HEAD`
