### PR TITLE
fix(alerts): normalize levels before filtering

### DIFF
--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -86,6 +86,35 @@ describe('SystemAlertsPage', () => {
     expect(screen.getByText('A newer backend emitted this level')).toBeInTheDocument();
   });
 
+  it('filters backend alert levels case-insensitively', async () => {
+    vi.mocked(listSystemAlerts).mockResolvedValue([
+      {
+        id: 'alert-error',
+        level: 'Error',
+        title: 'Mixed-case error',
+        description: 'error',
+        time: '2026-08-10 01:00',
+        acknowledged: false,
+      },
+      {
+        id: 'alert-warning',
+        level: 'WARNING',
+        title: 'Mixed-case warning',
+        description: 'warning',
+        time: '2026-08-10 01:01',
+        acknowledged: false,
+      },
+    ]);
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText('Mixed-case error');
+
+    await user.click(screen.getByRole('button', { name: /严重/ }));
+
+    expect(screen.getByText('Mixed-case error')).toBeInTheDocument();
+    expect(screen.queryByText('Mixed-case warning')).not.toBeInTheDocument();
+  });
+
   it('tracks simultaneous acknowledgements independently', async () => {
     vi.mocked(acknowledgeAlert).mockImplementation(() => new Promise(() => {}));
     const user = userEvent.setup();

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -29,6 +29,8 @@ import type { SystemAlert } from '../../api/ops';
 
 const { Text } = Typography;
 
+const normalizeAlertLevel = (level: string) => level.toLowerCase();
+
 const SystemAlertsPage = () => {
   const { t } = useLang();
 
@@ -63,7 +65,10 @@ const SystemAlertsPage = () => {
     };
   }, []);
 
-  const filtered = levelFilter === 'all' ? alerts : alerts.filter((a) => a.level === levelFilter);
+  const filtered =
+    levelFilter === 'all'
+      ? alerts
+      : alerts.filter((a) => normalizeAlertLevel(a.level) === levelFilter);
 
   const unackCount = alerts.filter((a) => !a.acknowledged).length;
 
@@ -125,7 +130,7 @@ const SystemAlertsPage = () => {
             {level === 'all' ? t('common.all') : alertLevelConfig[level]?.label}
             {level !== 'all' && (
               <Badge
-                count={alerts.filter((a) => a.level === level).length}
+                count={alerts.filter((a) => normalizeAlertLevel(a.level) === level).length}
                 style={{
                   marginLeft: 4,
                   backgroundColor:
@@ -142,7 +147,7 @@ const SystemAlertsPage = () => {
         {loading && <Card loading />}
         {!loading &&
           filtered.map((alert) => {
-            const normalizedLevel = alert.level.toLowerCase();
+            const normalizedLevel = normalizeAlertLevel(alert.level);
             const cfg = alertLevelConfig[normalizedLevel] ?? {
               color: '#8c8c8c',
               bg: '#fafafa',


### PR DESCRIPTION
## Summary
- normalize backend alert levels before applying level filters
- use the same normalization for filter badges and rendered tags
- cover mixed-case backend values

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/pages/ops/__tests__/SystemAlertsPage.test.tsx --reporter=dot`
