### PR TITLE
fix(ai): bound buffered SSE events

### DIFF
--- a/web/src/api/ai.test.ts
+++ b/web/src/api/ai.test.ts
@@ -31,12 +31,13 @@ import {
 const mock = new MockAdapter(client);
 const encoder = new TextEncoder();
 
-function streamResponse(chunks: string[]): Response {
+function streamResponse(chunks: string[], onCancel?: () => void): Response {
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
       chunks.forEach((chunk) => controller.enqueue(encoder.encode(chunk)));
-      controller.close();
+      if (!onCancel) controller.close();
     },
+    cancel: onCancel,
   });
   return new Response(body, { status: 200 });
 }
@@ -114,6 +115,34 @@ describe('AI API', () => {
       );
 
       expect(chunks).toEqual(['hello', 'raw text']);
+    });
+
+    it('cancels the reader after the done event', async () => {
+      const onCancel = vi.fn();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(streamResponse(['data: [DONE]\n\n'], onCancel)),
+      );
+
+      await chatStream({ message: 'hello', mode: 'chat', model: 'stub' }, vi.fn());
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects an unbounded SSE event and cancels the reader', async () => {
+      const onCancel = vi.fn();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(streamResponse(['data: ' + 'x'.repeat(1024 * 1024)], onCancel)),
+      );
+
+      await expect(
+        chatStream({ message: 'hello', mode: 'chat', model: 'stub' }, vi.fn()),
+      ).rejects.toMatchObject({
+        message: 'AI stream event exceeds 1 MiB',
+        code: 'llm.stream.event_too_large',
+      });
+      expect(onCancel).toHaveBeenCalledTimes(1);
     });
 
     it('throws structured errors from SSE error events', async () => {

--- a/web/src/api/ai.ts
+++ b/web/src/api/ai.ts
@@ -17,6 +17,8 @@
 
 import client from './client';
 
+const MAX_SSE_EVENT_CHARS = 1024 * 1024;
+
 // ─── Types ──────────────────────────────────────────────────────
 export interface McpTool {
   name: string;
@@ -176,22 +178,35 @@ export async function chatStream(
   const decoder = new TextDecoder();
   let buffer = '';
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
 
-    buffer += decoder.decode(value, { stream: true });
-    let boundary = getEventBoundary(buffer);
-    while (boundary) {
-      const event = buffer.slice(0, boundary.index);
-      buffer = buffer.slice(boundary.index + boundary.length);
-      if (emitEvent(event, onChunk, onEnhance)) return;
-      boundary = getEventBoundary(buffer);
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.length > MAX_SSE_EVENT_CHARS && !getEventBoundary(buffer)) {
+        throw new AiStreamError('AI stream event exceeds 1 MiB', 'llm.stream.event_too_large');
+      }
+      let boundary = getEventBoundary(buffer);
+      while (boundary) {
+        const event = buffer.slice(0, boundary.index);
+        buffer = buffer.slice(boundary.index + boundary.length);
+        if (event.length > MAX_SSE_EVENT_CHARS) {
+          throw new AiStreamError('AI stream event exceeds 1 MiB', 'llm.stream.event_too_large');
+        }
+        if (emitEvent(event, onChunk, onEnhance)) return;
+        boundary = getEventBoundary(buffer);
+      }
     }
-  }
 
-  buffer += decoder.decode();
-  if (buffer && emitEvent(buffer, onChunk, onEnhance)) return;
+    buffer += decoder.decode();
+    if (buffer.length > MAX_SSE_EVENT_CHARS) {
+      throw new AiStreamError('AI stream event exceeds 1 MiB', 'llm.stream.event_too_large');
+    }
+    if (buffer && emitEvent(buffer, onChunk, onEnhance)) return;
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
 }
 
 export async function executeAiCommand(data: AiExecuteRequest) {


### PR DESCRIPTION
## Summary
- cap a single buffered AI SSE event at 1 MiB
- cancel the stream reader on done, parse failure, or size rejection
- cover early completion and oversized unterminated events

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/api/ai.test.ts --reporter=dot`
