### PR TITLE
fix(web): format blank dates as unavailable

### DIFF
--- a/web/src/utils/format.test.ts
+++ b/web/src/utils/format.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatDate, formatDateTime } from './format';
+
+describe('date formatters', () => {
+  it('renders missing and blank date values consistently', () => {
+    for (const value of [null, undefined, '', '   ']) {
+      expect(formatDateTime(value)).toBe('-');
+      expect(formatDate(value)).toBe('-');
+    }
+  });
+
+  it('preserves a nonblank invalid value for diagnostics', () => {
+    expect(formatDateTime('not-a-date')).toBe('not-a-date');
+    expect(formatDate('not-a-date')).toBe('not-a-date');
+  });
+});

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -21,7 +21,7 @@ const pad = (n: number, width = 2): string => String(n).padStart(width, '0');
  * Format a date string or Date object to 'YYYY-MM-DD HH:mm:ss'.
  */
 export function formatDateTime(date: string | Date | null | undefined): string {
-  if (date === null || date === undefined) return '-';
+  if (date === null || date === undefined || (typeof date === 'string' && !date.trim())) return '-';
   const d = typeof date === 'string' ? new Date(date) : date;
   if (isNaN(d.getTime())) return String(date);
   return (
@@ -34,7 +34,7 @@ export function formatDateTime(date: string | Date | null | undefined): string {
  * Format a date string or Date object to 'YYYY-MM-DD'.
  */
 export function formatDate(date: string | Date | null | undefined): string {
-  if (date === null || date === undefined) return '-';
+  if (date === null || date === undefined || (typeof date === 'string' && !date.trim())) return '-';
   const d = typeof date === 'string' ? new Date(date) : date;
   if (isNaN(d.getTime())) return String(date);
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;


### PR DESCRIPTION
## Summary
- render blank and whitespace-only date strings as unavailable
- align blank strings with existing null/undefined formatting
- preserve nonblank invalid values for diagnostics

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/utils/format.test.ts --reporter=dot`
