### PR TITLE
fix: restrict runtime diagnostics to Apache instances

### DIFF
--- a/web/src/api/instance.test.ts
+++ b/web/src/api/instance.test.ts
@@ -18,7 +18,13 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { createInstance, deleteInstance, listInstances, updateInstance } from './instance';
+import {
+  createInstance,
+  deleteInstance,
+  listInstances,
+  supportsApacheRuntime,
+  updateInstance,
+} from './instance';
 
 const mock = new MockAdapter(client);
 const instance = {
@@ -83,5 +89,12 @@ describe('instance API', () => {
     });
 
     await expect(deleteInstance(instance.id)).resolves.toBeUndefined();
+  });
+
+  it('identifies instances supported by Apache MQAdmin runtime APIs', () => {
+    expect(supportsApacheRuntime({ vendor: 'APACHE' })).toBe(true);
+    expect(supportsApacheRuntime({})).toBe(true);
+    expect(supportsApacheRuntime({ vendor: 'ALIYUN' })).toBe(false);
+    expect(supportsApacheRuntime({ vendor: 'TENCENT' })).toBe(false);
   });
 });

--- a/web/src/api/instance.ts
+++ b/web/src/api/instance.ts
@@ -61,6 +61,11 @@ export interface InstanceQuery {
   search?: string;
 }
 
+/** Whether an instance can be queried through the Apache MQAdmin runtime APIs. */
+export function supportsApacheRuntime(instance: Pick<Instance, 'vendor'>): boolean {
+  return instance.vendor === undefined || instance.vendor === 'APACHE';
+}
+
 // ─── Instance CRUD ──────────────────────────────────────────────
 export async function listInstances(query: InstanceQuery = {}) {
   const search = query.search?.trim();

--- a/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
@@ -101,6 +101,19 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.mocked(connectionsService.listConnections).mockResolvedValue([connection]);
+  vi.mocked(instanceService.listInstances).mockResolvedValue([
+    {
+      id: 'instance-1',
+      name: 'Instance 1',
+      endpoint: 'namesrv-1:9876',
+      type: 'DIRECT',
+      remark: '',
+      topicCount: 0,
+      consumerGroupCount: 0,
+      createdAt: '',
+      updatedAt: '',
+    },
+  ]);
 });
 
 afterEach(() => {
@@ -115,6 +128,40 @@ const renderWithProviders = (ui: React.ReactElement) =>
   );
 
 describe('Clients page', () => {
+  it('selects an Apache instance instead of a cloud instance for runtime diagnostics', async () => {
+    vi.mocked(instanceService.listInstances).mockResolvedValue([
+      {
+        id: 'cloud-instance',
+        name: 'Cloud instance',
+        endpoint: 'cloud:9876',
+        type: 'DIRECT',
+        vendor: 'TENCENT',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+      {
+        id: 'apache-instance',
+        name: 'Apache instance',
+        endpoint: 'apache:9876',
+        type: 'DIRECT',
+        vendor: 'APACHE',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
+    renderWithProviders(<ClientsPage />);
+
+    await screen.findByText('order-svc-0@10.0.1.12:49152');
+    expect(connectionsService.listConnections).toHaveBeenCalledWith({ instanceId: 'apache-instance' });
+    expect(screen.queryByText('Cloud instance')).not.toBeInTheDocument();
+  });
+
   it('loads connections for the selected instance', async () => {
     renderWithProviders(<ClientsPage />);
 

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -40,7 +40,7 @@ import { useLang } from '../../i18n/LangContext';
 import type { ClientConnection } from '../../api/connections';
 import { listConnections } from '../../services/connectionsService';
 import { listInstances } from '../../services/instanceService';
-import type { Instance } from '../../api/instance';
+import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { formatDateTime } from '../../utils/format';
 
 const { Text } = Typography;
@@ -131,8 +131,13 @@ const ClientsPage = () => {
     void listInstances()
       .then((nextInstances) => {
         if (cancelled) return;
-        setInstances(nextInstances);
-        setSelectedInstanceId((current) => current || nextInstances[0]?.id || '');
+        const apacheInstances = nextInstances.filter(supportsApacheRuntime);
+        setInstances(apacheInstances);
+        setSelectedInstanceId((current) =>
+          apacheInstances.some((instance) => instance.id === current)
+            ? current
+            : (apacheInstances[0]?.id ?? ''),
+        );
         setLoadError(null);
       })
       .catch((error) => {

--- a/web/src/pages/home/__tests__/DashboardPage.test.tsx
+++ b/web/src/pages/home/__tests__/DashboardPage.test.tsx
@@ -170,4 +170,42 @@ describe('DashboardPage', () => {
 
     expect(screen.getByTestId('location')).toHaveTextContent('/cluster?instanceId=instance-b');
   });
+
+  it('does not offer cloud instances for MQAdmin runtime diagnostics', async () => {
+    vi.mocked(instanceService.listInstances).mockResolvedValue([
+      {
+        id: 'apache-instance',
+        name: 'Apache instance',
+        endpoint: 'apache:9876',
+        type: 'DIRECT',
+        vendor: 'APACHE',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+      {
+        id: 'cloud-instance',
+        name: 'Cloud instance',
+        endpoint: 'cloud:9876',
+        type: 'DIRECT',
+        vendor: 'ALIYUN',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
+    vi.mocked(dashboardService.getDashboard).mockResolvedValue(dashboard('apache-cluster'));
+    const user = userEvent.setup();
+    renderWithProviders(<DashboardPage />);
+
+    await screen.findByText('apache-cluster');
+    await user.click(screen.getByRole('combobox', { name: 'Dashboard instance' }));
+
+    expect(await screen.findByText('Apache instance')).toBeInTheDocument();
+    expect(screen.queryByText('Cloud instance')).not.toBeInTheDocument();
+  });
 });

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -24,7 +24,7 @@ import { CLUSTER_TYPE_MAP } from '../../constants/theme';
 import { getDashboard } from '../../services/dashboardService';
 import type { DashboardData } from '../../api/metrics';
 import { listInstances } from '../../services/instanceService';
-import type { Instance } from '../../api/instance';
+import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { useLang } from '../../i18n/LangContext';
 
 const { Text } = Typography;
@@ -66,7 +66,9 @@ const DashboardPage = () => {
     let cancelled = false;
     void listInstances()
       .then((nextInstances) => {
-        if (!cancelled) setInstances(nextInstances);
+        if (!cancelled) {
+          setInstances(nextInstances.filter(supportsApacheRuntime));
+        }
       })
       .catch(() => {
         if (!cancelled) setInstances([]);

--- a/web/src/pages/studio/Producer.tsx
+++ b/web/src/pages/studio/Producer.tsx
@@ -40,7 +40,7 @@ import {
   type ProducerConnectionWarning,
   type ProducerReadiness,
 } from '../../api/producer';
-import type { Instance } from '../../api/instance';
+import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { listInstances } from '../../services/instanceService';
 
 const readinessConfig: Record<ProducerReadiness, { color: string; type: 'success' | 'warning' }> = {
@@ -71,8 +71,13 @@ const ProducerPage = () => {
     void listInstances()
       .then((nextInstances) => {
         if (cancelled) return;
-        setInstances(nextInstances);
-        setSelectedInstanceId((current) => current || nextInstances[0]?.id || '');
+        const apacheInstances = nextInstances.filter(supportsApacheRuntime);
+        setInstances(apacheInstances);
+        setSelectedInstanceId((current) =>
+          apacheInstances.some((instance) => instance.id === current)
+            ? current
+            : (apacheInstances[0]?.id ?? ''),
+        );
       })
       .catch(() => {
         if (!cancelled) {

--- a/web/src/pages/studio/__tests__/Producer.test.tsx
+++ b/web/src/pages/studio/__tests__/Producer.test.tsx
@@ -109,6 +109,39 @@ describe('ProducerPage', () => {
     });
   });
 
+  it('uses an Apache instance rather than a cloud instance for producer diagnostics', async () => {
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'cloud-instance',
+        name: 'Cloud instance',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: 'cloud:9876',
+        vendor: 'ALIYUN',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-08-01T00:00:00',
+        updatedAt: '2026-08-01T00:00:00',
+      },
+      {
+        id: 'apache-instance',
+        name: 'Apache instance',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: 'apache:9876',
+        vendor: 'APACHE',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-08-01T00:00:00',
+        updatedAt: '2026-08-01T00:00:00',
+      },
+    ]);
+    renderWithProviders(<ProducerPage />);
+
+    await waitFor(() => expect(fetchTopicList).toHaveBeenCalledWith('apache-instance'));
+    expect(screen.queryByText('Cloud instance')).not.toBeInTheDocument();
+  });
+
   it('renders topic options loaded from the API', async () => {
     const user = userEvent.setup();
     renderWithProviders(<ProducerPage />);


### PR DESCRIPTION
## Summary
- add a shared capability predicate for Apache MQAdmin runtime APIs
- exclude explicit cloud instances from Dashboard, client-connection, and producer diagnostic selectors
- keep legacy instances without a vendor marker selectable for backward compatibility
- add page-level and capability regression coverage

Closes #1741

## Validation
- `npx vitest run src/api/instance.test.ts src/pages/home/__tests__/DashboardPage.test.tsx src/pages/cluster/__tests__/ClientsPage.test.tsx src/pages/studio/__tests__/Producer.test.tsx`
- `npm run build`