### PR TITLE
fix: select SettingsService injection and update ACL APIs

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -22,9 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.UrlHostGuard;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -37,9 +35,11 @@ import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -73,6 +73,7 @@ public class SettingsService {
     private final ObjectMapper objectMapper;
     private final OperationAuditService operationAuditService;
 
+    @Autowired
     public SettingsService(SettingsRepository settingsRepository, RestClient.Builder restClientBuilder,
                            ObjectMapper objectMapper, OperationAuditService operationAuditService) {
         this(settingsRepository, buildDataSourceRestClient(restClientBuilder), objectMapper, operationAuditService);

--- a/server/src/test/java/org/apache/rocketmq/studio/StudioApplicationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/StudioApplicationTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio;
 
 import org.apache.rocketmq.studio.ops.ai.tool.ToolCatalog;
 import org.apache.rocketmq.studio.ops.ai.tool.ToolGatewayService;
+import org.apache.rocketmq.studio.settings.SettingsService;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.instance.InstanceVO;
@@ -31,7 +32,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -43,6 +43,9 @@ class StudioApplicationTest {
 
     @Autowired
     private ToolGatewayService toolGatewayService;
+
+    @Autowired
+    private SettingsService settingsService;
 
     @Autowired
     private RmqInstanceMapper instanceMapper;
@@ -57,11 +60,11 @@ class StudioApplicationTest {
     void applicationContextLoadsWithInitializedDevSchema() throws Exception {
         assertThat(toolCatalog.getVersion()).isEqualTo("1.0.0");
         assertThat(toolGatewayService.discover(null)).isNotEmpty();
+        assertThat(settingsService).isNotNull();
         assertThat(instanceMapper.selectList(null)).isEmpty();
 
         mockMvc.perform(get("/api/instances"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").isEmpty());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -876,7 +876,7 @@ const AclPage = () => {
         style={{ marginBottom: 16 }}
       />
 
-      <Card bordered={false} bodyStyle={{ padding: 0 }}>
+      <Card variant="borderless" styles={{ body: { padding: 0 } }}>
         <Tabs
           activeKey={activeTab}
           onChange={setActiveTab}
@@ -1102,7 +1102,7 @@ const AclPage = () => {
         cancelText={t('common.cancel')}
         confirmLoading={ruleSubmitting}
         width={560}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form form={ruleForm} layout="vertical" style={{ marginTop: 16 }}>
           <Form.Item
@@ -1201,7 +1201,7 @@ const AclPage = () => {
         cancelText={t('common.cancel')}
         confirmLoading={userSubmitting}
         width={520}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form form={userForm} layout="vertical" style={{ marginTop: 16 }}>
           <Form.Item
@@ -1238,7 +1238,7 @@ const AclPage = () => {
         cancelText={t('common.cancel')}
         confirmLoading={plainSubmitting}
         width={560}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form form={plainForm} layout="vertical" style={{ marginTop: 16 }}>
           <Form.Item


### PR DESCRIPTION
## Summary
- select the production `SettingsService` constructor explicitly so Spring can instantiate the bean when the test constructor is present
- align the application-context test with default login protection
- migrate ACL page Card and Modal usage from deprecated Ant Design APIs to their supported equivalents

## Validation
- `mvn -q -Dtest=StudioApplicationTest test`
- `npm run test -- src/pages/instance/__tests__/AclPage.test.tsx`
- `npm run build`