### PR TITLE
[ISSUE #1763] Handle empty trace message bodies

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/model/MessageTraceView.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/model/MessageTraceView.java
@@ -52,10 +52,10 @@ public class MessageTraceView {
 
     public static List<MessageTraceView> decodeFromTraceTransData(String key, MessageExt messageExt) {
         List<MessageTraceView> messageTraceViewList = new ArrayList<MessageTraceView>();
-        String messageBody = new String(messageExt.getBody(), Charsets.UTF_8);
-        if (messageBody == null || messageBody.length() <= 0) {
+        if (messageExt == null || messageExt.getBody() == null || messageExt.getBody().length == 0) {
             return messageTraceViewList;
         }
+        String messageBody = new String(messageExt.getBody(), Charsets.UTF_8);
 
         List<TraceContext> traceContextList = MsgTraceDecodeUtil.decoderFromTraceDataString(messageBody);
         for (TraceContext context : traceContextList) {

--- a/src/test/java/org/apache/rocketmq/dashboard/model/MessageTraceViewTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/model/MessageTraceViewTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.dashboard.model;
+
+import java.util.List;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MessageTraceViewTest {
+
+    @Test
+    public void testDecodeEmptyMessageBody() {
+        MessageExt messageExt = new MessageExt();
+
+        List<MessageTraceView> result = MessageTraceView.decodeFromTraceTransData("message-id", messageExt);
+
+        Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testDecodeNullMessage() {
+        List<MessageTraceView> result = MessageTraceView.decodeFromTraceTransData("message-id", null);
+
+        Assert.assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Avoid NullPointerException when trace decoding receives a null message or a message without a body. Such input now produces the same empty trace result as an empty payload.

Fixes #1763

## Brief changelog

- Check the message and raw body before constructing the trace-data String.
- Add regression tests for null messages and null bodies.

## Verifying this change

- JDK: Temurin 17.0.19
- Backend-only Maven verification: `mvn -q compiler:compile compiler:testCompile -Dtest=<target> surefire:test`
- `MessageTraceViewTest`: 2 tests, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 45 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.