### PR TITLE
[ISSUE #1764] Tolerate empty DLQ export fields

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/model/DlqMessageExcelModel.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/model/DlqMessageExcelModel.java
@@ -80,8 +80,8 @@ public class DlqMessageExcelModel extends BaseRowModel implements Serializable {
         this.bornTimestamp = DateUtils.format(new Date(messageExt.getBornTimestamp()), DateUtils.DATE_FORMAT_19);
         this.storeTimestamp = DateUtils.format(new Date(messageExt.getStoreTimestamp()), DateUtils.DATE_FORMAT_19);
         this.reconsumeTimes = messageExt.getReconsumeTimes();
-        this.properties = messageExt.getProperties().toString();
-        this.messageBody = new String(messageExt.getBody(), Charsets.UTF_8);
+        this.properties = messageExt.getProperties() == null ? "" : messageExt.getProperties().toString();
+        this.messageBody = messageExt.getBody() == null ? "" : new String(messageExt.getBody(), Charsets.UTF_8);
         this.bodyCRC = messageExt.getBodyCRC();
     }
 

--- a/src/test/java/org/apache/rocketmq/dashboard/model/DlqMessageExcelModelTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/model/DlqMessageExcelModelTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.dashboard.model;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DlqMessageExcelModelTest {
+
+    @Test
+    public void testCreateWithEmptyPropertiesAndBody() {
+        MessageExt messageExt = createMessage();
+        messageExt.setBody(null);
+
+        DlqMessageExcelModel model = new DlqMessageExcelModel(messageExt);
+
+        Assert.assertEquals("", model.getProperties());
+        Assert.assertEquals("", model.getMessageBody());
+    }
+
+    @Test
+    public void testCreateWithPropertiesAndBody() {
+        MessageExt messageExt = createMessage();
+        messageExt.putUserProperty("key", "value");
+        messageExt.setBody("消息内容".getBytes(StandardCharsets.UTF_8));
+
+        DlqMessageExcelModel model = new DlqMessageExcelModel(messageExt);
+
+        Assert.assertEquals("{key=value}", model.getProperties());
+        Assert.assertEquals("消息内容", model.getMessageBody());
+    }
+
+    private MessageExt createMessage() {
+        MessageExt messageExt = new MessageExt();
+        messageExt.setBornHost(new InetSocketAddress("127.0.0.1", 10911));
+        return messageExt;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Allow DLQ Excel rows to be built when optional message properties or the body are absent. Previously either field could cause a NullPointerException and abort the export.

Fixes #1764

## Brief changelog

- Normalize absent properties and bodies to empty cell values.
- Keep UTF-8 decoding for populated bodies and cover both absent-field paths.

## Verifying this change

- JDK: Temurin 17.0.19
- Backend-only Maven verification: `mvn -q compiler:compile compiler:testCompile -Dtest=<target> surefire:test`
- `DlqMessageExcelModelTest`: 2 tests, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 59 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.