### PR TITLE
[ISSUE #1761] Escape regex metacharacters in permission paths

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/util/MatcherUtil.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/util/MatcherUtil.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.dashboard.util;
 import java.util.regex.Pattern;
 
 public class MatcherUtil {
+    private static final String REGEX_META_CHARACTERS = "\\.^$|?*+()[]{}";
 
     public static boolean match(String accessUrl, String reqPath) {
         String regPath = getRegPath(accessUrl);
@@ -26,33 +27,29 @@ public class MatcherUtil {
     }
 
     private static String getRegPath(String path) {
-        char[] chars = path.toCharArray();
-        int len = chars.length;
         StringBuilder sb = new StringBuilder();
-        boolean preX = false;
-        for (int i = 0; i < len; i++) {
-            if (chars[i] == '*') {
-                if (preX) {
+        for (int i = 0; i < path.length(); i++) {
+            char current = path.charAt(i);
+            if (current == '*') {
+                if (i + 1 < path.length() && path.charAt(i + 1) == '*') {
                     sb.append(".*");
-                    preX = false;
-                } else if (i + 1 == len) {
-                    sb.append("[^/]*");
+                    i++;
                 } else {
-                    preX = true;
-                    continue;
+                    sb.append("[^/]*");
                 }
+            } else if (current == '?') {
+                sb.append('.');
             } else {
-                if (preX) {
-                    sb.append("[^/]*");
-                    preX = false;
-                }
-                if (chars[i] == '?') {
-                    sb.append('.');
-                } else {
-                    sb.append(chars[i]);
-                }
+                appendLiteral(sb, current);
             }
         }
         return sb.toString();
+    }
+
+    private static void appendLiteral(StringBuilder regex, char current) {
+        if (REGEX_META_CHARACTERS.indexOf(current) >= 0) {
+            regex.append('\\');
+        }
+        regex.append(current);
     }
 }

--- a/src/test/java/org/apache/rocketmq/dashboard/util/MatcherUtilTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/util/MatcherUtilTest.java
@@ -30,5 +30,23 @@ public class MatcherUtilTest {
         Assert.assertTrue(b1);
         Assert.assertFalse(b2);
     }
-}
 
+    @Test
+    public void testRegexMetacharactersAreMatchedLiterally() {
+        Assert.assertFalse(MatcherUtil.match("/topic/*.query", "/topic/routeXquery"));
+        Assert.assertTrue(MatcherUtil.match("/acl/[user.query", "/acl/[user.query"));
+        Assert.assertTrue(MatcherUtil.match("/acl/[user](admin)+{$^|}\\.query",
+            "/acl/[user](admin)+{$^|}\\.query"));
+        Assert.assertFalse(MatcherUtil.match("/acl/[user](admin)+{$^|}\\.query",
+            "/acl/u(admin)+{$^|}\\.query"));
+    }
+
+    @Test
+    public void testGlobMetacharactersKeepTheirSemantics() {
+        Assert.assertTrue(MatcherUtil.match("/topic/*.query", "/topic/route.query"));
+        Assert.assertFalse(MatcherUtil.match("/topic/*.query", "/topic/a/b.query"));
+        Assert.assertTrue(MatcherUtil.match("/topic/**.query", "/topic/a/b.query"));
+        Assert.assertTrue(MatcherUtil.match("/topic/?.query", "/topic/a.query"));
+        Assert.assertFalse(MatcherUtil.match("/topic/?.query", "/topic/ab.query"));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix permission glob matching so ordinary path characters are treated literally. Previously, characters such as `.` and `[` were copied into a Java regular expression, causing false matches or pattern compilation failures.

Fixes #1761

## Brief changelog

- Escape Java regex metacharacters during glob translation.
- Preserve the existing `*`, `**`, and `?` wildcard semantics and cover them with regression tests.

## Verifying this change

- JDK: Temurin 17.0.19
- Backend-only Maven verification: `mvn -q compiler:compile compiler:testCompile -Dtest=<target> surefire:test`
- `MatcherUtilTest`: 3 tests, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 57 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.