### PR TITLE
[ISSUE #1762] Enforce minimum message query page size

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/model/MessageQueryByPage.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/model/MessageQueryByPage.java
@@ -82,7 +82,7 @@ public class MessageQueryByPage {
     }
 
     public int getPageSize() {
-        if (pageSize <= 1) {
+        if (pageSize < MIN_PAGE_SIZE) {
             return MIN_PAGE_SIZE;
         } else if (pageSize > MAX_PAGE_SIZE) {
             return MAX_PAGE_SIZE;

--- a/src/test/java/org/apache/rocketmq/dashboard/model/MessageQueryByPageTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/model/MessageQueryByPageTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.dashboard.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MessageQueryByPageTest {
+
+    @Test
+    public void testGetPageSizeKeepsConfiguredBounds() {
+        assertPageSize(0, MessageQueryByPage.MIN_PAGE_SIZE);
+        assertPageSize(1, MessageQueryByPage.MIN_PAGE_SIZE);
+        assertPageSize(2, MessageQueryByPage.MIN_PAGE_SIZE);
+        assertPageSize(9, MessageQueryByPage.MIN_PAGE_SIZE);
+        assertPageSize(10, 10);
+        assertPageSize(100, 100);
+        assertPageSize(101, MessageQueryByPage.MAX_PAGE_SIZE);
+    }
+
+    private void assertPageSize(int configuredPageSize, int expectedPageSize) {
+        MessageQueryByPage query = new MessageQueryByPage(1, configuredPageSize, "testTopic", 0, 1);
+        Assert.assertEquals(expectedPageSize, query.getPageSize());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Make MessageQueryByPage enforce its declared minimum page size consistently. Values from 2 through 9 previously bypassed `MIN_PAGE_SIZE = 10`.

Fixes #1762

## Brief changelog

- Compare requested page size directly against `MIN_PAGE_SIZE`.
- Cover lower, exact, and upper page-size boundaries.

## Verifying this change

- JDK: Temurin 17.0.19
- Backend-only Maven verification: `mvn -q compiler:compile compiler:testCompile -Dtest=<target> surefire:test`
- `MessageQueryByPageTest`: 1 test, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 41 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.