### PR TITLE
fix: surface metrics errors and replace deprecated input API

### DIFF
--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -230,6 +230,25 @@ interface DataSourceCredentials extends AuthFormValues {
   key: string;
 }
 
+const getQueryErrorMessage = (error: unknown, fallback: string): string => {
+  if (typeof error !== 'object' || error === null || !('response' in error)) {
+    return fallback;
+  }
+
+  const response = error.response;
+  if (typeof response !== 'object' || response === null || !('data' in response)) {
+    return fallback;
+  }
+
+  const data = response.data;
+  if (typeof data !== 'object' || data === null || !('message' in data)) {
+    return fallback;
+  }
+
+  const message = data.message;
+  return typeof message === 'string' && message.trim() ? message : fallback;
+};
+
 const getDataSourceAuthMode = (auth: string): DataSourceAuthMode => {
   const normalized = auth.trim().toLowerCase();
   if (normalized === 'basic' || normalized === 'basic auth') return 'basic';
@@ -239,6 +258,7 @@ const getDataSourceAuthMode = (auth: string): DataSourceAuthMode => {
 
 const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
   const { lang } = useLang();
+  const queryErrorFallback = lang === 'zh' ? 'Prometheus 查询失败' : 'Prometheus query failed';
   const copy =
     lang === 'zh'
       ? {
@@ -248,7 +268,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
           range: '时间范围',
           refresh: '刷新指标',
           profileError: '指标模板加载失败',
-          queryError: 'Prometheus 查询失败',
+          queryError: queryErrorFallback,
           noProfiles: '暂无指标模板',
           noSamples: '暂无标量数据',
           defaultDataSource: '默认数据源',
@@ -268,7 +288,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
           range: 'Time range',
           refresh: 'Refresh metrics',
           profileError: 'Failed to load metric profiles',
-          queryError: 'Prometheus query failed',
+          queryError: queryErrorFallback,
           noProfiles: 'No metric profiles',
           noSamples: 'No scalar samples',
           defaultDataSource: 'Default source',
@@ -291,7 +311,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
   const [profilesLoading, setProfilesLoading] = useState(true);
   const [queryLoading, setQueryLoading] = useState(false);
   const [profileError, setProfileError] = useState(false);
-  const [queryError, setQueryError] = useState(false);
+  const [queryError, setQueryError] = useState<string | null>(null);
   const [dataSources, setDataSources] = useState<DataSource[]>([]);
   const [dataSourceKey, setDataSourceKey] = useState('');
   const [dataSourcesLoading, setDataSourcesLoading] = useState(true);
@@ -333,7 +353,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
         step: range.step,
       };
       setQueryLoading(true);
-      setQueryError(false);
+      setQueryError(null);
       try {
         const currentDataSourceKey = dataSourceKeyRef.current;
         const credentials =
@@ -353,16 +373,16 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
             })
           : await queryMetrics(query);
         if (currentRequest === requestId.current) setData(result);
-      } catch {
+      } catch (error) {
         if (currentRequest === requestId.current) {
           setData(null);
-          setQueryError(true);
+          setQueryError(getQueryErrorMessage(error, queryErrorFallback));
         }
       } finally {
         if (currentRequest === requestId.current) setQueryLoading(false);
       }
     },
-    [instanceId],
+    [instanceId, queryErrorFallback],
   );
 
   useEffect(() => {
@@ -563,7 +583,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
       ) : profiles.length === 0 ? (
         <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={copy.noProfiles} />
       ) : queryError ? (
-        <Alert type="error" showIcon message={copy.queryError} />
+        <Alert type="error" showIcon message={queryError} />
       ) : queryLoading && !data ? (
         <Skeleton active paragraph={{ rows: 5 }} />
       ) : data && selectedMetric ? (

--- a/web/src/components/__tests__/MetricsExplorer.test.tsx
+++ b/web/src/components/__tests__/MetricsExplorer.test.tsx
@@ -224,6 +224,16 @@ describe('MetricsExplorer', () => {
     expect(screen.getByRole('button', { name: '刷新指标' })).toBeInTheDocument();
   });
 
+  it('shows the actionable message returned by the metrics API', async () => {
+    vi.mocked(queryMetrics).mockRejectedValue({
+      response: { data: { message: 'Prometheus base URL is not configured' } },
+    });
+
+    renderWithProviders(<MetricsExplorer />);
+
+    expect(await screen.findByText('Prometheus base URL is not configured')).toBeInTheDocument();
+  });
+
   it('shows an empty state when Prometheus returns no scalar samples', async () => {
     vi.mocked(queryMetrics).mockResolvedValue({ ...metricData, series: [] });
 

--- a/web/src/pages/settings/__tests__/GeneralSettingsTab.test.tsx
+++ b/web/src/pages/settings/__tests__/GeneralSettingsTab.test.tsx
@@ -72,4 +72,15 @@ describe('GeneralSettingsTab', () => {
 
     await waitFor(() => expect(saveGeneralSettings).toHaveBeenCalledTimes(1));
   });
+
+  it('keeps the session timeout field bound when displaying its unit', async () => {
+    render(
+      <App>
+        <GeneralSettingsTab />
+      </App>,
+    );
+
+    expect(await screen.findByDisplayValue('30')).toBeInTheDocument();
+    expect(screen.getByLabelText('会话超时单位')).toHaveValue('分钟');
+  });
 });

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -211,12 +211,13 @@ export const GeneralSettingsTab = () => {
         </Title>
       </Divider>
 
-      <Form.Item
-        label="会话超时"
-        name="sessionTimeout"
-        extra="应用于新创建的会话，已登录用户保持原到期时间"
-      >
-        <InputNumber min={5} max={1440} addonAfter="分钟" />
+      <Form.Item label="会话超时" extra="应用于新创建的会话，已登录用户保持原到期时间">
+        <Space.Compact>
+          <Form.Item name="sessionTimeout" noStyle>
+            <InputNumber min={5} max={1440} style={{ width: 120 }} />
+          </Form.Item>
+          <Input aria-label="会话超时单位" readOnly value="分钟" style={{ width: 64 }} />
+        </Space.Compact>
       </Form.Item>
 
       <Form.Item name="requireLogin" hidden>


### PR DESCRIPTION
## Summary
- display the actionable error message returned by the metrics query API while retaining a localized fallback for unstructured failures
- replace the deprecated `InputNumber.addonAfter` usage with a `Space.Compact` session-timeout field and read-only unit input
- add focused regression coverage for both behaviors

Closes #1765

## Validation
- `npm run test -- src/components/__tests__/MetricsExplorer.test.tsx src/pages/settings/__tests__/GeneralSettingsTab.test.tsx`
- `npm run build`
- `npm run lint` *(blocked by an existing `BrokerCluster.tsx` React hooks error on the current base branch; changed files are clean)*