### PR TITLE
fix: preserve unknown consumer lag during aggregation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -293,13 +293,22 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                 try {
                     ConsumeStats stats = admin.examineConsumeStats(group, name);
                     long diffTotal = 0;
+                    boolean hasUnknown = false;
                     double consumeTps = 0;
                     if (stats != null && stats.getOffsetTable() != null) {
                         for (Map.Entry<MessageQueue, OffsetWrapper> entry : stats.getOffsetTable().entrySet()) {
                             OffsetWrapper ow = entry.getValue();
-                            diffTotal += resolveDiff(ow.getBrokerOffset(), ow.getConsumerOffset());
+                            long diff = resolveDiff(ow.getBrokerOffset(), ow.getConsumerOffset());
+                            if (diff == ConsumerLagResolver.UNKNOWN) {
+                                hasUnknown = true;
+                            } else {
+                                diffTotal += diff;
+                            }
                         }
                         consumeTps = stats.getConsumeTps();
+                    }
+                    if (hasUnknown) {
+                        diffTotal = ConsumerLagResolver.UNKNOWN;
                     }
 
                     ConsumeType consumeType = ConsumeType.CLUSTERING;


### PR DESCRIPTION
This PR implemented the valid #1772 behavior: if any queue reports the `UNKNOWN` lag sentinel, the group aggregate should remain unknown instead of summing negative sentinel values.

It was closed because merged PR #1652 (`01f629f1`) already contained the same implementation and tests for both unknown propagation and all-known summation.