### PR TITLE
[ISSUE #1775] Preserve successful broker stats retry results

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/task/DashboardCollectTask.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/task/DashboardCollectTask.java
@@ -156,9 +156,7 @@ public class DashboardCollectTask {
                 Throwables.throwIfUnchecked(e1);
                 throw new RuntimeException(e1);
             }
-            fetchBrokerRuntimeStats(brokerAddr, retryTime - 1);
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
+            return fetchBrokerRuntimeStats(brokerAddr, retryTime - 1);
         }
     }
 

--- a/src/test/java/org/apache/rocketmq/dashboard/task/DashboardCollectTaskTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/task/DashboardCollectTaskTest.java
@@ -176,19 +176,14 @@ public class DashboardCollectTaskTest extends BaseTest {
                     .thenReturn(kvTable);
             when(rmqConfigure.isEnableDashBoardCollect()).thenReturn(true);
         }
-        // fetchBrokerRuntimeStats exception
-        try {
-            dashboardCollectTask.collectBroker();
-        } catch (Exception e) {
-            Assert.assertEquals(e.getMessage(), "fetchBrokerRuntimeStats exception");
-        }
+        dashboardCollectTask.collectBroker();
 
         for (int i = 0; i < taskExecuteNum; i++) {
             dashboardCollectTask.collectBroker();
         }
         LoadingCache<String, List<String>> map = dashboardCollectService.getBrokerMap();
         Assert.assertEquals(map.size(), 1);
-        Assert.assertEquals(map.get("broker-a" + ":" + MixAll.MASTER_ID).size(), taskExecuteNum);
+        Assert.assertEquals(map.get("broker-a" + ":" + MixAll.MASTER_ID).size(), taskExecuteNum + 1);
         mockBrokerFileExistBeforeSaveData();
         dashboardCollectTask.saveData();
         Assert.assertEquals(brokerFile.exists(), true);
@@ -196,7 +191,7 @@ public class DashboardCollectTaskTest extends BaseTest {
                 JsonUtil.string2Obj(MixAll.file2String(brokerFile),
                         new TypeReference<Map<String, List<String>>>() {
                         });
-        Assert.assertEquals(brokerData.get("broker-a" + ":" + MixAll.MASTER_ID).size(), taskExecuteNum + 2);
+        Assert.assertEquals(brokerData.get("broker-a" + ":" + MixAll.MASTER_ID).size(), taskExecuteNum + 3);
     }
 
     @After


### PR DESCRIPTION
## What is the purpose of the change

Return a successful recursive broker-stats retry instead of discarding its value and always rethrowing the first failure. Exhausted retries retain the existing exception behavior.

Fixes #1775

## Brief changelog

- Return the recursive `fetchBrokerRuntimeStats` result directly.
- Update collection coverage to prove recovered data is retained after the first attempt fails.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `DashboardCollectTaskTest`: 2 tests, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 15 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.