### PR TITLE
[ISSUE #1776] Reject collect tasks when executor is saturated

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/config/CollectExecutorConfig.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/config/CollectExecutorConfig.java
@@ -54,7 +54,7 @@ public class CollectExecutorConfig {
                         return new Thread(r, "collectTopicThread_" + this.threadIndex.incrementAndGet());
                     }
                 },
-                new ThreadPoolExecutor.DiscardOldestPolicy()
+                new ThreadPoolExecutor.AbortPolicy()
         );
         return collectExecutor;
     }

--- a/src/test/java/org/apache/rocketmq/dashboard/config/CollectExecutorConfigTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/config/CollectExecutorConfigTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class CollectExecutorConfigTest {
@@ -47,5 +49,43 @@ public class CollectExecutorConfigTest {
         countDownLatch.await();
         System.out.println(collectExecutor.isTerminated());
         Assert.assertEquals(COUNT, num.get());
+    }
+
+    @Test
+    public void testCollectExecutorRejectsWhenQueueIsFull() throws Exception {
+        CollectExecutorConfig config = new CollectExecutorConfig();
+        config.setCoreSize(1);
+        config.setMaxSize(1);
+        config.setQueueSize(1);
+        ExecutorService collectExecutor = config.collectExecutor(config);
+        CountDownLatch taskStarted = new CountDownLatch(1);
+        CountDownLatch releaseTask = new CountDownLatch(1);
+        CountDownLatch queuedTaskCompleted = new CountDownLatch(1);
+
+        try {
+            collectExecutor.submit(() -> {
+                taskStarted.countDown();
+                try {
+                    releaseTask.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            Assert.assertTrue(taskStarted.await(5, TimeUnit.SECONDS));
+            collectExecutor.submit(queuedTaskCompleted::countDown);
+
+            try {
+                collectExecutor.submit(() -> { });
+                Assert.fail("Expected the saturated executor to reject the task");
+            } catch (RejectedExecutionException expected) {
+                Assert.assertNotNull(expected);
+            }
+
+            releaseTask.countDown();
+            Assert.assertTrue(queuedTaskCompleted.await(5, TimeUnit.SECONDS));
+        } finally {
+            releaseTask.countDown();
+            collectExecutor.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Make collection executor saturation observable and preserve already queued work. `DiscardOldestPolicy` silently removed the oldest pending task when a new task arrived.

Fixes #1776

## Brief changelog

- Use `AbortPolicy` to report saturation with `RejectedExecutionException`.
- Verify that the rejected submission does not replace the previously queued task.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `CollectExecutorConfigTest`: 2 tests, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 42 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.