### PR TITLE
[ISSUE #1773] Handle null ACL policy entry lists

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/model/AclInfo.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/model/AclInfo.java
@@ -191,8 +191,8 @@ public class AclInfo {
                     for (org.apache.rocketmq.remoting.protocol.body.AclInfo.PolicyEntryInfo entry : policy.getEntries()) {
                         PolicyEntryInfo copiedEntry = new PolicyEntryInfo();
                         copiedEntry.setResource(entry.getResource());
-                        copiedEntry.setActions(new ArrayList<>(entry.getActions()));
-                        copiedEntry.setSourceIps(new ArrayList<>(entry.getSourceIps()));
+                        copiedEntry.setActions(copyOrEmpty(entry.getActions()));
+                        copiedEntry.setSourceIps(copyOrEmpty(entry.getSourceIps()));
                         copiedEntry.setDecision(entry.getDecision());
                         copiedEntries.add(copiedEntry);
                     }
@@ -204,6 +204,10 @@ public class AclInfo {
         } else {
             this.setPolicies(null);
         }
+    }
+
+    private static <T> List<T> copyOrEmpty(List<T> source) {
+        return source == null ? new ArrayList<>() : new ArrayList<>(source);
     }
 
 }

--- a/src/test/java/org/apache/rocketmq/dashboard/model/AclInfoTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/model/AclInfoTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.dashboard.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AclInfoTest {
+
+    @Test
+    public void testCopyFromUsesEmptyActionsWhenSourceActionsAreNull() {
+        org.apache.rocketmq.remoting.protocol.body.AclInfo source = createSource(
+            null, Collections.singletonList("127.0.0.1"));
+
+        AclInfo target = new AclInfo();
+        target.copyFrom(source);
+
+        AclInfo.PolicyEntryInfo entry = target.getPolicies().get(0).getEntries().get(0);
+        Assert.assertNotNull(entry.getActions());
+        Assert.assertTrue(entry.getActions().isEmpty());
+        Assert.assertEquals(Collections.singletonList("127.0.0.1"), entry.getSourceIps());
+    }
+
+    @Test
+    public void testCopyFromUsesEmptySourceIpsWhenSourceIpsAreNull() {
+        org.apache.rocketmq.remoting.protocol.body.AclInfo source = createSource(
+            Collections.singletonList("PUB"), null);
+
+        AclInfo target = new AclInfo();
+        target.copyFrom(source);
+
+        AclInfo.PolicyEntryInfo entry = target.getPolicies().get(0).getEntries().get(0);
+        Assert.assertEquals(Collections.singletonList("PUB"), entry.getActions());
+        Assert.assertNotNull(entry.getSourceIps());
+        Assert.assertTrue(entry.getSourceIps().isEmpty());
+    }
+
+    @Test
+    public void testCopyFromDefensivelyCopiesNonNullLists() {
+        List<String> actions = new ArrayList<>(Collections.singletonList("PUB"));
+        List<String> sourceIps = new ArrayList<>(Collections.singletonList("127.0.0.1"));
+        org.apache.rocketmq.remoting.protocol.body.AclInfo source = createSource(actions, sourceIps);
+
+        AclInfo target = new AclInfo();
+        target.copyFrom(source);
+        actions.add("SUB");
+        sourceIps.add("127.0.0.2");
+
+        AclInfo.PolicyEntryInfo entry = target.getPolicies().get(0).getEntries().get(0);
+        Assert.assertEquals(Collections.singletonList("PUB"), entry.getActions());
+        Assert.assertEquals(Collections.singletonList("127.0.0.1"), entry.getSourceIps());
+    }
+
+    private org.apache.rocketmq.remoting.protocol.body.AclInfo createSource(
+        List<String> actions, List<String> sourceIps) {
+        org.apache.rocketmq.remoting.protocol.body.AclInfo.PolicyEntryInfo entry =
+            org.apache.rocketmq.remoting.protocol.body.AclInfo.PolicyEntryInfo.of(
+                "Topic:test", actions, sourceIps, "ALLOW");
+        org.apache.rocketmq.remoting.protocol.body.AclInfo.PolicyInfo policy =
+            new org.apache.rocketmq.remoting.protocol.body.AclInfo.PolicyInfo();
+        policy.setEntries(Collections.singletonList(entry));
+        org.apache.rocketmq.remoting.protocol.body.AclInfo source =
+            new org.apache.rocketmq.remoting.protocol.body.AclInfo();
+        source.setSubject("User:test");
+        source.setPolicies(Collections.singletonList(policy));
+        return source;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Prevent ACL model conversion from failing when protocol policy entries omit optional `actions` or `sourceIps` lists. The conversion now exposes mutable empty lists while retaining defensive copies for populated values.

Fixes #1773

## Brief changelog

- Normalize absent policy entry lists through a shared copy helper.
- Cover both nullable fields and verify that populated lists remain independent copies.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `AclInfoTest`: 3 tests, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 93 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.