### PR TITLE
[ISSUE #1774] Restrict authentication argument resolver types

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/config/AuthWebMVCConfigurerAdapter.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/config/AuthWebMVCConfigurerAdapter.java
@@ -73,7 +73,7 @@ public class AuthWebMVCConfigurerAdapter implements WebMvcConfigurer {
 
             @Override
             public boolean supportsParameter(MethodParameter methodParameter) {
-                return methodParameter.getParameterType().isAssignableFrom(UserInfo.class);
+                return UserInfo.class.isAssignableFrom(methodParameter.getParameterType());
             }
 
             @Override

--- a/src/test/java/org/apache/rocketmq/dashboard/config/AuthWebMVCConfigurerAdapterTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/config/AuthWebMVCConfigurerAdapterTest.java
@@ -17,42 +17,31 @@
 
 package org.apache.rocketmq.dashboard.config;
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.rocketmq.dashboard.BaseTest;
+import org.apache.rocketmq.dashboard.model.UserInfo;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 
 public class AuthWebMVCConfigurerAdapterTest extends BaseTest {
 
-//    @InjectMocks
-//    private AuthWebMVCConfigurerAdapter authWebMVCConfigurerAdapter;
-//
-//    @Mock
-//    private RMQConfigure configure;
-//
-//    @Mock
-//    private AuthInterceptor authInterceptor;
-//
-//    @Before
-//    public void init() throws Exception {
-//        MockitoAnnotations.initMocks(this);
-//    }
-//
-//
-//    @Test
-//    public void addInterceptors() {
-//        Mockito.when(configure.isLoginRequired()).thenReturn(true);
-//        InterceptorRegistry registry = new InterceptorRegistry();
-//        Assertions.assertDoesNotThrow(() -> authWebMVCConfigurerAdapter.addInterceptors(registry));
-//    }
-//
-//    @Test
-//    public void addArgumentResolvers() {
-//        List<HandlerMethodArgumentResolver> argumentResolvers = Lists.newArrayList();
-//        authWebMVCConfigurerAdapter.addArgumentResolvers(argumentResolvers);
-//        Assertions.assertEquals(1, argumentResolvers.size());
-//    }
-//
-//    @Test
-//    public void addViewControllers() {
-//        ViewControllerRegistry registry = new ViewControllerRegistry(new ClassPathXmlApplicationContext());
-//        Assertions.assertDoesNotThrow(() -> authWebMVCConfigurerAdapter.addViewControllers(registry));
-//    }
+    @Test
+    public void testUserInfoArgumentResolverSupportsOnlyUserInfo() throws Exception {
+        AuthWebMVCConfigurerAdapter configurer = new AuthWebMVCConfigurerAdapter();
+        List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>();
+        configurer.addArgumentResolvers(resolvers);
+
+        Assert.assertEquals(1, resolvers.size());
+        HandlerMethodArgumentResolver resolver = resolvers.get(0);
+        Method method = getClass().getDeclaredMethod("handleArguments", UserInfo.class, Object.class);
+        Assert.assertTrue(resolver.supportsParameter(new MethodParameter(method, 0)));
+        Assert.assertFalse(resolver.supportsParameter(new MethodParameter(method, 1)));
+    }
+
+    private void handleArguments(UserInfo userInfo, Object object) {
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

Correct the authentication argument resolver type check. Reversed `isAssignableFrom` operands caused unrelated supertypes such as `Object` to be accepted.

Fixes #1774

## Brief changelog

- Reverse the assignability check to select `UserInfo` parameters correctly.
- Add a regression test that accepts `UserInfo` and rejects `Object`.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `AuthWebMVCConfigurerAdapterTest`: 1 test, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 59 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.