### PR TITLE
[ISSUE #1777] Use XLSX content type for exports

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/util/ExcelUtil.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/util/ExcelUtil.java
@@ -47,9 +47,9 @@ public class ExcelUtil {
                 .excelType(ExcelTypeEnum.XLSX).sheet(sheetName).registerWriteHandler(horizontalCellStyleStrategy).doWrite(data);
     }
 
-    private static OutputStream getOutputStream(String fileName, HttpServletResponse response) throws Exception {
+    static OutputStream getOutputStream(String fileName, HttpServletResponse response) throws Exception {
         fileName = URLEncoder.encode(fileName, "UTF-8");
-        response.setContentType("application/vnd.ms-excel");
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         response.setCharacterEncoding("utf8");
         response.setHeader("Content-Disposition", "attachment;filename=" + fileName + ".xlsx");
         return response.getOutputStream();

--- a/src/test/java/org/apache/rocketmq/dashboard/controller/DlqMessageControllerTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/controller/DlqMessageControllerTest.java
@@ -133,7 +133,8 @@ public class DlqMessageControllerTest extends BaseControllerTest {
         // 2、export dlqMessage success
         perform = mockMvc.perform(requestBuilder);
         perform.andExpect(status().is(200))
-                .andExpect(content().contentType("application/vnd.ms-excel;charset=utf-8"));
+                .andExpect(content().contentType(
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=utf-8"));
 
     }
 
@@ -170,7 +171,8 @@ public class DlqMessageControllerTest extends BaseControllerTest {
         requestBuilder.content(JSON.toJSONString(dlqMessages));
         perform = mockMvc.perform(requestBuilder);
         perform.andExpect(status().is(200))
-                .andExpect(content().contentType("application/vnd.ms-excel;charset=utf-8"));
+                .andExpect(content().contentType(
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=utf-8"));
     }
 
     @Override

--- a/src/test/java/org/apache/rocketmq/dashboard/util/ExcelUtilTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/util/ExcelUtilTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.dashboard.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class ExcelUtilTest {
+
+    @Test
+    public void testWriteExcelUsesXlsxContentType() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ExcelUtil.getOutputStream("messages", response);
+
+        Assert.assertEquals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=utf8",
+                response.getContentType());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Advertise generated XLSX workbooks with the standard Open XML spreadsheet media type. The previous legacy Excel type and charset parameter did not match the response format.

Fixes #1777

## Brief changelog

- Set the response Content-Type to `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`.
- Cover the helper header directly and update existing DLQ export expectations.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `ExcelUtilTest`: 1 test, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (3 files, 45 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.