### PR TITLE
[ISSUE #1791] Support consumer queries without broker addresses

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImpl.java
@@ -288,9 +288,13 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
         List<ConsumeStats> consumeStatses = new ArrayList<>();
         String topic = null;
         try {
-            String[] addresses = address.split(",");
-            for (String addr : addresses) {
-                consumeStatses.add(mqAdminExt.examineConsumeStats(addr, groupName, null, 3000));
+            if (StringUtils.isBlank(address)) {
+                consumeStatses.add(mqAdminExt.examineConsumeStats(groupName));
+            } else {
+                String[] addresses = address.split(",");
+                for (String addr : addresses) {
+                    consumeStatses.add(mqAdminExt.examineConsumeStats(addr, groupName, null, 3000));
+                }
             }
         } catch (Exception e) {
             Throwables.throwIfUnchecked(e);
@@ -522,6 +526,9 @@ public class ConsumerServiceImpl extends AbstractCommonService implements Consum
     public ConsumerConnection getConsumerConnection(String consumerGroup, String address) {
         consumerGroup = getConsumerGroup(consumerGroup);
         try {
+            if (StringUtils.isBlank(address)) {
+                return mqAdminExt.examineConsumerConnectionInfo(consumerGroup);
+            }
             String[] addresses = address.split(",");
             String addr = addresses[0];
             return mqAdminExt.examineConsumerConnectionInfo(consumerGroup, addr);

--- a/src/test/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImplTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/service/impl/ConsumerServiceImplTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.dashboard.service.impl;
+
+import org.apache.rocketmq.remoting.protocol.admin.ConsumeStats;
+import org.apache.rocketmq.remoting.protocol.body.ConsumerConnection;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsumerServiceImplTest {
+
+    @InjectMocks
+    private ConsumerServiceImpl consumerService;
+
+    @Mock
+    private MQAdminExt mqAdminExt;
+
+    @Test
+    public void testQueryConsumeStatsWithoutAddress() throws Exception {
+        ConsumeStats consumeStats = new ConsumeStats();
+        when(mqAdminExt.examineConsumeStats("group")).thenReturn(consumeStats);
+
+        Assert.assertTrue(consumerService.queryConsumeStatsListByGroupName("group", null).isEmpty());
+
+        verify(mqAdminExt).examineConsumeStats("group");
+        verify(mqAdminExt, never()).examineConsumeStats(null, "group", null, 3000);
+    }
+
+    @Test
+    public void testGetConsumerConnectionWithoutAddress() throws Exception {
+        ConsumerConnection expected = new ConsumerConnection();
+        when(mqAdminExt.examineConsumerConnectionInfo("group")).thenReturn(expected);
+
+        Assert.assertSame(expected, consumerService.getConsumerConnection("group", " "));
+
+        verify(mqAdminExt).examineConsumerConnectionInfo("group");
+        verify(mqAdminExt, never()).examineConsumerConnectionInfo("group", " ");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Support consumer stats and connection queries when the optional broker address is absent or blank. These cases now use the standard group-based admin methods instead of splitting a null value.

Fixes #1791

## Brief changelog

- Fall back to group-based consume stats for blank addresses.
- Fall back to group-based consumer connection lookup for blank addresses.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `ConsumerServiceImplTest`: 2 tests, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 76 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.