### PR TITLE
[ISSUE #1789] Encode topic message bodies as UTF-8

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/TopicServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/TopicServiceImpl.java
@@ -62,6 +62,7 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -401,7 +402,7 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
                 Message msg = new Message(sendTopicMessageRequest.getTopic(),
                         sendTopicMessageRequest.getTag(),
                         sendTopicMessageRequest.getKey(),
-                        sendTopicMessageRequest.getMessageBody().getBytes()
+                        sendTopicMessageRequest.getMessageBody().getBytes(StandardCharsets.UTF_8)
                 );
                 return producer.sendMessageInTransaction(msg, null);
             } catch (Exception e) {
@@ -422,7 +423,7 @@ public class TopicServiceImpl extends AbstractCommonService implements TopicServ
                 Message msg = new Message(sendTopicMessageRequest.getTopic(),
                         sendTopicMessageRequest.getTag(),
                         sendTopicMessageRequest.getKey(),
-                        sendTopicMessageRequest.getMessageBody().getBytes()
+                        sendTopicMessageRequest.getMessageBody().getBytes(StandardCharsets.UTF_8)
                 );
                 return producer.send(msg);
             } catch (Exception e) {

--- a/src/test/java/org/apache/rocketmq/dashboard/service/impl/TopicServiceImplTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/service/impl/TopicServiceImplTest.java
@@ -43,6 +43,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -81,7 +82,7 @@ public class TopicServiceImplTest extends BaseTest {
         request.setTopic("testTopic");
         request.setTag("testTag");
         request.setKey("testKey");
-        request.setMessageBody("Hello RocketMQ");
+        request.setMessageBody("RocketMQ-\u4E16\u754C");
         request.setTraceEnabled(false);
 
         // Mock the topic config
@@ -121,7 +122,7 @@ public class TopicServiceImplTest extends BaseTest {
         Assert.assertEquals("testTopic", sentMessage.getTopic());
         Assert.assertEquals("testTag", sentMessage.getTags());
         Assert.assertEquals("testKey", sentMessage.getKeys());
-        Assert.assertEquals("Hello RocketMQ", new String(sentMessage.getBody()));
+        Assert.assertArrayEquals(request.getMessageBody().getBytes(StandardCharsets.UTF_8), sentMessage.getBody());
 
         // Verify producer shutdown
         verify(mockProducer).shutdown();
@@ -134,7 +135,7 @@ public class TopicServiceImplTest extends BaseTest {
         request.setTopic("testTopic");
         request.setTag("testTag");
         request.setKey("testKey");
-        request.setMessageBody("Hello RocketMQ");
+        request.setMessageBody("RocketMQ-\u4E16\u754C");
         request.setTraceEnabled(false);
 
         // Mock the topic config
@@ -175,7 +176,7 @@ public class TopicServiceImplTest extends BaseTest {
         Assert.assertEquals("testTopic", sentMessage.getTopic());
         Assert.assertEquals("testTag", sentMessage.getTags());
         Assert.assertEquals("testKey", sentMessage.getKeys());
-        Assert.assertEquals("Hello RocketMQ", new String(sentMessage.getBody()));
+        Assert.assertArrayEquals(request.getMessageBody().getBytes(StandardCharsets.UTF_8), sentMessage.getBody());
 
         // Verify producer shutdown
         verify(mockProducer).shutdown();


### PR DESCRIPTION
## What is the purpose of the change

Encode normal and transactional topic message bodies deterministically. Platform-default `String.getBytes()` corrupted non-ASCII text when the JVM default charset was not UTF-8.

Fixes #1789

## Brief changelog

- Use `StandardCharsets.UTF_8` in both send paths.
- Verify both paths under an ISO-8859-1 JVM default.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `TopicServiceImplTest`: 2 focused tests, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 14 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.