### PR TITLE
[ISSUE #1792] Keep cluster cache refresh scheduled after failures

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/ClusterInfoService.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/ClusterInfoService.java
@@ -46,8 +46,15 @@ public class ClusterInfoService {
 
     @PostConstruct
     public void init() {
-        scheduler.scheduleAtFixedRate(this::refresh,
+        scheduler.scheduleAtFixedRate(this::refreshSafely,
                 0, cacheExpireMs / 2, TimeUnit.MILLISECONDS);
+    }
+
+    void refreshSafely() {
+        try {
+            refresh();
+        } catch (RuntimeException ignored) {
+        }
     }
 
     public ClusterInfo get() {

--- a/src/test/java/org/apache/rocketmq/dashboard/service/ClusterInfoServiceTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/service/ClusterInfoServiceTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.dashboard.service;
+
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterInfoServiceTest {
+
+    @InjectMocks
+    private ClusterInfoService clusterInfoService;
+
+    @Mock
+    private MQAdminExt mqAdminExt;
+
+    @Test
+    public void testScheduledRefreshFailureDoesNotPreventNextRefresh() throws Exception {
+        ClusterInfo expected = new ClusterInfo();
+        when(mqAdminExt.examineBrokerClusterInfo())
+                .thenThrow(new RuntimeException("temporary failure"))
+                .thenReturn(expected);
+
+        clusterInfoService.refreshSafely();
+
+        Assert.assertSame(expected, clusterInfoService.refresh());
+        verify(mqAdminExt, times(2)).examineBrokerClusterInfo();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Keep periodic cluster cache refresh alive after transient failures. Exceptions remain visible to direct callers but are contained at the scheduled task boundary.

Fixes #1792

## Brief changelog

- Schedule a failure-containing refresh wrapper instead of `refresh` directly.
- Verify a failed scheduled attempt does not prevent a subsequent successful refresh.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `ClusterInfoServiceTest`: 1 test, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 62 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.