### PR TITLE
[ISSUE #1790] Clear ACL user intersection for empty broker results

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/AclServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/AclServiceImpl.java
@@ -83,6 +83,8 @@ public class AclServiceImpl extends AbstractCommonService implements AclService 
                 }
             } else {
                 logger.warn("No users found for broker: {}", address);
+                commonUsers.clear();
+                firstIteration[0] = false;
             }
         });
 

--- a/src/test/java/org/apache/rocketmq/dashboard/service/impl/AclServiceImplTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/service/impl/AclServiceImplTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.dashboard.service.impl;
+
+import org.apache.rocketmq.dashboard.service.ClusterInfoService;
+import org.apache.rocketmq.remoting.protocol.body.UserInfo;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AclServiceImplTest {
+
+    @InjectMocks
+    @Spy
+    private AclServiceImpl aclService;
+
+    @Mock
+    private MQAdminExt mqAdminExt;
+
+    @Mock
+    private ClusterInfoService clusterInfoService;
+
+    @Test
+    public void testListUsersIsEmptyWhenAnyBrokerHasNoUsers() throws Exception {
+        String clusterName = "cluster-a";
+        String brokerName = "broker-a";
+        String firstAddress = "127.0.0.1:10911";
+        String secondAddress = "127.0.0.1:10912";
+        UserInfo user = new UserInfo();
+        user.setUsername("user-a");
+
+        doReturn(Arrays.asList(firstAddress, secondAddress))
+            .when(aclService).getBrokerAddressList(clusterName, brokerName);
+        when(mqAdminExt.listUser(firstAddress, "")).thenReturn(Collections.singletonList(user));
+        when(mqAdminExt.listUser(secondAddress, "")).thenReturn(Collections.emptyList());
+
+        Assert.assertTrue(aclService.listUsers(clusterName, brokerName).isEmpty());
+        verify(mqAdminExt).listUser(firstAddress, "");
+        verify(mqAdminExt).listUser(secondAddress, "");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Calculate multi-broker ACL user intersections correctly when any selected broker has no users. Empty results are no longer skipped.

Fixes #1790

## Brief changelog

- Clear and initialize the common-user set when a broker result is empty.
- Cover a non-empty broker followed by an empty broker.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `AclServiceImplTest`: 1 test, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 71 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.