### PR TITLE
[ISSUE #1788] Forward broker name when examining topic config

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/controller/TopicController.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/controller/TopicController.java
@@ -101,6 +101,9 @@ public class TopicController {
     @ResponseBody
     public Object examineTopicConfig(@RequestParam String topic,
                                      @RequestParam(required = false) String brokerName) throws RemotingException, MQClientException, InterruptedException {
+        if (brokerName != null) {
+            return topicService.examineTopicConfig(topic, brokerName);
+        }
         return topicService.examineTopicConfig(topic);
     }
 

--- a/src/test/java/org/apache/rocketmq/dashboard/controller/TopicControllerBrokerTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/controller/TopicControllerBrokerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.dashboard.controller;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.rocketmq.common.TopicConfig;
+import org.apache.rocketmq.dashboard.service.TopicService;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class TopicControllerBrokerTest {
+
+    @Test
+    public void testExamineTopicConfigForwardsBrokerName() throws Exception {
+        String topic = "topic-test";
+        String brokerName = "broker-a";
+        TopicConfig expected = new TopicConfig(topic);
+        AtomicReference<Object[]> receivedArguments = new AtomicReference<>();
+        TopicService topicService = (TopicService) Proxy.newProxyInstance(
+            TopicService.class.getClassLoader(), new Class<?>[] {TopicService.class},
+            (proxy, method, arguments) -> {
+                if (method.getName().equals("examineTopicConfig") && method.getParameterCount() == 2) {
+                    receivedArguments.set(arguments);
+                    return expected;
+                }
+                throw new AssertionError("Unexpected service call: " + method);
+            });
+        TopicController controller = new TopicController();
+        ReflectionTestUtils.setField(controller, "topicService", topicService);
+
+        Object result = controller.examineTopicConfig(topic, brokerName);
+
+        Assert.assertSame(expected, result);
+        Assert.assertArrayEquals(new Object[] {topic, brokerName}, receivedArguments.get());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Honor the broker selected by the topic config endpoint. When `brokerName` is present the controller now calls the broker-specific service overload; requests without it keep the aggregate route behavior.

Fixes #1788

## Brief changelog

- Forward both topic and broker name to the targeted service method.
- Add a lightweight controller test that records the exact overload and arguments.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `TopicControllerBrokerTest`: 1 test, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 55 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.