### PR TITLE
fix: validate plain ACL whiteRemoteAddress

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -209,6 +209,11 @@ public class AclService {
         if (config == null || !StringUtils.hasText(config.getAccessKey())) {
             throw new BusinessException(400, "accessKey is required");
         }
+        if (StringUtils.hasText(config.getWhiteRemoteAddress())
+                && !IpRangeMatcher.isValidRange(config.getWhiteRemoteAddress())) {
+            throw new BusinessException(400,
+                    "whiteRemoteAddress is not a valid IP/CIDR range: " + config.getWhiteRemoteAddress());
+        }
         log.info("Creating/updating plain access config accessKey={}", config.getAccessKey());
         PlainAccessConfigVO saved = aclRepository.createAndUpdatePlainAccessConfig(config);
         String auditDetail = "admin=" + saved.isAdmin()

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -209,6 +209,11 @@ public class AclService {
         if (config == null || !StringUtils.hasText(config.getAccessKey())) {
             throw new BusinessException(400, "accessKey is required");
         }
+        if (config.getWhiteRemoteAddress() != null) {
+            String normalizedWhiteRemoteAddress = config.getWhiteRemoteAddress().trim();
+            config.setWhiteRemoteAddress(normalizedWhiteRemoteAddress.isEmpty()
+                    ? null : normalizedWhiteRemoteAddress);
+        }
         if (StringUtils.hasText(config.getWhiteRemoteAddress())
                 && !IpRangeMatcher.isValidRange(config.getWhiteRemoteAddress())) {
             throw new BusinessException(400,

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
@@ -451,6 +451,7 @@ class AclControllerTest {
                 .accessKey("svc-x")
                 .admin(false)
                 .defaultTopicPerm("PUB")
+                .whiteRemoteAddress("10.0.1.0/24")
                 .topicPerms(List.of("order-*=PUB"))
                 .build();
         when(aclService.createAndUpdatePlainAccessConfig(any(PlainAccessConfigVO.class))).thenReturn(saved);
@@ -459,11 +460,14 @@ class AclControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(Map.of(
                                 "accessKey", "svc-x", "admin", false,
-                                "defaultTopicPerm", "PUB", "topicPerms", List.of("order-*=PUB")))))
+                                "defaultTopicPerm", "PUB",
+                                "whiteRemoteAddress", "10.0.1.0/24",
+                                "topicPerms", List.of("order-*=PUB")))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.accessKey").value("svc-x"))
                 .andExpect(jsonPath("$.data.admin").value(false))
+                .andExpect(jsonPath("$.data.whiteRemoteAddress").value("10.0.1.0/24"))
                 .andExpect(jsonPath("$.data.topicPerms[0]").value("order-*=PUB"));
 
         ArgumentCaptor<PlainAccessConfigVO> captor = ArgumentCaptor.forClass(PlainAccessConfigVO.class);
@@ -471,6 +475,27 @@ class AclControllerTest {
         PlainAccessConfigVO request = captor.getValue();
         assertThat(request.getAccessKey()).isEqualTo("svc-x");
         assertThat(request.getDefaultTopicPerm()).isEqualTo("PUB");
+        assertThat(request.getWhiteRemoteAddress()).isEqualTo("10.0.1.0/24");
         assertThat(request.getTopicPerms()).containsExactly("order-*=PUB");
+    }
+
+    @Test
+    void createUpdatePlainAccessConfigShouldReturnBadRequestForInvalidWhiteRemoteAddress() throws Exception {
+        when(aclService.createAndUpdatePlainAccessConfig(any(PlainAccessConfigVO.class)))
+                .thenThrow(new BusinessException(400, "whiteRemoteAddress is not a valid IP/CIDR range: invalid"));
+
+        mockMvc.perform(post("/api/acl/plain-access-config")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "accessKey", "svc-x",
+                                "whiteRemoteAddress", "invalid"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message")
+                        .value("whiteRemoteAddress is not a valid IP/CIDR range: invalid"));
+
+        ArgumentCaptor<PlainAccessConfigVO> captor = ArgumentCaptor.forClass(PlainAccessConfigVO.class);
+        verify(aclService).createAndUpdatePlainAccessConfig(captor.capture());
+        assertThat(captor.getValue().getWhiteRemoteAddress()).isEqualTo("invalid");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -599,6 +599,35 @@ class AclServiceTest {
         verify(aclRepository, never()).createAndUpdatePlainAccessConfig(any());
     }
 
+
+    @Test
+    void createAndUpdatePlainAccessConfigShouldRejectInvalidWhiteRemoteAddress() {
+        PlainAccessConfigVO config = PlainAccessConfigVO.builder()
+                .accessKey("ak-1")
+                .whiteRemoteAddress("999.999.999.999")
+                .build();
+
+        assertThatThrownBy(() -> aclService.createAndUpdatePlainAccessConfig(config))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("whiteRemoteAddress is not a valid IP/CIDR range")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        verify(aclRepository, never()).createAndUpdatePlainAccessConfig(any());
+    }
+
+    @Test
+    void createAndUpdatePlainAccessConfigShouldAcceptValidWhiteRemoteAddress() {
+        PlainAccessConfigVO config = PlainAccessConfigVO.builder()
+                .accessKey("ak-1")
+                .whiteRemoteAddress("10.0.0.0/8")
+                .build();
+        when(aclRepository.createAndUpdatePlainAccessConfig(config)).thenReturn(config);
+
+        PlainAccessConfigVO result = aclService.createAndUpdatePlainAccessConfig(config);
+
+        assertThat(result).isSameAs(config);
+        verify(aclRepository).createAndUpdatePlainAccessConfig(config);
+    }
+
     @Test
     void createAndUpdatePlainAccessConfigShouldDelegateToRepository() {
         PlainAccessConfigVO config = PlainAccessConfigVO.builder()

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -629,6 +629,36 @@ class AclServiceTest {
     }
 
     @Test
+    void createAndUpdatePlainAccessConfigShouldNormalizeWhiteRemoteAddressBeforePersistence() {
+        PlainAccessConfigVO config = PlainAccessConfigVO.builder()
+                .accessKey("ak-1")
+                .whiteRemoteAddress(" 192.168.1.10 ")
+                .build();
+        when(aclRepository.createAndUpdatePlainAccessConfig(config)).thenReturn(config);
+
+        PlainAccessConfigVO result = aclService.createAndUpdatePlainAccessConfig(config);
+
+        assertThat(result.getWhiteRemoteAddress()).isEqualTo("192.168.1.10");
+        verify(aclRepository).createAndUpdatePlainAccessConfig(argThat(saved ->
+                "192.168.1.10".equals(saved.getWhiteRemoteAddress())));
+    }
+
+    @Test
+    void createAndUpdatePlainAccessConfigShouldNormalizeBlankWhiteRemoteAddressToNull() {
+        PlainAccessConfigVO config = PlainAccessConfigVO.builder()
+                .accessKey("ak-1")
+                .whiteRemoteAddress("   ")
+                .build();
+        when(aclRepository.createAndUpdatePlainAccessConfig(config)).thenReturn(config);
+
+        PlainAccessConfigVO result = aclService.createAndUpdatePlainAccessConfig(config);
+
+        assertThat(result.getWhiteRemoteAddress()).isNull();
+        verify(aclRepository).createAndUpdatePlainAccessConfig(argThat(saved ->
+                saved.getWhiteRemoteAddress() == null));
+    }
+
+    @Test
     void createAndUpdatePlainAccessConfigShouldDelegateToRepository() {
         PlainAccessConfigVO config = PlainAccessConfigVO.builder()
                 .accessKey("ak-1")


### PR DESCRIPTION
Fixes #1798.

This change normalizes and validates plain ACL `whiteRemoteAddress` before saving the configuration. Surrounding whitespace is removed, whitespace-only input becomes an unset value, and invalid non-empty values return a 400 `BusinessException`. Valid IPv4 addresses, supported wildcards, and IPv4 CIDR ranges continue through the existing repository path.

The tests cover both the service boundary and the HTTP endpoint, including request mapping, normalization before persistence, the successful response, and propagation of the validation error.

## Testing

```bash
cd server
mvn -DskipTests=false "-Dtest=AclControllerTest#createUpdatePlainAccessConfigShouldReturnSavedConfig+createUpdatePlainAccessConfigShouldReturnBadRequestForInvalidWhiteRemoteAddress,AclServiceTest#createAndUpdatePlainAccessConfigShouldRejectInvalidWhiteRemoteAddress+createAndUpdatePlainAccessConfigShouldAcceptValidWhiteRemoteAddress+createAndUpdatePlainAccessConfigShouldNormalizeWhiteRemoteAddressBeforePersistence+createAndUpdatePlainAccessConfigShouldNormalizeBlankWhiteRemoteAddressToNull" test
```

`BUILD SUCCESS` — 6 tests, 0 failures, 0 errors.
