### PR TITLE
[ISSUE #1800] Apply user-specific admin client config

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/admin/UserSpecificMQAdminPooledObjectFactory.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/admin/UserSpecificMQAdminPooledObjectFactory.java
@@ -58,6 +58,7 @@ public class UserSpecificMQAdminPooledObjectFactory implements PooledObjectFacto
     @Override
     public PooledObject<MQAdminExt> makeObject() throws Exception {
         DefaultMQAdminExt mqAdminExt = new DefaultMQAdminExt(rpcHook);
+        mqAdminExt.resetClientConfig(userSpecificClientConfig);
 
         mqAdminExt.setAdminExtGroup("MQ_ADMIN_GROUP_FOR_" + userAk + "_" + instanceCreationCounter.getAndIncrement());
 

--- a/src/test/java/org/apache/rocketmq/dashboard/admin/UserSpecificMQAdminPooledObjectFactoryTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/admin/UserSpecificMQAdminPooledObjectFactoryTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.dashboard.admin;
+
+import org.apache.commons.pool2.PooledObject;
+import org.apache.rocketmq.client.ClientConfig;
+import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UserSpecificMQAdminPooledObjectFactoryTest {
+
+    @Test
+    public void testMakeObjectAppliesUserSpecificClientConfig() throws Exception {
+        ClientConfig baseClientConfig = new ClientConfig();
+        baseClientConfig.setNamesrvAddr("127.0.0.1:19876");
+        baseClientConfig.setClientCallbackExecutorThreads(7);
+        baseClientConfig.setVipChannelEnabled(false);
+        baseClientConfig.setUseTLS(true);
+        UserSpecificMQAdminPooledObjectFactory factory =
+                new UserSpecificMQAdminPooledObjectFactory(baseClientConfig, "test-user", "test-secret");
+
+        PooledObject<MQAdminExt> pooledObject = factory.makeObject();
+        try {
+            DefaultMQAdminExt mqAdminExt = (DefaultMQAdminExt) pooledObject.getObject();
+            Assert.assertEquals(baseClientConfig.getNamesrvAddr(), mqAdminExt.getNamesrvAddr());
+            Assert.assertEquals(baseClientConfig.getClientCallbackExecutorThreads(),
+                    mqAdminExt.getClientCallbackExecutorThreads());
+            Assert.assertEquals(baseClientConfig.isVipChannelEnabled(), mqAdminExt.isVipChannelEnabled());
+            Assert.assertEquals(baseClientConfig.isUseTLS(), mqAdminExt.isUseTLS());
+            Assert.assertTrue(mqAdminExt.getInstanceName().startsWith("MQ_ADMIN_INSTANCE_test-user_"));
+        } finally {
+            factory.destroyObject(pooledObject);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Apply the prepared user ClientConfig to every pooled `DefaultMQAdminExt` before startup. Previously nameserver, TLS, VIP, callback threads, and instance settings were cloned but never used.

Fixes #1800

## Brief changelog

- Use RocketMQ `resetClientConfig` instead of custom field copying.
- Keep the dedicated user admin group after applying the cloned configuration.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `UserSpecificMQAdminPooledObjectFactoryTest`: 1 test, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 53 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.