### PR TITLE
[ISSUE #1801] Clear MQAdmin ThreadLocal when pool return fails

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/aspect/admin/MQAdminAspect.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/aspect/admin/MQAdminAspect.java
@@ -101,8 +101,11 @@ public class MQAdminAspect {
 
             if (currentUserInfo != null) {
                 if (mqAdminExt != null) {
-                    userMQAdminPoolManager.returnMQAdminExt(currentUserInfo.getUsername(), mqAdminExt);
-                    MQAdminInstance.clearCurrentMQAdminExt();
+                    try {
+                        userMQAdminPoolManager.returnMQAdminExt(currentUserInfo.getUsername(), mqAdminExt);
+                    } finally {
+                        MQAdminInstance.clearCurrentMQAdminExt();
+                    }
                     log.debug("MQAdminExt returned for user {} and cleared from ThreadLocal.", currentUserInfo.getUsername());
                 }
                 log.debug("Operation {} for user {} cost {}ms",
@@ -111,8 +114,11 @@ public class MQAdminAspect {
                         System.currentTimeMillis() - start);
             } else {
                 if (mqAdminExt != null) {
-                    mqAdminExtPool.returnObject(mqAdminExt);
-                    MQAdminInstance.clearCurrentMQAdminExt();
+                    try {
+                        mqAdminExtPool.returnObject(mqAdminExt);
+                    } finally {
+                        MQAdminInstance.clearCurrentMQAdminExt();
+                    }
                     log.debug("MQAdminExt returned to default pool and cleared from ThreadLocal.");
                 }
                 log.debug("Operation {} cost {}ms",

--- a/src/test/java/org/apache/rocketmq/dashboard/admin/MQAdminAspectTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/admin/MQAdminAspectTest.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.dashboard.admin;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.rocketmq.dashboard.aspect.admin.MQAdminAspect;
 import org.apache.rocketmq.dashboard.config.RMQConfigure;
+import org.apache.rocketmq.dashboard.service.client.MQAdminInstance;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -92,6 +93,16 @@ public class MQAdminAspectTest {
             fail("Expected RuntimeException but no exception was thrown");
         } catch (RuntimeException e) {
             assertEquals("returnObject exception", e.getMessage());
+        }
+
+        try {
+            MQAdminInstance.threadLocalMQAdminExt();
+            fail("Expected the MQAdminExt ThreadLocal to be cleared");
+        } catch (IllegalStateException expected) {
+            assertEquals("MQAdminExt instance should be set by MQAdminAspect before it's accessed.",
+                    expected.getMessage());
+        } finally {
+            MQAdminInstance.clearCurrentMQAdminExt();
         }
 
         // 6. 验证 borrowObject() 和 returnObject() 各调用了两次


### PR DESCRIPTION
## What is the purpose of the change

Always clear the current-thread MQ admin reference when an intercepted request completes. Pool return exceptions still propagate but can no longer skip ThreadLocal cleanup.

Fixes #1801

## Brief changelog

- Wrap default-pool and user-pool return operations in `try/finally`.
- Cover cleanup after `returnObject` throws.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `MQAdminAspectTest`: 1 focused test, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 25 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.