### PR TITLE
[ISSUE #1804] Accept frontend topic field in DLQ resend requests

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/model/DlqMessageRequest.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/model/DlqMessageRequest.java
@@ -16,11 +16,13 @@
  */
 package org.apache.rocketmq.dashboard.model;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 
 @Data
 public class DlqMessageRequest {
 
+    @JsonAlias("topic")
     private String topicName;
 
     private String consumerGroup;

--- a/src/test/java/org/apache/rocketmq/dashboard/model/DlqMessageRequestTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/model/DlqMessageRequestTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.dashboard.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DlqMessageRequestTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testDeserializeFrontendTopicField() throws Exception {
+        DlqMessageRequest request = objectMapper.readValue(
+                "{\"topic\":\"retry-topic\",\"consumerGroup\":\"group\"}",
+                DlqMessageRequest.class);
+
+        Assert.assertEquals("retry-topic", request.getTopicName());
+        Assert.assertEquals("group", request.getConsumerGroup());
+    }
+
+    @Test
+    public void testDeserializeTopicNameField() throws Exception {
+        DlqMessageRequest request = objectMapper.readValue(
+                "{\"topicName\":\"retry-topic\"}", DlqMessageRequest.class);
+
+        Assert.assertEquals("retry-topic", request.getTopicName());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Bind the existing frontend `topic` property to the backend DLQ resend request. Without the alias, batch resend passed a null topic to `consumeMessageDirectly`.

Fixes #1804

## Brief changelog

- Add a Jackson alias from `topic` to canonical `topicName`.
- Verify both frontend and canonical JSON property names.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `DlqMessageRequestTest`: 2 tests, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 46 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.