### PR TITLE
[ISSUE #1803] Handle empty dashboard data files

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/DashboardCollectServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/DashboardCollectServiceImpl.java
@@ -116,6 +116,9 @@ public class DashboardCollectServiceImpl implements DashboardCollectService {
             sb.append(string);
         }
         JSONObject json = (JSONObject) JSONObject.parse(sb.toString());
+        if (json == null) {
+            return Maps.newHashMap();
+        }
         Set<Map.Entry<String, Object>> entries = json.entrySet();
         Map<String, List<String>> map = Maps.newHashMap();
         for (Map.Entry<String, Object> entry : entries) {

--- a/src/test/java/org/apache/rocketmq/dashboard/service/impl/DashboardCollectServiceImplTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/service/impl/DashboardCollectServiceImplTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.dashboard.service.impl;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class DashboardCollectServiceImplTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private final DashboardCollectServiceImpl service = new DashboardCollectServiceImpl();
+
+    @Test
+    public void testJsonDataFile2mapReturnsEmptyMapForEmptyFile() throws Exception {
+        File file = temporaryFolder.newFile("empty.json");
+
+        Assert.assertTrue(service.jsonDataFile2map(file).isEmpty());
+    }
+
+    @Test
+    public void testJsonDataFile2mapReturnsEmptyMapForWhitespaceFile() throws Exception {
+        File file = temporaryFolder.newFile("whitespace.json");
+        Files.writeString(file.toPath(), " \n\t\r", StandardCharsets.UTF_8);
+
+        Assert.assertTrue(service.jsonDataFile2map(file).isEmpty());
+    }
+
+    @Test
+    public void testJsonDataFile2mapPreservesNonEmptyData() throws Exception {
+        File file = temporaryFolder.newFile("data.json");
+        Files.writeString(file.toPath(),
+            "{\"broker-a\":[\"topic-a\",\"topic-b\"],\"broker-b\":null}", StandardCharsets.UTF_8);
+
+        Map<String, List<String>> result = service.jsonDataFile2map(file);
+
+        Assert.assertEquals(Collections.singleton("broker-a"), result.keySet());
+        Assert.assertEquals(Arrays.asList("topic-a", "topic-b"), result.get("broker-a"));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Treat empty and whitespace-only dashboard collection files as empty historical maps. FastJSON returns null for these inputs, which previously caused an immediate `entrySet` NullPointerException.

Fixes #1803

## Brief changelog

- Return a new empty map when parsed JSON is null.
- Cover empty, whitespace-only, and populated local files.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `DashboardCollectServiceImplTest`: 3 tests, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 67 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.