### PR TITLE
[ISSUE #1805] Preserve message totals for out-of-range task pages

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImpl.java
@@ -420,7 +420,7 @@ public class MessageServiceImpl implements MessageService {
                 total += end - start;
             }
             if (total <= offset) {
-                return Page.empty();
+                return new PageImpl<>(Collections.emptyList(), query.page(), total);
             }
             long pageSize = total - offset > query.getPageSize() ? query.getPageSize() : total - offset;
 

--- a/src/test/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImplTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImplTest.java
@@ -46,6 +46,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.domain.Page;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -431,6 +432,23 @@ public class MessageServiceImplTest {
 
         // Verify total endOffset increment is page size
         assertEquals(10, (qo1.getEndOffset() - 5L) + (qo2.getEndOffset() - 10L));
+    }
+
+    @Test
+    public void testOutOfRangeTaskPagePreservesTotalElements() throws Exception {
+        MessageQueue messageQueue = new MessageQueue(TOPIC, "broker", 0);
+        List<QueueOffsetInfo> queueOffsets = Collections.singletonList(
+                new QueueOffsetInfo(0, 0L, 5L, 0L, 0L, messageQueue));
+        MessageQueryByPage query = new MessageQueryByPage(2, 10, TOPIC, 1000, 3000);
+
+        Method method = MessageServiceImpl.class.getDeclaredMethod(
+                "queryMessageByTaskPage", MessageQueryByPage.class, List.class);
+        method.setAccessible(true);
+        Page<?> page = (Page<?>) method.invoke(messageService, query, queueOffsets);
+
+        assertTrue(page.isEmpty());
+        assertEquals(5L, page.getTotalElements());
+        assertEquals(1, page.getNumber());
     }
 
     // Helper methods


### PR DESCRIPTION
## What is the purpose of the change

Preserve known pagination metadata when a message task page is beyond the available rows. The response remains empty but keeps total elements and the requested page number.

Fixes #1805

## Brief changelog

- Replace the default empty Page with a PageImpl containing the calculated total and requested pageable.
- Cover an out-of-range task page with five known messages.

## Verifying this change

- JDK: Temurin 17.0.19
- Focused backend Maven compile and test phases completed
- `MessageServiceImplTest`: 1 focused test, 0 failures, 0 errors
- `mvn validate`: passed
- `git diff --check`: passed
- PR scope check: passed (2 files, 20 changed lines, one commit, base `master`)
- Full lifecycle, integration, E2E, and container checks were not run because this five-PR workflow requires lightweight local verification and leaves heavyweight checks to upstream CI.

Follow this checklist to help us incorporate your contribution quickly and easily.

- [x] Make sure there is a Github issue filed for the change. This PR addresses only that issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit has a meaningful subject and body.
- [x] Write a pull request description that explains what, how, and why.
- [x] Write necessary unit tests to verify the logic correction.
- [ ] Run the repository full basic, install, and integration command matrix. The focused backend checks above pass; heavyweight checks are delegated to upstream CI.
- [ ] If this contribution is large, file an Apache Individual Contributor License Agreement.