### PR TITLE
fix: validate DLQ resend time range

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -142,6 +142,9 @@ public class RocketMQDLQProvider implements DLQProvider {
 
         long end = endTime != null ? endTime : System.currentTimeMillis();
         long begin = startTime != null ? startTime : end - ONE_HOUR_MILLIS;
+        if (begin >= end) {
+            throw new BusinessException(400, "DLQ resend start time must be before end time");
+        }
 
         DeadLetterScanResult scanResult;
         try {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -119,6 +119,27 @@ class RocketMQDLQProviderTest {
         });
     }
 
+
+    @Test
+    void resendMessagesShouldRejectInvertedTimeRangeBeforeCreatingConsumers() {
+        assertThatThrownBy(() -> provider.resendMessages("instance-a", "group-a", 200L, 100L, "target-topic"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("DLQ resend start time must be before end time")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+
+        verify(runtimeAdminClientResolver).resolveEndpoint("instance-a");
+    }
+
+    @Test
+    void resendMessagesShouldRejectEqualStartAndEndTimeBeforeCreatingConsumers() {
+        assertThatThrownBy(() -> provider.resendMessages("instance-a", "group-a", 100L, 100L, "target-topic"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("DLQ resend start time must be before end time")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+
+        verify(runtimeAdminClientResolver).resolveEndpoint("instance-a");
+    }
+
     @Test
     void resendMessagesDoesNotPullWhenDlqQueueSetIsNull() throws Exception {
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";


### PR DESCRIPTION
Fixes #1802.

Reject DLQ resend requests when the start time is not earlier than the end time. The check runs at the beginning of `RocketMQDLQProvider.resendMessages(...)`, before consumer creation or queue scanning.

Regression tests cover equal and inverted ranges and verify that invalid requests do not create a DLQ consumer.

## Testing

```bash
cd server
mvn -DskipTests=false "-Dtest=RocketMQDLQProviderTest#resendMessagesShouldRejectInvertedTimeRangeBeforeCreatingConsumers+resendMessagesShouldRejectEqualStartAndEndTimeBeforeCreatingConsumers" test
```

`BUILD SUCCESS` — 2 tests, 0 failures, 0 errors.
