### PR TITLE
fix: handle empty Aliyun trace responses

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
@@ -442,12 +442,16 @@ public class AliyunInstanceProvider implements InstanceProvider {
         GetTraceResponseBody body = response == null ? null : response.getBody();
         GetTraceResponseBody.Data data = body == null ? null : body.getData();
         if (data == null) {
-            return TraceRecordVO.builder()
-                    .nodes(Collections.emptyList())
-                    .consumerStatus(Collections.emptyList())
-                    .build();
+            return emptyTraceRecord();
         }
         return AliyunConverters.toTraceRecord(data);
+    }
+
+    private static TraceRecordVO emptyTraceRecord() {
+        return TraceRecordVO.builder()
+                .nodes(Collections.emptyList())
+                .consumerStatus(Collections.emptyList())
+                .build();
     }
 
     private Context resolve(String instanceId) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
@@ -441,7 +441,10 @@ public class AliyunInstanceProvider implements InstanceProvider {
         GetTraceResponseBody body = response == null ? null : response.getBody();
         GetTraceResponseBody.Data data = body == null ? null : body.getData();
         if (data == null) {
-            throw new BusinessException(404, "Message trace not found: " + msgId);
+            return TraceRecordVO.builder()
+                    .nodes(java.util.Collections.emptyList())
+                    .consumerStatus(java.util.Collections.emptyList())
+                    .build();
         }
         return AliyunConverters.toTraceRecord(data);
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
@@ -61,6 +61,7 @@ import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -442,8 +443,8 @@ public class AliyunInstanceProvider implements InstanceProvider {
         GetTraceResponseBody.Data data = body == null ? null : body.getData();
         if (data == null) {
             return TraceRecordVO.builder()
-                    .nodes(java.util.Collections.emptyList())
-                    .consumerStatus(java.util.Collections.emptyList())
+                    .nodes(Collections.emptyList())
+                    .consumerStatus(Collections.emptyList())
                     .build();
         }
         return AliyunConverters.toTraceRecord(data);

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -361,6 +361,22 @@ class AliyunInstanceProviderTest {
     }
 
     @Test
+    void getMessageTraceShouldReturnEmptyTraceWhenAliyunDataIsNullTest() {
+        stubInstance();
+        stubCallThrough();
+        GetTraceResponse response = GetTraceResponse.create().toBuilder()
+                .statusCode(200)
+                .body(GetTraceResponseBody.builder().data(null).build())
+                .build();
+        when(asyncClient.getTrace(any())).thenReturn(CompletableFuture.completedFuture(response));
+
+        TraceRecordVO trace = provider.getMessageTrace(STUDIO_INSTANCE_ID, "msg-without-trace");
+
+        assertThat(trace.getNodes()).isEmpty();
+        assertThat(trace.getConsumerStatus()).isEmpty();
+    }
+
+    @Test
     void mappedBusinessExceptionShouldPropagateTest() {
         stubInstance();
         when(clientFactory.call(anyString(), anyString(), any()))

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -377,6 +377,34 @@ class AliyunInstanceProviderTest {
     }
 
     @Test
+    void getMessageTraceShouldReturnEmptyTraceWhenAliyunBodyIsNullTest() {
+        stubInstance();
+        stubCallThrough();
+        GetTraceResponse response = GetTraceResponse.create().toBuilder()
+                .statusCode(200)
+                .body(null)
+                .build();
+        when(asyncClient.getTrace(any())).thenReturn(CompletableFuture.completedFuture(response));
+
+        TraceRecordVO trace = provider.getMessageTrace(STUDIO_INSTANCE_ID, "msg-without-body", "orders");
+
+        assertThat(trace.getNodes()).isEmpty();
+        assertThat(trace.getConsumerStatus()).isEmpty();
+    }
+
+    @Test
+    void getMessageTraceShouldReturnEmptyTraceWhenAliyunResponseIsNullTest() {
+        stubInstance();
+        stubCallThrough();
+        when(asyncClient.getTrace(any())).thenReturn(CompletableFuture.completedFuture(null));
+
+        TraceRecordVO trace = provider.getMessageTrace(STUDIO_INSTANCE_ID, "msg-without-response", "orders");
+
+        assertThat(trace.getNodes()).isEmpty();
+        assertThat(trace.getConsumerStatus()).isEmpty();
+    }
+
+    @Test
     void mappedBusinessExceptionShouldPropagateTest() {
         stubInstance();
         when(clientFactory.call(anyString(), anyString(), any()))

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -370,7 +370,7 @@ class AliyunInstanceProviderTest {
                 .build();
         when(asyncClient.getTrace(any())).thenReturn(CompletableFuture.completedFuture(response));
 
-        TraceRecordVO trace = provider.getMessageTrace(STUDIO_INSTANCE_ID, "msg-without-trace");
+        TraceRecordVO trace = provider.getMessageTrace(STUDIO_INSTANCE_ID, "msg-without-trace", "orders");
 
         assertThat(trace.getNodes()).isEmpty();
         assertThat(trace.getConsumerStatus()).isEmpty();


### PR DESCRIPTION
Fixes #1814.

Return an empty `TraceRecordVO` when Aliyun's `GetTrace` call returns no response, no body, or no `data`, instead of converting those empty response shapes into a 404. Responses containing trace data continue through the existing node and consumer-status mapping.

The empty result is created through one helper so every empty response path returns initialized `nodes` and `consumerStatus` lists.

## Testing

```bash
cd server
mvn -DskipTests=false "-Dtest=AliyunInstanceProviderTest#getMessageTraceShouldMapNodesTest+getMessageTraceShouldReturnEmptyTraceWhenAliyunDataIsNullTest+getMessageTraceShouldReturnEmptyTraceWhenAliyunBodyIsNullTest+getMessageTraceShouldReturnEmptyTraceWhenAliyunResponseIsNullTest" test
```

`BUILD SUCCESS` — 4 tests, 0 failures, 0 errors.
