### PR TITLE
test: cover Aliyun timestamp timezone independence

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -56,9 +56,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -358,6 +360,22 @@ class AliyunInstanceProviderTest {
         TraceNodeVO consumer = trace.getNodes().get(2);
         assertThat(consumer.getTitle()).isEqualTo("Consumer GID_test");
         assertThat(consumer.getStatus()).isEqualTo("CONSUME_OK");
+    }
+
+    @Test
+    void aliyunTimeConversionShouldUseShanghaiZoneIndependentOfJvmDefaultTest() {
+        long expected = Instant.parse("2023-03-22T04:17:08Z").toEpochMilli();
+        TimeZone original = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+
+            assertThat(AliyunConverters.parseTimeMillis("2023-03-22 12:17:08"))
+                    .isEqualTo(expected);
+            assertThat(AliyunConverters.formatTimeMillis(expected))
+                    .isEqualTo("2023-03-22 12:17:08");
+        } finally {
+            TimeZone.setDefault(original);
+        }
     }
 
     @Test


### PR DESCRIPTION
#1816 is already fixed in the current base by #1978 (`ec912d32`), which uses an explicit `Asia/Shanghai` timezone in `AliyunConverters`.

This PR adds the missing regression coverage. The test temporarily changes the JVM default timezone to `America/Los_Angeles`, verifies both parsing and formatting against the Shanghai timestamp, and restores the original timezone in a `finally` block.

## Testing

```bash
cd server
mvn -DskipTests=false -Dtest=AliyunInstanceProviderTest#aliyunTimeConversionShouldUseShanghaiZoneIndependentOfJvmDefaultTest test
```

`BUILD SUCCESS` — 1 test, 0 failures, 0 errors. Checkstyle and test compilation also completed successfully as part of the Maven run.
