### PR TITLE
fix: validate DLQ resend group name

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -140,6 +140,7 @@ public class RocketMQDLQProvider implements DLQProvider {
         if (!StringUtils.hasText(groupName)) {
             throw new BusinessException(400, "groupName is required for DLQ resend");
         }
+        groupName = groupName.trim();
         String endpoint = runtimeAdminClientResolver.resolveEndpoint(instanceId);
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + groupName;
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -137,6 +137,9 @@ public class RocketMQDLQProvider implements DLQProvider {
     @Override
     public DLQResendResultVO resendMessages(String instanceId, String groupName, Long startTime, Long endTime,
                                              String targetTopic) {
+        if (!StringUtils.hasText(groupName)) {
+            throw new BusinessException(400, "groupName is required for DLQ resend");
+        }
         String endpoint = runtimeAdminClientResolver.resolveEndpoint(instanceId);
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + groupName;
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -120,6 +120,28 @@ class RocketMQDLQProviderTest {
     }
 
     @Test
+    void resendMessagesShouldRejectBlankGroupNameBeforeResolvingEndpoint() {
+        assertThatThrownBy(() -> provider.resendMessages("instance-a", " ", 100L, 200L, "target-topic"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("groupName is required for DLQ resend")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+
+        verify(runtimeAdminClientResolver, never()).resolveEndpoint(anyString());
+        verify(auditService, never()).record(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void resendMessagesShouldRejectNullGroupNameBeforeResolvingEndpoint() {
+        assertThatThrownBy(() -> provider.resendMessages("instance-a", null, 100L, 200L, "target-topic"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("groupName is required for DLQ resend")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+
+        verify(runtimeAdminClientResolver, never()).resolveEndpoint(anyString());
+        verify(auditService, never()).record(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
     void resendMessagesDoesNotPullWhenDlqQueueSetIsNull() throws Exception {
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
         try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -142,6 +142,27 @@ class RocketMQDLQProviderTest {
     }
 
     @Test
+    void resendMessagesShouldNormalizeGroupNameBeforeBuildingDlqTopicAndAuditing() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(null);
+                         doNothing().when(consumer).shutdown();
+                     });
+             MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class)) {
+            provider.resendMessages("instance-a", " group-a ", 100L, 200L, "target-topic");
+
+            assertThat(mockedConsumers.constructed()).hasSize(1);
+            verify(mockedConsumers.constructed().get(0)).fetchSubscribeMessageQueues(dlqTopic);
+            assertThat(mockedProducers.constructed()).isEmpty();
+        }
+        verify(auditService).record(eq("RESEND_DLQ"), eq("group-a"),
+                contains("group=group-a, dlqTopic=%DLQ%group-a"), eq("NO_MESSAGES"));
+    }
+
+    @Test
     void resendMessagesDoesNotPullWhenDlqQueueSetIsNull() throws Exception {
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
         try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =


### PR DESCRIPTION
Fixes #1818.

Validate and normalize `groupName` at the start of DLQ resend. Null and blank values now return a 400 `BusinessException` before the provider derives the `%DLQ%` topic or performs any external work. Valid values are trimmed once, and the normalized name is used consistently for topic lookup, logs, and audit records.

The tests verify that invalid requests do not resolve an endpoint or write an audit record, and that surrounding whitespace does not leak into the DLQ topic or audit resource name.

## Testing

```bash
cd server
mvn -DskipTests=false "-Dtest=RocketMQDLQProviderTest#resendMessagesShouldRejectBlankGroupNameBeforeResolvingEndpoint+resendMessagesShouldRejectNullGroupNameBeforeResolvingEndpoint+resendMessagesShouldNormalizeGroupNameBeforeBuildingDlqTopicAndAuditing" test
```

`BUILD SUCCESS` — 3 tests, 0 failures, 0 errors.
