### PR TITLE
fix: validate alert rule names in the service

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -96,6 +96,9 @@ public class AlertService {
         if (rule == null) {
             throw new BusinessException(400, "Alert rule request is required");
         }
+        if (!hasText(rule.getName())) {
+            throw new BusinessException(400, "Alert rule name is required");
+        }
         log.info("Creating alert rule: {}", rule.getName());
         rule.setId(UUID.randomUUID().toString());
         AlertRuleVO saved = alertRepository.saveRule(rule);
@@ -107,6 +110,9 @@ public class AlertService {
     public AlertRuleVO updateRule(AlertRuleVO rule) {
         if (rule == null) {
             throw new BusinessException(400, "Alert rule request is required");
+        }
+        if (!hasText(rule.getName())) {
+            throw new BusinessException(400, "Alert rule name is required");
         }
         String id = rule.getId();
         log.info("Updating alert rule: {}", id);

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -99,6 +99,7 @@ public class AlertService {
         if (!hasText(rule.getName())) {
             throw new BusinessException(400, "Alert rule name is required");
         }
+        rule.setName(rule.getName().trim());
         log.info("Creating alert rule: {}", rule.getName());
         rule.setId(UUID.randomUUID().toString());
         AlertRuleVO saved = alertRepository.saveRule(rule);
@@ -114,6 +115,7 @@ public class AlertService {
         if (!hasText(rule.getName())) {
             throw new BusinessException(400, "Alert rule name is required");
         }
+        rule.setName(rule.getName().trim());
         String id = rule.getId();
         log.info("Updating alert rule: {}", id);
         validateRuleId(id);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -482,6 +483,36 @@ class AlertServiceTest {
         verify(alertRepository, never()).replaceRule(any());
         verify(operationAuditService, never()).record(anyString(), anyString(), anyString(),
                 any(), any(), anyString(), any());
+    }
+
+    @Test
+    void createRuleShouldNormalizeNameBeforeSavingAndAuditing() {
+        AlertRuleVO input = AlertRuleVO.builder().name(" CPU Alert ").metric("tps").build();
+        when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        AlertRuleVO result = alertService.createRule(input);
+
+        assertThat(result.getName()).isEqualTo("CPU Alert");
+        verify(alertRepository).saveRule(argThat(rule -> "CPU Alert".equals(rule.getName())));
+        verify(operationAuditService).record(eq("CREATE_ALERT_RULE"), eq("ALERT_RULE"), anyString(),
+                eq(null), eq("name=CPU Alert"), eq("SUCCESS"), eq(null));
+    }
+
+    @Test
+    void updateRuleShouldNormalizeNameBeforeReplacingAndAuditing() {
+        AlertRuleVO update = AlertRuleVO.builder()
+                .id("rule-1")
+                .name(" CPU Alert ")
+                .threshold(90.0)
+                .build();
+        when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(true);
+
+        AlertRuleVO result = alertService.updateRule(update);
+
+        assertThat(result.getName()).isEqualTo("CPU Alert");
+        verify(alertRepository).replaceRule(argThat(rule -> "CPU Alert".equals(rule.getName())));
+        verify(operationAuditService).record(eq("UPDATE_ALERT_RULE"), eq("ALERT_RULE"), eq("rule-1"),
+                eq(null), eq("name=CPU Alert"), eq("SUCCESS"), eq(null));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -35,6 +35,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -453,6 +454,34 @@ class AlertServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
 
         verify(alertRepository, never()).saveRule(any());
+    }
+
+    @Test
+    void createRuleShouldRejectBlankName() {
+        AlertRuleVO input = AlertRuleVO.builder().name(" ").metric("tps").build();
+
+        assertThatThrownBy(() -> alertService.createRule(input))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule name is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(alertRepository, never()).saveRule(any());
+        verify(operationAuditService, never()).record(anyString(), anyString(), anyString(),
+                any(), any(), anyString(), any());
+    }
+
+    @Test
+    void updateRuleShouldRejectBlankNameBeforeRepositoryUpdate() {
+        AlertRuleVO update = AlertRuleVO.builder().id("rule-1").name(" ").metric("tps").build();
+
+        assertThatThrownBy(() -> alertService.updateRule(update))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule name is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(alertRepository, never()).replaceRule(any());
+        verify(operationAuditService, never()).record(anyString(), anyString(), anyString(),
+                any(), any(), anyString(), any());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1820.

Enforce and normalize the alert rule name in `AlertService`, in addition to the existing request-DTO validation. Both create and update reject a null or blank name before repository or audit operations. Valid names are trimmed before they are saved, logged, exported, or included in audit details.

## Testing

```bash
cd server
mvn -DskipTests=false "-Dtest=AlertServiceTest#createRuleShouldRejectBlankName+updateRuleShouldRejectBlankNameBeforeRepositoryUpdate+createRuleShouldNormalizeNameBeforeSavingAndAuditing+updateRuleShouldNormalizeNameBeforeReplacingAndAuditing" test
```

`BUILD SUCCESS` — 4 tests, 0 failures, 0 errors.
