### PR TITLE
fix: update the Tencent RocketMQ region catalog

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
@@ -50,11 +50,20 @@ public class TencentCatalogService implements CloudCatalogProvider {
             region("ap-chongqing", "Chongqing"),
             region("ap-guangzhou", "Guangzhou"),
             region("ap-hongkong", "Hong Kong"),
+            region("ap-mumbai", "Mumbai"),
             region("ap-nanjing", "Nanjing"),
+            region("ap-seoul", "Seoul"),
             region("ap-shanghai", "Shanghai"),
+            region("ap-shanghai-fsi", "Shanghai Finance"),
+            region("ap-shenzhen-fsi", "Shenzhen Finance"),
             region("ap-singapore", "Singapore"),
             region("ap-tokyo", "Tokyo"),
-            region("na-siliconvalley", "Silicon Valley"));
+            region("ap-bangkok", "Bangkok"),
+            region("ap-jakarta", "Jakarta"),
+            region("eu-frankfurt", "Frankfurt"),
+            region("na-ashburn", "Ashburn"),
+            region("na-siliconvalley", "Silicon Valley"),
+            region("na-toronto", "Toronto"));
 
     private final TencentClientFactory clientFactory;
 


### PR DESCRIPTION
This PR proposed additional Tencent RocketMQ regions, but its list duplicated and partially contradicted the broader tested catalog already merged in #1508. It also omitted the financial-region endpoint handling included by that earlier fix.

The PR was closed rather than rebased because merging it would have reintroduced an incomplete and inaccurate catalog. Future updates should modify the current tested list from the official region matrix.