### PR TITLE
fix: validate K8s certificate types in the service

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
@@ -68,11 +68,14 @@ public class K8sCertService {
         LocalDateTime now = LocalDateTime.now(clock);
         LocalDateTime notAfter = now.plusYears(1);
 
+        if (command.getType() == null) {
+            throw new BusinessException(400, "Type is required");
+        }
         K8sCertVO cert = K8sCertVO.builder()
                 .name(command.getName())
                 .namespace(command.getNamespace())
                 .cluster(command.getCluster())
-                .type(CertType.valueOf(command.getType()))
+                .type(parseCertType(command.getType()))
                 .issuer(command.getIssuer())
                 .notBefore(now)
                 .notAfter(notAfter)
@@ -107,7 +110,7 @@ public class K8sCertService {
             updated.setCluster(command.getCluster());
         }
         if (command.getType() != null) {
-            updated.setType(CertType.valueOf(command.getType()));
+            updated.setType(parseCertType(command.getType()));
         }
         if (command.getIssuer() != null) {
             updated.setIssuer(command.getIssuer());
@@ -155,6 +158,15 @@ public class K8sCertService {
         recordAudit("DELETE_K8S_CERTIFICATE", "K8S_CERTIFICATE", command.getId(), null,
                 null);
         log.info("K8s certificate deleted: {}", command.getId());
+    }
+
+    private CertType parseCertType(String type) {
+        try {
+            return CertType.valueOf(type);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(400, "Invalid certificate type: " + type
+                    + ". Valid types: TLS, mTLS, ServiceAccount");
+        }
     }
 
     private void requireCommand(Object command) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
@@ -216,6 +216,23 @@ class K8sCertControllerTest {
     }
 
     @Test
+    void updateCertShouldRejectUnsupportedType() throws Exception {
+        mockMvc.perform(post("/api/k8s-certs/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "id": "cert-1",
+                                    "type": "PEM"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("type must be one of TLS, mTLS, ServiceAccount"));
+
+        verifyNoInteractions(k8sCertService);
+    }
+
+    @Test
     void renewCertShouldRejectBlankId() throws Exception {
         mockMvc.perform(post("/api/k8s-certs/renew")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -199,6 +200,42 @@ class K8sCertServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
 
         verifyNoInteractions(k8sCertRepository);
+    }
+
+    @Test
+    void createCertShouldRejectInvalidTypeBeforeSave() {
+        CreateCertDTO command = CreateCertDTO.builder()
+                .name("bad-cert")
+                .namespace("default")
+                .cluster("test-cluster")
+                .type("INVALID")
+                .issuer("test-issuer")
+                .build();
+
+        assertThatThrownBy(() -> k8sCertService.createCert(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Invalid certificate type: INVALID. Valid types: TLS, mTLS, ServiceAccount")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(k8sCertRepository, never()).save(any());
+        verify(operationAuditService, never()).record(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void updateCertShouldRejectInvalidTypeBeforeSave() {
+        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        UpdateCertDTO command = UpdateCertDTO.builder()
+                .id("cert-1")
+                .type("INVALID")
+                .build();
+
+        assertThatThrownBy(() -> k8sCertService.updateCert(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Invalid certificate type: INVALID. Valid types: TLS, mTLS, ServiceAccount")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(k8sCertRepository, never()).save(any());
+        verify(operationAuditService, never()).record(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1826.

Centralize K8s certificate type parsing in `K8sCertService`. Unsupported values now produce a 400 `BusinessException` instead of leaking the exception from `CertType.valueOf(...)`.

Create still requires a type, while update keeps the existing behavior that a null type leaves the stored type unchanged.

The PR also includes controller coverage for both create and update requests. Unsupported types are rejected by Bean Validation before `K8sCertService` is invoked, while the service tests protect direct and future internal callers.

## Testing

```bash
cd server
mvn -DskipTests=false "-Dtest=K8sCertControllerTest#updateCertShouldRejectUnsupportedType+createCertShouldRejectUnsupportedType,K8sCertServiceTest#createCertShouldRejectInvalidTypeBeforeSave+updateCertShouldRejectInvalidTypeBeforeSave" test
```

`BUILD SUCCESS` — 4 tests, 0 failures, 0 errors.
