### PR TITLE
[Studio] feat: support persisted SSL/TLS settings validation

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -104,23 +104,26 @@
 | 61 | POST | `/api/audit-logs/cleanup` | 清理审计日志 |
 | 62 | GET | `/api/settings/general` | 获取通用设置 |
 | 63 | POST | `/api/settings/general/save` | 保存通用设置 |
-| 64 | GET | `/api/settings/datasources` | 数据源列表 |
-| 65 | POST | `/api/settings/datasources/create` | 创建数据源 |
-| 66 | POST | `/api/settings/datasources/update` | 更新数据源 |
-| 67 | POST | `/api/settings/datasources/delete` | 删除数据源 |
-| 68 | POST | `/api/settings/datasources/test` | 测试数据源连接 |
-| 69 | POST | `/api/ai/chat` | AI 对话（SSE） |
-| 70 | POST | `/api/ai/execute` | 执行 AI 指令 |
-| 71 | GET | `/api/ai/tools` | 可用工具列表 |
-| 72 | POST | `/api/ai/tools/:name/execute` | 执行只读 AI 工具 |
-| 73 | POST | `/api/metrics/query` | 查询监控指标数据 |
-| 74 | GET | `/api/acl/cluster-config` | 集群 ACL 配置概要（存储级） |
-| 75 | POST | `/api/acl/plain-access-config` | 创建/更新 Plain Access 账号 |
-| 76 | GET | `/api/acl/users/:id/credentials` | 查看单个用户明文凭证 |
-| 77 | GET | `/api/metrics/grafana/dashboards` | Grafana 看板列表 |
-| 78 | GET | `/api/metrics/grafana/dashboards/:uid` | Grafana 看板 JSON 模型 |
-| 79 | GET | `/api/metrics/grafana/dashboards/:uid/export` | 导出单个 Grafana 看板 JSON |
-| 80 | GET | `/api/metrics/grafana/dashboards/export` | 打包导出全部 Grafana 看板 |
+| 64 | GET | `/api/settings/ssl` | 获取 SSL/TLS 设置 |
+| 65 | POST | `/api/settings/ssl/save` | 保存 SSL/TLS 设置 |
+| 66 | POST | `/api/settings/ssl/validate` | 验证 SSL/TLS KeyStore/TrustStore |
+| 67 | GET | `/api/settings/datasources` | 数据源列表 |
+| 68 | POST | `/api/settings/datasources/create` | 创建数据源 |
+| 69 | POST | `/api/settings/datasources/update` | 更新数据源 |
+| 70 | POST | `/api/settings/datasources/delete` | 删除数据源 |
+| 71 | POST | `/api/settings/datasources/test` | 测试数据源连接 |
+| 72 | POST | `/api/ai/chat` | AI 对话（SSE） |
+| 73 | POST | `/api/ai/execute` | 执行 AI 指令 |
+| 74 | GET | `/api/ai/tools` | 可用工具列表 |
+| 75 | POST | `/api/ai/tools/:name/execute` | 执行只读 AI 工具 |
+| 76 | POST | `/api/metrics/query` | 查询监控指标数据 |
+| 77 | GET | `/api/acl/cluster-config` | 集群 ACL 配置概要（存储级） |
+| 78 | POST | `/api/acl/plain-access-config` | 创建/更新 Plain Access 账号 |
+| 79 | GET | `/api/acl/users/:id/credentials` | 查看单个用户明文凭证 |
+| 80 | GET | `/api/metrics/grafana/dashboards` | Grafana 看板列表 |
+| 81 | GET | `/api/metrics/grafana/dashboards/:uid` | Grafana 看板 JSON 模型 |
+| 82 | GET | `/api/metrics/grafana/dashboards/:uid/export` | 导出单个 Grafana 看板 JSON |
+| 83 | GET | `/api/metrics/grafana/dashboards/export` | 打包导出全部 Grafana 看板 |
 
 ## 通用响应格式
 
@@ -1678,7 +1681,70 @@ POST /api/settings/general/save
 
 **Response `data`:** `null`
 
-### 14.3 获取数据源列表
+### 14.3 获取 SSL/TLS 设置
+
+```
+GET /api/settings/ssl
+```
+
+**Response `data`:**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `enabled` | `boolean` | 是否启用 SSL/TLS |
+| `protocol` | `string` | 协议: `TLSv1.3` / `TLSv1.2` |
+| `clientAuth` | `string` | 客户端认证: `none` / `want` / `need` |
+| `keyStoreType` | `string` | KeyStore 类型: `PKCS12` / `JKS` |
+| `keyStorePath` | `string` | KeyStore 文件路径 |
+| `keyStorePasswordConfigured` | `boolean` | 是否已保存 KeyStore 密码；响应不会返回密码内容 |
+| `trustStoreType` | `string` | TrustStore 类型: `PKCS12` / `JKS` |
+| `trustStorePath` | `string` | TrustStore 文件路径 |
+| `trustStorePasswordConfigured` | `boolean` | 是否已保存 TrustStore 密码；响应不会返回密码内容 |
+| `restartRequired` | `boolean` | 保存后是否需要重启服务才能生效 |
+
+### 14.4 保存 SSL/TLS 设置
+
+```
+POST /api/settings/ssl/save
+```
+
+**Request Body:**
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `enabled` | `boolean` | 否 | 是否启用 SSL/TLS |
+| `protocol` | `string` | 否 | 协议: `TLSv1.3` / `TLSv1.2` |
+| `clientAuth` | `string` | 否 | 客户端认证: `none` / `want` / `need` |
+| `keyStoreType` | `string` | 否 | KeyStore 类型: `PKCS12` / `JKS` |
+| `keyStorePath` | `string` | 否 | KeyStore 文件路径；启用 SSL/TLS 时必填 |
+| `keyStorePassword` | `string` | 否 | 新 KeyStore 密码；省略或传空值时保留现有密码 |
+| `clearKeyStorePassword` | `boolean` | 否 | 传 `true` 时显式清除现有 KeyStore 密码 |
+| `trustStoreType` | `string` | 否 | TrustStore 类型: `PKCS12` / `JKS` |
+| `trustStorePath` | `string` | 否 | TrustStore 文件路径；启用客户端认证时必填 |
+| `trustStorePassword` | `string` | 否 | 新 TrustStore 密码；省略或传空值时保留现有密码 |
+| `clearTrustStorePassword` | `boolean` | 否 | 传 `true` 时显式清除现有 TrustStore 密码 |
+
+**Response `data`:** `SslSettings`
+
+> 保存配置不会热切换运行中的服务端 TLS，也不会自动写入容器启动参数；运维需将配置同步到部署参数后重启 Studio。
+
+### 14.5 验证 SSL/TLS KeyStore/TrustStore
+
+```
+POST /api/settings/ssl/validate
+```
+
+**Request Body:** 同 `POST /api/settings/ssl/save`
+
+**Response `data`:**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `success` | `boolean` | KeyStore/TrustStore 是否可加载 |
+| `message` | `string` | 验证结果说明 |
+| `warnings` | `string[]` | 非阻断告警，例如 TrustStore 已配置但未启用客户端认证 |
+
+### 14.6 获取数据源列表
 
 ```
 GET /api/settings/datasources
@@ -1695,7 +1761,7 @@ GET /api/settings/datasources
 | `auth` | `string` | 认证方式: `None` / `Basic Auth` / `Bearer Token` |
 | `status` | `string` | 状态: `healthy` / `error` |
 
-### 14.4 创建数据源
+### 14.7 创建数据源
 
 ```
 POST /api/settings/datasources/create
@@ -1712,7 +1778,7 @@ POST /api/settings/datasources/create
 
 **Response `data`:** `DataSource`
 
-### 14.5 更新数据源
+### 14.8 更新数据源
 
 ```
 POST /api/settings/datasources/update
@@ -1730,7 +1796,7 @@ POST /api/settings/datasources/update
 
 **Response `data`:** `DataSource`
 
-### 14.6 删除数据源
+### 14.9 删除数据源
 
 ```
 POST /api/settings/datasources/delete
@@ -1744,7 +1810,7 @@ POST /api/settings/datasources/delete
 
 **Response `data`:** `null`
 
-### 14.7 测试数据源连接
+### 14.10 测试数据源连接
 
 ```
 POST /api/settings/datasources/test

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1700,7 +1700,7 @@ GET /api/settings/ssl
 | `trustStoreType` | `string` | TrustStore 类型: `PKCS12` / `JKS` |
 | `trustStorePath` | `string` | TrustStore 文件路径 |
 | `trustStorePasswordConfigured` | `boolean` | 是否已保存 TrustStore 密码；响应不会返回密码内容 |
-| `restartRequired` | `boolean` | 保存后是否需要重启服务才能生效 |
+| `restartRequired` | `boolean` | 保存的 SSL/TLS 参数需要同步到部署配置并重启服务才能生效 |
 
 ### 14.4 保存 SSL/TLS 设置
 
@@ -1712,16 +1712,16 @@ POST /api/settings/ssl/save
 
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|------|------|
-| `enabled` | `boolean` | 否 | 是否启用 SSL/TLS |
+| `enabled` | `boolean` | 是 | 是否启用 SSL/TLS |
 | `protocol` | `string` | 否 | 协议: `TLSv1.3` / `TLSv1.2` |
 | `clientAuth` | `string` | 否 | 客户端认证: `none` / `want` / `need` |
 | `keyStoreType` | `string` | 否 | KeyStore 类型: `PKCS12` / `JKS` |
 | `keyStorePath` | `string` | 否 | KeyStore 文件路径；启用 SSL/TLS 时必填 |
-| `keyStorePassword` | `string` | 否 | 新 KeyStore 密码；省略或传空值时保留现有密码 |
+| `keyStorePassword` | `string` | 否 | 新 KeyStore 密码；省略或传空值时保留现有密码；服务端以 base64 编码形式持久化 |
 | `clearKeyStorePassword` | `boolean` | 否 | 传 `true` 时显式清除现有 KeyStore 密码 |
 | `trustStoreType` | `string` | 否 | TrustStore 类型: `PKCS12` / `JKS` |
 | `trustStorePath` | `string` | 否 | TrustStore 文件路径；启用客户端认证时必填 |
-| `trustStorePassword` | `string` | 否 | 新 TrustStore 密码；省略或传空值时保留现有密码 |
+| `trustStorePassword` | `string` | 否 | 新 TrustStore 密码；省略或传空值时保留现有密码；服务端以 base64 编码形式持久化 |
 | `clearTrustStorePassword` | `boolean` | 否 | 传 `true` 时显式清除现有 TrustStore 密码 |
 
 **Response `data`:** `SslSettings`
@@ -1735,6 +1735,10 @@ POST /api/settings/ssl/validate
 ```
 
 **Request Body:** 同 `POST /api/settings/ssl/save`
+
+验证接口会读取 KeyStore/TrustStore 文件。为避免任意文件探测，文件路径必须位于
+`studio.settings.ssl.store-base-dir`（默认 `${user.dir}/config/tls`，可通过
+`STUDIO_SSL_STORE_BASE_DIR` 覆盖）目录内。
 
 **Response `data`:**
 

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.persistence;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.persistence.entity.RmqDataSource;
 import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
 import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
@@ -31,7 +32,9 @@ import org.apache.rocketmq.studio.settings.SslSettingsRecord;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -93,7 +96,7 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
             return SslSettingsRecord.defaults();
         }
         try {
-            return objectMapper.readValue(entity.getJson(), SslSettingsRecord.class);
+            return withDecodedSslPasswords(objectMapper.readValue(entity.getJson(), SslSettingsRecord.class));
         } catch (JsonProcessingException e) {
             log.error("Failed to deserialize SSL settings", e);
             throw new BusinessException(500, "Persisted SSL settings are invalid");
@@ -103,7 +106,53 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
     @Override
     @Transactional
     public void saveSslSettings(SslSettingsRecord settings) {
-        saveSettingsJson(SSL_SETTINGS_ID, settings);
+        saveSettingsJson(SSL_SETTINGS_ID, withEncodedSslPasswords(settings));
+    }
+
+    private SslSettingsRecord withDecodedSslPasswords(SslSettingsRecord settings) {
+        if (settings == null) {
+            return null;
+        }
+        return copySslSettings(settings, decodeStoredSslPassword(settings.getKeyStorePassword()),
+                decodeStoredSslPassword(settings.getTrustStorePassword()));
+    }
+
+    private SslSettingsRecord withEncodedSslPasswords(SslSettingsRecord settings) {
+        if (settings == null) {
+            return null;
+        }
+        return copySslSettings(settings, CredentialUtils.encodeBase64(settings.getKeyStorePassword()),
+                CredentialUtils.encodeBase64(settings.getTrustStorePassword()));
+    }
+
+    private String decodeStoredSslPassword(String stored) {
+        if (stored == null || stored.isEmpty()) {
+            return stored;
+        }
+        try {
+            String decoded = new String(Base64.getDecoder().decode(stored), StandardCharsets.UTF_8);
+            if (stored.equals(CredentialUtils.encodeBase64(decoded))) {
+                return decoded;
+            }
+        } catch (IllegalArgumentException ignored) {
+            // Legacy values written by early SSL settings builds were stored without encoding.
+        }
+        return stored;
+    }
+
+    private SslSettingsRecord copySslSettings(SslSettingsRecord source, String keyStorePassword,
+                                              String trustStorePassword) {
+        return SslSettingsRecord.builder()
+                .enabled(source.isEnabled())
+                .protocol(source.getProtocol())
+                .clientAuth(source.getClientAuth())
+                .keyStoreType(source.getKeyStoreType())
+                .keyStorePath(source.getKeyStorePath())
+                .keyStorePassword(keyStorePassword)
+                .trustStoreType(source.getTrustStoreType())
+                .trustStorePath(source.getTrustStorePath())
+                .trustStorePassword(trustStorePassword)
+                .build();
     }
 
     private void saveSettingsJson(String id, Object settings) {

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.settings.DataSourceVO;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.apache.rocketmq.studio.settings.SettingsRepository;
+import org.apache.rocketmq.studio.settings.SslSettingsRecord;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +41,7 @@ import java.util.stream.Collectors;
 public class MybatisPlusSettingsRepository implements SettingsRepository {
 
     private static final String SETTINGS_ID = "singleton";
+    private static final String SSL_SETTINGS_ID = "ssl";
 
     private final RmqSettingsMapper settingsMapper;
     private final RmqDataSourceMapper dataSourceMapper;
@@ -81,12 +83,36 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
     @Override
     @Transactional
     public void saveGeneralSettings(GeneralSettingsVO settings) {
+        saveSettingsJson(SETTINGS_ID, settings);
+    }
+
+    @Override
+    public SslSettingsRecord loadSslSettings() {
+        RmqSettings entity = settingsMapper.selectById(SSL_SETTINGS_ID);
+        if (entity == null || entity.getJson() == null) {
+            return SslSettingsRecord.defaults();
+        }
+        try {
+            return objectMapper.readValue(entity.getJson(), SslSettingsRecord.class);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to deserialize SSL settings", e);
+            throw new BusinessException(500, "Persisted SSL settings are invalid");
+        }
+    }
+
+    @Override
+    @Transactional
+    public void saveSslSettings(SslSettingsRecord settings) {
+        saveSettingsJson(SSL_SETTINGS_ID, settings);
+    }
+
+    private void saveSettingsJson(String id, Object settings) {
         try {
             String json = objectMapper.writeValueAsString(settings);
-            RmqSettings entity = settingsMapper.selectById(SETTINGS_ID);
+            RmqSettings entity = settingsMapper.selectById(id);
             if (entity == null) {
                 entity = new RmqSettings();
-                entity.setId(SETTINGS_ID);
+                entity.setId(id);
                 entity.setJson(json);
                 entity.setUpdatedAt(LocalDateTime.now());
                 settingsMapper.insert(entity);
@@ -96,7 +122,7 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
                 settingsMapper.updateById(entity);
             }
         } catch (JsonProcessingException e) {
-            log.error("Failed to serialize general settings", e);
+            log.error("Failed to serialize settings: {}", id, e);
             throw new RuntimeException("Failed to save settings", e);
         }
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsController.java
@@ -46,6 +46,22 @@ public class SettingsController {
         return Result.ok();
     }
 
+    @GetMapping("/ssl")
+    public Result<SslSettingsVO> getSslSettings() {
+        return Result.ok(settingsService.getSslSettings());
+    }
+
+    @PostMapping("/ssl/save")
+    public Result<SslSettingsVO> saveSslSettings(@RequestBody(required = false) SslSettingsUpdateDTO request) {
+        return Result.ok(settingsService.saveSslSettings(request));
+    }
+
+    @PostMapping("/ssl/validate")
+    public Result<SslSettingsValidationResultVO> validateSslSettings(
+            @RequestBody(required = false) SslSettingsUpdateDTO request) {
+        return Result.ok(settingsService.validateSslSettings(request));
+    }
+
     @GetMapping("/datasources")
     public Result<List<DataSourceVO>> listDataSources() {
         return Result.ok(settingsService.listDataSources());

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsController.java
@@ -52,13 +52,13 @@ public class SettingsController {
     }
 
     @PostMapping("/ssl/save")
-    public Result<SslSettingsVO> saveSslSettings(@RequestBody(required = false) SslSettingsUpdateDTO request) {
+    public Result<SslSettingsVO> saveSslSettings(@Valid @RequestBody SslSettingsUpdateDTO request) {
         return Result.ok(settingsService.saveSslSettings(request));
     }
 
     @PostMapping("/ssl/validate")
     public Result<SslSettingsValidationResultVO> validateSslSettings(
-            @RequestBody(required = false) SslSettingsUpdateDTO request) {
+            @Valid @RequestBody SslSettingsUpdateDTO request) {
         return Result.ok(settingsService.validateSslSettings(request));
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -22,9 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.UrlHostGuard;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -37,10 +34,18 @@ import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -67,6 +72,9 @@ public class SettingsService {
     private static final String AUTH_BEARER = "bearer token";
     private static final Duration DATA_SOURCE_TEST_CONNECT_TIMEOUT = Duration.ofSeconds(3);
     private static final Duration DATA_SOURCE_TEST_READ_TIMEOUT = Duration.ofSeconds(5);
+    private static final Set<String> SSL_PROTOCOLS = Set.of("TLSv1.2", "TLSv1.3");
+    private static final Set<String> SSL_CLIENT_AUTH = Set.of("none", "want", "need");
+    private static final Set<String> SSL_STORE_TYPES = Set.of("JKS", "PKCS12");
 
     private final SettingsRepository settingsRepository;
     private final RestClient restClient;
@@ -120,6 +128,181 @@ public class SettingsService {
         } catch (Exception auditFailure) {
             log.warn("Failed to record general settings audit: {}", auditFailure.getMessage());
         }
+    }
+
+    public SslSettingsVO getSslSettings() {
+        log.debug("Loading SSL settings");
+        return toSslSettingsVO(settingsRepository.loadSslSettings());
+    }
+
+    public synchronized SslSettingsVO saveSslSettings(SslSettingsUpdateDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "SSL settings request is required");
+        }
+        SslSettingsRecord updated = mergeSslSettings(settingsRepository.loadSslSettings(), request);
+        validateSslSettingsRecord(updated);
+        settingsRepository.saveSslSettings(updated);
+        recordSslSettingsAudit(updated);
+        return toSslSettingsVO(updated);
+    }
+
+    public SslSettingsValidationResultVO validateSslSettings(SslSettingsUpdateDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "SSL settings request is required");
+        }
+        SslSettingsRecord settings = mergeSslSettings(settingsRepository.loadSslSettings(), request);
+        validateSslSettingsRecord(settings);
+        if (!settings.isEnabled()) {
+            return SslSettingsValidationResultVO.builder()
+                    .success(true)
+                    .message("SSL/TLS is disabled")
+                    .warnings(List.of())
+                    .build();
+        }
+
+        List<String> warnings = new ArrayList<>();
+        try {
+            loadKeyStore("KeyStore", settings.getKeyStoreType(), settings.getKeyStorePath(),
+                    settings.getKeyStorePassword());
+            if (!AUTH_NONE.equals(settings.getClientAuth())) {
+                loadKeyStore("TrustStore", settings.getTrustStoreType(), settings.getTrustStorePath(),
+                        settings.getTrustStorePassword());
+            } else if (StringUtils.hasText(settings.getTrustStorePath())) {
+                warnings.add("TrustStore is configured but client authentication is disabled");
+            }
+        } catch (IllegalArgumentException exception) {
+            return SslSettingsValidationResultVO.builder()
+                    .success(false)
+                    .message(exception.getMessage())
+                    .warnings(warnings)
+                    .build();
+        }
+
+        return SslSettingsValidationResultVO.builder()
+                .success(true)
+                .message("SSL/TLS keystore settings are valid")
+                .warnings(warnings)
+                .build();
+    }
+
+    private void recordSslSettingsAudit(SslSettingsRecord settings) {
+        try {
+            operationAuditService.record("UPDATE_SSL_SETTINGS", "SETTINGS", "ssl",
+                    null, "enabled=" + settings.isEnabled() + ", protocol=" + settings.getProtocol()
+                            + ", clientAuth=" + settings.getClientAuth(), "SUCCESS", null);
+        } catch (Exception auditFailure) {
+            log.warn("Failed to record SSL settings audit: {}", auditFailure.getMessage());
+        }
+    }
+
+    private SslSettingsVO toSslSettingsVO(SslSettingsRecord settings) {
+        SslSettingsRecord normalized = settings == null ? SslSettingsRecord.defaults() : settings;
+        return SslSettingsVO.builder()
+                .enabled(normalized.isEnabled())
+                .protocol(defaultIfBlank(normalized.getProtocol(), "TLSv1.3"))
+                .clientAuth(defaultIfBlank(normalized.getClientAuth(), AUTH_NONE))
+                .keyStoreType(defaultIfBlank(normalized.getKeyStoreType(), "PKCS12"))
+                .keyStorePath(defaultIfBlank(normalized.getKeyStorePath(), ""))
+                .keyStorePasswordConfigured(StringUtils.hasText(normalized.getKeyStorePassword()))
+                .trustStoreType(defaultIfBlank(normalized.getTrustStoreType(), "PKCS12"))
+                .trustStorePath(defaultIfBlank(normalized.getTrustStorePath(), ""))
+                .trustStorePasswordConfigured(StringUtils.hasText(normalized.getTrustStorePassword()))
+                .restartRequired(normalized.isEnabled())
+                .build();
+    }
+
+    private SslSettingsRecord mergeSslSettings(SslSettingsRecord current, SslSettingsUpdateDTO request) {
+        SslSettingsRecord existing = current == null ? SslSettingsRecord.defaults() : current;
+        String keyStorePassword = existing.getKeyStorePassword();
+        if (request.isClearKeyStorePassword()) {
+            keyStorePassword = "";
+        } else if (StringUtils.hasText(request.getKeyStorePassword())) {
+            keyStorePassword = request.getKeyStorePassword();
+        }
+
+        String trustStorePassword = existing.getTrustStorePassword();
+        if (request.isClearTrustStorePassword()) {
+            trustStorePassword = "";
+        } else if (StringUtils.hasText(request.getTrustStorePassword())) {
+            trustStorePassword = request.getTrustStorePassword();
+        }
+
+        return SslSettingsRecord.builder()
+                .enabled(request.getEnabled() == null ? existing.isEnabled() : request.getEnabled())
+                .protocol(normalizeSslProtocol(defaultIfBlank(request.getProtocol(), existing.getProtocol())))
+                .clientAuth(normalizeSslClientAuth(defaultIfBlank(request.getClientAuth(), existing.getClientAuth())))
+                .keyStoreType(normalizeSslStoreType(defaultIfBlank(request.getKeyStoreType(),
+                        existing.getKeyStoreType())))
+                .keyStorePath(defaultIfBlank(request.getKeyStorePath(), existing.getKeyStorePath()).trim())
+                .keyStorePassword(defaultIfBlank(keyStorePassword, ""))
+                .trustStoreType(normalizeSslStoreType(defaultIfBlank(request.getTrustStoreType(),
+                        existing.getTrustStoreType())))
+                .trustStorePath(defaultIfBlank(request.getTrustStorePath(), existing.getTrustStorePath()).trim())
+                .trustStorePassword(defaultIfBlank(trustStorePassword, ""))
+                .build();
+    }
+
+    private void validateSslSettingsRecord(SslSettingsRecord settings) {
+        if (!settings.isEnabled()) {
+            return;
+        }
+        if (!StringUtils.hasText(settings.getKeyStorePath())) {
+            throw new BusinessException(400, "KeyStore path is required when SSL/TLS is enabled");
+        }
+        if (!AUTH_NONE.equals(settings.getClientAuth()) && !StringUtils.hasText(settings.getTrustStorePath())) {
+            throw new BusinessException(400,
+                    "TrustStore path is required when SSL/TLS client authentication is enabled");
+        }
+    }
+
+    private void loadKeyStore(String label, String type, String rawPath, String password) {
+        if (!StringUtils.hasText(rawPath)) {
+            throw new IllegalArgumentException(label + " path is required");
+        }
+        Path path = Path.of(rawPath.trim()).normalize();
+        if (!Files.isRegularFile(path)) {
+            throw new IllegalArgumentException(label + " file does not exist: " + path);
+        }
+        if (!Files.isReadable(path)) {
+            throw new IllegalArgumentException(label + " file is not readable: " + path);
+        }
+        try (InputStream input = Files.newInputStream(path)) {
+            KeyStore keyStore = KeyStore.getInstance(type);
+            keyStore.load(input, StringUtils.hasText(password) ? password.toCharArray() : null);
+        } catch (IOException | GeneralSecurityException exception) {
+            throw new IllegalArgumentException(label + " cannot be loaded: " + exception.getMessage(), exception);
+        }
+    }
+
+    private String normalizeSslProtocol(String protocol) {
+        String normalized = defaultIfBlank(protocol, "TLSv1.3").trim();
+        if (!SSL_PROTOCOLS.contains(normalized)) {
+            throw new BusinessException(400, "SSL protocol must be one of TLSv1.2, TLSv1.3");
+        }
+        return normalized;
+    }
+
+    private String normalizeSslClientAuth(String clientAuth) {
+        String normalized = defaultIfBlank(clientAuth, AUTH_NONE).trim().toLowerCase(Locale.ROOT);
+        if (!SSL_CLIENT_AUTH.contains(normalized)) {
+            throw new BusinessException(400, "SSL client authentication must be one of none, want, need");
+        }
+        return normalized;
+    }
+
+    private String normalizeSslStoreType(String storeType) {
+        String normalized = defaultIfBlank(storeType, "PKCS12").trim().toUpperCase(Locale.ROOT);
+        if (!SSL_STORE_TYPES.contains(normalized)) {
+            throw new BusinessException(400, "SSL store type must be one of JKS, PKCS12");
+        }
+        return normalized;
+    }
+
+    private String defaultIfBlank(String value, String fallback) {
+        if (StringUtils.hasText(value)) {
+            return value;
+        }
+        return fallback == null ? "" : fallback;
     }
 
     private void recordDataSourceAudit(String operation, DataSourceVO dataSource) {

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.UrlHostGuard;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -80,18 +81,29 @@ public class SettingsService {
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final OperationAuditService operationAuditService;
+    private final Path sslStoreBaseDir;
 
     public SettingsService(SettingsRepository settingsRepository, RestClient.Builder restClientBuilder,
-                           ObjectMapper objectMapper, OperationAuditService operationAuditService) {
-        this(settingsRepository, buildDataSourceRestClient(restClientBuilder), objectMapper, operationAuditService);
+                           ObjectMapper objectMapper, OperationAuditService operationAuditService,
+                           @Value("${studio.settings.ssl.store-base-dir:${user.dir}/config/tls}")
+                           String sslStoreBaseDir) {
+        this(settingsRepository, buildDataSourceRestClient(restClientBuilder), objectMapper, operationAuditService,
+                sslStoreBaseDir);
     }
 
     SettingsService(SettingsRepository settingsRepository, RestClient restClient,
                     ObjectMapper objectMapper, OperationAuditService operationAuditService) {
+        this(settingsRepository, restClient, objectMapper, operationAuditService, "config/tls");
+    }
+
+    SettingsService(SettingsRepository settingsRepository, RestClient restClient,
+                    ObjectMapper objectMapper, OperationAuditService operationAuditService,
+                    String sslStoreBaseDir) {
         this.settingsRepository = settingsRepository;
         this.restClient = restClient;
         this.objectMapper = objectMapper;
         this.operationAuditService = operationAuditService;
+        this.sslStoreBaseDir = Path.of(defaultIfBlank(sslStoreBaseDir, "config/tls")).toAbsolutePath().normalize();
     }
 
     private static RestClient buildDataSourceRestClient(RestClient.Builder restClientBuilder) {
@@ -207,7 +219,7 @@ public class SettingsService {
                 .trustStoreType(defaultIfBlank(normalized.getTrustStoreType(), "PKCS12"))
                 .trustStorePath(defaultIfBlank(normalized.getTrustStorePath(), ""))
                 .trustStorePasswordConfigured(StringUtils.hasText(normalized.getTrustStorePassword()))
-                .restartRequired(normalized.isEnabled())
+                .restartRequired(true)
                 .build();
     }
 
@@ -259,7 +271,10 @@ public class SettingsService {
         if (!StringUtils.hasText(rawPath)) {
             throw new IllegalArgumentException(label + " path is required");
         }
-        Path path = Path.of(rawPath.trim()).normalize();
+        Path path = Path.of(rawPath.trim()).toAbsolutePath().normalize();
+        if (!path.startsWith(sslStoreBaseDir)) {
+            throw new IllegalArgumentException(label + " path must be under " + sslStoreBaseDir);
+        }
         if (!Files.isRegularFile(path)) {
             throw new IllegalArgumentException(label + " file does not exist: " + path);
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SslSettingsRecord.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SslSettingsRecord.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.settings;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SslSettingsRecord {
+    private boolean enabled;
+    private String protocol;
+    private String clientAuth;
+    private String keyStoreType;
+    private String keyStorePath;
+    @ToString.Exclude
+    private String keyStorePassword;
+    private String trustStoreType;
+    private String trustStorePath;
+    @ToString.Exclude
+    private String trustStorePassword;
+
+    public static SslSettingsRecord defaults() {
+        return SslSettingsRecord.builder()
+                .enabled(false)
+                .protocol("TLSv1.3")
+                .clientAuth("none")
+                .keyStoreType("PKCS12")
+                .keyStorePath("")
+                .keyStorePassword("")
+                .trustStoreType("PKCS12")
+                .trustStorePath("")
+                .trustStorePassword("")
+                .build();
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SslSettingsUpdateDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SslSettingsUpdateDTO.java
@@ -16,27 +16,22 @@
  */
 package org.apache.rocketmq.studio.settings;
 
+import lombok.Data;
+import lombok.ToString;
 
-import java.util.List;
-import java.util.Optional;
-
-public interface SettingsRepository {
-
-    GeneralSettingsVO loadGeneralSettings();
-
-    void saveGeneralSettings(GeneralSettingsVO settings);
-
-    SslSettingsRecord loadSslSettings();
-
-    void saveSslSettings(SslSettingsRecord settings);
-
-    List<DataSourceVO> findAllDataSources();
-
-    DataSourceVO saveDataSource(DataSourceVO dataSource);
-
-    boolean replaceDataSource(DataSourceVO dataSource);
-
-    boolean deleteDataSource(String key);
-
-    Optional<DataSourceVO> findDataSourceByKey(String key);
+@Data
+public class SslSettingsUpdateDTO {
+    private Boolean enabled;
+    private String protocol;
+    private String clientAuth;
+    private String keyStoreType;
+    private String keyStorePath;
+    @ToString.Exclude
+    private String keyStorePassword;
+    private boolean clearKeyStorePassword;
+    private String trustStoreType;
+    private String trustStorePath;
+    @ToString.Exclude
+    private String trustStorePassword;
+    private boolean clearTrustStorePassword;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SslSettingsUpdateDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SslSettingsUpdateDTO.java
@@ -16,22 +16,47 @@
  */
 package org.apache.rocketmq.studio.settings;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.ToString;
 
 @Data
 public class SslSettingsUpdateDTO {
+    @NotNull(message = "enabled is required")
     private Boolean enabled;
+
+    @Pattern(regexp = "TLSv1\\.2|TLSv1\\.3", message = "SSL protocol must be one of TLSv1.2, TLSv1.3")
     private String protocol;
+
+    @Pattern(regexp = "none|want|need", flags = Pattern.Flag.CASE_INSENSITIVE,
+            message = "SSL client authentication must be one of none, want, need")
     private String clientAuth;
+
+    @Pattern(regexp = "JKS|PKCS12", flags = Pattern.Flag.CASE_INSENSITIVE,
+            message = "SSL store type must be one of JKS, PKCS12")
     private String keyStoreType;
+
+    @Size(max = 1024, message = "KeyStore path is too long")
     private String keyStorePath;
+
+    @Size(max = 4096, message = "KeyStore password is too long")
     @ToString.Exclude
     private String keyStorePassword;
+
     private boolean clearKeyStorePassword;
+
+    @Pattern(regexp = "JKS|PKCS12", flags = Pattern.Flag.CASE_INSENSITIVE,
+            message = "SSL store type must be one of JKS, PKCS12")
     private String trustStoreType;
+
+    @Size(max = 1024, message = "TrustStore path is too long")
     private String trustStorePath;
+
+    @Size(max = 4096, message = "TrustStore password is too long")
     @ToString.Exclude
     private String trustStorePassword;
+
     private boolean clearTrustStorePassword;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SslSettingsVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SslSettingsVO.java
@@ -16,27 +16,24 @@
  */
 package org.apache.rocketmq.studio.settings;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import java.util.List;
-import java.util.Optional;
-
-public interface SettingsRepository {
-
-    GeneralSettingsVO loadGeneralSettings();
-
-    void saveGeneralSettings(GeneralSettingsVO settings);
-
-    SslSettingsRecord loadSslSettings();
-
-    void saveSslSettings(SslSettingsRecord settings);
-
-    List<DataSourceVO> findAllDataSources();
-
-    DataSourceVO saveDataSource(DataSourceVO dataSource);
-
-    boolean replaceDataSource(DataSourceVO dataSource);
-
-    boolean deleteDataSource(String key);
-
-    Optional<DataSourceVO> findDataSourceByKey(String key);
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SslSettingsVO {
+    private boolean enabled;
+    private String protocol;
+    private String clientAuth;
+    private String keyStoreType;
+    private String keyStorePath;
+    private boolean keyStorePasswordConfigured;
+    private String trustStoreType;
+    private String trustStorePath;
+    private boolean trustStorePasswordConfigured;
+    private boolean restartRequired;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SslSettingsValidationResultVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SslSettingsValidationResultVO.java
@@ -16,27 +16,19 @@
  */
 package org.apache.rocketmq.studio.settings;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.Optional;
 
-public interface SettingsRepository {
-
-    GeneralSettingsVO loadGeneralSettings();
-
-    void saveGeneralSettings(GeneralSettingsVO settings);
-
-    SslSettingsRecord loadSslSettings();
-
-    void saveSslSettings(SslSettingsRecord settings);
-
-    List<DataSourceVO> findAllDataSources();
-
-    DataSourceVO saveDataSource(DataSourceVO dataSource);
-
-    boolean replaceDataSource(DataSourceVO dataSource);
-
-    boolean deleteDataSource(String key);
-
-    Optional<DataSourceVO> findDataSourceByKey(String key);
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SslSettingsValidationResultVO {
+    private boolean success;
+    private String message;
+    private List<String> warnings;
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -49,6 +49,9 @@ studio:
   query-history:
     retention-days: ${STUDIO_QUERY_HISTORY_RETENTION_DAYS:90}
     cleanup-interval: ${STUDIO_QUERY_HISTORY_CLEANUP_INTERVAL:PT24H}
+  settings:
+    ssl:
+      store-base-dir: ${STUDIO_SSL_STORE_BASE_DIR:${user.dir}/config/tls}
   llm:
     token: ${RMQ_LLM_TOKEN:}
     anthropic-base-url: ${RMQ_ANTHROPIC_BASE_URL:}

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -8,6 +8,7 @@ package org.apache.rocketmq.studio.persistence;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.persistence.entity.RmqDataSource;
 import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
 import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
@@ -94,6 +95,48 @@ class MybatisPlusSettingsRepositoryTest {
                   "clientAuth": "need",
                   "keyStoreType": "PKCS12",
                   "keyStorePath": "/etc/server.p12",
+                  "keyStorePassword": "%s"
+                }
+                """.formatted(CredentialUtils.encodeBase64("secret")));
+        when(settingsMapper.selectById("ssl")).thenReturn(settings);
+
+        SslSettingsRecord loaded = repository.loadSslSettings();
+
+        assertThat(loaded.isEnabled()).isTrue();
+        assertThat(loaded.getProtocol()).isEqualTo("TLSv1.2");
+        assertThat(loaded.getKeyStorePassword()).isEqualTo("secret");
+    }
+
+    @Test
+    void shouldTolerateLegacyPlainTextSslPasswords() {
+        RmqSettings settings = new RmqSettings();
+        settings.setJson("""
+                {
+                  "enabled": true,
+                  "protocol": "TLSv1.2",
+                  "clientAuth": "none",
+                  "keyStoreType": "PKCS12",
+                  "keyStorePath": "/etc/server.p12",
+                  "keyStorePassword": "legacy-secret"
+                }
+                """);
+        when(settingsMapper.selectById("ssl")).thenReturn(settings);
+
+        SslSettingsRecord loaded = repository.loadSslSettings();
+
+        assertThat(loaded.getKeyStorePassword()).isEqualTo("legacy-secret");
+    }
+
+    @Test
+    void shouldTolerateLegacyPlainTextSslPasswordThatLooksBase64Decodable() {
+        RmqSettings settings = new RmqSettings();
+        settings.setJson("""
+                {
+                  "enabled": true,
+                  "protocol": "TLSv1.2",
+                  "clientAuth": "none",
+                  "keyStoreType": "PKCS12",
+                  "keyStorePath": "/etc/server.p12",
                   "keyStorePassword": "secret"
                 }
                 """);
@@ -101,8 +144,6 @@ class MybatisPlusSettingsRepositoryTest {
 
         SslSettingsRecord loaded = repository.loadSslSettings();
 
-        assertThat(loaded.isEnabled()).isTrue();
-        assertThat(loaded.getProtocol()).isEqualTo("TLSv1.2");
         assertThat(loaded.getKeyStorePassword()).isEqualTo("secret");
     }
 
@@ -119,7 +160,8 @@ class MybatisPlusSettingsRepositoryTest {
         verify(settingsMapper).insert(argThat((RmqSettings entity) ->
                 "ssl".equals(entity.getId())
                         && entity.getJson().contains("/etc/server.p12")
-                        && entity.getJson().contains("secret")));
+                        && entity.getJson().contains(CredentialUtils.encodeBase64("secret"))
+                        && !entity.getJson().contains("\"keyStorePassword\":\"secret\"")));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -13,12 +13,15 @@ import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
 import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqSettingsMapper;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
+import org.apache.rocketmq.studio.settings.SslSettingsRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MybatisPlusSettingsRepositoryTest {
@@ -68,6 +71,68 @@ class MybatisPlusSettingsRepositoryTest {
 
         assertThat(loaded.getTheme()).isEqualTo("dark");
         assertThat(loaded.isRequireLogin()).isTrue();
+    }
+
+    @Test
+    void shouldReturnDefaultsWhenSslSettingsDoNotExist() {
+        when(settingsMapper.selectById("ssl")).thenReturn(null);
+
+        SslSettingsRecord settings = repository.loadSslSettings();
+
+        assertThat(settings.isEnabled()).isFalse();
+        assertThat(settings.getProtocol()).isEqualTo("TLSv1.3");
+        assertThat(settings.getKeyStoreType()).isEqualTo("PKCS12");
+    }
+
+    @Test
+    void shouldReadValidPersistedSslSettings() {
+        RmqSettings settings = new RmqSettings();
+        settings.setJson("""
+                {
+                  "enabled": true,
+                  "protocol": "TLSv1.2",
+                  "clientAuth": "need",
+                  "keyStoreType": "PKCS12",
+                  "keyStorePath": "/etc/server.p12",
+                  "keyStorePassword": "secret"
+                }
+                """);
+        when(settingsMapper.selectById("ssl")).thenReturn(settings);
+
+        SslSettingsRecord loaded = repository.loadSslSettings();
+
+        assertThat(loaded.isEnabled()).isTrue();
+        assertThat(loaded.getProtocol()).isEqualTo("TLSv1.2");
+        assertThat(loaded.getKeyStorePassword()).isEqualTo("secret");
+    }
+
+    @Test
+    void shouldSaveSslSettingsUnderDedicatedSettingsRow() {
+        when(settingsMapper.selectById("ssl")).thenReturn(null);
+        SslSettingsRecord settings = SslSettingsRecord.defaults();
+        settings.setEnabled(true);
+        settings.setKeyStorePath("/etc/server.p12");
+        settings.setKeyStorePassword("secret");
+
+        repository.saveSslSettings(settings);
+
+        verify(settingsMapper).insert(argThat((RmqSettings entity) ->
+                "ssl".equals(entity.getId())
+                        && entity.getJson().contains("/etc/server.p12")
+                        && entity.getJson().contains("secret")));
+    }
+
+    @Test
+    void shouldRejectCorruptPersistedSslSettings() {
+        RmqSettings settings = new RmqSettings();
+        settings.setJson("{not-json");
+        when(settingsMapper.selectById("ssl")).thenReturn(settings);
+
+        assertThatThrownBy(repository::loadSslSettings)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Persisted SSL settings are invalid")
+                .extracting("code")
+                .isEqualTo(500);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
@@ -17,7 +17,9 @@
 package org.apache.rocketmq.studio.settings;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.auth.AuthService;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -54,6 +56,15 @@ class SettingsControllerTest {
 
     @MockBean
     private SettingsService settingsService;
+
+    @MockBean
+    private AuthService authService;
+
+    @BeforeEach
+    void setUpAuth() {
+        when(authService.isAuthenticated(any())).thenReturn(true);
+        when(authService.isAdmin(any())).thenReturn(true);
+    }
 
     @Test
     void getGeneralSettingsShouldReturnSettings() throws Exception {
@@ -157,6 +168,97 @@ class SettingsControllerTest {
                 .andExpect(status().isBadRequest());
 
         verifyNoInteractions(settingsService);
+    }
+
+    @Test
+    void getSslSettingsShouldReturnSettingsWithoutPasswords() throws Exception {
+        SslSettingsVO settings = SslSettingsVO.builder()
+                .enabled(true)
+                .protocol("TLSv1.3")
+                .clientAuth("need")
+                .keyStoreType("PKCS12")
+                .keyStorePath("/etc/rocketmq/server.p12")
+                .keyStorePasswordConfigured(true)
+                .trustStoreType("PKCS12")
+                .trustStorePath("/etc/rocketmq/trust.p12")
+                .trustStorePasswordConfigured(false)
+                .restartRequired(true)
+                .build();
+        when(settingsService.getSslSettings()).thenReturn(settings);
+
+        mockMvc.perform(get("/api/settings/ssl"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code", is(200)))
+                .andExpect(jsonPath("$.data.enabled", is(true)))
+                .andExpect(jsonPath("$.data.protocol", is("TLSv1.3")))
+                .andExpect(jsonPath("$.data.clientAuth", is("need")))
+                .andExpect(jsonPath("$.data.keyStorePath", is("/etc/rocketmq/server.p12")))
+                .andExpect(jsonPath("$.data.keyStorePassword").doesNotExist())
+                .andExpect(jsonPath("$.data.keyStorePasswordConfigured", is(true)))
+                .andExpect(jsonPath("$.data.trustStorePassword").doesNotExist());
+    }
+
+    @Test
+    void saveSslSettingsShouldReturnSanitizedSettings() throws Exception {
+        SslSettingsVO saved = SslSettingsVO.builder()
+                .enabled(true)
+                .protocol("TLSv1.3")
+                .clientAuth("none")
+                .keyStoreType("PKCS12")
+                .keyStorePath("/etc/rocketmq/server.p12")
+                .keyStorePasswordConfigured(true)
+                .trustStoreType("PKCS12")
+                .trustStorePath("")
+                .restartRequired(true)
+                .build();
+        when(settingsService.saveSslSettings(any(SslSettingsUpdateDTO.class))).thenReturn(saved);
+
+        mockMvc.perform(post("/api/settings/ssl/save")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "enabled": true,
+                                  "protocol": "TLSv1.3",
+                                  "clientAuth": "none",
+                                  "keyStoreType": "PKCS12",
+                                  "keyStorePath": "/etc/rocketmq/server.p12",
+                                  "keyStorePassword": "secret",
+                                  "trustStoreType": "PKCS12",
+                                  "trustStorePath": ""
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.keyStorePassword").doesNotExist())
+                .andExpect(jsonPath("$.data.keyStorePasswordConfigured", is(true)));
+
+        verify(settingsService).saveSslSettings(argThat(request ->
+                "secret".equals(request.getKeyStorePassword())
+                        && "/etc/rocketmq/server.p12".equals(request.getKeyStorePath())));
+    }
+
+    @Test
+    void validateSslSettingsShouldReturnValidationResult() throws Exception {
+        when(settingsService.validateSslSettings(any(SslSettingsUpdateDTO.class))).thenReturn(
+                SslSettingsValidationResultVO.builder()
+                        .success(true)
+                        .message("SSL/TLS keystore settings are valid")
+                        .warnings(List.of())
+                        .build());
+
+        mockMvc.perform(post("/api/settings/ssl/validate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "enabled": true,
+                                  "protocol": "TLSv1.3",
+                                  "clientAuth": "none",
+                                  "keyStoreType": "PKCS12",
+                                  "keyStorePath": "/etc/rocketmq/server.p12"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.success", is(true)))
+                .andExpect(jsonPath("$.data.message", is("SSL/TLS keystore settings are valid")));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
@@ -237,6 +237,24 @@ class SettingsControllerTest {
     }
 
     @Test
+    void saveSslSettingsShouldRejectInvalidProtocolBeforeServiceCall() throws Exception {
+        mockMvc.perform(post("/api/settings/ssl/save")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "enabled": true,
+                                  "protocol": "SSLv3",
+                                  "clientAuth": "none",
+                                  "keyStoreType": "PKCS12",
+                                  "keyStorePath": "/etc/rocketmq/server.p12"
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(settingsService);
+    }
+
+    @Test
     void validateSslSettingsShouldReturnValidationResult() throws Exception {
         when(settingsService.validateSslSettings(any(SslSettingsUpdateDTO.class))).thenReturn(
                 SslSettingsValidationResultVO.builder()

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -79,12 +79,15 @@ class SettingsServiceTest {
 
     private MockRestServiceServer prometheusServer;
 
+    @TempDir
+    private Path sslStoreBaseDir;
+
     @BeforeEach
     void setUp() {
         RestClient.Builder restClientBuilder = RestClient.builder();
         prometheusServer = MockRestServiceServer.bindTo(restClientBuilder).build();
         settingsService = new SettingsService(settingsRepository, restClientBuilder.build(),
-                new ObjectMapper(), operationAuditService);
+                new ObjectMapper(), operationAuditService, sslStoreBaseDir.toString());
     }
 
 
@@ -272,8 +275,8 @@ class SettingsServiceTest {
     }
 
     @Test
-    void validateSslSettingsShouldLoadConfiguredKeyStore(@TempDir Path tempDir) throws Exception {
-        Path keyStore = tempDir.resolve("server.p12");
+    void validateSslSettingsShouldLoadConfiguredKeyStore() throws Exception {
+        Path keyStore = sslStoreBaseDir.resolve("server.p12");
         writePkcs12Store(keyStore, "secret");
         SslSettingsUpdateDTO request = new SslSettingsUpdateDTO();
         request.setEnabled(true);
@@ -298,13 +301,32 @@ class SettingsServiceTest {
         request.setProtocol("TLSv1.3");
         request.setClientAuth("none");
         request.setKeyStoreType("PKCS12");
-        request.setKeyStorePath("/path/not-found/server.p12");
+        request.setKeyStorePath(sslStoreBaseDir.resolve("not-found/server.p12").toString());
         request.setTrustStoreType("PKCS12");
 
         SslSettingsValidationResultVO result = settingsService.validateSslSettings(request);
 
         assertThat(result.isSuccess()).isFalse();
         assertThat(result.getMessage()).contains("KeyStore file does not exist");
+    }
+
+    @Test
+    void validateSslSettingsShouldRejectKeyStoreOutsideAllowedDirectory(@TempDir Path otherDir) throws Exception {
+        Path keyStore = otherDir.resolve("server.p12");
+        writePkcs12Store(keyStore, "secret");
+        SslSettingsUpdateDTO request = new SslSettingsUpdateDTO();
+        request.setEnabled(true);
+        request.setProtocol("TLSv1.3");
+        request.setClientAuth("none");
+        request.setKeyStoreType("PKCS12");
+        request.setKeyStorePath(keyStore.toString());
+        request.setKeyStorePassword("secret");
+        request.setTrustStoreType("PKCS12");
+
+        SslSettingsValidationResultVO result = settingsService.validateSslSettings(request);
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getMessage()).contains("KeyStore path must be under");
     }
 
     private void writePkcs12Store(Path path, String password) throws Exception {
@@ -435,31 +457,28 @@ class SettingsServiceTest {
 
     @Test
     void updateDataSourceShouldRejectUnknownKey() {
-        SettingsService service = new SettingsService(settingsRepository, RestClient.builder(), new ObjectMapper(), operationAuditService);
         DataSourceVO input = DataSourceVO.builder().key("missing").name("Unexpected DS").type("rocketmq")
                 .url("http://10.1.2.3").build();
 
-        assertThatThrownBy(() -> service.updateDataSource(input))
+        assertThatThrownBy(() -> settingsService.updateDataSource(input))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Data source not found: missing")
                 .extracting("code")
                 .isEqualTo(404);
-        assertThat(service.listDataSources()).isEmpty();
+        assertThat(settingsService.listDataSources()).isEmpty();
     }
 
     @Test
     void updateDataSourceShouldRejectBlankKey() {
-        SettingsService service = new SettingsService(settingsRepository, RestClient.builder(), new ObjectMapper(),
-                operationAuditService);
         DataSourceVO input = DataSourceVO.builder().key(" ").name("Unexpected DS").type("rocketmq")
                 .url("http://10.1.2.3").build();
 
-        assertThatThrownBy(() -> service.updateDataSource(input))
+        assertThatThrownBy(() -> settingsService.updateDataSource(input))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Data source key is required")
                 .extracting("code")
                 .isEqualTo(400);
-        assertThat(service.listDataSources()).isEmpty();
+        assertThat(settingsService.listDataSources()).isEmpty();
     }
 
     @Test
@@ -475,10 +494,7 @@ class SettingsServiceTest {
 
     @Test
     void deleteDataSourceShouldRejectUnknownKey() {
-        SettingsService service = new SettingsService(settingsRepository, RestClient.builder(), new ObjectMapper(),
-                operationAuditService);
-
-        assertThatThrownBy(() -> service.deleteDataSource("missing"))
+        assertThatThrownBy(() -> settingsService.deleteDataSource("missing"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Data source not found: missing")
                 .extracting("code")

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
@@ -32,8 +33,12 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
+import java.io.OutputStream;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -44,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -194,6 +200,119 @@ class SettingsServiceTest {
         verify(settingsRepository).saveGeneralSettings(update);
         verify(operationAuditService).record("UPDATE_SETTINGS", "SETTINGS", "general",
                 null, "General settings updated", "SUCCESS", null);
+    }
+
+    @Test
+    void getSslSettingsShouldHidePersistedPasswords() {
+        when(settingsRepository.loadSslSettings()).thenReturn(SslSettingsRecord.builder()
+                .enabled(true)
+                .protocol("TLSv1.3")
+                .clientAuth("none")
+                .keyStoreType("PKCS12")
+                .keyStorePath("/etc/rocketmq/server.p12")
+                .keyStorePassword("secret")
+                .trustStoreType("PKCS12")
+                .trustStorePath("")
+                .trustStorePassword("")
+                .build());
+
+        SslSettingsVO result = settingsService.getSslSettings();
+
+        assertThat(result.isEnabled()).isTrue();
+        assertThat(result.getKeyStorePath()).isEqualTo("/etc/rocketmq/server.p12");
+        assertThat(result.isKeyStorePasswordConfigured()).isTrue();
+        assertThat(result.isTrustStorePasswordConfigured()).isFalse();
+    }
+
+    @Test
+    void saveSslSettingsShouldPreserveExistingPasswordsWhenOmitted() {
+        when(settingsRepository.loadSslSettings()).thenReturn(SslSettingsRecord.builder()
+                .enabled(true)
+                .protocol("TLSv1.2")
+                .clientAuth("none")
+                .keyStoreType("PKCS12")
+                .keyStorePath("/old/server.p12")
+                .keyStorePassword("existing-secret")
+                .trustStoreType("PKCS12")
+                .trustStorePath("")
+                .trustStorePassword("")
+                .build());
+        SslSettingsUpdateDTO request = new SslSettingsUpdateDTO();
+        request.setEnabled(true);
+        request.setProtocol("TLSv1.3");
+        request.setClientAuth("none");
+        request.setKeyStoreType("PKCS12");
+        request.setKeyStorePath("/etc/rocketmq/server.p12");
+        request.setTrustStoreType("PKCS12");
+
+        SslSettingsVO saved = settingsService.saveSslSettings(request);
+
+        assertThat(saved.getProtocol()).isEqualTo("TLSv1.3");
+        assertThat(saved.isKeyStorePasswordConfigured()).isTrue();
+        verify(settingsRepository).saveSslSettings(argThat(settings ->
+                "existing-secret".equals(settings.getKeyStorePassword())
+                        && "/etc/rocketmq/server.p12".equals(settings.getKeyStorePath())));
+        verify(operationAuditService).record("UPDATE_SSL_SETTINGS", "SETTINGS", "ssl",
+                null, "enabled=true, protocol=TLSv1.3, clientAuth=none", "SUCCESS", null);
+    }
+
+    @Test
+    void saveSslSettingsShouldRejectEnabledConfigWithoutKeyStorePath() {
+        SslSettingsUpdateDTO request = new SslSettingsUpdateDTO();
+        request.setEnabled(true);
+        request.setProtocol("TLSv1.3");
+        request.setClientAuth("none");
+        request.setKeyStoreType("PKCS12");
+
+        assertThatThrownBy(() -> settingsService.saveSslSettings(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("KeyStore path is required when SSL/TLS is enabled")
+                .extracting("code")
+                .isEqualTo(400);
+    }
+
+    @Test
+    void validateSslSettingsShouldLoadConfiguredKeyStore(@TempDir Path tempDir) throws Exception {
+        Path keyStore = tempDir.resolve("server.p12");
+        writePkcs12Store(keyStore, "secret");
+        SslSettingsUpdateDTO request = new SslSettingsUpdateDTO();
+        request.setEnabled(true);
+        request.setProtocol("TLSv1.3");
+        request.setClientAuth("none");
+        request.setKeyStoreType("PKCS12");
+        request.setKeyStorePath(keyStore.toString());
+        request.setKeyStorePassword("secret");
+        request.setTrustStoreType("PKCS12");
+
+        SslSettingsValidationResultVO result = settingsService.validateSslSettings(request);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getMessage()).isEqualTo("SSL/TLS keystore settings are valid");
+        assertThat(result.getWarnings()).isEmpty();
+    }
+
+    @Test
+    void validateSslSettingsShouldReportMissingKeyStoreFile() {
+        SslSettingsUpdateDTO request = new SslSettingsUpdateDTO();
+        request.setEnabled(true);
+        request.setProtocol("TLSv1.3");
+        request.setClientAuth("none");
+        request.setKeyStoreType("PKCS12");
+        request.setKeyStorePath("/path/not-found/server.p12");
+        request.setTrustStoreType("PKCS12");
+
+        SslSettingsValidationResultVO result = settingsService.validateSslSettings(request);
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getMessage()).contains("KeyStore file does not exist");
+    }
+
+    private void writePkcs12Store(Path path, String password) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, password.toCharArray());
+        try (OutputStream output = Files.newOutputStream(path)) {
+            keyStore.store(output, password.toCharArray());
+        }
     }
 
     @Test

--- a/web/src/api/settings.test.ts
+++ b/web/src/api/settings.test.ts
@@ -21,11 +21,14 @@ import client from './client';
 import {
   createDataSource,
   deleteDataSource,
+  getSslSettings,
   listDataSources,
+  saveSslSettings,
   testDataSource,
   updateDataSource,
+  validateSslSettings,
 } from './settings';
-import type { DataSource } from './settings';
+import type { DataSource, SslSettings } from './settings';
 
 const mock = new MockAdapter(client);
 const source: DataSource = {
@@ -35,6 +38,19 @@ const source: DataSource = {
   url: 'http://prometheus:9090',
   auth: 'None',
   status: 'healthy',
+};
+
+const sslSettings: SslSettings = {
+  enabled: true,
+  protocol: 'TLSv1.3',
+  clientAuth: 'none',
+  keyStoreType: 'PKCS12',
+  keyStorePath: '/etc/rocketmq/server.p12',
+  keyStorePasswordConfigured: true,
+  trustStoreType: 'PKCS12',
+  trustStorePath: '',
+  trustStorePasswordConfigured: false,
+  restartRequired: true,
 };
 
 describe('data sources API', () => {
@@ -76,5 +92,83 @@ describe('data sources API', () => {
     await expect(
       testDataSource({ type: source.type, url: source.url, auth: source.auth }),
     ).resolves.toEqual({ success: true, message: 'Connection successful' });
+  });
+});
+
+describe('SSL settings API', () => {
+  beforeEach(() => {
+    mock.reset();
+    vi.stubGlobal('localStorage', { getItem: vi.fn().mockReturnValue(null) });
+  });
+
+  afterEach(() => {
+    mock.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('loads SSL settings and strips blank passwords before saving', async () => {
+    mock.onGet('/settings/ssl').reply(200, { code: 200, data: sslSettings });
+    mock.onPost('/settings/ssl/save').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({
+        enabled: true,
+        protocol: 'TLSv1.3',
+        clientAuth: 'none',
+        keyStoreType: 'PKCS12',
+        keyStorePath: '/etc/rocketmq/server.p12',
+        trustStoreType: 'PKCS12',
+        trustStorePath: '',
+      });
+      return [200, { code: 200, data: sslSettings }];
+    });
+
+    await expect(getSslSettings()).resolves.toEqual(sslSettings);
+    await expect(
+      saveSslSettings({
+        enabled: true,
+        protocol: 'TLSv1.3',
+        clientAuth: 'none',
+        keyStoreType: 'PKCS12',
+        keyStorePath: '/etc/rocketmq/server.p12',
+        keyStorePassword: ' ',
+        trustStoreType: 'PKCS12',
+        trustStorePath: '',
+      }),
+    ).resolves.toEqual(sslSettings);
+  });
+
+  it('validates SSL settings through the backend validation endpoint', async () => {
+    mock.onPost('/settings/ssl/validate').reply((config) => {
+      expect(JSON.parse(config.data)).toMatchObject({
+        enabled: true,
+        keyStorePath: '/etc/rocketmq/server.p12',
+      });
+      return [
+        200,
+        {
+          code: 200,
+          data: {
+            success: true,
+            message: 'SSL/TLS keystore settings are valid',
+            warnings: [],
+          },
+        },
+      ];
+    });
+
+    await expect(
+      validateSslSettings({
+        enabled: true,
+        protocol: 'TLSv1.3',
+        clientAuth: 'none',
+        keyStoreType: 'PKCS12',
+        keyStorePath: '/etc/rocketmq/server.p12',
+        trustStoreType: 'PKCS12',
+        trustStorePath: '',
+      }),
+    ).resolves.toEqual({
+      success: true,
+      message: 'SSL/TLS keystore settings are valid',
+      warnings: [],
+    });
   });
 });

--- a/web/src/api/settings.test.ts
+++ b/web/src/api/settings.test.ts
@@ -136,6 +136,36 @@ describe('SSL settings API', () => {
     ).resolves.toEqual(sslSettings);
   });
 
+  it('keeps explicit SSL password clear flags when saving', async () => {
+    mock.onPost('/settings/ssl/save').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({
+        enabled: true,
+        protocol: 'TLSv1.3',
+        clientAuth: 'none',
+        keyStoreType: 'PKCS12',
+        keyStorePath: '/etc/rocketmq/server.p12',
+        clearKeyStorePassword: true,
+        trustStoreType: 'PKCS12',
+        trustStorePath: '',
+      });
+      return [200, { code: 200, data: { ...sslSettings, keyStorePasswordConfigured: false } }];
+    });
+
+    await expect(
+      saveSslSettings({
+        enabled: true,
+        protocol: 'TLSv1.3',
+        clientAuth: 'none',
+        keyStoreType: 'PKCS12',
+        keyStorePath: '/etc/rocketmq/server.p12',
+        keyStorePassword: ' ',
+        clearKeyStorePassword: true,
+        trustStoreType: 'PKCS12',
+        trustStorePath: '',
+      }),
+    ).resolves.toMatchObject({ keyStorePasswordConfigured: false });
+  });
+
   it('validates SSL settings through the backend validation endpoint', async () => {
     mock.onPost('/settings/ssl/validate').reply((config) => {
       expect(JSON.parse(config.data)).toMatchObject({

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -49,6 +49,35 @@ export interface DataSource {
   instanceIds?: string[];
 }
 
+export interface SslSettings {
+  enabled: boolean;
+  protocol: string;
+  clientAuth: string;
+  keyStoreType: string;
+  keyStorePath: string;
+  keyStorePasswordConfigured: boolean;
+  trustStoreType: string;
+  trustStorePath: string;
+  trustStorePasswordConfigured: boolean;
+  restartRequired: boolean;
+}
+
+export type SslSettingsUpdate = Omit<
+  SslSettings,
+  'keyStorePasswordConfigured' | 'trustStorePasswordConfigured' | 'restartRequired'
+> & {
+  keyStorePassword?: string;
+  clearKeyStorePassword?: boolean;
+  trustStorePassword?: string;
+  clearTrustStorePassword?: boolean;
+};
+
+export interface SslSettingsValidationResult {
+  success: boolean;
+  message: string;
+  warnings: string[];
+}
+
 // ─── General Settings ───────────────────────────────────────────
 export async function getGeneralSettings() {
   const res = await client.get<{ data: GeneralSettings }>('/settings/general');
@@ -60,6 +89,34 @@ export async function saveGeneralSettings(data: GeneralSettingsUpdate) {
   delete payload.apiKeyConfigured;
   if (!payload.apiKey?.trim()) delete payload.apiKey;
   await client.post('/settings/general/save', payload);
+}
+
+// ─── SSL Settings ────────────────────────────────────────────────
+export async function getSslSettings() {
+  const res = await client.get<{ data: SslSettings }>('/settings/ssl');
+  return res.data.data;
+}
+
+export async function saveSslSettings(data: SslSettingsUpdate) {
+  const payload = cleanSslSettingsPayload(data);
+  const res = await client.post<{ data: SslSettings }>('/settings/ssl/save', payload);
+  return res.data.data;
+}
+
+export async function validateSslSettings(data: SslSettingsUpdate) {
+  const payload = cleanSslSettingsPayload(data);
+  const res = await client.post<{ data: SslSettingsValidationResult }>(
+    '/settings/ssl/validate',
+    payload,
+  );
+  return res.data.data;
+}
+
+function cleanSslSettingsPayload(data: SslSettingsUpdate) {
+  const payload = { ...data };
+  if (!payload.keyStorePassword?.trim()) delete payload.keyStorePassword;
+  if (!payload.trustStorePassword?.trim()) delete payload.trustStorePassword;
+  return payload;
 }
 
 // ─── Data Sources ───────────────────────────────────────────────

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1179,12 +1179,32 @@ const translations: Record<string, Record<Lang, string>> = {
   },
   'ssl.uploadTruststore': { zh: '上传 TrustStore 文件', en: 'Upload TrustStore File' },
   'ssl.save': { zh: '保存', en: 'Save' },
+  'ssl.validate': { zh: '验证配置', en: 'Validate configuration' },
   'ssl.upload': { zh: '上传', en: 'Upload' },
   'ssl.certInfo': { zh: '证书信息', en: 'Certificate Information' },
   'ssl.issuer': { zh: '颁发者', en: 'Issuer' },
   'ssl.expiryDate': { zh: '过期日期', en: 'Expiry Date' },
   'ssl.active': { zh: '有效', en: 'Active' },
   'ssl.saveSuccess': { zh: 'SSL 配置保存成功', en: 'SSL configuration saved successfully' },
+  'ssl.saveFailed': { zh: 'SSL 配置保存失败', en: 'Failed to save SSL configuration' },
+  'ssl.loadFailed': { zh: 'SSL 配置加载失败', en: 'Failed to load SSL configuration' },
+  'ssl.validateFailed': { zh: 'SSL 配置验证失败', en: 'Failed to validate SSL configuration' },
+  'ssl.restartRequired': {
+    zh: 'SSL/TLS 配置用于重启前校验',
+    en: 'SSL/TLS settings are validated before restart',
+  },
+  'ssl.restartRequiredDesc': {
+    zh: 'Studio 会保存配置并验证 KeyStore/TrustStore 文件是否可加载，但不会热切换 TLS，也不会自动写入容器启动参数。请同步到部署配置后重启生效。',
+    en: 'Studio saves the configuration and validates that KeyStore/TrustStore files are loadable, but it does not hot-swap TLS or rewrite container startup parameters. Sync the values to deployment config before restart.',
+  },
+  'ssl.passwordConfigured': {
+    zh: '已保存密码；留空将继续保留现有密码',
+    en: 'Password is saved; leave blank to keep it unchanged',
+  },
+  'ssl.passwordPreservePlaceholder': {
+    zh: '留空保留现有密码',
+    en: 'Leave blank to keep the existing password',
+  },
   'ssl.saveUnavailable': {
     zh: 'SSL 配置保存功能尚未接入真实后端接口',
     en: 'SSL configuration persistence is not wired to a backend API yet',

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1201,6 +1201,14 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: '已保存密码；留空将继续保留现有密码',
     en: 'Password is saved; leave blank to keep it unchanged',
   },
+  'ssl.clearKeystorePassword': {
+    zh: '清除已保存的 KeyStore 密码',
+    en: 'Clear the saved KeyStore password',
+  },
+  'ssl.clearTruststorePassword': {
+    zh: '清除已保存的 TrustStore 密码',
+    en: 'Clear the saved TrustStore password',
+  },
   'ssl.passwordPreservePlaceholder': {
     zh: '留空保留现有密码',
     en: 'Leave blank to keep the existing password',

--- a/web/src/pages/studio/SslSettings.tsx
+++ b/web/src/pages/studio/SslSettings.tsx
@@ -16,7 +16,19 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Alert, Button, Card, Form, Input, Select, Space, Switch, Typography, message } from 'antd';
+import {
+  Alert,
+  Button,
+  Card,
+  Checkbox,
+  Form,
+  Input,
+  Select,
+  Space,
+  Switch,
+  Typography,
+  message,
+} from 'antd';
 import { ShieldCheck } from '@phosphor-icons/react';
 import {
   getSslSettings,
@@ -199,7 +211,12 @@ const SslSettingsPage = () => {
               <Input.Password placeholder={t('ssl.passwordPreservePlaceholder')} />
             </Form.Item>
             {settings?.keyStorePasswordConfigured && (
-              <Text type="secondary">{t('ssl.passwordConfigured')}</Text>
+              <Space direction="vertical" size={4}>
+                <Text type="secondary">{t('ssl.passwordConfigured')}</Text>
+                <Form.Item name="clearKeyStorePassword" valuePropName="checked" noStyle>
+                  <Checkbox>{t('ssl.clearKeystorePassword')}</Checkbox>
+                </Form.Item>
+              </Space>
             )}
           </Card>
 
@@ -218,7 +235,12 @@ const SslSettingsPage = () => {
               <Input.Password placeholder={t('ssl.passwordPreservePlaceholder')} />
             </Form.Item>
             {settings?.trustStorePasswordConfigured && (
-              <Text type="secondary">{t('ssl.passwordConfigured')}</Text>
+              <Space direction="vertical" size={4}>
+                <Text type="secondary">{t('ssl.passwordConfigured')}</Text>
+                <Form.Item name="clearTrustStorePassword" valuePropName="checked" noStyle>
+                  <Checkbox>{t('ssl.clearTruststorePassword')}</Checkbox>
+                </Form.Item>
+              </Space>
             )}
           </Card>
 

--- a/web/src/pages/studio/SslSettings.tsx
+++ b/web/src/pages/studio/SslSettings.tsx
@@ -15,32 +15,222 @@
  * limitations under the License.
  */
 
-import { Alert, Card, Space } from 'antd';
+import { useEffect, useState } from 'react';
+import { Alert, Button, Card, Form, Input, Select, Space, Switch, Typography, message } from 'antd';
 import { ShieldCheck } from '@phosphor-icons/react';
+import {
+  getSslSettings,
+  saveSslSettings,
+  validateSslSettings,
+  type SslSettings,
+  type SslSettingsUpdate,
+  type SslSettingsValidationResult,
+} from '../../api/settings';
 import { useLang } from '../../i18n/LangContext';
+
+const { Text } = Typography;
+
+const STORE_TYPE_OPTIONS = [
+  { value: 'PKCS12', label: 'PKCS12' },
+  { value: 'JKS', label: 'JKS' },
+];
+
+const PROTOCOL_OPTIONS = [
+  { value: 'TLSv1.3', label: 'TLSv1.3' },
+  { value: 'TLSv1.2', label: 'TLSv1.2' },
+];
+
+const defaultFormValues: SslSettingsUpdate = {
+  enabled: false,
+  protocol: 'TLSv1.3',
+  clientAuth: 'none',
+  keyStoreType: 'PKCS12',
+  keyStorePath: '',
+  trustStoreType: 'PKCS12',
+  trustStorePath: '',
+};
+
+const toFormValues = (settings: SslSettings): SslSettingsUpdate => ({
+  enabled: settings.enabled,
+  protocol: settings.protocol,
+  clientAuth: settings.clientAuth,
+  keyStoreType: settings.keyStoreType,
+  keyStorePath: settings.keyStorePath,
+  trustStoreType: settings.trustStoreType,
+  trustStorePath: settings.trustStorePath,
+});
 
 const SslSettingsPage = () => {
   const { t } = useLang();
+  const [form] = Form.useForm<SslSettingsUpdate>();
+  const [settings, setSettings] = useState<SslSettings | null>(null);
+  const [validation, setValidation] = useState<SslSettingsValidationResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [validating, setValidating] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    getSslSettings()
+      .then((data) => {
+        if (!active) return;
+        setSettings(data);
+        form.setFieldsValue(toFormValues(data));
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        message.error(error instanceof Error ? error.message : t('ssl.loadFailed'));
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [form, t]);
+
+  const currentPayload = async () => ({
+    ...defaultFormValues,
+    ...(settings ? toFormValues(settings) : {}),
+    ...(await form.validateFields()),
+  });
+
+  const refreshSavedSettings = (data: SslSettings) => {
+    setSettings(data);
+    form.setFieldsValue({
+      ...toFormValues(data),
+      keyStorePassword: '',
+      trustStorePassword: '',
+      clearKeyStorePassword: false,
+      clearTrustStorePassword: false,
+    });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setValidation(null);
+    try {
+      const saved = await saveSslSettings(await currentPayload());
+      refreshSavedSettings(saved);
+      message.success(t('ssl.saveSuccess'));
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : t('ssl.saveFailed'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleValidate = async () => {
+    setValidating(true);
+    setValidation(null);
+    try {
+      setValidation(await validateSslSettings(await currentPayload()));
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : t('ssl.validateFailed'));
+    } finally {
+      setValidating(false);
+    }
+  };
 
   return (
     <div style={{ padding: 0 }}>
       <Card
+        loading={loading}
         title={
           <Space>
             <ShieldCheck size={18} style={{ color: '#1677ff' }} />
             <span>{t('ssl.title')}</span>
           </Space>
         }
-        bordered={false}
+        variant="borderless"
         style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}
       >
         <Alert
-          message={t('ssl.unavailable')}
-          description={t('ssl.unavailableDesc')}
-          type="warning"
+          message={t('ssl.restartRequired')}
+          description={t('ssl.restartRequiredDesc')}
+          type="info"
           showIcon
-          data-testid="ssl-settings-unavailable"
+          style={{ marginBottom: 16 }}
         />
+        {validation && (
+          <Alert
+            data-testid="ssl-validation-result"
+            message={validation.message}
+            description={validation.warnings?.length ? validation.warnings.join('; ') : undefined}
+            type={validation.success ? 'success' : 'error'}
+            showIcon
+            style={{ marginBottom: 16 }}
+          />
+        )}
+        <Form
+          form={form}
+          layout="vertical"
+          initialValues={defaultFormValues}
+          data-testid="ssl-settings-form"
+        >
+          <Form.Item name="enabled" label={t('ssl.enabled')} valuePropName="checked">
+            <Switch />
+          </Form.Item>
+          <Form.Item name="protocol" label={t('ssl.protocol')} rules={[{ required: true }]}>
+            <Select options={PROTOCOL_OPTIONS} />
+          </Form.Item>
+          <Form.Item name="clientAuth" label={t('ssl.clientAuth')} rules={[{ required: true }]}>
+            <Select
+              options={[
+                { value: 'none', label: t('ssl.none') },
+                { value: 'want', label: t('ssl.want') },
+                { value: 'need', label: t('ssl.need') },
+              ]}
+            />
+          </Form.Item>
+
+          <Card size="small" title={t('ssl.keystoreConfig')} style={{ marginBottom: 16 }}>
+            <Form.Item
+              name="keyStoreType"
+              label={t('ssl.keystoreType')}
+              rules={[{ required: true }]}
+            >
+              <Select options={STORE_TYPE_OPTIONS} />
+            </Form.Item>
+            <Form.Item name="keyStorePath" label={t('ssl.keystorePath')}>
+              <Input placeholder={t('ssl.keystorePathPlaceholder')} />
+            </Form.Item>
+            <Form.Item name="keyStorePassword" label={t('ssl.keystorePassword')}>
+              <Input.Password placeholder={t('ssl.passwordPreservePlaceholder')} />
+            </Form.Item>
+            {settings?.keyStorePasswordConfigured && (
+              <Text type="secondary">{t('ssl.passwordConfigured')}</Text>
+            )}
+          </Card>
+
+          <Card size="small" title={t('ssl.truststoreConfig')} style={{ marginBottom: 16 }}>
+            <Form.Item
+              name="trustStoreType"
+              label={t('ssl.truststoreType')}
+              rules={[{ required: true }]}
+            >
+              <Select options={STORE_TYPE_OPTIONS} />
+            </Form.Item>
+            <Form.Item name="trustStorePath" label={t('ssl.truststorePath')}>
+              <Input placeholder={t('ssl.truststorePathPlaceholder')} />
+            </Form.Item>
+            <Form.Item name="trustStorePassword" label={t('ssl.truststorePassword')}>
+              <Input.Password placeholder={t('ssl.passwordPreservePlaceholder')} />
+            </Form.Item>
+            {settings?.trustStorePasswordConfigured && (
+              <Text type="secondary">{t('ssl.passwordConfigured')}</Text>
+            )}
+          </Card>
+
+          <Space>
+            <Button aria-label={t('ssl.validate')} onClick={handleValidate} loading={validating}>
+              {t('ssl.validate')}
+            </Button>
+            <Button aria-label={t('ssl.save')} type="primary" onClick={handleSave} loading={saving}>
+              {t('ssl.save')}
+            </Button>
+          </Space>
+        </Form>
       </Card>
     </div>
   );

--- a/web/src/pages/studio/__tests__/SslSettings.test.tsx
+++ b/web/src/pages/studio/__tests__/SslSettings.test.tsx
@@ -2,24 +2,55 @@
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
  */
 
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App } from 'antd';
+import {
+  getSslSettings,
+  saveSslSettings,
+  validateSslSettings,
+  type SslSettings as SslSettingsModel,
+} from '../../../api/settings';
 import { LangProvider } from '../../../i18n/LangContext';
 import SslSettings from '../SslSettings';
+
+vi.mock('../../../api/settings', () => ({
+  getSslSettings: vi.fn(),
+  saveSslSettings: vi.fn(),
+  validateSslSettings: vi.fn(),
+}));
+
+const sslSettings: SslSettingsModel = {
+  enabled: true,
+  protocol: 'TLSv1.3',
+  clientAuth: 'need',
+  keyStoreType: 'PKCS12',
+  keyStorePath: '/etc/rocketmq/server.p12',
+  keyStorePasswordConfigured: true,
+  trustStoreType: 'PKCS12',
+  trustStorePath: '/etc/rocketmq/trust.p12',
+  trustStorePasswordConfigured: false,
+  restartRequired: true,
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
 
 const renderWithProviders = () =>
   render(
@@ -31,21 +62,61 @@ const renderWithProviders = () =>
   );
 
 describe('SslSettings Page', () => {
-  it('explains that SSL settings cannot be saved before backend support exists', () => {
-    renderWithProviders();
-
-    expect(screen.getByTestId('ssl-settings-unavailable')).toHaveTextContent(
-      'SSL/TLS 配置暂不可用',
-    );
-    expect(screen.getByText(/暂不支持保存或上传/)).toBeInTheDocument();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSslSettings).mockResolvedValue(sslSettings);
+    vi.mocked(saveSslSettings).mockResolvedValue(sslSettings);
+    vi.mocked(validateSslSettings).mockResolvedValue({
+      success: true,
+      message: 'SSL/TLS keystore settings are valid',
+      warnings: [],
+    });
   });
 
-  it('does not expose local-only controls that imply TLS is configured', () => {
+  it('loads persisted SSL settings instead of showing the old unavailable placeholder', async () => {
     renderWithProviders();
 
-    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /保\s*存/ })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /上\s*传/ })).not.toBeInTheDocument();
-    expect(screen.queryByText('证书信息')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('ssl-settings-form')).toBeInTheDocument();
+    expect(screen.getByText('SSL/TLS 配置用于重启前校验')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('/etc/rocketmq/server.p12')).toBeInTheDocument();
+    expect(screen.getByText('已保存密码；留空将继续保留现有密码')).toBeInTheDocument();
+    expect(screen.queryByTestId('ssl-settings-unavailable')).not.toBeInTheDocument();
+  });
+
+  it('validates the current SSL form through the backend endpoint', async () => {
+    renderWithProviders();
+
+    fireEvent.click(await screen.findByRole('button', { name: '验证配置' }));
+
+    await waitFor(() =>
+      expect(validateSslSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: true,
+          protocol: 'TLSv1.3',
+          clientAuth: 'need',
+          keyStorePath: '/etc/rocketmq/server.p12',
+          trustStorePath: '/etc/rocketmq/trust.p12',
+        }),
+      ),
+    );
+    expect(await screen.findByTestId('ssl-validation-result')).toHaveTextContent(
+      'SSL/TLS keystore settings are valid',
+    );
+  });
+
+  it('saves settings and clears password fields after the backend accepts them', async () => {
+    renderWithProviders();
+
+    fireEvent.click(await screen.findByRole('button', { name: '保存' }));
+
+    await waitFor(() =>
+      expect(saveSslSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: true,
+          keyStorePath: '/etc/rocketmq/server.p12',
+        }),
+      ),
+    );
+    expect(screen.getAllByPlaceholderText('留空保留现有密码')[0]).toHaveValue('');
   });
 });

--- a/web/src/pages/studio/__tests__/SslSettings.test.tsx
+++ b/web/src/pages/studio/__tests__/SslSettings.test.tsx
@@ -80,6 +80,7 @@ describe('SslSettings Page', () => {
     expect(screen.getByText('SSL/TLS 配置用于重启前校验')).toBeInTheDocument();
     expect(screen.getByDisplayValue('/etc/rocketmq/server.p12')).toBeInTheDocument();
     expect(screen.getByText('已保存密码；留空将继续保留现有密码')).toBeInTheDocument();
+    expect(screen.getByText('清除已保存的 KeyStore 密码')).toBeInTheDocument();
     expect(screen.queryByTestId('ssl-settings-unavailable')).not.toBeInTheDocument();
   });
 
@@ -118,5 +119,20 @@ describe('SslSettings Page', () => {
       ),
     );
     expect(screen.getAllByPlaceholderText('留空保留现有密码')[0]).toHaveValue('');
+  });
+
+  it('sends clear flags when an operator chooses to remove stored passwords', async () => {
+    renderWithProviders();
+
+    fireEvent.click(await screen.findByLabelText('清除已保存的 KeyStore 密码'));
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() =>
+      expect(saveSslSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clearKeyStorePassword: true,
+        }),
+      ),
+    );
   });
 });


### PR DESCRIPTION
## What is the purpose of the change

Add backend-backed SSL/TLS settings so Studio can persist deployment TLS parameters, preserve stored passwords safely, and validate KeyStore/TrustStore files before operators restart the service.

## Brief changelog

- Added SSL/TLS settings read, save, and validation endpoints.
- Persisted SSL/TLS settings in the existing settings repository without returning password values in API responses.
- Replaced the SSL settings unavailable page with a real configuration form and validation action.
- Documented the new SSL/TLS settings APIs.

## Verifying this change

- `mvn -Dtest=SettingsControllerTest,SettingsServiceTest,MybatisPlusSettingsRepositoryTest test`
- `npx vitest run src/pages/studio/__tests__/SslSettings.test.tsx src/api/settings.test.ts`
- `npx eslint src/pages/studio/SslSettings.tsx src/pages/studio/__tests__/SslSettings.test.tsx src/api/settings.ts src/api/settings.test.ts`
- `npm run build`