### PR TITLE
fix: keep observability asset load failures retryable

### DIFF
--- a/web/src/components/AlertRuleAssetList.tsx
+++ b/web/src/components/AlertRuleAssetList.tsx
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef, useState } from 'react';
-import { App, Button, Modal, Space, Table, Tag, Typography } from 'antd';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Alert, App, Button, Modal, Space, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { DownloadSimple, Eye } from '@phosphor-icons/react';
+import { ArrowClockwise, DownloadSimple, Eye } from '@phosphor-icons/react';
 import { useLang } from '../i18n/LangContext';
 import {
   exportAlertRuleAsset,
@@ -40,30 +40,44 @@ export const AlertRuleAssetList: React.FC = () => {
   const { message } = App.useApp();
   const [assets, setAssets] = useState<AlertRuleAssetInfo[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [viewing, setViewing] = useState<AlertRuleAssetInfo | null>(null);
   const [viewContent, setViewContent] = useState('');
   const [viewLoading, setViewLoading] = useState(false);
+  const mountedRef = useRef(true);
+  const listRequestId = useRef(0);
   const viewRequestId = useRef(0);
   const [exportingNames, setExportingNames] = useState<Set<string>>(() => new Set());
 
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const data = await listAlertRuleAssets();
-        if (!cancelled) setAssets(data);
-      } catch {
-        if (!cancelled) message.error(t('alertAssets.loadFailed'));
-      } finally {
-        if (!cancelled) setLoading(false);
+  const loadAssets = useCallback(async () => {
+    const requestId = ++listRequestId.current;
+    setLoading(true);
+    setLoadError(false);
+    try {
+      const data = await listAlertRuleAssets();
+      if (mountedRef.current && requestId === listRequestId.current) {
+        setAssets(data);
       }
-    };
-    void load();
+    } catch {
+      if (mountedRef.current && requestId === listRequestId.current) {
+        setLoadError(true);
+        message.error(t('alertAssets.loadFailed'));
+      }
+    } finally {
+      if (mountedRef.current && requestId === listRequestId.current) {
+        setLoading(false);
+      }
+    }
+  }, [message, t]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    const timeoutId = window.setTimeout(() => void loadAssets());
     return () => {
-      cancelled = true;
-      viewRequestId.current += 1;
+      window.clearTimeout(timeoutId);
+      mountedRef.current = false;
     };
-  }, [t, message]);
+  }, [loadAssets]);
 
   const handleView = async (info: AlertRuleAssetInfo) => {
     const requestId = ++viewRequestId.current;
@@ -72,15 +86,15 @@ export const AlertRuleAssetList: React.FC = () => {
     setViewLoading(true);
     try {
       const yaml = await getAlertRuleAsset(info.name);
-      if (requestId === viewRequestId.current) {
+      if (mountedRef.current && requestId === viewRequestId.current) {
         setViewContent(yaml);
       }
     } catch {
-      if (requestId === viewRequestId.current) {
+      if (mountedRef.current && requestId === viewRequestId.current) {
         message.error(t('alertAssets.loadFailed'));
       }
     } finally {
-      if (requestId === viewRequestId.current) {
+      if (mountedRef.current && requestId === viewRequestId.current) {
         setViewLoading(false);
       }
     }
@@ -177,6 +191,24 @@ export const AlertRuleAssetList: React.FC = () => {
 
   return (
     <div>
+      {loadError && (
+        <Alert
+          showIcon
+          type="error"
+          message={t('alertAssets.loadFailed')}
+          action={
+            <Button
+              size="small"
+              icon={<ArrowClockwise size={16} />}
+              onClick={() => void loadAssets()}
+            >
+              {t('common.retry')}
+            </Button>
+          }
+          style={{ marginBottom: 12 }}
+        />
+      )}
+
       <Table
         columns={columns}
         dataSource={assets}

--- a/web/src/components/GrafanaDashboardList.tsx
+++ b/web/src/components/GrafanaDashboardList.tsx
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef, useState } from 'react';
-import { App, Button, Modal, Space, Table, Tag, Typography } from 'antd';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Alert, App, Button, Modal, Space, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { DownloadSimple, Eye } from '@phosphor-icons/react';
+import { ArrowClockwise, DownloadSimple, Eye } from '@phosphor-icons/react';
 import { useLang } from '../i18n/LangContext';
 import {
   getGrafanaDashboard,
@@ -35,31 +35,45 @@ export const GrafanaDashboardList: React.FC = () => {
   const { message } = App.useApp();
   const [dashboards, setDashboards] = useState<GrafanaDashboardInfo[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [viewing, setViewing] = useState<GrafanaDashboardInfo | null>(null);
   const [viewContent, setViewContent] = useState('');
   const [viewLoading, setViewLoading] = useState(false);
+  const mountedRef = useRef(true);
+  const listRequestId = useRef(0);
   const viewRequestId = useRef(0);
   const [exportingUids, setExportingUids] = useState<Set<string>>(() => new Set());
   const [exportingAll, setExportingAll] = useState(false);
 
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const data = await listGrafanaDashboards();
-        if (!cancelled) setDashboards(data);
-      } catch {
-        if (!cancelled) message.error(t('grafana.loadFailed'));
-      } finally {
-        if (!cancelled) setLoading(false);
+  const loadDashboards = useCallback(async () => {
+    const requestId = ++listRequestId.current;
+    setLoading(true);
+    setLoadError(false);
+    try {
+      const data = await listGrafanaDashboards();
+      if (mountedRef.current && requestId === listRequestId.current) {
+        setDashboards(data);
       }
-    };
-    void load();
+    } catch {
+      if (mountedRef.current && requestId === listRequestId.current) {
+        setLoadError(true);
+        message.error(t('grafana.loadFailed'));
+      }
+    } finally {
+      if (mountedRef.current && requestId === listRequestId.current) {
+        setLoading(false);
+      }
+    }
+  }, [message, t]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    const timeoutId = window.setTimeout(() => void loadDashboards());
     return () => {
-      cancelled = true;
-      viewRequestId.current += 1;
+      window.clearTimeout(timeoutId);
+      mountedRef.current = false;
     };
-  }, [t, message]);
+  }, [loadDashboards]);
 
   const handleView = async (info: GrafanaDashboardInfo) => {
     const requestId = ++viewRequestId.current;
@@ -68,15 +82,15 @@ export const GrafanaDashboardList: React.FC = () => {
     setViewLoading(true);
     try {
       const model = await getGrafanaDashboard(info.uid);
-      if (requestId === viewRequestId.current) {
+      if (mountedRef.current && requestId === viewRequestId.current) {
         setViewContent(JSON.stringify(model, null, 2));
       }
     } catch {
-      if (requestId === viewRequestId.current) {
+      if (mountedRef.current && requestId === viewRequestId.current) {
         message.error(t('grafana.loadFailed'));
       }
     } finally {
-      if (requestId === viewRequestId.current) {
+      if (mountedRef.current && requestId === viewRequestId.current) {
         setViewLoading(false);
       }
     }
@@ -191,6 +205,24 @@ export const GrafanaDashboardList: React.FC = () => {
           {t('grafana.exportAll')}
         </Button>
       </Space>
+
+      {loadError && (
+        <Alert
+          showIcon
+          type="error"
+          message={t('grafana.loadFailed')}
+          action={
+            <Button
+              size="small"
+              icon={<ArrowClockwise size={16} />}
+              onClick={() => void loadDashboards()}
+            >
+              {t('common.retry')}
+            </Button>
+          }
+          style={{ marginBottom: 12 }}
+        />
+      )}
 
       <Table
         columns={columns}

--- a/web/src/components/__tests__/AlertRuleAssetList.test.tsx
+++ b/web/src/components/__tests__/AlertRuleAssetList.test.tsx
@@ -81,6 +81,23 @@ describe('AlertRuleAssetList', () => {
     expect(screen.getByText('rocketmq-consumer-lag-high')).toBeInTheDocument();
   });
 
+  it('keeps a failed list request visible and recovers when retried', async () => {
+    vi.mocked(alertRuleAssetService.listAlertRuleAssets)
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce(sampleAssets);
+
+    renderWithProviders(<AlertRuleAssetList />);
+
+    const retryButton = await screen.findByRole('button', { name: /Retry|重试/ });
+    expect(alertRuleAssetService.listAlertRuleAssets).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(retryButton);
+
+    expect(await screen.findByText('rocketmq-broker-down')).toBeInTheDocument();
+    expect(alertRuleAssetService.listAlertRuleAssets).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('button', { name: /Retry|重试/ })).not.toBeInTheDocument();
+  });
+
   it('opens a modal with yaml content when View is clicked', async () => {
     vi.mocked(alertRuleAssetService.listAlertRuleAssets).mockResolvedValue(sampleAssets);
     vi.mocked(alertRuleAssetService.getAlertRuleAsset).mockResolvedValue(

--- a/web/src/components/__tests__/GrafanaDashboardList.test.tsx
+++ b/web/src/components/__tests__/GrafanaDashboardList.test.tsx
@@ -99,6 +99,30 @@ describe('GrafanaDashboardList', () => {
     expect(screen.getByText('RocketMQ Broker')).toBeInTheDocument();
   });
 
+  it('keeps a failed list request visible and recovers when retried', async () => {
+    vi.mocked(listGrafanaDashboards)
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce(dashboards);
+    const user = userEvent.setup();
+
+    render(
+      <App>
+        <LangProvider>
+          <GrafanaDashboardList />
+        </LangProvider>
+      </App>,
+    );
+
+    const retryButton = await screen.findByRole('button', { name: /Retry|重试/ });
+    expect(listGrafanaDashboards).toHaveBeenCalledTimes(1);
+
+    await user.click(retryButton);
+
+    expect(await screen.findByText('RocketMQ Cluster Overview')).toBeInTheDocument();
+    expect(listGrafanaDashboards).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('button', { name: /Retry|重试/ })).not.toBeInTheDocument();
+  });
+
   it('opens the view modal and renders the dashboard JSON', async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
## Summary

- keep Grafana dashboard and alert-rule asset list failures visible after the toast disappears
- add explicit retry actions that clear the error state and reload the catalog
- ignore stale or unmounted list and preview responses
- cover failure-then-retry recovery for both asset views

## Validation

- `npx eslint src/components/GrafanaDashboardList.tsx src/components/AlertRuleAssetList.tsx src/components/__tests__/GrafanaDashboardList.test.tsx src/components/__tests__/AlertRuleAssetList.test.tsx`
- `npm test -- --run src/components/__tests__/GrafanaDashboardList.test.tsx src/components/__tests__/AlertRuleAssetList.test.tsx` (13 tests passed)
- `npm run build`

Closes #1825
