### PR TITLE
fix: make global layout commands accessible

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -76,6 +76,18 @@ const translations: Record<string, Record<Lang, string>> = {
   'common.no': { zh: '否', en: 'No' },
   'common.retry': { zh: '重试', en: 'Retry' },
 
+  // ─── Global layout controls ───
+  'layout.skipToMain': { zh: '跳到主要内容', en: 'Skip to main content' },
+  'layout.goHome': { zh: '返回首页', en: 'Go to home' },
+  'layout.openSearch': { zh: '打开导航搜索', en: 'Open navigation search' },
+  'layout.switchToRealData': { zh: '切换到真实数据', en: 'Switch to real data' },
+  'layout.switchToMockData': { zh: '切换到模拟数据', en: 'Switch to mock data' },
+  'layout.switchToEnglish': { zh: '切换到英语', en: 'Switch to English' },
+  'layout.switchToChinese': { zh: '切换到中文', en: 'Switch to Chinese' },
+  'layout.switchToLightTheme': { zh: '切换到浅色主题', en: 'Switch to light theme' },
+  'layout.switchToDarkTheme': { zh: '切换到深色主题', en: 'Switch to dark theme' },
+  'layout.openUserMenu': { zh: '打开用户菜单', en: 'Open user menu' },
+
   // ─── Dashboard ───
   'dashboard.title': { zh: '监控面板', en: 'Dashboard' },
   'dashboard.subtitle': { zh: 'RocketMQ 集群运行概览', en: 'RocketMQ Cluster Overview' },

--- a/web/src/layouts/MainLayout.test.tsx
+++ b/web/src/layouts/MainLayout.test.tsx
@@ -39,7 +39,12 @@ vi.mock('antd', async () => {
   return {
     Layout,
     Menu: () => null,
-    Breadcrumb: () => null,
+    Breadcrumb: ({ items }: { items: Array<{ key: string; title: React.ReactNode }> }) =>
+      React.createElement(
+        'nav',
+        null,
+        items.map((item) => React.createElement(React.Fragment, { key: item.key }, item.title)),
+      ),
     Avatar: () => React.createElement('span', null, 'avatar'),
     Dropdown: ({ children, menu }: { children?: React.ReactNode; menu: DropdownMenu }) =>
       React.createElement(
@@ -66,6 +71,7 @@ vi.mock('antd', async () => {
 
 describe('MainLayout authentication navigation', () => {
   beforeEach(() => {
+    localStorage.clear();
     vi.mocked(logout).mockReset().mockResolvedValue(undefined);
     useAuthStore.getState().login('test-token', 'admin', true);
   });
@@ -94,5 +100,41 @@ describe('MainLayout authentication navigation', () => {
     expect(screen.queryByText('protected home')).not.toBeInTheDocument();
     expect(logout).toHaveBeenCalledOnce();
     expect(localStorage.getItem('token')).toBeNull();
+  });
+
+  it('exposes global layout commands as localized semantic buttons', () => {
+    render(
+      <LangProvider>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/']}>
+            <Routes>
+              <Route path="/" element={<MainLayout />}>
+                <Route index element={<div>protected home</div>} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </LangProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: '返回首页' })).toBeInTheDocument();
+    const searchButton = screen.getByRole('button', { name: '打开导航搜索' });
+    expect(searchButton).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '切换到模拟数据' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+    expect(screen.getByRole('button', { name: '切换到英语' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '切换到深色主题' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+    expect(screen.getByRole('button', { name: '打开用户菜单' })).toBeInTheDocument();
+
+    fireEvent.click(searchButton);
+    expect(screen.getByRole('button', { name: '首页' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '切换到英语' }));
+    expect(screen.getByRole('button', { name: 'Switch to Chinese' })).toBeInTheDocument();
   });
 });

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -202,14 +202,25 @@ const MainLayout = () => {
     [t],
   );
 
-  const pathSnippets = location.pathname.split('/').filter((i) => i);
-  const breadcrumbItems = useMemo(
-    () => [
+  const breadcrumbItems = useMemo(() => {
+    const pathSnippets = location.pathname.split('/').filter((segment) => segment);
+    return [
       {
         title: (
-          <span onClick={() => navigate('/')} style={{ cursor: 'pointer' }}>
+          <button
+            type="button"
+            aria-label={t('layout.goHome')}
+            onClick={() => navigate('/')}
+            style={{
+              cursor: 'pointer',
+              border: 0,
+              padding: 0,
+              background: 'transparent',
+              font: 'inherit',
+            }}
+          >
             🏠
-          </span>
+          </button>
         ),
         key: 'home',
       },
@@ -224,9 +235,8 @@ const MainLayout = () => {
           key: path,
         };
       }),
-    ],
-    [location.pathname, navigate, breadcrumbMap, instanceScopedMatch],
-  );
+    ];
+  }, [location.pathname, navigate, breadcrumbMap, instanceScopedMatch, t]);
 
   const userMenu = {
     onClick: handleUserMenuClick,
@@ -273,7 +283,7 @@ const MainLayout = () => {
           event.currentTarget.style.transform = 'translateY(-150%)';
         }}
       >
-        跳到主要内容
+        {t('layout.skipToMain')}
       </a>
       <Layout style={{ height: '100vh', minHeight: 0, overflow: 'hidden' }}>
         <Sider
@@ -339,7 +349,9 @@ const MainLayout = () => {
             {/* Right: Search + Lang + Theme + User */}
             <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
               {/* Search button */}
-              <div
+              <button
+                type="button"
+                aria-label={t('layout.openSearch')}
                 onClick={() => setSearchOpen(true)}
                 style={{
                   display: 'flex',
@@ -352,6 +364,8 @@ const MainLayout = () => {
                   fontSize: 13,
                   color: '#9CA3AF',
                   minWidth: 160,
+                  background: 'transparent',
+                  font: 'inherit',
                 }}
               >
                 <MagnifyingGlass size={14} />
@@ -368,10 +382,15 @@ const MainLayout = () => {
                 >
                   ⌘K
                 </span>
-              </div>
+              </button>
 
               {/* Data mode toggle */}
-              <div
+              <button
+                type="button"
+                aria-label={
+                  useMock ? t('layout.switchToRealData') : t('layout.switchToMockData')
+                }
+                aria-pressed={useMock}
                 onClick={handleDataModeToggle}
                 style={{
                   cursor: 'pointer',
@@ -385,12 +404,10 @@ const MainLayout = () => {
                   fontWeight: 500,
                   color: useMock ? '#d48806' : '#389e0d',
                   transition: 'all 0.2s',
+                  background: 'transparent',
+                  font: 'inherit',
                 }}
-                title={
-                  useMock
-                    ? 'Data Mode: Mock (click to switch to Real)'
-                    : 'Data Mode: Real (click to switch to Mock)'
-                }
+                title={useMock ? t('layout.switchToRealData') : t('layout.switchToMockData')}
               >
                 <span
                   style={{
@@ -402,10 +419,14 @@ const MainLayout = () => {
                   }}
                 />
                 {useMock ? 'Mock' : 'Real'}
-              </div>
+              </button>
 
               {/* Language toggle */}
-              <div
+              <button
+                type="button"
+                aria-label={
+                  lang === 'zh' ? t('layout.switchToEnglish') : t('layout.switchToChinese')
+                }
                 onClick={() => setLang(lang === 'zh' ? 'en' : 'zh')}
                 style={{
                   cursor: 'pointer',
@@ -419,14 +440,25 @@ const MainLayout = () => {
                   fontWeight: 600,
                   color: '#1677ff',
                   transition: 'background 0.2s',
+                  border: 0,
+                  padding: 0,
+                  background: 'transparent',
+                  font: 'inherit',
                 }}
-                title={lang === 'zh' ? 'Switch to English' : '切换到中文'}
+                title={
+                  lang === 'zh' ? t('layout.switchToEnglish') : t('layout.switchToChinese')
+                }
               >
                 {lang === 'zh' ? 'En' : '中'}
-              </div>
+              </button>
 
               {/* Theme toggle */}
-              <div
+              <button
+                type="button"
+                aria-label={
+                  darkMode ? t('layout.switchToLightTheme') : t('layout.switchToDarkTheme')
+                }
+                aria-pressed={darkMode}
                 onClick={toggleTheme}
                 style={{
                   cursor: 'pointer',
@@ -437,23 +469,41 @@ const MainLayout = () => {
                   height: 28,
                   borderRadius: 6,
                   transition: 'background 0.2s',
+                  border: 0,
+                  padding: 0,
+                  background: 'transparent',
+                  font: 'inherit',
                 }}
-                title={darkMode ? 'Light mode' : 'Dark mode'}
+                title={
+                  darkMode ? t('layout.switchToLightTheme') : t('layout.switchToDarkTheme')
+                }
               >
                 {darkMode ? (
                   <Sun size={18} color="#9CA3AF" weight="fill" />
                 ) : (
                   <Moon size={18} color="#9CA3AF" weight="fill" />
                 )}
-              </div>
+              </button>
 
               {/* User avatar */}
               <Dropdown menu={userMenu} trigger={['click']}>
-                <Avatar
-                  size={28}
-                  style={{ backgroundColor: '#1677ff', cursor: 'pointer' }}
-                  icon={<UserGear size={16} />}
-                />
+                <button
+                  type="button"
+                  aria-label={t('layout.openUserMenu')}
+                  style={{
+                    cursor: 'pointer',
+                    border: 0,
+                    padding: 0,
+                    background: 'transparent',
+                    font: 'inherit',
+                  }}
+                >
+                  <Avatar
+                    size={28}
+                    style={{ backgroundColor: '#1677ff' }}
+                    icon={<UserGear size={16} />}
+                  />
+                </button>
               </Dropdown>
             </div>
           </div>
@@ -509,7 +559,8 @@ const MainLayout = () => {
         <div style={{ maxHeight: 360, overflow: 'auto', padding: '8px 12px 12px' }}>
           {searchResults.length ? (
             searchResults.map((item) => (
-              <div
+              <button
+                type="button"
                 key={item.key}
                 onClick={() => {
                   navigate(item.key as string);
@@ -525,6 +576,12 @@ const MainLayout = () => {
                   cursor: 'pointer',
                   fontSize: 14,
                   transition: 'background 0.15s',
+                  width: '100%',
+                  border: 0,
+                  background: 'transparent',
+                  color: 'inherit',
+                  textAlign: 'left',
+                  font: 'inherit',
                 }}
                 onMouseEnter={(e) => {
                   e.currentTarget.style.background = darkMode ? '#1a1a1a' : '#f5f5f5';
@@ -535,7 +592,7 @@ const MainLayout = () => {
               >
                 {item.icon}
                 <span>{item.label}</span>
-              </div>
+              </button>
             ))
           ) : (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="未找到匹配页面" />


### PR DESCRIPTION
## Summary

- replace pointer-only global layout commands with semantic buttons
- make breadcrumb Home, navigation search, data mode, language, theme, user menu, and search results keyboard-operable
- expose localized accessible names and toggle states
- localize the skip-navigation label and remove the existing breadcrumb hook warning
- add focused regression coverage for control roles, state, search results, and language changes

## Validation

- `npx eslint src/layouts/MainLayout.tsx src/layouts/MainLayout.test.tsx src/i18n/translations.ts`
- `npm test -- --run src/layouts/MainLayout.test.tsx` (2 tests passed)
- `npm run build`

Closes #1831
