### PR TITLE
fix(web): migrate client page Ant Design props

### DIFF
--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -504,7 +504,7 @@ const ClientsPage = () => {
       </Flex>
 
       {/* ─── Table ─── */}
-      <Card bodyStyle={{ padding: 0 }}>
+      <Card styles={{ body: { padding: 0 } }}>
         <Table
           columns={columns}
           dataSource={filtered}
@@ -528,7 +528,7 @@ const ClientsPage = () => {
         onCancel={() => setSelectedConnection(null)}
         footer={<Button onClick={() => setSelectedConnection(null)}>{t('common.close')}</Button>}
         width={640}
-        destroyOnClose
+        destroyOnHidden
       >
         {selectedConnection && (
           <Descriptions column={1} bordered size="small">


### PR DESCRIPTION
## Summary
- migrate client page Ant Design props
- preserve the existing page behavior while removing deprecated Ant Design property usage

## Validation
- `npm run build`
- pre-commit ESLint and Prettier