### PR TITLE
fix(web): migrate DLQ page Ant Design props

### DIFF
--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -395,7 +395,7 @@ const DLQPage = () => {
       )}
 
       {/* ── Table ── */}
-      <Card bodyStyle={{ padding: 0 }}>
+      <Card styles={{ body: { padding: 0 } }}>
         <Table
           columns={columns}
           dataSource={filtered}
@@ -439,7 +439,7 @@ const DLQPage = () => {
         okText="确认重投"
         cancelText="取消"
         width={520}
-        destroyOnClose
+        destroyOnHidden
       >
         {retryGroup && (
           <div style={{ marginTop: 16 }}>
@@ -516,7 +516,7 @@ const DLQPage = () => {
         onCancel={() => setDetailGroup(null)}
         footer={<Button onClick={() => setDetailGroup(null)}>关闭</Button>}
         width={560}
-        destroyOnClose
+        destroyOnHidden
       >
         {detailGroup && (
           <div style={{ marginTop: 8 }}>


### PR DESCRIPTION
## Summary
- migrate DLQ page Ant Design props
- preserve the existing page behavior while removing deprecated Ant Design property usage

## Validation
- `npm run build`
- pre-commit ESLint and Prettier