### PR TITLE
fix(web): migrate settings modal lifecycle prop

### DIFF
--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -498,7 +498,7 @@ export const DataSourceTab = () => {
         }}
         onOk={() => void handleSubmit()}
         confirmLoading={submitting}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form form={dsForm} layout="vertical" preserve={false}>
           <Form.Item


### PR DESCRIPTION
## Summary
- migrate settings modal lifecycle prop
- preserve the existing page behavior while removing deprecated Ant Design property usage

## Validation
- `npm run build`
- pre-commit ESLint and Prettier