### PR TITLE
fix(web): migrate proxy page Card props

### DIFF
--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -383,7 +383,7 @@ const ProxyPage: React.FC = () => {
         {/* Node Table */}
         <Card
           title={t('proxy.nodes')}
-          bordered={false}
+          variant="borderless"
           style={{ borderRadius: 8, marginBottom: 24 }}
         >
           <Table columns={columns} dataSource={proxyNodes} pagination={false} size="middle" />


### PR DESCRIPTION
## Summary
- migrate proxy page Card props
- preserve the existing page behavior while removing deprecated Ant Design property usage

## Validation
- `npm run build`
- pre-commit ESLint and Prettier