### PR TITLE
fix(web): migrate SSL settings Card props

### DIFF
--- a/web/src/pages/studio/SslSettings.tsx
+++ b/web/src/pages/studio/SslSettings.tsx
@@ -31,7 +31,7 @@ const SslSettingsPage = () => {
             <span>{t('ssl.title')}</span>
           </Space>
         }
-        bordered={false}
+        variant="borderless"
         style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}
       >
         <Alert


### PR DESCRIPTION
## Summary
- migrate SSL settings Card props
- preserve the existing page behavior while removing deprecated Ant Design property usage

## Validation
- `npm run build`
- pre-commit ESLint and Prettier