### PR TITLE
fix(credentials): preserve invalid UTF-8 legacy values

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/CredentialUtils.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/CredentialUtils.java
@@ -16,6 +16,9 @@
  */
 package org.apache.rocketmq.studio.common.util;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
@@ -44,9 +47,15 @@ public final class CredentialUtils {
             return null;
         }
         try {
-            return new String(Base64.getDecoder().decode(stored), StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException ex) {
-            // tolerate legacy values that were stored without encoding
+            byte[] decoded = Base64.getDecoder().decode(stored);
+            return StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(decoded))
+                    .toString();
+        } catch (IllegalArgumentException | CharacterCodingException ex) {
+            // Tolerate legacy plaintext, including text that is syntactically Base64 but does
+            // not decode to valid UTF-8. Returning replacement characters would corrupt it.
             return stored;
         }
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/CredentialUtilsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/CredentialUtilsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CredentialUtilsTest {
+
+    @Test
+    void decodeBase64ShouldPreserveLegacyTextWhenDecodedBytesAreNotUtf8() {
+        String legacyValue = Base64.getEncoder().encodeToString(new byte[]{(byte) 0xC3, 0x28});
+
+        assertThat(CredentialUtils.decodeBase64(legacyValue)).isEqualTo(legacyValue);
+    }
+}


### PR DESCRIPTION
## Summary
- preserve invalid UTF-8 legacy values
- add focused regression coverage for the affected edge case

## Validation
- `cd server && mvn -q -Dtest=CredentialUtilsTest test`