### PR TITLE
fix(security): reject multicast endpoint addresses

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/UrlHostGuard.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/UrlHostGuard.java
@@ -100,7 +100,8 @@ public final class UrlHostGuard {
         }
         try {
             InetAddress address = InetAddress.getByName(normalized);
-            if (address.isAnyLocalAddress() || address.isLinkLocalAddress()) {
+            if (address.isAnyLocalAddress() || address.isLinkLocalAddress()
+                    || address.isMulticastAddress()) {
                 return false;
             }
             if (address.isLoopbackAddress()) {

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardMulticastTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardMulticastTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UrlHostGuardMulticastTest {
+
+    @Test
+    void isAllowedHostShouldRejectIpv4AndIpv6MulticastAddresses() {
+        assertThat(UrlHostGuard.isAllowedHost("224.0.0.1", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("ff02::1", false)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- reject multicast endpoint addresses
- add focused regression coverage for the affected edge case

## Validation
- `cd server && mvn -q -Dtest=UrlHostGuardMulticastTest test`