### PR TITLE
fix(alerts): infer teams case-insensitively

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -290,16 +290,19 @@ public class AlertService {
         if (!hasText(metric)) {
             return "broker";
         }
-        if (metric.contains("replication") || metric.contains("fall_behind") || metric.contains("slave")) {
+        String normalizedMetric = metric.toLowerCase(Locale.ROOT);
+        if (normalizedMetric.contains("replication") || normalizedMetric.contains("fall_behind")
+                || normalizedMetric.contains("slave")) {
             return "broker";
         }
-        if (metric.contains("consumer") || metric.contains("lag")) {
+        if (normalizedMetric.contains("consumer") || normalizedMetric.contains("lag")) {
             return "consumer";
         }
-        if (metric.contains("producer") || metric.contains("client")) {
+        if (normalizedMetric.contains("producer") || normalizedMetric.contains("client")) {
             return "client";
         }
-        if (metric.contains("topic") || metric.contains("messages_in") || metric.contains("messages_out")) {
+        if (normalizedMetric.contains("topic") || normalizedMetric.contains("messages_in")
+                || normalizedMetric.contains("messages_out")) {
             return "topic";
         }
         return "broker";

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -179,6 +179,22 @@ class AlertServiceTest {
     }
 
     @Test
+    void exportPrometheusRulesYamlShouldInferTeamWithoutMetricCaseSensitivity() {
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .name("Uppercase lag")
+                .metric("ROCKETMQ_CONSUMER_LAG_MESSAGES")
+                .operator(">")
+                .threshold(10)
+                .enabled(true)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+
+        String result = alertService.exportPrometheusRulesYaml();
+
+        assertThat(result).contains("- name: rocketmq-consumer.rules");
+    }
+
+    @Test
     void exportPrometheusRulesYamlShouldRenderReplicationLagRuleWithScopeAndSeverity() {
         AlertRuleVO rule = AlertRuleVO.builder()
                 .name("Replication Lag High")


### PR DESCRIPTION
## Summary
- infer teams case-insensitively
- add focused regression coverage for the affected edge case

## Validation
- `cd server && mvn -q -Dtest=AlertServiceTest test`