### PR TITLE
fix(alerts): avoid blank exported summaries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -308,7 +308,10 @@ public class AlertService {
     private String summary(AlertRuleVO rule) {
         String description = rule.getDescription();
         if (hasText(description) && description.contains(" - ")) {
-            return description.substring(0, description.indexOf(" - "));
+            String candidate = description.substring(0, description.indexOf(" - "));
+            if (hasText(candidate)) {
+                return candidate;
+            }
         }
         return hasText(rule.getName()) ? rule.getName() : "RocketMQ alert";
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -269,6 +269,27 @@ class AlertServiceTest {
     }
 
     @Test
+    void exportPrometheusRulesYamlShouldNotEmitABlankSummary() throws Exception {
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .name("Lag alert")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(1)
+                .description(" - consumer is behind")
+                .enabled(true)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+
+        JsonNode exportedRule = new ObjectMapper(new YAMLFactory())
+                .readTree(alertService.exportPrometheusRulesYaml())
+                .path("groups").get(0).path("rules").get(0);
+
+        assertThat(exportedRule.path("annotations").path("summary").asText()).isEqualTo("Lag alert");
+        assertThat(exportedRule.path("annotations").path("description").asText())
+                .isEqualTo("consumer is behind");
+    }
+
+    @Test
     void exportPrometheusRulesYamlShouldEscapeSpecialCharacters() throws Exception {
         AlertRuleVO rule = AlertRuleVO.builder()
                 .name("Scoped rule")


### PR DESCRIPTION
## Summary
- avoid blank exported summaries
- add focused regression coverage for the affected edge case

## Validation
- `cd server && mvn -q -Dtest=AlertServiceTest test`