### PR TITLE
fix(alerts): normalize stored alert levels

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -172,7 +172,7 @@ public class MybatisPlusAlertRepository implements AlertRepository {
             return AlertLevel.info;
         }
         try {
-            return AlertLevel.valueOf(level);
+            return AlertLevel.valueOf(level.trim().toLowerCase(Locale.ROOT));
         } catch (IllegalArgumentException exception) {
             return AlertLevel.info;
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Locale;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
@@ -46,6 +47,17 @@ class MybatisPlusAlertRepositoryTest {
 
     @InjectMocks
     private MybatisPlusAlertRepository repository;
+
+    @Test
+    void findAlertsShouldNormalizeStoredLevelValues() {
+        RmqSystemAlert entity = new RmqSystemAlert();
+        entity.setLevel(" WARNING ");
+        when(alertMapper.selectList(any())).thenReturn(List.of(entity));
+
+        assertThat(repository.findAlerts(null)).singleElement()
+                .satisfies(alert -> assertThat(alert.getLevel()).isEqualTo(
+                        org.apache.rocketmq.studio.common.domain.enums.AlertLevel.warning));
+    }
 
     @Test
     void findAlertsShouldNormalizeLevelIndependentlyOfDefaultLocale() {


### PR DESCRIPTION
## Summary
- normalize stored alert levels
- add focused regression coverage for the affected edge case

## Validation
- `cd server && mvn -q -Dtest=MybatisPlusAlertRepositoryTest test`