### PR TITLE
fix(metrics): reject unsupported stored auth modes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
@@ -121,9 +121,10 @@ public class MetricsService {
             return "none";
         }
         return switch (auth.trim().toLowerCase(Locale.ROOT)) {
+            case "none" -> "none";
             case "basic auth", "basic" -> "basic";
             case "bearer token", "bearer" -> "bearer";
-            default -> "none";
+            default -> throw badRequest("Unsupported data source authentication mode: " + auth.trim());
         };
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
@@ -423,6 +423,28 @@ class MetricsServiceTest {
     }
 
     @Test
+    void queryByDataSourceShouldRejectUnsupportedStoredAuthMode() {
+        MetricsDataSourceQueryRequest request = dataSourceRequest(null);
+        DataSourceVO dataSource = DataSourceVO.builder()
+                .key("ds-1")
+                .name("prometheus-a")
+                .type("prometheus")
+                .url("http://prometheus:9090")
+                .auth("digest")
+                .build();
+        when(settingsService.getDataSource("ds-1")).thenReturn(dataSource);
+
+        assertThatExceptionOfType(PrometheusException.class)
+                .isThrownBy(() -> metricsService.queryByDataSource("ds-1", request))
+                .satisfies(exception -> {
+                    assertThat(exception.getStatusCode()).isEqualTo(400);
+                    assertThat(exception.getMessage())
+                            .isEqualTo("Unsupported data source authentication mode: digest");
+                });
+        verifyNoInteractions(metricsSourceFactory, metricsSource);
+    }
+
+    @Test
     void queryByDataSourceShouldNormalizeAuthIndependentlyOfDefaultLocale() {
         MetricQueryDTO query = MetricQueryDTO.builder()
                 .metric("cpu")


### PR DESCRIPTION
## Summary
- reject unsupported stored auth modes
- add focused regression coverage for the affected edge case

## Validation
- `cd server && mvn -q -Dtest=MetricsServiceTest test`