### PR TITLE
fix(aliyun): clamp instance catalog counts

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
@@ -336,6 +336,15 @@ final class AliyunConverters {
     }
 
     private static Integer toInteger(Long value) {
-        return value == null ? null : value.intValue();
+        if (value == null) {
+            return null;
+        }
+        if (value > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        if (value < 0) {
+            return 0;
+        }
+        return value.intValue();
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.alibaba;
+
+import com.aliyun.sdk.service.rocketmq20220801.models.ListInstancesResponseBody;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AliyunConvertersTest {
+
+    @Test
+    void toInstanceOptionShouldClampCountsOutsideTheIntegerRange() {
+        ListInstancesResponseBody.List data = ListInstancesResponseBody.List.builder()
+                .topicCount(Long.MAX_VALUE)
+                .groupCount(Long.MIN_VALUE)
+                .build();
+
+        var result = AliyunConverters.toInstanceOptionVO(data);
+
+        assertThat(result.getTopicCount()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(result.getGroupCount()).isZero();
+    }
+}


### PR DESCRIPTION
## Summary
- clamp instance catalog counts
- add focused regression coverage for the affected edge case

## Validation
- `cd server && mvn -q -Dtest=AliyunConvertersTest test`