### PR TITLE
fix(aliyun): skip null instance catalog records

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogService.java
@@ -86,6 +86,9 @@ public class AliyunCatalogService implements CloudCatalogProvider {
         List<ListInstancesResponseBody.List> all = fetchAllInstances(credentialId, regionId);
         List<CloudInstanceOptionVO> options = new ArrayList<>();
         for (ListInstancesResponseBody.List item : all) {
+            if (item == null) {
+                continue;
+            }
             CloudInstanceOptionVO vo = AliyunConverters.toInstanceOptionVO(item);
             if (matchesSearch(search, vo)) {
                 options.add(vo);

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogServiceTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,6 +89,16 @@ class AliyunCatalogServiceTest {
         assertThat(regions).extracting(CloudRegionVO::getRegionId)
                 .containsExactly("cn-beijing", "cn-hangzhou", "cn-shanghai");
         assertThat(regions.get(1).getRegionName()).isEqualTo("hangzhou");
+    }
+
+    @Test
+    void listCloudInstancesShouldSkipNullSdkRecords() {
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any()))
+                .thenReturn(instancesResponse(Arrays.asList(null, instanceRow("rmq-a", "A"))));
+
+        assertThat(service.listCloudInstances(CREDENTIAL_ID, REGION, null))
+                .extracting(CloudInstanceOptionVO::getInstanceId)
+                .containsExactly("rmq-a");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- skip null instance catalog records
- add focused regression coverage for the affected edge case

## Validation
- `cd server && mvn -q -Dtest=AliyunCatalogServiceTest test`