### PR TITLE
fix(tencent): skip non-scalar message properties

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -673,7 +673,12 @@ public class TencentInstanceProvider implements InstanceProvider {
                 return Collections.emptyMap();
             }
             Map<String, String> properties = new LinkedHashMap<>();
-            root.fields().forEachRemaining(entry -> properties.put(entry.getKey(), entry.getValue().asText("")));
+            root.fields().forEachRemaining(entry -> {
+                JsonNode value = entry.getValue();
+                if (value != null && value.isValueNode() && !value.isNull()) {
+                    properties.put(entry.getKey(), value.asText());
+                }
+            });
             return properties;
         } catch (Exception e) {
             return Collections.emptyMap();

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -437,6 +437,25 @@ class TencentInstanceProviderTest {
     }
 
     @Test
+    void queryMessagesShouldSkipNullAndStructuredPropertyValues() throws Exception {
+        DescribeMessageResponse detail = new DescribeMessageResponse();
+        detail.setMessageId("MSG-1");
+        detail.setShowTopicName("orders");
+        detail.setProperties("{\"KEYS\":\"keyA\",\"TAGS\":null,"
+                + "\"nested\":{\"x\":1},\"retry\":3,\"enabled\":true}");
+        when(client.DescribeMessage(any())).thenReturn(detail);
+
+        MessageRecordVO record = provider.queryMessages(
+                STUDIO_INSTANCE_ID, "orders", "MSG-1", null, null, null, null).get(0);
+
+        assertThat(record.getProperties())
+                .containsEntry("KEYS", "keyA")
+                .containsEntry("retry", "3")
+                .containsEntry("enabled", "true")
+                .doesNotContainKeys("TAGS", "nested");
+    }
+
+    @Test
     void queryMessagesByTopicShouldUseMessageListTest() throws Exception {
         MessageItem one = new MessageItem();
         one.setMsgId("MSG-A");


### PR DESCRIPTION
## Summary
- skip non-scalar message properties
- add focused regression coverage for the affected edge case

## Validation
- `cd server && mvn -q -Dtest=TencentInstanceProviderTest test`