### PR TITLE
fix(tencent): clamp consumer retry counts

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -859,7 +859,10 @@ public class TencentInstanceProvider implements InstanceProvider {
     }
 
     private static int toInt(Long value) {
-        return value == null ? 0 : Math.toIntExact(value);
+        if (value == null || value <= 0L) {
+            return 0;
+        }
+        return value > Integer.MAX_VALUE ? Integer.MAX_VALUE : value.intValue();
     }
 
     private static ConsumeType toConsumeType(Boolean consumeMessageOrderly) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -294,6 +294,20 @@ class TencentInstanceProviderTest {
     }
 
     @Test
+    void listConsumerGroupsShouldClampOversizedRetryCounts() throws Exception {
+        ConsumeGroupItem item = new ConsumeGroupItem();
+        item.setConsumerGroup("GID_test");
+        item.setMaxRetryTimes(Long.MAX_VALUE);
+        DescribeConsumerGroupListResponse response = new DescribeConsumerGroupListResponse();
+        response.setData(new ConsumeGroupItem[]{item});
+        when(client.DescribeConsumerGroupList(any())).thenReturn(response);
+
+        assertThat(provider.listConsumerGroups(STUDIO_INSTANCE_ID, null))
+                .singleElement()
+                .satisfies(group -> assertThat(group.getRetryMaxTimes()).isEqualTo(Integer.MAX_VALUE));
+    }
+
+    @Test
     void listConsumerGroupsShouldMapAndFilterTest() throws Exception {
         ConsumeGroupItem one = new ConsumeGroupItem();
         one.setConsumerGroup("GID_test");


### PR DESCRIPTION
## Summary
- clamp consumer retry counts
- add focused regression coverage for the affected edge case

## Validation
- `cd server && mvn -q -Dtest=TencentInstanceProviderTest test`