### PR TITLE
fix(clients): skip null producer connection entries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionSummaryVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionSummaryVO.java
@@ -49,7 +49,9 @@ public class ProducerConnectionSummaryVO {
     private String readiness = READY;
 
     public static ProducerConnectionSummaryVO from(List<ProducerConnectionVO> connections) {
-        List<ProducerConnectionVO> safeConnections = connections == null ? List.of() : connections;
+        List<ProducerConnectionVO> safeConnections = connections == null
+                ? List.of()
+                : connections.stream().filter(Objects::nonNull).toList();
         ProducerConnectionSummaryVO summary = new ProducerConnectionSummaryVO();
         summary.totalConnections = safeConnections.size();
         summary.uniqueClientCount = countDistinct(safeConnections, ProducerConnectionVO::getClientId);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionSummaryVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionSummaryVOTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.client;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +32,15 @@ class ProducerConnectionSummaryVOTest {
         assertThat(summary.getTotalConnections()).isZero();
         assertThat(summary.getReadiness()).isEqualTo(ProducerConnectionSummaryVO.UNAVAILABLE);
         assertThat(summary.getWarnings()).containsExactly(ProducerConnectionSummaryVO.NO_CONNECTIONS);
+    }
+
+    @Test
+    void fromShouldSkipNullConnectionEntries() {
+        ProducerConnectionSummaryVO summary = ProducerConnectionSummaryVO.from(Arrays.asList(
+                null, connection("producer-a", "10.0.0.1:38888", "Java", "5.1.0")));
+
+        assertThat(summary.getTotalConnections()).isEqualTo(1);
+        assertThat(summary.getReadiness()).isEqualTo(ProducerConnectionSummaryVO.READY);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- skip null producer connection entries
- add focused regression coverage for the affected edge case

## Validation
- `cd server && mvn -q -Dtest=ProducerConnectionSummaryVOTest test`