### PR TITLE
fix(k8s): normalize stored certificate enums

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -32,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -116,11 +117,13 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         if (!StringUtils.hasText(value)) {
             return null;
         }
-        try {
-            return CertType.valueOf(value);
-        } catch (IllegalArgumentException exception) {
-            throw invalidPersistedValue(certificateId, "type", value);
+        String normalized = value.trim();
+        for (CertType type : CertType.values()) {
+            if (type.name().equalsIgnoreCase(normalized)) {
+                return type;
+            }
         }
+        throw invalidPersistedValue(certificateId, "type", value);
     }
 
     private CertStatus parseCertStatus(String certificateId, String value) {
@@ -128,7 +131,7 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
             return null;
         }
         try {
-            return CertStatus.valueOf(value);
+            return CertStatus.valueOf(value.trim().toLowerCase(Locale.ROOT));
         } catch (IllegalArgumentException exception) {
             throw invalidPersistedValue(certificateId, "status", value);
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
@@ -22,11 +22,29 @@ import org.apache.rocketmq.studio.persistence.entity.RmqK8sCertificate;
 import org.apache.rocketmq.studio.persistence.mapper.RmqK8sCertificateMapper;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class MybatisPlusK8sCertRepositoryTest {
+
+    @Test
+    void findByIdNormalizesPersistedCertificateEnums() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        RmqK8sCertificate entity = certificate();
+        entity.setCertType(" mtls ");
+        entity.setStatus(" EXPIRING ");
+        when(mapper.selectById("cert-1")).thenReturn(entity);
+
+        assertThat(repository(mapper).findById("cert-1")).get()
+                .satisfies(cert -> {
+                    assertThat(cert.getType()).isEqualTo(
+                            org.apache.rocketmq.studio.common.domain.enums.CertType.mTLS);
+                    assertThat(cert.getStatus()).isEqualTo(
+                            org.apache.rocketmq.studio.common.domain.enums.CertStatus.expiring);
+                });
+    }
 
     @Test
     void findByIdSurfacesInvalidPersistedCertificateType() {


### PR DESCRIPTION
## Summary
- normalize stored certificate enums
- add focused regression coverage for the affected edge case

## Validation
- `cd server && mvn -q -Dtest=MybatisPlusK8sCertRepositoryTest test`