### PR TITLE
fix(web): preserve 401 errors for malformed request URLs

### DIFF
--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -148,4 +148,13 @@ describe('API client response contract', () => {
     expect(localStorage.getItem('rocketmq-studio-user')).toBeNull();
     expect(localStorage.getItem('rocketmq-studio-user-admin')).toBeNull();
   });
+
+  it('preserves the original 401 error when the request URL is malformed', async () => {
+    localStorage.setItem('token', 'expired-token');
+    mock.onGet('http://[').reply(401, { code: 401, message: 'Unauthorized', data: null });
+
+    await expect(client.get('http://[')).rejects.toMatchObject({ response: { status: 401 } });
+
+    expect(localStorage.getItem('token')).toBeNull();
+  });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -47,12 +47,16 @@ function getBusinessError(data: unknown): string | null {
 
 function isPublicAuthRequest(url?: string): boolean {
   if (!url) return false;
-  const requestPath = new URL(url, window.location.origin).pathname;
-  const apiBasePath = new URL(API_BASE_URL, window.location.origin).pathname;
-  const relativePath = requestPath.startsWith(`${apiBasePath}/`)
-    ? requestPath.slice(apiBasePath.length)
-    : requestPath;
-  return PUBLIC_AUTH_PATHS.has(relativePath);
+  try {
+    const requestPath = new URL(url, window.location.origin).pathname;
+    const apiBasePath = new URL(API_BASE_URL, window.location.origin).pathname;
+    const relativePath = requestPath.startsWith(`${apiBasePath}/`)
+      ? requestPath.slice(apiBasePath.length)
+      : requestPath;
+    return PUBLIC_AUTH_PATHS.has(relativePath);
+  } catch {
+    return false;
+  }
 }
 
 const client = axios.create({


### PR DESCRIPTION
## Summary
- preserve 401 errors for malformed request URLs
- add focused regression coverage for the affected edge case

## Validation
- `npm test -- --run src/api/client.test.ts`