### PR TITLE
[ISSUE #1885] 修复消息分页拉取 offset 不推进

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImpl.java
@@ -384,6 +384,14 @@ public class MessageServiceImpl implements MessageService {
                                 size--;
                             }
                         }
+                        long nextBeginOffset = pullResult.getNextBeginOffset();
+                        if (size > 0 && nextBeginOffset <= start) {
+                            logger.warn("Pull offset did not advance, topic={}, queueId={}, offset={}",
+                                    queueOffsetInfo.getMessageQueues().getTopic(),
+                                    queueOffsetInfo.getMessageQueues().getQueueId(), start);
+                            break;
+                        }
+                        start = nextBeginOffset;
                     } else {
                         break;
                     }
@@ -451,6 +459,14 @@ public class MessageServiceImpl implements MessageService {
                                 size--;
                             }
                         }
+                        long nextBeginOffset = pullResult.getNextBeginOffset();
+                        if (size > 0 && nextBeginOffset <= start) {
+                            logger.warn("Pull offset did not advance, topic={}, queueId={}, offset={}",
+                                    queueOffsetInfo.getMessageQueues().getTopic(),
+                                    queueOffsetInfo.getMessageQueues().getQueueId(), start);
+                            break;
+                        }
+                        start = nextBeginOffset;
                     } else {
                         break;
                     }

--- a/src/test/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImplTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/service/impl/MessageServiceImplTest.java
@@ -32,6 +32,7 @@ import org.apache.rocketmq.dashboard.model.MessagePage;
 import org.apache.rocketmq.dashboard.model.MessageQueryByPage;
 import org.apache.rocketmq.dashboard.model.MessageView;
 import org.apache.rocketmq.dashboard.model.QueueOffsetInfo;
+import org.apache.rocketmq.dashboard.model.request.MessageQuery;
 import org.apache.rocketmq.dashboard.support.AutoCloseConsumerWrapper;
 import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.remoting.protocol.body.Connection;
@@ -433,6 +434,70 @@ public class MessageServiceImplTest {
         assertEquals(10, (qo1.getEndOffset() - 5L) + (qo2.getEndOffset() - 10L));
     }
 
+    @Test
+    public void testQueryMessageByPageAdvancesPullOffsetAcrossBatches() throws Exception {
+        MessageQueue messageQueue = new MessageQueue(TOPIC, "broker-1", 0);
+        when(defaultMQPullConsumer.fetchSubscribeMessageQueues(TOPIC))
+                .thenReturn(Collections.singleton(messageQueue));
+        when(defaultMQPullConsumer.searchOffset(messageQueue, 1000L)).thenReturn(0L);
+        when(defaultMQPullConsumer.searchOffset(messageQueue, 3000L)).thenReturn(4L);
+
+        PullResult boundaryResult = createPullResult(PullStatus.FOUND,
+                Collections.singletonList(createMessageExt("boundary", TOPIC, "body", 1500L)), 1L, 0L);
+        PullResult endResult = createPullResult(PullStatus.FOUND, Arrays.asList(
+                createMessageExt("id1", TOPIC, "body1", 1500L),
+                createMessageExt("id2", TOPIC, "body2", 1600L),
+                createMessageExt("id3", TOPIC, "body3", 1700L),
+                createMessageExt("id4", TOPIC, "body4", 1800L)), 4L, 0L);
+        PullResult firstBatch = createPullResult(PullStatus.FOUND, Arrays.asList(
+                createMessageExt("id1", TOPIC, "body1", 1500L),
+                createMessageExt("id2", TOPIC, "body2", 1600L)), 2L, 0L);
+        PullResult secondBatch = createPullResult(PullStatus.FOUND, Arrays.asList(
+                createMessageExt("id3", TOPIC, "body3", 1700L),
+                createMessageExt("id4", TOPIC, "body4", 1800L)), 4L, 2L);
+
+        when(defaultMQPullConsumer.pull(messageQueue, "*", 0L, 32))
+                .thenReturn(boundaryResult)
+                .thenReturn(firstBatch);
+        when(defaultMQPullConsumer.pull(messageQueue, "*", 0L, 4)).thenReturn(endResult);
+        when(defaultMQPullConsumer.pull(messageQueue, "*", 2L, 32)).thenReturn(secondBatch);
+
+        MessagePage result = messageService.queryMessageByPage(createMessageQuery(4));
+
+        assertEquals(Arrays.asList("id1", "id2", "id3", "id4"), result.getPage().getContent().stream()
+                .map(MessageView::getMsgId).collect(java.util.stream.Collectors.toList()));
+        verify(defaultMQPullConsumer).pull(messageQueue, "*", 2L, 32);
+    }
+
+    @Test
+    public void testQueryMessageByPageStopsWhenPullOffsetDoesNotAdvance() throws Exception {
+        MessageQueue messageQueue = new MessageQueue(TOPIC, "broker-1", 0);
+        when(defaultMQPullConsumer.fetchSubscribeMessageQueues(TOPIC))
+                .thenReturn(Collections.singleton(messageQueue));
+        when(defaultMQPullConsumer.searchOffset(messageQueue, 1000L)).thenReturn(0L);
+        when(defaultMQPullConsumer.searchOffset(messageQueue, 3000L)).thenReturn(3L);
+
+        PullResult boundaryResult = createPullResult(PullStatus.FOUND,
+                Collections.singletonList(createMessageExt("boundary", TOPIC, "body", 1500L)), 1L, 0L);
+        PullResult endResult = createPullResult(PullStatus.FOUND, Arrays.asList(
+                createMessageExt("id1", TOPIC, "body1", 1500L),
+                createMessageExt("id2", TOPIC, "body2", 1600L),
+                createMessageExt("id3", TOPIC, "body3", 1700L)), 3L, 0L);
+        PullResult stalledResult = createPullResult(PullStatus.FOUND,
+                Collections.singletonList(createMessageExt("id1", TOPIC, "body1", 1500L)), 0L, 0L);
+
+        when(defaultMQPullConsumer.pull(messageQueue, "*", 0L, 32))
+                .thenReturn(boundaryResult)
+                .thenReturn(stalledResult);
+        when(defaultMQPullConsumer.pull(messageQueue, "*", 0L, 3)).thenReturn(endResult);
+
+        MessagePage result = messageService.queryMessageByPage(createMessageQuery(3));
+
+        assertEquals(1, result.getPage().getContent().size());
+        assertEquals("id1", result.getPage().getContent().get(0).getMsgId());
+        verify(defaultMQPullConsumer, times(2)).pull(messageQueue, "*", 0L, 32);
+    }
+
     // Helper methods
 
     private MessageExt createMessageExt(String msgId, String topic, String body, long storeTimestamp) {
@@ -446,5 +511,16 @@ public class MessageServiceImplTest {
 
     private PullResult createPullResult(PullStatus status, List<MessageExt> msgFoundList, long nextBeginOffset, long minOffset) {
         return new PullResult(status, nextBeginOffset, minOffset, minOffset + msgFoundList.size(), msgFoundList);
+    }
+
+    private MessageQuery createMessageQuery(int pageSize) {
+        MessageQuery query = new MessageQuery();
+        query.setPageNum(1);
+        query.setPageSize(pageSize);
+        query.setTopic(TOPIC);
+        query.setTaskId("");
+        query.setBegin(1000L);
+        query.setEnd(3000L);
+        return query;
     }
 }


### PR DESCRIPTION
## 变更目的

消息分页在一次 pull 未填满页面时会从同一 offset 重复拉取，产生重复消息；broker 返回不前进的 offset 时还可能形成无效循环。

## 简要变更

- 两个分页 pull 循环在成功拉取后统一推进到 `nextBeginOffset`。
- next offset 未前进时停止当前队列拉取并记录告警。
- 增加多批次拉取与停滞 offset 回归测试。

## 本地验证

- `MessageServiceImplTest`：17/17 通过（Temurin 17，预加载项目现有 Byte Buddy agent 以适配本机 Mockito attach 限制）
- `git diff --check`：通过
- 400 行范围门禁：通过

## 未执行

未运行容器、RocketMQ 集群、完整 E2E、压力测试或镜像构建；这些重量级验证交由 PR 自动触发的上游检查。

## 提交清单

- [x] 已创建唯一对应 Issue
- [x] 一个 PR 只解决一个问题
- [x] 已增加必要回归测试
- [x] 已完成受影响范围的本地轻量验证

Fixes #1885