### PR TITLE
[ISSUE #1887] 修复 DLQ 空结果页码偏移

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/DlqMessageServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/DlqMessageServiceImpl.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.dashboard.model.DlqMessageRequest;
 import org.apache.rocketmq.dashboard.model.DlqMessageResendResult;
 import org.apache.rocketmq.dashboard.model.MessagePage;
+import org.apache.rocketmq.dashboard.model.MessageQueryByPage;
 import org.apache.rocketmq.dashboard.model.MessageView;
 import org.apache.rocketmq.dashboard.model.request.MessageQuery;
 import org.apache.rocketmq.dashboard.service.DlqMessageService;
@@ -53,7 +54,9 @@ public class DlqMessageServiceImpl implements DlqMessageService {
     @Override
     public MessagePage queryDlqMessageByPage(MessageQuery query) {
         List<MessageView> messageViews = new ArrayList<>();
-        PageRequest page = PageRequest.of(query.getPageNum(), query.getPageSize());
+        MessageQueryByPage pageQuery = new MessageQueryByPage(query.getPageNum(), query.getPageSize(),
+                query.getTopic(), query.getBegin(), query.getEnd());
+        PageRequest page = pageQuery.page();
         String topic = query.getTopic();
         try {
             mqAdminExt.examineTopicRouteInfo(topic);

--- a/src/test/java/org/apache/rocketmq/dashboard/controller/DlqMessageControllerTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/controller/DlqMessageControllerTest.java
@@ -89,7 +89,9 @@ public class DlqMessageControllerTest extends BaseControllerTest {
         // 1、%DLQ%group_test is not exist
         perform = mockMvc.perform(requestBuilder);
         perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.page.content", hasSize(0)));
+                .andExpect(jsonPath("$.data.page.content", hasSize(0)))
+                .andExpect(jsonPath("$.data.page.number").value(0))
+                .andExpect(jsonPath("$.data.page.size").value(10));
 
         // 2、Other MQClientException occur
         perform = mockMvc.perform(requestBuilder);


### PR DESCRIPTION
## 变更目的

DLQ Topic 不存在时，异常分支把一基页码直接交给零基 PageRequest，导致第一页响应显示为第二页。

## 简要变更

- 空结果分支复用 `MessageQueryByPage#page` 的页码和页大小规范化。
- Controller 回归测试断言第一页返回 `page.number=0` 且页大小保持为 10。

## 本地验证

- `DlqMessageControllerTest#testQueryDlqMessageByConsumerGroup`：1/1 通过（Temurin 17）
- `git diff --check`：通过
- 400 行范围门禁：通过

## 未执行

未运行容器、RocketMQ 集群、完整 E2E、压力测试或镜像构建；这些重量级验证交由 PR 自动触发的上游检查。

## 提交清单

- [x] 已创建唯一对应 Issue
- [x] 一个 PR 只解决一个问题
- [x] 已增加必要回归测试
- [x] 已完成受影响范围的本地轻量验证

Fixes #1887