### PR TITLE
[ISSUE #1888] 从备份恢复损坏的 Monitor 配置

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/MonitorServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/MonitorServiceImpl.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Throwables;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.dashboard.config.RMQConfigure;
 import org.apache.rocketmq.dashboard.model.ConsumerMonitorConfig;
@@ -33,6 +34,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
+@Slf4j
 public class MonitorServiceImpl implements MonitorService {
 
 
@@ -88,15 +90,30 @@ public class MonitorServiceImpl implements MonitorService {
     }
 
     @PostConstruct
-    private void loadData() throws IOException {
-        String content = MixAll.file2String(getConsumerMonitorConfigDataPath());
-        if (content == null) {
-            content = MixAll.file2String(getConsumerMonitorConfigDataPathBackUp());
+    private void loadData() {
+        Map<String, ConsumerMonitorConfig> loadedConfig = loadConfig(getConsumerMonitorConfigDataPath());
+        if (loadedConfig == null) {
+            loadedConfig = loadConfig(getConsumerMonitorConfigDataPathBackUp());
         }
-        if (content == null) {
-            return;
+        configMap = loadedConfig == null ? new ConcurrentHashMap<>() : loadedConfig;
+    }
+
+    private Map<String, ConsumerMonitorConfig> loadConfig(String path) {
+        try {
+            String content = MixAll.file2String(path);
+            if (content == null) {
+                return null;
+            }
+            Map<String, ConsumerMonitorConfig> result = JsonUtil.string2Obj(content,
+                    new TypeReference<ConcurrentHashMap<String, ConsumerMonitorConfig>>() {
+                    });
+            if (result == null) {
+                log.warn("Failed to parse consumer monitor config file: {}", path);
+            }
+            return result;
+        } catch (IOException e) {
+            log.warn("Failed to read consumer monitor config file: {}", path, e);
+            return null;
         }
-        configMap = JsonUtil.string2Obj(content, new TypeReference<ConcurrentHashMap<String, ConsumerMonitorConfig>>() {
-        });
     }
 }

--- a/src/test/java/org/apache/rocketmq/dashboard/service/impl/MonitorServiceImplTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/service/impl/MonitorServiceImplTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.dashboard.service.impl;
+
+import org.apache.rocketmq.dashboard.config.RMQConfigure;
+import org.apache.rocketmq.dashboard.model.ConsumerMonitorConfig;
+import org.apache.rocketmq.dashboard.util.JsonUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MonitorServiceImplTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private MonitorServiceImpl monitorService;
+    private File configFile;
+
+    @Before
+    public void setUp() throws Exception {
+        File dataDirectory = temporaryFolder.newFolder("dashboard-data");
+        File monitorDirectory = new File(dataDirectory, "monitor");
+        Assert.assertTrue(monitorDirectory.mkdirs());
+        configFile = new File(monitorDirectory, "consumerMonitorConfig.json");
+
+        RMQConfigure configure = mock(RMQConfigure.class);
+        when(configure.getRocketMqDashboardDataPath()).thenReturn(dataDirectory.getAbsolutePath());
+        monitorService = new MonitorServiceImpl();
+        ReflectionTestUtils.setField(monitorService, "configure", configure);
+    }
+
+    @Test
+    public void testLoadDataFallsBackToBackupWhenPrimaryFileIsCorrupted() throws Exception {
+        Files.write(configFile.toPath(), "not-json".getBytes(StandardCharsets.UTF_8));
+        Map<String, ConsumerMonitorConfig> backupConfig = Collections.singletonMap(
+                "group-test", new ConsumerMonitorConfig(1, 100));
+        Files.write(new File(configFile.getPath() + ".bak").toPath(),
+                JsonUtil.obj2String(backupConfig).getBytes(StandardCharsets.UTF_8));
+
+        ReflectionTestUtils.invokeMethod(monitorService, "loadData");
+
+        ConsumerMonitorConfig loaded = monitorService.queryConsumerMonitorConfigByGroupName("group-test");
+        Assert.assertNotNull(loaded);
+        Assert.assertEquals(1, loaded.getMinCount());
+        Assert.assertEquals(100, loaded.getMaxDiffTotal());
+    }
+
+    @Test
+    public void testLoadDataUsesEmptyMapWhenPrimaryAndBackupAreCorrupted() throws Exception {
+        Files.write(configFile.toPath(), "not-json".getBytes(StandardCharsets.UTF_8));
+        Files.write(new File(configFile.getPath() + ".bak").toPath(),
+                "also-not-json".getBytes(StandardCharsets.UTF_8));
+
+        ReflectionTestUtils.invokeMethod(monitorService, "loadData");
+
+        Assert.assertNotNull(monitorService.queryConsumerMonitorConfig());
+        Assert.assertTrue(monitorService.queryConsumerMonitorConfig().isEmpty());
+        Assert.assertTrue(monitorService.createOrUpdateConsumerMonitor(
+                "group-test", new ConsumerMonitorConfig(2, 200)));
+    }
+}


### PR DESCRIPTION
## 变更目的

主监控配置存在但 JSON 损坏时，当前实现不会尝试备份，并会把运行时 configMap 置为 null。

## 简要变更

- 按主文件、备份文件、空 `ConcurrentHashMap` 顺序恢复。
- 读取或解析失败时保留可写的非空运行时 Map。
- 覆盖主文件损坏但备份有效、主备份都损坏两条路径。

## 本地验证

- `MonitorServiceImplTest`：2/2 通过（Temurin 17）
- `git diff --check`：通过
- 400 行范围门禁：通过

## 未执行

未运行容器、RocketMQ 集群、完整 E2E、压力测试或镜像构建；这些重量级验证交由 PR 自动触发的上游检查。

## 提交清单

- [x] 已创建唯一对应 Issue
- [x] 一个 PR 只解决一个问题
- [x] 已增加必要回归测试
- [x] 已完成受影响范围的本地轻量验证

Fixes #1888