### PR TITLE
[ISSUE #1889] 使用 Jakarta PreDestroy 清理用户管理池

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/admin/UserMQAdminPoolManager.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/admin/UserMQAdminPoolManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.dashboard.admin;
 
+import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
@@ -25,7 +26,6 @@ import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PreDestroy;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 

--- a/src/test/java/org/apache/rocketmq/dashboard/admin/UserMQAdminPoolManagerTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/admin/UserMQAdminPoolManagerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.dashboard.admin;
+
+import jakarta.annotation.PreDestroy;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.rocketmq.dashboard.config.RMQConfigure;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class UserMQAdminPoolManagerTest {
+
+    private UserMQAdminPoolManager poolManager;
+
+    @Before
+    public void setUp() {
+        RMQConfigure configure = mock(RMQConfigure.class);
+        when(configure.getNamesrvAddr()).thenReturn("127.0.0.1:9876");
+        when(configure.getClientCallbackExecutorThreads()).thenReturn(4);
+        when(configure.getIsVIPChannel()).thenReturn("false");
+        poolManager = new UserMQAdminPoolManager(configure);
+    }
+
+    @Test
+    public void testShutdownAllPoolsUsesJakartaPreDestroy() throws Exception {
+        Method shutdownMethod = UserMQAdminPoolManager.class.getMethod("shutdownAllPools");
+
+        Assert.assertNotNull(shutdownMethod.getAnnotation(PreDestroy.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testShutdownAllPoolsClosesAndRemovesPools() {
+        GenericObjectPool<MQAdminExt> pool = mock(GenericObjectPool.class);
+        ConcurrentMap<String, GenericObjectPool<MQAdminExt>> userPools =
+                (ConcurrentMap<String, GenericObjectPool<MQAdminExt>>) ReflectionTestUtils
+                        .getField(poolManager, "userPools");
+        Assert.assertNotNull(userPools);
+        userPools.put("user-a", pool);
+
+        poolManager.shutdownAllPools();
+
+        verify(pool).close();
+        Assert.assertTrue(userPools.isEmpty());
+    }
+}


### PR DESCRIPTION
## 变更目的

Spring Boot 3 使用 Jakarta 生命周期注解，但用户 MQAdmin 池仍引用旧的 javax PreDestroy，销毁回调可能无法正确注册。

## 简要变更

- 将销毁注解切换为 `jakarta.annotation.PreDestroy`。
- 验证销毁方法使用 Jakarta 注解，并关闭、清空全部用户池。

## 本地验证

- `UserMQAdminPoolManagerTest`：2/2 通过（Temurin 17）
- `git diff --check`：通过
- 400 行范围门禁：通过

## 未执行

未运行容器、RocketMQ 集群、完整 E2E、压力测试或镜像构建；这些重量级验证交由 PR 自动触发的上游检查。

## 提交清单

- [x] 已创建唯一对应 Issue
- [x] 一个 PR 只解决一个问题
- [x] 已增加必要回归测试
- [x] 已完成受影响范围的本地轻量验证

Fixes #1889