### PR TITLE
[ISSUE #1890] 应用关闭时停止集群缓存调度器

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/ClusterInfoService.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/ClusterInfoService.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.dashboard.service;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
@@ -48,6 +49,11 @@ public class ClusterInfoService {
     public void init() {
         scheduler.scheduleAtFixedRate(this::refresh,
                 0, cacheExpireMs / 2, TimeUnit.MILLISECONDS);
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        scheduler.shutdown();
     }
 
     public ClusterInfo get() {

--- a/src/test/java/org/apache/rocketmq/dashboard/service/ClusterInfoServiceTest.java
+++ b/src/test/java/org/apache/rocketmq/dashboard/service/ClusterInfoServiceTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.dashboard.service;
+
+import jakarta.annotation.PreDestroy;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class ClusterInfoServiceTest {
+
+    @Test
+    public void testShutdownSchedulerOnDestroy() throws Exception {
+        ClusterInfoService service = new ClusterInfoService();
+        ScheduledExecutorService scheduler =
+                (ScheduledExecutorService) ReflectionTestUtils.getField(service, "scheduler");
+        Method shutdown = ClusterInfoService.class.getMethod("shutdown");
+
+        Assert.assertNotNull(shutdown.getAnnotation(PreDestroy.class));
+        Assert.assertNotNull(scheduler);
+        Assert.assertFalse(scheduler.isShutdown());
+
+        service.shutdown();
+
+        Assert.assertTrue(scheduler.isShutdown());
+    }
+}


### PR DESCRIPTION
## 变更目的

ClusterInfoService 创建的 ScheduledExecutorService 没有销毁入口，应用上下文关闭后线程仍可能存活。

## 简要变更

- 增加 Jakarta `@PreDestroy` 生命周期方法。
- 销毁时调用 `scheduler.shutdown()`，不强制中断正在执行的刷新。
- 增加调度器关闭状态回归测试。

## 本地验证

- `ClusterInfoServiceTest`：1/1 通过（Temurin 17）
- `git diff --check`：通过
- 400 行范围门禁：通过

## 未执行

未运行容器、RocketMQ 集群、完整 E2E、压力测试或镜像构建；这些重量级验证交由 PR 自动触发的上游检查。

## 提交清单

- [x] 已创建唯一对应 Issue
- [x] 一个 PR 只解决一个问题
- [x] 已增加必要回归测试
- [x] 已完成受影响范围的本地轻量验证

Fixes #1890