### PR TITLE
[ISSUE #1891] 保存失败时保留 Consumer 配置表单

### DIFF
--- a/frontend-new/src/components/consumer/ConsumerConfigItem.jsx
+++ b/frontend-new/src/components/consumer/ConsumerConfigItem.jsx
@@ -21,6 +21,53 @@ import {remoteApi} from '../../api/remoteApi/remoteApi'; // 确保路径正确
 
 const {Option} = Select;
 
+export const submitConsumerConfig = async ({
+                                               form,
+                                               initialConfig,
+                                               isAddConfig,
+                                               group,
+                                               onCancel,
+                                               onSuccess,
+                                               t,
+                                               messageApi = message,
+                                           }) => {
+    try {
+        const values = await form.validateFields();
+        const numericValues = {
+            retryQueueNums: Number(values.retryQueueNums),
+            retryMaxTimes: Number(values.retryMaxTimes),
+            brokerId: Number(values.brokerId),
+            whichBrokerWhenConsumeSlowly: Number(values.whichBrokerWhenConsumeSlowly),
+        };
+
+        const finalBrokerNameList = Array.isArray(values.brokerName) ? values.brokerName : [values.brokerName];
+        const finalClusterNameList = Array.isArray(values.clusterName) ? values.clusterName : [values.clusterName];
+        const payload = {
+            subscriptionGroupConfig: {
+                ...(initialConfig && initialConfig.subscriptionGroupConfig ? initialConfig.subscriptionGroupConfig : {}),
+                ...values,
+                ...numericValues,
+                groupName: isAddConfig ? values.groupName : group,
+            },
+            brokerNameList: finalBrokerNameList,
+            clusterNameList: isAddConfig ? finalClusterNameList : null,
+        };
+
+        const response = await remoteApi.createOrUpdateConsumer(payload);
+        if (response.status === 0) {
+            messageApi.success(t.SUCCESS);
+            onSuccess();
+            onCancel();
+        } else {
+            messageApi.error(`${t.OPERATION_FAILED}: ${response.errMsg}`);
+            console.error('Failed to create or update consumer:', response.errMsg);
+        }
+    } catch (error) {
+        console.error('Validation failed or API call error:', error);
+        messageApi.error(t.FORM_VALIDATION_FAILED);
+    }
+};
+
 const ConsumerConfigItem = ({
                                 initialConfig,
                                 isAddConfig,
@@ -72,47 +119,15 @@ const ConsumerConfigItem = ({
         }
     }, [initialConfig, isAddConfig, form]);
 
-    const handleSubmit = async () => {
-        try {
-            const values = await form.validateFields();
-            const numericValues = {
-                retryQueueNums: Number(values.retryQueueNums),
-                retryMaxTimes: Number(values.retryMaxTimes),
-                brokerId: Number(values.brokerId),
-                whichBrokerWhenConsumeSlowly: Number(values.whichBrokerWhenConsumeSlowly),
-            };
-
-            // 确保brokerNameList是数组
-            let finalBrokerNameList = Array.isArray(values.brokerName) ? values.brokerName : [values.brokerName];
-            // 确保clusterNameList是数组
-            let finalClusterNameList = Array.isArray(values.clusterName) ? values.clusterName : [values.clusterName];
-
-            const payload = {
-                subscriptionGroupConfig: {
-                    ...(initialConfig && initialConfig.subscriptionGroupConfig ? initialConfig.subscriptionGroupConfig : {}), // 保留旧的配置，除非被新值覆盖
-                    ...values,
-                    ...numericValues,
-                    groupName: isAddConfig ? values.groupName : group, // 添加模式使用表单中的groupName，更新模式使用传入的group
-                },
-                brokerNameList: finalBrokerNameList,
-                clusterNameList: isAddConfig ? finalClusterNameList : null, // 更新模式保留原有clusterNameList
-            };
-
-            const response = await remoteApi.createOrUpdateConsumer(payload);
-            if (response.status === 0) {
-                message.success(t.SUCCESS);
-                onSuccess();
-            } else {
-                message.error(`${t.OPERATION_FAILED}: ${response.errMsg}`);
-                console.error('Failed to create or update consumer:', response.errMsg);
-            }
-        } catch (error) {
-            console.error('Validation failed or API call error:', error);
-            message.error(t.FORM_VALIDATION_FAILED);
-        } finally {
-            onCancel()
-        }
-    };
+    const handleSubmit = () => submitConsumerConfig({
+        form,
+        initialConfig,
+        isAddConfig,
+        group,
+        onCancel,
+        onSuccess,
+        t,
+    });
 
     // Helper function to parse input value to number
     const parseNumber = (event) => {

--- a/frontend-new/src/components/consumer/ConsumerConfigItem.test.jsx
+++ b/frontend-new/src/components/consumer/ConsumerConfigItem.test.jsx
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {remoteApi} from '../../api/remoteApi/remoteApi';
+import {submitConsumerConfig} from './ConsumerConfigItem';
+
+jest.mock('../../api/remoteApi/remoteApi', () => ({
+    remoteApi: {
+        createOrUpdateConsumer: jest.fn(),
+    },
+}));
+
+const values = {
+    groupName: 'group-a',
+    brokerName: ['broker-a'],
+    clusterName: ['cluster-a'],
+    retryQueueNums: 1,
+    retryMaxTimes: 16,
+    brokerId: 0,
+    whichBrokerWhenConsumeSlowly: 0,
+};
+
+const createArguments = (validateFields = jest.fn().mockResolvedValue(values)) => ({
+    form: {validateFields},
+    initialConfig: {subscriptionGroupConfig: {}},
+    isAddConfig: true,
+    group: 'group-a',
+    onCancel: jest.fn(),
+    onSuccess: jest.fn(),
+    t: {
+        FORM_VALIDATION_FAILED: 'Validation failed',
+        OPERATION_FAILED: 'Operation failed',
+        SUCCESS: 'Success',
+    },
+    messageApi: {
+        error: jest.fn(),
+        success: jest.fn(),
+    },
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    console.error.mockRestore();
+});
+
+test('keeps the form open when validation fails', async () => {
+    const args = createArguments(jest.fn().mockRejectedValue(new Error('invalid form')));
+
+    await submitConsumerConfig(args);
+
+    expect(remoteApi.createOrUpdateConsumer).not.toHaveBeenCalled();
+    expect(args.onSuccess).not.toHaveBeenCalled();
+    expect(args.onCancel).not.toHaveBeenCalled();
+    expect(args.messageApi.error).toHaveBeenCalledWith(args.t.FORM_VALIDATION_FAILED);
+});
+
+test('keeps the form open when the API rejects the update', async () => {
+    remoteApi.createOrUpdateConsumer.mockResolvedValue({status: 1, errMsg: 'rejected'});
+    const args = createArguments();
+
+    await submitConsumerConfig(args);
+
+    expect(args.onSuccess).not.toHaveBeenCalled();
+    expect(args.onCancel).not.toHaveBeenCalled();
+    expect(args.messageApi.error).toHaveBeenCalledWith('Operation failed: rejected');
+});
+
+test('closes the form only after a successful update', async () => {
+    remoteApi.createOrUpdateConsumer.mockResolvedValue({status: 0});
+    const args = createArguments();
+
+    await submitConsumerConfig(args);
+
+    expect(args.messageApi.success).toHaveBeenCalledWith(args.t.SUCCESS);
+    expect(args.onSuccess).toHaveBeenCalledTimes(1);
+    expect(args.onCancel).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
## 变更目的

Consumer 配置提交在 finally 中无条件关闭弹窗，校验或 API 失败时会丢失用户输入。

## 简要变更

- 仅在后端返回成功时调用成功回调并关闭表单。
- 校验失败和 API 失败时保留表单。
- 提取可测试的提交控制流，覆盖失败与成功三条路径。

## 本地验证

- `ConsumerConfigItem.test.jsx`：3/3 通过（`CI=true npm test -- --runInBand`）
- `git diff --check`：通过
- 400 行范围门禁：通过

## 未执行

未运行容器、RocketMQ 集群、完整 E2E、压力测试或镜像构建；这些重量级验证交由 PR 自动触发的上游检查。

## 提交清单

- [x] 已创建唯一对应 Issue
- [x] 一个 PR 只解决一个问题
- [x] 已增加必要回归测试
- [x] 已完成受影响范围的本地轻量验证

Fixes #1891