### PR TITLE
[ISSUE #1892] 切换 Consumer 时重置删除 Broker 选择

### DIFF
--- a/frontend-new/src/components/consumer/DeleteConsumerModal.jsx
+++ b/frontend-new/src/components/consumer/DeleteConsumerModal.jsx
@@ -25,6 +25,10 @@ const DeleteConsumerModal = ({visible, group, onCancel, onSuccess, t}) => {
     const [loading, setLoading] = useState(false);
 
     useEffect(() => {
+        // 切换消费者组或重新打开弹窗时，不复用上一次的 Broker 选择。
+        setSelectedBrokers([]);
+        setBrokerList([]);
+
         const fetchBrokers = async () => {
             if (!visible) return;
 

--- a/frontend-new/src/components/consumer/DeleteConsumerModal.test.jsx
+++ b/frontend-new/src/components/consumer/DeleteConsumerModal.test.jsx
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {remoteApi} from '../../api/remoteApi/remoteApi';
+import DeleteConsumerModal from './DeleteConsumerModal';
+
+jest.mock('antd', () => {
+    const React = require('react');
+    const GroupContext = React.createContext(null);
+    const Checkbox = ({value, children}) => {
+        const group = React.useContext(GroupContext);
+        const checked = group.value.includes(value);
+        return (
+            <label>
+                <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={(event) => {
+                        const nextValue = event.target.checked
+                            ? [...group.value, value]
+                            : group.value.filter(item => item !== value);
+                        group.onChange(nextValue);
+                    }}
+                />
+                {children}
+            </label>
+        );
+    };
+    Checkbox.Group = ({value, onChange, children}) => (
+        <GroupContext.Provider value={{value, onChange}}>{children}</GroupContext.Provider>
+    );
+
+    return {
+        Button: ({children, onClick}) => <button onClick={onClick}>{children}</button>,
+        Checkbox,
+        Modal: ({visible, title, footer, children}) => visible && <div>{title}{children}{footer}</div>,
+        notification: {success: jest.fn(), warning: jest.fn()},
+        Spin: ({children}) => children,
+    };
+});
+
+jest.mock('../../api/remoteApi/remoteApi', () => ({
+    remoteApi: {
+        deleteConsumerGroup: jest.fn(),
+        fetchBrokerNameList: jest.fn(),
+    },
+}));
+
+const t = {
+    CANCEL: 'Cancel',
+    CONFIRM_DELETE: 'Confirm delete',
+    DELETE_CONSUMER_GROUP: 'Delete consumer group',
+    SELECT_DELETE_BROKERS: 'Select brokers',
+};
+
+test('clears old brokers and selections when reopened for another group', async () => {
+    remoteApi.fetchBrokerNameList
+        .mockResolvedValueOnce({status: 0, data: ['broker-a']})
+        .mockResolvedValueOnce({status: 0, data: ['broker-b']});
+
+    const commonProps = {
+        onCancel: jest.fn(),
+        onSuccess: jest.fn(),
+        t,
+    };
+    const {rerender} = render(
+        <DeleteConsumerModal {...commonProps} visible group="group-a"/>
+    );
+
+    const brokerA = await screen.findByRole('checkbox', {name: 'broker-a'});
+    userEvent.click(brokerA);
+    await waitFor(() => expect(brokerA).toBeChecked());
+
+    rerender(<DeleteConsumerModal {...commonProps} visible={false} group="group-a"/>);
+    rerender(<DeleteConsumerModal {...commonProps} visible group="group-b"/>);
+
+    await waitFor(() => expect(screen.queryByText('broker-a')).not.toBeInTheDocument());
+    const brokerB = await screen.findByRole('checkbox', {name: 'broker-b'});
+    expect(brokerB).not.toBeChecked();
+});


### PR DESCRIPTION
## 变更目的

删除 Consumer 弹窗会跨关闭和 Consumer Group 切换保留旧 Broker 列表与选择，可能把错误 Broker 提交给新组。

## 简要变更

- 在弹窗重新打开或 group 变化时清空旧 Broker 列表和选择。
- 增加从组 A 重新打开到组 B 的 rerender 回归测试。

## 本地验证

- `DeleteConsumerModal.test.jsx`：1/1 通过（`CI=true npm test -- --runInBand`）
- `git diff --check`：通过
- 400 行范围门禁：通过

## 未执行

未运行容器、RocketMQ 集群、完整 E2E、压力测试或镜像构建；这些重量级验证交由 PR 自动触发的上游检查。

## 提交清单

- [x] 已创建唯一对应 Issue
- [x] 一个 PR 只解决一个问题
- [x] 已增加必要回归测试
- [x] 已完成受影响范围的本地轻量验证

Fixes #1892