### PR TITLE
[ISSUE #1893] 使用 brokerId 生成 Dashboard 图表标签

### DIFF
--- a/frontend-new/src/pages/Dashboard/DashboardPage.jsx
+++ b/frontend-new/src/pages/Dashboard/DashboardPage.jsx
@@ -24,6 +24,20 @@ import {remoteApi, tools} from '../../api/remoteApi/remoteApi';
 
 const {Option} = Select;
 
+// 生成 Broker Top 10 图表数据，标签使用后端返回的 brokerId 区分主从节点。
+export const buildBrokerTop10Data = (brokers) => {
+    const sortedBrokers = [...brokers].sort((firstBroker, lastBroker) => {
+        const firstTotalMsg = parseFloat(firstBroker.msgGetTotalTodayNow || 0);
+        const lastTotalMsg = parseFloat(lastBroker.msgGetTotalTodayNow || 0);
+        return lastTotalMsg - firstTotalMsg;
+    });
+
+    return {
+        xAxisData: sortedBrokers.slice(0, 10).map(broker => `${broker.brokerName}:${broker.brokerId}`),
+        data: sortedBrokers.slice(0, 10).map(broker => parseFloat(broker.msgGetTotalTodayNow || 0)),
+    };
+};
+
 const DashboardPage = () => {
     const {t} = useLanguage();
     const barChartRef = useRef(null);
@@ -261,18 +275,7 @@ const DashboardPage = () => {
                 }));
                 setBrokerTableData(newData);
 
-                brokerArray.sort((firstBroker, lastBroker) => {
-                    const firstTotalMsg = parseFloat(firstBroker.msgGetTotalTodayNow || 0);
-                    const lastTotalMsg = parseFloat(lastBroker.msgGetTotalTodayNow || 0);
-                    return lastTotalMsg - firstTotalMsg;
-                });
-
-                const xAxisData = [];
-                const data = [];
-                brokerArray.slice(0, 10).forEach(broker => {
-                    xAxisData.push(`${broker.brokerName}:${broker.index}`);
-                    data.push(parseFloat(broker.msgGetTotalTodayNow || 0));
-                });
+                const {xAxisData, data} = buildBrokerTop10Data(brokerArray);
                 barChartInstance.current?.setOption(getBrokerBarChartOp(xAxisData, data));
             } else {
                 notificationApi.error({message: resp.errMsg || t.QUERY_CLUSTER_LIST_FAILED, duration: 2});

--- a/frontend-new/src/pages/Dashboard/DashboardPage.test.jsx
+++ b/frontend-new/src/pages/Dashboard/DashboardPage.test.jsx
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {buildBrokerTop10Data} from './DashboardPage';
+
+test('uses brokerId in Broker Top 10 labels', () => {
+    const brokers = [
+        {brokerName: 'broker-a', brokerId: 1, msgGetTotalTodayNow: '20'},
+        {brokerName: 'broker-a', brokerId: 0, msgGetTotalTodayNow: '50'},
+    ];
+
+    expect(buildBrokerTop10Data(brokers)).toEqual({
+        xAxisData: ['broker-a:0', 'broker-a:1'],
+        data: [50, 20],
+    });
+});


### PR DESCRIPTION
## 变更目的

Broker Top 10 图表引用不存在的 broker.index，横轴标签显示 brokerName:undefined。

## 简要变更

- 改用后端映射实际提供的 `brokerId`。
- 提取图表数据生成函数，保持原有消息量排序和数值转换。
- 覆盖主从 Broker 标签与排序回归。

## 本地验证

- `DashboardPage.test.jsx`：1/1 通过（`CI=true npm test -- --runInBand`）
- `git diff --check`：通过
- 400 行范围门禁：通过

## 未执行

未运行容器、RocketMQ 集群、完整 E2E、压力测试或镜像构建；这些重量级验证交由 PR 自动触发的上游检查。

## 提交清单

- [x] 已创建唯一对应 Issue
- [x] 一个 PR 只解决一个问题
- [x] 已增加必要回归测试
- [x] 已完成受影响范围的本地轻量验证

Fixes #1893