### PR TITLE
[ISSUE #1894] 默认 Broker 建立后加载 ACL 数据

### DIFF
--- a/frontend-new/src/pages/Acl/acl.jsx
+++ b/frontend-new/src/pages/Acl/acl.jsx
@@ -70,7 +70,7 @@ const Acl = () => {
 
     const [searchValue, setSearchValue] = useState('');
 
-    // --- Data Fetching and Initial Setup ---
+    // 集群初始化只执行一次，列表加载由 broker 选择状态单独触发。
     useEffect(() => {
         const fetchData = async () => {
             const clusterResponse = await remoteApi.getClusterList();
@@ -87,11 +87,8 @@ const Acl = () => {
                     const defaultCluster = clusterNames[0];
                     setSelectedCluster(defaultCluster);
 
-                    // Manually trigger broker list update for the default cluster
-                    updateBrokerOptions(defaultCluster, clusterInfo);
-
-                    // Set default broker and its address if available
                     const brokersInDefaultCluster = clusterInfo.clusterAddrTable[defaultCluster] || [];
+                    setBrokerNamesOptions(brokersInDefaultCluster.map(broker => ({label: broker, value: broker})));
                     if (brokersInDefaultCluster.length > 0) {
                         const defaultBroker = brokersInDefaultCluster[0];
                         setSelectedBroker(defaultBroker);
@@ -105,19 +102,22 @@ const Acl = () => {
                 console.error('Failed to fetch cluster list:', clusterResponse.errMsg);
             }
         };
-        if (!clusterData) {
-            setLoading(true);
-            fetchData().finally(() => setLoading(false));
-        }
+        setLoading(true);
+        fetchData().finally(() => setLoading(false));
+    }, []);
+
+    useEffect(() => {
         if (brokerAddress) {
+            setLoading(true);
             if (activeTab === 'users') {
                 fetchUsers().finally(() => setLoading(false));
             } else {
                 fetchAcls().finally(() => setLoading(false));
             }
         }
-
-    }, [activeTab]); // Dependencies for useEffect
+        // selectedBroker 和 selectedCluster 与 brokerAddress 在同一次选择操作中更新。
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [activeTab, brokerAddress, selectedBroker, selectedCluster]);
 
     useEffect(() => {
         const userPermission = localStorage.getItem('userrole');

--- a/frontend-new/src/pages/Acl/acl.test.jsx
+++ b/frontend-new/src/pages/Acl/acl.test.jsx
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {render, waitFor} from '@testing-library/react';
+import {remoteApi} from '../../api/remoteApi/remoteApi';
+import Acl from './acl';
+
+jest.mock('antd', () => {
+    const React = require('react');
+    const Component = ({children}) => <div>{children}</div>;
+    const Form = Component;
+    Form.Item = Component;
+    Form.useForm = () => [{resetFields: jest.fn(), setFieldsValue: jest.fn(), validateFields: jest.fn()}];
+    const Input = Component;
+    Input.Password = Component;
+    Input.Search = Component;
+    const Select = Component;
+    Select.Option = Component;
+    const Tabs = Component;
+    Tabs.TabPane = Component;
+    return {
+        Button: Component,
+        Form,
+        Input,
+        message: {useMessage: () => [{error: jest.fn(), success: jest.fn()}, null]},
+        Modal: Component,
+        Popconfirm: Component,
+        Select,
+        Space: Component,
+        Table: Component,
+        Tabs,
+        Tag: Component,
+    };
+});
+
+jest.mock('@ant-design/icons', () => ({
+    DeleteOutlined: () => null,
+    EditOutlined: () => null,
+    EyeInvisibleOutlined: () => null,
+    EyeOutlined: () => null,
+}));
+
+jest.mock('../../api/remoteApi/remoteApi', () => ({
+    remoteApi: {
+        getClusterList: jest.fn(),
+        listUsers: jest.fn(),
+        listAcls: jest.fn(),
+    },
+}));
+
+jest.mock('../../components/acl/ResourceInput', () => () => null);
+jest.mock('../../components/acl/SubjectInput', () => () => null);
+
+describe('Acl initial data loading', () => {
+    test('loads users after selecting the first broker asynchronously', async () => {
+        remoteApi.getClusterList.mockResolvedValue({
+            status: 0,
+            data: {
+                clusterInfo: {
+                    clusterAddrTable: {'cluster-a': ['broker-a']},
+                    brokerAddrTable: {
+                        'broker-a': {brokerAddrs: {'0': '127.0.0.1:10911'}},
+                    },
+                },
+            },
+        });
+        remoteApi.listUsers.mockResolvedValue({status: 0, data: []});
+
+        render(<Acl/>);
+
+        await waitFor(() => {
+            expect(remoteApi.listUsers).toHaveBeenCalledWith('broker-a', 'cluster-a');
+        });
+    });
+});


### PR DESCRIPTION
## 变更目的

ACL 首次初始化时 brokerAddress 尚未建立，列表请求被跳过；异步选择默认 Broker 后原 effect 不会重跑。

## 简要变更

- 拆分只执行一次的集群初始化与依赖 Broker 状态的列表加载。
- 默认 Broker 建立后立即加载当前 Tab，并在 Tab、Broker 或集群变化时刷新。
- 增加异步默认选择回归测试。

## 本地验证

- `acl.test.jsx`：1/1 通过；变更文件 ESLint `--quiet` 通过
- `git diff --check`：通过
- 400 行范围门禁：通过

## 未执行

未运行容器、RocketMQ 集群、完整 E2E、压力测试或镜像构建；这些重量级验证交由 PR 自动触发的上游检查。

## 提交清单

- [x] 已创建唯一对应 Issue
- [x] 一个 PR 只解决一个问题
- [x] 已增加必要回归测试
- [x] 已完成受影响范围的本地轻量验证

Fixes #1894