### PR TITLE
perf: pause runtime polling while hidden

### DIFF
--- a/web/src/hooks/useVisiblePolling.ts
+++ b/web/src/hooks/useVisiblePolling.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from 'react';
+
+export function useVisiblePolling(
+  enabled: boolean,
+  intervalMs: number,
+  poll: () => void | Promise<void>,
+): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const pollWhenVisible = () => {
+      if (document.visibilityState === 'visible') {
+        void poll();
+      }
+    };
+    const intervalId = window.setInterval(pollWhenVisible, intervalMs);
+    document.addEventListener('visibilitychange', pollWhenVisible);
+
+    return () => {
+      window.clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', pollWhenVisible);
+    };
+  }, [enabled, intervalMs, poll]);
+}

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -40,6 +40,7 @@ import { listClusters } from '../../services/clusterService';
 import type { ClusterInfo } from '../../api/cluster';
 import { listInstances } from '../../services/instanceService';
 import type { Instance } from '../../api/instance';
+import { useVisiblePolling } from '../../hooks/useVisiblePolling';
 
 // ─── Types ──────────────────────────────────────────────────────
 type NodeStatus = 'running' | 'readonly' | 'maintenance' | 'unknown';
@@ -167,6 +168,7 @@ const BrokerClusterPage = () => {
   const [proxyData, setProxyData] = useState<ProxyRecord[]>([]);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState('');
+  const mountedRef = useRef(true);
   const loadRequestId = useRef(0);
   const { t } = useLang();
   const { message } = App.useApp();
@@ -186,16 +188,16 @@ const BrokerClusterPage = () => {
     setLoading(true);
     try {
       const clusters = await listClusters(selectedInstanceId);
-      if (requestId !== loadRequestId.current) return;
+      if (!mountedRef.current || requestId !== loadRequestId.current) return;
       const mapped = mapClusters(clusters);
       setBrokerData(mapped.brokers);
       setNameServerData(mapped.nameServers);
       setProxyData(mapped.proxies);
     } catch {
-      if (requestId !== loadRequestId.current) return;
+      if (!mountedRef.current || requestId !== loadRequestId.current) return;
       message.error(t('common.refreshFailed'));
     } finally {
-      if (requestId === loadRequestId.current) {
+      if (mountedRef.current && requestId === loadRequestId.current) {
         setLoading(false);
       }
     }
@@ -220,20 +222,15 @@ const BrokerClusterPage = () => {
   }, [clearData, message, t]);
 
   useEffect(() => {
-    void loadData();
+    mountedRef.current = true;
+    const timeoutId = window.setTimeout(() => void loadData());
     return () => {
-      ++loadRequestId.current;
+      window.clearTimeout(timeoutId);
+      mountedRef.current = false;
     };
   }, [loadData]);
 
-  useEffect(() => {
-    if (!autoRefresh) return;
-
-    const intervalId = window.setInterval(() => {
-      void loadData();
-    }, REFRESH_INTERVAL_MS);
-    return () => window.clearInterval(intervalId);
-  }, [autoRefresh, loadData]);
+  useVisiblePolling(autoRefresh, REFRESH_INTERVAL_MS, loadData);
 
   const renderStatus = (status: string) => {
     const config: Record<string, { color: string; label: string }> = {

--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -39,6 +39,7 @@ import {
   getConsumerSubscriptions,
   listConsumerGroups,
 } from '../../services/consumerService';
+import { useVisiblePolling } from '../../hooks/useVisiblePolling';
 
 // ─── Helpers ────────────────────────────────────────────────────
 type GroupStatus = 'running' | 'warning' | 'stopped';
@@ -121,14 +122,7 @@ const GroupManagementPage = () => {
     };
   }, [loadGroups]);
 
-  useEffect(() => {
-    if (!autoRefresh) return;
-
-    const intervalId = window.setInterval(() => {
-      void loadGroups();
-    }, GROUP_REFRESH_INTERVAL_MS);
-    return () => window.clearInterval(intervalId);
-  }, [autoRefresh, loadGroups]);
+  useVisiblePolling(autoRefresh, GROUP_REFRESH_INTERVAL_MS, loadGroups);
 
   const handleRefresh = useCallback(() => {
     void loadGroups();

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -150,6 +150,7 @@ describe('BrokerCluster Page', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('should render the page title', () => {
@@ -231,24 +232,37 @@ describe('BrokerCluster Page', () => {
     expect(screen.queryByText('proxy-a')).not.toBeInTheDocument();
   });
 
-  it('polls only while live refresh is enabled', async () => {
-    vi.useFakeTimers();
+  it('polls only while live refresh is enabled and the document is visible', async () => {
+    const visibilityState = vi
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('hidden');
     renderWithProviders(<BrokerCluster />);
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
-    });
+    await screen.findByText('broker-api-a');
     expect(listClusters).toHaveBeenCalledTimes(1);
+    vi.useFakeTimers();
 
     const liveRefreshSwitch = screen.getByRole('switch');
     fireEvent.click(liveRefreshSwitch);
     await act(async () => {
       await vi.advanceTimersByTimeAsync(6000);
     });
+    expect(listClusters).toHaveBeenCalledTimes(1);
+
+    visibilityState.mockReturnValue('visible');
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(listClusters).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
     expect(listClusters).toHaveBeenCalledTimes(4);
 
     fireEvent.click(liveRefreshSwitch);
     await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
       await vi.advanceTimersByTimeAsync(4000);
     });
     expect(listClusters).toHaveBeenCalledTimes(4);

--- a/web/src/pages/studio/__tests__/GroupManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/GroupManagement.test.tsx
@@ -102,6 +102,7 @@ describe('GroupManagement Page', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('should render the page title', () => {
@@ -218,27 +219,40 @@ describe('GroupManagement Page', () => {
     expect(screen.queryByText('initial-group')).not.toBeInTheDocument();
   });
 
-  it('polls only while auto refresh is enabled', async () => {
-    vi.useFakeTimers();
+  it('polls only while auto refresh is enabled and the document is visible', async () => {
+    const visibilityState = vi
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('hidden');
     renderWithProviders(<GroupManagement />);
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
-    });
+    await screen.findByText('order-consumer-group');
     expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(1);
+    vi.useFakeTimers();
 
     const autoRefreshSwitch = screen.getByRole('switch');
     fireEvent.click(autoRefreshSwitch);
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2000);
     });
+    expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(1);
+
+    visibilityState.mockReturnValue('visible');
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
     expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(3);
 
     fireEvent.click(autoRefreshSwitch);
     await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
       await vi.advanceTimersByTimeAsync(4000);
     });
-    expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(2);
+    expect(consumerService.listConsumerGroups).toHaveBeenCalledTimes(3);
   });
 
   it('should filter groups by search text', async () => {


### PR DESCRIPTION
## Summary

- add a shared visibility-aware polling hook for Studio runtime pages
- skip scheduled Broker Cluster and Consumer Group refreshes while the document is hidden
- refresh once when the document becomes visible again
- remove timers and visibility listeners when polling is disabled or the page unmounts
- keep Broker Cluster initial loading lint-compliant and suppress unmounted results
- cover hidden, restored, interval, and disabled polling behavior on both pages

## Validation

- `npx eslint src/hooks/useVisiblePolling.ts src/pages/studio/BrokerCluster.tsx src/pages/studio/GroupManagement.tsx src/pages/studio/__tests__/BrokerCluster.test.tsx src/pages/studio/__tests__/GroupManagement.test.tsx`
- `npm test -- --run src/pages/studio/__tests__/BrokerCluster.test.tsx src/pages/studio/__tests__/GroupManagement.test.tsx` (26 tests passed)
- `npm run build`

Closes #1834

Related: #1585
