### PR TITLE
refactor: replace deprecated Ant Design APIs

### DIFF
--- a/web/src/pages/settings/__tests__/GeneralSettingsTab.test.tsx
+++ b/web/src/pages/settings/__tests__/GeneralSettingsTab.test.tsx
@@ -72,4 +72,15 @@ describe('GeneralSettingsTab', () => {
 
     await waitFor(() => expect(saveGeneralSettings).toHaveBeenCalledTimes(1));
   });
+
+  it('keeps the session timeout field bound when displaying its unit', async () => {
+    render(
+      <App>
+        <GeneralSettingsTab />
+      </App>,
+    );
+
+    expect(await screen.findByDisplayValue('30')).toBeInTheDocument();
+    expect(screen.getByLabelText('会话超时单位')).toHaveValue('分钟');
+  });
 });

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -211,12 +211,13 @@ export const GeneralSettingsTab = () => {
         </Title>
       </Divider>
 
-      <Form.Item
-        label="会话超时"
-        name="sessionTimeout"
-        extra="应用于新创建的会话，已登录用户保持原到期时间"
-      >
-        <InputNumber min={5} max={1440} addonAfter="分钟" />
+      <Form.Item label="会话超时" extra="应用于新创建的会话，已登录用户保持原到期时间">
+        <Space.Compact>
+          <Form.Item name="sessionTimeout" noStyle>
+            <InputNumber min={5} max={1440} style={{ width: 120 }} />
+          </Form.Item>
+          <Input aria-label="会话超时单位" readOnly value="分钟" style={{ width: 64 }} />
+        </Space.Compact>
       </Form.Item>
 
       <Form.Item name="requireLogin" hidden>

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -476,7 +476,7 @@ const BrokerClusterPage = () => {
       </div>
 
       <Spin spinning={loading} tip={t('common.loading')}>
-        <Card bordered={false} style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}>
+        <Card variant="borderless" style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}>
           <Tabs
             activeKey={activeTab}
             onChange={setActiveTab}


### PR DESCRIPTION
## Summary

- replace deprecated Ant Design `Card.bodyStyle`, `Card.bordered`, and Modal/Drawer `destroyOnClose` usages with supported APIs
- include the ACL page migrations previously carried by #1757
- replace the deprecated General Settings `InputNumber.addonAfter` usage with a `Space.Compact` field and unit input
- preserve page behavior and visual configuration

Closes #1906
Part of #1765

## Verification

- `npm test -- --run src/pages/settings/__tests__/GeneralSettingsTab.test.tsx src/pages/instance/__tests__/AclPage.test.tsx` (15 tests passed)
- targeted ESLint passed for all changed files except the pre-existing `BrokerCluster.tsx` hooks violation already documented by the original PR
- `npm run build`
- `git diff --check origin/rocketmq-studio...HEAD`
