### PR TITLE
fix: declare the Studio favicon

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/svg+xml" href="/src/assets/logos/apache-feather.svg" />
   <title>RocketMQ Studio</title>
 </head>
 <body>


### PR DESCRIPTION
## Summary

- declare the existing Apache Feather SVG as the RocketMQ Studio favicon
- let Vite fingerprint and bundle the existing asset
- avoid the browser's fallback request for the missing `/favicon.ico`

## Validation

- `npm run build`
- verified generated `dist/index.html` references `/assets/apache-feather-<hash>.svg`
- verified the emitted SVG returns HTTP 200 with `Content-Type: image/svg+xml` under `vite preview`

Closes #1909
