### PR TITLE
[studio][ISSUE #1694] Export mock Grafana bundles as JSON

### DIFF
--- a/web/src/components/GrafanaDashboardList.tsx
+++ b/web/src/components/GrafanaDashboardList.tsx
@@ -120,8 +120,8 @@ export const GrafanaDashboardList: React.FC = () => {
   const handleExportAll = async () => {
     setExportingAll(true);
     try {
-      const blob = await exportGrafanaDashboards();
-      triggerDownload('rocketmq-grafana-dashboards.zip', blob);
+      const { blob, filename } = await exportGrafanaDashboards();
+      triggerDownload(filename, blob);
       message.success(t('grafana.exportAllDone'));
     } catch {
       message.error(t('grafana.exportAllFailed'));

--- a/web/src/components/__tests__/GrafanaDashboardList.test.tsx
+++ b/web/src/components/__tests__/GrafanaDashboardList.test.tsx
@@ -76,9 +76,10 @@ beforeEach(() => {
   vi.mocked(exportGrafanaDashboard).mockResolvedValue(
     new Blob([JSON.stringify(dashboardModel, null, 2)], { type: 'application/json' }),
   );
-  vi.mocked(exportGrafanaDashboards).mockResolvedValue(
-    new Blob(['zip-content'], { type: 'application/zip' }),
-  );
+  vi.mocked(exportGrafanaDashboards).mockResolvedValue({
+    blob: new Blob(['zip-content'], { type: 'application/zip' }),
+    filename: 'rocketmq-grafana-dashboards.zip',
+  });
 });
 
 afterEach(() => {
@@ -205,8 +206,12 @@ describe('GrafanaDashboardList', () => {
     clickSpy.mockRestore();
   });
 
-  it('exports all dashboards and downloads the archive', async () => {
+  it('exports all dashboards with the filename supplied by the service', async () => {
     const user = userEvent.setup();
+    vi.mocked(exportGrafanaDashboards).mockResolvedValueOnce({
+      blob: new Blob(['json-content'], { type: 'application/json' }),
+      filename: 'rocketmq-grafana-dashboards.json',
+    });
     const createObjectURL = vi.fn().mockReturnValue('blob:grafana-all');
     const revokeObjectURL = vi.fn();
     let downloadedFilename = '';
@@ -230,7 +235,7 @@ describe('GrafanaDashboardList', () => {
     await user.click(screen.getByRole('button', { name: /Export all|导出全部/ }));
 
     await waitFor(() => expect(exportGrafanaDashboards).toHaveBeenCalledTimes(1));
-    expect(downloadedFilename).toBe('rocketmq-grafana-dashboards.zip');
+    expect(downloadedFilename).toBe('rocketmq-grafana-dashboards.json');
     expect(createObjectURL).toHaveBeenCalledTimes(1);
     expect(clickSpy).toHaveBeenCalled();
 

--- a/web/src/services/grafanaService.test.ts
+++ b/web/src/services/grafanaService.test.ts
@@ -45,11 +45,12 @@ describe('grafanaService', () => {
     await expect(blob.text()).resolves.toContain('rocketmq-overview');
   });
 
-  it('exports all dashboards as a blob in mock mode', async () => {
-    const blob = await exportGrafanaDashboards();
-    expect(blob).toBeInstanceOf(Blob);
-    expect(blob.type).toBe('application/zip');
-    await expect(blob.text()).resolves.toContain('rocketmq-overview.json');
+  it('exports all mock dashboards as a JSON bundle', async () => {
+    const result = await exportGrafanaDashboards();
+    expect(result.filename).toBe('rocketmq-grafana-dashboards.json');
+    expect(result.blob).toBeInstanceOf(Blob);
+    expect(result.blob.type).toBe('application/json');
+    await expect(result.blob.text()).resolves.toContain('rocketmq-overview.json');
   });
 
   it('delegates to the api in real mode', async () => {
@@ -73,6 +74,7 @@ describe('grafanaService', () => {
 
     const result = await exportGrafanaDashboards();
     expect(exportSpy).toHaveBeenCalledTimes(1);
-    expect(result.type).toBe('application/zip');
+    expect(result.filename).toBe('rocketmq-grafana-dashboards.zip');
+    expect(result.blob.type).toBe('application/zip');
   });
 });

--- a/web/src/services/grafanaService.ts
+++ b/web/src/services/grafanaService.ts
@@ -6,6 +6,11 @@ import * as metricsApi from '../api/metrics';
 import type { GrafanaDashboardInfo } from '../api/metrics';
 import { mockGrafanaDashboards } from '../mock/grafanaDashboards';
 
+export interface GrafanaDashboardBundleExport {
+  blob: Blob;
+  filename: string;
+}
+
 export async function listGrafanaDashboards(): Promise<GrafanaDashboardInfo[]> {
   if (isMockMode()) {
     return mockGrafanaDashboards.map(({ uid, title, description, tags }) => ({
@@ -38,13 +43,19 @@ export async function exportGrafanaDashboard(uid: string): Promise<Blob> {
   return metricsApi.exportGrafanaDashboard(uid);
 }
 
-export async function exportGrafanaDashboards(): Promise<Blob> {
+export async function exportGrafanaDashboards(): Promise<GrafanaDashboardBundleExport> {
   if (isMockMode()) {
     const bundle = mockGrafanaDashboards.map(({ uid, model }) => ({
       filename: `${uid}.json`,
       model,
     }));
-    return new Blob([JSON.stringify(bundle, null, 2)], { type: 'application/zip' });
+    return {
+      blob: new Blob([JSON.stringify(bundle, null, 2)], { type: 'application/json' }),
+      filename: 'rocketmq-grafana-dashboards.json',
+    };
   }
-  return metricsApi.exportGrafanaDashboards();
+  return {
+    blob: await metricsApi.exportGrafanaDashboards(),
+    filename: 'rocketmq-grafana-dashboards.zip',
+  };
 }


### PR DESCRIPTION
## Summary
- return a filename together with the exported Grafana dashboard bundle
- download mock-mode bundles as JSON instead of labeling JSON bytes as a ZIP archive
- preserve ZIP downloads for real backend exports

## Root cause
The mock implementation serialized dashboards as JSON but assigned `application/zip` and the UI always used a `.zip` filename. The resulting download could not be opened as a ZIP archive.

Closes #1694

## Validation
- `npm run test -- --run src/services/grafanaService.test.ts` (7 passed)
- `npm run test -- --run src/components/__tests__/GrafanaDashboardList.test.tsx` (6 passed)
- focused ESLint on all four changed files
- `npm run build`
- `git diff --check`