### PR TITLE
[studio][ISSUE #1913] Interpolate translation parameters literally

### DIFF
--- a/web/src/i18n/LangContext.tsx
+++ b/web/src/i18n/LangContext.tsx
@@ -43,7 +43,7 @@ export const LangProvider = ({ children }: { children: ReactNode }) => {
     let text = translations[key]?.[lang] ?? key;
     if (params) {
       Object.entries(params).forEach(([k, v]) => {
-        text = text.replace(`{${k}}`, String(v));
+        text = text.split(`{${k}}`).join(String(v));
       });
     }
     return text;

--- a/web/src/i18n/__tests__/LangContext.test.tsx
+++ b/web/src/i18n/__tests__/LangContext.test.tsx
@@ -29,6 +29,7 @@ const LangConsumer = () => {
       <span data-testid="translated">{t('nav.home')}</span>
       <span data-testid="missing">{t('nonexistent.key')}</span>
       <span data-testid="param">{t('common.total', { count: 42 })}</span>
+      <span data-testid="literal-param">{t('instance.confirmDelete', { name: 'orders$&' })}</span>
       <button onClick={() => setLang('en')}>switch-en</button>
       <button onClick={() => setLang('zh')}>switch-zh</button>
     </div>
@@ -109,6 +110,19 @@ describe('LangContext', () => {
     // Even if the key doesn't have a {count} placeholder, the t() function
     // should not throw — it simply replaces matching placeholders.
     expect(screen.getByTestId('param')).toHaveTextContent('Total');
+  });
+
+  it('interpolates replacement-pattern characters literally', async () => {
+    const user = userEvent.setup();
+    render(
+      <LangProvider>
+        <LangConsumer />
+      </LangProvider>,
+    );
+
+    await user.click(screen.getByText('switch-en'));
+
+    expect(screen.getByTestId('literal-param')).toHaveTextContent('Delete "orders$&"?');
   });
 
   it('useLanguage alias provides the same context as useLang', () => {


### PR DESCRIPTION
## Summary
- interpolate translation parameters as literal text
- replace every matching placeholder without invoking JavaScript replacement-string semantics
- add regression coverage for resource names containing `$&`

## Root cause
`String.replace(token, String(value))` interprets `$&`, ``$` ``, and `$'` in parameter values as replacement patterns. This can corrupt valid Topic, consumer group, certificate, and other user-controlled names displayed through translated messages.

Closes #1913

## Validation
- `npm run test -- --run src/i18n/__tests__/LangContext.test.tsx` (8 passed)
- focused ESLint on both changed files
- `npm run build`
- `git diff --check`