### PR TITLE
fix(ai): bound the LLM gateway thread pool and close error response streams

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -133,8 +133,10 @@ public class OpenAiCompatibleLlmClient {
             HttpResponse<java.io.InputStream> response = httpClient.send(
                     request, HttpResponse.BodyHandlers.ofInputStream());
             if (response.statusCode() >= 400) {
-                throw upstreamException(response.statusCode(),
-                        new String(response.body().readAllBytes(), StandardCharsets.UTF_8));
+                try (java.io.InputStream errorBody = response.body()) {
+                    throw upstreamException(response.statusCode(),
+                            new String(errorBody.readAllBytes(), StandardCharsets.UTF_8));
+                }
             }
             parseStreamWithTimeout(response, tokenConsumer);
         } catch (HttpTimeoutException exception) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
@@ -31,7 +31,9 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Primary
@@ -43,7 +45,12 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
     private final OpenAiCompatibleLlmClient llmClient;
     private final AgentProviderRegistry agentProviders;
     private final ObjectMapper objectMapper;
-    private final ExecutorService executor = Executors.newCachedThreadPool();
+    // Bounded pool: cached threads grow without limit under load and, combined with a hung CLI
+    // child, can exhaust memory. CallerRunsPolicy keeps SSE work from being dropped under load.
+    private final ExecutorService executor = new ThreadPoolExecutor(
+            0, 16, 60L, TimeUnit.SECONDS,
+            new SynchronousQueue<>(),
+            new ThreadPoolExecutor.CallerRunsPolicy());
 
     @Override
     public SseEmitter chat(ChatDTO request) {


### PR DESCRIPTION
## What is the purpose of the change

Harden the LLM gateway against two resource-exhaustion and lifecycle issues:

- The gateway executor was unbounded (`Executors.newCachedThreadPool`), so a burst of concurrent LLM requests could spawn unbounded threads.
- The HTTP error branch of the LLM client read the error body with `readAllBytes()` without closing the underlying `InputStream`.

## Brief changelog

- Bound the LLM gateway executor to a fixed thread pool so concurrent agent chats cannot exhaust the thread pool.
- Close the error response `InputStream` via try-with-resources in `OpenAiCompatibleLlmClient`, preventing the stream from leaking on upstream error responses.

## Verifying this change

- `mvn -q compile -DskipTests`
- `mvn -q -Dtest=OpenAiCompatibleLlmClientTest,OpenAiCompatibleLlmGatewayTest test`
- `git diff --check`
