### PR TITLE
fix(topic): require positive queue counts on topic creation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/CreateTopicDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/CreateTopicDTO.java
@@ -17,7 +17,7 @@
 package org.apache.rocketmq.studio.instance.topic;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Positive;
 import lombok.Data;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
@@ -29,9 +29,9 @@ public class CreateTopicDTO {
     private String namespace;
     private String clusterId;
     private TopicType type;
-    @PositiveOrZero(message = "writeQueues must be zero or positive")
+    @Positive(message = "writeQueues must be positive")
     private Integer writeQueues;
-    @PositiveOrZero(message = "readQueues must be zero or positive")
+    @Positive(message = "readQueues must be positive")
     private Integer readQueues;
     private TopicPerm perm;
     private String remark;

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/TopicControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/TopicControllerTest.java
@@ -180,7 +180,7 @@ class TopicControllerTest {
                                 """))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
-                .andExpect(jsonPath("$.message").value("writeQueues must be zero or positive"));
+                .andExpect(jsonPath("$.message").value("writeQueues must be positive"));
 
         verifyNoInteractions(metadataService);
     }


### PR DESCRIPTION
## What is the purpose of the change

Topic creation currently accepts zero read/write queues (`@PositiveOrZero`), which produces a broker topic with no usable queues. Queues must be positive for a newly created topic.

## Brief changelog

- Change `writeQueues` and `readQueues` validation on `CreateTopicDTO` from `@PositiveOrZero` to `@Positive`.
- Align the controller test expectation with the new message.

## Verifying this change

- `mvn -q -Dtest=TopicControllerTest test`
- `git diff --check`
