### PR TITLE
feat(proxy): persist instance-scoped address preferences

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/MybatisPlusProxyAddressRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/MybatisPlusProxyAddressRepository.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.proxy;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.persistence.entity.RmqProxyAddress;
+import org.apache.rocketmq.studio.persistence.mapper.RmqProxyAddressMapper;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MybatisPlusProxyAddressRepository implements ProxyAddressRepository {
+    private final RmqProxyAddressMapper mapper;
+
+    @Override
+    public List<ProxyAddressRecord> findByScope(String scopeId) {
+        return mapper.selectList(new QueryWrapper<RmqProxyAddress>()
+                        .eq("scope_id", scopeId)
+                        .orderByAsc("id"))
+                .stream().map(MybatisPlusProxyAddressRepository::toRecord).toList();
+    }
+
+    @Override
+    public boolean insert(String scopeId, String address, boolean selected) {
+        RmqProxyAddress entity = new RmqProxyAddress();
+        entity.setScopeId(scopeId);
+        entity.setAddress(address);
+        entity.setSelected(selected);
+        LocalDateTime now = LocalDateTime.now();
+        entity.setCreatedAt(now);
+        entity.setUpdatedAt(now);
+        return mapper.insert(entity) > 0;
+    }
+
+    @Override
+    public boolean delete(String scopeId, String address) {
+        return mapper.delete(new QueryWrapper<RmqProxyAddress>()
+                .eq("scope_id", scopeId).eq("address", address)) > 0;
+    }
+
+    @Override
+    @Transactional
+    public boolean select(String scopeId, String address) {
+        mapper.update(null, new UpdateWrapper<RmqProxyAddress>()
+                .eq("scope_id", scopeId)
+                .set("selected", false));
+        return mapper.update(null, new UpdateWrapper<RmqProxyAddress>()
+                .eq("scope_id", scopeId)
+                .eq("address", address)
+                .set("selected", true)
+                .set("updated_at", LocalDateTime.now())) > 0;
+    }
+
+    private static ProxyAddressRecord toRecord(RmqProxyAddress entity) {
+        return ProxyAddressRecord.builder()
+                .id(entity.getId())
+                .scopeId(entity.getScopeId())
+                .address(entity.getAddress())
+                .selected(Boolean.TRUE.equals(entity.getSelected()))
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressRecord.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressRecord.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.proxy;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProxyAddressRecord {
+    private Long id;
+    private String scopeId;
+    private String address;
+    private boolean selected;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressRepository.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.cluster.proxy;
+
+import java.util.List;
+
+public interface ProxyAddressRepository {
+    List<ProxyAddressRecord> findByScope(String scopeId);
+
+    boolean insert(String scopeId, String address, boolean selected);
+
+    boolean delete(String scopeId, String address);
+
+    boolean select(String scopeId, String address);
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.proxy;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -30,10 +31,7 @@ import org.springframework.web.client.RestTemplate;
 import java.io.IOException;
 import java.time.Duration;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -47,12 +45,23 @@ public class ProxyAddressService {
     private static final int MAX_PORT = 65535;
 
     private static final String RELOAD_PATH = "/admin/reloadConfig";
+    static final String DEFAULT_SCOPE = "default";
+    static final String DEFAULT_PROXY_ADDRESS = "127.0.0.1:8081";
 
-    private final Set<String> proxyAddrs = new LinkedHashSet<>(List.of("127.0.0.1:8081"));
-    private String currentProxyAddr = "127.0.0.1:8081";
+    private final ProxyAddressRepository repository;
     private final RestTemplate restTemplate;
 
-    public ProxyAddressService() {
+    @Autowired
+    public ProxyAddressService(ProxyAddressRepository repository) {
+        this(repository, createRestTemplate());
+    }
+
+    ProxyAddressService(ProxyAddressRepository repository, RestTemplate restTemplate) {
+        this.repository = repository;
+        this.restTemplate = restTemplate;
+    }
+
+    private static RestTemplate createRestTemplate() {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory() {
             @Override
             protected void prepareConnection(java.net.HttpURLConnection connection, String httpMethod) throws IOException {
@@ -62,34 +71,60 @@ public class ProxyAddressService {
         };
         factory.setConnectTimeout(Duration.ofSeconds(3));
         factory.setReadTimeout(Duration.ofSeconds(3));
-        this.restTemplate = new RestTemplate(factory);
+        return new RestTemplate(factory);
     }
 
     public synchronized ProxyHomeVO getHomePage() {
+        return getHomePage(DEFAULT_SCOPE);
+    }
+
+    public synchronized ProxyHomeVO getHomePage(String scopeId) {
+        String scope = normalizeScope(scopeId);
+        List<ProxyAddressRecord> records = loadOrCreateDefault(scope);
         return ProxyHomeVO.builder()
-                .proxyAddrList(new ArrayList<>(proxyAddrs))
-                .currentProxyAddr(currentProxyAddr)
+                .proxyAddrList(records.stream().map(ProxyAddressRecord::getAddress).toList())
+                .currentProxyAddr(records.stream().filter(ProxyAddressRecord::isSelected)
+                        .map(ProxyAddressRecord::getAddress).findFirst()
+                        .orElse(records.get(0).getAddress()))
                 .build();
     }
 
     public synchronized void addProxyAddr(String newProxyAddr) {
+        addProxyAddr(DEFAULT_SCOPE, newProxyAddr);
+    }
+
+    public synchronized void addProxyAddr(String scopeId, String newProxyAddr) {
+        String scope = normalizeScope(scopeId);
         String normalized = normalizeProxyAddr(newProxyAddr, "newProxyAddr");
-        proxyAddrs.add(normalized);
-        if (currentProxyAddr == null || currentProxyAddr.isBlank()) {
-            currentProxyAddr = normalized;
+        List<ProxyAddressRecord> existing = repository.findByScope(scope);
+        if (existing.stream().anyMatch(record -> normalized.equals(record.getAddress()))) {
+            return;
         }
-        log.info("Added Proxy address {}", normalized);
+        if (!repository.insert(scope, normalized, existing.isEmpty())) {
+            throw new BusinessException(500, "Failed to persist Proxy address");
+        }
+        log.info("Added Proxy address {} for scope {}", normalized, scope);
     }
 
     public synchronized void removeProxyAddr(String proxyAddr) {
+        removeProxyAddr(DEFAULT_SCOPE, proxyAddr);
+    }
+
+    public synchronized void removeProxyAddr(String scopeId, String proxyAddr) {
+        String scope = normalizeScope(scopeId);
         String normalized = normalizeProxyAddr(proxyAddr, "proxyAddr");
-        if (!proxyAddrs.remove(normalized)) {
+        List<ProxyAddressRecord> before = repository.findByScope(scope);
+        ProxyAddressRecord removed = before.stream()
+                .filter(record -> normalized.equals(record.getAddress())).findFirst()
+                .orElseThrow(() -> new BusinessException(404, "Proxy address not found: " + normalized));
+        if (!repository.delete(scope, normalized)) {
             throw new BusinessException(404, "Proxy address not found: " + normalized);
         }
-        if (normalized.equals(currentProxyAddr)) {
-            currentProxyAddr = proxyAddrs.stream().findFirst().orElse("");
+        if (removed.isSelected()) {
+            repository.findByScope(scope).stream().findFirst()
+                    .ifPresent(next -> repository.select(scope, next.getAddress()));
         }
-        log.info("Removed Proxy address {}", normalized);
+        log.info("Removed Proxy address {} from scope {}", normalized, scope);
     }
 
     /**
@@ -98,9 +133,15 @@ public class ProxyAddressService {
      * on transport or protocol failure so the caller receives a structured error response.
      */
     public void reloadConfig(String addr) {
+        reloadConfig(DEFAULT_SCOPE, addr);
+    }
+
+    public void reloadConfig(String scopeId, String addr) {
+        String scope = normalizeScope(scopeId);
         String normalized = normalizeProxyAddr(addr, "addr");
         synchronized (this) {
-            if (!proxyAddrs.contains(normalized)) {
+            if (repository.findByScope(scope).stream()
+                    .noneMatch(record -> normalized.equals(record.getAddress()))) {
                 throw new BusinessException(400, "addr is not a registered proxy address");
             }
         }
@@ -123,6 +164,25 @@ public class ProxyAddressService {
             log.warn("Proxy config reload via {} failed: {}", url, ex.getMessage());
             throw new BusinessException(500, "Config reload failed: " + ex.getMessage());
         }
+    }
+
+    private List<ProxyAddressRecord> loadOrCreateDefault(String scope) {
+        List<ProxyAddressRecord> records = repository.findByScope(scope);
+        if (!records.isEmpty()) {
+            return records;
+        }
+        if (!repository.insert(scope, DEFAULT_PROXY_ADDRESS, true)) {
+            throw new BusinessException(500, "Failed to initialize Proxy address");
+        }
+        records = repository.findByScope(scope);
+        if (records.isEmpty()) {
+            throw new BusinessException(500, "Proxy address persistence returned no records");
+        }
+        return records;
+    }
+
+    private String normalizeScope(String scopeId) {
+        return scopeId == null || scopeId.isBlank() ? DEFAULT_SCOPE : scopeId.trim();
     }
 
     private String normalizeProxyAddr(String proxyAddr, String fieldName) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyCompatController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyCompatController.java
@@ -34,19 +34,21 @@ public class ProxyCompatController {
     private final ProxyAddressService proxyAddressService;
 
     @GetMapping("/homePage.query")
-    public Result<ProxyHomeVO> homePage() {
-        return Result.ok(proxyAddressService.getHomePage());
+    public Result<ProxyHomeVO> homePage(@RequestParam(required = false) String clusterId) {
+        return Result.ok(proxyAddressService.getHomePage(clusterId));
     }
 
     @PostMapping(value = "/addProxyAddr.do", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    public Result<Void> addProxyAddr(@RequestParam String newProxyAddr) {
-        proxyAddressService.addProxyAddr(newProxyAddr);
+    public Result<Void> addProxyAddr(@RequestParam String newProxyAddr,
+                                     @RequestParam(required = false) String clusterId) {
+        proxyAddressService.addProxyAddr(clusterId, newProxyAddr);
         return Result.ok();
     }
 
     @PostMapping(value = "/removeProxyAddr.do", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    public Result<Void> removeProxyAddr(@RequestParam String proxyAddr) {
-        proxyAddressService.removeProxyAddr(proxyAddr);
+    public Result<Void> removeProxyAddr(@RequestParam String proxyAddr,
+                                        @RequestParam(required = false) String clusterId) {
+        proxyAddressService.removeProxyAddr(clusterId, proxyAddr);
         return Result.ok();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyController.java
@@ -42,7 +42,7 @@ public class ProxyController {
     @GetMapping
     public Result<List<ProxyVO>> listProxies(@RequestParam(required = false) String clusterId) {
         requireClusterId(clusterId);
-        List<ProxyVO> proxies = proxyAddressService.getHomePage().getProxyAddrList().stream()
+        List<ProxyVO> proxies = proxyAddressService.getHomePage(clusterId).getProxyAddrList().stream()
                 .map(addr -> ProxyVO.builder().addr(addr).build())
                 .toList();
         return Result.ok(proxies);
@@ -50,7 +50,7 @@ public class ProxyController {
 
     @PostMapping("/config/reload")
     public Result<Map<String, Boolean>> reloadProxyConfig(@Valid @RequestBody RestartProxyDTO command) {
-        proxyAddressService.reloadConfig(command.getAddr());
+        proxyAddressService.reloadConfig(command.getClusterId(), command.getAddr());
         return Result.ok(Map.of("success", true));
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqProxyAddress.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqProxyAddress.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.persistence.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("rmq_proxy_address")
+public class RmqProxyAddress {
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String scopeId;
+    private String address;
+    private Boolean selected;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqProxyAddressMapper.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqProxyAddressMapper.java
@@ -1,0 +1,15 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.persistence.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.rocketmq.studio.persistence.entity.RmqProxyAddress;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface RmqProxyAddressMapper extends BaseMapper<RmqProxyAddress> {
+}

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -33,6 +33,18 @@ CREATE TABLE IF NOT EXISTS rmq_instance (
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+-- 2a. Proxy address preferences, isolated by managed cluster/instance scope
+CREATE TABLE IF NOT EXISTS rmq_proxy_address (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  scope_id VARCHAR(64) NOT NULL,
+  address VARCHAR(512) NOT NULL,
+  selected TINYINT(1) DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uk_proxy_scope_address (scope_id, address),
+  INDEX idx_proxy_scope_selected (scope_id, selected)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 -- 3. Topic 管理记录（通过 Studio 创建/管理的 Topic 元数据）
 CREATE TABLE IF NOT EXISTS rmq_topic (
   id BIGINT AUTO_INCREMENT PRIMARY KEY,

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
@@ -2,135 +2,141 @@
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
  */
-
 package org.apache.rocketmq.studio.cluster.proxy;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ProxyAddressServiceTest {
+    private InMemoryRepository repository;
+    private ProxyAddressService service;
 
-    private final ProxyAddressService proxyAddressService = new ProxyAddressService();
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryRepository();
+        service = new ProxyAddressService(repository, new RestTemplate());
+    }
 
     @Test
-    void homePageShouldReturnDefaultProxyAddress() {
-        ProxyHomeVO home = proxyAddressService.getHomePage();
+    void homePageShouldInitializeAndPersistDefaultProxyAddress() {
+        assertThat(service.getHomePage().getProxyAddrList())
+                .containsExactly(ProxyAddressService.DEFAULT_PROXY_ADDRESS);
 
-        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081");
-        assertThat(home.getCurrentProxyAddr()).isEqualTo("127.0.0.1:8081");
+        ProxyAddressService restarted = new ProxyAddressService(repository, new RestTemplate());
+        assertThat(restarted.getHomePage().getCurrentProxyAddr())
+                .isEqualTo(ProxyAddressService.DEFAULT_PROXY_ADDRESS);
+    }
+
+    @Test
+    void addressesShouldRemainIsolatedByClusterScope() {
+        service.addProxyAddr("cluster-a", "10.0.0.1:8081");
+        service.addProxyAddr("cluster-b", "10.0.0.2:8081");
+
+        assertThat(service.getHomePage("cluster-a").getProxyAddrList())
+                .containsExactly("10.0.0.1:8081");
+        assertThat(service.getHomePage("cluster-b").getProxyAddrList())
+                .containsExactly("10.0.0.2:8081");
     }
 
     @Test
     void addProxyAddrShouldTrimAndKeepUniqueAddresses() {
-        proxyAddressService.addProxyAddr(" 10.0.0.1:8081 ");
-        proxyAddressService.addProxyAddr("10.0.0.1:8081");
+        service.addProxyAddr(" 10.0.0.1:8081 ");
+        service.addProxyAddr("10.0.0.1:8081");
 
-        ProxyHomeVO home = proxyAddressService.getHomePage();
-        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081", "10.0.0.1:8081");
-        assertThat(home.getCurrentProxyAddr()).isEqualTo("127.0.0.1:8081");
-    }
-
-    @Test
-    void addProxyAddrShouldRejectBlankAddress() {
-        assertThatThrownBy(() -> proxyAddressService.addProxyAddr(" "))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("newProxyAddr is required")
-                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        assertThat(service.getHomePage().getProxyAddrList()).containsExactly("10.0.0.1:8081");
+        assertThat(service.getHomePage().getCurrentProxyAddr()).isEqualTo("10.0.0.1:8081");
     }
 
     @Test
     void addProxyAddrShouldAcceptBracketedIpv6Address() {
-        proxyAddressService.addProxyAddr(" [::1]:8081 ");
-
-        ProxyHomeVO home = proxyAddressService.getHomePage();
-        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081", "[::1]:8081");
+        service.addProxyAddr(" [::1]:8081 ");
+        assertThat(service.getHomePage().getProxyAddrList()).containsExactly("[::1]:8081");
     }
 
     @Test
     void addProxyAddrShouldRejectInvalidAddressFormats() {
-        List<String> invalidProxyAddrs = List.of(
-                "10.0.0.1",
-                "10.0.0.1:abc",
-                "10.0.0.1:0",
-                "10.0.0.1:65536",
-                "http://10.0.0.1:8081",
-                "10.0.0.1:8081/path"
-        );
-
-        for (String invalidProxyAddr : invalidProxyAddrs) {
-            assertThatThrownBy(() -> proxyAddressService.addProxyAddr(invalidProxyAddr))
-                    .as("invalid proxy address %s", invalidProxyAddr)
-                    .isInstanceOf(BusinessException.class)
-                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+        List<String> invalid = List.of("10.0.0.1", "10.0.0.1:abc", "10.0.0.1:0",
+                "10.0.0.1:65536", "http://10.0.0.1:8081", "10.0.0.1:8081/path");
+        for (String address : invalid) {
+            assertThatThrownBy(() -> service.addProxyAddr(address))
+                    .as(address).isInstanceOf(BusinessException.class)
+                    .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
         }
     }
 
     @Test
-    void removeProxyAddrShouldTrimAndRemoveAddress() {
-        proxyAddressService.addProxyAddr("10.0.0.1:8081");
+    void removingSelectedAddressShouldSelectNextPersistedAddress() {
+        service.addProxyAddr("cluster-a", "10.0.0.1:8081");
+        service.addProxyAddr("cluster-a", "10.0.0.2:8081");
+        service.removeProxyAddr("cluster-a", "10.0.0.1:8081");
 
-        proxyAddressService.removeProxyAddr(" 10.0.0.1:8081 ");
-
-        ProxyHomeVO home = proxyAddressService.getHomePage();
-        assertThat(home.getProxyAddrList()).containsExactly("127.0.0.1:8081");
-        assertThat(home.getCurrentProxyAddr()).isEqualTo("127.0.0.1:8081");
-    }
-
-    @Test
-    void removeProxyAddrShouldSelectNextProxyWhenCurrentIsRemoved() {
-        proxyAddressService.removeProxyAddr("127.0.0.1:8081");
-
-        ProxyHomeVO emptyHome = proxyAddressService.getHomePage();
-        assertThat(emptyHome.getProxyAddrList()).isEmpty();
-        assertThat(emptyHome.getCurrentProxyAddr()).isEmpty();
-
-        proxyAddressService.addProxyAddr("10.0.0.1:8081");
-        proxyAddressService.addProxyAddr("10.0.0.2:8081");
-        proxyAddressService.removeProxyAddr("10.0.0.1:8081");
-
-        ProxyHomeVO home = proxyAddressService.getHomePage();
+        ProxyHomeVO home = service.getHomePage("cluster-a");
         assertThat(home.getProxyAddrList()).containsExactly("10.0.0.2:8081");
         assertThat(home.getCurrentProxyAddr()).isEqualTo("10.0.0.2:8081");
     }
 
     @Test
-    void removeProxyAddrShouldRejectBlankAddress() {
-        assertThatThrownBy(() -> proxyAddressService.removeProxyAddr(" "))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("proxyAddr is required")
-                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
-    }
-
-    @Test
     void removeProxyAddrShouldRejectUnknownAddress() {
-        assertThatThrownBy(() -> proxyAddressService.removeProxyAddr("10.0.0.1:8081"))
+        assertThatThrownBy(() -> service.removeProxyAddr("10.0.0.1:8081"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Proxy address not found: 10.0.0.1:8081")
-                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
     }
 
     @Test
-    void reloadConfigShouldRejectUnregisteredAddressTest() {
-        assertThatThrownBy(() -> proxyAddressService.reloadConfig("10.0.0.1:8081"))
+    void reloadConfigShouldRejectAddressRegisteredInAnotherScope() {
+        service.addProxyAddr("cluster-a", "10.0.0.1:8081");
+
+        assertThatThrownBy(() -> service.reloadConfig("cluster-b", "10.0.0.1:8081"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("addr is not a registered proxy address")
-                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+                .hasMessage("addr is not a registered proxy address");
+    }
+
+    private static final class InMemoryRepository implements ProxyAddressRepository {
+        private final Map<String, LinkedHashMap<String, ProxyAddressRecord>> scopes = new LinkedHashMap<>();
+        private long nextId = 1;
+
+        @Override
+        public List<ProxyAddressRecord> findByScope(String scopeId) {
+            return new ArrayList<>(scopes.getOrDefault(scopeId, new LinkedHashMap<>()).values());
+        }
+
+        @Override
+        public boolean insert(String scopeId, String address, boolean selected) {
+            LinkedHashMap<String, ProxyAddressRecord> records =
+                    scopes.computeIfAbsent(scopeId, ignored -> new LinkedHashMap<>());
+            if (records.containsKey(address)) return false;
+            LocalDateTime now = LocalDateTime.now();
+            records.put(address, ProxyAddressRecord.builder().id(nextId++).scopeId(scopeId)
+                    .address(address).selected(selected).createdAt(now).updatedAt(now).build());
+            return true;
+        }
+
+        @Override
+        public boolean delete(String scopeId, String address) {
+            LinkedHashMap<String, ProxyAddressRecord> records = scopes.get(scopeId);
+            return records != null && records.remove(address) != null;
+        }
+
+        @Override
+        public boolean select(String scopeId, String address) {
+            LinkedHashMap<String, ProxyAddressRecord> records = scopes.get(scopeId);
+            if (records == null || !records.containsKey(address)) return false;
+            records.values().forEach(record -> record.setSelected(address.equals(record.getAddress())));
+            return true;
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyCompatControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyCompatControllerTest.java
@@ -27,7 +27,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -51,7 +50,7 @@ class ProxyCompatControllerTest {
                 .proxyAddrList(List.of("127.0.0.1:8081", "10.0.0.1:8081"))
                 .currentProxyAddr("127.0.0.1:8081")
                 .build();
-        when(proxyAddressService.getHomePage()).thenReturn(home);
+        when(proxyAddressService.getHomePage(null)).thenReturn(home);
 
         mockMvc.perform(get("/api/proxy/homePage.query"))
                 .andExpect(status().isOk())
@@ -68,7 +67,7 @@ class ProxyCompatControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200));
 
-        verify(proxyAddressService).addProxyAddr(eq("10.0.0.1:8081"));
+        verify(proxyAddressService).addProxyAddr(null, "10.0.0.1:8081");
     }
 
     @Test
@@ -79,6 +78,6 @@ class ProxyCompatControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200));
 
-        verify(proxyAddressService).removeProxyAddr(eq("10.0.0.1:8081"));
+        verify(proxyAddressService).removeProxyAddr(null, "10.0.0.1:8081");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyControllerTest.java
@@ -105,7 +105,7 @@ class ProxyControllerTest {
 
     @Test
     void listProxiesShouldReturnProxiesForCluster() throws Exception {
-        when(proxyAddressService.getHomePage())
+        when(proxyAddressService.getHomePage("cluster-1"))
                 .thenReturn(ProxyHomeVO.builder()
                         .proxyAddrList(List.of("127.0.0.1:8081"))
                         .currentProxyAddr("127.0.0.1:8081")
@@ -116,7 +116,7 @@ class ProxyControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data[0].addr").value("127.0.0.1:8081"));
 
-        verify(proxyAddressService).getHomePage();
+        verify(proxyAddressService).getHomePage("cluster-1");
     }
 
     @Test
@@ -141,7 +141,7 @@ class ProxyControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.success").value(true));
 
-        verify(proxyAddressService).reloadConfig("127.0.0.1:8081");
+        verify(proxyAddressService).reloadConfig("cluster-1", "127.0.0.1:8081");
     }
 
     @Test

--- a/web/src/api/proxy.test.ts
+++ b/web/src/api/proxy.test.ts
@@ -18,7 +18,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { queryProxyHomePage } from './proxy';
+import { addProxyAddress, queryProxyHomePage, removeProxyAddress } from './proxy';
 
 const mock = new MockAdapter(client);
 
@@ -53,5 +53,25 @@ describe('Proxy API', () => {
     const result = await queryProxyHomePage();
     expect(result.proxyAddrList).toHaveLength(0);
     expect(result.currentProxyAddr).toBe('');
+  });
+
+  it('scopes reads and mutations to the selected cluster', async () => {
+    mock.onGet('/proxy/homePage.query').reply((config) => {
+      expect(config.params).toEqual({ clusterId: 'cluster-a' });
+      return [200, { code: 200, data: { proxyAddrList: [], currentProxyAddr: '' } }];
+    });
+    mock.onPost('/proxy/addProxyAddr.do').reply((config) => {
+      expect(String(config.data)).toContain('clusterId=cluster-a');
+      expect(String(config.data)).toContain('newProxyAddr=10.0.0.1%3A8081');
+      return [200, { code: 200 }];
+    });
+    mock.onPost('/proxy/removeProxyAddr.do').reply((config) => {
+      expect(String(config.data)).toContain('proxyAddr=10.0.0.1%3A8081');
+      return [200, { code: 200 }];
+    });
+
+    await queryProxyHomePage('cluster-a');
+    await addProxyAddress('cluster-a', '10.0.0.1:8081');
+    await removeProxyAddress('cluster-a', '10.0.0.1:8081');
   });
 });

--- a/web/src/api/proxy.ts
+++ b/web/src/api/proxy.ts
@@ -39,9 +39,21 @@ export interface ProxyNode {
 
 // ─── API Functions ───────────────────────────────────────────────
 
-export async function queryProxyHomePage(): Promise<ProxyHomePageData> {
-  const res = await client.get<{ data: ProxyHomePageData }>('/proxy/homePage.query');
+export async function queryProxyHomePage(clusterId?: string): Promise<ProxyHomePageData> {
+  const res = await client.get<{ data: ProxyHomePageData }>('/proxy/homePage.query', {
+    params: clusterId ? { clusterId } : undefined,
+  });
   return res.data.data;
+}
+
+export async function addProxyAddress(clusterId: string, address: string): Promise<void> {
+  const body = new URLSearchParams({ clusterId, newProxyAddr: address });
+  await client.post('/proxy/addProxyAddr.do', body);
+}
+
+export async function removeProxyAddress(clusterId: string, address: string): Promise<void> {
+  const body = new URLSearchParams({ clusterId, proxyAddr: address });
+  await client.post('/proxy/removeProxyAddr.do', body);
 }
 
 /**

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1074,6 +1074,14 @@ const translations: Record<string, Record<Lang, string>> = {
   'proxy.reloadFailed': { zh: '配置重载失败', en: 'Config reload failed' },
   'proxy.statusOffline': { zh: '离线', en: 'Offline' },
   'proxy.statusError': { zh: '错误', en: 'Error' },
+  'proxy.address': { zh: 'Proxy 地址', en: 'Proxy address' },
+  'proxy.addAddress': { zh: '添加地址', en: 'Add address' },
+  'proxy.removeAddress': { zh: '删除地址', en: 'Remove address' },
+  'proxy.removeConfirm': { zh: '确认删除此 Proxy 地址？', en: 'Remove this Proxy address?' },
+  'proxy.addSuccess': { zh: 'Proxy 地址已添加', en: 'Proxy address added' },
+  'proxy.addFailed': { zh: '添加 Proxy 地址失败', en: 'Failed to add Proxy address' },
+  'proxy.removeSuccess': { zh: 'Proxy 地址已删除', en: 'Proxy address removed' },
+  'proxy.removeFailed': { zh: '删除 Proxy 地址失败', en: 'Failed to remove Proxy address' },
 
   // ─── Broker Cluster ───
   'brokerCluster.title': { zh: 'Broker 集群', en: 'Broker Cluster' },

--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -42,21 +42,32 @@ import {
   CheckCircle,
   XCircle,
   Warning,
+  Plus,
+  Trash,
 } from '@phosphor-icons/react';
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
-import { queryProxyHomePage, reloadProxyConfig, type ProxyNode } from '../../api/proxy';
+import {
+  addProxyAddress,
+  queryProxyHomePage,
+  reloadProxyConfig,
+  removeProxyAddress,
+  type ProxyNode,
+} from '../../api/proxy';
 
 const { Text } = Typography;
 
 const ProxyPage: React.FC = () => {
   const { t } = useLang();
-  const { message } = App.useApp();
+  const { message, modal } = App.useApp();
 
   const [loading, setLoading] = useState(false);
   const [proxyNodes, setProxyNodes] = useState<ProxyNode[]>([]);
   const [selectedNode, setSelectedNode] = useState<ProxyNode | null>(null);
   const [configModalOpen, setConfigModalOpen] = useState(false);
+  const [addressModalOpen, setAddressModalOpen] = useState(false);
+  const [newAddress, setNewAddress] = useState('');
+  const [addressSaving, setAddressSaving] = useState(false);
   const [clusterId, setClusterId] = useState<string>(
     localStorage.getItem('clusterId') || 'DefaultCluster',
   );
@@ -73,7 +84,7 @@ const ProxyPage: React.FC = () => {
     const requestId = ++loadRequestId.current;
     setLoading(true);
     try {
-      const { proxyAddrList, currentProxyAddr } = await queryProxyHomePage();
+      const { proxyAddrList, currentProxyAddr } = await queryProxyHomePage(clusterId);
       if (requestId !== loadRequestId.current) return false;
       const nodes: ProxyNode[] = (proxyAddrList || []).map((addr) => ({
         key: addr,
@@ -112,7 +123,7 @@ const ProxyPage: React.FC = () => {
         setLoading(false);
       }
     }
-  }, [message, t]);
+  }, [clusterId, message, t]);
 
   useEffect(() => {
     const requestId = loadRequestId.current;
@@ -153,6 +164,40 @@ const ProxyPage: React.FC = () => {
     } catch {
       message.error(t('proxy.reloadFailed'));
     }
+  };
+
+  const handleAddAddress = async () => {
+    const address = newAddress.trim();
+    if (!address) return;
+    setAddressSaving(true);
+    try {
+      await addProxyAddress(clusterId, address);
+      await loadProxyNodes();
+      setNewAddress('');
+      setAddressModalOpen(false);
+      message.success(t('proxy.addSuccess'));
+    } catch {
+      message.error(t('proxy.addFailed'));
+    } finally {
+      setAddressSaving(false);
+    }
+  };
+
+  const handleRemoveAddress = (node: ProxyNode) => {
+    modal.confirm({
+      title: t('proxy.removeConfirm'),
+      content: node.address,
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        try {
+          await removeProxyAddress(clusterId, node.address);
+          await loadProxyNodes();
+          message.success(t('proxy.removeSuccess'));
+        } catch {
+          message.error(t('proxy.removeFailed'));
+        }
+      },
+    });
   };
 
   const renderStatus = (status: string) => {
@@ -307,6 +352,16 @@ const ProxyPage: React.FC = () => {
               onClick={() => handleReloadConfig(record)}
             />
           </Tooltip>
+          <Tooltip title={t('proxy.removeAddress')}>
+            <Button
+              type="link"
+              danger
+              size="small"
+              icon={<Trash size={14} />}
+              aria-label={t('proxy.removeAddress')}
+              onClick={() => handleRemoveAddress(record)}
+            />
+          </Tooltip>
         </Space>
       ),
     },
@@ -328,6 +383,9 @@ const ProxyPage: React.FC = () => {
               style={{ width: 200 }}
               aria-label={t('proxy.clusterId')}
             />
+            <Button icon={<Plus size={14} />} onClick={() => setAddressModalOpen(true)}>
+              {t('proxy.addAddress')}
+            </Button>
             <Button type="primary" icon={<ArrowClockwise size={14} />} onClick={handleRefresh}>
               {t('common.refresh')}
             </Button>
@@ -407,6 +465,26 @@ const ProxyPage: React.FC = () => {
             {t('proxy.configUnavailableHint')}
           </Descriptions.Item>
         </Descriptions>
+      </Modal>
+      <Modal
+        title={t('proxy.addAddress')}
+        open={addressModalOpen}
+        confirmLoading={addressSaving}
+        okButtonProps={{ disabled: !newAddress.trim() }}
+        onOk={handleAddAddress}
+        onCancel={() => {
+          setAddressModalOpen(false);
+          setNewAddress('');
+        }}
+      >
+        <Input
+          autoFocus
+          value={newAddress}
+          placeholder="proxy.example.com:8081"
+          aria-label={t('proxy.address')}
+          onChange={(event) => setNewAddress(event.target.value)}
+          onPressEnter={() => void handleAddAddress()}
+        />
       </Modal>
     </div>
   );

--- a/web/src/pages/studio/__tests__/Proxy.test.tsx
+++ b/web/src/pages/studio/__tests__/Proxy.test.tsx
@@ -19,13 +19,20 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
-import { queryProxyHomePage, reloadProxyConfig } from '../../../api/proxy';
+import {
+  addProxyAddress,
+  queryProxyHomePage,
+  reloadProxyConfig,
+  removeProxyAddress,
+} from '../../../api/proxy';
 import { LangProvider } from '../../../i18n/LangContext';
 import ProxyPage from '../Proxy';
 
 vi.mock('../../../api/proxy', () => ({
   queryProxyHomePage: vi.fn(),
   reloadProxyConfig: vi.fn(),
+  addProxyAddress: vi.fn(),
+  removeProxyAddress: vi.fn(),
 }));
 
 beforeAll(() => {
@@ -74,13 +81,15 @@ describe('ProxyPage', () => {
     vi.mocked(reloadProxyConfig).mockResolvedValue({
       success: true,
     });
+    vi.mocked(addProxyAddress).mockResolvedValue();
+    vi.mocked(removeProxyAddress).mockResolvedValue();
   });
 
   it('loads Proxy nodes once after the page mounts', async () => {
     renderPage();
 
     await screen.findByText('127.0.0.1:8081');
-    expect(queryProxyHomePage).toHaveBeenCalledTimes(1);
+    expect(queryProxyHomePage).toHaveBeenCalledWith('DefaultCluster');
   });
 
   it('shows success after the proxy list refreshes', async () => {
@@ -140,6 +149,27 @@ describe('ProxyPage', () => {
       expect(reloadProxyConfig).toHaveBeenCalledWith('DefaultCluster', '127.0.0.1:8081'),
     );
     expect(await screen.findByText('配置重载成功')).toBeInTheDocument();
+  });
+
+  it('adds a scoped Proxy address and refreshes the table', async () => {
+    const user = userEvent.setup();
+    vi.mocked(queryProxyHomePage)
+      .mockResolvedValueOnce(proxyHome)
+      .mockResolvedValueOnce({
+        proxyAddrList: [...proxyHome.proxyAddrList, '10.0.0.1:8081'],
+        currentProxyAddr: proxyHome.currentProxyAddr,
+      });
+    renderPage();
+    await screen.findByText('127.0.0.1:8081');
+
+    await user.click(screen.getByRole('button', { name: '添加地址' }));
+    await user.type(screen.getByRole('textbox', { name: 'Proxy 地址' }), '10.0.0.1:8081');
+    await user.click(screen.getByRole('button', { name: 'OK' }));
+
+    await waitFor(() =>
+      expect(addProxyAddress).toHaveBeenCalledWith('DefaultCluster', '10.0.0.1:8081'),
+    );
+    expect(await screen.findByText('10.0.0.1:8081')).toBeInTheDocument();
   });
 
   it('keeps the latest Proxy list when an older refresh resolves last', async () => {


### PR DESCRIPTION
## Summary
- persist proxy address preferences in MySQL instead of process memory
- isolate address lists and selections by RocketMQ instance while retaining the legacy compatibility endpoint
- add address add/remove/select controls to the Proxy page and cover persistence, scoping, and API behavior

## Validation
- `mvn -q -Dtest=ProxyAddressServiceTest,ProxyCompatControllerTest,ProxyControllerTest test`
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/api/proxy.test.ts src/pages/studio/__tests__/Proxy.test.tsx`
- frontend ESLint and Prettier hooks

Fixes #1824