### PR TITLE
feat(instances): add versioned import and export

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
@@ -60,4 +60,15 @@ public class InstanceController {
         instanceService.deleteInstance(request.getId());
         return Result.ok();
     }
+
+    @GetMapping("/export")
+    public Result<InstanceExportVO> exportInstances() {
+        return Result.ok(instanceService.exportInstances());
+    }
+
+    @PostMapping("/import")
+    public Result<InstanceImportResultVO> importInstances(
+            @Valid @RequestBody InstanceImportRequestDTO request) {
+        return Result.ok(instanceService.importInstances(request));
+    }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceExportVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceExportVO.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class InstanceExportVO {
+    private int schemaVersion;
+    private LocalDateTime exportedAt;
+    private List<InstanceImportItemDTO> instances;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceImportItemDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceImportItemDTO.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import lombok.Data;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+
+@Data
+public class InstanceImportItemDTO {
+    private String id;
+    private String name;
+    private String remark;
+    private InstanceType type;
+    private String endpoint;
+    private InstanceVendor vendor;
+    private String cloudInstanceId;
+    private String credentialId;
+    private String adminCredentialRef;
+    private String regionId;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceImportRequestDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceImportRequestDTO.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class InstanceImportRequestDTO {
+    @Valid
+    @NotEmpty(message = "instances are required")
+    @Size(max = 200, message = "at most 200 instances can be imported")
+    private List<InstanceImportItemDTO> instances;
+    private boolean overwrite;
+    private boolean dryRun;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceImportResultVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceImportResultVO.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+public class InstanceImportResultVO {
+    private List<String> createdIds;
+    private List<String> updatedIds;
+    private List<String> skippedIds;
+    private Map<String, String> errors;
+    private boolean dryRun;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -34,10 +34,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -260,6 +265,123 @@ public class InstanceService {
         releaseApacheEndpointIfUnused(existing, null);
         recordAudit("DELETE_INSTANCE", "INSTANCE", id, null,
                 instanceAuditDetail(existing));
+    }
+
+    public InstanceExportVO exportInstances() {
+        List<InstanceImportItemDTO> items = instanceRepository.findAll().stream()
+                .sorted(Comparator.comparing(InstanceVO::getName, String.CASE_INSENSITIVE_ORDER)
+                        .thenComparing(InstanceVO::getId))
+                .map(this::toImportItem)
+                .toList();
+        return InstanceExportVO.builder()
+                .schemaVersion(1)
+                .exportedAt(LocalDateTime.now())
+                .instances(items)
+                .build();
+    }
+
+    public InstanceImportResultVO importInstances(InstanceImportRequestDTO request) {
+        if (request == null || request.getInstances() == null || request.getInstances().isEmpty()) {
+            throw new BusinessException(400, "instances are required");
+        }
+        List<String> created = new ArrayList<>();
+        List<String> updated = new ArrayList<>();
+        List<String> skipped = new ArrayList<>();
+        LinkedHashMap<String, String> errors = new LinkedHashMap<>();
+        Set<String> seenIds = new HashSet<>();
+        for (int index = 0; index < request.getInstances().size(); index++) {
+            InstanceImportItemDTO item = request.getInstances().get(index);
+            String rowKey = item == null || !StringUtils.hasText(item.getId())
+                    ? "row-" + (index + 1) : item.getId().trim();
+            try {
+                InstanceVO candidate = validateImportItem(item);
+                if (!seenIds.add(candidate.getId())) {
+                    throw new BusinessException(400, "Duplicate instance id in import file");
+                }
+                InstanceVO existing = instanceRepository.findById(candidate.getId()).orElse(null);
+                if (existing != null && !request.isOverwrite()) {
+                    skipped.add(candidate.getId());
+                    continue;
+                }
+                LocalDateTime now = LocalDateTime.now();
+                candidate.setCreatedAt(existing == null ? now : existing.getCreatedAt());
+                candidate.setUpdatedAt(now);
+                if (!request.isDryRun()) {
+                    instanceRepository.save(candidate);
+                    if (existing != null) {
+                        releaseApacheClientIfChanged(existing, candidate);
+                    }
+                }
+                (existing == null ? created : updated).add(candidate.getId());
+            } catch (RuntimeException failure) {
+                errors.put(rowKey, failure.getMessage() == null ? "Import failed" : failure.getMessage());
+            }
+        }
+        InstanceImportResultVO result = InstanceImportResultVO.builder()
+                .createdIds(created).updatedIds(updated).skippedIds(skipped)
+                .errors(errors).dryRun(request.isDryRun()).build();
+        if (!request.isDryRun()) {
+            recordAudit("IMPORT_INSTANCES", "INSTANCE", "bulk", null,
+                    String.format("created=%d, updated=%d, skipped=%d, failed=%d",
+                            created.size(), updated.size(), skipped.size(), errors.size()));
+        }
+        return result;
+    }
+
+    private InstanceVO validateImportItem(InstanceImportItemDTO item) {
+        if (item == null) {
+            throw new BusinessException(400, "Instance entry is required");
+        }
+        String id = StringUtils.hasText(item.getId()) ? item.getId().trim() : UUID.randomUUID().toString();
+        InstanceVendor vendor = item.getVendor() == null ? InstanceVendor.APACHE : item.getVendor();
+        InstanceType type = item.getType();
+        if (type == null) {
+            throw new BusinessException(400, "Instance type is required");
+        }
+        String endpoint = requireValidEndpoint(item.getEndpoint());
+        if (vendor != InstanceVendor.APACHE) {
+            if (!StringUtils.hasText(item.getCredentialId())) {
+                throw new BusinessException(400, "credentialId is required for " + vendor + " instances");
+            }
+            CloudCredentialVO credential = cloudCredentialRepository.findById(item.getCredentialId().trim())
+                    .orElseThrow(() -> new BusinessException(404,
+                            "Cloud credential not found: " + item.getCredentialId().trim()));
+            if (credential.getVendor() != vendor) {
+                throw new BusinessException(400, "Cloud credential vendor does not match " + vendor);
+            }
+        }
+        InstanceVO candidate = InstanceVO.builder()
+                .name(requireInstanceName(item.getName()))
+                .remark(item.getRemark())
+                .type(type)
+                .endpoint(endpoint)
+                .vendor(vendor)
+                .cloudInstanceId(trimToNull(item.getCloudInstanceId()))
+                .credentialId(trimToNull(item.getCredentialId()))
+                .adminCredentialRef(normalizeCredentialRef(item.getAdminCredentialRef()))
+                .regionId(trimToNull(item.getRegionId()))
+                .build();
+        candidate.setId(id);
+        return candidate;
+    }
+
+    private InstanceImportItemDTO toImportItem(InstanceVO instance) {
+        InstanceImportItemDTO item = new InstanceImportItemDTO();
+        item.setId(instance.getId());
+        item.setName(instance.getName());
+        item.setRemark(instance.getRemark());
+        item.setType(instance.getType());
+        item.setEndpoint(instance.getEndpoint());
+        item.setVendor(instance.getVendor() == null ? InstanceVendor.APACHE : instance.getVendor());
+        item.setCloudInstanceId(instance.getCloudInstanceId());
+        item.setCredentialId(instance.getCredentialId());
+        item.setAdminCredentialRef(instance.getAdminCredentialRef());
+        item.setRegionId(instance.getRegionId());
+        return item;
+    }
+
+    private String trimToNull(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
     }
 
     private void requireInstance(InstanceVO instance) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
@@ -243,6 +243,43 @@ class InstanceControllerTest {
         verifyNoInteractions(instanceService);
     }
 
+    @Test
+    void exportInstancesShouldReturnVersionedBundle() throws Exception {
+        when(instanceService.exportInstances()).thenReturn(InstanceExportVO.builder()
+                .schemaVersion(1).exportedAt(LocalDateTime.of(2026, 8, 5, 12, 0))
+                .instances(List.of()).build());
+
+        mockMvc.perform(get("/api/instances/export"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.schemaVersion").value(1))
+                .andExpect(jsonPath("$.data.instances").isArray());
+    }
+
+    @Test
+    void importInstancesShouldReturnDryRunPlan() throws Exception {
+        when(instanceService.importInstances(any(InstanceImportRequestDTO.class)))
+                .thenReturn(InstanceImportResultVO.builder()
+                        .createdIds(List.of("new-instance")).updatedIds(List.of())
+                        .skippedIds(List.of()).errors(Map.of()).dryRun(true).build());
+
+        mockMvc.perform(post("/api/instances/import")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"instances\":[{\"id\":\"new-instance\",\"name\":\"New\","
+                                + "\"type\":\"PROXY\",\"endpoint\":\"proxy:8080\"}],\"dryRun\":true}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.dryRun").value(true))
+                .andExpect(jsonPath("$.data.createdIds[0]").value("new-instance"));
+    }
+
+    @Test
+    void importInstancesShouldRejectEmptyBundle() throws Exception {
+        mockMvc.perform(post("/api/instances/import")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"instances\":[]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("instances are required"));
+    }
+
     private InstanceVO buildInstance(String id, String name, InstanceType type, String endpoint) {
         InstanceVO instance = InstanceVO.builder()
                 .name(name)

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -908,4 +908,76 @@ class InstanceServiceTest {
         assertThat(updated.getRemark()).isEqualTo("updated");
         assertThat(updated.getCloudInstanceId()).isEqualTo("rmq-cn-xxx");
     }
+
+    @Test
+    void exportInstancesShouldSortAndExcludeRuntimeCounts() {
+        InstanceVO second = InstanceVO.builder().name("zeta").type(InstanceType.PROXY)
+                .endpoint("zeta:8080").topicCount(12).consumerGroupCount(4).build();
+        second.setId("instance-z");
+        InstanceVO first = InstanceVO.builder().name("Alpha").type(InstanceType.DIRECT)
+                .endpoint("alpha:9876").topicCount(8).consumerGroupCount(2).build();
+        first.setId("instance-a");
+        when(instanceRepository.findAll()).thenReturn(List.of(second, first));
+
+        InstanceExportVO exported = instanceService.exportInstances();
+
+        assertThat(exported.getSchemaVersion()).isEqualTo(1);
+        assertThat(exported.getInstances()).extracting(InstanceImportItemDTO::getId)
+                .containsExactly("instance-a", "instance-z");
+    }
+
+    @Test
+    void importInstancesShouldCreateSkipAndReportInvalidRows() {
+        InstanceVO existing = InstanceVO.builder().name("Existing").type(InstanceType.PROXY)
+                .endpoint("old:8080").build();
+        existing.setId("existing");
+        existing.setCreatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+        when(instanceRepository.findById("new-instance")).thenReturn(Optional.empty());
+        when(instanceRepository.findById("existing")).thenReturn(Optional.of(existing));
+        when(instanceRepository.save(any(InstanceVO.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        InstanceImportItemDTO created = importItem("new-instance", "New", "new:8080");
+        InstanceImportItemDTO skipped = importItem("existing", "Existing replacement", "next:8080");
+        InstanceImportItemDTO invalid = importItem("invalid", "Invalid", " ");
+        InstanceImportRequestDTO request = new InstanceImportRequestDTO();
+        request.setInstances(List.of(created, skipped, invalid));
+
+        InstanceImportResultVO result = instanceService.importInstances(request);
+
+        assertThat(result.getCreatedIds()).containsExactly("new-instance");
+        assertThat(result.getSkippedIds()).containsExactly("existing");
+        assertThat(result.getErrors()).containsKey("invalid");
+        verify(instanceRepository).save(argThat(instance -> "new-instance".equals(instance.getId())));
+    }
+
+    @Test
+    void dryRunImportShouldPlanOverwriteWithoutSaving() {
+        InstanceVO existing = InstanceVO.builder().name("Existing").type(InstanceType.PROXY)
+                .endpoint("old:8080").build();
+        existing.setId("existing");
+        existing.setCreatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+        when(instanceRepository.findById("existing")).thenReturn(Optional.of(existing));
+        InstanceImportRequestDTO request = new InstanceImportRequestDTO();
+        request.setInstances(List.of(importItem("existing", "Replacement", "next:8080")));
+        request.setOverwrite(true);
+        request.setDryRun(true);
+
+        InstanceImportResultVO result = instanceService.importInstances(request);
+
+        assertThat(result.isDryRun()).isTrue();
+        assertThat(result.getUpdatedIds()).containsExactly("existing");
+        verify(instanceRepository, never()).save(any());
+        verifyNoInteractions(operationAuditService);
+    }
+
+    private static InstanceImportItemDTO importItem(String id, String name, String endpoint) {
+        InstanceImportItemDTO item = new InstanceImportItemDTO();
+        item.setId(id);
+        item.setName(name);
+        item.setType(InstanceType.PROXY);
+        item.setEndpoint(endpoint);
+        item.setVendor(InstanceVendor.APACHE);
+        return item;
+    }
 }

--- a/web/src/api/instance.test.ts
+++ b/web/src/api/instance.test.ts
@@ -18,7 +18,14 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { createInstance, deleteInstance, listInstances, updateInstance } from './instance';
+import {
+  createInstance,
+  deleteInstance,
+  exportInstances,
+  importInstances,
+  listInstances,
+  updateInstance,
+} from './instance';
 
 const mock = new MockAdapter(client);
 const instance = {
@@ -83,5 +90,30 @@ describe('instance API', () => {
     });
 
     await expect(deleteInstance(instance.id)).resolves.toBeUndefined();
+  });
+
+  it('exports and imports versioned instance bundles', async () => {
+    const bundle = { schemaVersion: 1, exportedAt: '2026-08-12T00:00:00Z', instances: [instance] };
+    const result = {
+      createdIds: [instance.id],
+      updatedIds: [],
+      skippedIds: [],
+      errors: {},
+      dryRun: true,
+    };
+    mock.onGet('/instances/export').reply(200, { code: 200, data: bundle });
+    mock.onPost('/instances/import').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({
+        instances: [instance],
+        overwrite: true,
+        dryRun: true,
+      });
+      return [200, { code: 200, data: result }];
+    });
+
+    await expect(exportInstances()).resolves.toEqual(bundle);
+    await expect(
+      importInstances({ instances: [instance], overwrite: true, dryRun: true }),
+    ).resolves.toEqual(result);
   });
 });

--- a/web/src/api/instance.ts
+++ b/web/src/api/instance.ts
@@ -64,6 +64,39 @@ export interface InstanceQuery {
   search?: string;
 }
 
+export interface InstanceImportItem {
+  id?: string;
+  name: string;
+  remark?: string | null;
+  type: Instance['type'];
+  endpoint: string;
+  vendor?: InstanceVendor;
+  cloudInstanceId?: string;
+  credentialId?: string;
+  adminCredentialRef?: string;
+  regionId?: string;
+}
+
+export interface InstanceExportBundle {
+  schemaVersion: number;
+  exportedAt: string;
+  instances: InstanceImportItem[];
+}
+
+export interface InstanceImportRequest {
+  instances: InstanceImportItem[];
+  overwrite: boolean;
+  dryRun: boolean;
+}
+
+export interface InstanceImportResult {
+  createdIds: string[];
+  updatedIds: string[];
+  skippedIds: string[];
+  errors: Record<string, string>;
+  dryRun: boolean;
+}
+
 // ─── Instance CRUD ──────────────────────────────────────────────
 export async function listInstances(query: InstanceQuery = {}) {
   const search = query.search?.trim();
@@ -87,4 +120,14 @@ export async function updateInstance(data: UpdateInstanceRequest) {
 
 export async function deleteInstance(id: string) {
   await client.post('/instances/delete', { id });
+}
+
+export async function exportInstances() {
+  const res = await client.get<{ data: InstanceExportBundle }>('/instances/export');
+  return res.data.data;
+}
+
+export async function importInstances(data: InstanceImportRequest) {
+  const res = await client.post<{ data: InstanceImportResult }>('/instances/import', data);
+  return res.data.data;
 }

--- a/web/src/pages/instance/InstanceImportDialog.tsx
+++ b/web/src/pages/instance/InstanceImportDialog.tsx
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+import { Alert, Button, Checkbox, Descriptions, Modal, Space, Table, Upload, message } from 'antd';
+import { InboxOutlined } from '@ant-design/icons';
+import type { InstanceImportItem, InstanceImportResult } from '../../api/instance';
+import { importInstances } from '../../services/instanceService';
+import { parseInstanceBundle } from './instanceImport';
+
+interface Props {
+  open: boolean;
+  onCancel: () => void;
+  onImported: () => Promise<void> | void;
+}
+
+const ResultSummary = ({ result }: { result: InstanceImportResult }) => (
+  <>
+    <Descriptions size="small" column={4} bordered style={{ marginTop: 16 }}>
+      <Descriptions.Item label="新增">{result.createdIds.length}</Descriptions.Item>
+      <Descriptions.Item label="更新">{result.updatedIds.length}</Descriptions.Item>
+      <Descriptions.Item label="跳过">{result.skippedIds.length}</Descriptions.Item>
+      <Descriptions.Item label="失败">{Object.keys(result.errors).length}</Descriptions.Item>
+    </Descriptions>
+    {Object.keys(result.errors).length > 0 && (
+      <Table
+        size="small"
+        rowKey="id"
+        pagination={{ pageSize: 5, hideOnSinglePage: true }}
+        style={{ marginTop: 12 }}
+        dataSource={Object.entries(result.errors).map(([id, reason]) => ({ id, reason }))}
+        columns={[
+          { title: '记录', dataIndex: 'id', width: 160 },
+          { title: '错误原因', dataIndex: 'reason' },
+        ]}
+      />
+    )}
+  </>
+);
+
+const InstanceImportDialog = ({ open, onCancel, onImported }: Props) => {
+  const [fileName, setFileName] = useState('');
+  const [instances, setInstances] = useState<InstanceImportItem[]>([]);
+  const [overwrite, setOverwrite] = useState(false);
+  const [preview, setPreview] = useState<InstanceImportResult | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [importing, setImporting] = useState(false);
+
+  const close = () => {
+    setFileName('');
+    setInstances([]);
+    setOverwrite(false);
+    setPreview(null);
+    onCancel();
+  };
+
+  const readFile = async (file: File) => {
+    try {
+      const bundle = parseInstanceBundle(await file.text());
+      setFileName(file.name);
+      setInstances(bundle.instances);
+      setPreview(null);
+      message.success(`已读取 ${bundle.instances.length} 个实例`);
+    } catch (error) {
+      setFileName('');
+      setInstances([]);
+      setPreview(null);
+      message.error(error instanceof Error ? error.message : 'JSON 文件解析失败');
+    }
+  };
+
+  const previewImport = async () => {
+    setPreviewing(true);
+    try {
+      setPreview(await importInstances({ instances, overwrite, dryRun: true }));
+    } catch {
+      message.error('预检失败，请检查导入内容');
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  const executeImport = async () => {
+    setImporting(true);
+    try {
+      const result = await importInstances({ instances, overwrite, dryRun: false });
+      setPreview(result);
+      await onImported();
+      const changed = result.createdIds.length + result.updatedIds.length;
+      if (Object.keys(result.errors).length > 0) {
+        message.warning(`已导入 ${changed} 个实例，${Object.keys(result.errors).length} 个失败`);
+      } else {
+        message.success(`成功导入 ${changed} 个实例`);
+        close();
+      }
+    } catch {
+      message.error('导入失败，请稍后重试');
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <Modal
+      title="导入实例配置"
+      open={open}
+      onCancel={close}
+      width={680}
+      footer={
+        <Space>
+          <Button onClick={close}>取消</Button>
+          <Button
+            disabled={!instances.length}
+            loading={previewing}
+            onClick={() => void previewImport()}
+          >
+            预检
+          </Button>
+          <Button
+            type="primary"
+            disabled={!instances.length}
+            loading={importing}
+            onClick={() => void executeImport()}
+          >
+            确认导入
+          </Button>
+        </Space>
+      }
+    >
+      <Alert
+        type="info"
+        showIcon
+        message="先预检，再导入"
+        description="支持由控制台导出的 schemaVersion 1 JSON，也支持实例数组。预检不会修改任何数据。"
+        style={{ marginBottom: 16 }}
+      />
+      <Upload.Dragger
+        accept="application/json,.json"
+        maxCount={1}
+        fileList={[]}
+        beforeUpload={(file) => {
+          void readFile(file);
+          return Upload.LIST_IGNORE;
+        }}
+      >
+        <p className="ant-upload-drag-icon">
+          <InboxOutlined />
+        </p>
+        <p className="ant-upload-text">点击或拖放实例 JSON 文件到此处</p>
+        <p className="ant-upload-hint">最多 200 条记录，凭据字段仅包含服务端引用</p>
+      </Upload.Dragger>
+      {fileName && (
+        <Space direction="vertical" size={8} style={{ width: '100%', marginTop: 16 }}>
+          <span>
+            文件：{fileName}（{instances.length} 个实例）
+          </span>
+          <Checkbox
+            checked={overwrite}
+            onChange={(event) => {
+              setOverwrite(event.target.checked);
+              setPreview(null);
+            }}
+          >
+            覆盖 ID 相同的已有实例
+          </Checkbox>
+        </Space>
+      )}
+      {preview && <ResultSummary result={preview} />}
+    </Modal>
+  );
+};
+
+export default InstanceImportDialog;

--- a/web/src/pages/instance/__tests__/InstanceImportDialog.test.tsx
+++ b/web/src/pages/instance/__tests__/InstanceImportDialog.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseInstanceBundle } from '../instanceImport';
+
+const item = { id: 'instance-1', name: 'orders', type: 'PROXY' as const, endpoint: 'proxy:8080' };
+
+describe('InstanceImportDialog bundle parsing', () => {
+  it('accepts versioned exports and legacy arrays', () => {
+    expect(
+      parseInstanceBundle(JSON.stringify({ schemaVersion: 1, instances: [item] })).instances,
+    ).toEqual([item]);
+    expect(parseInstanceBundle(JSON.stringify([item])).instances).toEqual([item]);
+  });
+
+  it('rejects unsupported and empty bundles', () => {
+    expect(() =>
+      parseInstanceBundle(JSON.stringify({ schemaVersion: 2, instances: [item] })),
+    ).toThrow('schemaVersion');
+    expect(() => parseInstanceBundle(JSON.stringify({ schemaVersion: 1, instances: [] }))).toThrow(
+      '没有实例记录',
+    );
+  });
+});

--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -44,6 +44,8 @@ vi.mock('../../../api/tencentCatalog', () => ({
 vi.mock('../../../services/instanceService', () => ({
   createInstance: vi.fn(),
   deleteInstance: vi.fn(),
+  exportInstances: vi.fn(),
+  importInstances: vi.fn(),
   listInstances: vi.fn(),
   updateInstance: vi.fn(),
 }));
@@ -149,7 +151,11 @@ describe('InstancePage', () => {
 
   it('keeps unavailable resource counts after available values in both sort directions', async () => {
     vi.mocked(instanceService.listInstances).mockResolvedValue([
-      { ...instance('unavailable', 'unavailable-instance'), topicCount: 0, resourceCountsAvailable: false },
+      {
+        ...instance('unavailable', 'unavailable-instance'),
+        topicCount: 0,
+        resourceCountsAvailable: false,
+      },
       { ...instance('zero', 'zero-instance'), topicCount: 0 },
       { ...instance('many', 'many-instance'), topicCount: 10 },
     ]);

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -35,7 +35,7 @@ import {
 } from 'antd';
 import { useLang } from '../../i18n/LangContext';
 import { Plus, MagnifyingGlass } from '@phosphor-icons/react';
-import { EditOutlined, DeleteOutlined } from '@ant-design/icons';
+import { DownloadOutlined, EditOutlined, DeleteOutlined, UploadOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import type { SortOrder } from 'antd/es/table/interface';
 import type { Instance, InstanceQuery } from '../../api/instance';
@@ -51,10 +51,13 @@ import { formatDateTime } from '../../utils/format';
 import {
   createInstance,
   deleteInstance,
+  exportInstances,
   listInstances,
   updateInstance,
 } from '../../services/instanceService';
+import { downloadBlob } from '../../utils/download';
 import { DEFAULT_VENDOR, VENDOR_OPTIONS, type InstanceVendor } from './vendorOptions';
+import InstanceImportDialog from './InstanceImportDialog';
 
 const { Text } = Typography;
 
@@ -113,6 +116,8 @@ const InstancePage = () => {
   const [cloudInstances, setCloudInstances] = useState<CloudInstanceOption[]>([]);
   const [cloudInstancesLoading, setCloudInstancesLoading] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
+  const [importModalOpen, setImportModalOpen] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const [editingInstance, setEditingInstance] = useState<Instance | null>(null);
   const [editForm] = Form.useForm();
   const [submitting, setSubmitting] = useState(false);
@@ -364,6 +369,23 @@ const InstancePage = () => {
     }
   };
 
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const bundle = await exportInstances();
+      const date = new Date().toISOString().slice(0, 10);
+      downloadBlob(
+        new Blob([JSON.stringify(bundle, null, 2)], { type: 'application/json;charset=utf-8' }),
+        `rocketmq-instances-${date}.json`,
+      );
+      message.success(`已导出 ${bundle.instances.length} 个实例`);
+    } catch {
+      message.error('导出实例配置失败');
+    } finally {
+      setExporting(false);
+    }
+  };
+
   const sortedInstances = [...instances].sort((a, b) => a.name.localeCompare(b.name));
 
   const columns: ColumnsType<Instance> = [
@@ -436,8 +458,7 @@ const InstancePage = () => {
       key: 'consumerGroupCount',
       width: 80,
       align: 'center' as const,
-      sorter: (a, b, sortOrder) =>
-        compareResourceCounts(a, b, 'consumerGroupCount', sortOrder),
+      sorter: (a, b, sortOrder) => compareResourceCounts(a, b, 'consumerGroupCount', sortOrder),
       render: (count: number, record: Instance) =>
         record.resourceCountsAvailable === false ? '不可用' : count,
     },
@@ -545,13 +566,25 @@ const InstancePage = () => {
             ]}
           />
         </Space>
-        <Button
-          type="primary"
-          icon={<Plus size={14} weight="bold" />}
-          onClick={() => setAddModalOpen(true)}
-        >
-          添加实例
-        </Button>
+        <Space>
+          <Button icon={<UploadOutlined />} onClick={() => setImportModalOpen(true)}>
+            导入配置
+          </Button>
+          <Button
+            icon={<DownloadOutlined />}
+            loading={exporting}
+            onClick={() => void handleExport()}
+          >
+            导出配置
+          </Button>
+          <Button
+            type="primary"
+            icon={<Plus size={14} weight="bold" />}
+            onClick={() => setAddModalOpen(true)}
+          >
+            添加实例
+          </Button>
+        </Space>
       </Flex>
 
       {/* Table */}
@@ -782,6 +815,12 @@ const InstancePage = () => {
           </Form.Item>
         </Form>
       </Modal>
+
+      <InstanceImportDialog
+        open={importModalOpen}
+        onCancel={() => setImportModalOpen(false)}
+        onImported={loadInstances}
+      />
     </div>
   );
 };

--- a/web/src/pages/instance/instanceImport.ts
+++ b/web/src/pages/instance/instanceImport.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { InstanceImportItem } from '../../api/instance';
+
+export interface ParsedInstanceBundle {
+  schemaVersion?: number;
+  instances: InstanceImportItem[];
+}
+
+export function parseInstanceBundle(contents: string): ParsedInstanceBundle {
+  const value: unknown = JSON.parse(contents);
+  if (Array.isArray(value)) return { instances: value as InstanceImportItem[] };
+  if (!value || typeof value !== 'object') throw new Error('导入文件必须是 JSON 对象或数组');
+  const bundle = value as { schemaVersion?: number; instances?: unknown };
+  if (bundle.schemaVersion !== undefined && bundle.schemaVersion !== 1) {
+    throw new Error(`不支持的 schemaVersion：${bundle.schemaVersion}`);
+  }
+  if (!Array.isArray(bundle.instances) || bundle.instances.length === 0) {
+    throw new Error('导入文件中没有实例记录');
+  }
+  if (bundle.instances.length > 200) throw new Error('单次最多导入 200 个实例');
+  return {
+    schemaVersion: bundle.schemaVersion,
+    instances: bundle.instances as InstanceImportItem[],
+  };
+}

--- a/web/src/services/instanceService.test.ts
+++ b/web/src/services/instanceService.test.ts
@@ -22,7 +22,14 @@ vi.mock('../config', () => ({
   API_BASE_URL: '/api',
 }));
 
-import { createInstance, deleteInstance, listInstances, updateInstance } from './instanceService';
+import {
+  createInstance,
+  deleteInstance,
+  exportInstances,
+  importInstances,
+  listInstances,
+  updateInstance,
+} from './instanceService';
 
 describe('instanceService mock instances', () => {
   it('returns defensive copies from list reads', async () => {
@@ -91,5 +98,34 @@ describe('instanceService mock instances', () => {
     );
 
     await expect(listInstances()).resolves.toEqual(before);
+  });
+
+  it('previews and applies mock imports without mutating during dry runs', async () => {
+    const bundle = await exportInstances();
+    expect(bundle.schemaVersion).toBe(1);
+    expect(bundle.instances.length).toBeGreaterThan(0);
+
+    const imported = {
+      id: 'imported-instance-test',
+      name: 'imported-instance-test',
+      type: 'PROXY' as const,
+      endpoint: 'imported.example:8080',
+    };
+    const preview = await importInstances({
+      instances: [imported],
+      overwrite: false,
+      dryRun: true,
+    });
+    expect(preview.createdIds).toEqual([imported.id]);
+    expect((await listInstances()).some((item) => item.id === imported.id)).toBe(false);
+
+    const applied = await importInstances({
+      instances: [imported],
+      overwrite: false,
+      dryRun: false,
+    });
+    expect(applied.createdIds).toEqual([imported.id]);
+    expect((await listInstances()).some((item) => item.id === imported.id)).toBe(true);
+    await deleteInstance(imported.id);
   });
 });

--- a/web/src/services/instanceService.ts
+++ b/web/src/services/instanceService.ts
@@ -3,6 +3,9 @@ import * as instanceApi from '../api/instance';
 import type {
   Instance,
   CreateInstanceRequest,
+  InstanceExportBundle,
+  InstanceImportRequest,
+  InstanceImportResult,
   InstanceQuery,
   UpdateInstanceRequest,
 } from '../api/instance';
@@ -74,4 +77,84 @@ export async function deleteInstance(id: string): Promise<void> {
     return;
   }
   return instanceApi.deleteInstance(id);
+}
+
+const toImportItem = (instance: Instance) => ({
+  id: instance.id,
+  name: instance.name,
+  remark: instance.remark,
+  type: instance.type,
+  endpoint: instance.endpoint,
+  vendor: instance.vendor || ('APACHE' as const),
+  cloudInstanceId: instance.cloudInstanceId,
+  credentialId: instance.credentialId,
+  adminCredentialRef: instance.adminCredentialRef,
+  regionId: instance.regionId,
+});
+
+export async function exportInstances(): Promise<InstanceExportBundle> {
+  if (isMockMode()) {
+    return {
+      schemaVersion: 1,
+      exportedAt: new Date().toISOString(),
+      instances: mockInstances
+        .slice()
+        .sort((left, right) => left.name.localeCompare(right.name))
+        .map(toImportItem),
+    };
+  }
+  return instanceApi.exportInstances();
+}
+
+export async function importInstances(
+  request: InstanceImportRequest,
+): Promise<InstanceImportResult> {
+  if (!isMockMode()) return instanceApi.importInstances(request);
+
+  const result: InstanceImportResult = {
+    createdIds: [],
+    updatedIds: [],
+    skippedIds: [],
+    errors: {},
+    dryRun: request.dryRun,
+  };
+  const seenIds = new Set<string>();
+  request.instances.forEach((item, index) => {
+    const id = item.id?.trim() || `mock-import-${Date.now()}-${index}`;
+    if (seenIds.has(id)) {
+      result.errors[id] = 'Duplicate instance id in import file';
+      return;
+    }
+    seenIds.add(id);
+    const existingIndex = mockInstances.findIndex((instance) => instance.id === id);
+    if (existingIndex >= 0 && !request.overwrite) {
+      result.skippedIds.push(id);
+      return;
+    }
+    if (!item.name?.trim() || !item.type || !item.endpoint?.trim()) {
+      result.errors[id] = 'name, type and endpoint are required';
+      return;
+    }
+    const now = new Date().toISOString().replace('T', ' ').slice(0, 19);
+    const imported: Instance = {
+      ...item,
+      id,
+      name: item.name.trim(),
+      endpoint: item.endpoint.trim(),
+      remark: item.remark || '',
+      vendor: item.vendor || 'APACHE',
+      topicCount: 0,
+      consumerGroupCount: 0,
+      createdAt: existingIndex >= 0 ? mockInstances[existingIndex].createdAt : now,
+      updatedAt: now,
+    };
+    if (existingIndex >= 0) {
+      result.updatedIds.push(id);
+      if (!request.dryRun) mockInstances.splice(existingIndex, 1, imported);
+    } else {
+      result.createdIds.push(id);
+      if (!request.dryRun) mockInstances.push(imported);
+    }
+  });
+  return result;
 }


### PR DESCRIPTION
## Summary
- add schema-versioned JSON export for RocketMQ instance connection metadata
- add bounded import with validation, generated IDs, overwrite policy, dry-run previews, and per-record results
- preserve creation metadata, invalidate changed Apache clients, validate cloud credential ownership, and audit applied imports
- add a full import dialog, JSON download, mock-mode parity, and backend/frontend tests

## Validation
- `mvn -q -Dtest=InstanceServiceTest,InstanceControllerTest test`
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/api/instance.test.ts src/services/instanceService.test.ts src/pages/instance/__tests__/InstanceImportDialog.test.tsx src/pages/instance/__tests__/InstancePage.test.tsx`
- `npm run build`
- frontend ESLint and Prettier hooks