### PR TITLE
feat(k8s): add certificate lifecycle management UI

### DIFF
--- a/web/src/pages/cluster/K8sCertEditor.tsx
+++ b/web/src/pages/cluster/K8sCertEditor.tsx
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Form, Input, Modal, Select } from 'antd';
+import { useEffect } from 'react';
+import type { K8sCertInfo } from '../../api/cluster';
+
+export interface K8sCertFormValue {
+  name: string;
+  namespace: string;
+  cluster: string;
+  type: string;
+  issuer: string;
+  sanText?: string;
+}
+
+interface Props {
+  open: boolean;
+  certificate: K8sCertInfo | null;
+  loading: boolean;
+  onCancel: () => void;
+  onSubmit: (value: Partial<K8sCertInfo>) => Promise<void> | void;
+}
+
+const parseSubjectAlternativeNames = (value?: string): string[] =>
+  Array.from(
+    new Set(
+      (value || '')
+        .split(/[\n,]/)
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  );
+
+const K8sCertEditor = ({ open, certificate, loading, onCancel, onSubmit }: Props) => {
+  const [form] = Form.useForm<K8sCertFormValue>();
+
+  useEffect(() => {
+    if (!open) return;
+    form.setFieldsValue(
+      certificate
+        ? {
+            name: certificate.name,
+            namespace: certificate.namespace,
+            cluster: certificate.cluster,
+            type: certificate.type,
+            issuer: certificate.issuer,
+            sanText: certificate.san?.join('\n'),
+          }
+        : {
+            namespace: 'rocketmq',
+            type: 'TLS',
+            issuer: 'kubernetes-ca',
+          },
+    );
+  }, [certificate, form, open]);
+
+  const submit = async () => {
+    const values = await form.validateFields();
+    await onSubmit({
+      ...(certificate ? { id: certificate.id } : {}),
+      name: values.name.trim(),
+      namespace: values.namespace.trim(),
+      cluster: values.cluster.trim(),
+      type: values.type,
+      issuer: values.issuer.trim(),
+      san: parseSubjectAlternativeNames(values.sanText),
+    });
+  };
+
+  return (
+    <Modal
+      title={certificate ? `编辑证书 — ${certificate.name}` : '添加证书'}
+      open={open}
+      onCancel={() => {
+        form.resetFields();
+        onCancel();
+      }}
+      onOk={() => void submit()}
+      confirmLoading={loading}
+      okText={certificate ? '保存' : '创建'}
+      destroyOnClose
+      width={560}
+    >
+      <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
+        <Form.Item
+          name="name"
+          label="证书名称"
+          rules={[
+            { required: true, whitespace: true, message: '请输入证书名称' },
+            { max: 128, message: '证书名称不能超过 128 个字符' },
+          ]}
+        >
+          <Input placeholder="rocketmq-prod-tls" />
+        </Form.Item>
+        <Form.Item
+          name="cluster"
+          label="K8s 集群名称"
+          rules={[{ required: true, whitespace: true, message: '请输入集群名称' }]}
+        >
+          <Input placeholder="production-cluster" />
+        </Form.Item>
+        <Form.Item
+          name="namespace"
+          label="命名空间"
+          rules={[{ required: true, whitespace: true, message: '请输入命名空间' }]}
+        >
+          <Input placeholder="rocketmq" />
+        </Form.Item>
+        <Form.Item name="type" label="证书类型" rules={[{ required: true }]}>
+          <Select
+            options={[
+              { value: 'TLS', label: 'TLS' },
+              { value: 'mTLS', label: 'mTLS' },
+              { value: 'ServiceAccount', label: 'ServiceAccount' },
+            ]}
+          />
+        </Form.Item>
+        <Form.Item
+          name="issuer"
+          label="签发者"
+          rules={[{ required: true, whitespace: true, message: '请输入签发者' }]}
+        >
+          <Input placeholder="kubernetes-ca" />
+        </Form.Item>
+        <Form.Item
+          name="sanText"
+          label="Subject Alternative Names"
+          extra="每行一个或使用逗号分隔；重复项会自动去除"
+        >
+          <Input.TextArea rows={4} placeholder={'broker.example.com\nproxy.example.com'} />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default K8sCertEditor;

--- a/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
@@ -16,15 +16,25 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import type { K8sCertInfo } from '../../../api/cluster';
-import { listK8sCerts } from '../../../services/clusterService';
+import {
+  createK8sCert,
+  deleteK8sCert,
+  listK8sCerts,
+  renewK8sCert,
+  updateK8sCert,
+} from '../../../services/clusterService';
 import K8sCertsPage from '../certs';
 
 vi.mock('../../../services/clusterService', () => ({
+  createK8sCert: vi.fn(),
+  deleteK8sCert: vi.fn(),
   listK8sCerts: vi.fn(),
+  renewK8sCert: vi.fn(),
+  updateK8sCert: vi.fn(),
 }));
 
 const certs: K8sCertInfo[] = [
@@ -77,6 +87,10 @@ describe('K8sCertsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(listK8sCerts).mockResolvedValue(certs);
+    vi.mocked(createK8sCert).mockResolvedValue(certs[0]);
+    vi.mocked(updateK8sCert).mockResolvedValue(certs[0]);
+    vi.mocked(renewK8sCert).mockResolvedValue(certs[0]);
+    vi.mocked(deleteK8sCert).mockResolvedValue();
   });
 
   const renderPage = () =>
@@ -101,7 +115,7 @@ describe('K8sCertsPage', () => {
     renderPage();
 
     expect(await screen.findByTestId('k8s-cert-local-metadata-notice')).toHaveTextContent(
-      '当前证书记录仅保存为 Studio 本地元数据',
+      '证书记录保存为 Studio 本地元数据',
     );
   });
 
@@ -142,15 +156,20 @@ describe('K8sCertsPage', () => {
     expect(screen.queryByText('rocketmq-prod-tls')).not.toBeInTheDocument();
   });
 
-  it('does not expose local metadata mutations as Kubernetes certificate operations', async () => {
+  it('exposes local metadata create, edit, renew and delete operations', async () => {
+    const user = userEvent.setup();
     renderPage();
 
     await screen.findByText('rocketmq-prod-tls');
 
-    expect(screen.queryByRole('button', { name: '添加证书' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: '编辑' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: '续期' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: '删除' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /添加证书/ })).toBeInTheDocument();
+    const renewButtons = screen.getAllByRole('button', { name: /续期/ });
+    await user.click(renewButtons[0]);
+    await waitFor(() => expect(renewK8sCert).toHaveBeenCalledWith('cert-prod'));
+
+    await user.click(screen.getAllByRole('button', { name: /编辑/ })[0]);
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByLabelText('证书名称')).toHaveValue('rocketmq-prod-tls');
   });
 
   it('trims certificate search text before filtering', async () => {

--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
+  Button,
   Table,
   Tag,
   Input,
+  Modal,
   Select,
   Flex,
   Space,
@@ -28,10 +30,18 @@ import {
   Alert,
   message,
 } from 'antd';
+import { DeleteOutlined, EditOutlined, PlusOutlined, ReloadOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import PageHeader from '../../components/PageHeader';
 import type { K8sCertInfo } from '../../api/cluster';
-import { listK8sCerts } from '../../services/clusterService';
+import {
+  createK8sCert,
+  deleteK8sCert,
+  listK8sCerts,
+  renewK8sCert,
+  updateK8sCert,
+} from '../../services/clusterService';
+import K8sCertEditor from './K8sCertEditor';
 
 const { Text } = Typography;
 
@@ -50,23 +60,84 @@ const K8sCertsPage = () => {
   const [certSearch, setCertSearch] = useState('');
   const [certTypeFilter, setCertTypeFilter] = useState<string>('');
   const [certNamespaceFilter, setCertNamespaceFilter] = useState<string>('');
+  const [selectedIds, setSelectedIds] = useState<React.Key[]>([]);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editingCert, setEditingCert] = useState<K8sCertInfo | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [bulkLoading, setBulkLoading] = useState(false);
+
+  const loadCerts = useCallback(async () => {
+    setLoading(true);
+    try {
+      setCerts(await listK8sCerts());
+    } catch (error) {
+      message.error(getErrorMessage(error));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    let active = true;
-    listK8sCerts()
-      .then((data) => {
-        if (active) setCerts(data);
-      })
-      .catch((error: unknown) => {
-        if (active) message.error(getErrorMessage(error));
-      })
-      .finally(() => {
-        if (active) setLoading(false);
-      });
-    return () => {
-      active = false;
-    };
-  }, []);
+    const timer = window.setTimeout(() => void loadCerts(), 0);
+    return () => window.clearTimeout(timer);
+  }, [loadCerts]);
+
+  const saveCert = async (data: Partial<K8sCertInfo>) => {
+    setSubmitting(true);
+    try {
+      if (data.id) {
+        await updateK8sCert(data);
+        message.success('证书信息已更新');
+      } else {
+        await createK8sCert(data);
+        message.success('证书已创建');
+      }
+      setEditorOpen(false);
+      setEditingCert(null);
+      await loadCerts();
+    } catch (error) {
+      message.error(getErrorMessage(error));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const renewOne = async (cert: K8sCertInfo) => {
+    try {
+      await renewK8sCert(cert.id);
+      message.success(`证书「${cert.name}」已续期一年`);
+      await loadCerts();
+    } catch (error) {
+      message.error(getErrorMessage(error));
+    }
+  };
+
+  const deleteOne = async (cert: K8sCertInfo) => {
+    try {
+      await deleteK8sCert(cert.id);
+      setSelectedIds((ids) => ids.filter((id) => id !== cert.id));
+      message.success(`证书「${cert.name}」已删除`);
+      await loadCerts();
+    } catch (error) {
+      message.error(getErrorMessage(error));
+    }
+  };
+
+  const runBulkAction = async (action: 'renew' | 'delete') => {
+    setBulkLoading(true);
+    try {
+      const operation = action === 'renew' ? renewK8sCert : deleteK8sCert;
+      const results = await Promise.allSettled(selectedIds.map((id) => operation(String(id))));
+      const succeeded = results.filter((result) => result.status === 'fulfilled').length;
+      const failed = results.length - succeeded;
+      if (failed) message.warning(`已完成 ${succeeded} 个，失败 ${failed} 个`);
+      else message.success(`已${action === 'renew' ? '续期' : '删除'} ${succeeded} 个证书`);
+      setSelectedIds([]);
+      await loadCerts();
+    } finally {
+      setBulkLoading(false);
+    }
+  };
 
   const normalizedCertSearch = certSearch.trim().toLowerCase();
   const namespaceOptions = Array.from(new Set(certs.map((cert) => cert.namespace)))
@@ -193,23 +264,59 @@ const K8sCertsPage = () => {
         return <Tag color={cfg.color}>{cfg.label}</Tag>;
       },
     },
+    {
+      title: '操作',
+      key: 'actions',
+      fixed: 'right',
+      width: 210,
+      render: (_, cert) => (
+        <Space size={4}>
+          <Button
+            size="small"
+            icon={<EditOutlined />}
+            onClick={() => {
+              setEditingCert(cert);
+              setEditorOpen(true);
+            }}
+          >
+            编辑
+          </Button>
+          <Button size="small" icon={<ReloadOutlined />} onClick={() => void renewOne(cert)}>
+            续期
+          </Button>
+          <Button
+            size="small"
+            danger
+            icon={<DeleteOutlined />}
+            onClick={() =>
+              Modal.confirm({
+                title: `删除证书「${cert.name}」？`,
+                content: '此操作仅删除 Studio 中保存的证书元数据，且不可恢复。',
+                okText: '删除',
+                okButtonProps: { danger: true },
+                onOk: () => deleteOne(cert),
+              })
+            }
+          >
+            删除
+          </Button>
+        </Space>
+      ),
+    },
   ];
 
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader
-        title="K8s 证书管理"
-        subtitle={`共 ${filteredCerts.length} 个证书`}
-      />
+      <PageHeader title="K8s 证书管理" subtitle={`共 ${filteredCerts.length} 个证书`} />
       <Alert
         data-testid="k8s-cert-local-metadata-notice"
         type="warning"
         showIcon
-        message="当前证书记录仅保存为 Studio 本地元数据"
-        description="创建、续期和删除操作尚不会应用到 Kubernetes 集群或 cert-manager。请在集群侧管理实际证书，直到 Kubernetes Provider 接入完成。"
+        message="证书记录保存为 Studio 本地元数据"
+        description="本页的创建、编辑、续期和删除不会直接修改 Kubernetes Secret 或 cert-manager 资源；实际证书仍需在集群侧同步管理。"
         style={{ marginBottom: 16 }}
       />
-      <Flex justify="space-between" style={{ marginBottom: 16 }}>
+      <Flex justify="space-between" gap={12} wrap="wrap" style={{ marginBottom: 16 }}>
         <Space>
           <Input.Search
             placeholder="搜索证书名称、集群、命名空间或 SAN"
@@ -237,6 +344,45 @@ const K8sCertsPage = () => {
             ]}
           />
         </Space>
+        <Space>
+          {selectedIds.length > 0 && (
+            <>
+              <Button
+                icon={<ReloadOutlined />}
+                loading={bulkLoading}
+                onClick={() => void runBulkAction('renew')}
+              >
+                批量续期 ({selectedIds.length})
+              </Button>
+              <Button
+                danger
+                icon={<DeleteOutlined />}
+                loading={bulkLoading}
+                onClick={() =>
+                  Modal.confirm({
+                    title: `删除选中的 ${selectedIds.length} 个证书？`,
+                    content: '删除后无法恢复。',
+                    okText: '批量删除',
+                    okButtonProps: { danger: true },
+                    onOk: () => runBulkAction('delete'),
+                  })
+                }
+              >
+                批量删除
+              </Button>
+            </>
+          )}
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => {
+              setEditingCert(null);
+              setEditorOpen(true);
+            }}
+          >
+            添加证书
+          </Button>
+        </Space>
       </Flex>
       <Card bodyStyle={{ padding: 0 }}>
         <Table
@@ -247,9 +393,19 @@ const K8sCertsPage = () => {
           pagination={{ pageSize: 20 }}
           size="small"
           scroll={{ x: 1750 }}
+          rowSelection={{ selectedRowKeys: selectedIds, onChange: setSelectedIds }}
         />
       </Card>
-
+      <K8sCertEditor
+        open={editorOpen}
+        certificate={editingCert}
+        loading={submitting}
+        onCancel={() => {
+          setEditorOpen(false);
+          setEditingCert(null);
+        }}
+        onSubmit={saveCert}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- expose the existing certificate create, update, renew, and delete APIs from the K8s certificate page
- add a reusable validated certificate editor with SAN normalization
- support row selection plus partial-success bulk renew and delete workflows
- keep the local-metadata boundary explicit so operators do not confuse these actions with direct cert-manager changes

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/pages/cluster/__tests__/K8sCertsPage.test.tsx`
- `npm run build`
- frontend ESLint and Prettier hooks