### PR TITLE
[studio][ISSUE #1917] Reject missing mock alert asset exports

### DIFF
--- a/web/src/services/alertRuleAssetService.test.ts
+++ b/web/src/services/alertRuleAssetService.test.ts
@@ -65,6 +65,14 @@ describe('alertRuleAssetService (mock mode)', () => {
     expect(blob).toBeInstanceOf(Blob);
     expect(blob.type).toBe('text/yaml');
   });
+
+  it('rejects an export for an unknown asset', async () => {
+    mode.mock = true;
+
+    await expect(exportAlertRuleAsset('does-not-exist')).rejects.toThrow(
+      'Alert rule asset not found: does-not-exist',
+    );
+  });
 });
 
 describe('alertRuleAssetService (real mode)', () => {

--- a/web/src/services/alertRuleAssetService.ts
+++ b/web/src/services/alertRuleAssetService.ts
@@ -6,6 +6,14 @@ import * as alertRuleAssetsApi from '../api/alertRuleAssets';
 import type { AlertRuleAssetInfo } from '../api/alertRuleAssets';
 import { mockAlertRuleAssets } from '../mock/alertRuleAssets';
 
+function getMockAlertRuleAsset(name: string) {
+  const found = mockAlertRuleAssets.find((asset) => asset.name === name);
+  if (!found) {
+    throw new Error(`Alert rule asset not found: ${name}`);
+  }
+  return found;
+}
+
 export async function listAlertRuleAssets(): Promise<AlertRuleAssetInfo[]> {
   if (isMockMode()) {
     return mockAlertRuleAssets.map(({ name, group, ruleCount, severities }) => ({
@@ -20,20 +28,14 @@ export async function listAlertRuleAssets(): Promise<AlertRuleAssetInfo[]> {
 
 export async function getAlertRuleAsset(name: string): Promise<string> {
   if (isMockMode()) {
-    const found = mockAlertRuleAssets.find((asset) => asset.name === name);
-    if (!found) {
-      throw new Error(`Alert rule asset not found: ${name}`);
-    }
-    return found.yaml;
+    return getMockAlertRuleAsset(name).yaml;
   }
   return alertRuleAssetsApi.getAlertRuleAsset(name);
 }
 
 export async function exportAlertRuleAsset(name: string): Promise<Blob> {
   if (isMockMode()) {
-    const found = mockAlertRuleAssets.find((asset) => asset.name === name);
-    const yaml = found ? found.yaml : '';
-    return new Blob([yaml], { type: 'text/yaml' });
+    return new Blob([getMockAlertRuleAsset(name).yaml], { type: 'text/yaml' });
   }
   return alertRuleAssetsApi.exportAlertRuleAsset(name);
 }


### PR DESCRIPTION
## Summary
- use one fail-fast lookup for mock alert-rule assets
- reject missing assets consistently for preview and export operations
- cover unknown export names with a regression test

## Root cause
The mock export path converted a failed lookup into an empty YAML Blob, while preview and real-mode requests surfaced a not-found error. This made stale exports look successful.

Closes #1917

## Validation
- `npm run test -- --run src/services/alertRuleAssetService.test.ts` (8 passed)
- focused ESLint on both changed files
- `npm run build`
- `git diff --check`