### PR TITLE
[studio][ISSUE #1925] Generate unique mock instance IDs

### DIFF
--- a/web/src/services/instanceService.test.ts
+++ b/web/src/services/instanceService.test.ts
@@ -92,4 +92,32 @@ describe('instanceService mock instances', () => {
 
     await expect(listInstances()).resolves.toEqual(before);
   });
+
+  it('assigns unique IDs when multiple instances are created in the same millisecond', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
+    const created = [];
+
+    try {
+      created.push(
+        await createInstance({
+          name: 'same-timestamp-a',
+          type: 'PROXY',
+          endpoint: 'proxy-a:8080',
+        }),
+        await createInstance({
+          name: 'same-timestamp-b',
+          type: 'PROXY',
+          endpoint: 'proxy-b:8080',
+        }),
+      );
+
+      expect(created[0].id).not.toBe(created[1].id);
+      expect(new Set((await listInstances()).map((instance) => instance.id)).size).toBe(
+        (await listInstances()).length,
+      );
+    } finally {
+      now.mockRestore();
+      await Promise.all(created.map((instance) => deleteInstance(instance.id)));
+    }
+  });
 });

--- a/web/src/services/instanceService.ts
+++ b/web/src/services/instanceService.ts
@@ -10,6 +10,13 @@ import { mockInstances } from '../mock/instances';
 
 // Compile-time switch: mock or real API
 
+let mockInstanceIdSequence = 0;
+
+function createMockInstanceId(): string {
+  mockInstanceIdSequence += 1;
+  return `mock-instance-${Date.now()}-${mockInstanceIdSequence}`;
+}
+
 function copyInstance(instance: Instance): Instance {
   return { ...instance };
 }
@@ -34,7 +41,7 @@ export async function listInstances(query: InstanceQuery = {}): Promise<Instance
 export async function createInstance(data: CreateInstanceRequest): Promise<Instance> {
   if (isMockMode()) {
     const instance: Instance = {
-      id: String(Date.now()),
+      id: createMockInstanceId(),
       ...data,
       name: data.name || '',
       type: data.type || 'PROXY',


### PR DESCRIPTION
## Summary
- add a monotonic suffix to mock instance IDs
- preserve timestamp context while guaranteeing uniqueness within the module lifetime
- cover two creations performed at the same clock value

## Root cause
Mock instances used `String(Date.now())` as their entire ID. Multiple creations within one millisecond produced duplicate row keys and made ID-based update/delete operations ambiguous.

Closes #1925

## Validation
- `npm run test -- --run src/services/instanceService.test.ts` (5 passed)
- focused ESLint on both changed files
- `npm run build`
- `git diff --check`