### PR TITLE
[studio][ISSUE #1927] Reject missing mock ACL deletions

### DIFF
--- a/web/src/services/aclService.test.ts
+++ b/web/src/services/aclService.test.ts
@@ -20,6 +20,8 @@ import {
   createAclRule,
   createAclUser,
   createAndUpdatePlainAccessConfig,
+  deleteAclRule,
+  deleteAclUser,
   examineBrokerClusterAclConfig,
   listAclRules,
   listAclUsers,
@@ -144,5 +146,16 @@ describe('ACL service mock data', () => {
     await expect(createAndUpdatePlainAccessConfig({ accessKey: 'svc-no-secret' })).rejects.toThrow(
       'secretKey is required',
     );
+  });
+
+  it('rejects deletion of missing ACL records', async () => {
+    const rulesBefore = await listAclRules();
+    const usersBefore = await listAclUsers();
+
+    await expect(deleteAclRule('missing-rule')).rejects.toThrow('ACL rule not found: missing-rule');
+    await expect(deleteAclUser('missing-user')).rejects.toThrow('ACL user not found: missing-user');
+
+    await expect(listAclRules()).resolves.toEqual(rulesBefore);
+    await expect(listAclUsers()).resolves.toEqual(usersBefore);
   });
 });

--- a/web/src/services/aclService.ts
+++ b/web/src/services/aclService.ts
@@ -108,7 +108,8 @@ export async function updateAclRule(data: Partial<AclRule>): Promise<AclRule> {
 export async function deleteAclRule(id: string): Promise<void> {
   if (isMockMode()) {
     const idx = aclRulesState.findIndex((rule) => rule.id === id);
-    if (idx >= 0) aclRulesState.splice(idx, 1);
+    if (idx < 0) throw new Error(`ACL rule not found: ${id}`);
+    aclRulesState.splice(idx, 1);
     return;
   }
   return aclApi.deleteAclRule(id);
@@ -149,7 +150,8 @@ export async function updateAclUser(data: Partial<AclUser>): Promise<AclUser> {
 export async function deleteAclUser(id: string): Promise<void> {
   if (isMockMode()) {
     const idx = aclUsersState.findIndex((user) => user.id === id);
-    if (idx >= 0) aclUsersState.splice(idx, 1);
+    if (idx < 0) throw new Error(`ACL user not found: ${id}`);
+    aclUsersState.splice(idx, 1);
     return;
   }
   return aclApi.deleteAclUser(id);


### PR DESCRIPTION
## Summary
- reject unknown ACL rule IDs in mock deletion
- reject unknown ACL user IDs in mock deletion
- verify failed deletes leave both mock collections unchanged

## Root cause
The mock delete paths treated a missing record as success, unlike get/update operations and real API deletion. Stale ACL rows could therefore produce false success feedback.

Closes #1927

## Validation
- `npm run test -- --run src/services/aclService.test.ts` (8 passed)
- focused ESLint on both changed files
- `npm run build`
- `git diff --check`