### PR TITLE
[Studio] feat(message): support recall events in message trace

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -397,6 +397,9 @@ public class RocketMQMessageProvider implements MessageProvider {
                     case "EndTransaction":
                         nodes.add(buildTransactionNode(fields));
                         break;
+                    case "Recall":
+                        nodes.add(buildRecallNode(fields));
+                        break;
                     default:
                         // SubBefore and unknown types are not surfaced as timeline nodes.
                         break;
@@ -454,6 +457,18 @@ public class RocketMQMessageProvider implements MessageProvider {
                 .status("finish")
                 .costTime(0L)
                 .description("group=" + field(f, 3) + ", transactionState=" + field(f, 11))
+                .build();
+    }
+
+    // Recall layout (RocketMQ 5.5.0 TraceDataEncoder):
+    //               type, time, region, group, topic, msgId, isSuccess
+    private TraceNodeVO buildRecallNode(String[] f) {
+        return TraceNodeVO.builder()
+                .title("recall")
+                .timestamp(parseLong(field(f, 1)))
+                .status(parseBoolean(field(f, 6)) ? "finish" : "failed")
+                .costTime(0L)
+                .description("group=" + field(f, 3) + ", topic=" + field(f, 4))
                 .build();
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -494,6 +494,28 @@ class RocketMQMessageProviderTest {
     }
 
     @Test
+    void getMessageTraceParsesRecallState() throws Exception {
+        String body = traceBody(traceContext("Recall", "2500", "cn", "producer-group", "TopicA",
+                "msg-recall", "false"));
+        MessageExt traceMessage = new MessageExt();
+        traceMessage.setBody(body.getBytes(StandardCharsets.UTF_8));
+        QueryResult queryResult = new QueryResult(0L, List.of(traceMessage));
+        when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
+                .thenReturn(queryResult);
+
+        TraceRecordVO record = provider.getMessageTrace("instance-a", "msg-recall", "TopicA");
+
+        assertThat(record.getNodes()).hasSize(1);
+        TraceNodeVO recall = record.getNodes().get(0);
+        assertThat(recall.getTitle()).isEqualTo("recall");
+        assertThat(recall.getTimestamp()).isEqualTo(2500L);
+        assertThat(recall.getStatus()).isEqualTo("failed");
+        assertThat(recall.getCostTime()).isZero();
+        assertThat(recall.getDescription()).contains("producer-group").contains("TopicA");
+        assertThat(record.getConsumerStatus()).isEmpty();
+    }
+
+    @Test
     void getMessageTraceSurfacesAdminFailure() throws Exception {
         when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
                 .thenThrow(new IllegalStateException("broker unavailable"));


### PR DESCRIPTION
## What is the purpose of the change

Support displaying RocketMQ Recall events in Apache message traces.

## Brief changelog

- Parse Recall trace records.
- Add Recall timeline nodes and regression tests.

## Verifying this change

```bash
cd server
mvn -Dtest=RocketMQMessageProviderTest test