### PR TITLE
fix(mock): generate collision-safe instance IDs

### DIFF
--- a/web/src/services/instanceService.test.ts
+++ b/web/src/services/instanceService.test.ts
@@ -83,6 +83,22 @@ describe('instanceService mock instances', () => {
     expect(storedUpdated?.remark).toBe('updated');
   });
 
+  it('assigns unique IDs to creations in the same millisecond', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
+    const first = await createInstance({ name: 'same-clock-a', endpoint: 'a:8080' });
+    const second = await createInstance({ name: 'same-clock-b', endpoint: 'b:8080' });
+
+    try {
+      expect(first.id).not.toBe(second.id);
+      expect(first.id).toContain('1800000000000');
+      expect(second.id).toContain('1800000000000');
+    } finally {
+      now.mockRestore();
+      await deleteInstance(first.id);
+      await deleteInstance(second.id);
+    }
+  });
+
   it('rejects deleting missing mock instances', async () => {
     const before = await listInstances();
 

--- a/web/src/services/instanceService.ts
+++ b/web/src/services/instanceService.ts
@@ -9,6 +9,12 @@ import type {
 import { mockInstances } from '../mock/instances';
 
 // Compile-time switch: mock or real API
+let mockInstanceIdSequence = 0;
+
+function nextMockInstanceId(): string {
+  mockInstanceIdSequence += 1;
+  return `mock-instance-${Date.now()}-${mockInstanceIdSequence}`;
+}
 
 function copyInstance(instance: Instance): Instance {
   return { ...instance };
@@ -34,7 +40,7 @@ export async function listInstances(query: InstanceQuery = {}): Promise<Instance
 export async function createInstance(data: CreateInstanceRequest): Promise<Instance> {
   if (isMockMode()) {
     const instance: Instance = {
-      id: String(Date.now()),
+      id: nextMockInstanceId(),
       ...data,
       name: data.name || '',
       type: data.type || 'PROXY',


### PR DESCRIPTION
## Summary
- replace millisecond-only mock instance IDs with a timestamp plus monotonic sequence
- preserve readable deterministic IDs while guaranteeing uniqueness for same-tick creates
- add a fixed-clock regression test and clean up created mock records

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/services/instanceService.test.ts`
- targeted ESLint and repository formatting hooks

Fixes #1925