### PR TITLE
fix(mock): generate collision-safe certificate IDs

### DIFF
--- a/web/src/services/clusterService.test.ts
+++ b/web/src/services/clusterService.test.ts
@@ -171,4 +171,20 @@ describe('clusterService mock clusters', () => {
       await deleteK8sCert(created.id);
     }
   });
+
+  it('assigns unique certificate IDs when the clock does not advance', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
+    const first = await createK8sCert({ name: 'same-clock-cert-a' });
+    const second = await createK8sCert({ name: 'same-clock-cert-b' });
+
+    try {
+      expect(first.id).not.toBe(second.id);
+      expect(first.id).toContain('1800000000000');
+      expect(second.id).toContain('1800000000000');
+    } finally {
+      now.mockRestore();
+      await deleteK8sCert(first.id);
+      await deleteK8sCert(second.id);
+    }
+  });
 });

--- a/web/src/services/clusterService.ts
+++ b/web/src/services/clusterService.ts
@@ -14,6 +14,12 @@ const mockCertStore: K8sCertInfo[] = mockK8sCerts.map((cert) => ({
   ...cert,
   san: [...cert.san],
 }));
+let mockCertificateIdSequence = 0;
+
+function nextMockCertificateId(): string {
+  mockCertificateIdSequence += 1;
+  return `cert-${Date.now()}-${mockCertificateIdSequence}`;
+}
 
 function copyCluster(cluster: ClusterInfo): ClusterInfo {
   return {
@@ -116,7 +122,7 @@ export async function createK8sCert(data: Partial<K8sCertInfo>): Promise<K8sCert
     const notAfter = new Date(now);
     notAfter.setFullYear(notAfter.getFullYear() + 1);
     const cert: K8sCertInfo = {
-      id: `cert-${Date.now()}`,
+      id: nextMockCertificateId(),
       name: data.name ?? '',
       namespace: data.namespace ?? '',
       cluster: data.cluster ?? '',


### PR DESCRIPTION
## Summary
- prevent mock K8s certificate creations from sharing IDs in the same millisecond
- retain the timestamp in generated IDs and add a monotonic suffix
- cover same-clock creation and cleanup in the cluster service test

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/services/clusterService.test.ts`
- targeted ESLint and repository formatting hooks