### PR TITLE
fix(mock): generate collision-safe ACL rule IDs

### DIFF
--- a/web/src/services/aclService.test.ts
+++ b/web/src/services/aclService.test.ts
@@ -20,6 +20,7 @@ import {
   createAclRule,
   createAclUser,
   createAndUpdatePlainAccessConfig,
+  deleteAclRule,
   examineBrokerClusterAclConfig,
   listAclRules,
   listAclUsers,
@@ -66,6 +67,22 @@ describe('ACL service mock data', () => {
 
     const afterUpdate = await listAclRules({ principal: 'user-created-copy-test' });
     expect(afterUpdate[0].actions).toEqual(['SUB']);
+  });
+
+  it('assigns unique ACL rule IDs within the same millisecond', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
+    const first = await createAclRule({ principal: 'same-clock-rule-a' });
+    const second = await createAclRule({ principal: 'same-clock-rule-b' });
+
+    try {
+      expect(first.id).not.toBe(second.id);
+      expect(first.id).toContain('1800000000000');
+      expect(second.id).toContain('1800000000000');
+    } finally {
+      now.mockRestore();
+      await deleteAclRule(first.id);
+      await deleteAclRule(second.id);
+    }
   });
 
   it('returns copied ACL user rows', async () => {

--- a/web/src/services/aclService.ts
+++ b/web/src/services/aclService.ts
@@ -11,6 +11,12 @@ import { aclRules as mockRules, aclUsers as mockUsers } from '../mock/acl';
 
 const aclRulesState = mockRules as unknown as AclRule[];
 const aclUsersState = mockUsers as unknown as AclUser[];
+let mockAclRuleIdSequence = 0;
+
+function nextMockAclRuleId(): string {
+  mockAclRuleIdSequence += 1;
+  return `acl-${Date.now()}-${mockAclRuleIdSequence}`;
+}
 const aclPlainAccessState = (mockUsers as unknown as AclUser[]).map((u): PlainAccessConfig => ({
   accessKey: u.username,
   secretKey: u.secretKey,
@@ -73,7 +79,7 @@ export async function getAclUserCredentials(id: string): Promise<AclUser> {
 export async function createAclRule(data: Partial<AclRule>): Promise<AclRule> {
   if (isMockMode()) {
     const rule: AclRule = {
-      id: `acl-${Date.now()}`,
+      id: nextMockAclRuleId(),
       principal: '',
       resource: '',
       resourceType: '',


### PR DESCRIPTION
## Summary
- prevent concurrent mock ACL rule creates from reusing a Date.now-based ID
- add a module-local monotonic suffix without changing real API behavior
- verify two fixed-clock rules remain independently addressable

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/services/aclService.test.ts`
- targeted ESLint and repository formatting hooks