### PR TITLE
fix(mock): generate collision-safe ACL user IDs

### DIFF
--- a/web/src/services/aclService.test.ts
+++ b/web/src/services/aclService.test.ts
@@ -20,6 +20,7 @@ import {
   createAclRule,
   createAclUser,
   createAndUpdatePlainAccessConfig,
+  deleteAclUser,
   examineBrokerClusterAclConfig,
   listAclRules,
   listAclUsers,
@@ -100,6 +101,22 @@ describe('ACL service mock data', () => {
 
     const afterUpdate = await listAclUsers({ keyword: 'user-created-copy-test' });
     expect(afterUpdate[0].clusters).toEqual(['rmq-updated']);
+  });
+
+  it('assigns unique ACL user IDs within the same millisecond', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
+    const first = await createAclUser({ username: 'same-clock-user-a' });
+    const second = await createAclUser({ username: 'same-clock-user-b' });
+
+    try {
+      expect(first.id).not.toBe(second.id);
+      expect(first.id).toContain('1800000000000');
+      expect(second.id).toContain('1800000000000');
+    } finally {
+      now.mockRestore();
+      await deleteAclUser(first.id);
+      await deleteAclUser(second.id);
+    }
   });
 
   it('builds cluster ACL config from mock accounts', async () => {

--- a/web/src/services/aclService.ts
+++ b/web/src/services/aclService.ts
@@ -11,6 +11,12 @@ import { aclRules as mockRules, aclUsers as mockUsers } from '../mock/acl';
 
 const aclRulesState = mockRules as unknown as AclRule[];
 const aclUsersState = mockUsers as unknown as AclUser[];
+let mockAclUserIdSequence = 0;
+
+function nextMockAclUserId(): string {
+  mockAclUserIdSequence += 1;
+  return `user-${Date.now()}-${mockAclUserIdSequence}`;
+}
 const aclPlainAccessState = (mockUsers as unknown as AclUser[]).map((u): PlainAccessConfig => ({
   accessKey: u.username,
   secretKey: u.secretKey,
@@ -117,7 +123,7 @@ export async function deleteAclRule(id: string): Promise<void> {
 export async function createAclUser(data: Partial<AclUser>): Promise<AclUser> {
   if (isMockMode()) {
     const user: AclUser = {
-      id: `user-${Date.now()}`,
+      id: nextMockAclUserId(),
       username: '',
       accessKey: '',
       secretKey: '',


### PR DESCRIPTION
## Summary
- generate unique mock ACL user IDs when multiple creates share a clock tick
- keep IDs readable by combining the timestamp and a monotonic sequence
- add regression coverage with deterministic cleanup

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/services/aclService.test.ts`
- targeted ESLint and repository formatting hooks