### PR TITLE
fix(mock): generate collision-safe alert rule IDs

### DIFF
--- a/web/src/services/opsService.test.ts
+++ b/web/src/services/opsService.test.ts
@@ -20,6 +20,7 @@ import type { AuditRecord } from '../api/ops';
 import { mockAuditRecords } from '../mock/audit';
 import {
   createAlertRule,
+  deleteAlertRule,
   exportAuditLogs,
   getAuditFilterOptions,
   listAlertRules,
@@ -81,6 +82,22 @@ describe('ops service mock data', () => {
     const afterUpdate = (await listAlertRules()).find((rule) => rule.id === created.id);
     expect(afterUpdate?.enabled).toBe(false);
     expect(afterUpdate?.channels).toEqual(['webhook']);
+  });
+
+  it('assigns unique alert rule IDs within the same millisecond', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
+    const first = await createAlertRule({ name: 'same-clock-alert-a' });
+    const second = await createAlertRule({ name: 'same-clock-alert-b' });
+
+    try {
+      expect(first.id).not.toBe(second.id);
+      expect(first.id).toContain('1800000000000');
+      expect(second.id).toContain('1800000000000');
+    } finally {
+      now.mockRestore();
+      await deleteAlertRule(first.id);
+      await deleteAlertRule(second.id);
+    }
   });
 
   it('rejects updates for unknown alert rule IDs', async () => {

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -9,6 +9,12 @@ import { systemAlerts as mockSystemAlerts } from '../mock/dashboard';
 
 let auditRecordsState = mockAuditRecords as unknown as AuditRecord[];
 const alertRulesState = mockAlertRules as unknown as AlertRule[];
+let mockAlertRuleIdSequence = 0;
+
+function nextMockAlertRuleId(): string {
+  mockAlertRuleIdSequence += 1;
+  return `alert-${Date.now()}-${mockAlertRuleIdSequence}`;
+}
 
 function copyAlertRule(rule: AlertRule): AlertRule {
   return {
@@ -97,7 +103,7 @@ export async function listAlertRules(): Promise<AlertRule[]> {
 export async function createAlertRule(data: Partial<AlertRule>): Promise<AlertRule> {
   if (isMockMode()) {
     const rule: AlertRule = {
-      id: `alert-${Date.now()}`,
+      id: nextMockAlertRuleId(),
       name: '',
       metric: '',
       operator: '>',


### PR DESCRIPTION
## Summary
- prevent same-millisecond mock alert-rule creation from producing duplicate React/store IDs
- use a monotonic suffix while preserving timestamp-based diagnostics
- add a fixed-clock regression test that deletes both independent records

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/services/opsService.test.ts`
- targeted ESLint and repository formatting hooks