### PR TITLE
fix(web): normalize navigation search locale-independently

### DIFF
--- a/web/src/layouts/navigationSearch.test.ts
+++ b/web/src/layouts/navigationSearch.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { filterNavigationEntries, isNavigationSearchShortcut } from './navigationSearch';
 
 describe('navigation search helpers', () => {
@@ -33,6 +33,22 @@ describe('navigation search helpers', () => {
   it('filters by route keys case-insensitively', () => {
     expect(filterNavigationEntries(entries, 'CLUSTER')).toEqual([entries[0]]);
     expect(filterNavigationEntries(entries, '/settings')).toEqual([entries[1]]);
+  });
+
+  it('does not depend on the browser locale for ASCII route matching', () => {
+    const localeLower = vi
+      .spyOn(String.prototype, 'toLocaleLowerCase')
+      .mockImplementation(function (this: string) {
+        return this.replace(/I/g, 'ı').toLowerCase();
+      });
+
+    try {
+      const instance = { key: '/INSTANCE', label: 'INSTANCE MANAGEMENT' };
+      expect(filterNavigationEntries([instance], 'instance')).toEqual([instance]);
+      expect(localeLower).not.toHaveBeenCalled();
+    } finally {
+      localeLower.mockRestore();
+    }
   });
 
   it('matches multiple terms across labels and normalized route segments', () => {

--- a/web/src/layouts/navigationSearch.ts
+++ b/web/src/layouts/navigationSearch.ts
@@ -26,7 +26,7 @@ export interface NavigationSearchEntry {
 function normalizeSearchText(value: string): string {
   return value
     .normalize('NFKC')
-    .toLocaleLowerCase()
+    .toLowerCase()
     .replace(/[^\p{L}\p{N}]+/gu, ' ')
     .trim();
 }
@@ -78,7 +78,7 @@ export function isNavigationSearchShortcut(event: {
     ) !== null;
 
   return (
-    event.key.toLocaleLowerCase() === 'k' &&
+    event.key.toLowerCase() === 'k' &&
     (event.metaKey || event.ctrlKey) &&
     !event.altKey &&
     !isEditableTarget


### PR DESCRIPTION
## Summary
- replace locale-sensitive lowercasing in navigation search and shortcut handling
- make ASCII route matching stable under locales such as Turkish
- add a regression that simulates locale-sensitive lowercasing and confirms it is not consulted

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/layouts/navigationSearch.test.ts`
- targeted ESLint and repository formatting hooks