### PR TITLE
fix(ai): normalize engine identifiers with Locale.ROOT

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistry.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistry.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.ops.ai;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -37,7 +38,8 @@ public class AgentProviderRegistry {
     }
 
     public AgentProvider forEngine(String engine) {
-        AgentProvider provider = providers.get(engine == null ? "" : engine.trim().toLowerCase());
+        AgentProvider provider = providers.get(
+                engine == null ? "" : engine.trim().toLowerCase(Locale.ROOT));
         if (provider == null) {
             throw new LlmGatewayException(400, "llm.config.unsupported_engine",
                     "Agent engine is not supported: " + engine,

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVO.java
@@ -25,6 +25,8 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.util.StringUtils;
 
+import java.util.Locale;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -67,6 +69,6 @@ public class LlmConfigVO {
     }
 
     public String normalizeEngine() {
-        return StringUtils.hasText(engine) ? engine.trim().toLowerCase() : ENGINE_HTTP;
+        return StringUtils.hasText(engine) ? engine.trim().toLowerCase(Locale.ROOT) : ENGINE_HTTP;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
@@ -29,6 +29,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -83,7 +84,8 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
 
     /** Request-level engine (per-user preference) overrides the global config. */
     private String resolveEngine(String requestEngine, LlmConfigVO config) {
-        String engine = StringUtils.hasText(requestEngine) ? requestEngine.trim().toLowerCase() : null;
+        String engine = StringUtils.hasText(requestEngine)
+                ? requestEngine.trim().toLowerCase(Locale.ROOT) : null;
         if (engine == null) {
             return config.normalizeEngine();
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiEngineLocaleTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiEngineLocaleTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AiEngineLocaleTest {
+
+    @Test
+    void engineIdentifiersShouldIgnoreTheJvmDefaultLocale() {
+        Locale previous = Locale.getDefault();
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+        try {
+            LlmConfigVO config = LlmConfigVO.builder().engine(" CUSTOM-CLI ").build();
+            AgentProvider provider = new StubProvider("custom-cli");
+            AgentProviderRegistry registry = new AgentProviderRegistry(List.of(provider));
+
+            assertThat(config.normalizeEngine()).isEqualTo("custom-cli");
+            assertThat(registry.forEngine(" CUSTOM-CLI ")).isSameAs(provider);
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+
+    private record StubProvider(String engine) implements AgentProvider {
+        @Override
+        public boolean available() {
+            return true;
+        }
+
+        @Override
+        public String complete(LlmConfigVO config, String prompt, String modelOverride) {
+            return "ok";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- normalize configured, requested, and registry AI engine identifiers with Locale.ROOT
- keep engine lookup deterministic when the JVM default locale changes
- add Turkish-locale regression coverage for config normalization and provider selection

## Validation
- `mvn -q -Dtest=AiEngineLocaleTest,OpenAiCompatibleLlmGatewayTest test`
- Java checkstyle executed by Maven