### PR TITLE
fix(mock): reject missing ACL rule deletions

### DIFF
--- a/web/src/services/aclService.test.ts
+++ b/web/src/services/aclService.test.ts
@@ -20,6 +20,7 @@ import {
   createAclRule,
   createAclUser,
   createAndUpdatePlainAccessConfig,
+  deleteAclRule,
   examineBrokerClusterAclConfig,
   listAclRules,
   listAclUsers,
@@ -144,5 +145,14 @@ describe('ACL service mock data', () => {
     await expect(createAndUpdatePlainAccessConfig({ accessKey: 'svc-no-secret' })).rejects.toThrow(
       'secretKey is required',
     );
+  });
+
+  it('rejects deletion of an unknown ACL rule without changing mock state', async () => {
+    const before = await listAclRules();
+
+    await expect(deleteAclRule('missing-acl-rule')).rejects.toThrow(
+      'ACL rule not found: missing-acl-rule',
+    );
+    await expect(listAclRules()).resolves.toEqual(before);
   });
 });

--- a/web/src/services/aclService.ts
+++ b/web/src/services/aclService.ts
@@ -108,7 +108,8 @@ export async function updateAclRule(data: Partial<AclRule>): Promise<AclRule> {
 export async function deleteAclRule(id: string): Promise<void> {
   if (isMockMode()) {
     const idx = aclRulesState.findIndex((rule) => rule.id === id);
-    if (idx >= 0) aclRulesState.splice(idx, 1);
+    if (idx < 0) throw new Error(`ACL rule not found: ${id}`);
+    aclRulesState.splice(idx, 1);
     return;
   }
   return aclApi.deleteAclRule(id);


### PR DESCRIPTION
## Summary
- make mock ACL rule deletion reject unknown IDs instead of silently succeeding
- align mock-mode failure behavior with persisted API semantics
- verify a failed deletion leaves the mock store unchanged

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/services/aclService.test.ts`
- targeted ESLint and repository formatting hooks