### PR TITLE
fix(mock): reject missing ACL user deletions

### DIFF
--- a/web/src/services/aclService.test.ts
+++ b/web/src/services/aclService.test.ts
@@ -20,6 +20,7 @@ import {
   createAclRule,
   createAclUser,
   createAndUpdatePlainAccessConfig,
+  deleteAclUser,
   examineBrokerClusterAclConfig,
   listAclRules,
   listAclUsers,
@@ -144,5 +145,14 @@ describe('ACL service mock data', () => {
     await expect(createAndUpdatePlainAccessConfig({ accessKey: 'svc-no-secret' })).rejects.toThrow(
       'secretKey is required',
     );
+  });
+
+  it('rejects deletion of an unknown ACL user without changing mock state', async () => {
+    const before = await listAclUsers();
+
+    await expect(deleteAclUser('missing-acl-user')).rejects.toThrow(
+      'ACL user not found: missing-acl-user',
+    );
+    await expect(listAclUsers()).resolves.toEqual(before);
   });
 });

--- a/web/src/services/aclService.ts
+++ b/web/src/services/aclService.ts
@@ -149,7 +149,8 @@ export async function updateAclUser(data: Partial<AclUser>): Promise<AclUser> {
 export async function deleteAclUser(id: string): Promise<void> {
   if (isMockMode()) {
     const idx = aclUsersState.findIndex((user) => user.id === id);
-    if (idx >= 0) aclUsersState.splice(idx, 1);
+    if (idx < 0) throw new Error(`ACL user not found: ${id}`);
+    aclUsersState.splice(idx, 1);
     return;
   }
   return aclApi.deleteAclUser(id);


### PR DESCRIPTION
## Summary
- reject unknown mock ACL user IDs during deletion
- avoid reporting successful UI mutations when no record was removed
- cover both the rejection and unchanged mock state

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/services/aclService.test.ts`
- targeted ESLint and repository formatting hooks