### PR TITLE
fix(mock): reject missing alert rule deletions

### DIFF
--- a/web/src/services/opsService.test.ts
+++ b/web/src/services/opsService.test.ts
@@ -20,6 +20,7 @@ import type { AuditRecord } from '../api/ops';
 import { mockAuditRecords } from '../mock/audit';
 import {
   createAlertRule,
+  deleteAlertRule,
   exportAuditLogs,
   getAuditFilterOptions,
   listAlertRules,
@@ -98,6 +99,15 @@ describe('ops service mock data', () => {
     const after = await listAlertRules();
     expect(after.map((rule) => rule.id)).toEqual(before.map((rule) => rule.id));
     expect(after.find((rule) => rule.id === 'missing-alert-rule')).toBeUndefined();
+  });
+
+  it('rejects deletion of an unknown alert rule without changing mock state', async () => {
+    const before = await listAlertRules();
+
+    await expect(deleteAlertRule('missing-alert-rule')).rejects.toThrow(
+      'Alert rule not found: missing-alert-rule',
+    );
+    await expect(listAlertRules()).resolves.toEqual(before);
   });
 
   it('returns copied system alert rows', async () => {

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -140,7 +140,8 @@ export async function toggleAlertRule(id: string, enabled: boolean): Promise<Ale
 export async function deleteAlertRule(id: string): Promise<void> {
   if (isMockMode()) {
     const idx = alertRulesState.findIndex((rule) => rule.id === id);
-    if (idx >= 0) alertRulesState.splice(idx, 1);
+    if (idx < 0) throw new Error(`Alert rule not found: ${id}`);
+    alertRulesState.splice(idx, 1);
     return;
   }
   return opsApi.deleteAlertRule(id);


### PR DESCRIPTION
## Summary
- make mock alert-rule deletion fail for unknown identifiers
- match real API and update behavior instead of silently masking stale IDs
- add regression coverage that verifies the rule store remains unchanged

## Validation
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run src/services/opsService.test.ts`
- targeted ESLint and repository formatting hooks