### PR TITLE
fix: preserve unavailable dashboard topology counts

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/ClusterOverviewVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/ClusterOverviewVO.java
@@ -36,7 +36,7 @@ public class ClusterOverviewVO {
     private ClusterType type;
     private ClusterStatus status;
     private int brokers;
-    private int proxies;
+    private Integer proxies;
     private int topics;
     private int groups;
     private long tpsIn;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardStatsVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardStatsVO.java
@@ -30,8 +30,8 @@ public class DashboardStatsVO {
     private int totalClusters;
     private int healthyClusters;
     private int totalBrokers;
-    private int totalProxies;
-    private int totalNameServers;
+    private Integer totalProxies;
+    private Integer totalNameServers;
     private int totalTopics;
     private int totalConsumerGroups;
     private long totalMessagesToday;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.KVTable;
@@ -73,17 +74,19 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             return emptyDashboard();
         }
         return adminFactory.execute(namesrvAddr, null,
-                admin -> collectDashboardData(admin, ClusterType.V5_PROXY_CLUSTER));
+                admin -> collectDashboardData(admin, ClusterType.V5_PROXY_CLUSTER,
+                        topologyCountsForNameServerAccess(namesrvAddr)));
     }
 
     @Override
     public DashboardDataVO getDashboardData(String instanceId) {
         InstanceVO instance = runtimeAdminClientResolver.resolveInstance(instanceId);
         return runtimeAdminClientResolver.execute(instance,
-                admin -> collectDashboardData(admin, clusterTypeFor(instance)));
+                admin -> collectDashboardData(admin, clusterTypeFor(instance), topologyCountsFor(instance)));
     }
 
-    private DashboardDataVO collectDashboardData(MQAdminExt admin, ClusterType clusterType) {
+    private DashboardDataVO collectDashboardData(
+            MQAdminExt admin, ClusterType clusterType, TopologyCounts topologyCounts) {
         int totalClusters = 0;
         int totalBrokers = 0;
         int totalTopics = 0;
@@ -262,7 +265,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                         .type(clusterType)
                         .status(runtimeMetricsUnavailable ? ClusterStatus.warning : ClusterStatus.healthy)
                         .brokers(clusterBrokers)
-                        .proxies(0)
+                        .proxies(topologyCounts.proxiesPerCluster())
                         .topics(topicsByCluster.getOrDefault(clusterName, Set.of()).size())
                         .groups(groupsByCluster.getOrDefault(clusterName, Set.of()).size())
                         .tpsIn(clusterTpsIn)
@@ -290,8 +293,8 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 .totalClusters(totalClusters)
                 .healthyClusters(healthyClusters)
                 .totalBrokers(totalBrokers)
-                .totalProxies(0)
-                .totalNameServers(0)
+                .totalProxies(topologyCounts.totalProxies())
+                .totalNameServers(topologyCounts.totalNameServers())
                 .totalTopics(totalTopics)
                 .totalConsumerGroups(totalGroups)
                 .totalMessagesToday(messagesToday)
@@ -311,13 +314,35 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 ? ClusterType.V4_DIRECT : ClusterType.V5_PROXY_CLUSTER;
     }
 
+    private TopologyCounts topologyCountsFor(InstanceVO instance) {
+        if (instance.getType() == InstanceType.DIRECT) {
+            return new TopologyCounts(0, countEndpoints(instance.getEndpoint()), 0);
+        }
+        return TopologyCounts.unavailable();
+    }
+
+    private TopologyCounts topologyCountsForNameServerAccess(String namesrvAddr) {
+        return new TopologyCounts(null, countEndpoints(namesrvAddr), null);
+    }
+
+    private int countEndpoints(String endpoints) {
+        if (!StringUtils.hasText(endpoints)) {
+            return 0;
+        }
+        return Math.toIntExact(Stream.of(endpoints.split("[;,]", -1))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .distinct()
+                .count());
+    }
+
     private DashboardDataVO emptyDashboard() {
         DashboardStatsVO stats = DashboardStatsVO.builder()
                 .totalClusters(0)
                 .healthyClusters(0)
                 .totalBrokers(0)
-                .totalProxies(0)
-                .totalNameServers(0)
+                .totalProxies(null)
+                .totalNameServers(null)
                 .totalTopics(0)
                 .totalConsumerGroups(0)
                 .totalMessagesToday(0)
@@ -363,6 +388,12 @@ public class RocketMQDashboardProvider implements DashboardProvider {
     private void markCountUnavailable(Set<String> unavailableClusters, String clusterName) {
         if (clusterName != null) {
             unavailableClusters.add(clusterName);
+        }
+    }
+
+    private record TopologyCounts(Integer totalProxies, Integer totalNameServers, Integer proxiesPerCluster) {
+        private static TopologyCounts unavailable() {
+            return new TopologyCounts(null, null, null);
         }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardControllerTest.java
@@ -118,6 +118,28 @@ class DashboardControllerTest {
     }
 
     @Test
+    void getDashboardShouldPreserveUnavailableTopologyCountsAsNull() throws Exception {
+        DashboardDataVO data = DashboardDataVO.builder()
+                .stats(DashboardStatsVO.builder()
+                        .totalClusters(1)
+                        .totalProxies(null)
+                        .totalNameServers(null)
+                        .build())
+                .clusters(List.of(ClusterOverviewVO.builder()
+                        .id("proxy-cluster")
+                        .proxies(null)
+                        .build()))
+                .build();
+        when(dashboardService.getDashboard(isNull())).thenReturn(data);
+
+        mockMvc.perform(get("/api/dashboard"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.stats.totalProxies").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.data.stats.totalNameServers").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.data.clusters[0].proxies").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    @Test
     void getDashboardShouldForwardSelectedInstance() throws Exception {
         DashboardDataVO data = DashboardDataVO.builder()
                 .stats(DashboardStatsVO.builder().totalClusters(1).build())

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -69,7 +69,10 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getClusters()).hasSize(1);
         assertThat(dashboard.getClusters().get(0).getVersion()).isEqualTo("V5_3_3");
         assertThat(dashboard.getClusters().get(0).getType()).isEqualTo(ClusterType.V5_PROXY_CLUSTER);
+        assertThat(dashboard.getClusters().get(0).getProxies()).isNull();
         assertThat(dashboard.getStats().getHealthyClusters()).isEqualTo(1);
+        assertThat(dashboard.getStats().getTotalProxies()).isNull();
+        assertThat(dashboard.getStats().getTotalNameServers()).isEqualTo(1);
         verify(adminExt, times(1)).fetchBrokerRuntimeStats("10.0.0.11:10911");
     }
 
@@ -259,7 +262,7 @@ class RocketMQDashboardProviderTest {
         RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
         InstanceVO instance = InstanceVO.builder()
                 .type(InstanceType.DIRECT)
-                .endpoint("namesrv-direct:9876")
+                .endpoint("namesrv-a:9876; namesrv-b:9876,namesrv-a:9876")
                 .build();
         instance.setId("instance-direct");
         when(resolver.resolveInstance("instance-direct")).thenReturn(instance);
@@ -273,7 +276,34 @@ class RocketMQDashboardProviderTest {
 
         assertThat(dashboard.getClusters()).hasSize(1);
         assertThat(dashboard.getClusters().get(0).getType()).isEqualTo(ClusterType.V4_DIRECT);
+        assertThat(dashboard.getClusters().get(0).getProxies()).isZero();
+        assertThat(dashboard.getStats().getTotalProxies()).isZero();
+        assertThat(dashboard.getStats().getTotalNameServers()).isEqualTo(2);
         verify(resolver).execute(eq(instance), any());
+    }
+
+    @Test
+    void dashboardShouldNotReportUnknownProxyTopologyAsZero() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        InstanceVO instance = InstanceVO.builder()
+                .type(InstanceType.PROXY)
+                .endpoint("proxy.example.com:8081")
+                .build();
+        instance.setId("instance-proxy");
+        when(resolver.resolveInstance("instance-proxy")).thenReturn(instance);
+        when(resolver.execute(eq(instance), any())).thenAnswer(invocation ->
+                invocation.<MqAdminExtFactory.AdminAction<DashboardDataVO>>getArgument(1).apply(adminExt));
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = newProvider(adminExt, resolver).getDashboardData("instance-proxy");
+
+        assertThat(dashboard.getStats().getTotalProxies()).isNull();
+        assertThat(dashboard.getStats().getTotalNameServers()).isNull();
+        assertThat(dashboard.getClusters()).singleElement()
+                .extracting(cluster -> cluster.getProxies())
+                .isNull();
     }
 
     @Test

--- a/web/src/api/metrics.ts
+++ b/web/src/api/metrics.ts
@@ -10,8 +10,8 @@ export interface DashboardStats {
   totalClusters: number;
   healthyClusters: number;
   totalBrokers: number;
-  totalProxies: number;
-  totalNameServers: number;
+  totalProxies: number | null;
+  totalNameServers: number | null;
   totalTopics: number;
   totalConsumerGroups: number;
   totalMessagesToday: number;
@@ -26,7 +26,7 @@ export interface ClusterOverview {
   type: string;
   status: string;
   brokers: number;
-  proxies: number;
+  proxies: number | null;
   topics: number;
   groups: number;
   tpsIn: number;

--- a/web/src/pages/home/__tests__/DashboardPage.test.tsx
+++ b/web/src/pages/home/__tests__/DashboardPage.test.tsx
@@ -189,4 +189,18 @@ describe('DashboardPage', () => {
 
     expect(screen.getByTestId('location')).toHaveTextContent('/cluster?instanceId=instance-b');
   });
+
+  it('renders unavailable topology counts as N/A instead of zero', async () => {
+    const unavailable = dashboard('proxy-cluster');
+    unavailable.stats.totalProxies = null;
+    unavailable.stats.totalNameServers = null;
+    unavailable.clusters[0].proxies = null;
+    vi.mocked(dashboardService.getDashboard).mockResolvedValue(unavailable);
+
+    renderWithProviders(<DashboardPage />);
+
+    await screen.findByText('proxy-cluster');
+    expect(screen.getByText('1 Brokers · N/A Proxy · N/A NameServer')).toBeInTheDocument();
+    expect(screen.getAllByText('N/A')).not.toHaveLength(0);
+  });
 });

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -137,6 +137,7 @@ const DashboardPage = () => {
   }
 
   const { stats, clusters } = visibleDashboard;
+  const topologyCount = (value: number | null) => value ?? t('common.na');
 
   const statCards = [
     {
@@ -145,7 +146,7 @@ const DashboardPage = () => {
       icon: <ClusterOutlined style={{ fontSize: 22, color: '#52c41a' }} />,
       color: '#52c41a',
       suffix: '',
-      detail: `${stats.totalBrokers} Brokers · ${stats.totalProxies} Proxy`,
+      detail: `${stats.totalBrokers} Brokers · ${topologyCount(stats.totalProxies)} Proxy · ${topologyCount(stats.totalNameServers)} NameServer`,
     },
     {
       title: t('dashboard.topics'),
@@ -218,7 +219,7 @@ const DashboardPage = () => {
       key: 'proxies',
       width: 80,
       align: 'center' as const,
-      render: (v: number) => Math.max(0, v),
+      render: (v: number | null) => (v === null ? t('common.na') : Math.max(0, v)),
     },
     {
       title: t('dashboard.topic'),


### PR DESCRIPTION
## Summary

- derive NameServer counts from normalized direct-access endpoints
- preserve undiscoverable Proxy and NameServer topology counts as `null` instead of reporting false zeroes
- render unavailable topology values as `N/A` in the home dashboard
- cover direct, Proxy, JSON contract, and UI behavior with regression tests

## Track

RocketMQ Studio Track 1: unified control plane.

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=RocketMQDashboardProviderTest,DashboardControllerTest test`
- `npm test -- --run src/pages/home/__tests__/DashboardPage.test.tsx`
- `npm run build`
- `npx eslint src/api/metrics.ts src/pages/home/dashboard.tsx src/pages/home/__tests__/DashboardPage.test.tsx`

Closes #1947