### PR TITLE
fix: scope topic/group deletes to the owning cluster and preserve queue counts on update

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -283,7 +283,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
         String namesrvAddr = namesrvAddr(instanceId);
         executeForInstance(instanceId, admin -> {
             try {
-                Set<String> brokerAddrs = getAllMasterBrokerAddrs(admin);
+                // Scope broker deletes to the current cluster; topic names may be shared by
+                // several clusters managed by this Studio instance (see the comment below).
+                Set<String> brokerAddrs = getMasterBrokerAddrsForCluster(admin, getClusterName(admin));
 
                 // Delete from brokers
                 if (!brokerAddrs.isEmpty()) {
@@ -467,7 +469,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
 
     private void doDeleteConsumerGroup(MQAdminExt admin, String name) {
         try {
-            Set<String> brokerAddrs = getAllMasterBrokerAddrs(admin);
+            // Scope broker deletes to the current cluster; consumer group names may be shared by
+            // several clusters managed by this Studio instance (see the comment below).
+            Set<String> brokerAddrs = getMasterBrokerAddrsForCluster(admin, getClusterName(admin));
 
             for (String addr : brokerAddrs) {
                 admin.deleteSubscriptionGroup(addr, name, true);

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -216,8 +216,6 @@ public class RocketMQAdminClientImpl implements AdminClient {
     @Override
     public TopicVO updateTopic(TopicVO topic) {
         String topicName = topic.getName();
-        int writeQueues = topic.getWriteQueues() > 0 ? topic.getWriteQueues() : 8;
-        int readQueues = topic.getReadQueues() > 0 ? topic.getReadQueues() : 8;
 
         return executeForInstance(topic.getInstanceId(), admin -> {
             try {
@@ -228,6 +226,17 @@ public class RocketMQAdminClientImpl implements AdminClient {
                         new LambdaQueryWrapper<RmqTopic>()
                                 .eq(RmqTopic::getClusterId, clusterName)
                                 .eq(RmqTopic::getName, topicName));
+                // Preserve the existing queue counts when the update request does not change them,
+                // matching the perm semantics below; defaulting to 8 would silently resize the
+                // topic on partial updates (e.g. perm or remark only).
+                int writeQueues = existing != null && existing.getWriteQueueNums() != null
+                                && existing.getWriteQueueNums() > 0
+                        ? existing.getWriteQueueNums()
+                        : topic.getWriteQueues() > 0 ? topic.getWriteQueues() : 8;
+                int readQueues = existing != null && existing.getReadQueueNums() != null
+                                && existing.getReadQueueNums() > 0
+                        ? existing.getReadQueueNums()
+                        : topic.getReadQueues() > 0 ? topic.getReadQueues() : 8;
                 TopicPerm effectivePerm = topic.getPerm() != null
                         ? topic.getPerm()
                         : existing == null ? TopicPerm.RW : fromRocketMQPerm(existing.getPerm());

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -49,6 +49,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -305,6 +306,72 @@ class RocketMQAdminClientImplTest {
         ArgumentCaptor<LambdaQueryWrapper<RmqGroup>> captor = ArgumentCaptor.forClass(LambdaQueryWrapper.class);
         verify(groupMapper).delete(captor.capture());
         assertThat(captor.getValue().getSqlSegment()).contains("cluster_id", "name");
+    }
+
+    @Test
+    void deleteTopicScopesBrokerDeleteToOwningCluster() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqTopic.class);
+        DefaultMQAdminExt selectedAdmin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        ClusterInfo clusterInfo = new ClusterInfo();
+        // LinkedHashMap keeps cluster-1 first so getClusterName() resolves to it.
+        Map<String, Set<String>> clusterAddrTable = new LinkedHashMap<>();
+        clusterAddrTable.put("cluster-1", new HashSet<>(List.of("broker-1")));
+        clusterAddrTable.put("cluster-2", new HashSet<>(List.of("broker-2")));
+        clusterInfo.setClusterAddrTable(clusterAddrTable);
+        Map<String, BrokerData> brokerAddrTable = new HashMap<>();
+        BrokerData broker1 = new BrokerData();
+        broker1.setBrokerName("broker-1");
+        broker1.setBrokerAddrs(new HashMap<>(Map.of(0L, "10.0.0.1:10911")));
+        BrokerData broker2 = new BrokerData();
+        broker2.setBrokerName("broker-2");
+        broker2.setBrokerAddrs(new HashMap<>(Map.of(0L, "10.0.0.2:10911")));
+        brokerAddrTable.put("broker-1", broker1);
+        brokerAddrTable.put("broker-2", broker2);
+        clusterInfo.setBrokerAddrTable(brokerAddrTable);
+        when(selectedAdmin.examineBrokerClusterInfo()).thenReturn(clusterInfo);
+        doNothing().when(selectedAdmin).deleteTopicInBroker(any(), anyString());
+        doNothing().when(selectedAdmin).deleteTopicInNameServer(any(), anyString(), anyString());
+        when(runtimeAdminClientResolver.resolveEndpoint("instance-a")).thenReturn("10.0.0.2:9876");
+        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("instance-a"), any()))
+                .thenAnswer(invocation -> invocation.<MqAdminExtFactory.AdminAction<Object>>getArgument(1)
+                        .apply(selectedAdmin));
+
+        adminClient.deleteTopic("instance-a", "orders");
+
+        // Only the owning cluster's broker is touched; the other cluster's broker is untouched.
+        verify(selectedAdmin).deleteTopicInBroker(Set.of("10.0.0.1:10911"), "orders");
+        verify(selectedAdmin, never()).deleteTopicInBroker(Set.of("10.0.0.2:10911"), "orders");
+    }
+
+    @Test
+    void deleteConsumerGroupScopesBrokerDeleteToOwningCluster() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqGroup.class);
+        DefaultMQAdminExt selectedAdmin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        ClusterInfo clusterInfo = new ClusterInfo();
+        Map<String, Set<String>> clusterAddrTable = new LinkedHashMap<>();
+        clusterAddrTable.put("cluster-1", new HashSet<>(List.of("broker-1")));
+        clusterAddrTable.put("cluster-2", new HashSet<>(List.of("broker-2")));
+        clusterInfo.setClusterAddrTable(clusterAddrTable);
+        Map<String, BrokerData> brokerAddrTable = new HashMap<>();
+        BrokerData broker1 = new BrokerData();
+        broker1.setBrokerName("broker-1");
+        broker1.setBrokerAddrs(new HashMap<>(Map.of(0L, "10.0.0.1:10911")));
+        BrokerData broker2 = new BrokerData();
+        broker2.setBrokerName("broker-2");
+        broker2.setBrokerAddrs(new HashMap<>(Map.of(0L, "10.0.0.2:10911")));
+        brokerAddrTable.put("broker-1", broker1);
+        brokerAddrTable.put("broker-2", broker2);
+        clusterInfo.setBrokerAddrTable(brokerAddrTable);
+        when(selectedAdmin.examineBrokerClusterInfo()).thenReturn(clusterInfo);
+        doNothing().when(selectedAdmin).deleteSubscriptionGroup(anyString(), anyString(), org.mockito.ArgumentMatchers.anyBoolean());
+        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("instance-a"), any()))
+                .thenAnswer(invocation -> invocation.<MqAdminExtFactory.AdminAction<Object>>getArgument(1)
+                        .apply(selectedAdmin));
+
+        adminClient.deleteConsumerGroup("instance-a", "cg-orders");
+
+        verify(selectedAdmin).deleteSubscriptionGroup("10.0.0.1:10911", "cg-orders", true);
+        verify(selectedAdmin, never()).deleteSubscriptionGroup("10.0.0.2:10911", "cg-orders", true);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -54,6 +54,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -227,6 +229,33 @@ class RocketMQAdminClientImplTest {
         assertThat(existing.getTopicType()).isEqualTo(TopicType.FIFO.name());
         assertThat(existing.getRemark()).isEqualTo("updated remark");
         verify(topicMapper).updateById(existing);
+    }
+
+    @Test
+    void updateTopicPreservesQueueCountsWhenNotSpecified() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqTopic.class);
+        RmqTopic existing = new RmqTopic();
+        existing.setWriteQueueNums(16);
+        existing.setReadQueueNums(16);
+        // RocketMQ perm int: 6 = RW, 4 = RO, 2 = WO.
+        existing.setPerm(6);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithMaster());
+        when(topicMapper.selectOne(any())).thenReturn(existing);
+        doNothing().when(adminExt).createAndUpdateTopicConfig(anyString(), any(TopicConfig.class));
+
+        TopicVO topic = new TopicVO();
+        topic.setName("orders");
+        topic.setPerm(TopicPerm.RO);
+
+        adminClient.updateTopic(topic);
+
+        // Partial update (perm only) must not reset queues to the default of 8.
+        ArgumentCaptor<TopicConfig> topicConfigCaptor = ArgumentCaptor.forClass(TopicConfig.class);
+        verify(adminExt).createAndUpdateTopicConfig(anyString(), topicConfigCaptor.capture());
+        assertThat(topicConfigCaptor.getValue().getWriteQueueNums()).isEqualTo(16);
+        assertThat(topicConfigCaptor.getValue().getReadQueueNums()).isEqualTo(16);
+        assertThat(existing.getWriteQueueNums()).isEqualTo(16);
+        assertThat(existing.getReadQueueNums()).isEqualTo(16);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Two correctness bugs in topic / consumer group management that can corrupt broker configuration or data:

- `deleteTopic` and `deleteConsumerGroup` removed the resource from the brokers of **every** cluster sharing the NameServer, while create/update only ever touch the owning cluster. With cluster-scoped resource names, deleting a topic or group in one cluster silently deleted the same-named resource on other clusters' brokers, and could also fail with `TOPIC_NOT_EXIST` when the neighbor cluster had no such resource.
- `updateTopic` reset `writeQueues`/`readQueues` to the default `8` whenever the request did not include queue counts (e.g. a perm or remark-only update), silently resizing the live topic and the stored record.

## Brief changelog

- Scope `deleteTopic` and `doDeleteConsumerGroup` broker deletes to the owning cluster via `getMasterBrokerAddrsForCluster`, matching create/update.
- Preserve the existing queue counts on `updateTopic` when the request omits them, matching the existing `perm` semantics.
- Cover both fixes with unit tests: a two-cluster topology asserting the foreign cluster's broker is untouched, and a partial-update asserting 16/16 queues survive a perm-only change.

## Verifying this change

- `mvn -q -Dtest=RocketMQAdminClientImplTest test`
- `mvn -q test` (1057/1057)
- `git diff --check`
