### PR TITLE
feat: drive selected-instance runtime dashboard behavior

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceCapabilitiesVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceCapabilitiesVO.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.provider.InstanceCapability;
+
+import java.util.List;
+
+public record InstanceCapabilitiesVO(
+        String instanceId,
+        InstanceVendor vendor,
+        InstanceType accessType,
+        List<InstanceCapability> capabilities) {
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceCapabilityService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceCapabilityService.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.provider.InstanceCapability;
+import org.apache.rocketmq.studio.provider.InstanceProvider;
+import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InstanceCapabilityService {
+
+    private final InstanceRepository instanceRepository;
+    private final InstanceProviderRegistry providerRegistry;
+
+    public InstanceCapabilitiesVO getCapabilities(String instanceId) {
+        InstanceVO instance = instanceRepository.findById(instanceId)
+                .orElseThrow(() -> new BusinessException(404, "Instance not found: " + instanceId));
+        InstanceVendor vendor = instance.getVendor() == null ? InstanceVendor.APACHE : instance.getVendor();
+        InstanceProvider provider = providerRegistry.forVendor(vendor);
+        List<InstanceCapability> capabilities = provider.capabilities().stream()
+                .sorted(Comparator.comparingInt(InstanceCapability::ordinal))
+                .toList();
+        return new InstanceCapabilitiesVO(instance.getId(), vendor, instance.getType(), capabilities);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,12 +38,18 @@ import java.util.List;
 public class InstanceController {
 
     private final InstanceService instanceService;
+    private final InstanceCapabilityService instanceCapabilityService;
 
     @GetMapping
     public Result<List<InstanceVO>> listInstances(
             @RequestParam(required = false) InstanceType type,
             @RequestParam(required = false) String search) {
         return Result.ok(instanceService.listInstances(type, search));
+    }
+
+    @GetMapping("/{instanceId}/capabilities")
+    public Result<InstanceCapabilitiesVO> getCapabilities(@PathVariable String instanceId) {
+        return Result.ok(instanceCapabilityService.getCapabilities(instanceId));
     }
 
     @PostMapping("/create")

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceCapability.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceCapability.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider;
+
+/**
+ * Stable, user-facing capabilities implemented by an instance provider.
+ */
+public enum InstanceCapability {
+    TOPIC_MANAGEMENT,
+    CONSUMER_GROUP_MANAGEMENT,
+    MESSAGE_QUERY,
+    MESSAGE_TRACE,
+    ACL_MANAGEMENT,
+    DLQ_MANAGEMENT
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.studio.instance.topic.TopicConsumerPageVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Unified instance-scoped operations SPI. Every method takes the Studio instance id as its
@@ -36,6 +37,10 @@ import java.util.List;
 public interface InstanceProvider {
 
     InstanceVendor vendor();
+
+    default Set<InstanceCapability> capabilities() {
+        return Set.of();
+    }
 
     int countTopics(String instanceId);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
@@ -57,12 +57,14 @@ import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.apache.rocketmq.studio.provider.InstanceProvider;
+import org.apache.rocketmq.studio.provider.InstanceCapability;
 import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Aliyun RocketMQ 5.x implementation of the instance-scoped operations SPI, backed by the
@@ -88,6 +90,16 @@ public class AliyunInstanceProvider implements InstanceProvider {
     @Override
     public InstanceVendor vendor() {
         return InstanceVendor.ALIYUN;
+    }
+
+    @Override
+    public Set<InstanceCapability> capabilities() {
+        return Set.of(
+                InstanceCapability.TOPIC_MANAGEMENT,
+                InstanceCapability.CONSUMER_GROUP_MANAGEMENT,
+                InstanceCapability.MESSAGE_QUERY,
+                InstanceCapability.MESSAGE_TRACE,
+                InstanceCapability.ACL_MANAGEMENT);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
@@ -28,11 +28,13 @@ import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerPageVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.apache.rocketmq.studio.provider.InstanceProvider;
+import org.apache.rocketmq.studio.provider.InstanceCapability;
 import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Open-source Apache RocketMQ implementation: pure delegation to the existing admin-client
@@ -50,6 +52,17 @@ public class ApacheInstanceProvider implements InstanceProvider {
     @Override
     public InstanceVendor vendor() {
         return InstanceVendor.APACHE;
+    }
+
+    @Override
+    public Set<InstanceCapability> capabilities() {
+        return Set.of(
+                InstanceCapability.TOPIC_MANAGEMENT,
+                InstanceCapability.CONSUMER_GROUP_MANAGEMENT,
+                InstanceCapability.MESSAGE_QUERY,
+                InstanceCapability.MESSAGE_TRACE,
+                InstanceCapability.ACL_MANAGEMENT,
+                InstanceCapability.DLQ_MANAGEMENT);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -61,6 +61,7 @@ import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.apache.rocketmq.studio.provider.InstanceProvider;
+import org.apache.rocketmq.studio.provider.InstanceCapability;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import lombok.RequiredArgsConstructor;
@@ -78,6 +79,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
@@ -121,6 +123,16 @@ public class TencentInstanceProvider implements InstanceProvider {
     @Override
     public InstanceVendor vendor() {
         return InstanceVendor.TENCENT;
+    }
+
+    @Override
+    public Set<InstanceCapability> capabilities() {
+        return Set.of(
+                InstanceCapability.TOPIC_MANAGEMENT,
+                InstanceCapability.CONSUMER_GROUP_MANAGEMENT,
+                InstanceCapability.MESSAGE_QUERY,
+                InstanceCapability.MESSAGE_TRACE,
+                InstanceCapability.ACL_MANAGEMENT);
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCorsIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCorsIntegrationTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.auth;
 
 import org.apache.rocketmq.studio.common.config.CorsConfig;
 import org.apache.rocketmq.studio.instance.InstanceController;
+import org.apache.rocketmq.studio.instance.InstanceCapabilityService;
 import org.apache.rocketmq.studio.instance.InstanceService;
 import org.apache.rocketmq.studio.settings.SettingsRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,6 +55,9 @@ class AuthCorsIntegrationTest {
 
     @MockBean
     private InstanceService instanceService;
+
+    @MockBean
+    private InstanceCapabilityService instanceCapabilityService;
 
     @MockBean
     private AuthProperties authProperties;

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceCapabilityServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceCapabilityServiceTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.provider.InstanceCapability;
+import org.apache.rocketmq.studio.provider.InstanceProvider;
+import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InstanceCapabilityServiceTest {
+
+    @Mock
+    private InstanceRepository instanceRepository;
+    @Mock
+    private InstanceProviderRegistry providerRegistry;
+    @Mock
+    private InstanceProvider instanceProvider;
+
+    private InstanceCapabilityService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new InstanceCapabilityService(instanceRepository, providerRegistry);
+    }
+
+    @Test
+    void shouldReturnProviderCapabilitiesInStableOrder() {
+        InstanceVO instance = InstanceVO.builder()
+                .vendor(InstanceVendor.ALIYUN)
+                .type(InstanceType.PROXY)
+                .build();
+        instance.setId("inst-1");
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(instanceProvider);
+        when(instanceProvider.capabilities()).thenReturn(Set.of(
+                InstanceCapability.MESSAGE_QUERY,
+                InstanceCapability.TOPIC_MANAGEMENT));
+
+        InstanceCapabilitiesVO result = service.getCapabilities("inst-1");
+
+        assertThat(result.instanceId()).isEqualTo("inst-1");
+        assertThat(result.vendor()).isEqualTo(InstanceVendor.ALIYUN);
+        assertThat(result.accessType()).isEqualTo(InstanceType.PROXY);
+        assertThat(result.capabilities()).containsExactly(
+                InstanceCapability.TOPIC_MANAGEMENT,
+                InstanceCapability.MESSAGE_QUERY);
+    }
+
+    @Test
+    void shouldDefaultLegacyNullVendorToApache() {
+        InstanceVO instance = InstanceVO.builder().type(InstanceType.DIRECT).build();
+        instance.setId("legacy");
+        when(instanceRepository.findById("legacy")).thenReturn(Optional.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.capabilities()).thenReturn(Set.of(InstanceCapability.DLQ_MANAGEMENT));
+
+        assertThat(service.getCapabilities("legacy").vendor()).isEqualTo(InstanceVendor.APACHE);
+    }
+
+    @Test
+    void shouldRejectUnknownInstance() {
+        when(instanceRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getCapabilities("missing"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
@@ -19,7 +19,9 @@ package org.apache.rocketmq.studio.instance;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.provider.InstanceCapability;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -54,6 +56,9 @@ class InstanceControllerTest {
 
     @MockBean
     private InstanceService instanceService;
+
+    @MockBean
+    private InstanceCapabilityService instanceCapabilityService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -101,6 +106,23 @@ class InstanceControllerTest {
                 .andExpect(jsonPath("$.data[0].name").value("production"));
 
         verify(instanceService).listInstances(isNull(), eq("prod"));
+    }
+
+    @Test
+    void getCapabilitiesShouldReturnSelectedInstanceContract() throws Exception {
+        when(instanceCapabilityService.getCapabilities("inst-1")).thenReturn(new InstanceCapabilitiesVO(
+                "inst-1",
+                InstanceVendor.APACHE,
+                InstanceType.DIRECT,
+                List.of(InstanceCapability.TOPIC_MANAGEMENT, InstanceCapability.DLQ_MANAGEMENT)));
+
+        mockMvc.perform(get("/api/instances/inst-1/capabilities"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.instanceId").value("inst-1"))
+                .andExpect(jsonPath("$.data.vendor").value("APACHE"))
+                .andExpect(jsonPath("$.data.accessType").value("DIRECT"))
+                .andExpect(jsonPath("$.data.capabilities[0]").value("TOPIC_MANAGEMENT"))
+                .andExpect(jsonPath("$.data.capabilities[1]").value("DLQ_MANAGEMENT"));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -48,6 +48,7 @@ import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
 import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
 import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
+import org.apache.rocketmq.studio.provider.InstanceCapability;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -93,6 +94,15 @@ class AliyunInstanceProviderTest {
     @BeforeEach
     void setUp() {
         provider = new AliyunInstanceProvider(clientFactory, instanceRepository);
+    }
+
+    @Test
+    void capabilitiesShouldExcludeUnsupportedDlqOperations() {
+        assertThat(provider.capabilities())
+                .contains(InstanceCapability.TOPIC_MANAGEMENT,
+                        InstanceCapability.MESSAGE_QUERY,
+                        InstanceCapability.ACL_MANAGEMENT)
+                .doesNotContain(InstanceCapability.DLQ_MANAGEMENT);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProviderTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.provider.apache;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.message.MessageProvider;
+import org.apache.rocketmq.studio.provider.InstanceCapability;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -50,6 +51,17 @@ class ApacheInstanceProviderTest {
     @Test
     void vendorShouldBeApacheTest() {
         assertThat(provider.vendor()).isEqualTo(InstanceVendor.APACHE);
+    }
+
+    @Test
+    void capabilitiesShouldIncludeApacheOnlyOperations() {
+        assertThat(provider.capabilities()).contains(
+                InstanceCapability.TOPIC_MANAGEMENT,
+                InstanceCapability.CONSUMER_GROUP_MANAGEMENT,
+                InstanceCapability.MESSAGE_QUERY,
+                InstanceCapability.MESSAGE_TRACE,
+                InstanceCapability.ACL_MANAGEMENT,
+                InstanceCapability.DLQ_MANAGEMENT);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -100,7 +100,7 @@ class TencentInstanceProviderTest {
     @BeforeEach
     void setUp() {
         provider = new TencentInstanceProvider(clientFactory, instanceRepository);
-        when(instanceRepository.findByIdentifier(STUDIO_INSTANCE_ID)).thenReturn(Optional.of(InstanceVO.builder()
+        lenient().when(instanceRepository.findByIdentifier(STUDIO_INSTANCE_ID)).thenReturn(Optional.of(InstanceVO.builder()
                 .name("tencent-prod")
                 .vendor(InstanceVendor.TENCENT)
                 .cloudInstanceId(CLOUD_INSTANCE_ID)

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -56,6 +56,7 @@ import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
 import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
+import org.apache.rocketmq.studio.provider.InstanceCapability;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -149,6 +150,15 @@ class TencentInstanceProviderTest {
 
         assertThat(provider.countTopics(STUDIO_INSTANCE_ID)).isEqualTo(501);
         verify(client, times(1)).DescribeTopicList(any());
+    }
+
+    @Test
+    void capabilitiesShouldExcludeUnsupportedDlqOperations() {
+        assertThat(provider.capabilities())
+                .contains(InstanceCapability.TOPIC_MANAGEMENT,
+                        InstanceCapability.MESSAGE_QUERY,
+                        InstanceCapability.ACL_MANAGEMENT)
+                .doesNotContain(InstanceCapability.DLQ_MANAGEMENT);
     }
 
     @Test

--- a/web/src/api/instance.test.ts
+++ b/web/src/api/instance.test.ts
@@ -18,7 +18,14 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { createInstance, deleteInstance, listInstances, updateInstance } from './instance';
+import {
+  createInstance,
+  deleteInstance,
+  getInstanceCapabilities,
+  listInstances,
+  supportsApacheRuntime,
+  updateInstance,
+} from './instance';
 
 const mock = new MockAdapter(client);
 const instance = {
@@ -83,5 +90,27 @@ describe('instance API', () => {
     });
 
     await expect(deleteInstance(instance.id)).resolves.toBeUndefined();
+  });
+
+  it('loads the capability contract for an encoded instance id', async () => {
+    const capabilities = {
+      instanceId: 'instance/proxy',
+      vendor: 'APACHE' as const,
+      accessType: 'PROXY' as const,
+      capabilities: ['TOPIC_MANAGEMENT', 'DLQ_MANAGEMENT'] as const,
+    };
+    mock.onGet('/instances/instance%2Fproxy/capabilities').reply(200, {
+      code: 200,
+      data: capabilities,
+    });
+
+    await expect(getInstanceCapabilities('instance/proxy')).resolves.toEqual(capabilities);
+  });
+
+  it('identifies instances supported by Apache MQAdmin runtime APIs', () => {
+    expect(supportsApacheRuntime({ vendor: 'APACHE' })).toBe(true);
+    expect(supportsApacheRuntime({})).toBe(true);
+    expect(supportsApacheRuntime({ vendor: 'ALIYUN' })).toBe(false);
+    expect(supportsApacheRuntime({ vendor: 'TENCENT' })).toBe(false);
   });
 });

--- a/web/src/api/instance.ts
+++ b/web/src/api/instance.ts
@@ -19,6 +19,13 @@ import client from './client';
 
 // ─── Types ──────────────────────────────────────────────────────
 export type InstanceVendor = 'APACHE' | 'ALIYUN' | 'TENCENT';
+export type InstanceCapability =
+  | 'TOPIC_MANAGEMENT'
+  | 'CONSUMER_GROUP_MANAGEMENT'
+  | 'MESSAGE_QUERY'
+  | 'MESSAGE_TRACE'
+  | 'ACL_MANAGEMENT'
+  | 'DLQ_MANAGEMENT';
 
 export interface Instance {
   id: string;
@@ -64,6 +71,18 @@ export interface InstanceQuery {
   search?: string;
 }
 
+/** Whether an instance can use Apache MQAdmin-backed runtime diagnostics. */
+export function supportsApacheRuntime(instance: Pick<Instance, 'vendor'>): boolean {
+  return instance.vendor === undefined || instance.vendor === 'APACHE';
+}
+
+export interface InstanceCapabilities {
+  instanceId: string;
+  vendor: InstanceVendor;
+  accessType: Instance['type'];
+  capabilities: InstanceCapability[];
+}
+
 // ─── Instance CRUD ──────────────────────────────────────────────
 export async function listInstances(query: InstanceQuery = {}) {
   const search = query.search?.trim();
@@ -72,6 +91,13 @@ export async function listInstances(query: InstanceQuery = {}) {
     ...(search ? { search } : {}),
   };
   const res = await client.get<{ data: Instance[] }>('/instances', { params });
+  return res.data.data;
+}
+
+export async function getInstanceCapabilities(instanceId: string) {
+  const res = await client.get<{ data: InstanceCapabilities }>(
+    `/instances/${encodeURIComponent(instanceId)}/capabilities`,
+  );
   return res.data.data;
 }
 

--- a/web/src/layouts/MainLayout.test.tsx
+++ b/web/src/layouts/MainLayout.test.tsx
@@ -24,7 +24,12 @@ import useAuthStore from '../stores/authStore';
 import { ThemeProvider } from '../theme/ThemeProvider';
 import MainLayout from './MainLayout';
 
+const instanceServiceMocks = vi.hoisted(() => ({
+  getInstanceCapabilities: vi.fn(),
+}));
+
 vi.mock('../api/auth', () => ({ logout: vi.fn() }));
+vi.mock('../services/instanceService', () => instanceServiceMocks);
 
 vi.mock('antd', async () => {
   const React = await import('react');
@@ -38,12 +43,27 @@ vi.mock('antd', async () => {
 
   return {
     Layout,
-    Menu: () => null,
+    Menu: ({
+      items,
+    }: {
+      items?: Array<{ key: string; label: React.ReactNode; children?: unknown[] }>;
+    }) => {
+      const renderItems = (entries: typeof items): React.ReactNode[] =>
+        (entries ?? []).flatMap((item) => [
+          React.createElement('span', { key: `${item.key}-label` }, item.label),
+          ...renderItems(item.children as typeof items),
+        ]);
+      return React.createElement('nav', null, renderItems(items));
+    },
     Breadcrumb: ({ items }: { items: Array<{ key: string; title: React.ReactNode }> }) =>
       React.createElement(
-        'nav',
+        'div',
         null,
-        items.map((item) => React.createElement(React.Fragment, { key: item.key }, item.title)),
+        React.createElement(
+          'nav',
+          null,
+          items.map((item) => React.createElement(React.Fragment, { key: item.key }, item.title)),
+        ),
       ),
     Avatar: () => React.createElement('span', null, 'avatar'),
     Dropdown: ({ children, menu }: { children?: React.ReactNode; menu: DropdownMenu }) =>
@@ -74,6 +94,19 @@ describe('MainLayout authentication navigation', () => {
     localStorage.clear();
     vi.mocked(logout).mockReset().mockResolvedValue(undefined);
     useAuthStore.getState().login('test-token', 'admin', true);
+    instanceServiceMocks.getInstanceCapabilities.mockReset().mockResolvedValue({
+      instanceId: 'apache-1',
+      vendor: 'APACHE',
+      accessType: 'DIRECT',
+      capabilities: [
+        'TOPIC_MANAGEMENT',
+        'CONSUMER_GROUP_MANAGEMENT',
+        'MESSAGE_QUERY',
+        'MESSAGE_TRACE',
+        'ACL_MANAGEMENT',
+        'DLQ_MANAGEMENT',
+      ],
+    });
   });
 
   it('replaces a protected route with the login page after logout', async () => {
@@ -130,11 +163,65 @@ describe('MainLayout authentication navigation', () => {
       'false',
     );
     expect(screen.getByRole('button', { name: '打开用户菜单' })).toBeInTheDocument();
-
     fireEvent.click(searchButton);
     expect(screen.getByRole('button', { name: '首页' })).toBeInTheDocument();
-
     fireEvent.click(screen.getByRole('button', { name: '切换到英语' }));
     expect(screen.getByRole('button', { name: 'Switch to Chinese' })).toBeInTheDocument();
+  });
+
+  it('hides unsupported instance navigation after capabilities load', async () => {
+    instanceServiceMocks.getInstanceCapabilities.mockResolvedValue({
+      instanceId: 'cloud-1',
+      vendor: 'ALIYUN',
+      accessType: 'PROXY',
+      capabilities: ['TOPIC_MANAGEMENT'],
+    });
+
+    render(
+      <LangProvider>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/instance/cloud-1/topic']}>
+            <Routes>
+              <Route path="/" element={<MainLayout />}>
+                <Route path="instance/:instanceId/topic" element={<div>cloud topic</div>} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </LangProvider>,
+    );
+
+    await waitFor(() =>
+      expect(instanceServiceMocks.getInstanceCapabilities).toHaveBeenCalledWith('cloud-1'),
+    );
+    expect(screen.queryByText('死信队列')).not.toBeInTheDocument();
+    expect(screen.queryByText('ACL 管理')).not.toBeInTheDocument();
+    expect(screen.queryByText('Consumer Group')).not.toBeInTheDocument();
+    expect(screen.queryByText('消息查询')).not.toBeInTheDocument();
+    expect(screen.getByText('Topic 管理')).toBeInTheDocument();
+  });
+
+  it('keeps navigation available when capability discovery fails', async () => {
+    instanceServiceMocks.getInstanceCapabilities.mockRejectedValue(new Error('unavailable'));
+
+    render(
+      <LangProvider>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/instance/apache-1/topic']}>
+            <Routes>
+              <Route path="/" element={<MainLayout />}>
+                <Route path="instance/:instanceId/topic" element={<div>apache topic</div>} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </LangProvider>,
+    );
+
+    await waitFor(() =>
+      expect(instanceServiceMocks.getInstanceCapabilities).toHaveBeenCalledWith('apache-1'),
+    );
+    expect(screen.getByText('ACL 管理')).toBeInTheDocument();
+    expect(screen.getByText('死信队列')).toBeInTheDocument();
   });
 });

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -51,10 +51,19 @@ import {
   type NavigationSearchEntry,
 } from './navigationSearch';
 import { useDataModeStore } from '../stores/dataModeStore';
+import { getInstanceCapabilities } from '../services/instanceService';
+import type { InstanceCapability } from '../api/instance';
 
 const { Sider, Content } = Layout;
 
 const iconSize = 18;
+
+function hasInstanceCapability(
+  capabilities: Set<InstanceCapability> | null,
+  capability: InstanceCapability,
+) {
+  return capabilities === null || capabilities.has(capability);
+}
 
 const MainLayout = () => {
   const navigate = useNavigate();
@@ -66,6 +75,10 @@ const MainLayout = () => {
   const clearAuth = useAuthStore((state) => state.logout);
   const useMock = useDataModeStore((state) => state.useMock);
   const toggleDataMode = useDataModeStore((state) => state.toggle);
+  const [capabilityState, setCapabilityState] = useState<{
+    instanceId: string;
+    capabilities: Set<InstanceCapability>;
+  } | null>(null);
 
   // Pages fetch on mount, so reload to re-request everything from the new data source.
   const handleDataModeToggle = () => {
@@ -107,6 +120,39 @@ const MainLayout = () => {
       ),
     [location.pathname],
   );
+  const selectedInstanceId = useMemo(() => {
+    const match = location.pathname.match(/^\/instance\/([^/]+)\//);
+    if (!match) return null;
+    try {
+      return decodeURIComponent(match[1]);
+    } catch {
+      return match[1];
+    }
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!selectedInstanceId) return;
+    let active = true;
+    void getInstanceCapabilities(selectedInstanceId)
+      .then((result) => {
+        if (active) {
+          setCapabilityState({
+            instanceId: selectedInstanceId,
+            capabilities: new Set(result.capabilities),
+          });
+        }
+      })
+      .catch(() => {
+        // Preserve existing navigation when capability discovery is unavailable.
+      });
+    return () => {
+      active = false;
+    };
+  }, [selectedInstanceId]);
+
+  const instanceCapabilities =
+    capabilityState?.instanceId === selectedInstanceId ? capabilityState.capabilities : null;
+
   const selectedMenuKey = instanceScopedMatch
     ? `/instance/${instanceScopedMatch[1]}`
     : location.pathname;
@@ -120,15 +166,33 @@ const MainLayout = () => {
         label: t('nav.instance'),
         children: [
           { key: '/instance', icon: <Database size={16} />, label: t('nav.instanceList') },
-          { key: '/instance/topic', icon: <ListDashes size={16} />, label: t('nav.topic') },
-          { key: '/instance/consumer', icon: <ChatCircleText size={16} />, label: t('nav.group') },
-          { key: '/instance/acl', icon: <Key size={16} />, label: t('nav.acl') },
-          {
-            key: '/instance/message',
-            icon: <MagnifyingGlass size={16} />,
-            label: t('nav.message'),
-          },
-          { key: '/instance/dlq', icon: <TrashSimple size={16} />, label: t('nav.dlq') },
+          ...(hasInstanceCapability(instanceCapabilities, 'TOPIC_MANAGEMENT')
+            ? [{ key: '/instance/topic', icon: <ListDashes size={16} />, label: t('nav.topic') }]
+            : []),
+          ...(hasInstanceCapability(instanceCapabilities, 'CONSUMER_GROUP_MANAGEMENT')
+            ? [
+                {
+                  key: '/instance/consumer',
+                  icon: <ChatCircleText size={16} />,
+                  label: t('nav.group'),
+                },
+              ]
+            : []),
+          ...(hasInstanceCapability(instanceCapabilities, 'ACL_MANAGEMENT')
+            ? [{ key: '/instance/acl', icon: <Key size={16} />, label: t('nav.acl') }]
+            : []),
+          ...(hasInstanceCapability(instanceCapabilities, 'MESSAGE_QUERY')
+            ? [
+                {
+                  key: '/instance/message',
+                  icon: <MagnifyingGlass size={16} />,
+                  label: t('nav.message'),
+                },
+              ]
+            : []),
+          ...(hasInstanceCapability(instanceCapabilities, 'DLQ_MANAGEMENT')
+            ? [{ key: '/instance/dlq', icon: <TrashSimple size={16} />, label: t('nav.dlq') }]
+            : []),
           {
             key: '/instance/resource-plan',
             icon: <Notebook size={16} />,
@@ -172,7 +236,7 @@ const MainLayout = () => {
         label: t('nav.settings'),
       },
     ],
-    [t],
+    [t, instanceCapabilities],
   );
 
   const breadcrumbMap: Record<string, string> = useMemo(

--- a/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
@@ -101,6 +101,21 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.mocked(connectionsService.listConnections).mockResolvedValue([connection]);
+  vi.mocked(instanceService.listInstances)
+    .mockReset()
+    .mockResolvedValue([
+      {
+        id: 'instance-1',
+        name: 'Instance 1',
+        endpoint: 'namesrv-1:9876',
+        type: 'DIRECT',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
 });
 
 afterEach(() => {
@@ -115,6 +130,42 @@ const renderWithProviders = (ui: React.ReactElement) =>
   );
 
 describe('Clients page', () => {
+  it('selects an Apache instance instead of a cloud instance for runtime diagnostics', async () => {
+    vi.mocked(instanceService.listInstances).mockResolvedValue([
+      {
+        id: 'cloud-instance',
+        name: 'Cloud instance',
+        endpoint: 'cloud:9876',
+        type: 'DIRECT',
+        vendor: 'TENCENT',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+      {
+        id: 'apache-instance',
+        name: 'Apache instance',
+        endpoint: 'apache:9876',
+        type: 'DIRECT',
+        vendor: 'APACHE',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
+    renderWithProviders(<ClientsPage />);
+
+    await screen.findByText('order-svc-0@10.0.1.12:49152');
+    expect(connectionsService.listConnections).toHaveBeenCalledWith({
+      instanceId: 'apache-instance',
+    });
+    expect(screen.queryByText('Cloud instance')).not.toBeInTheDocument();
+  });
+
   it('loads connections for the selected instance', async () => {
     renderWithProviders(<ClientsPage />);
 

--- a/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
@@ -25,12 +25,9 @@ import type { ClusterInfo } from '../../../api/cluster';
 import { LangProvider } from '../../../i18n/LangContext';
 
 const clusterServiceMocks = vi.hoisted(() => ({
-  createNameServer: vi.fn(),
   listClusters: vi.fn(),
-  restartProxy: vi.fn(),
   testClusterConnection: vi.fn(),
   updateClusterConfig: vi.fn(),
-  updateNameServer: vi.fn(),
 }));
 
 const instanceServiceMocks = vi.hoisted(() => ({
@@ -197,9 +194,7 @@ describe('Cluster page', () => {
         updatedAt: '',
       },
     ]);
-    clusterServiceMocks.createNameServer.mockReset().mockResolvedValue(undefined);
     clusterServiceMocks.listClusters.mockReset().mockResolvedValue([buildCluster()]);
-    clusterServiceMocks.restartProxy.mockReset().mockResolvedValue(undefined);
     clusterServiceMocks.testClusterConnection.mockReset();
     clusterServiceMocks.updateClusterConfig.mockReset().mockImplementation(async () => {
       const cluster = buildCluster();
@@ -210,7 +205,6 @@ describe('Cluster page', () => {
         failedBrokers: [],
       };
     });
-    clusterServiceMocks.updateNameServer.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -262,6 +256,20 @@ describe('Cluster page', () => {
     expect(within(dialog).getByText('1,842')).toBeInTheDocument();
     expect(within(dialog).getByText('8081')).toBeInTheDocument();
     expect(within(dialog).getByText('8080')).toBeInTheDocument();
+  });
+
+  it('keeps topology read-only when runtime actions are unsupported', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ClusterPage />);
+
+    await user.click(screen.getByRole('tab', { name: /NameServer 管理/ }));
+    expect(screen.getAllByText('rocketmq-prod').length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: /新建 NameServer|编辑/ })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: /Proxy 管理/ }));
+    const proxyRow = await screen.findByRole('row', { name: /10\.101\.2\.21:8081/ });
+    expect(within(proxyRow).getByRole('button', { name: /详情/ })).toBeInTheDocument();
+    expect(within(proxyRow).queryByRole('button', { name: /重启/ })).not.toBeInTheDocument();
   });
 
   it('keeps cluster tabs usable when address fields are missing', async () => {
@@ -437,72 +445,6 @@ describe('Cluster page', () => {
 
     expect(clusterServiceMocks.listClusters).toHaveBeenCalledTimes(2);
     expect(screen.getByRole('row', { name: /10\.101\.2\.11:10911/ })).toHaveTextContent('202');
-  });
-
-  it('queues an operation refresh behind an in-flight background request', async () => {
-    vi.useFakeTimers();
-    const successSpy = vi.spyOn(message, 'success').mockImplementation(vi.fn());
-    const backgroundRequest = deferred<ClusterInfo[]>();
-    const operationRequest = deferred<void>();
-    let backgroundSettled = false;
-    void backgroundRequest.promise.then(() => {
-      backgroundSettled = true;
-    });
-    clusterServiceMocks.restartProxy.mockReturnValueOnce(operationRequest.promise);
-    clusterServiceMocks.listClusters
-      .mockResolvedValueOnce([buildCluster({ connections: 601 })])
-      .mockReturnValueOnce(backgroundRequest.promise)
-      .mockResolvedValueOnce([buildCluster({ connections: 603 })]);
-
-    renderWithProviders(<ClusterPage />);
-    await flushPromises();
-    fireEvent.click(screen.getByRole('tab', { name: /Proxy 管理/ }));
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
-
-    const proxyRow = screen.getByRole('row', { name: /10\.101\.2\.21:8081/ });
-    fireEvent.click(within(proxyRow).getByRole('button', { name: /重启/ }));
-    await flushPromises();
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
-    });
-    const dialog = screen.getAllByText('确认重启')[0].closest('.ant-modal');
-    expect(dialog).not.toBeNull();
-    fireEvent.click(within(dialog as HTMLElement).getByRole('button', { name: /确\s*认/ }));
-    await flushPromises();
-
-    expect(clusterServiceMocks.restartProxy).toHaveBeenCalledWith({
-      clusterId: 'cluster-prod',
-      addr: '10.101.2.21:8081',
-    });
-    expect(clusterServiceMocks.listClusters).toHaveBeenCalledTimes(2);
-
-    await act(async () => {
-      operationRequest.resolve();
-      await operationRequest.promise;
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    expect(backgroundSettled).toBe(false);
-    expect(clusterServiceMocks.listClusters).toHaveBeenCalledTimes(2);
-    expect(successSpy).not.toHaveBeenCalled();
-
-    await act(async () => {
-      backgroundRequest.resolve([buildCluster({ connections: 602 })]);
-      await backgroundRequest.promise;
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    await flushPromises();
-
-    expect(clusterServiceMocks.listClusters).toHaveBeenCalledTimes(3);
-    const proxyTabPanel = screen.getByRole('tabpanel', { name: /Proxy 管理/ });
-    const proxyTable = within(proxyTabPanel).getByRole('table');
-    expect(within(proxyTable).getByRole('row', { name: /10\.101\.2\.21:8081/ })).toHaveTextContent(
-      '603',
-    );
-    expect(successSpy).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the last snapshot and silently retries after a background failure', async () => {

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -135,9 +135,9 @@ const ClientsPage = () => {
         const apacheInstances = nextInstances.filter(supportsApacheRuntime);
         setInstances(apacheInstances);
         setSelectedInstanceId((current) =>
-          apacheInstances.some((instance) => instance.name === current)
+          apacheInstances.some((instance) => instance.id === current)
             ? current
-            : (apacheInstances[0]?.name ?? ''),
+            : (apacheInstances[0]?.id ?? ''),
         );
         setLoadError(null);
       })

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -38,9 +38,9 @@ import type { ColumnsType } from 'antd/es/table';
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
 import type { ClientConnection } from '../../api/connections';
+import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { listConnections } from '../../services/connectionsService';
 import { listInstances } from '../../services/instanceService';
-import type { Instance } from '../../api/instance';
 import { formatDateTime } from '../../utils/format';
 
 const { Text } = Typography;
@@ -132,8 +132,13 @@ const ClientsPage = () => {
     void listInstances()
       .then((nextInstances) => {
         if (cancelled) return;
-        setInstances(nextInstances);
-        setSelectedInstanceId((current) => current || nextInstances[0]?.name || '');
+        const apacheInstances = nextInstances.filter(supportsApacheRuntime);
+        setInstances(apacheInstances);
+        setSelectedInstanceId((current) =>
+          apacheInstances.some((instance) => instance.name === current)
+            ? current
+            : (apacheInstances[0]?.name ?? ''),
+        );
         setLoadError(null);
       })
       .catch((error) => {

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -39,13 +39,7 @@ import {
   message,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import {
-  ReloadOutlined,
-  SettingOutlined,
-  EyeOutlined,
-  EditOutlined,
-  PlusOutlined,
-} from '@ant-design/icons';
+import { ReloadOutlined, SettingOutlined, EyeOutlined, PlusOutlined } from '@ant-design/icons';
 import { Cpu, HardDrives, Globe } from '@phosphor-icons/react';
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
@@ -59,15 +53,12 @@ import type {
   ClusterProbeResult,
 } from '../../api/cluster';
 import {
-  createNameServer,
   listClusters,
-  restartProxy,
   testClusterConnection,
   updateClusterConfig,
-  updateNameServer,
 } from '../../services/clusterService';
 import { listInstances } from '../../services/instanceService';
-import type { Instance } from '../../api/instance';
+import { supportsApacheRuntime, type Instance } from '../../api/instance';
 
 const { Text } = Typography;
 
@@ -101,10 +92,7 @@ const ClusterPage = () => {
 
   const [configModalOpen, setConfigModalOpen] = useState(false);
   const [selectedCluster, setSelectedCluster] = useState<ClusterInfo | null>(null);
-  const [nsModalOpen, setNsModalOpen] = useState(false);
-  const [nsModalMode, setNsModalMode] = useState<'create' | 'edit'>('create');
   const [selectedProxy, setSelectedProxy] = useState<ProxyDetail | null>(null);
-  const [nsForm] = Form.useForm();
   const [configForm] = Form.useForm();
 
   // ─── Connection test ──────────────────────────────────────────────────────
@@ -165,7 +153,7 @@ const ClusterPage = () => {
     void listInstances()
       .then((nextInstances) => {
         if (cancelled) return;
-        const apacheInstances = nextInstances.filter((instance) => instance.vendor === 'APACHE');
+        const apacheInstances = nextInstances.filter(supportsApacheRuntime);
         setInstances(apacheInstances);
         const initialInstanceId = apacheInstances.some(
           (instance) => instance.name === requestedInstanceId,
@@ -670,7 +658,7 @@ const ClusterPage = () => {
       })
       .filter((c) => c.filteredNameServers.length > 0);
 
-    const getNsSubColumns = (clusterId: string): ColumnsType<NameServerInfo> => [
+    const getNsSubColumns = (): ColumnsType<NameServerInfo> => [
       {
         title: t('common.address'),
         dataIndex: 'addr',
@@ -698,27 +686,6 @@ const ClusterPage = () => {
           const cfg = map[status] ?? { color: 'default', label: status };
           return <Tag color={cfg.color}>{cfg.label}</Tag>;
         },
-      },
-      {
-        title: t('common.actions'),
-        key: 'action',
-        width: 100,
-        render: (_: unknown, record: NameServerInfo) => (
-          <Flex gap={6}>
-            <Button
-              size="small"
-              icon={<EditOutlined />}
-              style={{ borderColor: '#722ed1', color: '#722ed1' }}
-              onClick={() => {
-                setNsModalMode('edit');
-                nsForm.setFieldsValue({ clusterId, addr: record.addr, newAddr: '' });
-                setNsModalOpen(true);
-              }}
-            >
-              {t('common.edit')}
-            </Button>
-          </Flex>
-        ),
       },
     ];
 
@@ -804,17 +771,6 @@ const ClusterPage = () => {
               style={{ width: 240 }}
             />
           </Space>
-          <Button
-            type="primary"
-            icon={<PlusOutlined />}
-            onClick={() => {
-              setNsModalMode('create');
-              nsForm.resetFields();
-              setNsModalOpen(true);
-            }}
-          >
-            {t('cluster.createNameServer')}
-          </Button>
         </Flex>
         <Card styles={{ body: { padding: 0 } }}>
           <Table
@@ -828,7 +784,7 @@ const ClusterPage = () => {
               expandedRowRender: (record) => (
                 <div style={{ padding: '8px 0' }}>
                   <Table
-                    columns={getNsSubColumns(record.id)}
+                    columns={getNsSubColumns()}
                     dataSource={record.filteredNameServers}
                     rowKey="addr"
                     pagination={false}
@@ -945,26 +901,6 @@ const ClusterPage = () => {
               onClick={() => setSelectedProxy(record)}
             >
               {t('common.detail')}
-            </Button>
-            <Button
-              size="small"
-              icon={<ReloadOutlined />}
-              style={{ borderColor: '#faad14', color: '#faad14' }}
-              onClick={() => {
-                Modal.confirm({
-                  title: t('cluster.confirmRestart'),
-                  content: t('cluster.restartProxyConfirm', { addr: record.addr }),
-                  okText: t('common.confirm'),
-                  cancelText: t('common.cancel'),
-                  onOk: async () => {
-                    await restartProxy({ clusterId: record.clusterId, addr: record.addr });
-                    await requestRefresh('operation');
-                    message.success(t('cluster.restartProxySubmitted', { addr: record.addr }));
-                  },
-                });
-              }}
-            >
-              {t('cluster.restart')}
             </Button>
           </Flex>
         ),

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -156,10 +156,10 @@ const ClusterPage = () => {
         const apacheInstances = nextInstances.filter(supportsApacheRuntime);
         setInstances(apacheInstances);
         const initialInstanceId = apacheInstances.some(
-          (instance) => instance.name === requestedInstanceId,
+          (instance) => instance.id === requestedInstanceId,
         )
           ? requestedInstanceId
-          : (apacheInstances[0]?.name ?? '');
+          : (apacheInstances[0]?.id ?? '');
         selectedInstanceIdRef.current = initialInstanceId;
         setSelectedInstanceId(initialInstanceId);
         setInstanceLoadError(null);
@@ -1018,63 +1018,6 @@ const ClusterPage = () => {
           50% { opacity: 0.6; box-shadow: 0 0 0 4px rgba(82, 196, 26, 0); }
         }
       `}</style>
-      {/* ─── NameServer Create/Edit Modal ─── */}
-      <Modal
-        title={
-          nsModalMode === 'create' ? t('cluster.createNameServer') : t('cluster.editNameServer')
-        }
-        open={nsModalOpen}
-        onCancel={() => setNsModalOpen(false)}
-        onOk={() => {
-          nsForm.validateFields().then(async (values: Record<string, string>) => {
-            if (nsModalMode === 'create') {
-              await createNameServer({ clusterId: values.clusterId, addr: values.addr });
-              message.success(`${t('cluster.nsCreated')}: ${values.addr}`);
-            } else {
-              await updateNameServer({
-                clusterId: values.clusterId,
-                addr: values.addr,
-                newAddr: values.newAddr,
-              });
-              message.success(
-                `${t('cluster.nsUpdated')}: ${values.addr}${values.newAddr ? ` → ${values.newAddr}` : ''}`,
-              );
-            }
-            await requestRefresh('operation');
-            setNsModalOpen(false);
-          });
-        }}
-        okText={t('common.confirm')}
-        cancelText={t('common.cancel')}
-        destroyOnHidden
-      >
-        <Form form={nsForm} layout="vertical" style={{ marginTop: 16 }}>
-          {nsModalMode === 'create' && (
-            <Form.Item
-              name="clusterId"
-              label={t('cluster.selectCluster')}
-              rules={[{ required: true, message: t('cluster.selectCluster') }]}
-            >
-              <Select
-                placeholder={t('cluster.selectCluster')}
-                options={clusters.map((c) => ({ label: c.name, value: c.id }))}
-              />
-            </Form.Item>
-          )}
-          <Form.Item
-            name="addr"
-            label={t('cluster.nsAddr')}
-            rules={[{ required: true, message: t('cluster.nsAddr') }]}
-          >
-            <Input placeholder={t('cluster.nsAddrPlaceholder')} disabled={nsModalMode === 'edit'} />
-          </Form.Item>
-          {nsModalMode === 'edit' && (
-            <Form.Item name="newAddr" label={t('cluster.newAddr')}>
-              <Input placeholder={t('cluster.newAddrPlaceholder')} />
-            </Form.Item>
-          )}
-        </Form>
-      </Modal>
       <Tabs items={tabItems} defaultActiveKey="broker" />
       <Modal
         title={t('cluster.proxyDetailTitle', { addr: selectedProxy?.addr ?? '' })}

--- a/web/src/pages/home/__tests__/DashboardPage.test.tsx
+++ b/web/src/pages/home/__tests__/DashboardPage.test.tsx
@@ -191,4 +191,42 @@ describe('DashboardPage', () => {
 
     expect(screen.getByTestId('location')).toHaveTextContent('/cluster?instanceId=instance-b');
   });
+
+  it('does not offer cloud instances for MQAdmin runtime diagnostics', async () => {
+    vi.mocked(instanceService.listInstances).mockResolvedValue([
+      {
+        id: 'apache-instance',
+        name: 'Apache instance',
+        endpoint: 'apache:9876',
+        type: 'DIRECT',
+        vendor: 'APACHE',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+      {
+        id: 'cloud-instance',
+        name: 'Cloud instance',
+        endpoint: 'cloud:9876',
+        type: 'DIRECT',
+        vendor: 'ALIYUN',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
+    vi.mocked(dashboardService.getDashboard).mockResolvedValue(dashboard('apache-cluster'));
+    const user = userEvent.setup();
+    renderWithProviders(<DashboardPage />);
+
+    await screen.findByText('apache-cluster');
+    await user.click(screen.getByRole('combobox', { name: 'Dashboard instance' }));
+
+    expect(await screen.findByText('Apache instance')).toBeInTheDocument();
+    expect(screen.queryByText('Cloud instance')).not.toBeInTheDocument();
+  });
 });

--- a/web/src/pages/home/__tests__/DashboardPage.test.tsx
+++ b/web/src/pages/home/__tests__/DashboardPage.test.tsx
@@ -226,7 +226,9 @@ describe('DashboardPage', () => {
     await screen.findByText('apache-cluster');
     await user.click(screen.getByRole('combobox', { name: 'Dashboard instance' }));
 
-    expect(await screen.findByText('Apache instance')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Apache instance', { selector: '.ant-select-item-option-content' }),
+    ).toBeInTheDocument();
     expect(screen.queryByText('Cloud instance')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -21,10 +21,10 @@ import StatusBadge from '../../components/StatusBadge';
 import MiniBar from '../../components/MiniBar';
 import MetricsExplorer from '../../components/MetricsExplorer';
 import { CLUSTER_TYPE_MAP } from '../../constants/theme';
+import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { getDashboard } from '../../services/dashboardService';
 import type { DashboardData } from '../../api/metrics';
 import { listInstances } from '../../services/instanceService';
-import type { Instance } from '../../api/instance';
 import { useLang } from '../../i18n/LangContext';
 
 const { Text } = Typography;
@@ -68,7 +68,7 @@ const DashboardPage = () => {
     let cancelled = false;
     void listInstances()
       .then((nextInstances) => {
-        if (!cancelled) setInstances(nextInstances);
+        if (!cancelled) setInstances(nextInstances.filter(supportsApacheRuntime));
       })
       .catch(() => {
         if (!cancelled) setInstances([]);

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Table, Button, Tag, Tabs, Card, Space, Switch, Progress, Spin, App, Select } from 'antd';
 import { ArrowClockwise, Cloud, ChartBar, PlugsConnected } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
+import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { listClusters } from '../../services/clusterService';
 import type { ClusterInfo } from '../../api/cluster';
 import { listInstances } from '../../services/instanceService';
@@ -191,8 +192,9 @@ const BrokerClusterPage = () => {
     void listInstances()
       .then((nextInstances) => {
         if (!active) return;
-        setInstances(nextInstances);
-        setSelectedInstanceId(nextInstances[0]?.name ?? '');
+        const apacheInstances = nextInstances.filter(supportsApacheRuntime);
+        setInstances(apacheInstances);
+        setSelectedInstanceId(apacheInstances[0]?.name ?? '');
       })
       .catch(() => {
         if (!active) return;

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -23,7 +23,6 @@ import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { listClusters } from '../../services/clusterService';
 import type { ClusterInfo } from '../../api/cluster';
 import { listInstances } from '../../services/instanceService';
-import type { Instance } from '../../api/instance';
 import { useVisiblePolling } from '../../hooks/useVisiblePolling';
 
 // ─── Types ──────────────────────────────────────────────────────
@@ -194,7 +193,7 @@ const BrokerClusterPage = () => {
         if (!active) return;
         const apacheInstances = nextInstances.filter(supportsApacheRuntime);
         setInstances(apacheInstances);
-        setSelectedInstanceId(apacheInstances[0]?.name ?? '');
+        setSelectedInstanceId(apacheInstances[0]?.id ?? '');
       })
       .catch(() => {
         if (!active) return;
@@ -474,7 +473,10 @@ const BrokerClusterPage = () => {
       </div>
 
       <Spin spinning={loading} tip={t('common.loading')}>
-        <Card variant="borderless" style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}>
+        <Card
+          variant="borderless"
+          style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}
+        >
           <Tabs
             activeKey={activeTab}
             onChange={setActiveTab}

--- a/web/src/pages/studio/Producer.tsx
+++ b/web/src/pages/studio/Producer.tsx
@@ -40,7 +40,7 @@ import {
   type ProducerConnectionWarning,
   type ProducerReadiness,
 } from '../../api/producer';
-import type { Instance } from '../../api/instance';
+import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { listInstances } from '../../services/instanceService';
 
 const readinessConfig: Record<ProducerReadiness, { color: string; type: 'success' | 'warning' }> = {
@@ -71,8 +71,13 @@ const ProducerPage = () => {
     void listInstances()
       .then((nextInstances) => {
         if (cancelled) return;
-        setInstances(nextInstances);
-        setSelectedInstanceId((current) => current || nextInstances[0]?.name || '');
+        const apacheInstances = nextInstances.filter(supportsApacheRuntime);
+        setInstances(apacheInstances);
+        setSelectedInstanceId((current) =>
+          apacheInstances.some((instance) => instance.name === current)
+            ? current
+            : (apacheInstances[0]?.name ?? ''),
+        );
       })
       .catch(() => {
         if (!cancelled) {

--- a/web/src/pages/studio/Producer.tsx
+++ b/web/src/pages/studio/Producer.tsx
@@ -74,9 +74,9 @@ const ProducerPage = () => {
         const apacheInstances = nextInstances.filter(supportsApacheRuntime);
         setInstances(apacheInstances);
         setSelectedInstanceId((current) =>
-          apacheInstances.some((instance) => instance.name === current)
+          apacheInstances.some((instance) => instance.id === current)
             ? current
-            : (apacheInstances[0]?.name ?? ''),
+            : (apacheInstances[0]?.id ?? ''),
         );
       })
       .catch(() => {

--- a/web/src/pages/studio/__tests__/Producer.test.tsx
+++ b/web/src/pages/studio/__tests__/Producer.test.tsx
@@ -109,6 +109,39 @@ describe('ProducerPage', () => {
     });
   });
 
+  it('uses an Apache instance rather than a cloud instance for producer diagnostics', async () => {
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'cloud-instance',
+        name: 'Cloud instance',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: 'cloud:9876',
+        vendor: 'ALIYUN',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-08-01T00:00:00',
+        updatedAt: '2026-08-01T00:00:00',
+      },
+      {
+        id: 'apache-instance',
+        name: 'Apache instance',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: 'apache:9876',
+        vendor: 'APACHE',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '2026-08-01T00:00:00',
+        updatedAt: '2026-08-01T00:00:00',
+      },
+    ]);
+    renderWithProviders(<ProducerPage />);
+
+    await waitFor(() => expect(fetchTopicList).toHaveBeenCalledWith('apache-instance'));
+    expect(screen.queryByText('Cloud instance')).not.toBeInTheDocument();
+  });
+
   it('renders topic options loaded from the API', async () => {
     const user = userEvent.setup();
     renderWithProviders(<ProducerPage />);

--- a/web/src/services/instanceService.test.ts
+++ b/web/src/services/instanceService.test.ts
@@ -22,7 +22,13 @@ vi.mock('../config', () => ({
   API_BASE_URL: '/api',
 }));
 
-import { createInstance, deleteInstance, listInstances, updateInstance } from './instanceService';
+import {
+  createInstance,
+  deleteInstance,
+  getInstanceCapabilities,
+  listInstances,
+  updateInstance,
+} from './instanceService';
 
 describe('instanceService mock instances', () => {
   it('returns defensive copies from list reads', async () => {
@@ -91,5 +97,14 @@ describe('instanceService mock instances', () => {
     );
 
     await expect(listInstances()).resolves.toEqual(before);
+  });
+
+  it('returns provider-specific mock capabilities without sharing mutable arrays', async () => {
+    const first = await getInstanceCapabilities('instance-direct-1');
+    first.capabilities.length = 0;
+
+    const second = await getInstanceCapabilities('instance-direct-1');
+
+    expect(second.capabilities).toContain('DLQ_MANAGEMENT');
   });
 });

--- a/web/src/services/instanceService.ts
+++ b/web/src/services/instanceService.ts
@@ -5,6 +5,7 @@ import type {
   CreateInstanceRequest,
   InstanceQuery,
   UpdateInstanceRequest,
+  InstanceCapabilities,
 } from '../api/instance';
 import { mockInstances } from '../mock/instances';
 
@@ -13,6 +14,23 @@ import { mockInstances } from '../mock/instances';
 function copyInstance(instance: Instance): Instance {
   return { ...instance };
 }
+
+const APACHE_CAPABILITIES: InstanceCapabilities['capabilities'] = [
+  'TOPIC_MANAGEMENT',
+  'CONSUMER_GROUP_MANAGEMENT',
+  'MESSAGE_QUERY',
+  'MESSAGE_TRACE',
+  'ACL_MANAGEMENT',
+  'DLQ_MANAGEMENT',
+];
+
+const CLOUD_CAPABILITIES: InstanceCapabilities['capabilities'] = [
+  'TOPIC_MANAGEMENT',
+  'CONSUMER_GROUP_MANAGEMENT',
+  'MESSAGE_QUERY',
+  'MESSAGE_TRACE',
+  'ACL_MANAGEMENT',
+];
 
 export async function listInstances(query: InstanceQuery = {}): Promise<Instance[]> {
   if (isMockMode()) {
@@ -29,6 +47,21 @@ export async function listInstances(query: InstanceQuery = {}): Promise<Instance
       .map(copyInstance);
   }
   return instanceApi.listInstances(query);
+}
+
+export async function getInstanceCapabilities(instanceId: string): Promise<InstanceCapabilities> {
+  if (!isMockMode()) {
+    return instanceApi.getInstanceCapabilities(instanceId);
+  }
+  const instance = mockInstances.find((candidate) => candidate.id === instanceId);
+  if (!instance) throw new Error(`Instance not found: ${instanceId}`);
+  const vendor = instance.vendor ?? 'APACHE';
+  return {
+    instanceId,
+    vendor,
+    accessType: instance.type,
+    capabilities: [...(vendor === 'APACHE' ? APACHE_CAPABILITIES : CLOUD_CAPABILITIES)],
+  };
 }
 
 export async function createInstance(data: CreateInstanceRequest): Promise<Instance> {


### PR DESCRIPTION
## Summary

- expose provider-owned capabilities for Apache, Aliyun, and Tencent managed instances
- drive instance-scoped navigation and diagnostics from the selected instance capability set
- require selected-instance context for Consumer Group management and prevent stale prior-instance responses from overwriting the current view
- represent undiscoverable Proxy and NameServer topology counts as unavailable rather than false zeroes, and render them as `N/A`
- preserve legacy compatibility while restricting MQAdmin runtime diagnostics to Apache-backed instances

Closes #1951
Closes #1741
Closes #1524
Closes #1947
Closes #1700

## Verification

- frontend runtime/capability suites: 7 files, 64 tests passed
- backend capability/dashboard suites: 77 tests passed
- `npm run build`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -f server/pom.xml -DskipTests package`
- `git diff --check origin/rocketmq-studio...HEAD`

The frontend test environment emits existing jsdom pseudo-element warnings only.
