### PR TITLE
fix: return empty consumer list for system-only groups and guard null cluster info

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProvider.java
@@ -101,6 +101,9 @@ public class RealClusterProvider implements ClusterProvider {
     }
 
     private List<ClusterVO> toClusterVOs(String namesrvAddr, ClusterInfo clusterInfo) {
+        if (clusterInfo == null) {
+            return List.of();
+        }
         Map<String, BrokerData> brokerAddrTable =
                 clusterInfo.getBrokerAddrTable() == null ? Map.of() : clusterInfo.getBrokerAddrTable();
         Map<String, Set<String>> clusterAddrTable =

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -209,12 +209,14 @@ public class RocketMQClientProvider implements ClientProvider {
     private List<ClientConnectionVO> findConsumerConnections(MQAdminExt adminExt, String clusterId) {
         List<ClientConnectionVO> result = new ArrayList<>();
         Map<String, String> groups = collectSubscriptionGroups(adminExt, clusterId);
+        int attemptedGroupQueries = 0;
         int successfulGroupQueries = 0;
         for (Map.Entry<String, String> groupEntry : groups.entrySet()) {
             String group = groupEntry.getKey();
             if (isSystemGroup(group)) {
                 continue;
             }
+            attemptedGroupQueries++;
             try {
                 ConsumerConnection consumerConnection = adminExt.examineConsumerConnectionInfo(group);
                 successfulGroupQueries++;
@@ -232,7 +234,9 @@ public class RocketMQClientProvider implements ClientProvider {
                 log.warn("Failed to examine consumer connection for group={}, skipping", group, e);
             }
         }
-        if (!groups.isEmpty() && successfulGroupQueries == 0) {
+        // Only fail when at least one non-system group was actually attempted and all of them
+        // failed; a cluster whose subscription table holds only system groups is not an error.
+        if (attemptedGroupQueries > 0 && successfulGroupQueries == 0) {
             throw new BusinessException(502, "Failed to query consumer connections from all groups");
         }
         return result;

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProviderTest.java
@@ -129,6 +129,13 @@ class RealClusterProviderTest {
     }
 
     @Test
+    void describeClustersShouldTolerateNullClusterInfo() throws Exception {
+        stubClusterInfo("10.0.0.1:9876", null);
+
+        assertThat(provider.describeClusters("10.0.0.1:9876")).isEmpty();
+    }
+
+    @Test
     void discoverClustersShouldUseConfiguredNamesrv() throws Exception {
         properties.setNamesrvAddr("10.0.0.1:9876");
         stubClusterInfo("10.0.0.1:9876", sampleClusterInfo());

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
@@ -330,6 +330,18 @@ class RocketMQClientProviderTest {
     }
 
     @Test
+    void consumerScanWithOnlySystemGroupsReturnsEmptyInsteadOf502() throws Exception {
+        SubscriptionGroupWrapper wrapper = subscriptionGroups("%RETRY%group-a", "%DLQ%group-b");
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo("127.0.0.1:10911"));
+        when(adminExt.getAllSubscriptionGroup("127.0.0.1:10911", 5000L)).thenReturn(wrapper);
+
+        List<ClientConnectionVO> connections = provider.findConnections("instance-a", "cluster-a", "Consumer");
+
+        assertThat(connections).isEmpty();
+        verify(adminExt, never()).examineConsumerConnectionInfo(anyString());
+    }
+
+    @Test
     void consumerScanReturnsPartialResultsWhenOneGroupQueryFails() throws Exception {
         SubscriptionGroupWrapper wrapper = subscriptionGroups("group-a", "group-b");
         ConsumerConnection consumerConnection = new ConsumerConnection();


### PR DESCRIPTION
## What is the purpose of the change

Two robustness bugs in the cluster/client discovery providers that surface as false 502 errors or crashes:

- `findConsumerConnections` threw a 502 whenever the subscription table contained only system groups (e.g. `%RETRY%`/`%DLQ%`), because the failure check compared the group count against the *successful* query count without accounting for skipped system groups. A cluster with no real consumer groups thus reported the clients endpoint as failed.
- `RealClusterProvider.toClusterVOs` dereferenced `clusterInfo` without a null check, unlike the sibling `RocketMQClusterProvider` and `RocketMQClientProvider`; a null `examineBrokerClusterInfo()` response caused an NPE instead of an empty result.

## Brief changelog

- Track attempted (non-system) group queries separately and only fail when at least one was attempted and all failed; system-only subscription tables now return an empty list.
- Guard `toClusterVOs` against a null `ClusterInfo` and return an empty list, matching the other providers.
- Cover both with unit tests: a system-only subscription table asserting an empty result with no admin calls, and a null `ClusterInfo` asserting an empty discovery result.

## Verifying this change

- `mvn -q -Dtest=RocketMQClientProviderTest,RealClusterProviderTest test`
- `mvn -q test` (1056/1056)
- `git diff --check`
