### PR TITLE
feat: harden Studio deployment readiness and persistent storage

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -39,6 +39,15 @@ cd deploy && docker compose up -d --build
 
 默认访问地址为 `http://127.0.0.1:6789`。
 
+后端提供两个独立的编排探针，前端 Nginx 仅透出这两个探针与 Actuator health：
+
+- `GET /livez`：仅检查 Studio 进程存活状态，不依赖数据库、RocketMQ、Prometheus 或云 API。
+- `GET /readyz`：检查 Studio 是否可接收控制面请求，包含数据库连接状态。Docker Compose
+  使用该端点决定何时启动前端。
+
+RocketMQ、Prometheus 和云 API 故障由 Studio 的运行态诊断页面展示，不纳入 liveness，避免下游
+故障触发 Studio 容器反复重启。
+
 默认 schema 只创建 Studio 所需的表，不会写入实例、Topic、消费组或 ACL 示例数据。需要演示数据时，
 请在开发环境中显式导入 `deploy/mysql/upgrade-demo-instance.sql` 和
 `deploy/mysql/upgrade-demo-acl.sql`，不要在生产环境导入这些脚本。

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       mysql:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8888/actuator/health"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:8888/readyz"]
       interval: 10s
       timeout: 5s
       retries: 30

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -16,6 +16,22 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location = /livez {
+        proxy_pass http://rocketmq-server:8888;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /readyz {
+        proxy_pass http://rocketmq-server:8888;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Only the health endpoint is reachable through the edge; the rest of
     # /actuator/ must never be exposed without authentication.
     location ~ ^/actuator/health {

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
@@ -155,6 +155,8 @@ public class AuthInterceptor implements HandlerInterceptor {
         path = normalizePath(path);
         return path.equals("/api/auth/login")
                 || path.equals("/api/auth/status")
+                || path.equals("/livez")
+                || path.equals("/readyz")
                 || path.startsWith("/api-docs")
                 || path.startsWith("/swagger-ui")
                 || path.startsWith("/actuator/health");

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -28,6 +28,18 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
 
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+        add-additional-paths: true
+      group:
+        liveness:
+          include: livenessState
+        readiness:
+          include: readinessState,db
+
 studio:
   auth:
     login-required: ${STUDIO_AUTH_LOGIN_REQUIRED:true}

--- a/server/src/test/java/org/apache/rocketmq/studio/HealthProbeIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/HealthProbeIntegrationTest.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(properties = {
-    "studio.auth.login-required=false",
+    "studio.auth.login-required=true",
     "management.endpoint.health.show-details=always"
 })
 @AutoConfigureMockMvc

--- a/server/src/test/java/org/apache/rocketmq/studio/HealthProbeIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/HealthProbeIntegrationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+    "studio.auth.login-required=false",
+    "management.endpoint.health.show-details=always"
+})
+@AutoConfigureMockMvc
+class HealthProbeIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void livenessShouldExcludeExternalDependencies() throws Exception {
+        mockMvc.perform(get("/livez"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.components.livenessState.status").value("UP"))
+                .andExpect(jsonPath("$.components.db").doesNotExist());
+    }
+
+    @Test
+    void readinessShouldIncludeDatabaseAvailability() throws Exception {
+        mockMvc.perform(get("/readyz"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.components.readinessState.status").value("UP"))
+                .andExpect(jsonPath("$.components.db.status").value("UP"));
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -179,6 +179,20 @@ class AuthInterceptorTest {
         assertThat(allowed).isTrue();
     }
 
+    @Test
+    void shouldAllowHealthProbesWhenLoginIsEnabled() throws Exception {
+        AuthProperties properties = new AuthProperties();
+        properties.setLoginRequired(true);
+        AuthInterceptor interceptor = new AuthInterceptor(properties, authService(properties), settingsRepository());
+
+        for (String path : List.of("/livez", "/readyz")) {
+            boolean allowed = interceptor.preHandle(new MockHttpServletRequest("GET", path),
+                    new MockHttpServletResponse(), new Object());
+
+            assertThat(allowed).as(path).isTrue();
+        }
+    }
+
     private AuthService authService(AuthProperties properties) {
         return new AuthService(properties, settingsRepositoryWithTimeout(30));
     }

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -52,6 +52,24 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location = /livez {
+        set $backend_livez http://rocketmq-server:8888;
+        proxy_pass $backend_livez;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /readyz {
+        set $backend_readyz http://rocketmq-server:8888;
+        proxy_pass $backend_readyz;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Only the health endpoint is reachable through the edge. The rest of
     # /actuator/ (env, beans, mappings, metrics, ...) must never be exposed
     # without authentication.


### PR DESCRIPTION
## Summary

- expose dedicated `/livez` and `/readyz` endpoints, keeping liveness independent from external services while readiness checks database connectivity
- configure Docker Compose and both Nginx configurations to use and expose the probe contract
- fail remote deployments before build when required persistent datasource settings are absent
- run remote backend deployments with the `prod` profile and forward datasource and NameServer settings
- document the persistent-storage deployment contract and cover deploy script behavior in CI

Closes #1954
Closes #1972

## Verification

```bash
bash deploy/deploy_test.sh
JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -B -ntp -f server/pom.xml -Dtest=HealthProbeIntegrationTest test
JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -B -ntp -f server/pom.xml -DskipTests package
docker compose -f deploy/docker-compose.yml config
# nginx:1.27-alpine validates deploy/nginx.conf and web/nginx.conf
```

All commands pass. `git diff --check` and modified-server-file diagnostics are clean.
