### PR TITLE
fix: export applied audit filters

### DIFF
--- a/web/src/pages/ops/__tests__/AuditPage.test.tsx
+++ b/web/src/pages/ops/__tests__/AuditPage.test.tsx
@@ -106,12 +106,18 @@ describe('Audit page', () => {
     vi.clearAllMocks();
   });
 
-  it('exports all audit records matching the current filters', async () => {
+  it('exports audit records with the search already applied to the table', async () => {
     const user = userEvent.setup();
     renderWithProviders(<AuditPage />);
 
     expect(await screen.findByText('topic-a')).toBeInTheDocument();
     await user.type(screen.getByPlaceholderText('搜索操作人或操作对象'), 'topic-a');
+
+    await waitFor(() =>
+      expect(opsService.listAuditRecords).toHaveBeenLastCalledWith(
+        expect.objectContaining({ search: 'topic-a' }),
+      ),
+    );
     await user.click(screen.getByRole('button', { name: /导出/ }));
 
     await waitFor(() =>
@@ -130,6 +136,27 @@ describe('Audit page', () => {
     await expect(blob.text()).resolves.toContain('"2026-08-01 10:00:00","admin"');
     expect(clickSpy).toHaveBeenCalledTimes(1);
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:audit');
+  });
+
+  it('does not export a pending search before the table applies it', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AuditPage />);
+
+    expect(await screen.findByText('topic-a')).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('搜索操作人或操作对象'), 'pending');
+    await user.click(screen.getByRole('button', { name: /导出/ }));
+
+    await waitFor(() =>
+      expect(opsService.exportAuditLogs).toHaveBeenCalledWith({
+        search: undefined,
+        operationType: undefined,
+        resourceType: undefined,
+        clusterId: undefined,
+        startDate: undefined,
+        endDate: undefined,
+        result: undefined,
+      }),
+    );
   });
 
   it('loads persisted filter values and forwards their original codes', async () => {

--- a/web/src/pages/ops/__tests__/AuditPage.test.tsx
+++ b/web/src/pages/ops/__tests__/AuditPage.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { App } from 'antd';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -139,12 +139,13 @@ describe('Audit page', () => {
   });
 
   it('does not export a pending search before the table applies it', async () => {
-    const user = userEvent.setup();
     renderWithProviders(<AuditPage />);
 
     expect(await screen.findByText('topic-a')).toBeInTheDocument();
-    await user.type(screen.getByPlaceholderText('搜索操作人或操作对象'), 'pending');
-    await user.click(screen.getByRole('button', { name: /导出/ }));
+    fireEvent.change(screen.getByPlaceholderText('搜索操作人或操作对象'), {
+      target: { value: 'pending' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /导出/ }));
 
     await waitFor(() =>
       expect(opsService.exportAuditLogs).toHaveBeenCalledWith({

--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -187,7 +187,7 @@ const AuditPage: React.FC = () => {
     try {
       const csv = await exportAuditLogs(
         buildAuditFilter(
-          searchText,
+          debouncedSearchText,
           selectedType,
           selectedResourceType,
           selectedClusterId,


### PR DESCRIPTION
## What is the purpose of the change

Keep audit CSV export aligned with the filters currently applied to the visible table.

## Brief changelog

- Use the debounced, applied search value for audit export instead of the pending text input.
- Add regression coverage for both an applied search and an immediate export during the debounce window.

## Verifying this change

```bash
cd web
npm test -- --run src/pages/ops/__tests__/AuditPage.test.tsx
npm run build
./node_modules/.bin/eslint --max-warnings=0 \
  src/pages/ops/audit.tsx \
  src/pages/ops/__tests__/AuditPage.test.tsx
```

Closes #1959
