### PR TITLE
fix: set a concrete cluster type in the real cluster provider

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -28,6 +28,7 @@ import org.apache.rocketmq.studio.cluster.nameserver.NameServerVO;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.BrokerStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
+import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -149,6 +150,7 @@ public class RocketMQClusterProvider implements ClusterProvider {
                                      List<NameServerVO> nameServers) {
         ClusterVO cluster = ClusterVO.builder()
                 .name(clusterName)
+                .type(ClusterType.V4_DIRECT)
                 .status(hasUnavailableRuntimeStats(brokers) ? ClusterStatus.warning : ClusterStatus.healthy)
                 .brokers(brokers != null ? brokers : Collections.emptyList())
                 .proxies(Collections.emptyList())

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
@@ -70,6 +70,8 @@ class RocketMQClusterProviderTest {
         assertThat(clusters).hasSize(1);
         ClusterVO cluster = clusters.get(0);
         assertThat(cluster.getName()).isEqualTo("DefaultCluster");
+        // A concrete type is required by AI tool projections (rmq.cluster.list) and must not be null.
+        assertThat(cluster.getType()).isNotNull();
         // Real cluster has no proxies configured - must never be null for the web UI
         assertThat(cluster.getProxies()).isNotNull().isEmpty();
         assertThat(cluster.getTpsHistory()).isNotNull().isEmpty();


### PR DESCRIPTION
## What is the purpose of the change

`RocketMQClusterProvider` (the `@Primary` cluster provider used by `ClusterService.listClusters()`) never set a `ClusterVO.type`, leaving it `null` for every cluster discovered from a live NameServer. The AI tool catalog's `rmq.cluster.list` handler projects `type` with `requiredEnumName(...)`, which throws `IllegalStateException` on a null value — so the most basic cluster tool failed with a 500 on real clusters.

## Brief changelog

- Set `ClusterType.V4_DIRECT` in `buildClusterVO`, matching the sibling `RealClusterProvider` default. This provider only discovers broker topology (proxies are always empty), so a V4 default is the accurate classification.
- Assert a non-null `type` in the safe-defaults discovery test.

## Verifying this change

- `mvn -q -Dtest=RocketMQClusterProviderTest test`
- `mvn -q test` (1056/1056)
- `git diff --check`
