### PR TITLE
fix: expose current Studio build metadata

### DIFF
--- a/web/src/pages/settings/__tests__/AboutTab.test.tsx
+++ b/web/src/pages/settings/__tests__/AboutTab.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+
+import { beforeAll, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AboutTab } from '../index';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+describe('AboutTab', () => {
+  it('shows metadata for the current frontend build', () => {
+    render(<AboutTab />);
+
+    expect(screen.getByText(__STUDIO_VERSION__)).toBeInTheDocument();
+    expect(screen.getByText(__STUDIO_BUILD_TIME__)).toBeInTheDocument();
+    expect(screen.queryByText('2024-01-15 14:30:00')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -602,11 +602,11 @@ export const DataSourceTab = () => {
 
 // ─── About Tab ──────────────────────────────────────────────────────────────
 
-const AboutTab = () => (
+export const AboutTab = () => (
   <div style={{ maxWidth: 800 }}>
     <Descriptions column={1} bordered size="small">
-      <Descriptions.Item label="版本">0.1.0</Descriptions.Item>
-      <Descriptions.Item label="构建时间">2024-01-15 14:30:00</Descriptions.Item>
+      <Descriptions.Item label="版本">{__STUDIO_VERSION__}</Descriptions.Item>
+      <Descriptions.Item label="构建时间">{__STUDIO_BUILD_TIME__}</Descriptions.Item>
       <Descriptions.Item label="RocketMQ 支持版本">4.x / 5.x</Descriptions.Item>
       <Descriptions.Item label="前端框架">React 18 + Ant Design 5</Descriptions.Item>
       <Descriptions.Item label="后端框架">Spring Boot 3 + RocketMQ MCP Server</Descriptions.Item>

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -16,3 +16,6 @@
  */
 
 /// <reference types="vite/client" />
+
+declare const __STUDIO_VERSION__: string;
+declare const __STUDIO_BUILD_TIME__: string;

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -9,6 +9,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,11 +1,17 @@
 import { defineConfig } from 'vitest/config';
 import { loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+import packageMetadata from './package.json';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, '.', '');
+  const buildTime = env.VITE_BUILD_TIME?.trim() || new Date().toISOString();
   return {
     plugins: [react()],
+    define: {
+      __STUDIO_VERSION__: JSON.stringify(packageMetadata.version),
+      __STUDIO_BUILD_TIME__: JSON.stringify(buildTime),
+    },
     build: {
       // Ant Design is shared by the application shell and most route components. Keep it
       // cacheable as one vendor chunk rather than splitting its cyclic internals.


### PR DESCRIPTION
## Summary

- inject the frontend package version into the Vite build
- generate an ISO-8601 build timestamp, with VITE_BUILD_TIME available for reproducible release builds
- show the injected values in Settings > About instead of stale constants
- cover the About metadata rendering with a focused test

Closes #1962

## Track

Track 1 / control-plane operability.

## Validation

- npm test -- --run src/pages/settings/__tests__ (3 files, 9 tests passed)
- npm run build
- VITE_BUILD_TIME=2030-01-02T03:04:05.000Z npm run build, then verified both injected values in dist/assets
- npx eslint vite.config.ts src/pages/settings/index.tsx src/pages/settings/__tests__/AboutTab.test.tsx
- git diff --check