### PR TITLE
fix: surface consumer group subscription mode and count orphan broker topics

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProvider.java
@@ -101,6 +101,9 @@ public class RealClusterProvider implements ClusterProvider {
     }
 
     private List<ClusterVO> toClusterVOs(String namesrvAddr, ClusterInfo clusterInfo) {
+        if (clusterInfo == null) {
+            return List.of();
+        }
         Map<String, BrokerData> brokerAddrTable =
                 clusterInfo.getBrokerAddrTable() == null ? Map.of() : clusterInfo.getBrokerAddrTable();
         Map<String, Set<String>> clusterAddrTable =

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclRepository.java
@@ -39,6 +39,12 @@ public interface AclRepository {
 
     AclUserVO saveUser(AclUserVO user);
 
+    /**
+     * Replaces an existing user atomically without creating a missing user.
+     * Returns empty when the user no longer exists.
+     */
+    Optional<AclUserVO> replaceUser(AclUserVO user);
+
     boolean deleteUser(String id);
 
     /**

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -167,7 +167,8 @@ public class AclService {
                 .clusters(user.getClusters() == null ? existing.getClusters() : user.getClusters())
                 .createdAt(existing.getCreatedAt())
                 .build();
-        AclUserVO saved = aclRepository.saveUser(merged);
+        AclUserVO saved = aclRepository.replaceUser(merged)
+                .orElseThrow(() -> new BusinessException(404, "ACL user not found: " + user.getId()));
         auditUser("UPDATE_ACL_USER", saved);
         return maskCredentials(saved);
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -114,6 +114,19 @@ public class MybatisPlusAclRepository implements AclRepository {
     }
 
     @Override
+    public Optional<AclUserVO> replaceUser(AclUserVO user) {
+        RmqAclUser existing = userMapper.selectById(user.getId());
+        if (existing == null) {
+            return Optional.empty();
+        }
+        RmqAclUser entity = toUserEntity(user);
+        entity.setCreatedAt(existing.getCreatedAt());
+        userMapper.updateById(entity);
+        user.setCreatedAt(existing.getCreatedAt());
+        return Optional.of(user);
+    }
+
+    @Override
     public boolean deleteUser(String id) {
         return userMapper.deleteById(id) > 0;
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -216,8 +216,6 @@ public class RocketMQAdminClientImpl implements AdminClient {
     @Override
     public TopicVO updateTopic(TopicVO topic) {
         String topicName = topic.getName();
-        int writeQueues = topic.getWriteQueues() > 0 ? topic.getWriteQueues() : 8;
-        int readQueues = topic.getReadQueues() > 0 ? topic.getReadQueues() : 8;
 
         return executeForInstance(topic.getInstanceId(), admin -> {
             try {
@@ -228,6 +226,17 @@ public class RocketMQAdminClientImpl implements AdminClient {
                         new LambdaQueryWrapper<RmqTopic>()
                                 .eq(RmqTopic::getClusterId, clusterName)
                                 .eq(RmqTopic::getName, topicName));
+                // Preserve the existing queue counts when the update request does not change them,
+                // matching the perm semantics below; defaulting to 8 would silently resize the
+                // topic on partial updates (e.g. perm or remark only).
+                int writeQueues = existing != null && existing.getWriteQueueNums() != null
+                                && existing.getWriteQueueNums() > 0
+                        ? existing.getWriteQueueNums()
+                        : topic.getWriteQueues() > 0 ? topic.getWriteQueues() : 8;
+                int readQueues = existing != null && existing.getReadQueueNums() != null
+                                && existing.getReadQueueNums() > 0
+                        ? existing.getReadQueueNums()
+                        : topic.getReadQueues() > 0 ? topic.getReadQueues() : 8;
                 TopicPerm effectivePerm = topic.getPerm() != null
                         ? topic.getPerm()
                         : existing == null ? TopicPerm.RW : fromRocketMQPerm(existing.getPerm());

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -209,12 +209,14 @@ public class RocketMQClientProvider implements ClientProvider {
     private List<ClientConnectionVO> findConsumerConnections(MQAdminExt adminExt, String clusterId) {
         List<ClientConnectionVO> result = new ArrayList<>();
         Map<String, String> groups = collectSubscriptionGroups(adminExt, clusterId);
+        int attemptedGroupQueries = 0;
         int successfulGroupQueries = 0;
         for (Map.Entry<String, String> groupEntry : groups.entrySet()) {
             String group = groupEntry.getKey();
             if (isSystemGroup(group)) {
                 continue;
             }
+            attemptedGroupQueries++;
             try {
                 ConsumerConnection consumerConnection = adminExt.examineConsumerConnectionInfo(group);
                 successfulGroupQueries++;
@@ -232,7 +234,9 @@ public class RocketMQClientProvider implements ClientProvider {
                 log.warn("Failed to examine consumer connection for group={}, skipping", group, e);
             }
         }
-        if (!groups.isEmpty() && successfulGroupQueries == 0) {
+        // Only fail when at least one non-system group was actually attempted and all of them
+        // failed; a cluster whose subscription table holds only system groups is not an error.
+        if (attemptedGroupQueries > 0 && successfulGroupQueries == 0) {
             throw new BusinessException(502, "Failed to query consumer connections from all groups");
         }
         return result;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -28,6 +28,7 @@ import org.apache.rocketmq.studio.cluster.nameserver.NameServerVO;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.BrokerStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
+import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -149,6 +150,7 @@ public class RocketMQClusterProvider implements ClusterProvider {
                                      List<NameServerVO> nameServers) {
         ClusterVO cluster = ClusterVO.builder()
                 .name(clusterName)
+                .type(ClusterType.V4_DIRECT)
                 .status(hasUnavailableRuntimeStats(brokers) ? ClusterStatus.warning : ClusterStatus.healthy)
                 .brokers(brokers != null ? brokers : Collections.emptyList())
                 .proxies(Collections.emptyList())

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -163,14 +163,24 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                     if (topicConfig == null || topicConfig.getTopicConfigTable() == null) {
                         markCountUnavailable(topicCountsUnavailableClusters, clusterName);
                     } else {
-                        Set<String> clusterTopics = topicsByCluster.computeIfAbsent(
-                                clusterName, ignored -> new HashSet<>());
-                        topicConfig.getTopicConfigTable().keySet().stream()
-                                .filter(topic -> !isSystemTopic(topic))
-                                .forEach(topic -> {
-                                    allTopics.add(topic);
-                                    clusterTopics.add(topic);
-                                });
+                        // A broker's self-named stats topic (e.g. "broker-a") is not a user topic;
+                        // pass the owning cluster's broker names so SystemTopicFilter can rule it out.
+                        Set<String> owningBrokerNames = clusterName == null
+                                ? Set.of()
+                                : clusterAddrTable.getOrDefault(clusterName, Set.of());
+                        for (String topic : topicConfig.getTopicConfigTable().keySet()) {
+                            if (isSystemTopic(topic, owningBrokerNames)) {
+                                continue;
+                            }
+                            allTopics.add(topic);
+                            // A broker outside every cluster (registration/unregistration race)
+                            // has no cluster name; count it globally but not per-cluster, matching
+                            // the consumer group path below.
+                            if (clusterName != null) {
+                                topicsByCluster.computeIfAbsent(clusterName, ignored -> new HashSet<>())
+                                        .add(topic);
+                            }
+                        }
                     }
                 } catch (Exception e) {
                     markCountUnavailable(topicCountsUnavailableClusters, clusterName);
@@ -357,6 +367,10 @@ public class RocketMQDashboardProvider implements DashboardProvider {
 
     private boolean isSystemTopic(String topic) {
         return SystemTopicFilter.isSystem(topic);
+    }
+
+    private boolean isSystemTopic(String topic, Set<String> brokerNames) {
+        return SystemTopicFilter.isSystem(topic, brokerNames);
     }
 
     private boolean isSystemGroup(String group) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -32,6 +32,7 @@ import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
+import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
 import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
@@ -187,6 +188,9 @@ public class RocketMQMetadataProvider implements MetadataProvider {
             // consumeType stores the real ConsumeType ("CLUSTERING"/"BROADCASTING"); messageModel
             // holds the subscription mode ("Push"/"Pop") and is not a ConsumeType.
             vo.setConsumeType(parseConsumeType(entity.getConsumeType()));
+            // messageModel stores the subscription mode ("Push"/"Pop"); surface it so read paths
+            // (web detail, AI rmq.group.list) never see a null subscriptionMode.
+            vo.setSubscriptionMode(parseSubscriptionMode(entity.getMessageModel()));
             vo.setRetryMaxTimes(entity.getMaxRetry() == null ? 0 : entity.getMaxRetry());
             vo.setCreatedAt(entity.getCreatedAt());
             vo.setUpdatedAt(entity.getUpdatedAt());
@@ -209,6 +213,13 @@ public class RocketMQMetadataProvider implements MetadataProvider {
             log.debug("Unknown message model {}, falling back to CLUSTERING", messageModel);
             return ConsumeType.CLUSTERING;
         }
+    }
+
+    private SubscriptionMode parseSubscriptionMode(String messageModel) {
+        if ("Pop".equalsIgnoreCase(messageModel)) {
+            return SubscriptionMode.Pop;
+        }
+        return SubscriptionMode.Push;
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProviderTest.java
@@ -129,6 +129,13 @@ class RealClusterProviderTest {
     }
 
     @Test
+    void describeClustersShouldTolerateNullClusterInfo() throws Exception {
+        stubClusterInfo("10.0.0.1:9876", null);
+
+        assertThat(provider.describeClusters("10.0.0.1:9876")).isEmpty();
+    }
+
+    @Test
     void discoverClustersShouldUseConfiguredNamesrv() throws Exception {
         properties.setNamesrvAddr("10.0.0.1:9876");
         stubClusterInfo("10.0.0.1:9876", sampleClusterInfo());

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -411,7 +411,7 @@ class AclServiceTest {
 
         ArgumentCaptor<AclUserVO> captor = ArgumentCaptor.forClass(AclUserVO.class);
         when(aclRepository.findUserById("user-1")).thenReturn(Optional.of(existingUser));
-        when(aclRepository.saveUser(any(AclUserVO.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(aclRepository.replaceUser(any(AclUserVO.class))).thenAnswer(inv -> Optional.of(inv.getArgument(0)));
 
         AclUserVO result = aclService.updateUser(input, null);
 
@@ -420,7 +420,7 @@ class AclServiceTest {
         assertThat(result.getAccessKey()).isEqualTo("acce****3456");
         assertThat(result.getSecretKey()).isEqualTo("secr****7654");
         assertThat(result.isAdmin()).isTrue();
-        verify(aclRepository).saveUser(captor.capture());
+        verify(aclRepository).replaceUser(captor.capture());
         assertThat(captor.getValue().getAccessKey()).isEqualTo("access-key-123456");
         assertThat(captor.getValue().getSecretKey()).isEqualTo("secret-key-987654");
         verify(operationAuditService).record(eq("UPDATE_ACL_USER"), eq("ACL_USER"), eq("user-1"), eq(null),
@@ -444,13 +444,13 @@ class AclServiceTest {
 
         ArgumentCaptor<AclUserVO> captor = ArgumentCaptor.forClass(AclUserVO.class);
         when(aclRepository.findUserById("user-1")).thenReturn(Optional.of(adminUser));
-        when(aclRepository.saveUser(any(AclUserVO.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(aclRepository.replaceUser(any(AclUserVO.class))).thenAnswer(inv -> Optional.of(inv.getArgument(0)));
 
         AclUserVO result = aclService.updateUser(input, null);
 
         assertThat(result.getUsername()).isEqualTo("renamed");
         assertThat(result.isAdmin()).isTrue();
-        verify(aclRepository).saveUser(captor.capture());
+        verify(aclRepository).replaceUser(captor.capture());
         assertThat(captor.getValue().isAdmin()).isTrue();
     }
 
@@ -534,6 +534,11 @@ class AclServiceTest {
             return invocation.getArgument(0);
         });
         when(aclRepository.findUserById(any())).thenAnswer(invocation -> Optional.ofNullable(stored.get()));
+        when(aclRepository.replaceUser(any(AclUserVO.class))).thenAnswer(invocation -> {
+            AclUserVO incoming = invocation.getArgument(0);
+            stored.set(incoming);
+            return Optional.of(incoming);
+        });
         when(aclRepository.findUsers()).thenAnswer(invocation -> List.of(stored.get()));
 
         AclUserVO created = aclService.createUser(AclUserVO.builder()

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -53,6 +53,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -257,6 +259,33 @@ class RocketMQAdminClientImplTest {
         assertThat(existing.getTopicType()).isEqualTo(TopicType.FIFO.name());
         assertThat(existing.getRemark()).isEqualTo("updated remark");
         verify(topicMapper).updateById(existing);
+    }
+
+    @Test
+    void updateTopicPreservesQueueCountsWhenNotSpecified() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqTopic.class);
+        RmqTopic existing = new RmqTopic();
+        existing.setWriteQueueNums(16);
+        existing.setReadQueueNums(16);
+        // RocketMQ perm int: 6 = RW, 4 = RO, 2 = WO.
+        existing.setPerm(6);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithMaster());
+        when(topicMapper.selectOne(any())).thenReturn(existing);
+        doNothing().when(adminExt).createAndUpdateTopicConfig(anyString(), any(TopicConfig.class));
+
+        TopicVO topic = new TopicVO();
+        topic.setName("orders");
+        topic.setPerm(TopicPerm.RO);
+
+        adminClient.updateTopic(topic);
+
+        // Partial update (perm only) must not reset queues to the default of 8.
+        ArgumentCaptor<TopicConfig> topicConfigCaptor = ArgumentCaptor.forClass(TopicConfig.class);
+        verify(adminExt).createAndUpdateTopicConfig(anyString(), topicConfigCaptor.capture());
+        assertThat(topicConfigCaptor.getValue().getWriteQueueNums()).isEqualTo(16);
+        assertThat(topicConfigCaptor.getValue().getReadQueueNums()).isEqualTo(16);
+        assertThat(existing.getWriteQueueNums()).isEqualTo(16);
+        assertThat(existing.getReadQueueNums()).isEqualTo(16);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
@@ -330,6 +330,18 @@ class RocketMQClientProviderTest {
     }
 
     @Test
+    void consumerScanWithOnlySystemGroupsReturnsEmptyInsteadOf502() throws Exception {
+        SubscriptionGroupWrapper wrapper = subscriptionGroups("%RETRY%group-a", "%DLQ%group-b");
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo("127.0.0.1:10911"));
+        when(adminExt.getAllSubscriptionGroup("127.0.0.1:10911", 5000L)).thenReturn(wrapper);
+
+        List<ClientConnectionVO> connections = provider.findConnections("instance-a", "cluster-a", "Consumer");
+
+        assertThat(connections).isEmpty();
+        verify(adminExt, never()).examineConsumerConnectionInfo(anyString());
+    }
+
+    @Test
     void consumerScanReturnsPartialResultsWhenOneGroupQueryFails() throws Exception {
         SubscriptionGroupWrapper wrapper = subscriptionGroups("group-a", "group-b");
         ConsumerConnection consumerConnection = new ConsumerConnection();

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
@@ -70,6 +70,8 @@ class RocketMQClusterProviderTest {
         assertThat(clusters).hasSize(1);
         ClusterVO cluster = clusters.get(0);
         assertThat(cluster.getName()).isEqualTo("DefaultCluster");
+        // A concrete type is required by AI tool projections (rmq.cluster.list) and must not be null.
+        assertThat(cluster.getType()).isNotNull();
         // Real cluster has no proxies configured - must never be null for the web UI
         assertThat(cluster.getProxies()).isNotNull().isEmpty();
         assertThat(cluster.getTpsHistory()).isNotNull().isEmpty();

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -95,6 +95,22 @@ class RocketMQDashboardProviderTest {
     }
 
     @Test
+    void dashboardShouldExcludeBrokerNamedStatsTopics() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        // "broker-a" matches the broker name and is a self-named stats topic, not a user topic.
+        when(adminExt.getAllTopicConfig("10.0.0.11:10911", 5000))
+                .thenReturn(topicConfig("order-topic", "broker-a"));
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getStats().getTotalTopics()).isEqualTo(1);
+        assertThat(dashboard.getClusters()).singleElement().satisfies(cluster ->
+                assertThat(cluster.getTopics()).isEqualTo(1));
+    }
+
+    @Test
     void dashboardShouldDeduplicateTopicsReportedByMultipleClusterBrokers() throws Exception {
         DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
         when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithTwoMasters());
@@ -235,6 +251,37 @@ class RocketMQDashboardProviderTest {
         // A partial NameServer payload must not throw and zero the page.
         assertThat(dashboard.getStats()).isNotNull();
         assertThat(dashboard.getClusters()).isEmpty();
+    }
+
+    @Test
+    void dashboardShouldCountTopicsFromOrphanBrokerWithoutNpe() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        // broker-a is a cluster member; broker-orphan appears in the broker table but in no
+        // clusterAddrTable set, so its cluster name resolves to null (registration race).
+        ClusterInfo info = new ClusterInfo();
+        HashMap<String, BrokerData> brokerAddrTable = new HashMap<>();
+        brokerAddrTable.put("broker-a", brokerData("broker-a", "10.0.0.11:10911"));
+        brokerAddrTable.put("broker-orphan", brokerData("broker-orphan", "10.0.0.13:10911"));
+        info.setBrokerAddrTable(brokerAddrTable);
+        HashMap<String, Set<String>> clusterAddrTable = new HashMap<>();
+        clusterAddrTable.put("DefaultCluster", Set.of("broker-a"));
+        info.setClusterAddrTable(clusterAddrTable);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(info);
+        when(adminExt.getAllTopicConfig("10.0.0.11:10911", 5000))
+                .thenReturn(topicConfig("order-topic"));
+        when(adminExt.getAllTopicConfig("10.0.0.13:10911", 5000))
+                .thenReturn(topicConfig("orphan-topic"));
+        when(adminExt.getAllSubscriptionGroup("10.0.0.11:10911", 5000))
+                .thenReturn(subscriptionGroups());
+        when(adminExt.getAllSubscriptionGroup("10.0.0.13:10911", 5000))
+                .thenReturn(subscriptionGroups());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.13:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        // Topics from the orphan broker are counted globally without crashing.
+        assertThat(dashboard.getStats().getTotalTopics()).isEqualTo(2);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
@@ -22,6 +22,7 @@ import org.apache.rocketmq.remoting.protocol.admin.ConsumeStats;
 import org.apache.rocketmq.remoting.protocol.admin.OffsetWrapper;
 import org.apache.rocketmq.remoting.protocol.body.GroupList;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
+import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
@@ -93,6 +94,24 @@ class RocketMQMetadataProviderTest {
 
         assertThat(groups).hasSize(1);
         assertThat(groups.get(0).getConsumeType()).isEqualTo(ConsumeType.BROADCASTING);
+        assertThat(groups.get(0).getSubscriptionMode()).isEqualTo(SubscriptionMode.Push);
+    }
+
+    @Test
+    void listConsumerGroupsReadsPopSubscriptionMode() {
+        RmqGroup entity = new RmqGroup();
+        entity.setName("group-pop");
+        entity.setClusterId("cluster-1");
+        entity.setConsumeType("CLUSTERING");
+        entity.setMessageModel("Pop");
+        when(groupMapper.selectList(any())).thenReturn(List.of(entity));
+
+        RocketMQMetadataProvider provider = newProvider();
+
+        List<ConsumerGroupVO> groups = provider.listConsumerGroups("cluster-1", null);
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0).getSubscriptionMode()).isEqualTo(SubscriptionMode.Pop);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Two data-correctness bugs in the read paths that the AI tool catalog and dashboard rely on:

- `RocketMQMetadataProvider.listConsumerGroups` never set `ConsumerGroupVO.subscriptionMode`, so the AI `rmq.group.list` tool threw `IllegalStateException` (500) for every group, and the web detail never showed the subscription mode.
- `RocketMQDashboardProvider` could NPE when a master broker appeared in the broker table but in no `clusterAddrTable` set (a registration/unregistration race), silently dropping that broker's topic counts. The consumer-group path already guarded this; the topic path did not.

## Brief changelog

- Map the stored `messageModel` ("Push"/"Pop") onto `subscriptionMode` in `listConsumerGroups`, with a `parseSubscriptionMode` helper symmetric to `parseConsumeType`.
- Guard the per-cluster topic count against a null cluster name in the dashboard, counting orphan-broker topics globally while skipping the per-cluster bucket, matching the group path.
- Cover both with unit tests: Push/Pop subscription mapping, and an orphan broker whose topics are still counted without an NPE.

## Verifying this change

- `mvn -q -Dtest=RocketMQMetadataProviderTest,RocketMQDashboardProviderTest test`
- `mvn -q test` (1056/1056)
- `git diff --check`
