### PR TITLE
[Studio] fix: preserve AI chat HTTP error messages

### DIFF
--- a/web/src/api/ai.test.ts
+++ b/web/src/api/ai.test.ts
@@ -180,6 +180,30 @@ describe('AI API', () => {
         status: 400,
       } satisfies Partial<AiStreamError>);
     });
+
+    it('throws backend error messages from failed HTTP responses', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              code: 400,
+              message: 'Chat request is required',
+              data: null,
+            }),
+            { status: 400, statusText: 'Bad Request' },
+          ),
+        ),
+      );
+
+      await expect(
+        chatStream({ message: '', mode: 'chat', model: 'stub' }, vi.fn()),
+      ).rejects.toMatchObject({
+        name: 'AiStreamError',
+        message: 'Chat request is required',
+        status: 400,
+      } satisfies Partial<AiStreamError>);
+    });
   });
 
   describe('executeAiCommand', () => {

--- a/web/src/api/ai.ts
+++ b/web/src/api/ai.ts
@@ -110,6 +110,33 @@ function parseStreamError(payload: string): AiStreamError {
   }
 }
 
+async function parseHttpError(response: Response): Promise<AiStreamError> {
+  const fallback = response.statusText || `HTTP ${response.status}`;
+  try {
+    const payload = await response.text();
+    if (!payload.trim()) {
+      return new AiStreamError(
+        `AI chat failed: ${fallback}`,
+        undefined,
+        undefined,
+        response.status,
+      );
+    }
+    try {
+      const parsed = JSON.parse(payload) as AiStreamPayload;
+      const message = typeof parsed.message === 'string' ? parsed.message : payload;
+      const code = typeof parsed.code === 'string' ? parsed.code : undefined;
+      const hint = typeof parsed.hint === 'string' ? parsed.hint : undefined;
+      const status = typeof parsed.status === 'number' ? parsed.status : response.status;
+      return new AiStreamError(message, code, hint, status);
+    } catch {
+      return new AiStreamError(payload, undefined, undefined, response.status);
+    }
+  } catch {
+    return new AiStreamError(`AI chat failed: ${fallback}`, undefined, undefined, response.status);
+  }
+}
+
 function emitEvent(
   event: string,
   onChunk: (text: string) => void,
@@ -170,7 +197,10 @@ export async function chatStream(
     signal,
   });
 
-  if (!response.ok || !response.body) {
+  if (!response.ok) {
+    throw await parseHttpError(response);
+  }
+  if (!response.body) {
     throw new Error(`AI chat failed: ${response.statusText}`);
   }
 


### PR DESCRIPTION
## What is the purpose of the change

Preserve backend error messages from failed AI chat HTTP responses before the SSE stream is opened.

The AI chat API uses `fetch` directly, so it does not use the shared axios response interceptor. When the backend returns a standard error payload such as `{ code, message, data }`, the UI previously replaced the real message with a generic `AI chat failed: Bad Request`.

## Brief changelog

- Parse failed AI chat HTTP response bodies before falling back to `statusText`.
- Throw `AiStreamError` with the backend message and HTTP status.
- Add regression coverage for standard backend error payloads.

## Verifying this change

- `git diff --check`
- `npm test -- --run src/api/ai.test.ts`
- `./node_modules/.bin/eslint --max-warnings=0 src/api/ai.ts src/api/ai.test.ts`