### PR TITLE
[studio][ISSUE #1968] Validate resource plan subscribed topics

### DIFF
--- a/web/src/services/resourcePlanService.test.ts
+++ b/web/src/services/resourcePlanService.test.ts
@@ -115,4 +115,33 @@ describe('resource plan service', () => {
       { field: 'writeQueues', currentValue: '16', desiredValue: '32' },
     ]);
   });
+
+  it('marks malformed subscribedTopics as invalid without aborting the preview', async () => {
+    topicServiceMocks.listTopics.mockResolvedValue([]);
+    consumerServiceMocks.listConsumerGroups.mockResolvedValue([existingGroup]);
+
+    const bundle = parseResourceBundle(`{
+      "consumerGroups": [
+        {"name": "cg-new", "subscribedTopics": "order-create"},
+        {"name": "cg-order-notify", "subscribedTopics": ["order-create", 42]}
+      ]
+    }`);
+    const plan = await previewResourcePlan({ instanceId: 'instance-proxy-1', ...bundle });
+
+    expect(plan.summary).toMatchObject({ total: 2, invalids: 2, applicable: 0 });
+    expect(plan.entries).toEqual([
+      expect.objectContaining({
+        name: 'cg-new',
+        action: 'INVALID',
+        applicable: false,
+        reason: 'Consumer group subscribedTopics must be an array of strings',
+      }),
+      expect.objectContaining({
+        name: 'cg-order-notify',
+        action: 'INVALID',
+        applicable: false,
+        reason: 'Consumer group subscribedTopics must be an array of strings',
+      }),
+    ]);
+  });
 });

--- a/web/src/services/resourcePlanService.ts
+++ b/web/src/services/resourcePlanService.ts
@@ -271,6 +271,14 @@ function planConsumerGroupEntries(
         'Consumer group delaySeconds must be zero or positive',
       );
     }
+    if (!isStringArrayOrUndefined(group.subscribedTopics)) {
+      return invalidEntry(
+        'CONSUMER_GROUP',
+        name,
+        index,
+        'Consumer group subscribedTopics must be an array of strings',
+      );
+    }
 
     const existing = existingGroups.get(name);
     if (!existing) {
@@ -392,4 +400,11 @@ function sortedTopics(topics?: string[]): string | undefined {
     .map((topic) => topic.trim())
     .sort()
     .join(',');
+}
+
+function isStringArrayOrUndefined(value: unknown): value is string[] | undefined {
+  return (
+    value === undefined ||
+    (Array.isArray(value) && value.every((item) => typeof item === 'string'))
+  );
 }


### PR DESCRIPTION
## Summary
- validate the runtime shape of Consumer Group subscribedTopics before planning
- mark malformed rows as INVALID instead of actionable CREATE entries
- prevent malformed topic arrays from aborting comparison against existing groups
- cover both new and existing Consumer Group paths with a parsed JSON regression test

Closes #1968

## Validation
- npm test -- --run src/services/resourcePlanService.test.ts
- npx eslint src/services/resourcePlanService.ts src/services/resourcePlanService.test.ts
- npm run build
- git diff --check