### PR TITLE
[studio][ISSUE #1970] Hide unsupported general settings controls

### DIFF
--- a/web/src/pages/settings/__tests__/GeneralSettingsTab.test.tsx
+++ b/web/src/pages/settings/__tests__/GeneralSettingsTab.test.tsx
@@ -72,4 +72,32 @@ describe('GeneralSettingsTab', () => {
 
     await waitFor(() => expect(saveGeneralSettings).toHaveBeenCalledTimes(1));
   });
+
+  it('hides unsupported appearance and notification controls while preserving their values', async () => {
+    vi.mocked(saveGeneralSettings).mockResolvedValue();
+    render(
+      <App>
+        <GeneralSettingsTab />
+      </App>,
+    );
+
+    const saveButton = await screen.findByRole('button', { name: '保存设置' });
+    expect(screen.queryByText('主题模式')).not.toBeInTheDocument();
+    expect(screen.queryByText('紧凑模式')).not.toBeInTheDocument();
+    expect(screen.queryByText('桌面通知')).not.toBeInTheDocument();
+    expect(screen.queryByText('通知声音')).not.toBeInTheDocument();
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() =>
+      expect(saveGeneralSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          theme: 'system',
+          compact: false,
+          desktopNotify: false,
+          notifySound: false,
+        }),
+      ),
+    );
+  });
 });

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -86,6 +86,10 @@ const DATA_SOURCE_TYPE_OPTIONS = [
 ];
 
 type DataSourceFormValues = Partial<DataSource>;
+type CompatibilitySettings = Pick<
+  GeneralSettingsUpdate,
+  'theme' | 'compact' | 'desktopNotify' | 'notifySound'
+>;
 
 const secretFieldNames = ['username', 'password', 'bearerToken'] as const;
 const authNeedsSecret = (auth?: string) => auth === 'Basic Auth' || auth === 'Bearer Token';
@@ -111,6 +115,12 @@ export const GeneralSettingsTab = () => {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const saveInFlightRef = useRef(false);
+  const compatibilitySettingsRef = useRef<CompatibilitySettings>({
+    theme: 'system',
+    compact: false,
+    desktopNotify: false,
+    notifySound: false,
+  });
   const [apiKeyConfigured, setApiKeyConfigured] = useState(false);
   const clearApiKey = Form.useWatch('clearApiKey', form);
 
@@ -120,6 +130,12 @@ export const GeneralSettingsTab = () => {
       .then((settings) => {
         if (!cancelled) {
           setApiKeyConfigured(settings.apiKeyConfigured);
+          compatibilitySettingsRef.current = {
+            theme: settings.theme,
+            compact: settings.compact,
+            desktopNotify: settings.desktopNotify,
+            notifySound: settings.notifySound,
+          };
           form.setFieldsValue({ ...settings, apiKey: undefined, clearApiKey: false });
         }
       })
@@ -140,7 +156,7 @@ export const GeneralSettingsTab = () => {
     saveInFlightRef.current = true;
     setSaving(true);
     try {
-      await saveGeneralSettings(values);
+      await saveGeneralSettings({ ...values, ...compatibilitySettingsRef.current });
       setApiKeyConfigured(
         values.clearApiKey ? false : apiKeyConfigured || Boolean(values.apiKey?.trim()),
       );
@@ -163,12 +179,6 @@ export const GeneralSettingsTab = () => {
       onFinish={handleFinish}
       style={{ maxWidth: 800 }}
     >
-      {(['theme', 'compact', 'desktopNotify', 'notifySound'] as const).map((name) => (
-        <Form.Item key={name} name={name} hidden>
-          <Input type="hidden" />
-        </Form.Item>
-      ))}
-
       {/* ── 安全 ── */}
       <Divider orientation="left">
         <Title level={5} style={{ margin: 0 }}>

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -27,10 +27,8 @@ import {
   InputNumber,
   Modal,
   Popconfirm,
-  Radio,
   Select,
   Space,
-  Switch,
   Table,
   Tabs,
   Tag,
@@ -165,44 +163,11 @@ export const GeneralSettingsTab = () => {
       onFinish={handleFinish}
       style={{ maxWidth: 800 }}
     >
-      {/* ── 外观 ── */}
-      <Divider orientation="left">
-        <Title level={5} style={{ margin: 0 }}>
-          外观
-        </Title>
-      </Divider>
-
-      <Form.Item label="主题模式" name="theme">
-        <Radio.Group>
-          <Radio value="light">浅色</Radio>
-          <Radio value="dark">深色</Radio>
-          <Radio value="system">跟随系统</Radio>
-        </Radio.Group>
-      </Form.Item>
-
-      <Form.Item label="紧凑模式" name="compact" valuePropName="checked">
-        <Switch />
-      </Form.Item>
-
-      {/* ── 通知 ── */}
-      <Divider orientation="left">
-        <Title level={5} style={{ margin: 0 }}>
-          通知
-        </Title>
-      </Divider>
-
-      <Form.Item
-        label="桌面通知"
-        name="desktopNotify"
-        valuePropName="checked"
-        extra="启用后将通过浏览器推送告警通知"
-      >
-        <Switch />
-      </Form.Item>
-
-      <Form.Item label="通知声音" name="notifySound" valuePropName="checked">
-        <Switch />
-      </Form.Item>
+      {(['theme', 'compact', 'desktopNotify', 'notifySound'] as const).map((name) => (
+        <Form.Item key={name} name={name} hidden>
+          <Input type="hidden" />
+        </Form.Item>
+      ))}
 
       {/* ── 安全 ── */}
       <Divider orientation="left">


### PR DESCRIPTION
## Summary
- remove visible General Settings controls that have no runtime effect
- keep persisted compatibility values in hidden form fields so existing backend settings are preserved
- leave the working header theme toggle unchanged
- cover visibility and save-payload preservation with a regression test

Closes #1970

## Validation
- npm test -- --run src/pages/settings/__tests__/GeneralSettingsTab.test.tsx
- npx eslint src/pages/settings/index.tsx src/pages/settings/__tests__/GeneralSettingsTab.test.tsx
- npm run build
- git diff --check