### PR TITLE
[studio][ISSUE #1972] Require persistent storage for remote deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@ on:
       - rocketmq-studio
 
 jobs:
+  deploy-script-test:
+    name: Deploy Script Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate remote deployment contract
+        run: bash deploy/deploy_test.sh
+
   backend-build:
     name: Backend Build (Java 21)
     runs-on: ubuntu-latest

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -12,6 +12,15 @@ REMOTE_PATH=/opt/rocketmq-studio
 # Frontend public port
 PUBLIC_PORT=6789
 
+# Required by deploy.sh server/all. The database must be reachable from the
+# remote Podman network and initialized with the Studio schema.
+SPRING_DATASOURCE_URL=jdbc:mysql://database-host:3306/rocketmq?useSSL=false&serverTimezone=UTC
+SPRING_DATASOURCE_USERNAME=rocketmq
+SPRING_DATASOURCE_PASSWORD=change-me
+
+# Optional default NameServer endpoint used by the Apache provider.
+STUDIO_ROCKETMQ_NAMESRV_ADDR=
+
 # Login protection is disabled by default for local development.
 # Set STUDIO_AUTH_LOGIN_REQUIRED=true and provide credentials in shared environments.
 STUDIO_AUTH_LOGIN_REQUIRED=false

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -21,12 +21,22 @@ REMOTE_USER=root
 REMOTE_PATH=/opt/rocketmq-studio
 PUBLIC_PORT=8080
 
+# deploy.sh server/all 必填：数据库需可从远程 Podman 网络访问
+SPRING_DATASOURCE_URL=jdbc:mysql://database-host:3306/rocketmq?useSSL=false&serverTimezone=UTC
+SPRING_DATASOURCE_USERNAME=rocketmq
+SPRING_DATASOURCE_PASSWORD=change-me
+
+# 可选：Apache RocketMQ 默认 NameServer 地址
+STUDIO_ROCKETMQ_NAMESRV_ADDR=nameserver.example.com:9876
+
 # 可选：自定义宿主机 Maven 缓存和构建镜像
 MAVEN_CACHE_DIR=/home/your-user/.m2
 MAVEN_IMAGE=maven:3.9.9-eclipse-temurin-21
 ```
 
 `MAVEN_CACHE_DIR` 默认为当前用户的 `~/.m2`。如果其中存在 `settings.xml`，构建容器也会自动使用该配置。
+远程后端固定使用 `prod` profile；脚本会在构建前校验数据库配置，避免容器退回开发环境的
+内存 H2。首次使用前请先在目标数据库执行 `server/src/main/resources/db/schema.sql`。
 
 ## 本地 Docker Compose
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -30,15 +30,25 @@ if [[ -f "$SCRIPT_DIR/.env" ]]; then
   set +a
 fi
 
-[[ -n "${REMOTE_HOST:-}" ]] || err "REMOTE_HOST 未配置，请在 deploy/.env 中设置"
-REMOTE="${REMOTE_USER:-root}@$REMOTE_HOST"
+TARGET="${1:-all}"  # all | server | web
+REMOTE="${REMOTE_USER:-root}@${REMOTE_HOST:-}"
 REMOTE_PATH="${REMOTE_PATH:-/opt/rocketmq-studio}"
 NETWORK="${PODMAN_NETWORK:-rocketmq-studio}"
 TMP_DIR="/tmp/rocketmq-studio-deploy"
 MAVEN_IMAGE="${MAVEN_IMAGE:-maven:3.9.9-eclipse-temurin-21}"
 MAVEN_CACHE_DIR="${MAVEN_CACHE_DIR:-$HOME/.m2}"
 
-TARGET="${1:-all}"  # all | server | web
+validate_config() {
+  [[ -n "${REMOTE_HOST:-}" ]] || err "REMOTE_HOST 未配置，请在 deploy/.env 中设置"
+  if [[ "$TARGET" == "all" || "$TARGET" == "server" ]]; then
+    [[ -n "${SPRING_DATASOURCE_URL:-}" ]] \
+      || err "SPRING_DATASOURCE_URL 未配置，远程部署必须使用持久化数据库"
+    [[ -n "${SPRING_DATASOURCE_USERNAME:-}" ]] \
+      || err "SPRING_DATASOURCE_USERNAME 未配置，远程部署必须使用持久化数据库"
+    [[ -n "${SPRING_DATASOURCE_PASSWORD:-}" ]] \
+      || err "SPRING_DATASOURCE_PASSWORD 未配置，远程部署必须使用持久化数据库"
+  fi
+}
 
 # ─── 前置检查 ───
 check_prereqs() {
@@ -135,6 +145,11 @@ deploy_remote() {
         --name rocketmq-server \
         --network $NETWORK \
         --restart unless-stopped \
+        -e SPRING_PROFILES_ACTIVE=\"prod\" \
+        -e SPRING_DATASOURCE_URL=\"${SPRING_DATASOURCE_URL}\" \
+        -e SPRING_DATASOURCE_USERNAME=\"${SPRING_DATASOURCE_USERNAME}\" \
+        -e SPRING_DATASOURCE_PASSWORD=\"${SPRING_DATASOURCE_PASSWORD}\" \
+        -e STUDIO_ROCKETMQ_NAMESRV_ADDR=\"${STUDIO_ROCKETMQ_NAMESRV_ADDR:-}\" \
         -e STUDIO_AUTH_LOGIN_REQUIRED=\"${STUDIO_AUTH_LOGIN_REQUIRED:-true}\" \
         -e STUDIO_AUTH_ADMIN_USERNAME=\"${STUDIO_AUTH_ADMIN_USERNAME:-}\" \
         -e STUDIO_AUTH_ADMIN_PASSWORD=\"${STUDIO_AUTH_ADMIN_PASSWORD:-}\" \
@@ -197,6 +212,7 @@ main() {
   echo "═══════════════════════════════════════════"
   echo ""
 
+  validate_config
   check_prereqs
 
   case "$TARGET" in
@@ -212,5 +228,7 @@ main() {
   cleanup
 }
 
-trap cleanup EXIT
-main
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  trap cleanup EXIT
+  main
+fi

--- a/deploy/deploy_test.sh
+++ b/deploy/deploy_test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+export REMOTE_HOST="example.test"
+export SPRING_DATASOURCE_URL="jdbc:mysql://db.example.test:3306/rocketmq"
+export SPRING_DATASOURCE_USERNAME="rocketmq"
+export SPRING_DATASOURCE_PASSWORD="secret"
+export STUDIO_ROCKETMQ_NAMESRV_ADDR="nameserver.example.test:9876"
+
+# shellcheck source=deploy.sh
+source "$SCRIPT_DIR/deploy.sh"
+
+if (
+  TARGET=server
+  unset SPRING_DATASOURCE_URL
+  validate_config
+) >/dev/null 2>&1; then
+  echo "expected server deployment validation to reject a missing datasource URL" >&2
+  exit 1
+fi
+
+(
+  TARGET=web
+  unset SPRING_DATASOURCE_URL SPRING_DATASOURCE_USERNAME SPRING_DATASOURCE_PASSWORD
+  validate_config
+)
+
+capture_file="$(mktemp)"
+trap 'rm -f "$capture_file"' EXIT
+
+ssh() {
+  printf '%s\n' "$*" >> "$capture_file"
+}
+
+TARGET=server
+REMOTE="root@example.test"
+REMOTE_PATH="/opt/rocketmq-studio"
+NETWORK="rocketmq-studio"
+deploy_remote >/dev/null
+
+grep -F 'SPRING_PROFILES_ACTIVE="prod"' "$capture_file" >/dev/null
+grep -F 'SPRING_DATASOURCE_URL="jdbc:mysql://db.example.test:3306/rocketmq"' "$capture_file" >/dev/null
+grep -F 'SPRING_DATASOURCE_USERNAME="rocketmq"' "$capture_file" >/dev/null
+grep -F 'SPRING_DATASOURCE_PASSWORD="secret"' "$capture_file" >/dev/null
+grep -F 'STUDIO_ROCKETMQ_NAMESRV_ADDR="nameserver.example.test:9876"' "$capture_file" >/dev/null
+
+echo "deploy.sh tests passed"


### PR DESCRIPTION
## Summary
- fail remote server deployments before build when persistent datasource settings are missing
- run the remote backend with the prod profile and forward datasource and NameServer configuration
- document the required remote database contract in the environment example and deployment guide
- add a deterministic deploy script regression test and run it in CI

Closes #1972

## Validation
- bash -n deploy/deploy.sh deploy/deploy_test.sh
- bash deploy/deploy_test.sh
- git diff --check