### PR TITLE
fix: reject hosts whose any resolved address is unsafe in UrlHostGuard

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/UrlHostGuard.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/UrlHostGuard.java
@@ -99,12 +99,17 @@ public final class UrlHostGuard {
             return allowLoopback;
         }
         try {
-            InetAddress address = InetAddress.getByName(normalized);
-            if (address.isAnyLocalAddress() || address.isLinkLocalAddress()) {
-                return false;
-            }
-            if (address.isLoopbackAddress()) {
-                return allowLoopback;
+            // getByName only resolves the first record; a host with multiple A/AAAA records can
+            // point both at a public address and at loopback/link-local/metadata. Reject the host
+            // when any resolved address is restricted, matching SettingsService behaviour.
+            InetAddress[] addresses = InetAddress.getAllByName(normalized);
+            for (InetAddress address : addresses) {
+                if (address.isAnyLocalAddress() || address.isLinkLocalAddress()) {
+                    return false;
+                }
+                if (address.isLoopbackAddress() && !allowLoopback) {
+                    return false;
+                }
             }
             return true;
         } catch (UnknownHostException exception) {

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UrlHostGuardTest {
+
+    @Test
+    void rejectsLoopbackWhenNotAllowed() {
+        assertThat(UrlHostGuard.isAllowedHost("127.0.0.1", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("localhost", false)).isFalse();
+    }
+
+    @Test
+    void allowsLoopbackWhenExplicitlyEnabled() {
+        assertThat(UrlHostGuard.isAllowedHost("127.0.0.1", true)).isTrue();
+        assertThat(UrlHostGuard.isAllowedHost("localhost", true)).isTrue();
+    }
+
+    @Test
+    void rejectsLinkLocalAndAnyLocalAddresses() {
+        assertThat(UrlHostGuard.isAllowedHost("169.254.169.254", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("0.0.0.0", false)).isFalse();
+    }
+
+    @Test
+    void allowsPublicAndPrivateEndpointAddresses() {
+        assertThat(UrlHostGuard.isAllowedHost("10.0.0.1", false)).isTrue();
+        assertThat(UrlHostGuard.isAllowedHost("192.168.1.10", false)).isTrue();
+        assertThat(UrlHostGuard.isAllowedHost("8.8.8.8", false)).isTrue();
+    }
+
+    @Test
+    void rejectsBlankAndUnresolvableHosts() {
+        assertThat(UrlHostGuard.isAllowedHost(null, false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("  ", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("definitely-not-a-real-host.invalid", false)).isFalse();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

`UrlHostGuard.isAllowedHost` resolved the host with `InetAddress.getByName`, which only returns the **first** DNS record. A host with multiple A/AAAA records (round-robin or wildcard DNS) can point both at a public address and at loopback / link-local / cloud-metadata addresses; the guard would see the public record, allow the host, and the HTTP client's independent resolution could then connect to the internal address. The same class of issue was already fixed for data sources in #1556, but the shared `UrlHostGuard` was left behind.

## Brief changelog

- Resolve all addresses with `InetAddress.getAllByName` and reject the host when *any* resolved address is any-local, link-local, or loopback (when loopback is not allowed), matching `SettingsService.areAllowedDataSourceAddresses`.
- Add a `UrlHostGuardTest` covering loopback gating, link-local/any-local rejection, public endpoints, and unresolvable hosts.

## Verifying this change

- `mvn -q -Dtest=UrlHostGuardTest test`
- `mvn -q test` (1056/1056)
- `git diff --check`
