### PR TITLE
[Studio] fix: preserve REST API error messages

### DIFF
--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -90,6 +90,17 @@ describe('API client response contract', () => {
     expect(message.error).toHaveBeenCalledWith('Topic already exists');
   });
 
+  it('rejects failed HTTP envelopes with the backend message', async () => {
+    mock.onPost('/topics/create').reply(400, {
+      code: 400,
+      message: 'Topic name is required',
+      data: null,
+    });
+
+    await expect(client.post('/topics/create', {})).rejects.toThrow('Topic name is required');
+    expect(message.error).toHaveBeenCalledWith('Topic name is required');
+  });
+
   it('uses a stable fallback for malformed error envelopes', async () => {
     mock.onGet('/clusters').reply(200, { code: '500', data: null });
 
@@ -144,6 +155,7 @@ describe('API client response contract', () => {
 
     expect(localStorage.getItem('rocketmq-studio-user')).toBeNull();
     expect(localStorage.getItem('rocketmq-studio-user-admin')).toBeNull();
+    expect(message.error).not.toHaveBeenCalled();
   });
 
   it('preserves the original 401 error when the request URL is malformed', async () => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -81,6 +81,14 @@ client.interceptors.response.use(
       clearAiChatHistories();
       clearAuthSession();
       window.location.href = '/';
+      return Promise.reject(error);
+    }
+    const errorMessage = getBusinessError(error.response?.data);
+    if (errorMessage) {
+      message.error(errorMessage);
+      if (error instanceof Error) {
+        error.message = errorMessage;
+      }
     }
     return Promise.reject(error);
   },


### PR DESCRIPTION
## What is the purpose of the change

Preserve backend error messages from failed REST API responses.

The shared axios client already handles non-success business codes in HTTP 200 responses, but HTTP 4xx/5xx responses with the same `Result.error` envelope kept the generic Axios error message. Pages that read `error.message` could therefore show a vague failure instead of the backend validation message.

## Brief changelog

- Read standard backend error envelopes from failed HTTP responses.
- Keep protected 401 session-expiry handling unchanged.
- Add regression coverage for HTTP error envelopes and protected 401 behavior.

## Verifying this change

- `git diff --check`
- `npm test -- --run src/api/client.test.ts src/api/auth.test.ts`
- `npm test -- --run src/api`
- `./node_modules/.bin/eslint --max-warnings=0 src/api/client.ts src/api/client.test.ts`