### PR TITLE
fix: round-trip check legacy credential values before base64 decode

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/CredentialUtils.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/CredentialUtils.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.common.util;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Shared credential helpers: secrets are stored base64-encoded (never plain text) and only
@@ -44,7 +45,14 @@ public final class CredentialUtils {
             return null;
         }
         try {
-            return new String(Base64.getDecoder().decode(stored), StandardCharsets.UTF_8);
+            String decoded = new String(Base64.getDecoder().decode(stored), StandardCharsets.UTF_8);
+            // A legacy plain-text value that happens to be valid base64 would decode into
+            // garbage here; re-encoding must round-trip exactly for a value that was really
+            // produced by encodeBase64. Otherwise treat it as legacy plain text.
+            if (!Objects.equals(encodeBase64(decoded), stored)) {
+                return stored;
+            }
+            return decoded;
         } catch (IllegalArgumentException ex) {
             // tolerate legacy values that were stored without encoding
             return stored;

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/CredentialUtilsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/CredentialUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CredentialUtilsTest {
+
+    @Test
+    void encodeDecodeRoundTrips() {
+        String secret = "sk-test-credential-12345";
+        assertThat(CredentialUtils.decodeBase64(CredentialUtils.encodeBase64(secret)))
+                .isEqualTo(secret);
+    }
+
+    @Test
+    void decodeReturnsLegacyPlainTextWhenItIsNotCanonicalBase64() {
+        // A legacy plain-text key that happens to be valid base64 characters must come back
+        // verbatim instead of being decoded into garbage.
+        assertThat(CredentialUtils.decodeBase64("abcd1234")).isEqualTo("abcd1234");
+        assertThat(CredentialUtils.decodeBase64("not-base64!!")).isEqualTo("not-base64!!");
+    }
+
+    @Test
+    void decodeHandlesNullAndEmpty() {
+        assertThat(CredentialUtils.decodeBase64(null)).isNull();
+        assertThat(CredentialUtils.decodeBase64("")).isEmpty();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

`CredentialUtils.decodeBase64` only fell back to the raw value when the stored string was *not* valid base64. A legacy plain-text credential that happens to be composed entirely of base64-alphabet characters (e.g. `abcd1234`) decoded successfully into garbage instead of returning the original value, breaking broker/cloud credential verification on such deployments.

## Brief changelog

- After decoding, re-encode and require an exact round trip; a value that was really produced by `encodeBase64` always round-trips exactly, while a legacy plain-text value does not and is returned verbatim.
- Add `CredentialUtilsTest` covering round-trip, legacy plain-text, and null/empty handling.

## Verifying this change

- `mvn -q -Dtest=CredentialUtilsTest,CloudCredentialServiceTest,MybatisPlusAclRepositoryTest test`
- `mvn -q test` (1056/1056)
- `git diff --check`
