### PR TITLE
fix: exclude broker-named stats topics from dashboard topic counts

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -165,8 +165,13 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                     } else {
                         Set<String> clusterTopics = topicsByCluster.computeIfAbsent(
                                 clusterName, ignored -> new HashSet<>());
+                        // A broker's self-named stats topic (e.g. "broker-a") is not a user topic;
+                        // pass the owning cluster's broker names so SystemTopicFilter can rule it out.
+                        Set<String> owningBrokerNames = clusterName == null
+                                ? Set.of()
+                                : clusterAddrTable.getOrDefault(clusterName, Set.of());
                         topicConfig.getTopicConfigTable().keySet().stream()
-                                .filter(topic -> !isSystemTopic(topic))
+                                .filter(topic -> !isSystemTopic(topic, owningBrokerNames))
                                 .forEach(topic -> {
                                     allTopics.add(topic);
                                     clusterTopics.add(topic);
@@ -354,6 +359,10 @@ public class RocketMQDashboardProvider implements DashboardProvider {
 
     private boolean isSystemTopic(String topic) {
         return SystemTopicFilter.isSystem(topic);
+    }
+
+    private boolean isSystemTopic(String topic, Set<String> brokerNames) {
+        return SystemTopicFilter.isSystem(topic, brokerNames);
     }
 
     private boolean isSystemGroup(String group) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -93,6 +93,22 @@ class RocketMQDashboardProviderTest {
     }
 
     @Test
+    void dashboardShouldExcludeBrokerNamedStatsTopics() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        // "broker-a" matches the broker name and is a self-named stats topic, not a user topic.
+        when(adminExt.getAllTopicConfig("10.0.0.11:10911", 5000))
+                .thenReturn(topicConfig("order-topic", "broker-a"));
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getStats().getTotalTopics()).isEqualTo(1);
+        assertThat(dashboard.getClusters()).singleElement().satisfies(cluster ->
+                assertThat(cluster.getTopics()).isEqualTo(1));
+    }
+
+    @Test
     void dashboardShouldDeduplicateTopicsReportedByMultipleClusterBrokers() throws Exception {
         DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
         when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithTwoMasters());


### PR DESCRIPTION
## What is the purpose of the change

The dashboard counts topics from each master broker's `getAllTopicConfig` table, filtering with `SystemTopicFilter.isSystem(topic)` (single-arg). That overload treats a topic whose name equals a broker name (e.g. `broker-a`) as a user topic, so every broker's self-named stats topic inflated the global and per-cluster topic counts. The sibling `RocketMQMetadataProvider` already passes the broker name set to `isSystem(topic, brokerNames)` precisely to exclude these.

## Brief changelog

- Pass the owning cluster's broker name set into `SystemTopicFilter.isSystem` when filtering dashboard topics, excluding broker-named stats topics.
- Add `RocketMQDashboardProviderTest.dashboardShouldExcludeBrokerNamedStatsTopics`.

## Verifying this change

- `mvn -q -Dtest=RocketMQDashboardProviderTest test`
- `mvn -q test` (1055/1055)
- `git diff --check`
