### PR TITLE
fix: mark in-flight Tencent consume trace nodes as process

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
@@ -91,7 +91,14 @@ public class MqAdminExtFactory {
         AdminClientCacheKey cacheKey = new AdminClientCacheKey(normalizedNamesrvAddr,
                 normalizeAuthenticationIdentity(authenticationIdentity));
         DefaultMQAdminExt admin = cache.computeIfAbsent(cacheKey,
-                key -> createAndStart(key.namesrvAddr(), rpcHook));
+                key -> {
+                    // Re-check under the cache lock so a request that passed the initial closed check
+                    // cannot create a fresh connection while the factory is shutting down.
+                    if (closed) {
+                        throw new BusinessException(503, "Admin factory is shutting down");
+                    }
+                    return createAndStart(key.namesrvAddr(), rpcHook);
+                });
         try {
             return action.apply(admin);
         } catch (BusinessException ex) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionSummaryVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionSummaryVO.java
@@ -49,7 +49,9 @@ public class ProducerConnectionSummaryVO {
     private String readiness = READY;
 
     public static ProducerConnectionSummaryVO from(List<ProducerConnectionVO> connections) {
-        List<ProducerConnectionVO> safeConnections = connections == null ? List.of() : connections;
+        List<ProducerConnectionVO> safeConnections = connections == null
+                ? List.of()
+                : connections.stream().filter(Objects::nonNull).toList();
         ProducerConnectionSummaryVO summary = new ProducerConnectionSummaryVO();
         summary.totalConnections = safeConnections.size();
         summary.uniqueClientCount = countDistinct(safeConnections, ProducerConnectionVO::getClientId);

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -32,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -63,7 +64,10 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
     public K8sCertVO save(K8sCertVO cert) {
         RmqK8sCertificate entity = toEntity(cert);
         if (entity.getId() != null && certMapper.selectById(entity.getId()) != null) {
-            certMapper.updateById(entity);
+            if (certMapper.updateById(entity) == 0) {
+                throw new BusinessException(409,
+                        "Certificate update was not applied: " + entity.getId());
+            }
         } else {
             certMapper.insert(entity);
             cert.setId(entity.getId());
@@ -116,11 +120,13 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         if (!StringUtils.hasText(value)) {
             return null;
         }
-        try {
-            return CertType.valueOf(value);
-        } catch (IllegalArgumentException exception) {
-            throw invalidPersistedValue(certificateId, "type", value);
+        String normalized = value.trim();
+        for (CertType type : CertType.values()) {
+            if (type.name().equalsIgnoreCase(normalized)) {
+                return type;
+            }
         }
+        throw invalidPersistedValue(certificateId, "type", value);
     }
 
     private CertStatus parseCertStatus(String certificateId, String value) {
@@ -128,7 +134,7 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
             return null;
         }
         try {
-            return CertStatus.valueOf(value);
+            return CertStatus.valueOf(value.trim().toLowerCase(Locale.ROOT));
         } catch (IllegalArgumentException exception) {
             throw invalidPersistedValue(certificateId, "status", value);
         }
@@ -139,8 +145,12 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
             return List.of();
         }
         try {
-            return objectMapper.readValue(json, new TypeReference<List<String>>() {
+            List<String> san = objectMapper.readValue(json, new TypeReference<List<String>>() {
             });
+            if (san == null) {
+                throw invalidPersistedValue(certificateId, "SAN JSON", json);
+            }
+            return san;
         } catch (JsonProcessingException exception) {
             throw invalidPersistedValue(certificateId, "SAN JSON", json);
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
@@ -268,6 +268,10 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
         Iterator<Map.Entry<String, JsonNode>> fields = metric.fields();
         fields.forEachRemaining(entry -> {
             String key = entry.getKey();
+            if (!entry.getValue().isTextual()) {
+                throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                        backendLabel() + " returned a malformed time-series label");
+            }
             String value = entry.getValue().asText();
             if (key.length() > MAX_LABEL_KEY_LENGTH || value.length() > MAX_LABEL_VALUE_LENGTH) {
                 throw new PrometheusException(HttpStatus.PAYLOAD_TOO_LARGE.value(),
@@ -291,12 +295,17 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
 
     private MetricDataVO.MetricSampleVO parseSample(JsonNode sampleNode) {
         if (sampleNode == null || !sampleNode.isArray() || sampleNode.size() != 2
-                || !sampleNode.get(0).isNumber()) {
+                || !sampleNode.get(0).isNumber() || !sampleNode.get(1).isTextual()) {
+            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                    backendLabel() + " returned a malformed sample");
+        }
+        double timestamp = sampleNode.get(0).asDouble();
+        if (!Double.isFinite(timestamp)) {
             throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
                     backendLabel() + " returned a malformed sample");
         }
         return MetricDataVO.MetricSampleVO.builder()
-                .timestamp(sampleNode.get(0).asDouble())
+                .timestamp(timestamp)
                 .value(sampleNode.get(1).asText())
                 .build();
     }
@@ -307,8 +316,13 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
             throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
                     backendLabel() + " returned a malformed histogram sample");
         }
+        double timestamp = sampleNode.get(0).asDouble();
+        if (!Double.isFinite(timestamp)) {
+            throw new PrometheusException(HttpStatus.BAD_GATEWAY.value(),
+                    backendLabel() + " returned a malformed histogram sample");
+        }
         return MetricDataVO.MetricHistogramSampleVO.builder()
-                .timestamp(sampleNode.get(0).asDouble())
+                .timestamp(timestamp)
                 .histogram(sampleNode.get(1))
                 .build();
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
@@ -121,9 +121,10 @@ public class MetricsService {
             return "none";
         }
         return switch (auth.trim().toLowerCase(Locale.ROOT)) {
+            case "none" -> "none";
             case "basic auth", "basic" -> "basic";
             case "bearer token", "bearer" -> "bearer";
-            default -> "none";
+            default -> throw badRequest("Unsupported data source authentication mode: " + auth.trim());
         };
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
@@ -100,6 +100,9 @@ public class GrafanaDashboardService {
         try (InputStream in = resource.getInputStream()) {
             @SuppressWarnings("unchecked")
             Map<String, Object> model = objectMapper.readValue(in, Map.class);
+            if (model == null) {
+                throw new BusinessException(500, "Failed to read Grafana dashboard: " + uid);
+            }
             return model;
         } catch (IOException e) {
             throw new BusinessException(500, "Failed to read Grafana dashboard: " + uid);

--- a/server/src/main/java/org/apache/rocketmq/studio/common/domain/PageResult.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/domain/PageResult.java
@@ -31,7 +31,7 @@ public class PageResult<T> {
 
     public static <T> PageResult<T> of(List<T> items, long total, int page, int size) {
         PageResult<T> result = new PageResult<>();
-        result.items = items;
+        result.items = items == null ? Collections.emptyList() : items;
         result.total = total;
         result.page = page;
         result.size = size;

--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/CredentialUtils.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/CredentialUtils.java
@@ -16,6 +16,9 @@
  */
 package org.apache.rocketmq.studio.common.util;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
@@ -44,9 +47,15 @@ public final class CredentialUtils {
             return null;
         }
         try {
-            return new String(Base64.getDecoder().decode(stored), StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException ex) {
-            // tolerate legacy values that were stored without encoding
+            byte[] decoded = Base64.getDecoder().decode(stored);
+            return StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(decoded))
+                    .toString();
+        } catch (IllegalArgumentException | CharacterCodingException ex) {
+            // Tolerate legacy plaintext, including text that is syntactically Base64 but does
+            // not decode to valid UTF-8. Returning replacement characters would corrupt it.
             return stored;
         }
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/UrlHostGuard.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/UrlHostGuard.java
@@ -99,17 +99,26 @@ public final class UrlHostGuard {
             return allowLoopback;
         }
         try {
-            InetAddress address = InetAddress.getByName(normalized);
-            if (address.isAnyLocalAddress() || address.isLinkLocalAddress()) {
-                return false;
-            }
-            if (address.isLoopbackAddress()) {
-                return allowLoopback;
-            }
-            return true;
+            return areAllowed(InetAddress.getAllByName(normalized), allowLoopback);
         } catch (UnknownHostException exception) {
             // Fail closed: an unresolvable host must not be handed to the connection layer.
             return false;
         }
+    }
+
+    static boolean areAllowed(InetAddress[] addresses, boolean allowLoopback) {
+        if (addresses == null || addresses.length == 0) {
+            return false;
+        }
+        for (InetAddress address : addresses) {
+            if (address == null || address.isAnyLocalAddress() || address.isLinkLocalAddress()
+                    || address.isMulticastAddress()) {
+                return false;
+            }
+            if (address.isLoopbackAddress() && !allowLoopback) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -148,6 +148,10 @@ public class InstanceService {
         }
         CloudInstanceDetailVO detail = providerRegistry.catalogFor(vendor)
                 .getCloudInstance(instance.getCredentialId(), instance.getRegionId(), instance.getCloudInstanceId());
+        if (detail == null) {
+            throw new BusinessException(502,
+                    "Cloud instance details unavailable: " + instance.getCloudInstanceId());
+        }
         if (!StringUtils.hasText(instance.getName())) {
             instance.setName(detail.getInstanceName() != null && !detail.getInstanceName().isBlank()
                     ? detail.getInstanceName() : detail.getInstanceId());
@@ -162,6 +166,7 @@ public class InstanceService {
             throw new BusinessException(502, "Cloud instance has no endpoint: " + detail.getInstanceId());
         }
         return detail.getEndpoints().stream()
+                .filter(Objects::nonNull)
                 .filter(endpoint -> endpoint.getEndpointUrl() != null && !endpoint.getEndpointUrl().isBlank())
                 .sorted((a, b) -> Integer.compare(endpointPriority(a.getEndpointType()), endpointPriority(b.getEndpointType())))
                 .map(CloudInstanceDetailVO.CloudEndpoint::getEndpointUrl)

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
@@ -112,7 +112,10 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
     public InstanceVO save(InstanceVO instance) {
         RmqInstance entity = toEntity(instance);
         if (instanceMapper.selectById(entity.getId()) != null) {
-            instanceMapper.updateById(entity);
+            if (instanceMapper.updateById(entity) == 0) {
+                throw new BusinessException(409,
+                        "Instance update was not applied: " + entity.getId());
+            }
         } else {
             instanceMapper.insert(entity);
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -77,7 +77,9 @@ public class MybatisPlusAclRepository implements AclRepository {
         }
         RmqAclRule entity = toRuleEntity(rule);
         entity.setCreatedAt(existing.getCreatedAt());
-        ruleMapper.updateById(entity);
+        if (ruleMapper.updateById(entity) == 0) {
+            return Optional.empty();
+        }
         rule.setCreatedAt(existing.getCreatedAt());
         return Optional.of(rule);
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistry.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistry.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.ops.ai;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -37,7 +38,7 @@ public class AgentProviderRegistry {
     }
 
     public AgentProvider forEngine(String engine) {
-        AgentProvider provider = providers.get(engine == null ? "" : engine.trim().toLowerCase());
+        AgentProvider provider = providers.get(engine == null ? "" : engine.trim().toLowerCase(Locale.ROOT));
         if (provider == null) {
             throw new LlmGatewayException(400, "llm.config.unsupported_engine",
                     "Agent engine is not supported: " + engine,

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVO.java
@@ -25,6 +25,8 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.util.StringUtils;
 
+import java.util.Locale;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -67,6 +69,6 @@ public class LlmConfigVO {
     }
 
     public String normalizeEngine() {
-        return StringUtils.hasText(engine) ? engine.trim().toLowerCase() : ENGINE_HTTP;
+        return StringUtils.hasText(engine) ? engine.trim().toLowerCase(Locale.ROOT) : ENGINE_HTTP;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetService.java
@@ -46,7 +46,15 @@ public class AlertRuleAssetService {
     private static final String LOCATION_PATTERN = "classpath*:alerts/*.yaml";
 
     private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
-    private final ResourcePatternResolver resourceResolver = new PathMatchingResourcePatternResolver();
+    private final ResourcePatternResolver resourceResolver;
+
+    public AlertRuleAssetService() {
+        this(new PathMatchingResourcePatternResolver());
+    }
+
+    AlertRuleAssetService(ResourcePatternResolver resourceResolver) {
+        this.resourceResolver = resourceResolver;
+    }
 
     /**
      * Lists metadata for every bundled alert rule asset.
@@ -166,8 +174,8 @@ public class AlertRuleAssetService {
         try {
             return resourceResolver.getResources(LOCATION_PATTERN);
         } catch (IOException e) {
-            log.warn("Unable to resolve alert rule assets: {}", e.getMessage());
-            return new Resource[0];
+            log.error("Unable to resolve alert rule assets", e);
+            throw new BusinessException(500, "Failed to resolve bundled alert rule assets");
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -120,9 +121,10 @@ public class AlertService {
 
     public AlertRuleVO toggleRule(String id, boolean enabled) {
         log.info("Toggling alert rule id={}, enabled={}", id, enabled);
+        validateRuleId(id);
         List<AlertRuleVO> rules = alertRepository.findAllRules();
         AlertRuleVO rule = rules.stream()
-                .filter(r -> r.getId().equals(id))
+                .filter(r -> Objects.equals(r.getId(), id))
                 .findFirst()
                 .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "Alert rule not found: " + id));
         rule.setEnabled(enabled);
@@ -134,6 +136,7 @@ public class AlertService {
 
     public void deleteRule(String id) {
         log.info("Deleting alert rule id={}", id);
+        validateRuleId(id);
         if (!alertRepository.deleteRule(id)) {
             throw ruleNotFound(id);
         }
@@ -149,9 +152,12 @@ public class AlertService {
 
     public SystemAlertVO acknowledgeAlert(String id) {
         log.info("Acknowledging system alert id={}", id);
+        if (id == null || id.isBlank()) {
+            throw new BusinessException(400, "System alert ID is required");
+        }
         List<SystemAlertVO> alerts = alertRepository.findAlerts(null);
         SystemAlertVO alert = alerts.stream()
-                .filter(a -> a.getId().equals(id))
+                .filter(a -> Objects.equals(a.getId(), id))
                 .findFirst()
                 .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "System alert not found: " + id));
         alert.setAcknowledged(true);
@@ -290,16 +296,19 @@ public class AlertService {
         if (!hasText(metric)) {
             return "broker";
         }
-        if (metric.contains("replication") || metric.contains("fall_behind") || metric.contains("slave")) {
+        String normalizedMetric = metric.toLowerCase(Locale.ROOT);
+        if (normalizedMetric.contains("replication") || normalizedMetric.contains("fall_behind")
+                || normalizedMetric.contains("slave")) {
             return "broker";
         }
-        if (metric.contains("consumer") || metric.contains("lag")) {
+        if (normalizedMetric.contains("consumer") || normalizedMetric.contains("lag")) {
             return "consumer";
         }
-        if (metric.contains("producer") || metric.contains("client")) {
+        if (normalizedMetric.contains("producer") || normalizedMetric.contains("client")) {
             return "client";
         }
-        if (metric.contains("topic") || metric.contains("messages_in") || metric.contains("messages_out")) {
+        if (normalizedMetric.contains("topic") || normalizedMetric.contains("messages_in")
+                || normalizedMetric.contains("messages_out")) {
             return "topic";
         }
         return "broker";
@@ -308,7 +317,10 @@ public class AlertService {
     private String summary(AlertRuleVO rule) {
         String description = rule.getDescription();
         if (hasText(description) && description.contains(" - ")) {
-            return description.substring(0, description.indexOf(" - "));
+            String candidate = description.substring(0, description.indexOf(" - "));
+            if (hasText(candidate)) {
+                return candidate;
+            }
         }
         return hasText(rule.getName()) ? rule.getName() : "RocketMQ alert";
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -67,8 +67,7 @@ public class MybatisPlusAlertRepository implements AlertRepository {
         if (ruleMapper.selectById(rule.getId()) == null) {
             return false;
         }
-        ruleMapper.updateById(toRuleEntity(rule));
-        return true;
+        return ruleMapper.updateById(toRuleEntity(rule)) > 0;
     }
 
     @Override
@@ -172,7 +171,7 @@ public class MybatisPlusAlertRepository implements AlertRepository {
             return AlertLevel.info;
         }
         try {
-            return AlertLevel.valueOf(level);
+            return AlertLevel.valueOf(level.trim().toLowerCase(Locale.ROOT));
         } catch (IllegalArgumentException exception) {
             return AlertLevel.info;
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditService.java
@@ -106,6 +106,9 @@ public class AuditService {
         if (beforeDays <= 0) {
             throw new BusinessException(400, "beforeDays must be greater than 0");
         }
+        if (beforeDays > 365) {
+            throw new BusinessException(400, "beforeDays must not exceed 365");
+        }
         log.info("Cleaning up audit logs older than {} days", beforeDays);
         LocalDateTime cutoff = LocalDateTime.now().minusDays(beforeDays);
         return auditRepository.deleteBefore(cutoff);

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -71,7 +71,11 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
                     .build();
         }
         try {
-            return objectMapper.readValue(entity.getJson(), GeneralSettingsVO.class);
+            GeneralSettingsVO settings = objectMapper.readValue(entity.getJson(), GeneralSettingsVO.class);
+            if (settings == null) {
+                throw new BusinessException(500, "Persisted general settings are invalid");
+            }
+            return settings;
         } catch (JsonProcessingException e) {
             log.error("Failed to deserialize general settings", e);
             throw new BusinessException(500, "Persisted general settings are invalid");
@@ -127,8 +131,7 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
         }
         existing.setJson(toJson(dataSource));
         existing.setUpdatedAt(LocalDateTime.now());
-        dataSourceMapper.updateById(existing);
-        return true;
+        return dataSourceMapper.updateById(existing) > 0;
     }
 
     @Override
@@ -148,9 +151,12 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
     private DataSourceVO toDataSourceVO(RmqDataSource entity) {
         try {
             DataSourceVO vo = objectMapper.readValue(entity.getJson(), DataSourceVO.class);
+            if (vo == null) {
+                throw new BusinessException(500, "Persisted data source is invalid: " + entity.getDsKey());
+            }
             vo.setKey(entity.getDsKey());
             return vo;
-        } catch (JsonProcessingException e) {
+        } catch (JsonProcessingException | IllegalArgumentException e) {
             log.error("Failed to deserialize data source: {}", entity.getDsKey(), e);
             throw new BusinessException(500, "Persisted data source is invalid: " + entity.getDsKey());
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogService.java
@@ -70,7 +70,7 @@ public class AliyunCatalogService implements CloudCatalogProvider {
             return regions;
         }
         for (ListRegionsResponseBody.Data item : data) {
-            if (Boolean.TRUE.equals(item.getSupportRocketmqV5())) {
+            if (item != null && Boolean.TRUE.equals(item.getSupportRocketmqV5())) {
                 regions.add(AliyunConverters.toRegionVO(item));
             }
         }
@@ -86,6 +86,9 @@ public class AliyunCatalogService implements CloudCatalogProvider {
         List<ListInstancesResponseBody.List> all = fetchAllInstances(credentialId, regionId);
         List<CloudInstanceOptionVO> options = new ArrayList<>();
         for (ListInstancesResponseBody.List item : all) {
+            if (item == null) {
+                continue;
+            }
             CloudInstanceOptionVO vo = AliyunConverters.toInstanceOptionVO(item);
             if (matchesSearch(search, vo)) {
                 options.add(vo);

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
@@ -66,6 +66,9 @@ final class AliyunConverters {
     static final int MESSAGE_MAX_PAGES = 5;
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    // Aliyun RocketMQ OpenAPI timestamps are unzoned "yyyy-MM-dd HH:mm:ss" strings interpreted as
+    // UTC+8 (Asia/Shanghai), regardless of the server's default zone.
+    private static final ZoneId ALIYUN_TIME_ZONE = ZoneId.of("Asia/Shanghai");
 
     private AliyunConverters() {
     }
@@ -96,6 +99,9 @@ final class AliyunConverters {
         List<CloudInstanceDetailVO.CloudEndpoint> endpoints = new ArrayList<>();
         if (data.getNetworkInfo() != null && data.getNetworkInfo().getEndpoints() != null) {
             for (GetInstanceResponseBody.Endpoints endpoint : data.getNetworkInfo().getEndpoints()) {
+                if (endpoint == null) {
+                    continue;
+                }
                 endpoints.add(new CloudInstanceDetailVO.CloudEndpoint(
                         endpoint.getEndpointType(), endpoint.getEndpointUrl()));
             }
@@ -211,7 +217,7 @@ final class AliyunConverters {
                 .msgId(data.getMessageId())
                 .topic(data.getTopicName())
                 .tag(data.getMessageTag())
-                .key(data.getMessageKeys() == null ? null : String.join(" ", data.getMessageKeys()))
+                .key(joinMessageKeys(data.getMessageKeys()))
                 .bornHost(data.getBornHost())
                 .storeHost(data.getStoreHost())
                 .storeTime(parseTimeMillis(data.getStoreTime()))
@@ -229,6 +235,9 @@ final class AliyunConverters {
         List<TraceNodeVO> nodes = new ArrayList<>();
         if (data.getProducerInfo() != null && data.getProducerInfo().getRecords() != null) {
             for (GetTraceResponseBody.ProducerInfoRecords record : data.getProducerInfo().getRecords()) {
+                if (record == null) {
+                    continue;
+                }
                 nodes.add(TraceNodeVO.builder()
                         .title("Producer")
                         .timestamp(parseTimeMillis(record.getProduceTime()))
@@ -240,6 +249,9 @@ final class AliyunConverters {
         }
         if (data.getBrokerInfo() != null && data.getBrokerInfo().getOperations() != null) {
             for (GetTraceResponseBody.Operations operation : data.getBrokerInfo().getOperations()) {
+                if (operation == null) {
+                    continue;
+                }
                 nodes.add(TraceNodeVO.builder()
                         .title("Broker " + operation.getOperateType())
                         .timestamp(parseTimeMillis(operation.getOperateTime()))
@@ -248,6 +260,9 @@ final class AliyunConverters {
         }
         if (data.getConsumerInfos() != null) {
             for (GetTraceResponseBody.ConsumerInfos consumerInfo : data.getConsumerInfos()) {
+                if (consumerInfo == null) {
+                    continue;
+                }
                 if (consumerInfo.getRecords() == null || consumerInfo.getRecords().isEmpty()) {
                     nodes.add(TraceNodeVO.builder()
                             .title("Consumer " + consumerInfo.getConsumerGroupId())
@@ -256,6 +271,9 @@ final class AliyunConverters {
                     continue;
                 }
                 for (GetTraceResponseBody.Records record : consumerInfo.getRecords()) {
+                    if (record == null) {
+                        continue;
+                    }
                     String operateTime = null;
                     if (record.getOperations() != null && !record.getOperations().isEmpty()) {
                         operateTime = record.getOperations().get(0).getOperateTime();
@@ -289,7 +307,7 @@ final class AliyunConverters {
         }
         try {
             LocalDateTime dateTime = LocalDateTime.parse(value, TIME_FORMATTER);
-            return dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            return dateTime.atZone(ALIYUN_TIME_ZONE).toInstant().toEpochMilli();
         } catch (RuntimeException ignored) {
             return 0L;
         }
@@ -297,7 +315,7 @@ final class AliyunConverters {
 
     static String formatTimeMillis(long epochMillis) {
         return TIME_FORMATTER.format(
-                LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault()));
+                LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ALIYUN_TIME_ZONE));
     }
 
     static String tryBase64Decode(String raw) {
@@ -321,6 +339,10 @@ final class AliyunConverters {
         }
     }
 
+    private static String joinMessageKeys(List<String> keys) {
+        return keys == null ? null : joinParts(" ", keys.toArray(String[]::new));
+    }
+
     private static String joinParts(String separator, String... parts) {
         StringBuilder sb = new StringBuilder();
         for (String part : parts) {
@@ -336,6 +358,15 @@ final class AliyunConverters {
     }
 
     private static Integer toInteger(Long value) {
-        return value == null ? null : value.intValue();
+        if (value == null) {
+            return null;
+        }
+        if (value > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        if (value < 0) {
+            return 0;
+        }
+        return value.intValue();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -260,6 +260,7 @@ public class RocketMQMessageProvider implements MessageProvider {
         } finally {
             consumer.shutdown();
         }
+        result.sort(Comparator.comparingLong(MessageRecordVO::getStoreTime).reversed());
         return result;
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
@@ -116,7 +116,9 @@ public class CloudCredentialService {
         if (instanceRepository.existsByCredentialId(id)) {
             throw new BusinessException(400, "Cloud credential is referenced by existing instances");
         }
-        credentialRepository.deleteById(id);
+        if (!credentialRepository.deleteById(id)) {
+            throw new BusinessException(404, "Cloud credential not found: " + id);
+        }
         invalidateCloudClients(existing);
         recordAudit("DELETE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", id, null,
                 credentialAuditDetail(existing));

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
@@ -68,7 +68,10 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
     public CloudCredentialVO save(CloudCredentialVO credential) {
         RmqCloudCredential entity = toEntity(credential);
         if (credentialMapper.selectById(entity.getId()) != null) {
-            credentialMapper.updateById(entity);
+            if (credentialMapper.updateById(entity) == 0) {
+                throw new BusinessException(409,
+                        "Cloud credential update was not applied: " + entity.getId());
+            }
         } else {
             credentialMapper.insert(entity);
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -137,7 +137,13 @@ public class TencentInstanceProvider implements InstanceProvider {
         }
         // Use the response total count if available; otherwise fall back to full scan
         Long total = response.getTotalCount();
-        return total != null ? Math.toIntExact(total) : listTopics(instanceId, null, null, false).size();
+        if (total == null) {
+            return listTopics(instanceId, null, null, false).size();
+        }
+        if (total <= 0L) {
+            return 0;
+        }
+        return total > Integer.MAX_VALUE ? Integer.MAX_VALUE : total.intValue();
     }
 
     @Override
@@ -476,6 +482,8 @@ public class TencentInstanceProvider implements InstanceProvider {
             request.setTopic(topic);
             request.setStartTime(begin);
             request.setEndTime(end);
+            // Reuse the task id returned by the previous page so paging continues the same
+            // logical query; fall back to the initial random id when the API omits it.
             request.setTaskRequestId(taskRequestId);
             if (StringUtils.hasText(key)) {
                 request.setMsgKey(key);
@@ -489,6 +497,9 @@ public class TencentInstanceProvider implements InstanceProvider {
                     client -> client.DescribeMessageList(request));
             MessageItem[] data = response == null ? null : response.getData();
             long total = response == null ? 0L : (response.getTotalCount() == null ? 0L : response.getTotalCount());
+            if (response != null && StringUtils.hasText(response.getTaskRequestId())) {
+                taskRequestId = response.getTaskRequestId();
+            }
             if (data != null) {
                 for (MessageItem item : data) {
                     if (item != null) {
@@ -673,7 +684,12 @@ public class TencentInstanceProvider implements InstanceProvider {
                 return Collections.emptyMap();
             }
             Map<String, String> properties = new LinkedHashMap<>();
-            root.fields().forEachRemaining(entry -> properties.put(entry.getKey(), entry.getValue().asText("")));
+            root.fields().forEachRemaining(entry -> {
+                JsonNode value = entry.getValue();
+                if (value != null && value.isValueNode() && !value.isNull()) {
+                    properties.put(entry.getKey(), value.asText());
+                }
+            });
             return properties;
         } catch (Exception e) {
             return Collections.emptyMap();
@@ -715,8 +731,16 @@ public class TencentInstanceProvider implements InstanceProvider {
     }
 
     private static String toConsumeTraceStatus(int status) {
-        // Tencent consume log Status uses the RocketMQ convention where 2 means consumed.
-        return status == 2 ? "finish" : "failed";
+        // Tencent consume log Status uses the RocketMQ convention where 0/1 are in-flight and
+        // 2 means consumed; keep the trace status consistent with toDeliveryStatus and with the
+        // frontend TraceNode.status values ('error' | 'wait' | 'process' | 'finish').
+        if (status == 2) {
+            return "finish";
+        }
+        if (status == 0 || status == 1) {
+            return "process";
+        }
+        return "error";
     }
 
     private static DeliveryStatus toDeliveryStatus(int status) {
@@ -859,7 +883,10 @@ public class TencentInstanceProvider implements InstanceProvider {
     }
 
     private static int toInt(Long value) {
-        return value == null ? 0 : Math.toIntExact(value);
+        if (value == null || value <= 0L) {
+            return 0;
+        }
+        return value > Integer.MAX_VALUE ? Integer.MAX_VALUE : value.intValue();
     }
 
     private static ConsumeType toConsumeType(Boolean consumeMessageOrderly) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
@@ -177,4 +177,17 @@ class MqAdminExtFactoryTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("shutting down");
     }
+
+    @Test
+    void executeShouldNotCreateConnectionAfterShutdown() {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+        factory.shutdown();
+
+        assertThatThrownBy(() -> factory.execute("10.0.0.1:9876", null, a -> "unused"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("shutting down");
+        // No fresh admin connection may be established while the factory is shut down.
+        assertThat(factory.created.get()).isZero();
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionSummaryVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionSummaryVOTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.client;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +32,15 @@ class ProducerConnectionSummaryVOTest {
         assertThat(summary.getTotalConnections()).isZero();
         assertThat(summary.getReadiness()).isEqualTo(ProducerConnectionSummaryVO.UNAVAILABLE);
         assertThat(summary.getWarnings()).containsExactly(ProducerConnectionSummaryVO.NO_CONNECTIONS);
+    }
+
+    @Test
+    void fromShouldSkipNullConnectionEntries() {
+        ProducerConnectionSummaryVO summary = ProducerConnectionSummaryVO.from(Arrays.asList(
+                null, connection("producer-a", "10.0.0.1:38888", "Java", "5.1.0")));
+
+        assertThat(summary.getTotalConnections()).isEqualTo(1);
+        assertThat(summary.getReadiness()).isEqualTo(ProducerConnectionSummaryVO.READY);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
@@ -22,11 +22,45 @@ import org.apache.rocketmq.studio.persistence.entity.RmqK8sCertificate;
 import org.apache.rocketmq.studio.persistence.mapper.RmqK8sCertificateMapper;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 class MybatisPlusK8sCertRepositoryTest {
+
+    @Test
+    void findByIdNormalizesPersistedCertificateEnums() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        RmqK8sCertificate entity = certificate();
+        entity.setCertType(" mtls ");
+        entity.setStatus(" EXPIRING ");
+        when(mapper.selectById("cert-1")).thenReturn(entity);
+
+        assertThat(repository(mapper).findById("cert-1")).get()
+                .satisfies(cert -> {
+                    assertThat(cert.getType()).isEqualTo(
+                            org.apache.rocketmq.studio.common.domain.enums.CertType.mTLS);
+                    assertThat(cert.getStatus()).isEqualTo(
+                            org.apache.rocketmq.studio.common.domain.enums.CertStatus.expiring);
+                });
+    }
+
+    @Test
+    void saveShouldReportALostConcurrentUpdate() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        when(mapper.selectById("cert-1")).thenReturn(certificate());
+        when(mapper.updateById(any(RmqK8sCertificate.class))).thenReturn(0);
+        K8sCertVO cert = K8sCertVO.builder().name("broker").build();
+        cert.setId("cert-1");
+
+        assertThatThrownBy(() -> repository(mapper).save(cert))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Certificate update was not applied: cert-1")
+                .satisfies(error -> org.assertj.core.api.Assertions.assertThat(
+                        ((BusinessException) error).getCode()).isEqualTo(409));
+    }
 
     @Test
     void findByIdSurfacesInvalidPersistedCertificateType() {
@@ -45,6 +79,18 @@ class MybatisPlusK8sCertRepositoryTest {
         RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
         RmqK8sCertificate entity = certificate();
         entity.setSan("not-json");
+        when(mapper.selectById("cert-1")).thenReturn(entity);
+
+        assertThatThrownBy(() -> repository(mapper).findById("cert-1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("SAN JSON");
+    }
+
+    @Test
+    void findByIdSurfacesNullPersistedSanJson() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        RmqK8sCertificate entity = certificate();
+        entity.setSan("null");
         when(mapper.selectById("cert-1")).thenReturn(entity);
 
         assertThatThrownBy(() -> repository(mapper).findById("cert-1"))

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
@@ -423,6 +423,28 @@ class MetricsServiceTest {
     }
 
     @Test
+    void queryByDataSourceShouldRejectUnsupportedStoredAuthMode() {
+        MetricsDataSourceQueryRequest request = dataSourceRequest(null);
+        DataSourceVO dataSource = DataSourceVO.builder()
+                .key("ds-1")
+                .name("prometheus-a")
+                .type("prometheus")
+                .url("http://prometheus:9090")
+                .auth("digest")
+                .build();
+        when(settingsService.getDataSource("ds-1")).thenReturn(dataSource);
+
+        assertThatExceptionOfType(PrometheusException.class)
+                .isThrownBy(() -> metricsService.queryByDataSource("ds-1", request))
+                .satisfies(exception -> {
+                    assertThat(exception.getStatusCode()).isEqualTo(400);
+                    assertThat(exception.getMessage())
+                            .isEqualTo("Unsupported data source authentication mode: digest");
+                });
+        verifyNoInteractions(metricsSourceFactory, metricsSource);
+    }
+
+    @Test
     void queryByDataSourceShouldNormalizeAuthIndependentlyOfDefaultLocale() {
         MetricQueryDTO query = MetricQueryDTO.builder()
                 .metric("cpu")

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusMetricsSourceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusMetricsSourceTest.java
@@ -230,6 +230,32 @@ class PrometheusMetricsSourceTest {
     }
 
     @Test
+    void queryShouldRejectNonTextSampleValues() {
+        server.createContext("/api/v1/query_range", exchange -> respond(exchange, 200, """
+                {"status":"success","data":{"resultType":"matrix","result":[
+                  {"metric":{"topic":"orders"},"values":[[1784107658,1.25]]}
+                ]}}
+                """));
+
+        assertThatThrownBy(() -> source(Duration.ofSeconds(2)).query(query()))
+                .isInstanceOf(PrometheusException.class)
+                .hasMessage("Prometheus returned a malformed sample");
+    }
+
+    @Test
+    void queryShouldRejectNonTextSeriesLabels() {
+        server.createContext("/api/v1/query_range", exchange -> respond(exchange, 200, """
+                {"status":"success","data":{"resultType":"matrix","result":[
+                  {"metric":{"topic":{"name":"orders"}},"values":[[1784107658,"1.25"]]}
+                ]}}
+                """));
+
+        assertThatThrownBy(() -> source(Duration.ofSeconds(2)).query(query()))
+                .isInstanceOf(PrometheusException.class)
+                .hasMessage("Prometheus returned a malformed time-series label");
+    }
+
+    @Test
     void queryShouldRejectResponseWithTooManySeries() {
         server.createContext("/api/v1/query_range", exchange -> respond(exchange, 200, responseWithSeries(1_001)));
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
@@ -66,6 +66,17 @@ class GrafanaDashboardServiceTest {
     }
 
     @Test
+    void getDashboardShouldRejectNullJsonAsset() {
+        GrafanaDashboardService service = serviceWithResources(resource("null.json", "null"));
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> service.getDashboard("null"));
+
+        assertEquals(500, exception.getCode());
+        assertEquals("Failed to read Grafana dashboard: null", exception.getMessage());
+    }
+
+    @Test
     void getDashboardShouldThrowWhenUidUnknown() {
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> service.getDashboard("no-such-dashboard"));

--- a/server/src/test/java/org/apache/rocketmq/studio/common/domain/PageResultTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/domain/PageResultTest.java
@@ -14,21 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.rocketmq.studio.ops.audit;
+package org.apache.rocketmq.studio.common.domain;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Positive;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class AuditCleanupDTO {
-    @Positive(message = "beforeDays must be greater than 0")
-    @Max(value = 365, message = "beforeDays must not exceed 365")
-    private Integer beforeDays;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PageResultTest {
+
+    @Test
+    void ofShouldNormalizeNullItemsToAnEmptyList() {
+        PageResult<String> result = PageResult.of(null, 0, 1, 20);
+
+        assertThat(result.getItems()).isNotNull().isEmpty();
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/CredentialUtilsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/CredentialUtilsTest.java
@@ -14,21 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.rocketmq.studio.ops.audit;
+package org.apache.rocketmq.studio.common.util;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Positive;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class AuditCleanupDTO {
-    @Positive(message = "beforeDays must be greater than 0")
-    @Max(value = 365, message = "beforeDays must not exceed 365")
-    private Integer beforeDays;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CredentialUtilsTest {
+
+    @Test
+    void decodeBase64ShouldPreserveLegacyTextWhenDecodedBytesAreNotUtf8() {
+        String legacyValue = Base64.getEncoder().encodeToString(new byte[]{(byte) 0xC3, 0x28});
+
+        assertThat(CredentialUtils.decodeBase64(legacyValue)).isEqualTo(legacyValue);
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardMulticastTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardMulticastTest.java
@@ -14,21 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.rocketmq.studio.ops.audit;
+package org.apache.rocketmq.studio.common.util;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Positive;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class AuditCleanupDTO {
-    @Positive(message = "beforeDays must be greater than 0")
-    @Max(value = 365, message = "beforeDays must not exceed 365")
-    private Integer beforeDays;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UrlHostGuardMulticastTest {
+
+    @Test
+    void isAllowedHostShouldRejectIpv4AndIpv6MulticastAddresses() {
+        assertThat(UrlHostGuard.isAllowedHost("224.0.0.1", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("ff02::1", false)).isFalse();
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UrlHostGuardTest {
+
+    @Test
+    void areAllowedShouldRejectAHostWhenAnyResolvedAddressIsDisallowed() throws Exception {
+        InetAddress publicAddress = InetAddress.getByAddress(new byte[]{8, 8, 8, 8});
+        InetAddress loopbackAddress = InetAddress.getByAddress(new byte[]{127, 0, 0, 1});
+
+        assertThat(UrlHostGuard.areAllowed(
+                new InetAddress[]{publicAddress, loopbackAddress}, false)).isFalse();
+    }
+
+    @Test
+    void areAllowedShouldAcceptEveryPublicResolvedAddress() throws Exception {
+        InetAddress first = InetAddress.getByAddress(new byte[]{8, 8, 8, 8});
+        InetAddress second = InetAddress.getByAddress(new byte[]{1, 1, 1, 1});
+
+        assertThat(UrlHostGuard.areAllowed(new InetAddress[]{first, second}, false)).isTrue();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -792,6 +793,28 @@ class InstanceServiceTest {
     }
 
     @Test
+    void createInstanceShouldRejectMissingCloudCatalogDetails() {
+        InstanceVO instance = InstanceVO.builder()
+                .vendor(InstanceVendor.ALIYUN)
+                .credentialId("cred-1")
+                .cloudInstanceId("rmq-missing")
+                .regionId("cn-hangzhou")
+                .build();
+        CloudCredentialVO credential = new CloudCredentialVO();
+        credential.setVendor(InstanceVendor.ALIYUN);
+        when(cloudCredentialRepository.findById("cred-1")).thenReturn(Optional.of(credential));
+        CloudCatalogProvider catalog = org.mockito.Mockito.mock(CloudCatalogProvider.class);
+        when(providerRegistry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
+        when(catalog.getCloudInstance("cred-1", "cn-hangzhou", "rmq-missing")).thenReturn(null);
+
+        assertThatThrownBy(() -> instanceService.createInstance(instance))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Cloud instance details unavailable: rmq-missing")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(502));
+        verify(instanceRepository, never()).save(any());
+    }
+
+    @Test
     void createInstanceShouldResolveAliyunEndpointFromCatalogTest() {
         InstanceVO instance = InstanceVO.builder()
                 .vendor(InstanceVendor.ALIYUN)
@@ -819,6 +842,30 @@ class InstanceServiceTest {
         assertThat(created.getName()).isEqualTo("prod-mq");
         assertThat(created.getEndpoint()).isEqualTo("vpc:8080");
         assertThat(created.getType()).isEqualTo(InstanceType.PROXY);
+    }
+
+    @Test
+    void createInstanceShouldSkipNullCloudEndpointEntries() {
+        InstanceVO instance = InstanceVO.builder()
+                .vendor(InstanceVendor.ALIYUN)
+                .credentialId("cred-1")
+                .cloudInstanceId("rmq-cn-xxx")
+                .regionId("cn-hangzhou")
+                .build();
+        CloudCredentialVO credential = new CloudCredentialVO();
+        credential.setVendor(InstanceVendor.ALIYUN);
+        when(cloudCredentialRepository.findById("cred-1")).thenReturn(Optional.of(credential));
+        CloudCatalogProvider catalog = org.mockito.Mockito.mock(CloudCatalogProvider.class);
+        CloudInstanceDetailVO detail = new CloudInstanceDetailVO();
+        detail.setInstanceId("rmq-cn-xxx");
+        detail.setInstanceName("prod-mq");
+        detail.setEndpoints(Arrays.asList(null,
+                new CloudInstanceDetailVO.CloudEndpoint("TCP_VPC", "vpc:8080")));
+        when(providerRegistry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
+        when(catalog.getCloudInstance("cred-1", "cn-hangzhou", "rmq-cn-xxx")).thenReturn(detail);
+        when(instanceRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThat(instanceService.createInstance(instance).getEndpoint()).isEqualTo("vpc:8080");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
@@ -172,11 +172,25 @@ class MybatisPlusInstanceRepositoryTest {
     void saveShouldUpdateWhenInstanceExists() {
         InstanceVO vo = vo("instance-proxy-2", InstanceType.PROXY);
         when(instanceMapper.selectById("instance-proxy-2")).thenReturn(entity("instance-proxy-2", InstanceType.PROXY));
+        when(instanceMapper.updateById(any(RmqInstance.class))).thenReturn(1);
 
         repository.save(vo);
 
         verify(instanceMapper).updateById(any(RmqInstance.class));
         verify(instanceMapper, never()).insert(any(RmqInstance.class));
+    }
+
+    @Test
+    void saveShouldReportALostConcurrentUpdate() {
+        InstanceVO vo = vo("instance-proxy-2", InstanceType.PROXY);
+        when(instanceMapper.selectById("instance-proxy-2"))
+                .thenReturn(entity("instance-proxy-2", InstanceType.PROXY));
+        when(instanceMapper.updateById(any(RmqInstance.class))).thenReturn(0);
+
+        assertThatThrownBy(() -> repository.save(vo))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Instance update was not applied: instance-proxy-2")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(409));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
@@ -58,6 +58,23 @@ class MybatisPlusAclRepositoryTest {
     private MybatisPlusAclRepository repository;
 
     @Test
+    void replaceRuleShouldReturnEmptyWhenConcurrentDeleteWins() {
+        RmqAclRule existing = new RmqAclRule();
+        existing.setId("rule-a");
+        existing.setCreatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+        when(ruleMapper.selectById("rule-a")).thenReturn(existing);
+        when(ruleMapper.updateById(any(RmqAclRule.class))).thenReturn(0);
+
+        AclRuleVO replacement = AclRuleVO.builder()
+                .id("rule-a")
+                .principal("svc-a")
+                .resource("orders")
+                .build();
+
+        assertThat(repository.replaceRule(replacement)).isEmpty();
+    }
+
+    @Test
     void upsertShouldAssignUniqueRuleIdPerPermission() {
         when(userMapper.selectOne(any(QueryWrapper.class))).thenReturn(null);
         when(userMapper.insert(any(RmqAclUser.class))).thenReturn(1);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AgentProviderRegistryTest {
+
+    @Test
+    void shouldResolveEngineIndependentlyOfDefaultLocale() {
+        AgentProvider provider = mock(AgentProvider.class);
+        when(provider.engine()).thenReturn("cli");
+        AgentProviderRegistry registry = new AgentProviderRegistry(List.of(provider));
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+            assertThat(registry.forEngine(" CLI ")).isSameAs(provider);
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVOTest.java
@@ -14,21 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.rocketmq.studio.ops.audit;
+package org.apache.rocketmq.studio.ops.ai;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Positive;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class AuditCleanupDTO {
-    @Positive(message = "beforeDays must be greater than 0")
-    @Max(value = 365, message = "beforeDays must not exceed 365")
-    private Integer beforeDays;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmConfigVOTest {
+
+    @Test
+    void shouldNormalizeEngineIndependentlyOfDefaultLocale() {
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            LlmConfigVO config = LlmConfigVO.builder().engine(" CLI ").build();
+
+            assertThat(config.normalizeEngine()).isEqualTo("cli");
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
@@ -20,7 +20,9 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -28,6 +30,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class AlertRuleAssetServiceTest {
 
@@ -74,6 +79,18 @@ class AlertRuleAssetServiceTest {
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> service.getAssetYaml("no-such-asset"));
         assertEquals(404, exception.getCode());
+    }
+
+    @Test
+    void listAssetsShouldSurfaceResourceDiscoveryFailures() throws IOException {
+        ResourcePatternResolver resolver = mock(ResourcePatternResolver.class);
+        when(resolver.getResources(anyString())).thenThrow(new IOException("classpath unavailable"));
+        AlertRuleAssetService failingService = new AlertRuleAssetService(resolver);
+
+        BusinessException exception = assertThrows(BusinessException.class, failingService::listAssets);
+
+        assertEquals(500, exception.getCode());
+        assertEquals("Failed to resolve bundled alert rule assets", exception.getMessage());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -179,6 +179,22 @@ class AlertServiceTest {
     }
 
     @Test
+    void exportPrometheusRulesYamlShouldInferTeamWithoutMetricCaseSensitivity() {
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .name("Uppercase lag")
+                .metric("ROCKETMQ_CONSUMER_LAG_MESSAGES")
+                .operator(">")
+                .threshold(10)
+                .enabled(true)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+
+        String result = alertService.exportPrometheusRulesYaml();
+
+        assertThat(result).contains("- name: rocketmq-consumer.rules");
+    }
+
+    @Test
     void exportPrometheusRulesYamlShouldRenderReplicationLagRuleWithScopeAndSeverity() {
         AlertRuleVO rule = AlertRuleVO.builder()
                 .name("Replication Lag High")
@@ -266,6 +282,27 @@ class AlertServiceTest {
         }
 
         assertThat(result).contains("severity: info");
+    }
+
+    @Test
+    void exportPrometheusRulesYamlShouldNotEmitABlankSummary() throws Exception {
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .name("Lag alert")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(1)
+                .description(" - consumer is behind")
+                .enabled(true)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+
+        JsonNode exportedRule = new ObjectMapper(new YAMLFactory())
+                .readTree(alertService.exportPrometheusRulesYaml())
+                .path("groups").get(0).path("rules").get(0);
+
+        assertThat(exportedRule.path("annotations").path("summary").asText()).isEqualTo("Lag alert");
+        assertThat(exportedRule.path("annotations").path("description").asText())
+                .isEqualTo("consumer is behind");
     }
 
     @Test
@@ -503,12 +540,41 @@ class AlertServiceTest {
     }
 
     @Test
+    void toggleRuleShouldRejectBlankIdBeforeLoadingRules() {
+        assertThatThrownBy(() -> alertService.toggleRule("  ", true))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule ID is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(alertRepository, never()).findAllRules();
+    }
+
+    @Test
+    void toggleRuleShouldIgnorePersistedRulesWithNullIds() {
+        when(alertRepository.findAllRules()).thenReturn(List.of(AlertRuleVO.builder().name("corrupt").build()));
+
+        assertThatThrownBy(() -> alertService.toggleRule("missing", true))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule not found: missing");
+    }
+
+    @Test
     void toggleRuleShouldThrowWhenRuleNotFound() {
         when(alertRepository.findAllRules()).thenReturn(Collections.emptyList());
 
         assertThatThrownBy(() -> alertService.toggleRule("non-existent", true))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Alert rule not found: non-existent");
+    }
+
+    @Test
+    void deleteRuleShouldRejectBlankIdBeforeDeleting() {
+        assertThatThrownBy(() -> alertService.deleteRule(" "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule ID is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(alertRepository, never()).deleteRule(any());
     }
 
     @Test
@@ -573,6 +639,25 @@ class AlertServiceTest {
         verify(alertRepository).saveAlert(result);
         verify(operationAuditService).record(eq("ACKNOWLEDGE_SYSTEM_ALERT"), eq("SYSTEM_ALERT"), eq("a1"),
                 eq(null), eq("acknowledged=true"), eq("SUCCESS"), eq(null));
+    }
+
+    @Test
+    void acknowledgeAlertShouldRejectBlankIdBeforeLoadingAlerts() {
+        assertThatThrownBy(() -> alertService.acknowledgeAlert(" "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("System alert ID is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+
+        verify(alertRepository, never()).findAlerts(any());
+    }
+
+    @Test
+    void acknowledgeAlertShouldIgnorePersistedAlertsWithNullIds() {
+        when(alertRepository.findAlerts(null)).thenReturn(List.of(SystemAlertVO.builder().title("corrupt").build()));
+
+        assertThatThrownBy(() -> alertService.acknowledgeAlert("missing"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("System alert not found: missing");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.ops.alert;
 
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import org.apache.rocketmq.studio.persistence.entity.RmqAlertRule;
 import org.apache.rocketmq.studio.persistence.entity.RmqSystemAlert;
 import org.apache.rocketmq.studio.persistence.mapper.RmqAlertRuleMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqSystemAlertMapper;
@@ -30,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Locale;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
@@ -46,6 +48,26 @@ class MybatisPlusAlertRepositoryTest {
 
     @InjectMocks
     private MybatisPlusAlertRepository repository;
+
+    @Test
+    void replaceRuleShouldReportAConcurrentDelete() {
+        AlertRuleVO rule = AlertRuleVO.builder().id("rule-1").name("Lag").build();
+        when(ruleMapper.selectById("rule-1")).thenReturn(new RmqAlertRule());
+        when(ruleMapper.updateById(any(RmqAlertRule.class))).thenReturn(0);
+
+        assertThat(repository.replaceRule(rule)).isFalse();
+    }
+
+    @Test
+    void findAlertsShouldNormalizeStoredLevelValues() {
+        RmqSystemAlert entity = new RmqSystemAlert();
+        entity.setLevel(" WARNING ");
+        when(alertMapper.selectList(any())).thenReturn(List.of(entity));
+
+        assertThat(repository.findAlerts(null)).singleElement()
+                .satisfies(alert -> assertThat(alert.getLevel()).isEqualTo(
+                        org.apache.rocketmq.studio.common.domain.enums.AlertLevel.warning));
+    }
 
     @Test
     void findAlertsShouldNormalizeLevelIndependentlyOfDefaultLocale() {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditControllerTest.java
@@ -135,6 +135,18 @@ class AuditControllerTest {
     }
 
     @Test
+    void cleanupLogsShouldRejectRetentionBeyondMaximum() throws Exception {
+        mockMvc.perform(post("/api/audit-logs/cleanup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("beforeDays", 366))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("beforeDays must not exceed 365"));
+
+        verifyNoInteractions(auditService);
+    }
+
+    @Test
     void cleanupLogsShouldRejectInvalidRetentionType() throws Exception {
         mockMvc.perform(post("/api/audit-logs/cleanup")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
@@ -182,4 +182,11 @@ class AuditServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("beforeDays must be greater than 0");
     }
+
+    @Test
+    void cleanupLogsRejectsRetentionBeyondMaximum() {
+        assertThatThrownBy(() -> auditService.cleanupLogs(366))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("beforeDays must not exceed 365");
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -12,6 +12,7 @@ import org.apache.rocketmq.studio.persistence.entity.RmqDataSource;
 import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
 import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqSettingsMapper;
+import org.apache.rocketmq.studio.settings.DataSourceVO;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,6 +60,19 @@ class MybatisPlusSettingsRepositoryTest {
     }
 
     @Test
+    void shouldRejectNullPersistedGeneralSettings() {
+        RmqSettings settings = new RmqSettings();
+        settings.setJson("null");
+        when(settingsMapper.selectById("singleton")).thenReturn(settings);
+
+        assertThatThrownBy(repository::loadGeneralSettings)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Persisted general settings are invalid")
+                .extracting("code")
+                .isEqualTo(500);
+    }
+
+    @Test
     void shouldReadValidPersistedGeneralSettings() {
         RmqSettings settings = new RmqSettings();
         settings.setJson("{\"theme\":\"dark\",\"requireLogin\":true}");
@@ -68,6 +82,20 @@ class MybatisPlusSettingsRepositoryTest {
 
         assertThat(loaded.getTheme()).isEqualTo("dark");
         assertThat(loaded.isRequireLogin()).isTrue();
+    }
+
+    @Test
+    void shouldRejectNullPersistedDataSource() {
+        RmqDataSource dataSource = new RmqDataSource();
+        dataSource.setDsKey("metrics-prod");
+        dataSource.setJson("null");
+        when(dataSourceMapper.selectById("metrics-prod")).thenReturn(dataSource);
+
+        assertThatThrownBy(() -> repository.findDataSourceByKey("metrics-prod"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Persisted data source is invalid: metrics-prod")
+                .extracting("code")
+                .isEqualTo(500);
     }
 
     @Test
@@ -82,5 +110,21 @@ class MybatisPlusSettingsRepositoryTest {
                 .hasMessage("Persisted data source is invalid: metrics-prod")
                 .extracting("code")
                 .isEqualTo(500);
+    }
+
+    @Test
+    void shouldReportWhenDataSourceDisappearsDuringReplacement() {
+        RmqDataSource existing = new RmqDataSource();
+        existing.setDsKey("metrics-prod");
+        when(dataSourceMapper.selectById("metrics-prod")).thenReturn(existing);
+        when(dataSourceMapper.updateById(existing)).thenReturn(0);
+        DataSourceVO replacement = DataSourceVO.builder()
+                .key("metrics-prod")
+                .name("Production metrics")
+                .type("prometheus")
+                .url("https://metrics.example.com")
+                .build();
+
+        assertThat(repository.replaceDataSource(replacement)).isFalse();
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogServiceTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,6 +58,25 @@ class AliyunCatalogServiceTest {
     @BeforeEach
     void setUp() {
         service = new AliyunCatalogService(clientFactory);
+    }
+
+    @Test
+    void listRegionsShouldSkipNullSdkRecords() {
+        ListRegionsResponse response = ListRegionsResponse.create().toBuilder()
+                .statusCode(200)
+                .body(ListRegionsResponseBody.builder()
+                        .data(Arrays.asList(null, ListRegionsResponseBody.Data.builder()
+                                .regionId("cn-hangzhou")
+                                .supportRocketmqV5(true)
+                                .build()))
+                        .build())
+                .build();
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(AliyunCatalogService.DEFAULT_REGION), any()))
+                .thenReturn(response);
+
+        assertThat(service.listRegions(CREDENTIAL_ID))
+                .extracting(CloudRegionVO::getRegionId)
+                .containsExactly("cn-hangzhou");
     }
 
     @Test
@@ -88,6 +108,16 @@ class AliyunCatalogServiceTest {
         assertThat(regions).extracting(CloudRegionVO::getRegionId)
                 .containsExactly("cn-beijing", "cn-hangzhou", "cn-shanghai");
         assertThat(regions.get(1).getRegionName()).isEqualTo("hangzhou");
+    }
+
+    @Test
+    void listCloudInstancesShouldSkipNullSdkRecords() {
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any()))
+                .thenReturn(instancesResponse(Arrays.asList(null, instanceRow("rmq-a", "A"))));
+
+        assertThat(service.listCloudInstances(CREDENTIAL_ID, REGION, null))
+                .extracting(CloudInstanceOptionVO::getInstanceId)
+                .containsExactly("rmq-a");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersMessageKeysTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersMessageKeysTest.java
@@ -14,21 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.rocketmq.studio.ops.audit;
+package org.apache.rocketmq.studio.provider.alibaba;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Positive;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.aliyun.sdk.service.rocketmq20220801.models.ListMessagesResponseBody;
+import org.junit.jupiter.api.Test;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class AuditCleanupDTO {
-    @Positive(message = "beforeDays must be greater than 0")
-    @Max(value = 365, message = "beforeDays must not exceed 365")
-    private Integer beforeDays;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AliyunConvertersMessageKeysTest {
+
+    @Test
+    void toMessageRecordShouldSkipNullAndBlankMessageKeys() {
+        ListMessagesResponseBody.List data = ListMessagesResponseBody.List.builder()
+                .messageKeys(Arrays.asList("key-a", null, " ", "key-b"))
+                .build();
+
+        assertThat(AliyunConverters.toMessageRecord(data).getKey()).isEqualTo("key-a key-b");
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersNullEndpointTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersNullEndpointTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.alibaba;
+
+import com.aliyun.sdk.service.rocketmq20220801.models.GetInstanceResponseBody;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AliyunConvertersNullEndpointTest {
+
+    @Test
+    void toInstanceDetailShouldSkipNullEndpointEntries() {
+        GetInstanceResponseBody.Endpoints endpoint = GetInstanceResponseBody.Endpoints.builder()
+                .endpointType("TCP_VPC")
+                .endpointUrl("10.0.0.1:8080")
+                .build();
+        GetInstanceResponseBody.NetworkInfo network = GetInstanceResponseBody.NetworkInfo.builder()
+                .endpoints(Arrays.asList(null, endpoint))
+                .build();
+        GetInstanceResponseBody.Data data = GetInstanceResponseBody.Data.builder()
+                .instanceId("rmq-a")
+                .networkInfo(network)
+                .build();
+
+        assertThat(AliyunConverters.toInstanceDetailVO(data).getEndpoints())
+                .singleElement()
+                .satisfies(value -> assertThat(value.getEndpointUrl()).isEqualTo("10.0.0.1:8080"));
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersTest.java
@@ -14,21 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.rocketmq.studio.ops.audit;
+package org.apache.rocketmq.studio.provider.alibaba;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Positive;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.aliyun.sdk.service.rocketmq20220801.models.ListInstancesResponseBody;
+import org.junit.jupiter.api.Test;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class AuditCleanupDTO {
-    @Positive(message = "beforeDays must be greater than 0")
-    @Max(value = 365, message = "beforeDays must not exceed 365")
-    private Integer beforeDays;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AliyunConvertersTest {
+
+    @Test
+    void toInstanceOptionShouldClampCountsOutsideTheIntegerRange() {
+        ListInstancesResponseBody.List data = ListInstancesResponseBody.List.builder()
+                .topicCount(Long.MAX_VALUE)
+                .groupCount(Long.MIN_VALUE)
+                .build();
+
+        var result = AliyunConverters.toInstanceOptionVO(data);
+
+        assertThat(result.getTopicCount()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(result.getGroupCount()).isZero();
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersTraceElementsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersTraceElementsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.alibaba;
+
+import com.aliyun.sdk.service.rocketmq20220801.models.GetTraceResponseBody;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AliyunConvertersTraceElementsTest {
+
+    @Test
+    void toTraceRecordShouldSkipNullSdkListElements() {
+        GetTraceResponseBody.ProducerInfo producer = GetTraceResponseBody.ProducerInfo.builder()
+                .records(Arrays.asList((GetTraceResponseBody.ProducerInfoRecords) null))
+                .build();
+        GetTraceResponseBody.BrokerInfo broker = GetTraceResponseBody.BrokerInfo.builder()
+                .operations(Arrays.asList((GetTraceResponseBody.Operations) null))
+                .build();
+        GetTraceResponseBody.ConsumerInfos consumer = GetTraceResponseBody.ConsumerInfos.builder()
+                .records(Arrays.asList((GetTraceResponseBody.Records) null))
+                .build();
+        GetTraceResponseBody.Data data = GetTraceResponseBody.Data.builder()
+                .producerInfo(producer)
+                .brokerInfo(broker)
+                .consumerInfos(Arrays.asList(null, consumer))
+                .build();
+
+        assertThat(AliyunConverters.toTraceRecord(data).getNodes()).isEmpty();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -555,4 +555,15 @@ class AliyunInstanceProviderTest {
         org.junit.jupiter.api.Assertions.assertEquals("Concurrently",
                 AliyunInstanceProvider.normalizeDeliveryOrderType("Concurrently"));
     }
+
+    @Test
+    void timeConversionUsesAliyunUtc8Zone() {
+        // "2024-01-01 00:00:00" is 2023-12-31T16:00:00Z in UTC+8 regardless of server zone.
+        long expectedUtc8 = java.time.LocalDateTime.of(2024, 1, 1, 0, 0)
+                .atZone(java.time.ZoneId.of("Asia/Shanghai")).toInstant().toEpochMilli();
+        assertThat(AliyunConverters.parseTimeMillis("2024-01-01 00:00:00")).isEqualTo(expectedUtc8);
+
+        // Round-trip formatting must restore the same calendar time in UTC+8.
+        assertThat(AliyunConverters.formatTimeMillis(expectedUtc8)).isEqualTo("2024-01-01 00:00:00");
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -159,6 +159,35 @@ class RocketMQMessageProviderTest {
     }
 
     @Test
+    void queryByTopicReturnsNewestMessagesFirst() throws Exception {
+        MessageQueue queue = new MessageQueue("TopicA", "broker-a", 0);
+        MessageExt older = new MessageExt();
+        older.setMsgId("older");
+        older.setTopic("TopicA");
+        older.setStoreTimestamp(150L);
+        MessageExt newer = new MessageExt();
+        newer.setMsgId("newer");
+        newer.setTopic("TopicA");
+        newer.setStoreTimestamp(250L);
+        PullResult pullResult = new PullResult(PullStatus.FOUND, 11L, 10L, 11L,
+                List.of(older, newer));
+        try (MockedConstruction<DefaultMQPullConsumer> ignored =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues("TopicA")).thenReturn(Set.of(queue));
+                         when(consumer.searchOffset(eq(queue), anyLong())).thenReturn(10L);
+                         when(consumer.pull(queue, "*", 10L, 32)).thenReturn(pullResult);
+                         doNothing().when(consumer).shutdown();
+                     })) {
+            List<MessageRecordVO> messages = provider.queryMessages(
+                    "instance-a", "TopicA", null, null, null, 100L, 300L);
+
+            assertThat(messages).extracting(MessageRecordVO::getMsgId)
+                    .containsExactly("newer", "older");
+        }
+    }
+
+    @Test
     void toRecordVOBoundsMessageBodyAndProperties() {
         MessageExt message = new MessageExt();
         message.setMsgId("msg-1");

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
@@ -182,6 +182,7 @@ class CloudCredentialServiceTest {
         stored.setVendor(InstanceVendor.ALIYUN);
         when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
         when(instanceRepository.existsByCredentialId("cred-1")).thenReturn(false);
+        when(credentialRepository.deleteById("cred-1")).thenReturn(true);
 
         service.delete("cred-1");
 
@@ -189,6 +190,22 @@ class CloudCredentialServiceTest {
         verify(aliyunClientFactory).invalidateCredential("cred-1");
         verify(operationAuditService).record(eq("DELETE_CLOUD_CREDENTIAL"), eq("CLOUD_CREDENTIAL"),
                 eq("cred-1"), eq(null), eq("name=null, vendor=ALIYUN"), eq("SUCCESS"), eq(null));
+    }
+
+    @Test
+    void deleteShouldRejectConcurrentRemovalBeforeInvalidatingClientsTest() {
+        CloudCredentialVO stored = new CloudCredentialVO();
+        stored.setId("cred-1");
+        stored.setVendor(InstanceVendor.ALIYUN);
+        when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
+        when(instanceRepository.existsByCredentialId("cred-1")).thenReturn(false);
+        when(credentialRepository.deleteById("cred-1")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.delete("cred-1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Cloud credential not found: cred-1");
+
+        verify(aliyunClientFactory, never()).invalidateCredential(any());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,6 +42,20 @@ class MybatisPlusCloudCredentialRepositoryTest {
 
     @InjectMocks
     private MybatisPlusCloudCredentialRepository repository;
+
+    @Test
+    void saveShouldReportALostConcurrentUpdate() {
+        CloudCredentialVO credential = new CloudCredentialVO();
+        credential.setId("cred-1");
+        credential.setVendor(InstanceVendor.ALIYUN);
+        when(credentialMapper.selectById("cred-1")).thenReturn(entity("cred-1", "ALIYUN"));
+        when(credentialMapper.updateById(any(RmqCloudCredential.class))).thenReturn(0);
+
+        assertThatThrownBy(() -> repository.save(credential))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Cloud credential update was not applied: cred-1")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(409));
+    }
 
     @Test
     void findByIdShouldMapValidPersistedVendor() {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -111,6 +111,16 @@ class TencentInstanceProviderTest {
     }
 
     @Test
+    void countTopicsShouldClampOversizedTotals() throws Exception {
+        DescribeTopicListResponse response = new DescribeTopicListResponse();
+        response.setData(new TopicItem[]{topicItem("orders", "NORMAL", 8L)});
+        response.setTotalCount(Long.MAX_VALUE);
+        when(client.DescribeTopicList(any())).thenReturn(response);
+
+        assertThat(provider.countTopics(STUDIO_INSTANCE_ID)).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
     void listTopicsShouldMapAndFilterAndEnrichTimesTest() throws Exception {
         TopicItem normal = topicItem("orders", "NORMAL", 8L);
         TopicItem fifo = topicItem("orders-fifo", "FIFO", 4L);
@@ -294,6 +304,20 @@ class TencentInstanceProviderTest {
     }
 
     @Test
+    void listConsumerGroupsShouldClampOversizedRetryCounts() throws Exception {
+        ConsumeGroupItem item = new ConsumeGroupItem();
+        item.setConsumerGroup("GID_test");
+        item.setMaxRetryTimes(Long.MAX_VALUE);
+        DescribeConsumerGroupListResponse response = new DescribeConsumerGroupListResponse();
+        response.setData(new ConsumeGroupItem[]{item});
+        when(client.DescribeConsumerGroupList(any())).thenReturn(response);
+
+        assertThat(provider.listConsumerGroups(STUDIO_INSTANCE_ID, null))
+                .singleElement()
+                .satisfies(group -> assertThat(group.getRetryMaxTimes()).isEqualTo(Integer.MAX_VALUE));
+    }
+
+    @Test
     void listConsumerGroupsShouldMapAndFilterTest() throws Exception {
         ConsumeGroupItem one = new ConsumeGroupItem();
         one.setConsumerGroup("GID_test");
@@ -437,6 +461,25 @@ class TencentInstanceProviderTest {
     }
 
     @Test
+    void queryMessagesShouldSkipNullAndStructuredPropertyValues() throws Exception {
+        DescribeMessageResponse detail = new DescribeMessageResponse();
+        detail.setMessageId("MSG-1");
+        detail.setShowTopicName("orders");
+        detail.setProperties("{\"KEYS\":\"keyA\",\"TAGS\":null,"
+                + "\"nested\":{\"x\":1},\"retry\":3,\"enabled\":true}");
+        when(client.DescribeMessage(any())).thenReturn(detail);
+
+        MessageRecordVO record = provider.queryMessages(
+                STUDIO_INSTANCE_ID, "orders", "MSG-1", null, null, null, null).get(0);
+
+        assertThat(record.getProperties())
+                .containsEntry("KEYS", "keyA")
+                .containsEntry("retry", "3")
+                .containsEntry("enabled", "true")
+                .doesNotContainKeys("TAGS", "nested");
+    }
+
+    @Test
     void queryMessagesByTopicShouldUseMessageListTest() throws Exception {
         MessageItem one = new MessageItem();
         one.setMsgId("MSG-A");
@@ -512,6 +555,38 @@ class TencentInstanceProviderTest {
     }
 
     @Test
+    void messageQueryReusesTaskRequestIdReturnedByPreviousPage() throws Exception {
+        MessageItem[] page1Items = new MessageItem[TencentInstanceProvider.MESSAGE_LIMIT];
+        for (int i = 0; i < TencentInstanceProvider.MESSAGE_LIMIT; i++) {
+            MessageItem item = new MessageItem();
+            item.setMsgId("MSG-" + (i + 1));
+            item.setProduceTime("2024-09-12 14:06:55,591");
+            page1Items[i] = item;
+        }
+        MessageItem last = new MessageItem();
+        last.setMsgId("MSG-LAST");
+        last.setProduceTime("2024-09-12 14:06:56,591");
+        DescribeMessageListResponse page1 = new DescribeMessageListResponse();
+        page1.setData(page1Items);
+        page1.setTaskRequestId("task-abc");
+        DescribeMessageListResponse page2 = new DescribeMessageListResponse();
+        page2.setData(new MessageItem[]{last});
+        page2.setTaskRequestId("task-abc");
+        when(client.DescribeMessageList(any()))
+                .thenReturn(page1)
+                .thenReturn(page2);
+
+        provider.queryMessages(STUDIO_INSTANCE_ID, "orders", null, null, null,
+                1600000000000L, 1600001000000L);
+
+        ArgumentCaptor<DescribeMessageListRequest> captor = ArgumentCaptor.forClass(DescribeMessageListRequest.class);
+        verify(client, org.mockito.Mockito.times(2)).DescribeMessageList(captor.capture());
+        java.util.List<DescribeMessageListRequest> requests = captor.getAllValues();
+        // The second page must carry the task id returned by the first page, not a fresh random id.
+        assertThat(requests.get(1).getTaskRequestId()).isEqualTo("task-abc");
+    }
+
+    @Test
     void getMessageTraceShouldMapStagesTest() throws Exception {
         MessageTraceItem produce = new MessageTraceItem();
         produce.setStage("produce");
@@ -545,5 +620,25 @@ class TencentInstanceProviderTest {
         assertThat(captor.getValue().getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
         assertThat(captor.getValue().getTopic()).isEqualTo("orders");
         assertThat(captor.getValue().getMsgId()).isEqualTo("MSG-1");
+    }
+
+    @Test
+    void getMessageTraceMarksInFlightConsumeAsProcessNotFailed() throws Exception {
+        MessageTraceItem consume = new MessageTraceItem();
+        consume.setStage("consume");
+        consume.setData("{\"TotalCount\":1,\"RocketMqConsumeLogs\":[{\"MsgId\":\"MSG-2\",\"Status\":1,"
+                + "\"PushTime\":\"2024-09-12 14:06:55,600\",\"ConsumerGroup\":\"GID_test\",\"RetryTimes\":0}]}");
+        DescribeMessageTraceResponse response = new DescribeMessageTraceResponse();
+        response.setData(new MessageTraceItem[]{consume});
+        when(client.DescribeMessageTrace(any())).thenReturn(response);
+
+        TraceRecordVO trace = provider.getMessageTrace(STUDIO_INSTANCE_ID, "MSG-2", "orders");
+
+        assertThat(trace.getNodes()).hasSize(1);
+        // In-flight (Status 1) must read "process", consistent with toDeliveryStatus and the
+        // frontend TraceNode status union, not "failed".
+        assertThat(trace.getNodes().get(0).getStatus()).isEqualTo("process");
+        assertThat(trace.getConsumerStatus().get(0).getDeliveryStatus())
+                .isEqualTo(DeliveryStatus.pending);
     }
 }

--- a/web/src/api/ai.test.ts
+++ b/web/src/api/ai.test.ts
@@ -31,12 +31,13 @@ import {
 const mock = new MockAdapter(client);
 const encoder = new TextEncoder();
 
-function streamResponse(chunks: string[]): Response {
+function streamResponse(chunks: string[], onCancel?: () => void): Response {
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
       chunks.forEach((chunk) => controller.enqueue(encoder.encode(chunk)));
-      controller.close();
+      if (!onCancel) controller.close();
     },
+    cancel: onCancel,
   });
   return new Response(body, { status: 200 });
 }
@@ -133,6 +134,34 @@ describe('AI API', () => {
       );
 
       expect(chunks).toEqual(['hello', 'raw text']);
+    });
+
+    it('cancels the reader after the done event', async () => {
+      const onCancel = vi.fn();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(streamResponse(['data: [DONE]\n\n'], onCancel)),
+      );
+
+      await chatStream({ message: 'hello', mode: 'chat', model: 'stub' }, vi.fn());
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects an unbounded SSE event and cancels the reader', async () => {
+      const onCancel = vi.fn();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(streamResponse(['data: ' + 'x'.repeat(1024 * 1024)], onCancel)),
+      );
+
+      await expect(
+        chatStream({ message: 'hello', mode: 'chat', model: 'stub' }, vi.fn()),
+      ).rejects.toMatchObject({
+        message: 'AI stream event exceeds 1 MiB',
+        code: 'llm.stream.event_too_large',
+      });
+      expect(onCancel).toHaveBeenCalledTimes(1);
     });
 
     it('throws structured errors from SSE error events', async () => {

--- a/web/src/api/ai.ts
+++ b/web/src/api/ai.ts
@@ -18,6 +18,8 @@
 import client from './client';
 import { readAuthSession } from '../stores/authStorage';
 
+const MAX_SSE_EVENT_CHARS = 1024 * 1024;
+
 // ─── Types ──────────────────────────────────────────────────────
 export interface McpTool {
   name: string;
@@ -178,22 +180,35 @@ export async function chatStream(
   const decoder = new TextDecoder();
   let buffer = '';
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
 
-    buffer += decoder.decode(value, { stream: true });
-    let boundary = getEventBoundary(buffer);
-    while (boundary) {
-      const event = buffer.slice(0, boundary.index);
-      buffer = buffer.slice(boundary.index + boundary.length);
-      if (emitEvent(event, onChunk, onEnhance)) return;
-      boundary = getEventBoundary(buffer);
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.length > MAX_SSE_EVENT_CHARS && !getEventBoundary(buffer)) {
+        throw new AiStreamError('AI stream event exceeds 1 MiB', 'llm.stream.event_too_large');
+      }
+      let boundary = getEventBoundary(buffer);
+      while (boundary) {
+        const event = buffer.slice(0, boundary.index);
+        buffer = buffer.slice(boundary.index + boundary.length);
+        if (event.length > MAX_SSE_EVENT_CHARS) {
+          throw new AiStreamError('AI stream event exceeds 1 MiB', 'llm.stream.event_too_large');
+        }
+        if (emitEvent(event, onChunk, onEnhance)) return;
+        boundary = getEventBoundary(buffer);
+      }
     }
-  }
 
-  buffer += decoder.decode();
-  if (buffer && emitEvent(buffer, onChunk, onEnhance)) return;
+    buffer += decoder.decode();
+    if (buffer.length > MAX_SSE_EVENT_CHARS) {
+      throw new AiStreamError('AI stream event exceeds 1 MiB', 'llm.stream.event_too_large');
+    }
+    if (buffer && emitEvent(buffer, onChunk, onEnhance)) return;
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
 }
 
 export async function executeAiCommand(data: AiExecuteRequest) {

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -148,4 +148,13 @@ describe('API client response contract', () => {
     expect(localStorage.getItem('rocketmq-studio-user')).toBeNull();
     expect(localStorage.getItem('rocketmq-studio-user-admin')).toBeNull();
   });
+
+  it('preserves the original 401 error when the request URL is malformed', async () => {
+    localStorage.setItem('token', 'expired-token');
+    mock.onGet('http://[').reply(401, { code: 401, message: 'Unauthorized', data: null });
+
+    await expect(client.get('http://[')).rejects.toMatchObject({ response: { status: 401 } });
+
+    expect(localStorage.getItem('token')).toBeNull();
+  });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -47,12 +47,16 @@ function getBusinessError(data: unknown): string | null {
 
 function isPublicAuthRequest(url?: string): boolean {
   if (!url) return false;
-  const requestPath = new URL(url, window.location.origin).pathname;
-  const apiBasePath = new URL(API_BASE_URL, window.location.origin).pathname;
-  const relativePath = requestPath.startsWith(`${apiBasePath}/`)
-    ? requestPath.slice(apiBasePath.length)
-    : requestPath;
-  return PUBLIC_AUTH_PATHS.has(relativePath);
+  try {
+    const requestPath = new URL(url, window.location.origin).pathname;
+    const apiBasePath = new URL(API_BASE_URL, window.location.origin).pathname;
+    const relativePath = requestPath.startsWith(`${apiBasePath}/`)
+      ? requestPath.slice(apiBasePath.length)
+      : requestPath;
+    return PUBLIC_AUTH_PATHS.has(relativePath);
+  } catch {
+    return false;
+  }
 }
 
 const client = axios.create({

--- a/web/src/api/message.test.ts
+++ b/web/src/api/message.test.ts
@@ -108,10 +108,10 @@ describe('message API', () => {
       ],
     };
     mock
-      .onGet('/messages/msg-1/trace', { params: { instanceId: 'instance-a' } })
+      .onGet('/messages/msg-1/trace', { params: { instanceId: 'instance-a', topic: 'orders' } })
       .reply(200, { code: 200, data: trace });
 
-    await expect(getMessageTrace('msg-1', 'instance-a')).resolves.toEqual(trace);
+    await expect(getMessageTrace('msg-1', 'instance-a', 'orders')).resolves.toEqual(trace);
   });
 
   it('encodes message IDs before requesting trace records', async () => {
@@ -120,9 +120,13 @@ describe('message API', () => {
       consumerStatus: [],
     };
     mock
-      .onGet('/messages/AC1E0A64%2F0000%202A9F%3A1/trace', { params: { instanceId: 'instance-a' } })
+      .onGet('/messages/AC1E0A64%2F0000%202A9F%3A1/trace', {
+        params: { instanceId: 'instance-a', topic: 'orders' },
+      })
       .reply(200, { code: 200, data: trace });
 
-    await expect(getMessageTrace('AC1E0A64/0000 2A9F:1', 'instance-a')).resolves.toEqual(trace);
+    await expect(getMessageTrace('AC1E0A64/0000 2A9F:1', 'instance-a', 'orders')).resolves.toEqual(
+      trace,
+    );
   });
 });

--- a/web/src/layouts/navigationSearch.test.ts
+++ b/web/src/layouts/navigationSearch.test.ts
@@ -15,10 +15,14 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { filterNavigationEntries, isNavigationSearchShortcut } from './navigationSearch';
 
 describe('navigation search helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   const entries = [
     { key: '/cluster', label: 'RocketMQ 集群' },
     { key: '/settings', label: 'Settings' },
@@ -28,6 +32,15 @@ describe('navigation search helpers', () => {
   it('filters labels case-insensitively and ignores query whitespace', () => {
     expect(filterNavigationEntries(entries, ' SETTINGS ')).toEqual([entries[1]]);
     expect(filterNavigationEntries(entries, '集群')).toEqual([entries[0]]);
+  });
+
+  it('normalizes searches independently of the browser locale', () => {
+    const localeLowerCase = String.prototype.toLocaleLowerCase;
+    vi.spyOn(String.prototype, 'toLocaleLowerCase').mockImplementation(function (this: string) {
+      return localeLowerCase.call(this, 'tr');
+    });
+
+    expect(filterNavigationEntries(entries, 'SETTINGS')).toEqual([entries[1]]);
   });
 
   it('filters by route keys case-insensitively', () => {

--- a/web/src/layouts/navigationSearch.ts
+++ b/web/src/layouts/navigationSearch.ts
@@ -26,7 +26,7 @@ export interface NavigationSearchEntry {
 function normalizeSearchText(value: string): string {
   return value
     .normalize('NFKC')
-    .toLocaleLowerCase()
+    .toLowerCase()
     .replace(/[^\p{L}\p{N}]+/gu, ' ')
     .trim();
 }
@@ -78,7 +78,7 @@ export function isNavigationSearchShortcut(event: {
     ) !== null;
 
   return (
-    event.key.toLocaleLowerCase() === 'k' &&
+    event.key.toLowerCase() === 'k' &&
     (event.metaKey || event.ctrlKey) &&
     !event.altKey &&
     !isEditableTarget

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -21,7 +21,7 @@ import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { MemoryRouter } from 'react-router-dom';
 import { LangProvider } from '../../../i18n/LangContext';
-import { executeTool, listTools } from '../../../api/ai';
+import { chatStream, executeTool, listTools } from '../../../api/ai';
 import { listClusters, type ClusterInfo } from '../../../api/cluster';
 import { getLlmConfig, getLlmModels } from '../../../api/llm';
 import AiPage from '../index';
@@ -59,11 +59,11 @@ beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn();
 });
 
-const renderPage = () =>
+const renderPage = (state?: unknown) =>
   render(
     <App>
       <LangProvider>
-        <MemoryRouter initialEntries={['/ai']}>
+        <MemoryRouter initialEntries={[state === undefined ? '/ai' : { pathname: '/ai', state }]}>
           <AiPage />
         </MemoryRouter>
       </LangProvider>
@@ -103,6 +103,20 @@ describe('AiPage tool runner', () => {
         permission: 'cluster:read',
       },
     ]);
+  });
+
+  it('uses the mode carried from the home-page draft', async () => {
+    vi.mocked(chatStream).mockResolvedValue(undefined);
+    renderPage({ prompt: '检查集群状态', mode: 'diagnose' });
+
+    await waitFor(() => {
+      expect(chatStream).toHaveBeenCalledWith(
+        expect.objectContaining({ message: '检查集群状态', mode: 'diagnose' }),
+        expect.any(Function),
+        expect.any(AbortSignal),
+        expect.any(Function),
+      );
+    });
   });
 
   it('loads the catalog, creates a schema template, and renders structured output', async () => {

--- a/web/src/pages/ai/chatDraft.test.ts
+++ b/web/src/pages/ai/chatDraft.test.ts
@@ -26,6 +26,16 @@ describe('AI chat draft navigation state', () => {
     });
   });
 
+  it('preserves supported home modes and drops unknown modes', () => {
+    expect(getChatDraft({ prompt: '检查集群状态', mode: 'diagnose' })).toEqual({
+      prompt: '检查集群状态',
+      mode: 'diagnose',
+    });
+    expect(getChatDraft({ prompt: '检查集群状态', mode: 'unknown' })).toEqual({
+      prompt: '检查集群状态',
+    });
+  });
+
   it('rejects invalid or empty navigation state', () => {
     expect(getChatDraft(null)).toBeNull();
     expect(getChatDraft({ prompt: '   ' })).toBeNull();

--- a/web/src/pages/ai/chatDraft.ts
+++ b/web/src/pages/ai/chatDraft.ts
@@ -15,9 +15,14 @@
  * limitations under the License.
  */
 
+export type ChatMode = 'chat' | 'diagnose' | 'manage' | 'query';
+
+const CHAT_MODES = new Set<ChatMode>(['chat', 'diagnose', 'manage', 'query']);
+
 export interface ChatDraft {
   prompt: string;
   model?: string;
+  mode?: ChatMode;
   enhance?: boolean;
 }
 
@@ -26,10 +31,15 @@ export function getChatDraft(state: unknown): ChatDraft | null {
   const candidate = state as Record<string, unknown>;
   if (typeof candidate.prompt !== 'string' || !candidate.prompt.trim()) return null;
   const model = typeof candidate.model === 'string' ? candidate.model.trim() : '';
+  const mode =
+    typeof candidate.mode === 'string' && CHAT_MODES.has(candidate.mode as ChatMode)
+      ? (candidate.mode as ChatMode)
+      : undefined;
 
   return {
     prompt: candidate.prompt.trim(),
     ...(model ? { model } : {}),
+    ...(mode ? { mode } : {}),
     ...(candidate.enhance === true ? { enhance: true } : {}),
   };
 }

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -46,7 +46,7 @@ import { AiStreamError, chatStream, executeTool, listTools, type McpTool } from 
 import { listClusters } from '../../api/cluster';
 import { getLlmConfig, getLlmModels, type LlmConfig } from '../../api/llm';
 import { useEngineStore } from '../../stores/engineStore';
-import { getChatDraft } from './chatDraft';
+import { getChatDraft, type ChatMode } from './chatDraft';
 
 const { Text } = Typography;
 
@@ -404,9 +404,12 @@ const AiPage = () => {
   const conversationIdRef = useRef<string | null>(null);
   const toolLoadRequestRef = useRef(0);
   const consumedDraftRef = useRef(false);
-  const pendingAutoSendRef = useRef<{ prompt: string; model?: string; enhance?: boolean } | null>(
-    null,
-  );
+  const pendingAutoSendRef = useRef<{
+    prompt: string;
+    model?: string;
+    mode?: ChatMode;
+    enhance?: boolean;
+  } | null>(null);
 
   const scrollToBottom = useCallback(() => {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -466,6 +469,7 @@ const AiPage = () => {
       pendingAutoSendRef.current = {
         prompt: draft.prompt,
         model: draft.model,
+        mode: draft.mode,
         enhance: draft.enhance,
       };
       navigate('/ai', { replace: true, state: null });
@@ -491,7 +495,12 @@ const AiPage = () => {
   const llmReady = Boolean((llmConfig?.ready ?? llmConfig?.enabled) && selectedModel);
 
   const handleSend = useCallback(
-    async (textOverride?: string, modelOverride?: string, enhance?: boolean) => {
+    async (
+      textOverride?: string,
+      modelOverride?: string,
+      enhance?: boolean,
+      modeOverride: ChatMode = 'chat',
+    ) => {
       const text = (textOverride ?? inputValue).trim();
       const model = modelOverride ?? selectedModel;
       if (!text || loading) return;
@@ -528,7 +537,7 @@ const AiPage = () => {
         await chatStream(
           {
             message: text,
-            mode: 'chat',
+            mode: modeOverride,
             model,
             engine: useEngineStore.getState().engine,
             enhance,
@@ -586,7 +595,7 @@ const AiPage = () => {
     const pending = pendingAutoSendRef.current;
     if (!pending || loading || !llmReady) return;
     pendingAutoSendRef.current = null;
-    void handleSend(pending.prompt, pending.model, pending.enhance);
+    void handleSend(pending.prompt, pending.model, pending.enhance, pending.mode);
   }, [llmReady, loading, handleSend]);
 
   const handleStop = useCallback(() => {

--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -16,18 +16,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import {
-  Table,
-  Tag,
-  Input,
-  Select,
-  Flex,
-  Space,
-  Typography,
-  Card,
-  Alert,
-  message,
-} from 'antd';
+import { Table, Tag, Input, Select, Flex, Space, Typography, Card, Alert, message } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import PageHeader from '../../components/PageHeader';
 import type { K8sCertInfo } from '../../api/cluster';
@@ -197,10 +186,7 @@ const K8sCertsPage = () => {
 
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader
-        title="K8s 证书管理"
-        subtitle={`共 ${filteredCerts.length} 个证书`}
-      />
+      <PageHeader title="K8s 证书管理" subtitle={`共 ${filteredCerts.length} 个证书`} />
       <Alert
         data-testid="k8s-cert-local-metadata-notice"
         type="warning"
@@ -238,7 +224,7 @@ const K8sCertsPage = () => {
           />
         </Space>
       </Flex>
-      <Card bodyStyle={{ padding: 0 }}>
+      <Card styles={{ body: { padding: 0 } }}>
         <Table
           columns={certColumns}
           dataSource={filteredCerts}
@@ -249,7 +235,6 @@ const K8sCertsPage = () => {
           scroll={{ x: 1750 }}
         />
       </Card>
-
     </div>
   );
 };

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -504,7 +504,7 @@ const ClientsPage = () => {
       </Flex>
 
       {/* ─── Table ─── */}
-      <Card bodyStyle={{ padding: 0 }}>
+      <Card styles={{ body: { padding: 0 } }}>
         <Table
           columns={columns}
           dataSource={filtered}
@@ -528,7 +528,7 @@ const ClientsPage = () => {
         onCancel={() => setSelectedConnection(null)}
         footer={<Button onClick={() => setSelectedConnection(null)}>{t('common.close')}</Button>}
         width={640}
-        destroyOnClose
+        destroyOnHidden
       >
         {selectedConnection && (
           <Descriptions column={1} bordered size="small">

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -553,7 +553,7 @@ const ClusterPage = () => {
             {t('cluster.createCluster')}
           </Button>
         </Flex>
-        <Card bodyStyle={{ padding: 0 }}>
+        <Card styles={{ body: { padding: 0 } }}>
           <Table
             columns={brokerColumns}
             dataSource={allBrokers}
@@ -816,7 +816,7 @@ const ClusterPage = () => {
             {t('cluster.createNameServer')}
           </Button>
         </Flex>
-        <Card bodyStyle={{ padding: 0 }}>
+        <Card styles={{ body: { padding: 0 } }}>
           <Table
             columns={clusterColumns}
             dataSource={filteredClusters}
@@ -987,7 +987,7 @@ const ClusterPage = () => {
             {t('cluster.createCluster')}
           </Button>
         </Flex>
-        <Card bodyStyle={{ padding: 0 }}>
+        <Card styles={{ body: { padding: 0 } }}>
           <Table
             columns={proxyColumns}
             dataSource={allProxies}
@@ -1110,7 +1110,7 @@ const ClusterPage = () => {
         }}
         okText={t('common.confirm')}
         cancelText={t('common.cancel')}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form form={nsForm} layout="vertical" style={{ marginTop: 16 }}>
           {nsModalMode === 'create' && (
@@ -1146,7 +1146,7 @@ const ClusterPage = () => {
         onCancel={() => setSelectedProxy(null)}
         footer={<Button onClick={() => setSelectedProxy(null)}>{t('common.close')}</Button>}
         width={560}
-        destroyOnClose
+        destroyOnHidden
       >
         {selectedProxy && (
           <Descriptions column={1} bordered size="small">
@@ -1197,7 +1197,7 @@ const ClusterPage = () => {
         confirmLoading={connectTesting}
         onOk={handleTestConnection}
         width={560}
-        destroyOnClose
+        destroyOnHidden
       >
         <Text type="secondary">{t('cluster.testConnectionDesc')}</Text>
         <Form form={connectForm} layout="vertical" style={{ marginTop: 16 }}>

--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -78,6 +78,18 @@ describe('HomePage LLM models', () => {
     expect(await screen.findByText('qwen3.8-max')).toBeInTheDocument();
   });
 
+  it('does not fetch LLM config in Mock mode', async () => {
+    const { useDataModeStore } = await import('../../../stores/dataModeStore');
+    useDataModeStore.getState().toggle();
+
+    renderHome();
+
+    expect(llmApiMocks.getLlmConfig).not.toHaveBeenCalled();
+    expect(await screen.findByText('qwen3.8-max')).toBeInTheDocument();
+
+    useDataModeStore.getState().toggle();
+  });
+
   it('submits the selected model and engine to the AI page', async () => {
     const user = userEvent.setup();
     renderHome();
@@ -94,6 +106,7 @@ describe('HomePage LLM models', () => {
           prompt: '查看集群状态',
           model: 'qwen3.8-max',
           engine: 'claude-code',
+          mode: 'chat',
         },
       });
     });

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -34,6 +34,7 @@ import {
 } from '@phosphor-icons/react';
 import { getLlmConfig } from '../../api/llm';
 import { useEngineStore } from '../../stores/engineStore';
+import { useDataModeStore } from '../../stores/dataModeStore';
 import { useLang } from '../../i18n/LangContext';
 
 /* ─── Time-aware greeting key ─── */
@@ -98,6 +99,17 @@ const HomePage = () => {
     let cancelled = false;
 
     const loadModels = async () => {
+      const useMock = useDataModeStore.getState().useMock;
+      if (useMock) {
+        if (cancelled) return;
+        setModelOptions(
+          HOME_MODELS.map((value) => ({ value, recommended: value === RECOMMENDED_MODEL })),
+        );
+        setSelectedModel((current) =>
+          current && HOME_MODELS.includes(current) ? current : HOME_MODELS[0] || '',
+        );
+        return;
+      }
       const config = await getLlmConfig().catch(() => null);
       if (cancelled) return;
 
@@ -192,6 +204,7 @@ const HomePage = () => {
             prompt,
             ...(selectedModel ? { model: selectedModel } : {}),
             engine,
+            mode: activeMode,
             ...(promoteOn ? { enhance: true } : {}),
           }
         : null,

--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -16,12 +16,12 @@
  */
 
 import { App } from 'antd';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { DLQGroup } from '../../../api/message';
+import type { DLQGroup, DLQResendResult } from '../../../api/message';
 import { LangProvider } from '../../../i18n/LangContext';
 import * as messageService from '../../../services/messageService';
 import DLQPage from '../dlq';
@@ -348,5 +348,46 @@ describe('DLQ page', () => {
 
     resolveSecondInstance([secondDlqGroup]);
     expect(await screen.findByText('-cg-"payment"')).toBeInTheDocument();
+  });
+
+  it('ignores a retry completion from the previously selected instance', async () => {
+    let resolveRetry!: (result: DLQResendResult) => void;
+    vi.mocked(messageService.resendDLQ).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRetry = resolve;
+        }),
+    );
+    vi.mocked(messageService.listDLQGroups)
+      .mockResolvedValueOnce([dlqGroup])
+      .mockResolvedValueOnce([secondDlqGroup]);
+    const user = userEvent.setup();
+    renderWithProviders(<DLQPage />);
+
+    const firstRow = (await screen.findByText('cg-order')).closest('tr');
+    if (!firstRow) throw new Error('DLQ group row not found');
+    await user.click(within(firstRow).getByRole('button', { name: '重投消息' }));
+    await user.type(screen.getByPlaceholderText('输入目标 Topic 名称'), 'orders-retry');
+    await user.click(screen.getByRole('button', { name: '确认重投' }));
+
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(
+      await screen.findByText('instance-2', { selector: '.ant-select-item-option-content' }),
+    );
+    const secondRow = (await screen.findByText('-cg-"payment"')).closest('tr');
+    if (!secondRow) throw new Error('second DLQ group row not found');
+    await user.click(within(secondRow).getByRole('button', { name: '重投消息' }));
+    let retryDialog = screen.getByText('重投死信消息').closest('.ant-modal');
+    if (!retryDialog) throw new Error('retry dialog not found');
+    expect(within(retryDialog as HTMLElement).getByText('-cg-"payment"')).toBeInTheDocument();
+
+    await act(async () =>
+      resolveRetry({ matched: 7, resent: 7, failed: 0, outcome: 'SUCCESS' }),
+    );
+
+    retryDialog = screen.getByText('重投死信消息').closest('.ant-modal');
+    if (!retryDialog) throw new Error('retry dialog was closed by the stale request');
+    expect(within(retryDialog as HTMLElement).getByText('-cg-"payment"')).toBeInTheDocument();
+    expect(messageService.listDLQGroups).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -877,7 +877,7 @@ const AclPage = () => {
         style={{ marginBottom: 16 }}
       />
 
-      <Card bordered={false} bodyStyle={{ padding: 0 }}>
+      <Card variant="borderless" styles={{ body: { padding: 0 } }}>
         <Tabs
           activeKey={activeTab}
           onChange={setActiveTab}
@@ -1101,7 +1101,7 @@ const AclPage = () => {
         cancelText={t('common.cancel')}
         confirmLoading={ruleSubmitting}
         width={560}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form form={ruleForm} layout="vertical" style={{ marginTop: 16 }}>
           <Form.Item
@@ -1200,7 +1200,7 @@ const AclPage = () => {
         cancelText={t('common.cancel')}
         confirmLoading={userSubmitting}
         width={520}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form form={userForm} layout="vertical" style={{ marginTop: 16 }}>
           <Form.Item
@@ -1237,7 +1237,7 @@ const AclPage = () => {
         cancelText={t('common.cancel')}
         confirmLoading={plainSubmitting}
         width={560}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form form={plainForm} layout="vertical" style={{ marginTop: 16 }}>
           <Form.Item

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -944,7 +944,7 @@ const ConsumerPageContent = ({
       </Flex>
 
       {/* ─── Table with expandable rows ─── */}
-      <Card bodyStyle={{ padding: 0 }}>
+      <Card styles={{ body: { padding: 0 } }}>
         <Table
           columns={columns}
           dataSource={filtered}
@@ -1005,7 +1005,7 @@ const ConsumerPageContent = ({
           setShowOnlyInconsistent(false);
         }}
         width={800}
-        destroyOnClose
+        destroyOnHidden
         footer={null}
       >
         {selectedGroup && (
@@ -1084,7 +1084,7 @@ const ConsumerPageContent = ({
                       bordered
                       column={2}
                       size="small"
-                      labelStyle={{ fontWeight: 500, width: 140 }}
+                      styles={{ label: { fontWeight: 500, width: 140 } }}
                     >
                       <Descriptions.Item label="Group 名称">
                         <Text strong>{selectedGroup.name}</Text>
@@ -1246,7 +1246,7 @@ const ConsumerPageContent = ({
                         background: '#fafafa',
                         borderRadius: 8,
                       }}
-                      bodyStyle={{ padding: '8px 16px' }}
+                      styles={{ body: { padding: '8px 16px' } }}
                     >
                       <Space size={24}>
                         <Space size={4}>
@@ -1306,7 +1306,7 @@ const ConsumerPageContent = ({
         }}
         footer={null}
         width={900}
-        destroyOnClose
+        destroyOnHidden
       >
         <Space direction="vertical" size={16} style={{ width: '100%' }}>
           <Descriptions bordered column={2} size="small">
@@ -1438,7 +1438,7 @@ const ConsumerPageContent = ({
         okText="创建"
         cancelText="取消"
         width={560}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form
           form={form}
@@ -1538,7 +1538,7 @@ const ConsumerPageContent = ({
             importRows.every((row) => row.status === 'success' || row.status === 'invalid'),
         }}
         width={720}
-        destroyOnClose
+        destroyOnHidden
       >
         <Space direction="vertical" style={{ width: '100%' }} size={12}>
           {importErrors.length > 0 ? (
@@ -1621,7 +1621,7 @@ const ConsumerPageContent = ({
         okText="确认重置"
         cancelText="取消"
         width={480}
-        destroyOnClose
+        destroyOnHidden
       >
         {resetGroup && (
           <div style={{ marginTop: 16 }}>

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Card,
@@ -121,6 +121,14 @@ const DLQPage = () => {
   const [selectedGroupNames, setSelectedGroupNames] = useState<string[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [retryError, setRetryError] = useState<string | null>(null);
+  const retryRequestIdRef = useRef(0);
+
+  useEffect(
+    () => () => {
+      retryRequestIdRef.current += 1;
+    },
+    [],
+  );
 
   // The retry dialog owns a group name that is meaningful only for the
   // currently selected instance. Clear all instance-scoped state before
@@ -197,6 +205,12 @@ const DLQPage = () => {
   }, [groups, selectedGroupNames]);
 
   /* ─── Handlers ─── */
+  const handleInstanceChange = (instanceId: string) => {
+    retryRequestIdRef.current += 1;
+    setRetrySubmitting(false);
+    selectInstance(instanceId);
+  };
+
   const openRetryModal = (group: DLQGroup) => {
     setRetryGroup(group);
     setRetryRange([dayjs().subtract(1, 'day'), dayjs()]);
@@ -212,16 +226,21 @@ const DLQPage = () => {
     }
     if (!retryGroup || !selectedInstanceId) return;
 
+    const requestId = retryRequestIdRef.current + 1;
+    retryRequestIdRef.current = requestId;
+    const groupName = retryGroup.groupName;
+    const targetTopic = retryTargetTopic;
     setRetrySubmitting(true);
     setRetryError(null);
     try {
       const result = await resendDLQ({
         instanceId: selectedInstanceId,
-        groupName: retryGroup.groupName,
+        groupName,
         startTime: retryRange[0].valueOf(),
         endTime: retryRange[1].valueOf(),
-        targetTopic: retryTargetTopic,
+        targetTopic,
       });
+      if (retryRequestIdRef.current !== requestId) return;
       setRefreshKey((key) => key + 1);
       if (result.scanIncomplete) {
         message.warning(
@@ -231,16 +250,20 @@ const DLQPage = () => {
         message.warning(`重投部分完成：成功 ${result.resent}，失败 ${result.failed}`);
       } else {
         message.success(
-          `重投完成：${retryGroup.groupName} → ${retryTargetTopic}（${result.resent} 条）`,
+          `重投完成：${groupName} → ${targetTopic}（${result.resent} 条）`,
         );
       }
       setRetryModalOpen(false);
       setRetryGroup(null);
       setRetryError(null);
     } catch (error) {
-      setRetryError(getErrorMessage(error, DEFAULT_RETRY_ERROR));
+      if (retryRequestIdRef.current === requestId) {
+        setRetryError(getErrorMessage(error, DEFAULT_RETRY_ERROR));
+      }
     } finally {
-      setRetrySubmitting(false);
+      if (retryRequestIdRef.current === requestId) {
+        setRetrySubmitting(false);
+      }
     }
   };
 
@@ -364,7 +387,7 @@ const DLQPage = () => {
         <Space size={12} wrap>
           <InstanceSelect
             value={selectedInstanceId || undefined}
-            onChange={selectInstance}
+            onChange={handleInstanceChange}
             options={instanceOptions}
             style={{ width: 220 }}
           />
@@ -393,7 +416,7 @@ const DLQPage = () => {
       )}
 
       {/* ── Table ── */}
-      <Card bodyStyle={{ padding: 0 }}>
+      <Card styles={{ body: { padding: 0 } }}>
         <Table
           columns={columns}
           dataSource={filtered}
@@ -437,7 +460,7 @@ const DLQPage = () => {
         okText="确认重投"
         cancelText="取消"
         width={520}
-        destroyOnClose
+        destroyOnHidden
       >
         {retryGroup && (
           <div style={{ marginTop: 16 }}>
@@ -514,7 +537,7 @@ const DLQPage = () => {
         onCancel={() => setDetailGroup(null)}
         footer={<Button onClick={() => setDetailGroup(null)}>关闭</Button>}
         width={560}
-        destroyOnClose
+        destroyOnHidden
       >
         {detailGroup && (
           <div style={{ marginTop: 8 }}>

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -563,7 +563,7 @@ const InstancePage = () => {
       </Flex>
 
       {/* Table */}
-      <Card bodyStyle={{ padding: 0 }}>
+      <Card styles={{ body: { padding: 0 } }}>
         <Table
           className="instance-table"
           columns={columns}

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -270,6 +270,7 @@ const MessagePageContent = ({
 }: InstanceFilterProps) => {
   const { t } = useLang();
   const [topicOptions, setTopicOptions] = useState<string[]>([]);
+  const [topicError, setTopicError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!selectedInstanceId) {
@@ -279,10 +280,13 @@ const MessagePageContent = ({
     void listTopics({ instanceId: selectedInstanceId })
       .then((nextTopics) => {
         if (cancelled) return;
+        setTopicError(null);
         setTopicOptions(nextTopics.map((topic) => topic.name));
       })
-      .catch(() => {
-        if (!cancelled) setTopicOptions([]);
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setTopicOptions([]);
+        setTopicError(error instanceof Error ? error.message : '加载 Topic 列表失败');
       });
     return () => {
       cancelled = true;
@@ -869,12 +873,16 @@ const MessagePageContent = ({
         </Space>
       </Card>
 
+      {topicError && (
+        <Alert showIcon type="error" message={topicError} style={{ marginBottom: 16 }} />
+      )}
+
       {queryError && (
         <Alert showIcon type="warning" message={queryError} style={{ marginBottom: 16 }} />
       )}
 
       {/* ── Results Table ── */}
-      <Card bodyStyle={{ padding: 0 }}>
+      <Card styles={{ body: { padding: 0 } }}>
         <Table
           columns={columns}
           dataSource={messages}
@@ -895,7 +903,7 @@ const MessagePageContent = ({
         width={800}
         open={modalOpen}
         onCancel={closeDetail}
-        destroyOnClose
+        destroyOnHidden
         footer={
           <Flex justify="flex-end" gap={8}>
             <Button onClick={closeDetail}>关闭</Button>

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -617,7 +617,7 @@ const TopicPage = () => {
     const typeInfo = TOPIC_TYPE_MAP[topic.type];
 
     return (
-      <Descriptions bordered column={2} size="small" labelStyle={{ fontWeight: 500 }}>
+      <Descriptions bordered column={2} size="small" styles={{ label: { fontWeight: 500 } }}>
         <Descriptions.Item label="Topic 名称" span={2}>
           {topic.name}
         </Descriptions.Item>
@@ -1112,7 +1112,7 @@ const TopicPage = () => {
         open={detailModalOpen}
         onCancel={() => setDetailModalOpen(false)}
         width={800}
-        destroyOnClose
+        destroyOnHidden
         footer={null}
       >
         {selectedTopic && (
@@ -1200,7 +1200,7 @@ const TopicPage = () => {
         okText="创建"
         cancelText="取消"
         width={560}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form
           form={form}
@@ -1299,7 +1299,7 @@ const TopicPage = () => {
             importRows.every((row) => row.status === 'success' || row.status === 'invalid'),
         }}
         width={720}
-        destroyOnClose
+        destroyOnHidden
       >
         <Space direction="vertical" style={{ width: '100%' }} size={12}>
           {importErrors.length > 0 ? (
@@ -1354,7 +1354,7 @@ const TopicPage = () => {
         cancelText="取消"
         confirmLoading={sending}
         width={640}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form
           form={sendForm}

--- a/web/src/pages/ops/__tests__/AuditPage.test.tsx
+++ b/web/src/pages/ops/__tests__/AuditPage.test.tsx
@@ -168,6 +168,41 @@ describe('Audit page', () => {
     );
   });
 
+  it('shows loading state while refreshed records are pending', async () => {
+    const user = userEvent.setup();
+    vi.mocked(opsService.listAuditRecords)
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 'audit-1',
+            timestamp: '2026-08-01 10:00:00',
+            operator: 'admin',
+            operationType: 'DELETE_TOPIC',
+            resourceType: 'TOPIC',
+            target: 'topic-a',
+            clusterId: 'prod-cn',
+            detail: 'removed topic-a',
+            result: 'SUCCESS',
+            errorMessage: '',
+          },
+        ],
+        total: 1,
+        page: 1,
+        size: 20,
+      })
+      .mockImplementationOnce(() => new Promise(() => {}));
+    const { container } = renderWithProviders(<AuditPage />);
+    expect(await screen.findByText('topic-a')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('combobox', { name: '操作类型' }));
+    await user.click(
+      await screen.findByText('CREATE TOPIC', { selector: '.ant-select-item-option-content' }),
+    );
+
+    await waitFor(() => expect(opsService.listAuditRecords).toHaveBeenCalledTimes(2));
+    expect(container.querySelector('.ant-spin-spinning')).not.toBeNull();
+  });
+
   it('still loads audit records when filter options cannot be loaded', async () => {
     vi.mocked(opsService.getAuditFilterOptions).mockRejectedValueOnce(new Error('unavailable'));
 

--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -86,6 +86,35 @@ describe('SystemAlertsPage', () => {
     expect(screen.getByText('A newer backend emitted this level')).toBeInTheDocument();
   });
 
+  it('filters backend alert levels case-insensitively', async () => {
+    vi.mocked(listSystemAlerts).mockResolvedValue([
+      {
+        id: 'alert-error',
+        level: 'Error',
+        title: 'Mixed-case error',
+        description: 'error',
+        time: '2026-08-10 01:00',
+        acknowledged: false,
+      },
+      {
+        id: 'alert-warning',
+        level: 'WARNING',
+        title: 'Mixed-case warning',
+        description: 'warning',
+        time: '2026-08-10 01:01',
+        acknowledged: false,
+      },
+    ]);
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText('Mixed-case error');
+
+    await user.click(screen.getByRole('button', { name: /严重/ }));
+
+    expect(screen.getByText('Mixed-case error')).toBeInTheDocument();
+    expect(screen.queryByText('Mixed-case warning')).not.toBeInTheDocument();
+  });
+
   it('tracks simultaneous acknowledgements independently', async () => {
     vi.mocked(acknowledgeAlert).mockImplementation(() => new Promise(() => {}));
     const user = userEvent.setup();

--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -364,7 +364,7 @@ const AlertsPage = () => {
       />
 
       {/* ─── Table ─── */}
-      <Card bodyStyle={{ padding: 0 }}>
+      <Card styles={{ body: { padding: 0 } }}>
         <Flex
           align="center"
           justify="space-between"

--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -125,6 +125,9 @@ const AuditPage: React.FC = () => {
 
   useEffect(() => {
     let cancelled = false;
+    void Promise.resolve().then(() => {
+      if (!cancelled) setLoading(true);
+    });
 
     void listAuditRecords({
       page,

--- a/web/src/pages/ops/nameServerConfigDrift.tsx
+++ b/web/src/pages/ops/nameServerConfigDrift.tsx
@@ -65,6 +65,7 @@ const NameServerConfigDriftPage = () => {
 
   useEffect(() => {
     let cancelled = false;
+    const sequence = ++requestSequence.current;
     void listInstances()
       .then(async (items) => {
         if (cancelled) return;
@@ -77,17 +78,19 @@ const NameServerConfigDriftPage = () => {
           return;
         }
         const clustersForInstance = await listClusters(firstInstanceId);
-        if (cancelled) return;
+        if (cancelled || sequence !== requestSequence.current) return;
         setClusters(clustersForInstance);
         const firstClusterId = clustersForInstance[0]?.id;
         setSelectedClusterId(firstClusterId);
         if (firstClusterId) void runCheck(firstClusterId, firstInstanceId);
       })
       .catch(() => {
-        if (!cancelled) message.error(t('nameServerDrift.loadClustersFailed'));
+        if (!cancelled && sequence === requestSequence.current) {
+          message.error(t('nameServerDrift.loadClustersFailed'));
+        }
       })
       .finally(() => {
-        if (!cancelled) setClustersLoading(false);
+        if (!cancelled && sequence === requestSequence.current) setClustersLoading(false);
       });
     return () => {
       cancelled = true;

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -29,6 +29,8 @@ import type { SystemAlert } from '../../api/ops';
 
 const { Text } = Typography;
 
+const normalizeAlertLevel = (level: string) => level.toLowerCase();
+
 const SystemAlertsPage = () => {
   const { t } = useLang();
 
@@ -63,7 +65,10 @@ const SystemAlertsPage = () => {
     };
   }, []);
 
-  const filtered = levelFilter === 'all' ? alerts : alerts.filter((a) => a.level === levelFilter);
+  const filtered =
+    levelFilter === 'all'
+      ? alerts
+      : alerts.filter((a) => normalizeAlertLevel(a.level) === levelFilter);
 
   const unackCount = alerts.filter((a) => !a.acknowledged).length;
 
@@ -88,7 +93,8 @@ const SystemAlertsPage = () => {
     setClearing(true);
     try {
       await clearAcknowledgedAlerts();
-      setAlerts((prev) => prev.filter((a) => !a.acknowledged));
+      const fresh = await listSystemAlerts();
+      setAlerts(fresh);
       message.success(t('sysAlerts.cleared'));
     } catch {
       message.error('清理已确认告警失败，请稍后重试');
@@ -125,7 +131,7 @@ const SystemAlertsPage = () => {
             {level === 'all' ? t('common.all') : alertLevelConfig[level]?.label}
             {level !== 'all' && (
               <Badge
-                count={alerts.filter((a) => a.level === level).length}
+                count={alerts.filter((a) => normalizeAlertLevel(a.level) === level).length}
                 style={{
                   marginLeft: 4,
                   backgroundColor:
@@ -142,7 +148,7 @@ const SystemAlertsPage = () => {
         {loading && <Card loading />}
         {!loading &&
           filtered.map((alert) => {
-            const normalizedLevel = alert.level.toLowerCase();
+            const normalizedLevel = normalizeAlertLevel(alert.level);
             const cfg = alertLevelConfig[normalizedLevel] ?? {
               color: '#8c8c8c',
               bg: '#fafafa',

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -476,7 +476,7 @@ export const DataSourceTab = () => {
   return (
     <>
       <Flex justify="flex-end" style={{ marginBottom: 16 }}>
-        <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
+        <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal} disabled={loading}>
           添加数据源
         </Button>
       </Flex>
@@ -500,7 +500,7 @@ export const DataSourceTab = () => {
         }}
         onOk={() => void handleSubmit()}
         confirmLoading={submitting}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form form={dsForm} layout="vertical" preserve={false}>
           <Form.Item

--- a/web/src/pages/studio/AlertManagement.tsx
+++ b/web/src/pages/studio/AlertManagement.tsx
@@ -737,7 +737,7 @@ const AlertManagementPage: React.FC = () => {
           form.resetFields();
         }}
         width={720}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
           <Row gutter={16}>

--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -318,7 +318,10 @@ const GroupManagementPage = () => {
         </Space>
       </div>
 
-      <Card bordered={false} style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}>
+      <Card
+        variant="borderless"
+        style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}
+      >
         <Table
           columns={columns}
           dataSource={filteredGroupData}
@@ -344,7 +347,7 @@ const GroupManagementPage = () => {
         }}
         footer={null}
         width={720}
-        destroyOnClose
+        destroyOnHidden
       >
         <div style={{ marginBottom: 16 }}>
           <h3 style={{ margin: 0, display: 'flex', alignItems: 'center' }}>
@@ -363,7 +366,7 @@ const GroupManagementPage = () => {
                   <div>
                     <Row gutter={16} style={{ marginBottom: 20 }}>
                       <Col span={8}>
-                        <Card bordered={false} style={{ background: '#f6ffed' }}>
+                        <Card variant="borderless" style={{ background: '#f6ffed' }}>
                           <div style={{ color: '#666', fontSize: 12 }}>
                             {t('groupMgmt.onlineInstances')}
                           </div>
@@ -381,7 +384,7 @@ const GroupManagementPage = () => {
                         </Card>
                       </Col>
                       <Col span={8}>
-                        <Card bordered={false} style={{ background: '#fff2f0' }}>
+                        <Card variant="borderless" style={{ background: '#fff2f0' }}>
                           <div style={{ color: '#666', fontSize: 12 }}>
                             {t('groupMgmt.totalDiff')}
                           </div>
@@ -391,7 +394,7 @@ const GroupManagementPage = () => {
                         </Card>
                       </Col>
                       <Col span={8}>
-                        <Card bordered={false} style={{ background: '#f0f5ff' }}>
+                        <Card variant="borderless" style={{ background: '#f0f5ff' }}>
                           <div style={{ color: '#666', fontSize: 12 }}>
                             {t('groupMgmt.subscribedTopics')}
                           </div>

--- a/web/src/pages/studio/LiteTopic.tsx
+++ b/web/src/pages/studio/LiteTopic.tsx
@@ -430,7 +430,7 @@ const LiteTopicPage: React.FC = () => {
         : 0;
 
     return (
-      <Card bordered={false} style={{ marginBottom: 16, borderRadius: 8 }}>
+      <Card variant="borderless" style={{ marginBottom: 16, borderRadius: 8 }}>
         <div style={{ display: 'flex', alignItems: 'center', marginBottom: 16 }}>
           <Gauge size={20} weight="bold" style={{ marginRight: 8, color: '#1677ff' }} />
           <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600 }}>
@@ -592,7 +592,7 @@ const LiteTopicPage: React.FC = () => {
         <Row gutter={16}>
           <Col span={8}>
             <Card
-              bordered={false}
+              variant="borderless"
               style={{ background: '#f6ffed', borderRadius: 8, textAlign: 'center', padding: 12 }}
             >
               <div style={{ fontSize: 12, color: '#8c8c8c', marginBottom: 4 }}>
@@ -603,7 +603,7 @@ const LiteTopicPage: React.FC = () => {
           </Col>
           <Col span={8}>
             <Card
-              bordered={false}
+              variant="borderless"
               style={{ background: '#f6ffed', borderRadius: 8, textAlign: 'center', padding: 12 }}
             >
               <div style={{ fontSize: 12, color: '#8c8c8c', marginBottom: 4 }}>
@@ -616,7 +616,7 @@ const LiteTopicPage: React.FC = () => {
           </Col>
           <Col span={8}>
             <Card
-              bordered={false}
+              variant="borderless"
               style={{ background: '#fffbe6', borderRadius: 8, textAlign: 'center', padding: 12 }}
             >
               <div style={{ fontSize: 12, color: '#8c8c8c', marginBottom: 4 }}>
@@ -724,7 +724,7 @@ const LiteTopicPage: React.FC = () => {
       {renderQuotaPanel()}
 
       {/* Search / Filter Bar */}
-      <Card bordered={false} style={{ marginBottom: 16, borderRadius: 8 }}>
+      <Card variant="borderless" style={{ marginBottom: 16, borderRadius: 8 }}>
         <Space size="middle" wrap>
           <Input
             placeholder={t('liteTopic.searchPlaceholder')}
@@ -770,7 +770,7 @@ const LiteTopicPage: React.FC = () => {
       </Card>
 
       {/* Main Table */}
-      <Card bordered={false} style={{ borderRadius: 8 }}>
+      <Card variant="borderless" style={{ borderRadius: 8 }}>
         <Table
           columns={columns}
           dataSource={filteredTopicList}
@@ -800,7 +800,7 @@ const LiteTopicPage: React.FC = () => {
           setSessionDrawerOpen(false);
           setSessionData(null);
         }}
-        destroyOnClose
+        destroyOnHidden
       >
         {renderSessionContent()}
       </Drawer>
@@ -814,7 +814,7 @@ const LiteTopicPage: React.FC = () => {
         confirmLoading={extendTTLLoading}
         okText={t('common.confirm')}
         cancelText={t('common.cancel')}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form layout="vertical" style={{ marginTop: 16 }}>
           <Form.Item label={t('liteTopic.pattern')}>

--- a/web/src/pages/studio/Producer.tsx
+++ b/web/src/pages/studio/Producer.tsx
@@ -237,7 +237,10 @@ const ProducerPage = () => {
         <h2 style={{ fontSize: 20, fontWeight: 600, margin: 0 }}>{t('producer.title')}</h2>
       </div>
 
-      <Card bordered={false} style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}>
+      <Card
+        variant="borderless"
+        style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}
+      >
         <Form form={form} layout="inline" onFinish={onFinish} style={{ marginBottom: 20 }}>
           <Form.Item label="INSTANCE">
             <Select

--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -49,6 +49,15 @@ import { queryProxyHomePage, reloadProxyConfig, type ProxyNode } from '../../api
 
 const { Text } = Typography;
 
+const persistProxyAddress = (address?: string) => {
+  if (!address) return;
+  try {
+    localStorage.setItem('proxyAddr', address);
+  } catch {
+    // Proxy discovery remains usable when browser storage is unavailable.
+  }
+};
+
 const ProxyPage: React.FC = () => {
   const { t } = useLang();
   const { message } = App.useApp();
@@ -96,12 +105,7 @@ const ProxyPage: React.FC = () => {
         totalTPS: null,
       });
 
-      if (currentProxyAddr) {
-        localStorage.setItem('proxyAddr', currentProxyAddr);
-      } else if (proxyAddrList && proxyAddrList.length > 0) {
-        localStorage.setItem('proxyAddr', proxyAddrList[0]);
-      }
-
+      persistProxyAddress(currentProxyAddr || proxyAddrList?.[0]);
       return true;
     } catch {
       if (requestId !== loadRequestId.current) return false;
@@ -383,7 +387,7 @@ const ProxyPage: React.FC = () => {
         {/* Node Table */}
         <Card
           title={t('proxy.nodes')}
-          bordered={false}
+          variant="borderless"
           style={{ borderRadius: 8, marginBottom: 24 }}
         >
           <Table columns={columns} dataSource={proxyNodes} pagination={false} size="middle" />

--- a/web/src/pages/studio/SslSettings.tsx
+++ b/web/src/pages/studio/SslSettings.tsx
@@ -31,7 +31,7 @@ const SslSettingsPage = () => {
             <span>{t('ssl.title')}</span>
           </Space>
         }
-        bordered={false}
+        variant="borderless"
         style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}
       >
         <Alert

--- a/web/src/pages/studio/__tests__/Proxy.test.tsx
+++ b/web/src/pages/studio/__tests__/Proxy.test.tsx
@@ -76,6 +76,19 @@ describe('ProxyPage', () => {
     });
   });
 
+  it('keeps discovered nodes when browser storage is unavailable', async () => {
+    const storageSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('storage disabled', 'SecurityError');
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('127.0.0.1:8081')).toBeInTheDocument();
+    expect(screen.queryByText('获取代理列表失败')).not.toBeInTheDocument();
+    expect(queryProxyHomePage).toHaveBeenCalledTimes(1);
+    storageSpy.mockRestore();
+  });
+
   it('loads Proxy nodes once after the page mounts', async () => {
     renderPage();
 

--- a/web/src/utils/format.test.ts
+++ b/web/src/utils/format.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatDate, formatDateTime } from './format';
+
+describe('date formatters', () => {
+  it('renders missing and blank date values consistently', () => {
+    for (const value of [null, undefined, '', '   ']) {
+      expect(formatDateTime(value)).toBe('-');
+      expect(formatDate(value)).toBe('-');
+    }
+  });
+
+  it('preserves a nonblank invalid value for diagnostics', () => {
+    expect(formatDateTime('not-a-date')).toBe('not-a-date');
+    expect(formatDate('not-a-date')).toBe('not-a-date');
+  });
+});

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -21,7 +21,7 @@ const pad = (n: number, width = 2): string => String(n).padStart(width, '0');
  * Format a date string or Date object to 'YYYY-MM-DD HH:mm:ss'.
  */
 export function formatDateTime(date: string | Date | null | undefined): string {
-  if (date === null || date === undefined) return '-';
+  if (date === null || date === undefined || (typeof date === 'string' && !date.trim())) return '-';
   const d = typeof date === 'string' ? new Date(date) : date;
   if (isNaN(d.getTime())) return String(date);
   return (
@@ -34,7 +34,7 @@ export function formatDateTime(date: string | Date | null | undefined): string {
  * Format a date string or Date object to 'YYYY-MM-DD'.
  */
 export function formatDate(date: string | Date | null | undefined): string {
-  if (date === null || date === undefined) return '-';
+  if (date === null || date === undefined || (typeof date === 'string' && !date.trim())) return '-';
   const d = typeof date === 'string' ? new Date(date) : date;
   if (isNaN(d.getTime())) return String(date);
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;


### PR DESCRIPTION
## What is the purpose of the change

In the Tencent RocketMQ message trace, `toConsumeTraceStatus` mapped every non-2 status to `"failed"`, so an in-flight message (status 0/1) showed a failed consume step. The sibling `toDeliveryStatus` correctly maps 0/1 to `pending`, and the frontend `TraceNode.status` union only accepts `'error' | 'wait' | 'process' | 'finish'` — `"failed"` is not even a legal value, so the step indicator was ignored.

## Brief changelog

- Map in-flight consume status (0/1) to `"process"`, consumed (2) to `"finish"`, and anything else to `"error"`, consistent with `toDeliveryStatus` and the frontend status union.
- Add a test asserting an in-flight consume node reads `"process"` and its delivery status reads `pending`.

## Verifying this change

- `mvn -q -Dtest=TencentInstanceProviderTest test`
- `mvn -q test` (1056/1056)
- `git diff --check`
