### PR TITLE
fix: interpret Aliyun OpenAPI timestamps as UTC+8 regardless of server zone

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
@@ -66,6 +66,9 @@ final class AliyunConverters {
     static final int MESSAGE_MAX_PAGES = 5;
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    // Aliyun RocketMQ OpenAPI timestamps are unzoned "yyyy-MM-dd HH:mm:ss" strings interpreted as
+    // UTC+8 (Asia/Shanghai), regardless of the server's default zone.
+    private static final ZoneId ALIYUN_TIME_ZONE = ZoneId.of("Asia/Shanghai");
 
     private AliyunConverters() {
     }
@@ -289,7 +292,7 @@ final class AliyunConverters {
         }
         try {
             LocalDateTime dateTime = LocalDateTime.parse(value, TIME_FORMATTER);
-            return dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            return dateTime.atZone(ALIYUN_TIME_ZONE).toInstant().toEpochMilli();
         } catch (RuntimeException ignored) {
             return 0L;
         }
@@ -297,7 +300,7 @@ final class AliyunConverters {
 
     static String formatTimeMillis(long epochMillis) {
         return TIME_FORMATTER.format(
-                LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault()));
+                LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ALIYUN_TIME_ZONE));
     }
 
     static String tryBase64Decode(String raw) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -555,4 +555,15 @@ class AliyunInstanceProviderTest {
         org.junit.jupiter.api.Assertions.assertEquals("Concurrently",
                 AliyunInstanceProvider.normalizeDeliveryOrderType("Concurrently"));
     }
+
+    @Test
+    void timeConversionUsesAliyunUtc8Zone() {
+        // "2024-01-01 00:00:00" is 2023-12-31T16:00:00Z in UTC+8 regardless of server zone.
+        long expectedUtc8 = java.time.LocalDateTime.of(2024, 1, 1, 0, 0)
+                .atZone(java.time.ZoneId.of("Asia/Shanghai")).toInstant().toEpochMilli();
+        assertThat(AliyunConverters.parseTimeMillis("2024-01-01 00:00:00")).isEqualTo(expectedUtc8);
+
+        // Round-trip formatting must restore the same calendar time in UTC+8.
+        assertThat(AliyunConverters.formatTimeMillis(expectedUtc8)).isEqualTo("2024-01-01 00:00:00");
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

`AliyunConverters` formatted and parsed Aliyun RocketMQ OpenAPI `yyyy-MM-dd HH:mm:ss` timestamps with `ZoneId.systemDefault()`. The Aliyun OpenAPI interprets these unzoned strings as UTC+8 (Asia/Shanghai) regardless of the server's zone, so on a non-UTC+8 server the message query window (`startTime`/`endTime`) and `resetConsumeOffset` `resetTime` were shifted by the server's zone offset, resetting offsets and querying messages at the wrong wall-clock times.

## Brief changelog

- Use an explicit `Asia/Shanghai` zone for all Aliyun OpenAPI timestamp parse/format, independent of the server default zone.
- Add a test asserting `parseTimeMillis`/`formatTimeMillis` round-trip in UTC+8.

## Verifying this change

- `mvn -q -Dtest=AliyunInstanceProviderTest test`
- `mvn -q test` (1056/1056)
- `git diff --check`
