### PR TITLE
fix: reuse the TaskRequestId returned by the previous Tencent message page

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -476,6 +476,8 @@ public class TencentInstanceProvider implements InstanceProvider {
             request.setTopic(topic);
             request.setStartTime(begin);
             request.setEndTime(end);
+            // Reuse the task id returned by the previous page so paging continues the same
+            // logical query; fall back to the initial random id when the API omits it.
             request.setTaskRequestId(taskRequestId);
             if (StringUtils.hasText(key)) {
                 request.setMsgKey(key);
@@ -489,6 +491,9 @@ public class TencentInstanceProvider implements InstanceProvider {
                     client -> client.DescribeMessageList(request));
             MessageItem[] data = response == null ? null : response.getData();
             long total = response == null ? 0L : (response.getTotalCount() == null ? 0L : response.getTotalCount());
+            if (response != null && StringUtils.hasText(response.getTaskRequestId())) {
+                taskRequestId = response.getTaskRequestId();
+            }
             if (data != null) {
                 for (MessageItem item : data) {
                     if (item != null) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -512,6 +512,38 @@ class TencentInstanceProviderTest {
     }
 
     @Test
+    void messageQueryReusesTaskRequestIdReturnedByPreviousPage() throws Exception {
+        MessageItem[] page1Items = new MessageItem[TencentInstanceProvider.MESSAGE_LIMIT];
+        for (int i = 0; i < TencentInstanceProvider.MESSAGE_LIMIT; i++) {
+            MessageItem item = new MessageItem();
+            item.setMsgId("MSG-" + (i + 1));
+            item.setProduceTime("2024-09-12 14:06:55,591");
+            page1Items[i] = item;
+        }
+        MessageItem last = new MessageItem();
+        last.setMsgId("MSG-LAST");
+        last.setProduceTime("2024-09-12 14:06:56,591");
+        DescribeMessageListResponse page1 = new DescribeMessageListResponse();
+        page1.setData(page1Items);
+        page1.setTaskRequestId("task-abc");
+        DescribeMessageListResponse page2 = new DescribeMessageListResponse();
+        page2.setData(new MessageItem[]{last});
+        page2.setTaskRequestId("task-abc");
+        when(client.DescribeMessageList(any()))
+                .thenReturn(page1)
+                .thenReturn(page2);
+
+        provider.queryMessages(STUDIO_INSTANCE_ID, "orders", null, null, null,
+                1600000000000L, 1600001000000L);
+
+        ArgumentCaptor<DescribeMessageListRequest> captor = ArgumentCaptor.forClass(DescribeMessageListRequest.class);
+        verify(client, org.mockito.Mockito.times(2)).DescribeMessageList(captor.capture());
+        java.util.List<DescribeMessageListRequest> requests = captor.getAllValues();
+        // The second page must carry the task id returned by the first page, not a fresh random id.
+        assertThat(requests.get(1).getTaskRequestId()).isEqualTo("task-abc");
+    }
+
+    @Test
     void getMessageTraceShouldMapStagesTest() throws Exception {
         MessageTraceItem produce = new MessageTraceItem();
         produce.setStage("produce");


### PR DESCRIPTION
## What is the purpose of the change

`TencentInstanceProvider.queryMessages` pages through `DescribeMessageList` with a single `UUID.randomUUID()` task id: the id was generated once before the loop and reused verbatim on every page, even though the API returns the task id to use for the next page in the response (`DescribeMessageListResponse.getTaskRequestId`). The code comment states the response hands the id back for the next page, but the implementation never read it — so when the API returns its own task id, the second page started a brand-new query and results could repeat, truncate, or come back empty.

## Brief changelog

- Capture `response.getTaskRequestId()` after each page and reuse it on the next request, falling back to the initial random id when the API omits it.
- Add a test asserting the second page carries the task id returned by the first page.

## Verifying this change

- `mvn -q -Dtest=TencentInstanceProviderTest test`
- `mvn -q test` (1055/1055)
- `git diff --check`
