### PR TITLE
[Studio] refactor(web): fix lint errors, stop refetching the instance list on selection change, confirm history clear

### DIFF
--- a/web/src/hooks/useInstanceFilter.ts
+++ b/web/src/hooks/useInstanceFilter.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { listInstances } from '../services/instanceService';
 import type { Instance } from '../api/instance';
@@ -38,13 +38,23 @@ export function useInstanceFilter() {
 
   const [instances, setInstances] = useState<Instance[]>([]);
 
+  // Keep the latest selected instance id in a ref so the instance *list* is only
+  // fetched when needed (section / navigation changes) and not re-fetched every
+  // time the user switches between instances — the list itself does not depend
+  // on the selection.
+  const routeInstanceIdRef = useRef(routeInstanceId);
+  useEffect(() => {
+    routeInstanceIdRef.current = routeInstanceId;
+  }, [routeInstanceId]);
+
   useEffect(() => {
     let cancelled = false;
     void listInstances()
       .then((nextInstances) => {
         if (cancelled) return;
         setInstances(nextInstances);
-        const isKnownInstance = nextInstances.some((instance) => instance.name === routeInstanceId);
+        const selectedInstanceId = routeInstanceIdRef.current;
+        const isKnownInstance = nextInstances.some((instance) => instance.name === selectedInstanceId);
         if (nextInstances.length > 0 && !isKnownInstance) {
           navigate(`/instance/${encodeURIComponent(nextInstances[0].name)}/${section}`, {
             replace: true,
@@ -57,7 +67,7 @@ export function useInstanceFilter() {
     return () => {
       cancelled = true;
     };
-  }, [navigate, routeInstanceId, section]);
+  }, [navigate, section]);
 
   const selectedInstanceId =
     routeInstanceId !== undefined && instances.some((instance) => instance.name === routeInstanceId)

--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { App } from 'antd';
+import { App, Modal } from 'antd';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
@@ -237,7 +237,19 @@ describe('Message page query history', () => {
     });
 
     await user.click(screen.getByRole('button', { name: /最近查询/ }));
+    // Clearing requires confirmation: the dialog is commanded imperatively, so spy on it
+    // and drive the confirm callback instead of depending on portal rendering in jsdom.
+    const confirmSpy = vi
+      .spyOn(Modal, 'confirm')
+      .mockImplementation((config) => {
+        config.onOk?.();
+        return { destroy: vi.fn(), update: vi.fn() } as unknown as ReturnType<
+          typeof Modal.confirm
+        >;
+      });
     await user.click(await screen.findByText('清空历史'));
+    expect(confirmSpy).toHaveBeenCalled();
+    confirmSpy.mockRestore();
     expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
     expect(localStorage).toHaveLength(0);
   });

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -446,7 +446,14 @@ const MessagePageContent = ({
 
   const handleRecentQueryMenuClick: MenuProps['onClick'] = ({ key }) => {
     if (key === 'clear') {
-      clearRecentQueries();
+      Modal.confirm({
+        title: '清空查询历史',
+        content: '确定要清空全部查询历史吗？此操作不可恢复。',
+        okText: '清空',
+        okType: 'danger',
+        cancelText: '取消',
+        onOk: clearRecentQueries,
+      });
       return;
     }
     const recentQuery = recentQueries[Number(key)];

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -208,9 +208,10 @@ const BrokerClusterPage = () => {
   useEffect(() => {
     mountedRef.current = true;
     const requestId = loadRequestId.current;
-    const timeoutId = window.setTimeout(() => void loadData());
+    void Promise.resolve().then(() => {
+      loadData();
+    });
     return () => {
-      window.clearTimeout(timeoutId);
       loadRequestId.current = requestId + 1;
       mountedRef.current = false;
     };


### PR DESCRIPTION
# PR: refactor(web): fix lint errors, stop refetching the instance list on selection change, confirm history clear

**Branch:** `feature/studio-web-fixes`
**Commit:** `372febfa` — pushed to `origin/feature/studio-web-fixes`
**Base:** `apache:rocketmq-studio` @ `103555a7`
**PR create link:** https://github.com/zhaohai666/rocketmq-dashboard/pull/new/feature/studio-web-fixes

## Summary

Frontend fixes from the 2026-08-12 code review (`docs/code-review-2026-08-12.md`):
frontend lint is now clean (was 1 error + 2 warnings), switching instances no
longer re-fetches the full instance list, clearing the message query history
requires confirmation, and the deprecated antd `bodyStyle` prop is migrated.

## Changes

### Lint — 0 problems (was 1 error + 2 warnings)

- **`src/pages/studio/BrokerCluster.tsx`** — the mount effect no longer calls
  `loadData()` synchronously inside the effect body
  (`react-hooks/set-state-in-effect`); it now runs in a microtask, and the
  request-id ref value is copied into the effect and used by the cleanup
  (`react-hooks/exhaustive-deps`).
- **`src/layouts/MainLayout.tsx`** — `pathSnippets` is memoized and added to the
  breadcrumb `useMemo` dependency array (fixes the missing-dependency warning and
  keeps the memo actually stable across unrelated re-renders).

### Perf — instance list no longer refetched on selection change

- **`src/hooks/useInstanceFilter.ts`** — the list effect previously depended on
  `routeInstanceId`, so every instance switch re-queried the full instance list
  in all 7 instance pages even though the list is independent of the selection.
  The latest route id is now tracked in a ref; the list is fetched on
  section/navigation changes only, while the redirect-to-first-instance logic
  still reads the current selection from the ref.

### UX — confirm destructive action

- **`src/pages/instance/message.tsx`** — the "清空历史" (clear query history) menu
  item now shows a confirmation dialog (`Modal.confirm`, danger) before clearing
  the in-memory history and `localStorage`, instead of acting immediately.

### Deprecations — antd `bodyStyle` → `styles.body`

- Replaced the deprecated `Card bodyStyle` prop with `styles={{ body: ... }}` in
  12 places across 9 files: `cluster/index.tsx` (3), `cluster/certs.tsx`,
  `cluster/clients.tsx`, `instance/index.tsx`, `instance/consumer.tsx` (2),
  `instance/acl.tsx`, `instance/message.tsx`, `instance/dlq.tsx`,
  `ops/alerts.tsx`.

## Verification

- `eslint .` — **0 problems**.
- `tsc -b` — clean.
- Full frontend suite — **532/532 tests, 92 files, all green** (BrokerCluster
  13, useInstanceFilter 15, MessagePage 14, plus cluster/instance/ops pages).
- `MessagePage.test.tsx` updated: the clear-history test now drives
  `Modal.confirm`'s `onOk` through a spy instead of relying on portal rendering
  in jsdom.

## Notes

- No behavior change besides: instance-list fetch frequency, the confirmation
  on clearing history, and equivalent style props on Card.
- The larger frontend items from the review (i18n migration ~840 hard-coded
  strings, cancelled-boilerplate unification, api/services layer split) are
  intentionally out of scope and tracked separately.
