### PR TITLE
fix: harden alert rule authoring and YAML export

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleController.java
@@ -24,8 +24,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Arrays;
 import java.util.List;
 
 @RestController
@@ -41,8 +43,11 @@ public class AlertRuleController {
     }
 
     @GetMapping("/export")
-    public Result<AlertRulesYamlVO> exportRules() {
-        return Result.ok(new AlertRulesYamlVO(alertService.exportPrometheusRulesYaml()));
+    public Result<AlertRulesYamlVO> exportRules(@RequestParam(name = "ids", required = false) String ids) {
+        String rules = ids == null
+                ? alertService.exportPrometheusRulesYaml()
+                : alertService.exportPrometheusRulesYaml(parseRuleIds(ids));
+        return Result.ok(new AlertRulesYamlVO(rules));
     }
 
     @PostMapping("/create")
@@ -87,5 +92,18 @@ public class AlertRuleController {
             throw new BusinessException(400, "Alert rule request is required");
         }
         return rule;
+    }
+
+    private List<String> parseRuleIds(String ids) {
+        if (ids.isBlank()) {
+            throw new BusinessException(400, "Selected alert rule IDs must not be blank");
+        }
+        List<String> ruleIds = Arrays.stream(ids.split(",", -1))
+                .map(String::trim)
+                .toList();
+        if (ruleIds.stream().anyMatch(String::isBlank)) {
+            throw new BusinessException(400, "Selected alert rule IDs must not be blank");
+        }
+        return ruleIds;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -53,9 +53,18 @@ public class AlertService {
     }
 
     public String exportPrometheusRulesYaml() {
+        return exportPrometheusRulesYaml(List.of());
+    }
+
+    public String exportPrometheusRulesYaml(List<String> selectedRuleIds) {
+        Set<String> selectedIds = validateSelectedRuleIds(selectedRuleIds);
         List<AlertRuleVO> rules = alertRepository.findAllRules().stream()
                 .filter(AlertRuleVO::isEnabled)
+                .filter(rule -> selectedIds.isEmpty() || selectedIds.contains(rule.getId()))
                 .toList();
+        if (!selectedIds.isEmpty() && rules.size() != selectedIds.size()) {
+            throw new BusinessException(400, "Selected alert rules are unavailable or disabled");
+        }
         List<PrometheusAlertRule> prometheusRules = rules.isEmpty()
                 ? defaultPrometheusRules()
                 : rules.stream().map(this::toPrometheusRule).toList();
@@ -266,6 +275,9 @@ public class AlertService {
     }
 
     private String groupName(String team) {
+        if ("proxy".equals(team)) {
+            return "rocketmq-proxy.rules";
+        }
         if ("client".equals(team)) {
             return "rocketmq-client.rules";
         }
@@ -369,6 +381,9 @@ public class AlertService {
             return "broker";
         }
         String normalizedMetric = metric.toLowerCase(Locale.ROOT);
+        if (normalizedMetric.startsWith("rocketmq_proxy_")) {
+            return "proxy";
+        }
         if (normalizedMetric.contains("replication") || normalizedMetric.contains("fall_behind")
                 || normalizedMetric.contains("slave")) {
             return "broker";
@@ -384,6 +399,20 @@ public class AlertService {
             return "topic";
         }
         return "broker";
+    }
+
+    private Set<String> validateSelectedRuleIds(List<String> selectedRuleIds) {
+        if (selectedRuleIds == null || selectedRuleIds.isEmpty()) {
+            return Set.of();
+        }
+        Set<String> selectedIds = new HashSet<>();
+        for (String ruleId : selectedRuleIds) {
+            if (!hasText(ruleId)) {
+                throw new BusinessException(400, "Selected alert rule IDs must not be blank");
+            }
+            selectedIds.add(ruleId.trim());
+        }
+        return selectedIds;
     }
 
     private String summary(AlertRuleVO rule) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleControllerTest.java
@@ -79,6 +79,19 @@ class AlertRuleControllerTest {
     }
 
     @Test
+    void exportRulesShouldForwardSelectedRuleIds() throws Exception {
+        when(alertService.exportPrometheusRulesYaml(List.of("rule-1", "rule-2")))
+                .thenReturn("groups:\n");
+
+        mockMvc.perform(get("/api/alert-rules/export")
+                        .param("ids", "rule-1,rule-2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rules").value("groups:\n"));
+
+        verify(alertService).exportPrometheusRulesYaml(List.of("rule-1", "rule-2"));
+    }
+
+    @Test
     void createRuleShouldReturnCreatedRule() throws Exception {
         AlertRuleVO request = AlertRuleVO.builder()
                 .name("High Lag")

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -121,6 +121,51 @@ class AlertServiceTest {
     }
 
     @Test
+    void exportPrometheusRulesYamlShouldExportOnlySelectedEnabledRules() {
+        AlertRuleVO selected = AlertRuleVO.builder()
+                .id("rule-selected")
+                .name("Selected Proxy Alert")
+                .metric("rocketmq_proxy_up")
+                .operator("==")
+                .threshold(0)
+                .enabled(true)
+                .build();
+        AlertRuleVO unselected = AlertRuleVO.builder()
+                .id("rule-unselected")
+                .name("Unselected Consumer Alert")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(1000)
+                .enabled(true)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(selected, unselected));
+
+        String result = alertService.exportPrometheusRulesYaml(List.of("rule-selected"));
+
+        assertThat(result)
+                .contains("SelectedProxyAlert")
+                .contains("rocketmq-proxy.rules")
+                .contains("team: proxy")
+                .doesNotContain("UnselectedConsumerAlert");
+    }
+
+    @Test
+    void exportPrometheusRulesYamlShouldRejectUnavailableSelectedRules() {
+        AlertRuleVO disabled = AlertRuleVO.builder()
+                .id("rule-disabled")
+                .name("Disabled Alert")
+                .metric("rocketmq_proxy_up")
+                .enabled(false)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(disabled));
+
+        assertThatThrownBy(() -> alertService.exportPrometheusRulesYaml(List.of("rule-disabled")))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Selected alert rules are unavailable or disabled")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+    }
+
+    @Test
     void exportPrometheusRulesYamlShouldEmitSingleGroupForSameTeamRules() {
         AlertRuleVO first = AlertRuleVO.builder()
                 .name("Lag Alert A")

--- a/web/src/api/alertManagement.test.ts
+++ b/web/src/api/alertManagement.test.ts
@@ -58,6 +58,17 @@ describe('AlertManagement API', () => {
     expect(result.rules).toBe('');
   });
 
+  it('exports only the selected persisted alert rules', async () => {
+    mock.onGet('/alert-rules/export').reply((config) => {
+      expect(config.params).toEqual({ ids: 'rule-1,rule-2' });
+      return [200, { code: 200, data: { rules: 'groups:\n' } }];
+    });
+
+    await expect(exportAlertRulesYaml(['rule-1', 'rule-2'])).resolves.toEqual({
+      rules: 'groups:\n',
+    });
+  });
+
   it('lists persisted alert rules', async () => {
     mock.onGet('/alert-rules').reply(200, {
       code: 200,

--- a/web/src/api/alertManagement.ts
+++ b/web/src/api/alertManagement.ts
@@ -45,8 +45,9 @@ export async function listAlertRules(): Promise<AlertRule[]> {
   return res.data.data;
 }
 
-export async function exportAlertRulesYaml(): Promise<AlertRuleData> {
-  const res = await client.get<{ data: AlertRuleData }>('/alert-rules/export');
+export async function exportAlertRulesYaml(ruleIds?: string[]): Promise<AlertRuleData> {
+  const params = ruleIds?.length ? { ids: ruleIds.join(',') } : undefined;
+  const res = await client.get<{ data: AlertRuleData }>('/alert-rules/export', { params });
   return res.data.data;
 }
 

--- a/web/src/pages/studio/AlertManagement.tsx
+++ b/web/src/pages/studio/AlertManagement.tsx
@@ -105,6 +105,8 @@ const TEAM_COLORS: Record<string, string> = {
 // ─── Mapping helpers ──────────────────────────────────────────────
 const DESCRIPTION_SEPARATOR = ' - ';
 const EXPRESSION_PATTERN = /^\s*(.+?)\s*(>=|<=|==|!=|>|<)\s*(-?\d+(?:\.\d+)?)\s*$/;
+const METRIC_NAME_PATTERN = /^[a-zA-Z_:][a-zA-Z0-9_:]*$/;
+const SCOPE_LABEL_PATTERN = /\s*(cluster|broker)\s*=\s*"((?:\\["\\]|[^"\\])*)"\s*(,|$)/y;
 
 function inferTeam(metric?: string): string {
   const value = metric || '';
@@ -236,48 +238,72 @@ function toUiRule(rule: PersistedAlertRule, index: number): AlertRule {
 
 function parseExpression(
   expr: string,
-): Pick<AlertRuleRequest, 'metric' | 'operator' | 'threshold'> {
+): Pick<AlertRuleRequest, 'metric' | 'operator' | 'threshold' | 'clusterName' | 'brokerName'> {
   const match = expr.match(EXPRESSION_PATTERN);
   if (!match) {
     throw new Error('Expression must look like: metric{labels} > 100');
   }
+  const scope = parseMetricScope(match[1].trim());
   return {
-    metric: match[1].trim(),
+    ...scope,
     operator: match[2],
     threshold: Number(match[3]),
   };
 }
 
-function parseScopeLabels(metric: string): {
-  metric: string;
-  clusterName?: string;
-  brokerName?: string;
-} {
-  const open = metric.indexOf('{');
-  if (open < 0) return { metric };
-  const metricName = metric.slice(0, open).trim();
-  const inner = metric.slice(open + 1, metric.lastIndexOf('}'));
-  let clusterName: string | undefined;
-  let brokerName: string | undefined;
-  const remaining: string[] = [];
-  for (const part of inner.split(',')) {
-    const eq = part.indexOf('=');
-    if (eq < 0) continue;
-    const key = part.slice(0, eq).trim();
-    const raw = part.slice(eq + 1).trim();
-    const value = raw.replace(/^"|"$/g, '').replace(/\\\\/g, '\\').replace(/\\"/g, '"');
-    if (key === 'cluster') clusterName = value;
-    else if (key === 'broker') brokerName = value;
-    else remaining.push(part.trim());
+function parseMetricScope(
+  scopedMetricValue: string,
+): Pick<AlertRuleRequest, 'metric' | 'clusterName' | 'brokerName'> {
+  const selectorStart = scopedMetricValue.indexOf('{');
+  if (selectorStart < 0) {
+    if (!METRIC_NAME_PATTERN.test(scopedMetricValue)) {
+      throw new Error('Expression metric must be a valid Prometheus metric name');
+    }
+    return { metric: scopedMetricValue };
   }
-  // Rebuild the metric expression preserving every non-scope label.
-  const metricExpr =
-    remaining.length > 0
-      ? `${metricName}{${remaining.join(',')}}`
-      : clusterName || brokerName
-        ? metricName
-        : metric;
-  return { metric: metricExpr, clusterName, brokerName };
+
+  if (!scopedMetricValue.endsWith('}') || scopedMetricValue.indexOf('{', selectorStart + 1) >= 0) {
+    throw new Error('Expression selector must use one balanced label block');
+  }
+  const metric = scopedMetricValue.slice(0, selectorStart).trim();
+  if (!METRIC_NAME_PATTERN.test(metric)) {
+    throw new Error('Expression metric must be a valid Prometheus metric name');
+  }
+
+  const selector = scopedMetricValue.slice(selectorStart + 1, -1);
+  const scope: Pick<AlertRuleRequest, 'metric' | 'clusterName' | 'brokerName'> = { metric };
+  const seenLabels = new Set<string>();
+  let offset = 0;
+  while (offset < selector.length) {
+    SCOPE_LABEL_PATTERN.lastIndex = offset;
+    const label = SCOPE_LABEL_PATTERN.exec(selector);
+    if (!label) {
+      throw new Error('Expression supports only exact cluster="..." and broker="..." selectors');
+    }
+    const labelName = label[1] as 'cluster' | 'broker';
+    if (seenLabels.has(labelName)) {
+      throw new Error(`Expression selector repeats ${labelName}`);
+    }
+    const value = unescapeScopeValue(label[2]);
+    if (!value || value === '*') {
+      throw new Error(`Expression ${labelName} selector must identify one resource`);
+    }
+    seenLabels.add(labelName);
+    if (labelName === 'cluster') scope.clusterName = value;
+    if (labelName === 'broker') scope.brokerName = value;
+    offset = SCOPE_LABEL_PATTERN.lastIndex;
+    if (label[3] === ',' && offset === selector.length) {
+      throw new Error('Expression selector must not end with a comma');
+    }
+  }
+  if (seenLabels.size === 0) {
+    throw new Error('Expression selector must include cluster or broker');
+  }
+  return scope;
+}
+
+function unescapeScopeValue(value: string): string {
+  return value.replace(/\\(["\\])/g, '$1');
 }
 
 function toAlertRuleRequest(
@@ -285,14 +311,10 @@ function toAlertRuleRequest(
   editingRule: AlertRule | null,
 ): AlertRuleRequest {
   const expression = parseExpression(values.expr);
-  const scope = parseScopeLabels(expression.metric ?? '');
   return {
     id: editingRule?.id,
     name: values.alert.trim(),
     ...expression,
-    metric: scope.metric,
-    clusterName: scope.clusterName,
-    brokerName: scope.brokerName,
     duration: values.for,
     enabled: values.enabled ?? true,
     description: combineDescription(values.summary, values.description),
@@ -463,7 +485,7 @@ const AlertManagementPage: React.FC = () => {
       setModalVisible(false);
       form.resetFields();
     } catch (error) {
-      if (error instanceof Error && error.message.startsWith('Expression must')) {
+      if (error instanceof Error && error.message.startsWith('Expression ')) {
         message.error(error.message);
         return;
       }
@@ -820,7 +842,10 @@ const AlertManagementPage: React.FC = () => {
               },
             ]}
           >
-            <TextArea rows={2} placeholder={'e.g. up{job=~"rocketmq.*broker.*"} == 0'} />
+            <TextArea
+              rows={2}
+              placeholder={'e.g. rocketmq_consumer_lag_messages{cluster="DefaultCluster"} > 1000'}
+            />
           </Form.Item>
           <Row gutter={16}>
             <Col span={12}>

--- a/web/src/pages/studio/AlertManagement.tsx
+++ b/web/src/pages/studio/AlertManagement.tsx
@@ -108,6 +108,7 @@ const EXPRESSION_PATTERN = /^\s*(.+?)\s*(>=|<=|==|!=|>|<)\s*(-?\d+(?:\.\d+)?)\s*
 
 function inferTeam(metric?: string): string {
   const value = metric || '';
+  if (value.startsWith('rocketmq_proxy_')) return 'proxy';
   if (value.includes('replication') || value.includes('fall_behind') || value.includes('slave')) {
     return 'broker';
   }
@@ -479,7 +480,12 @@ const AlertManagementPage: React.FC = () => {
 
   const handleExportYaml = async () => {
     try {
-      const data = await exportAlertRulesYaml();
+      const selectedRuleIds = selectedRules
+        .map((rule) => rule.id)
+        .filter((id): id is string => Boolean(id));
+      const data = await exportAlertRulesYaml(
+        selectedRuleIds.length > 0 ? selectedRuleIds : undefined,
+      );
       downloadBlob(new Blob([data.rules], { type: 'text/yaml' }), 'rocketmq-alert-rules.yaml');
       message.success(t('alertMgmt.exportSuccess'));
     } catch {

--- a/web/src/pages/studio/__tests__/AlertManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/AlertManagement.test.tsx
@@ -17,7 +17,7 @@
 
 import type { ReactElement } from 'react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
@@ -270,9 +270,15 @@ describe('AlertManagementPage', () => {
       within(dialog).getByPlaceholderText('e.g. RocketMQ_Broker_Down'),
       'TopicBacklogHigh',
     );
-    await user.type(
-      within(dialog).getByPlaceholderText('e.g. up{job=~"rocketmq.*broker.*"} == 0'),
-      'rocketmq_topic_messages > 500',
+    fireEvent.change(
+      within(dialog).getByPlaceholderText(
+        'e.g. rocketmq_consumer_lag_messages{cluster="DefaultCluster"} > 1000',
+      ),
+      {
+        target: {
+          value: 'rocketmq_topic_messages{cluster="DefaultCluster",broker="broker-a"} > 500',
+        },
+      },
     );
     await user.type(
       within(dialog).getByPlaceholderText('Brief description of the alert'),
@@ -285,6 +291,8 @@ describe('AlertManagementPage', () => {
         expect.objectContaining({
           name: 'TopicBacklogHigh',
           metric: 'rocketmq_topic_messages',
+          clusterName: 'DefaultCluster',
+          brokerName: 'broker-a',
           operator: '>',
           threshold: 500,
           duration: '5m',
@@ -301,30 +309,61 @@ describe('AlertManagementPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<AlertManagementPage />);
 
-    const brokerRule = await screen.findByText('BrokerDown');
-    const brokerRow = brokerRule.closest('tr');
-    expect(brokerRow).not.toBeNull();
-    await user.click(within(brokerRow!).getAllByRole('button')[0]);
+    const consumerRule = await screen.findByText('ConsumerLagHigh');
+    const consumerRow = consumerRule.closest('tr');
+    expect(consumerRow).not.toBeNull();
+    await user.click(within(consumerRow!).getAllByRole('button')[0]);
 
     const dialog = await screen.findByRole('dialog', { name: '编辑规则' });
     const summaryInput = within(dialog).getByPlaceholderText('Brief description of the alert');
     await user.clear(summaryInput);
-    await user.type(summaryInput, 'Broker unavailable updated');
+    await user.type(summaryInput, 'Consumer lag updated');
     await user.click(within(dialog).getByRole('button', { name: /OK|确/ }));
 
     await waitFor(() => {
       expect(updateAlertRule).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: 'rule-broker-down',
-          name: 'BrokerDown',
-          metric: 'up{job="rocketmq-broker"}',
-          operator: '==',
-          threshold: 0,
-          description: 'Broker unavailable updated - Broker has been unavailable for five minutes',
+          id: 'rule-consumer-lag',
+          name: 'ConsumerLagHigh',
+          metric: 'rocketmq_consumer_lag_messages',
+          clusterName: 'DefaultCluster',
+          brokerName: 'broker-a',
+          operator: '>',
+          threshold: 100000,
+          description: 'Consumer lag updated - Consumer lag has exceeded the threshold',
         }),
       );
     });
     expect(await screen.findByText('告警规则已更新')).toBeInTheDocument();
+  });
+
+  it('rejects selectors that the persisted alert contract cannot represent', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AlertManagementPage />);
+
+    await screen.findByText('BrokerDown');
+    await user.click(screen.getByRole('button', { name: '添加规则' }));
+
+    const dialog = await screen.findByRole('dialog', { name: '添加规则' });
+    await user.type(
+      within(dialog).getByPlaceholderText('e.g. RocketMQ_Broker_Down'),
+      'UnsupportedSelector',
+    );
+    fireEvent.change(
+      within(dialog).getByPlaceholderText(
+        'e.g. rocketmq_consumer_lag_messages{cluster="DefaultCluster"} > 1000',
+      ),
+      { target: { value: 'up{job=~"rocketmq.*broker.*"} == 0' } },
+    );
+    await user.type(
+      within(dialog).getByPlaceholderText('Brief description of the alert'),
+      'Unsupported selector',
+    );
+    await user.click(within(dialog).getByRole('button', { name: /OK|确/ }));
+
+    await waitFor(() => expect(createAlertRule).not.toHaveBeenCalled());
+    expect(dialog).toBeInTheDocument();
+    expect(await screen.findByText(/Expression supports only/)).toBeInTheDocument();
   });
 
   it('deletes a persisted alert rule', async () => {

--- a/web/src/pages/studio/__tests__/AlertManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/AlertManagement.test.tsx
@@ -260,7 +260,7 @@ describe('AlertManagementPage', () => {
 
   it('creates a persisted alert rule from the editor modal', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<AlertManagementPage />);
+    const { unmount } = renderWithProviders(<AlertManagementPage />);
 
     await screen.findByText('BrokerDown');
     await user.click(screen.getByRole('button', { name: '添加规则' }));
@@ -303,6 +303,10 @@ describe('AlertManagementPage', () => {
       );
     });
     expect(await screen.findByText('告警规则已创建')).toBeInTheDocument();
+    unmount();
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: '添加规则' })).not.toBeInTheDocument(),
+    );
   });
 
   it('updates a persisted alert rule from the editor modal', async () => {

--- a/web/src/pages/studio/__tests__/AlertManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/AlertManagement.test.tsx
@@ -183,7 +183,7 @@ describe('AlertManagementPage', () => {
     expect(within(brokerRow!).getAllByRole('button')[0]).toBeDisabled();
   });
 
-  it('exports the server-side YAML verbatim when rows are selected', async () => {
+  it('exports only the selected server-side rules when rows are selected', async () => {
     const user = userEvent.setup();
     renderWithProviders(<AlertManagementPage />);
 
@@ -196,7 +196,7 @@ describe('AlertManagementPage', () => {
     await user.click(screen.getByRole('button', { name: '导出 YAML' }));
 
     await waitFor(() => {
-      expect(exportAlertRulesYaml).toHaveBeenCalledTimes(1);
+      expect(exportAlertRulesYaml).toHaveBeenCalledWith(['rule-broker-down']);
     });
     expect(createObjectURL).toHaveBeenCalledTimes(1);
     const blob = createObjectURL.mock.calls[0][0] as Blob;
@@ -213,10 +213,33 @@ describe('AlertManagementPage', () => {
     await screen.findByText('BrokerDown');
     await user.click(screen.getByRole('button', { name: '导出 YAML' }));
 
+    expect(exportAlertRulesYaml).toHaveBeenCalledWith(undefined);
+
     const blob = createObjectURL.mock.calls[0][0] as Blob;
     const yaml = await blob.text();
     expect(yaml).toContain('alert: BrokerDown');
     expect(yaml).toContain('alert: ConsumerLagHigh');
+  });
+
+  it('classifies persisted Proxy metrics under the Proxy team and group', async () => {
+    vi.mocked(listAlertRules).mockResolvedValue([
+      {
+        id: 'rule-proxy-down',
+        name: 'ProxyDown',
+        metric: 'rocketmq_proxy_up',
+        operator: '==',
+        threshold: 0,
+        duration: '5m',
+        severity: 'critical',
+        enabled: true,
+      },
+    ]);
+    renderWithProviders(<AlertManagementPage />);
+
+    const proxyRule = await screen.findByText('ProxyDown');
+    const proxyRow = proxyRule.closest('tr');
+    expect(proxyRow).not.toBeNull();
+    expect(within(proxyRow!).getAllByText('proxy')).toHaveLength(2);
   });
 
   it('persists rule status changes through the alert rule API', async () => {


### PR DESCRIPTION
## Summary

- keep alert-rule authoring payloads aligned with the persisted backend contract by submitting stable Prometheus metric IDs and Prometheus duration literals
- preserve validated `cluster` and `broker` selectors through create, edit, selection, and YAML export
- allow YAML exports to be scoped to explicitly selected persisted enabled rules; reject stale, missing, or disabled IDs
- classify `rocketmq_proxy_*` metrics consistently as `team: proxy` on the server and in the UI
- add controller, service, API, and both UI regression coverage

Closes #1957
Closes #1984
Closes #1986

## Verification

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" \
  mvn -q -f server/pom.xml -Dtest=AlertRuleControllerTest,AlertServiceTest test
JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" \
  mvn -q -f server/pom.xml -DskipTests package

cd web
npm test -- --run src/api/alertManagement.test.ts \
  src/pages/studio/__tests__/AlertManagement.test.tsx \
  src/pages/ops/__tests__/AlertsPage.test.tsx \
  src/pages/ops/__tests__/alerts.test.tsx
npm run build
```

All commands pass. The Vitest run emits only existing jsdom pseudo-element warnings.
