### PR TITLE
fix: test metrics sources through backend-specific paths

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendType.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendType.java
@@ -29,22 +29,28 @@ import java.util.Locale;
  */
 public enum MetricsBackendType {
 
-    PROMETHEUS("/api/v1/query_range"),
-    VICTORIA_METRICS("/select/0/prometheus/api/v1/query_range"),
-    THANOS("/api/v1/query_range"),
-    CORTEX("/api/v1/query_range"),
-    MIMIR("/prometheus/api/v1/query_range"),
-    ARMS("/api/v1/query_range"),
-    CUSTOM("/api/v1/query_range");
+    PROMETHEUS("/api/v1/query_range", "/api/v1/query"),
+    VICTORIA_METRICS("/select/0/prometheus/api/v1/query_range", "/select/0/prometheus/api/v1/query"),
+    THANOS("/api/v1/query_range", "/api/v1/query"),
+    CORTEX("/api/v1/query_range", "/api/v1/query"),
+    MIMIR("/prometheus/api/v1/query_range", "/prometheus/api/v1/query"),
+    ARMS("/api/v1/query_range", "/api/v1/query"),
+    CUSTOM("/api/v1/query_range", "/api/v1/query");
 
     private final String queryPath;
+    private final String instantQueryPath;
 
-    MetricsBackendType(String queryPath) {
+    MetricsBackendType(String queryPath, String instantQueryPath) {
         this.queryPath = queryPath;
+        this.instantQueryPath = instantQueryPath;
     }
 
     public String getQueryPath() {
         return queryPath;
+    }
+
+    public String getInstantQueryPath() {
+        return instantQueryPath;
     }
 
     /**

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.cluster.metrics.MetricsBackendType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.UrlHostGuard;
 import java.net.InetAddress;
@@ -219,7 +220,7 @@ public class SettingsService {
 
         try {
             JsonNode response = restClient.get()
-                    .uri(prometheusQueryUri(request.getUrl()))
+                    .uri(prometheusQueryUri(request.getUrl(), request.getType()))
                     .accept(MediaType.APPLICATION_JSON)
                     .headers(headers -> applyAuthentication(headers, request))
                     .retrieve()
@@ -284,7 +285,7 @@ public class SettingsService {
         return auth.trim().replaceAll("\\s+", " ").toLowerCase(Locale.ROOT);
     }
 
-    private URI prometheusQueryUri(String baseUrl) throws URISyntaxException {
+    private URI prometheusQueryUri(String baseUrl, String providerType) throws URISyntaxException {
         if (!StringUtils.hasText(baseUrl)) {
             throw new IllegalArgumentException("Data source URL is required");
         }
@@ -301,7 +302,8 @@ public class SettingsService {
             throw new IllegalArgumentException(
                     "Data source URL must not point to a local or private address");
         }
-        return UriComponentsBuilder.fromUriString(normalized + "/api/v1/query")
+        String queryPath = MetricsBackendType.fromProviderType(providerType).getInstantQueryPath();
+        return UriComponentsBuilder.fromUriString(normalized + queryPath)
                 .queryParam("query", PROMETHEUS_TEST_QUERY)
                 .build()
                 .toUri();

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendTypeTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendTypeTest.java
@@ -70,4 +70,15 @@ class MetricsBackendTypeTest {
         assertThat(MetricsBackendType.CORTEX.getQueryPath()).isEqualTo("/api/v1/query_range");
         assertThat(MetricsBackendType.ARMS.getQueryPath()).isEqualTo("/api/v1/query_range");
     }
+
+    @Test
+    void shouldExposeDistinctInstantQueryPathsForBackends() {
+        assertThat(MetricsBackendType.PROMETHEUS.getInstantQueryPath()).isEqualTo("/api/v1/query");
+        assertThat(MetricsBackendType.VICTORIA_METRICS.getInstantQueryPath())
+                .isEqualTo("/select/0/prometheus/api/v1/query");
+        assertThat(MetricsBackendType.MIMIR.getInstantQueryPath()).isEqualTo("/prometheus/api/v1/query");
+        assertThat(MetricsBackendType.THANOS.getInstantQueryPath()).isEqualTo("/api/v1/query");
+        assertThat(MetricsBackendType.CORTEX.getInstantQueryPath()).isEqualTo("/api/v1/query");
+        assertThat(MetricsBackendType.ARMS.getInstantQueryPath()).isEqualTo("/api/v1/query");
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -60,6 +60,9 @@ class SettingsServiceTest {
 
     private static final String PROMETHEUS_BASE_URL = "http://192.0.2.1:9090";
     private static final String PROMETHEUS_QUERY_URL = PROMETHEUS_BASE_URL + "/api/v1/query?query=up";
+    private static final String VICTORIA_METRICS_QUERY_URL =
+            PROMETHEUS_BASE_URL + "/select/0/prometheus/api/v1/query?query=up";
+    private static final String MIMIR_QUERY_URL = PROMETHEUS_BASE_URL + "/prometheus/api/v1/query?query=up";
     private static final String PROMETHEUS_SUCCESS_BODY =
             "{\"status\":\"success\",\"data\":{\"resultType\":\"vector\",\"result\":[]}}";
 
@@ -416,7 +419,7 @@ class SettingsServiceTest {
     void testConnectionShouldNormalizeIdentifiersIndependentlyOfDefaultLocale() {
         String expectedAuthorization = "Basic "
                 + Base64.getEncoder().encodeToString("prom:secret".getBytes(StandardCharsets.UTF_8));
-        prometheusServer.expect(requestTo(PROMETHEUS_QUERY_URL))
+        prometheusServer.expect(requestTo(MIMIR_QUERY_URL))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header(HttpHeaders.AUTHORIZATION, expectedAuthorization))
                 .andRespond(withSuccess(PROMETHEUS_SUCCESS_BODY, MediaType.APPLICATION_JSON));
@@ -572,7 +575,7 @@ class SettingsServiceTest {
 
     @Test
     void testConnectionShouldReturnPrometheusErrorDetails() {
-        prometheusServer.expect(requestTo(PROMETHEUS_QUERY_URL))
+        prometheusServer.expect(requestTo(VICTORIA_METRICS_QUERY_URL))
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(withStatus(HttpStatus.UNPROCESSABLE_ENTITY)
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
### Track

RocketMQ Studio Track 1: unified control plane / METRICS-01.

### Summary

- model both range-query and instant-query paths in `MetricsBackendType`
- probe VictoriaMetrics and Mimir through their backend-specific Prometheus API prefixes
- keep Prometheus, Thanos, Cortex, ARMS, and custom backends on the standard instant-query path
- preserve existing authentication, timeout, redirect, and SSRF protections

### Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=SettingsServiceTest,MetricsBackendTypeTest test` (40 tests)
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -DskipTests package`
- Checkstyle: 0 violations

### Local baseline note

`MultiBackendMetricsSourceTest` was also run on this branch and the untouched `origin/rocketmq-studio` baseline. Both fail identically in this local environment because the embedded site-local HTTP server cannot be reached; this patch does not modify that runtime test path.

Closes #1987