### PR TITLE
fix: preserve selected-instance ACL credentials across runtime diagnostics

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolver.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolver.java
@@ -41,6 +41,15 @@ public class RuntimeAdminClientResolver {
         return instance.getEndpoint().trim();
     }
 
+    /**
+     * Resolves the ACL hook for short-lived runtime clients that cannot be created by
+     * {@link MqAdminExtFactory}, such as a {@code DefaultMQPullConsumer}.
+     */
+    public RPCHook resolveCredentialHook(String instanceId) {
+        InstanceVO instance = requireApacheInstance(resolveInstance(instanceId));
+        return resolveCredential(credentialRef(instance));
+    }
+
     public <T> T execute(String instanceId, MqAdminExtFactory.AdminAction<T> action) {
         return execute(resolveInstance(instanceId), action);
     }
@@ -50,10 +59,14 @@ public class RuntimeAdminClientResolver {
         if (instance == null || !StringUtils.hasText(instance.getEndpoint())) {
             throw new BusinessException(400, "Instance endpoint is required");
         }
-        String credentialRef = StringUtils.hasText(instance.getAdminCredentialRef())
-                ? instance.getAdminCredentialRef().trim() : null;
+        String credentialRef = credentialRef(instance);
         return adminFactory.execute(instance.getEndpoint().trim(), resolveCredential(credentialRef),
                 credentialRef, action);
+    }
+
+    private String credentialRef(InstanceVO instance) {
+        return StringUtils.hasText(instance.getAdminCredentialRef())
+                ? instance.getAdminCredentialRef().trim() : null;
     }
 
     private RPCHook resolveCredential(String credentialRef) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffService.java
@@ -22,7 +22,9 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 import org.apache.rocketmq.studio.cluster.broker.ClusterVO;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -70,19 +72,24 @@ public class NameServerConfigDiffService {
 
     private final ClusterService clusterService;
     private final MqAdminExtFactory adminFactory;
+    private final RuntimeAdminClientResolver runtimeAdminClientResolver;
 
     public NameServerConfigDiffVO compare(String clusterId) {
         String normalizedClusterId = requireClusterId(clusterId);
-        return compare(normalizedClusterId, clusterService.getCluster(normalizedClusterId));
+        return compare(normalizedClusterId, clusterService.getCluster(normalizedClusterId), null);
     }
 
     public NameServerConfigDiffVO compare(String clusterId, String instanceId) {
         String normalizedClusterId = requireClusterId(clusterId);
+        String normalizedInstanceId = normalizeInstanceId(instanceId);
         return compare(normalizedClusterId,
-                clusterService.getCluster(normalizedClusterId, normalizeInstanceId(instanceId)));
+                clusterService.getCluster(normalizedClusterId, normalizedInstanceId), normalizedInstanceId);
     }
 
-    private NameServerConfigDiffVO compare(String normalizedClusterId, ClusterVO cluster) {
+    private NameServerConfigDiffVO compare(
+            String normalizedClusterId,
+            ClusterVO cluster,
+            String instanceId) {
         List<String> addresses = collectNameServerAddresses(cluster);
         if (addresses.isEmpty()) {
             throw new BusinessException(409,
@@ -95,7 +102,7 @@ public class NameServerConfigDiffService {
 
         for (String address : addresses) {
             try {
-                Properties config = readConfig(connectionEndpoint, address);
+                Properties config = readConfig(instanceId, connectionEndpoint, address);
                 reachableConfigs.put(address, config);
                 nodes.add(NameServerConfigDiffVO.NodeStatusVO.builder()
                         .address(address)
@@ -124,16 +131,23 @@ public class NameServerConfigDiffService {
                 .build();
     }
 
-    private Properties readConfig(String connectionEndpoint, String address) {
+    private Properties readConfig(String instanceId, String connectionEndpoint, String address) {
+        if (instanceId != null) {
+            return runtimeAdminClientResolver.execute(instanceId, admin -> readConfig(admin, address));
+        }
         return adminFactory.execute(connectionEndpoint, null, admin -> {
-            Map<String, Properties> configs = admin.getNameServerConfig(List.of(address));
-            Properties config = configs == null ? null : configs.get(address);
-            if (config == null) {
-                throw new BusinessException(502,
-                        "NameServer returned no configuration: " + address);
-            }
-            return config;
+            return readConfig(admin, address);
         });
+    }
+
+    private Properties readConfig(MQAdminExt admin, String address) throws Exception {
+        Map<String, Properties> configs = admin.getNameServerConfig(List.of(address));
+        Properties config = configs == null ? null : configs.get(address);
+        if (config == null) {
+            throw new BusinessException(502,
+                    "NameServer returned no configuration: " + address);
+        }
+        return config;
     }
 
     private List<NameServerConfigDiffVO.ConfigDifferenceVO> findDifferences(

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.client.producer.SendResult;
 import org.apache.rocketmq.client.producer.SendStatus;
 import org.apache.rocketmq.common.TopicConfig;
 import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
@@ -342,8 +343,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
         }
 
         String namesrvAddr = namesrvAddr(request.getInstanceId());
+        RPCHook credentialHook = credentialHook(request.getInstanceId());
 
-        DefaultMQProducer producer = new DefaultMQProducer(nextMessageSenderGroup());
+        DefaultMQProducer producer = new DefaultMQProducer(nextMessageSenderGroup(), credentialHook);
         producer.setNamesrvAddr(namesrvAddr);
         producer.setSendMsgTimeout(5000);
 
@@ -571,6 +573,12 @@ public class RocketMQAdminClientImpl implements AdminClient {
         return StringUtils.hasText(instanceId)
                 ? runtimeAdminClientResolver.resolveEndpoint(instanceId)
                 : namesrvAddr();
+    }
+
+    private RPCHook credentialHook(String instanceId) {
+        return StringUtils.hasText(instanceId)
+                ? runtimeAdminClientResolver.resolveCredentialHook(instanceId)
+                : null;
     }
 
     private <T> T executeForInstance(String instanceId, MqAdminExtFactory.AdminAction<T> action) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -70,7 +70,7 @@ public class RocketMQClusterProvider implements ClusterProvider {
         }
 
         try {
-            return adminFactory.execute(namesrvAddr, null, admin -> {
+            return executeAdmin(instanceId, namesrvAddr, admin -> {
                 ClusterInfo clusterInfo = admin.examineBrokerClusterInfo();
                 if (clusterInfo == null || clusterInfo.getClusterAddrTable() == null) {
                     return Collections.<ClusterVO>emptyList();
@@ -113,7 +113,7 @@ public class RocketMQClusterProvider implements ClusterProvider {
         }
 
         try {
-            return adminFactory.execute(namesrvAddr, null, admin -> {
+            return executeAdmin(instanceId, namesrvAddr, admin -> {
                 ClusterInfo clusterInfo = admin.examineBrokerClusterInfo();
                 if (clusterInfo == null || clusterInfo.getClusterAddrTable() == null) {
                     return null;
@@ -279,6 +279,14 @@ public class RocketMQClusterProvider implements ClusterProvider {
             return runtimeAdminClientResolver.resolveEndpoint(instanceId);
         }
         return properties.getNamesrvAddr();
+    }
+
+    private <T> T executeAdmin(String instanceId, String namesrvAddr,
+                               MqAdminExtFactory.AdminAction<T> action) {
+        if (StringUtils.hasText(instanceId)) {
+            return runtimeAdminClientResolver.execute(instanceId, action);
+        }
+        return adminFactory.execute(namesrvAddr, null, action);
     }
 
     private List<NameServerVO> buildNameServerList(String namesrvAddr) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.remoting.protocol.admin.TopicOffset;
 import org.apache.rocketmq.remoting.protocol.admin.TopicStatsTable;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
@@ -138,6 +139,7 @@ public class RocketMQDLQProvider implements DLQProvider {
     public DLQResendResultVO resendMessages(String instanceId, String groupName, Long startTime, Long endTime,
                                              String targetTopic) {
         String endpoint = runtimeAdminClientResolver.resolveEndpoint(instanceId);
+        RPCHook credentialHook = runtimeAdminClientResolver.resolveCredentialHook(instanceId);
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + groupName;
 
         long end = endTime != null ? endTime : System.currentTimeMillis();
@@ -145,7 +147,7 @@ public class RocketMQDLQProvider implements DLQProvider {
 
         DeadLetterScanResult scanResult;
         try {
-            scanResult = collectDeadLetters(endpoint, dlqTopic, begin, end);
+            scanResult = collectDeadLetters(endpoint, credentialHook, dlqTopic, begin, end);
         } catch (BusinessException e) {
             String detail = String.format("instanceId=%s, group=%s, dlqTopic=%s, targetTopic=%s, "
                             + "matched=0, resent=0, failed=0, scanIncomplete=true, scanFailedQueues=all",
@@ -158,7 +160,7 @@ public class RocketMQDLQProvider implements DLQProvider {
         int resent = 0;
         int failed = 0;
         if (!deadLetters.isEmpty()) {
-            DefaultMQProducer producer = newProducer(endpoint);
+            DefaultMQProducer producer = newProducer(endpoint, credentialHook);
             try {
                 producer.start();
                 for (MessageExt deadLetter : deadLetters) {
@@ -193,8 +195,9 @@ public class RocketMQDLQProvider implements DLQProvider {
                 .build();
     }
 
-    private DeadLetterScanResult collectDeadLetters(String endpoint, String dlqTopic, long begin, long end) {
-        DefaultMQPullConsumer consumer = newPullConsumer(endpoint);
+    private DeadLetterScanResult collectDeadLetters(String endpoint, RPCHook credentialHook, String dlqTopic,
+                                                     long begin, long end) {
+        DefaultMQPullConsumer consumer = newPullConsumer(endpoint, credentialHook);
         List<MessageExt> result = new ArrayList<>();
         int failedQueueCount = 0;
         try {
@@ -345,15 +348,15 @@ public class RocketMQDLQProvider implements DLQProvider {
         return null;
     }
 
-    private DefaultMQPullConsumer newPullConsumer(String endpoint) {
-        DefaultMQPullConsumer consumer = new DefaultMQPullConsumer("studio-dlq-query-group");
+    private DefaultMQPullConsumer newPullConsumer(String endpoint, RPCHook credentialHook) {
+        DefaultMQPullConsumer consumer = new DefaultMQPullConsumer("studio-dlq-query-group", credentialHook);
         consumer.setInstanceName(ShortLivedClientName.next("studio-dlq-query"));
         consumer.setNamesrvAddr(endpoint);
         return consumer;
     }
 
-    private DefaultMQProducer newProducer(String endpoint) {
-        DefaultMQProducer producer = new DefaultMQProducer(nextResendProducerGroup());
+    private DefaultMQProducer newProducer(String endpoint, RPCHook credentialHook) {
+        DefaultMQProducer producer = new DefaultMQProducer(nextResendProducerGroup(), credentialHook);
         producer.setInstanceName(ShortLivedClientName.next("studio-dlq-resend"));
         producer.setRetryTimesWhenSendFailed(2);
         producer.setNamesrvAddr(endpoint);

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageId;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
@@ -94,12 +95,14 @@ public class RocketMQMessageProvider implements MessageProvider {
     public List<MessageRecordVO> queryMessages(String instanceId, String topic, String msgId, String tag, String key,
                                                Long startTime, Long endTime) {
         String endpoint = runtimeAdminClientResolver.resolveEndpoint(instanceId);
+        RPCHook credentialHook = runtimeAdminClientResolver.resolveCredentialHook(instanceId);
         return runtimeAdminClientResolver.execute(instanceId,
                 adminExt -> queryMessages(instanceId, (DefaultMQAdminExt) adminExt, endpoint,
-                        topic, msgId, tag, key, startTime, endTime));
+                        credentialHook, topic, msgId, tag, key, startTime, endTime));
     }
 
     private List<MessageRecordVO> queryMessages(String instanceId, DefaultMQAdminExt adminExt, String endpoint,
+                                                 RPCHook credentialHook,
                                                  String topic, String msgId, String tag, String key,
                                                  Long startTime, Long endTime) {
 
@@ -119,7 +122,7 @@ public class RocketMQMessageProvider implements MessageProvider {
             result = queryByKey(adminExt, topic, key, tag, begin, end);
         } else if (StringUtils.hasText(topic)) {
             queryType = "TOPIC";
-            result = queryByTopic(endpoint, topic, tag, begin, end, DEFAULT_TOPIC_LIMIT);
+            result = queryByTopic(endpoint, credentialHook, topic, tag, begin, end, DEFAULT_TOPIC_LIMIT);
         } else {
             log.warn("queryMessages requires at least one of msgId/topic, returning empty list");
             return Collections.emptyList();
@@ -194,8 +197,9 @@ public class RocketMQMessageProvider implements MessageProvider {
      * Scan a topic within a time range using a short-lived pull consumer, mirroring the approach
      * used by the RocketMQ dashboard for time-range topic queries.
      */
-    private List<MessageRecordVO> queryByTopic(String endpoint, String topic, String tag, long begin, long end, int limit) {
-        DefaultMQPullConsumer consumer = newPullConsumer("studio-msg-query", endpoint);
+    private List<MessageRecordVO> queryByTopic(String endpoint, RPCHook credentialHook, String topic, String tag,
+                                                long begin, long end, int limit) {
+        DefaultMQPullConsumer consumer = newPullConsumer("studio-msg-query", endpoint, credentialHook);
         int resultLimit = Math.min(limit, TOPIC_QUERY_HARD_CAP);
         PriorityQueue<MessageRecordVO> newestMessages = new PriorityQueue<>(TOPIC_QUERY_ORDER);
         try {
@@ -581,8 +585,8 @@ public class RocketMQMessageProvider implements MessageProvider {
         return tag.equals(messageExt.getTags());
     }
 
-    private DefaultMQPullConsumer newPullConsumer(String groupPrefix, String endpoint) {
-        DefaultMQPullConsumer consumer = new DefaultMQPullConsumer(groupPrefix + "-group");
+    private DefaultMQPullConsumer newPullConsumer(String groupPrefix, String endpoint, RPCHook credentialHook) {
+        DefaultMQPullConsumer consumer = new DefaultMQPullConsumer(groupPrefix + "-group", credentialHook);
         consumer.setInstanceName(ShortLivedClientName.next(groupPrefix));
         consumer.setNamesrvAddr(endpoint);
         return consumer;

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolverTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolverTest.java
@@ -142,6 +142,40 @@ class RuntimeAdminClientResolverTest {
     }
 
     @Test
+    void resolvesCredentialHookForShortLivedRuntimeClients() {
+        InstanceVO instance = InstanceVO.builder()
+                .endpoint("namesrv-b:9876")
+                .adminCredentialRef("production-admin")
+                .build();
+        MqAdminProperties properties = new MqAdminProperties();
+        MqAdminProperties.Credential credential = new MqAdminProperties.Credential();
+        credential.setAccessKey("admin-ak");
+        credential.setSecretKey("admin-sk");
+        properties.getCredentials().put("production-admin", credential);
+        when(instanceRepository.findByIdentifier("instance-b")).thenReturn(Optional.of(instance));
+        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory,
+                properties);
+
+        org.apache.rocketmq.acl.common.AclClientRPCHook hook =
+                (org.apache.rocketmq.acl.common.AclClientRPCHook) resolver.resolveCredentialHook("instance-b");
+
+        assertThat(hook.getSessionCredentials().getAccessKey()).isEqualTo("admin-ak");
+        assertThat(hook.getSessionCredentials().getSecretKey()).isEqualTo("admin-sk");
+        verifyNoInteractions(adminFactory);
+    }
+
+    @Test
+    void returnsNoCredentialHookWhenTheSelectedInstanceHasNoCredentialReference() {
+        InstanceVO instance = InstanceVO.builder().endpoint("namesrv-b:9876").build();
+        when(instanceRepository.findByIdentifier("instance-b")).thenReturn(Optional.of(instance));
+        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory,
+                new MqAdminProperties());
+
+        assertThat(resolver.resolveCredentialHook("instance-b")).isNull();
+        verifyNoInteractions(adminFactory);
+    }
+
+    @Test
     void rejectsUnknownOrIncompleteCredentialReferencesBeforeNetworkCalls() {
         MqAdminProperties properties = new MqAdminProperties();
         MqAdminProperties.Credential credential = new MqAdminProperties.Credential();

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.nameserver;
 import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 import org.apache.rocketmq.studio.cluster.broker.ClusterVO;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +37,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
@@ -50,13 +54,17 @@ class NameServerConfigDiffServiceTest {
     private MqAdminExtFactory adminFactory;
 
     @Mock
+    private RuntimeAdminClientResolver runtimeAdminClientResolver;
+
+    @Mock
     private MQAdminExt admin;
 
     private NameServerConfigDiffService service;
 
     @BeforeEach
     void setUp() {
-        service = new NameServerConfigDiffService(clusterService, adminFactory);
+        service = new NameServerConfigDiffService(
+                clusterService, adminFactory, runtimeAdminClientResolver);
     }
 
     private void stubAdminFactory() {
@@ -111,10 +119,13 @@ class NameServerConfigDiffServiceTest {
 
     @Test
     void compareShouldResolveClusterThroughSelectedInstance() throws Exception {
-        stubAdminFactory();
         when(clusterService.getCluster("cluster-a", "instance-a")).thenReturn(cluster(
                 "ns-a:9876;ns-b:9876",
                 List.of(nameServer("ns-a:9876"), nameServer("ns-b:9876"))));
+        when(runtimeAdminClientResolver.execute(eq("instance-a"), any())).thenAnswer(invocation -> {
+            MqAdminExtFactory.AdminAction<Object> action = invocation.getArgument(1);
+            return action.apply(admin);
+        });
         when(admin.getNameServerConfig(List.of("ns-a:9876")))
                 .thenReturn(Map.of("ns-a:9876", properties("listenPort", "9876")));
         when(admin.getNameServerConfig(List.of("ns-b:9876")))
@@ -124,6 +135,9 @@ class NameServerConfigDiffServiceTest {
 
         assertThat(result.isComplete()).isTrue();
         verify(clusterService).getCluster("cluster-a", "instance-a");
+        verify(runtimeAdminClientResolver, times(2))
+                .execute(eq("instance-a"), any());
+        verify(adminFactory, never()).execute(anyString(), isNull(), any());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -21,6 +21,7 @@ import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.client.producer.SendResult;
 import org.apache.rocketmq.client.producer.SendStatus;
 import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.remoting.exception.RemotingTimeoutException;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
@@ -47,6 +48,7 @@ import org.mockito.MockedConstruction;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -536,8 +538,10 @@ class RocketMQAdminClientImplTest {
     @Test
     void sendMessageShouldAllowBodyAtMaximumSize() throws Exception {
         when(properties.getNamesrvAddr()).thenReturn("10.0.0.1:9876");
+        List<List<?>> constructorArguments = new ArrayList<>();
         try (MockedConstruction<DefaultMQProducer> mockedProducers =
                      mockConstruction(DefaultMQProducer.class, (producer, context) -> {
+                         constructorArguments.add(context.arguments());
                          doNothing().when(producer).start();
                          SendResult sendResult = new SendResult();
                          sendResult.setSendStatus(SendStatus.SEND_OK);
@@ -557,14 +561,21 @@ class RocketMQAdminClientImplTest {
             ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
             verify(producer).send(messageCaptor.capture());
             assertThat(messageCaptor.getValue().getBody()).hasSize(4 * 1024 * 1024);
+            assertThat(constructorArguments).singleElement();
+            assertThat(constructorArguments.get(0)).hasSize(2);
+            assertThat(constructorArguments.get(0).get(1)).isNull();
         }
     }
 
     @Test
-    void sendMessageUsesSelectedInstanceEndpoint() throws Exception {
+    void sendMessageUsesSelectedInstanceEndpointAndCredentialHook() throws Exception {
+        RPCHook credentialHook = org.mockito.Mockito.mock(RPCHook.class);
+        List<List<?>> constructorArguments = new ArrayList<>();
         when(runtimeAdminClientResolver.resolveEndpoint("instance-a")).thenReturn("10.0.0.2:9876");
+        when(runtimeAdminClientResolver.resolveCredentialHook("instance-a")).thenReturn(credentialHook);
         try (MockedConstruction<DefaultMQProducer> mockedProducers =
                      mockConstruction(DefaultMQProducer.class, (producer, context) -> {
+                         constructorArguments.add(context.arguments());
                          doNothing().when(producer).start();
                          SendResult sendResult = new SendResult();
                          sendResult.setSendStatus(SendStatus.SEND_OK);
@@ -582,7 +593,11 @@ class RocketMQAdminClientImplTest {
 
             DefaultMQProducer producer = mockedProducers.constructed().getFirst();
             verify(producer).setNamesrvAddr("10.0.0.2:9876");
+            assertThat(constructorArguments).singleElement();
+            assertThat(constructorArguments.get(0)).hasSize(2);
+            assertThat(constructorArguments.get(0).get(1)).isSameAs(credentialHook);
         }
+        verify(runtimeAdminClientResolver).resolveCredentialHook("instance-a");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
@@ -206,7 +206,7 @@ class RocketMQClusterProviderTest {
                 .adminCredentialRef("cluster-admin")
                 .build();
         instance.setId("instance-a");
-        when(instanceRepository.findById("instance-a")).thenReturn(Optional.of(instance));
+        when(instanceRepository.findByIdentifier("instance-a")).thenReturn(Optional.of(instance));
         MqAdminProperties adminProperties = new MqAdminProperties();
         MqAdminProperties.Credential credential = new MqAdminProperties.Credential();
         credential.setAccessKey("admin-ak");

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
@@ -16,26 +16,38 @@
  */
 package org.apache.rocketmq.studio.provider.apache;
 
+import org.apache.rocketmq.acl.common.AclClientRPCHook;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.KVTable;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.ClusterVO;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.MqAdminProperties;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RocketMQClusterProviderTest {
@@ -141,6 +153,39 @@ class RocketMQClusterProviderTest {
         });
     }
 
+    @Test
+    void discoverClustersShouldUseSelectedInstanceAdminCredential() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        MqAdminExtFactory adminFactory = mock(MqAdminExtFactory.class);
+        RocketMQClusterProvider provider = newAuthenticatedInstanceProvider(adminFactory, adminExt);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+
+        List<ClusterVO> clusters = provider.discoverClusters("instance-a");
+
+        assertThat(clusters).singleElement()
+                .extracting(ClusterVO::getName)
+                .isEqualTo("DefaultCluster");
+        verify(adminFactory).execute(eq("10.0.0.2:9876"), isA(AclClientRPCHook.class),
+                eq("cluster-admin"), any());
+        verify(adminFactory, never()).execute(eq("10.0.0.2:9876"), isNull(), any());
+    }
+
+    @Test
+    void refreshClusterDetailShouldUseSelectedInstanceAdminCredential() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        MqAdminExtFactory adminFactory = mock(MqAdminExtFactory.class);
+        RocketMQClusterProvider provider = newAuthenticatedInstanceProvider(adminFactory, adminExt);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+
+        ClusterVO cluster = provider.refreshClusterDetail("DefaultCluster", "instance-a");
+
+        assertThat(cluster).isNotNull();
+        assertThat(cluster.getName()).isEqualTo("DefaultCluster");
+        verify(adminFactory).execute(eq("10.0.0.2:9876"), isA(AclClientRPCHook.class),
+                eq("cluster-admin"), any());
+        verify(adminFactory, never()).execute(eq("10.0.0.2:9876"), isNull(), any());
+    }
+
     private RocketMQClusterProvider newProvider(DefaultMQAdminExt adminExt) {
         MqAdminExtFactory adminFactory = mock(MqAdminExtFactory.class);
         when(adminFactory.execute(anyString(), any(), any())).thenAnswer(invocation ->
@@ -148,6 +193,33 @@ class RocketMQClusterProviderTest {
         RocketMQProperties properties = new RocketMQProperties();
         properties.setNamesrvAddr("10.0.0.1:9876");
         return new RocketMQClusterProvider(adminFactory, properties, mock(RuntimeAdminClientResolver.class));
+    }
+
+    private RocketMQClusterProvider newAuthenticatedInstanceProvider(MqAdminExtFactory adminFactory,
+                                                                      DefaultMQAdminExt adminExt) {
+        InstanceRepository instanceRepository = mock(InstanceRepository.class);
+        InstanceVO instance = InstanceVO.builder()
+                .name("Authenticated instance")
+                .vendor(InstanceVendor.APACHE)
+                .type(InstanceType.DIRECT)
+                .endpoint("10.0.0.2:9876")
+                .adminCredentialRef("cluster-admin")
+                .build();
+        instance.setId("instance-a");
+        when(instanceRepository.findById("instance-a")).thenReturn(Optional.of(instance));
+        MqAdminProperties adminProperties = new MqAdminProperties();
+        MqAdminProperties.Credential credential = new MqAdminProperties.Credential();
+        credential.setAccessKey("admin-ak");
+        credential.setSecretKey("admin-sk");
+        adminProperties.getCredentials().put("cluster-admin", credential);
+        RuntimeAdminClientResolver resolver =
+                new RuntimeAdminClientResolver(instanceRepository, adminFactory, adminProperties);
+        when(adminFactory.execute(eq("10.0.0.2:9876"), any(), eq("cluster-admin"), any()))
+                .thenAnswer(invocation -> invocation.<MqAdminExtFactory.AdminAction<Object>>getArgument(3)
+                        .apply(adminExt));
+        RocketMQProperties properties = new RocketMQProperties();
+        properties.setNamesrvAddr("10.0.0.1:9876");
+        return new RocketMQClusterProvider(adminFactory, properties, resolver);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.remoting.protocol.admin.TopicStatsTable;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
@@ -45,6 +46,7 @@ import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -124,8 +126,10 @@ class RocketMQDLQProviderTest {
     @Test
     void resendMessagesDoesNotPullWhenDlqQueueSetIsNull() throws Exception {
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        List<List<?>> consumerConstructorArguments = new ArrayList<>();
         try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
                      mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         consumerConstructorArguments.add(context.arguments());
                          doNothing().when(consumer).start();
                          when(consumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(null);
                          doNothing().when(consumer).shutdown();
@@ -135,6 +139,9 @@ class RocketMQDLQProviderTest {
             provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic");
 
             assertThat(mockedConsumers.constructed()).hasSize(1);
+            assertThat(consumerConstructorArguments).singleElement();
+            assertThat(consumerConstructorArguments.get(0)).hasSize(2);
+            assertThat(consumerConstructorArguments.get(0).get(1)).isNull();
             DefaultMQPullConsumer consumer = mockedConsumers.constructed().get(0);
             verify(consumer).setNamesrvAddr("namesrv-a:9876");
             verify(consumer).start();
@@ -149,6 +156,54 @@ class RocketMQDLQProviderTest {
                 contains("matched=0, resent=0, failed=0"),
                 eq("NO_MESSAGES"));
         verify(runtimeAdminClientResolver).resolveEndpoint("instance-a");
+        verify(runtimeAdminClientResolver).resolveCredentialHook("instance-a");
+    }
+
+    @Test
+    void resendMessagesUsesSelectedInstanceCredentialHookForScanAndResend() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        MessageQueue queue = new MessageQueue(dlqTopic, "broker-a", 0);
+        MessageExt deadLetter = new MessageExt();
+        deadLetter.setMsgId("acl-dlq-message");
+        deadLetter.setTopic(dlqTopic);
+        deadLetter.setBody(new byte[] {1});
+        deadLetter.setStoreTimestamp(150L);
+        PullResult pullResult = new PullResult(PullStatus.FOUND, 1L, 0L, 0L, List.of(deadLetter));
+        SendResult sendResult = new SendResult();
+        sendResult.setSendStatus(SendStatus.SEND_OK);
+        RPCHook credentialHook = org.mockito.Mockito.mock(RPCHook.class);
+        List<List<?>> consumerConstructorArguments = new ArrayList<>();
+        List<List<?>> producerConstructorArguments = new ArrayList<>();
+        when(runtimeAdminClientResolver.resolveCredentialHook("instance-a")).thenReturn(credentialHook);
+
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         consumerConstructorArguments.add(context.arguments());
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(Set.of(queue));
+                         when(consumer.searchOffset(queue, 100L)).thenReturn(0L);
+                         when(consumer.searchOffset(queue, 200L)).thenReturn(0L);
+                         when(consumer.pull(queue, "*", 0L, 32)).thenReturn(pullResult);
+                         doNothing().when(consumer).shutdown();
+                     });
+             MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class, (producer, context) -> {
+                         producerConstructorArguments.add(context.arguments());
+                         doNothing().when(producer).start();
+                         when(producer.send(any(Message.class))).thenReturn(sendResult);
+                         doNothing().when(producer).shutdown();
+                     })) {
+            provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic");
+
+            assertThat(mockedConsumers.constructed()).singleElement();
+            assertThat(mockedProducers.constructed()).singleElement();
+        }
+
+        assertThat(consumerConstructorArguments).singleElement();
+        assertThat(consumerConstructorArguments.get(0).get(1)).isSameAs(credentialHook);
+        assertThat(producerConstructorArguments).singleElement();
+        assertThat(producerConstructorArguments.get(0).get(1)).isSameAs(credentialHook);
+        verify(runtimeAdminClientResolver).resolveCredentialHook("instance-a");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageId;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -48,6 +49,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -97,8 +99,10 @@ class RocketMQMessageProviderTest {
 
     @Test
     void queryByTopicReturnsEmptyListWhenQueueSetIsNull() throws Exception {
+        List<List<?>> constructorArguments = new ArrayList<>();
         try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
                      mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         constructorArguments.add(context.arguments());
                          doNothing().when(consumer).start();
                          when(consumer.fetchSubscribeMessageQueues("TopicA")).thenReturn(null);
                          doNothing().when(consumer).shutdown();
@@ -108,6 +112,10 @@ class RocketMQMessageProviderTest {
             assertThat(messages).isEmpty();
             assertThat(mockedConsumers.constructed()).hasSize(1);
             DefaultMQPullConsumer consumer = mockedConsumers.constructed().get(0);
+            assertThat(constructorArguments).singleElement();
+            assertThat(constructorArguments.get(0)).hasSize(2);
+            assertThat(constructorArguments.get(0).get(0)).isEqualTo("studio-msg-query-group");
+            assertThat(constructorArguments.get(0).get(1)).isNull();
             verify(consumer).setNamesrvAddr("namesrv-a:9876");
             verify(consumer).start();
             verify(consumer).fetchSubscribeMessageQueues("TopicA");
@@ -115,9 +123,34 @@ class RocketMQMessageProviderTest {
             verify(consumer).shutdown();
         }
         verify(runtimeAdminClientResolver).resolveEndpoint("instance-a");
+        verify(runtimeAdminClientResolver).resolveCredentialHook("instance-a");
         verify(runtimeAdminClientResolver).execute(eq("instance-a"), any());
         verify(queryHistoryService).recordMessageQuery("instance-a", "TOPIC", "TopicA", null, null, null,
                 100L, 200L, 0);
+    }
+
+    @Test
+    void queryByTopicUsesSelectedInstanceCredentialHook() throws Exception {
+        RPCHook credentialHook = mock(RPCHook.class);
+        List<List<?>> constructorArguments = new ArrayList<>();
+        when(runtimeAdminClientResolver.resolveCredentialHook("instance-a")).thenReturn(credentialHook);
+
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         constructorArguments.add(context.arguments());
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues("TopicA")).thenReturn(Set.of());
+                         doNothing().when(consumer).shutdown();
+                     })) {
+            provider.queryMessages("instance-a", "TopicA", null, null, null, 100L, 200L);
+
+            assertThat(mockedConsumers.constructed()).singleElement();
+            assertThat(constructorArguments).singleElement();
+            assertThat(constructorArguments.get(0)).hasSize(2);
+            assertThat(constructorArguments.get(0).get(0)).isEqualTo("studio-msg-query-group");
+            assertThat(constructorArguments.get(0).get(1)).isSameAs(credentialHook);
+        }
+        verify(runtimeAdminClientResolver).resolveCredentialHook("instance-a");
     }
 
     @Test

--- a/web/src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx
@@ -236,11 +236,11 @@ describe('NameServerConfigDriftPage', () => {
     renderWithProviders(<NameServerConfigDriftPage />);
 
     await user.click(await screen.findByRole('combobox', { name: 'NameServer drift instance' }));
-    await user.click(await screen.findByText('Backup instance'));
+    await user.click(await screen.findByTitle('Backup instance'));
 
     await waitFor(() => {
-      expect(listClusters).toHaveBeenCalledWith('instance-b');
-      expect(getNameServerConfigDiff).toHaveBeenCalledWith('cluster-b', 'instance-b');
+      expect(listClusters).toHaveBeenCalledWith(instanceB.name);
+      expect(getNameServerConfigDiff).toHaveBeenCalledWith('cluster-b', instanceB.name);
     });
     expect(await screen.findByText('39876')).toBeInTheDocument();
 

--- a/web/src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx
@@ -39,6 +39,16 @@ vi.mock('../../../services/instanceService', () => ({
 const createObjectURL = vi.fn(() => 'blob:nameserver-config-drift');
 const revokeObjectURL = vi.fn();
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -186,5 +196,59 @@ describe('NameServerConfigDriftPage', () => {
 
     expect(await screen.findByText('暂无可检查的集群')).toBeInTheDocument();
     expect(getNameServerConfigDiff).not.toHaveBeenCalled();
+  });
+
+  it('ignores a stale bootstrap cluster response after the user selects another instance', async () => {
+    const user = userEvent.setup();
+    const instanceB = {
+      ...instance,
+      id: 'instance-b',
+      name: 'Backup instance',
+    };
+    const clusterB = {
+      ...cluster,
+      id: 'cluster-b',
+      name: 'Backup cluster',
+    };
+    const bootstrapClusters = deferred<ClusterInfo[]>();
+    vi.mocked(listInstances).mockResolvedValue([instance, instanceB]);
+    vi.mocked(listClusters).mockImplementation((instanceId) =>
+      instanceId === 'instance-a' ? bootstrapClusters.promise : Promise.resolve([clusterB]),
+    );
+    vi.mocked(getNameServerConfigDiff).mockResolvedValue({
+      ...driftResult,
+      cluster: 'cluster-b',
+      nodes: [
+        { address: 'ns-b:9876', reachable: true },
+        { address: 'ns-c:9876', reachable: true },
+      ],
+      differences: [
+        {
+          key: 'listenPort',
+          values: [
+            { address: 'ns-b:9876', configured: true, value: '29876' },
+            { address: 'ns-c:9876', configured: true, value: '39876' },
+          ],
+        },
+      ],
+    });
+
+    renderWithProviders(<NameServerConfigDriftPage />);
+
+    await user.click(await screen.findByRole('combobox', { name: 'NameServer drift instance' }));
+    await user.click(await screen.findByText('Backup instance'));
+
+    await waitFor(() => {
+      expect(listClusters).toHaveBeenCalledWith('instance-b');
+      expect(getNameServerConfigDiff).toHaveBeenCalledWith('cluster-b', 'instance-b');
+    });
+    expect(await screen.findByText('39876')).toBeInTheDocument();
+
+    bootstrapClusters.resolve([cluster]);
+
+    await waitFor(() => expect(listClusters).toHaveBeenCalledTimes(2));
+    expect(getNameServerConfigDiff).not.toHaveBeenCalledWith('cluster-a', 'instance-a');
+    expect(screen.getByText('39876')).toBeInTheDocument();
+    expect(screen.queryByText('19876')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/ops/nameServerConfigDrift.tsx
+++ b/web/src/pages/ops/nameServerConfigDrift.tsx
@@ -35,7 +35,8 @@ const { Text, Title } = Typography;
 const NameServerConfigDriftPage = () => {
   const { t } = useLang();
   const { message } = App.useApp();
-  const requestSequence = useRef(0);
+  const clusterRequestSequence = useRef(0);
+  const checkRequestSequence = useRef(0);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string>();
   const [clusters, setClusters] = useState<ClusterInfo[]>([]);
@@ -46,18 +47,18 @@ const NameServerConfigDriftPage = () => {
 
   const runCheck = useCallback(
     async (clusterId: string, instanceId: string) => {
-      const sequence = ++requestSequence.current;
+      const sequence = ++checkRequestSequence.current;
       setChecking(true);
       try {
         const nextResult = await getNameServerConfigDiff(clusterId, instanceId);
-        if (sequence === requestSequence.current) setResult(nextResult);
+        if (sequence === checkRequestSequence.current) setResult(nextResult);
       } catch {
-        if (sequence === requestSequence.current) {
+        if (sequence === checkRequestSequence.current) {
           setResult(undefined);
           message.error(t('nameServerDrift.checkFailed'));
         }
       } finally {
-        if (sequence === requestSequence.current) setChecking(false);
+        if (sequence === checkRequestSequence.current) setChecking(false);
       }
     },
     [message, t],
@@ -65,10 +66,10 @@ const NameServerConfigDriftPage = () => {
 
   useEffect(() => {
     let cancelled = false;
-    const sequence = ++requestSequence.current;
+    const sequence = ++clusterRequestSequence.current;
     void listInstances()
       .then(async (items) => {
-        if (cancelled) return;
+        if (cancelled || sequence !== clusterRequestSequence.current) return;
         const apacheInstances = items.filter((instance) => instance.vendor === 'APACHE');
         setInstances(apacheInstances);
         const firstInstanceId = apacheInstances[0]?.id;
@@ -78,45 +79,51 @@ const NameServerConfigDriftPage = () => {
           return;
         }
         const clustersForInstance = await listClusters(firstInstanceId);
-        if (cancelled || sequence !== requestSequence.current) return;
+        if (cancelled || sequence !== clusterRequestSequence.current) return;
         setClusters(clustersForInstance);
         const firstClusterId = clustersForInstance[0]?.id;
         setSelectedClusterId(firstClusterId);
         if (firstClusterId) void runCheck(firstClusterId, firstInstanceId);
       })
       .catch(() => {
-        if (!cancelled && sequence === requestSequence.current) {
+        if (!cancelled && sequence === clusterRequestSequence.current) {
           message.error(t('nameServerDrift.loadClustersFailed'));
         }
       })
       .finally(() => {
-        if (!cancelled && sequence === requestSequence.current) setClustersLoading(false);
+        if (!cancelled && sequence === clusterRequestSequence.current) {
+          setClustersLoading(false);
+        }
       });
     return () => {
       cancelled = true;
-      requestSequence.current += 1;
+      clusterRequestSequence.current += 1;
+      checkRequestSequence.current += 1;
     };
   }, [message, runCheck, t]);
 
   const selectInstance = async (instanceId: string) => {
-    const sequence = ++requestSequence.current;
+    const sequence = ++clusterRequestSequence.current;
+    checkRequestSequence.current += 1;
     setSelectedInstanceId(instanceId);
     setSelectedClusterId(undefined);
     setClusters([]);
     setResult(undefined);
     setClustersLoading(true);
+    setChecking(false);
     try {
       const nextClusters = await listClusters(instanceId);
-      if (sequence !== requestSequence.current) return;
+      if (sequence !== clusterRequestSequence.current) return;
       setClusters(nextClusters);
       const firstClusterId = nextClusters[0]?.id;
       setSelectedClusterId(firstClusterId);
       if (firstClusterId) void runCheck(firstClusterId, instanceId);
     } catch {
-      if (sequence === requestSequence.current)
+      if (sequence === clusterRequestSequence.current) {
         message.error(t('nameServerDrift.loadClustersFailed'));
+      }
     } finally {
-      if (sequence === requestSequence.current) setClustersLoading(false);
+      if (sequence === clusterRequestSequence.current) setClustersLoading(false);
     }
   };
 


### PR DESCRIPTION
## Summary

- Route selected Apache-instance cluster discovery, detail refresh, and NameServer drift diagnostics through `RuntimeAdminClientResolver`.
- Preserve the selected instance ACL credential for all short-lived runtime clients used by diagnostics:
  - time-range topic message query consumers;
  - DLQ scan consumers and resend producers;
  - test-message producers.
- Keep stale NameServer drift bootstrap results from overwriting newer instance selection.
- Stabilize selected-instance credential coverage by resolving test instances through the current identifier contract.

## Validation

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -q -f server/pom.xml -Dtest=RocketMQClusterProviderTest,NameServerConfigDiffServiceTest,RuntimeAdminClientResolverTest,RocketMQMessageProviderTest,RocketMQDLQProviderTest,RocketMQAdminClientImplTest test
```

Closes #1989
Closes #2009
Closes #2202
Closes #2204
Closes #2205