### PR TITLE
fix(web): guard topic consumer pagination race, stale metrics datasource, and dead buttons

### DIFF
--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -490,6 +490,9 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
   useEffect(() => {
     if (dataSourceKey && !availableDataSources.some((source) => source.key === dataSourceKey)) {
       window.setTimeout(() => {
+        // Keep the ref in sync with the state; queries read the ref, so a stale key would
+        // keep hitting the de-registered data source while the UI shows the default.
+        dataSourceKeyRef.current = '';
         setDataSourceKey('');
         setData(null);
       }, 0);

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -390,6 +390,7 @@ const AiPage = () => {
   const [modelsLoading, setModelsLoading] = useState(false);
   const [selectedModel, setSelectedModel] = useState('');
   const [toolModalOpen, setToolModalOpen] = useState(false);
+  const [enhance, setEnhance] = useState(false);
   const [tools, setTools] = useState<McpTool[]>([]);
   const [toolsLoading, setToolsLoading] = useState(false);
   const [clusterOptions, setClusterOptions] = useState<{ value: string; label: string }[]>([]);
@@ -850,7 +851,15 @@ const AiPage = () => {
                       <SlidersHorizontal size={17} />
                       <span>工具</span>
                     </button>
-                    <button className="tool-btn">
+                    <button
+                      className="tool-btn"
+                      onClick={() => setEnhance((value) => !value)}
+                      style={{
+                        borderColor: enhance ? '#1677ff' : undefined,
+                        color: enhance ? '#1677ff' : undefined,
+                      }}
+                      title="发送前增强 Prompt"
+                    >
                       <Sparkle size={17} />
                       <span>Prompt 增强</span>
                     </button>
@@ -859,7 +868,7 @@ const AiPage = () => {
                 <div className="shrink-0 flex items-center gap-1">
                   <button
                     className="flex items-center justify-center w-9 h-9 rounded-full bg-gradient-to-r from-purple-500 to-violet-600 text-white shadow-lg hover:shadow-xl transition-all hover:scale-105"
-                    onClick={() => void handleSend()}
+                    onClick={() => void handleSend(undefined, undefined, enhance)}
                     disabled={loading || !inputValue.trim() || !llmReady}
                     style={{
                       opacity: loading || !inputValue.trim() || !llmReady ? 0.5 : 1,

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -685,6 +685,8 @@ const ConsumerPageContent = ({
         <Button
           size="small"
           icon={<Eye size={14} />}
+          disabled
+          title="队列分布暂未支持"
           style={{ borderColor: '#1677ff', color: '#1677ff' }}
         >
           查看分布

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -335,6 +335,7 @@ const TopicPage = () => {
 
   const topicRequestIdRef = useRef(0);
   const detailRequestIdRef = useRef(0);
+  const consumersRequestIdRef = useRef(0);
   const createInFlightRef = useRef(false);
 
   useEffect(() => {
@@ -392,13 +393,17 @@ const TopicPage = () => {
   };
 
   const loadTopicConsumers = async (topic: Topic, page = 1, pageSize = 20) => {
+    const requestId = ++consumersRequestIdRef.current;
     const consumers = await getTopicConsumerPage(
       topic.name,
       selectedInstanceId || undefined,
       page,
       pageSize,
     );
-    setConsumersByTopic((previous) => ({ ...previous, [topic.name]: consumers }));
+    // Guard against a slower earlier page overwriting a newer one when the user pages quickly.
+    if (requestId === consumersRequestIdRef.current) {
+      setConsumersByTopic((previous) => ({ ...previous, [topic.name]: consumers }));
+    }
   };
 
   // ─── Open detail modal ────────────────────────────────────────


### PR DESCRIPTION
## What is the purpose of the change

Three web UI bugs found in the Studio pages:

- `loadTopicConsumers` in the topic detail modal had no request guard, so paging or switching topics quickly let a slower earlier response overwrite a newer one (the same guard pattern already exists in `message.tsx` / `consumer.tsx`).
- `MetricsExplorer` reset `dataSourceKey` state to `''` when the selected data source left `availableDataSources`, but left `dataSourceKeyRef.current` pointing at the stale key; subsequent queries kept hitting the de-registered data source while the UI showed the default.
- Two visible buttons did nothing: the consumer table's "查看分布" action and the AI page's "Prompt 增强" toggle had no click handling.

## Brief changelog

- Guard `loadTopicConsumers` with a per-request sequence id so only the latest page applies.
- Sync `dataSourceKeyRef.current` when the selected data source is reset because it left the available set.
- Disable the unimplemented "查看分布" button instead of leaving a dead control.
- Wire the AI page "Prompt 增强" toggle to an `enhance` state passed into `handleSend`/`chatStream`.

## Verifying this change

- `npx tsc -b` (type check clean)
- `npx eslint src/pages/instance/topic.tsx src/components/MetricsExplorer.tsx src/pages/instance/consumer.tsx src/pages/ai/index.tsx` (only a pre-existing refs warning on an untouched line)
- `git diff --check`
