### PR TITLE
fix: preserve identical producers across clusters

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -183,7 +183,8 @@ public class RocketMQClientProvider implements ClientProvider {
                 if (producerInfo == null) {
                     continue;
                 }
-                String key = producerGroup + '\0'
+                String key = Objects.toString(clusterId, "") + '\0'
+                        + producerGroup + '\0'
                         + Objects.toString(producerInfo.getClientId(), "") + '\0'
                         + Objects.toString(producerInfo.getRemoteIP(), "");
                 connections.putIfAbsent(key, toConnectionVO(producerInfo, producerGroup, clusterId));

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
@@ -116,6 +116,25 @@ class RocketMQClientProviderTest {
     }
 
     @Test
+    void producerScanPreservesIdenticalConnectionsAcrossClusters() throws Exception {
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo(Map.of(
+                "127.0.0.1:10911", "cluster-a",
+                "127.0.0.2:10911", "cluster-b")));
+        ProducerInfo shared = producerInfo("producer-client", "10.0.0.1:1000");
+        when(adminExt.getAllProducerInfo("127.0.0.1:10911"))
+                .thenReturn(new ProducerTableInfo(Map.of("pg-order", List.of(shared))));
+        when(adminExt.getAllProducerInfo("127.0.0.2:10911"))
+                .thenReturn(new ProducerTableInfo(Map.of("pg-order", List.of(shared))));
+
+        List<ClientConnectionVO> connections = provider.findConnections("instance-a", null, "Producer");
+
+        assertThat(connections).hasSize(2);
+        assertThat(connections)
+                .extracting(ClientConnectionVO::getClusterName)
+                .containsExactlyInAnyOrder("cluster-a", "cluster-b");
+    }
+
+    @Test
     void clientScanUsesActualBrokerClustersAndFiltersRequestedCluster() throws Exception {
         when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo(Map.of(
                 "127.0.0.1:10911", "cluster-a",


### PR DESCRIPTION
## Summary

- include the discovered RocketMQ cluster in the Producer aggregation key
- keep collapsing duplicate Broker reports inside one cluster
- preserve identical Producer identities that belong to different clusters
- add a regression test covering the cross-cluster collision

Closes #1991

## Verification

- failure proof before the production fix: `RocketMQClientProviderTest.producerScanPreservesIdenticalConnectionsAcrossClusters` expected 2 rows but received 1
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -f server/pom.xml -Dtest=RocketMQClientProviderTest test` (17 tests passed)
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -f server/pom.xml -DskipTests package`
- `git diff --check`
