### PR TITLE
fix: preserve structured reset offset errors

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -507,6 +507,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
             }
             recordAudit("RESET_OFFSET", name,
                     "instanceId=" + instanceId + ", topic=" + topic + ", timestamp=" + timestamp, "SUCCESS");
+        } catch (BusinessException e) {
+            recordAudit("RESET_OFFSET", name, e.getMessage(), "FAILED");
+            throw e;
         } catch (Exception e) {
             recordAudit("RESET_OFFSET", name, e.getMessage(), "FAILED");
             throw new BusinessException(500, "Failed to reset offset: " + e.getMessage());

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -135,6 +135,33 @@ class RocketMQAdminClientImplTest {
     }
 
     @Test
+    void resetOffsetShouldPreserveStructuredResolverFailure() {
+        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("missing-instance"), any()))
+                .thenThrow(new BusinessException(404, "Instance not found: missing-instance"));
+
+        assertThatThrownBy(() -> adminClient.resetOffset(
+                "missing-instance", "cg-orders", 1784246400000L, "orders"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Instance not found: missing-instance")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
+        verify(auditService).record("RESET_OFFSET", "cg-orders",
+                "Instance not found: missing-instance", "FAILED");
+    }
+
+    @Test
+    void resetOffsetShouldWrapUnexpectedAdminFailure() {
+        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("instance-a"), any()))
+                .thenThrow(new IllegalStateException("broker unavailable"));
+
+        assertThatThrownBy(() -> adminClient.resetOffset(
+                "instance-a", "cg-orders", 1784246400000L, "orders"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Failed to reset offset: broker unavailable")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(500));
+        verify(auditService).record("RESET_OFFSET", "cg-orders", "broker unavailable", "FAILED");
+    }
+
+    @Test
     void getConsumerGroupSurfacesAdminTimeout() throws Exception {
         when(adminExt.examineConsumerConnectionInfo("orders"))
                 .thenThrow(new RemotingTimeoutException("broker-0", 3_000));


### PR DESCRIPTION
## Summary

- preserve structured `BusinessException` status codes and messages from instance and credential resolution
- keep unexpected Admin failures wrapped by the existing reset-offset 500 response
- retain failed audit records for both error paths
- add regression coverage for a resolver 404 and an unexpected Broker/Admin failure

Closes #1994

## Verification

- failure proof before the production fix: the new resolver test expected `Instance not found: missing-instance` with code 404 but received `Failed to reset offset: Instance not found: missing-instance` with code 500
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -f server/pom.xml -Dtest=RocketMQAdminClientImplTest test` (21 tests passed)
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -f server/pom.xml -DskipTests package`
- `git diff --check`
