### PR TITLE
fix: preserve instance mutation and deletion integrity

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceRepository.java
@@ -35,7 +35,7 @@ public interface InstanceRepository {
 
     InstanceVO save(InstanceVO instance);
 
-    void deleteById(String id);
+    boolean deleteById(String id);
 
     boolean existsByCredentialId(String credentialId);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -256,7 +256,9 @@ public class InstanceService {
                     "Cannot delete instance with managed resources: topics=%d, consumerGroups=%d",
                     topicCount, consumerGroupCount));
         }
-        instanceRepository.deleteById(id);
+        if (!instanceRepository.deleteById(id)) {
+            throw new BusinessException(404, "InstanceVO not found: " + id);
+        }
         releaseApacheEndpointIfUnused(existing, null);
         recordAudit("DELETE_INSTANCE", "INSTANCE", id, null,
                 instanceAuditDetail(existing));

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
@@ -107,8 +107,8 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
     }
 
     @Override
-    public void deleteById(String id) {
-        instanceMapper.deleteById(id);
+    public boolean deleteById(String id) {
+        return instanceMapper.deleteById(id) > 0;
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -649,6 +649,7 @@ class InstanceServiceTest {
         when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
         when(instanceProvider.countTopics("inst-1")).thenReturn(0);
         when(instanceProvider.countGroups("inst-1")).thenReturn(0);
+        when(instanceRepository.deleteById("inst-1")).thenReturn(true);
 
         instanceService.deleteInstance("inst-1");
 
@@ -707,11 +708,32 @@ class InstanceServiceTest {
         when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
         when(instanceRepository.findAll()).thenReturn(List.of());
         when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceRepository.deleteById("inst-1")).thenReturn(true);
 
         instanceService.deleteInstance("inst-1");
 
         verify(instanceRepository).deleteById("inst-1");
         verify(adminFactory).release("namesrv:9876");
+    }
+
+    @Test
+    void deleteInstanceShouldRejectConcurrentRemoval() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("concurrently-removed")
+                .endpoint("namesrv:9876")
+                .build();
+        existing.setId("inst-1");
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceRepository.deleteById("inst-1")).thenReturn(false);
+
+        assertThatThrownBy(() -> instanceService.deleteInstance("inst-1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO not found: inst-1")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
+
+        verify(adminFactory, never()).release(any());
+        verifyNoInteractions(operationAuditService);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
@@ -180,10 +180,12 @@ class MybatisPlusInstanceRepositoryTest {
     }
 
     @Test
-    void deleteByIdShouldDelegateToMapper() {
-        repository.deleteById("instance-direct-1");
+    void deleteByIdShouldReportWhetherARowWasRemoved() {
+        when(instanceMapper.deleteById("deleted")).thenReturn(1);
+        when(instanceMapper.deleteById("missing")).thenReturn(0);
 
-        verify(instanceMapper).deleteById("instance-direct-1");
+        assertThat(repository.deleteById("deleted")).isTrue();
+        assertThat(repository.deleteById("missing")).isFalse();
     }
 
     private RmqInstance entity(String id, InstanceType type) {

--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { App } from 'antd';
+import { App, Modal } from 'antd';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -149,7 +149,11 @@ describe('InstancePage', () => {
 
   it('keeps unavailable resource counts after available values in both sort directions', async () => {
     vi.mocked(instanceService.listInstances).mockResolvedValue([
-      { ...instance('unavailable', 'unavailable-instance'), topicCount: 0, resourceCountsAvailable: false },
+      {
+        ...instance('unavailable', 'unavailable-instance'),
+        topicCount: 0,
+        resourceCountsAvailable: false,
+      },
       { ...instance('zero', 'zero-instance'), topicCount: 0 },
       { ...instance('many', 'many-instance'), topicCount: 10 },
     ]);
@@ -271,6 +275,36 @@ describe('InstancePage', () => {
       }),
     );
     expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' });
+  });
+
+  it('reloads the latest filters after a pending instance deletion completes', async () => {
+    const user = userEvent.setup();
+    const pendingDelete = deferred<void>();
+    vi.mocked(instanceService.deleteInstance).mockReturnValue(pendingDelete.promise);
+    const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
+      void config.onOk?.();
+      return { destroy: vi.fn(), update: vi.fn() } as unknown as ReturnType<typeof Modal.confirm>;
+    });
+    renderPage();
+
+    const proxyName = await screen.findByText('production-proxy');
+    await user.click(within(proxyName.closest('tr')!).getByRole('button', { name: /删除/ }));
+    await waitFor(() => expect(instanceService.deleteInstance).toHaveBeenCalledWith('proxy-1'));
+
+    const typeSelect = screen.getByRole('combobox');
+    fireEvent.mouseDown(typeSelect.parentElement!);
+    await user.click(
+      await screen.findByText('Direct 模式', { selector: '.ant-select-item-option-content' }),
+    );
+    await waitFor(() =>
+      expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' }),
+    );
+
+    await act(async () => pendingDelete.resolve());
+
+    await waitFor(() => expect(instanceService.listInstances).toHaveBeenCalledTimes(3));
+    expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' });
+    confirmSpy.mockRestore();
   });
 
   it('shows vendor tabs in the add instance modal and switches description', async () => {

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -118,6 +118,7 @@ const InstancePage = () => {
   const [submitting, setSubmitting] = useState(false);
   const requestIdRef = useRef(0);
   const mutationInFlightRef = useRef(false);
+  const listQueryRef = useRef<InstanceQuery>({});
 
   useEffect(() => {
     const timer = window.setTimeout(() => setDebouncedSearch(search.trim()), 300);
@@ -126,10 +127,7 @@ const InstancePage = () => {
 
   const loadInstances = useCallback(async () => {
     const requestId = ++requestIdRef.current;
-    const query: InstanceQuery = {
-      ...(typeFilter === 'ALL' ? {} : { type: typeFilter }),
-      ...(debouncedSearch ? { search: debouncedSearch } : {}),
-    };
+    const query = listQueryRef.current;
 
     setLoading(true);
     try {
@@ -146,16 +144,20 @@ const InstancePage = () => {
         setLoading(false);
       }
     }
-  }, [debouncedSearch, typeFilter]);
+  }, []);
 
   useEffect(() => {
+    listQueryRef.current = {
+      ...(typeFilter === 'ALL' ? {} : { type: typeFilter }),
+      ...(debouncedSearch ? { search: debouncedSearch } : {}),
+    };
     const timer = window.setTimeout(() => void loadInstances(), 0);
 
     return () => {
       window.clearTimeout(timer);
       requestIdRef.current += 1;
     };
-  }, [loadInstances]);
+  }, [debouncedSearch, loadInstances, typeFilter]);
 
   const cloudVendor = vendor === 'ALIYUN' || vendor === 'TENCENT';
 
@@ -436,8 +438,7 @@ const InstancePage = () => {
       key: 'consumerGroupCount',
       width: 80,
       align: 'center' as const,
-      sorter: (a, b, sortOrder) =>
-        compareResourceCounts(a, b, 'consumerGroupCount', sortOrder),
+      sorter: (a, b, sortOrder) => compareResourceCounts(a, b, 'consumerGroupCount', sortOrder),
       render: (count: number, record: Instance) =>
         record.resourceCountsAvailable === false ? '不可用' : count,
     },


### PR DESCRIPTION
## Summary

- keep instance-list reload callbacks stable while reading the latest committed search and type filters after mutations
- preserve the existing request sequence guard against obsolete list responses
- return `404` when an instance was removed concurrently instead of reporting a successful deletion
- avoid releasing runtime clients or recording successful audits when no instance row was deleted
- add focused frontend and backend regression coverage

Closes #1996
Closes #2000

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -q -f server/pom.xml -Dtest=InstanceServiceTest,MybatisPlusInstanceRepositoryTest test`
- `npm test -- --run src/pages/instance/__tests__/InstancePage.test.tsx` (12 tests passed)
- `npx eslint src/pages/instance/index.tsx src/pages/instance/__tests__/InstancePage.test.tsx`
- `npm run build`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) PATH="$JAVA_HOME/bin:$PATH" mvn -q -f server/pom.xml -DskipTests package`
- `git diff --check origin/rocketmq-studio...HEAD`
