### PR TITLE
fix: preserve K8s certificate mutation integrity

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertRepository.java
@@ -28,5 +28,5 @@ public interface K8sCertRepository {
 
     K8sCertVO save(K8sCertVO cert);
 
-    void deleteById(String id);
+    boolean deleteById(String id);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
@@ -97,20 +97,24 @@ public class K8sCertService {
                 .orElseThrow(() -> new BusinessException(404, "Certificate not found: " + command.getId()));
 
         K8sCertVO updated = copyOf(existing);
-        if (command.getName() != null) {
-            updated.setName(command.getName());
+        String name = normalizeOptionalIdentity(command.getName(), "name");
+        String namespace = normalizeOptionalIdentity(command.getNamespace(), "namespace");
+        String cluster = normalizeOptionalIdentity(command.getCluster(), "cluster");
+        String issuer = normalizeOptionalIdentity(command.getIssuer(), "issuer");
+        if (name != null) {
+            updated.setName(name);
         }
-        if (command.getNamespace() != null) {
-            updated.setNamespace(command.getNamespace());
+        if (namespace != null) {
+            updated.setNamespace(namespace);
         }
-        if (command.getCluster() != null) {
-            updated.setCluster(command.getCluster());
+        if (cluster != null) {
+            updated.setCluster(cluster);
         }
         if (command.getType() != null) {
             updated.setType(CertType.valueOf(command.getType()));
         }
-        if (command.getIssuer() != null) {
-            updated.setIssuer(command.getIssuer());
+        if (issuer != null) {
+            updated.setIssuer(issuer);
         }
         if (command.getSan() != null) {
             updated.setSan(command.getSan());
@@ -151,7 +155,9 @@ public class K8sCertService {
         log.info("Deleting K8s certificate: {}", command.getId());
         k8sCertRepository.findById(command.getId())
                 .orElseThrow(() -> new BusinessException(404, "Certificate not found: " + command.getId()));
-        k8sCertRepository.deleteById(command.getId());
+        if (!k8sCertRepository.deleteById(command.getId())) {
+            throw new BusinessException(404, "Certificate not found: " + command.getId());
+        }
         recordAudit("DELETE_K8S_CERTIFICATE", "K8S_CERTIFICATE", command.getId(), null,
                 null);
         log.info("K8s certificate deleted: {}", command.getId());
@@ -161,6 +167,17 @@ public class K8sCertService {
         if (command == null) {
             throw new BusinessException(400, "K8s certificate request is required");
         }
+    }
+
+    private String normalizeOptionalIdentity(String value, String field) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        if (normalized.isEmpty()) {
+            throw new BusinessException(400, "Certificate " + field + " cannot be blank");
+        }
+        return normalized;
     }
 
     private K8sCertVO refreshExpirationState(K8sCertVO cert, LocalDateTime now) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -72,8 +72,8 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
     }
 
     @Override
-    public void deleteById(String id) {
-        certMapper.deleteById(id);
+    public boolean deleteById(String id) {
+        return certMapper.deleteById(id) > 0;
     }
 
     private K8sCertVO toVO(RmqK8sCertificate entity) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
@@ -34,13 +34,16 @@ import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -301,6 +304,28 @@ class K8sCertServiceTest {
     }
 
     @Test
+    void updateCertShouldRejectBlankIdentityFields() {
+        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        List<Map.Entry<String, Consumer<UpdateCertDTO>>> invalidUpdates = List.of(
+                Map.entry("name", command -> command.setName(" ")),
+                Map.entry("namespace", command -> command.setNamespace("\t")),
+                Map.entry("cluster", command -> command.setCluster("\n")),
+                Map.entry("issuer", command -> command.setIssuer("  ")));
+
+        for (Map.Entry<String, Consumer<UpdateCertDTO>> invalidUpdate : invalidUpdates) {
+            UpdateCertDTO command = UpdateCertDTO.builder().id("cert-1").build();
+            invalidUpdate.getValue().accept(command);
+
+            assertThatThrownBy(() -> k8sCertService.updateCert(command))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage("Certificate " + invalidUpdate.getKey() + " cannot be blank")
+                    .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+        }
+
+        verify(k8sCertRepository, never()).save(any(K8sCertVO.class));
+    }
+
+    @Test
     void updateCertShouldThrowWhenNotFound() {
         when(k8sCertRepository.findById("nonexistent")).thenReturn(Optional.empty());
 
@@ -404,6 +429,7 @@ class K8sCertServiceTest {
     @Test
     void deleteCertShouldDeleteWhenFound() {
         when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.deleteById("cert-1")).thenReturn(true);
 
         DeleteCertDTO command = DeleteCertDTO.builder().id("cert-1").build();
 
@@ -412,6 +438,20 @@ class K8sCertServiceTest {
         verify(k8sCertRepository).deleteById("cert-1");
         verify(operationAuditService).record(eq("DELETE_K8S_CERTIFICATE"), eq("K8S_CERTIFICATE"),
                 eq("cert-1"), eq(null), eq(null), eq("SUCCESS"), eq(null));
+    }
+
+    @Test
+    void deleteCertShouldRejectConcurrentRemoval() {
+        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.deleteById("cert-1")).thenReturn(false);
+
+        DeleteCertDTO command = DeleteCertDTO.builder().id("cert-1").build();
+
+        assertThatThrownBy(() -> k8sCertService.deleteCert(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Certificate not found: cert-1")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
+        verifyNoInteractions(operationAuditService);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
@@ -22,11 +22,24 @@ import org.apache.rocketmq.studio.persistence.entity.RmqK8sCertificate;
 import org.apache.rocketmq.studio.persistence.mapper.RmqK8sCertificateMapper;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class MybatisPlusK8sCertRepositoryTest {
+
+    @Test
+    void deleteByIdShouldReportWhetherARowWasRemoved() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        when(mapper.deleteById("deleted")).thenReturn(1);
+        when(mapper.deleteById("missing")).thenReturn(0);
+
+        MybatisPlusK8sCertRepository repository = repository(mapper);
+
+        assertThat(repository.deleteById("deleted")).isTrue();
+        assertThat(repository.deleteById("missing")).isFalse();
+    }
 
     @Test
     void findByIdSurfacesInvalidPersistedCertificateType() {


### PR DESCRIPTION
## Summary

- reject blank certificate identity fields during partial updates
- surface concurrent certificate deletion as `404` instead of reporting success
- preserve repository delete outcomes so the service can distinguish deleted and missing records

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -f server/pom.xml -Dtest=K8sCertServiceTest,MybatisPlusK8sCertRepositoryTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -f server/pom.xml -DskipTests package`
- `git diff --check`

Closes #1998
