### PR TITLE
fix: preserve instance deletion integrity

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceRepository.java
@@ -35,7 +35,7 @@ public interface InstanceRepository {
 
     InstanceVO save(InstanceVO instance);
 
-    void deleteById(String id);
+    boolean deleteById(String id);
 
     boolean existsByCredentialId(String credentialId);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -256,7 +256,9 @@ public class InstanceService {
                     "Cannot delete instance with managed resources: topics=%d, consumerGroups=%d",
                     topicCount, consumerGroupCount));
         }
-        instanceRepository.deleteById(id);
+        if (!instanceRepository.deleteById(id)) {
+            throw new BusinessException(404, "InstanceVO not found: " + id);
+        }
         releaseApacheEndpointIfUnused(existing, null);
         recordAudit("DELETE_INSTANCE", "INSTANCE", id, null,
                 instanceAuditDetail(existing));

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
@@ -107,8 +107,8 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
     }
 
     @Override
-    public void deleteById(String id) {
-        instanceMapper.deleteById(id);
+    public boolean deleteById(String id) {
+        return instanceMapper.deleteById(id) > 0;
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -649,6 +649,7 @@ class InstanceServiceTest {
         when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
         when(instanceProvider.countTopics("inst-1")).thenReturn(0);
         when(instanceProvider.countGroups("inst-1")).thenReturn(0);
+        when(instanceRepository.deleteById("inst-1")).thenReturn(true);
 
         instanceService.deleteInstance("inst-1");
 
@@ -707,11 +708,32 @@ class InstanceServiceTest {
         when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
         when(instanceRepository.findAll()).thenReturn(List.of());
         when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceRepository.deleteById("inst-1")).thenReturn(true);
 
         instanceService.deleteInstance("inst-1");
 
         verify(instanceRepository).deleteById("inst-1");
         verify(adminFactory).release("namesrv:9876");
+    }
+
+    @Test
+    void deleteInstanceShouldRejectConcurrentRemoval() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("concurrently-removed")
+                .endpoint("namesrv:9876")
+                .build();
+        existing.setId("inst-1");
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceRepository.deleteById("inst-1")).thenReturn(false);
+
+        assertThatThrownBy(() -> instanceService.deleteInstance("inst-1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO not found: inst-1")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
+
+        verify(adminFactory, never()).release(any());
+        verifyNoInteractions(operationAuditService);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
@@ -180,10 +180,12 @@ class MybatisPlusInstanceRepositoryTest {
     }
 
     @Test
-    void deleteByIdShouldDelegateToMapper() {
-        repository.deleteById("instance-direct-1");
+    void deleteByIdShouldReportWhetherARowWasRemoved() {
+        when(instanceMapper.deleteById("deleted")).thenReturn(1);
+        when(instanceMapper.deleteById("missing")).thenReturn(0);
 
-        verify(instanceMapper).deleteById("instance-direct-1");
+        assertThat(repository.deleteById("deleted")).isTrue();
+        assertThat(repository.deleteById("missing")).isFalse();
     }
 
     private RmqInstance entity(String id, InstanceType type) {


### PR DESCRIPTION
## Summary

- preserve the affected-row result from instance repository deletion
- return `404` when an instance was removed concurrently
- avoid runtime client release and successful audit records when no row was deleted

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -f server/pom.xml -Dtest=InstanceServiceTest,MybatisPlusInstanceRepositoryTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -f server/pom.xml -DskipTests package`
- `git diff --check`

Closes #2000
