### PR TITLE
fix: preserve and reconcile system alert state

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
@@ -30,7 +30,7 @@ public interface AlertRepository {
 
     List<SystemAlertVO> findAlerts(String level);
 
-    SystemAlertVO saveAlert(SystemAlertVO alert);
+    boolean acknowledgeAlert(SystemAlertVO alert);
 
     int deleteAcknowledgedAlerts();
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -155,10 +155,12 @@ public class AlertService {
                 .findFirst()
                 .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "System alert not found: " + id));
         alert.setAcknowledged(true);
-        SystemAlertVO saved = alertRepository.saveAlert(alert);
-        recordAudit("ACKNOWLEDGE_SYSTEM_ALERT", "SYSTEM_ALERT", saved.getId(), null,
+        if (!alertRepository.acknowledgeAlert(alert)) {
+            throw new BusinessException(404, "System alert not found: " + id);
+        }
+        recordAudit("ACKNOWLEDGE_SYSTEM_ALERT", "SYSTEM_ALERT", alert.getId(), null,
                 "acknowledged=true");
-        return saved;
+        return alert;
     }
 
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -87,14 +87,8 @@ public class MybatisPlusAlertRepository implements AlertRepository {
     }
 
     @Override
-    public SystemAlertVO saveAlert(SystemAlertVO alert) {
-        RmqSystemAlert entity = toAlertEntity(alert);
-        if (entity.getId() != null && alertMapper.selectById(entity.getId()) != null) {
-            alertMapper.updateById(entity);
-        } else {
-            alertMapper.insert(entity);
-        }
-        return alert;
+    public boolean acknowledgeAlert(SystemAlertVO alert) {
+        return alertMapper.updateById(toAlertEntity(alert)) > 0;
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -565,12 +565,12 @@ class AlertServiceTest {
         SystemAlertVO existing = SystemAlertVO.builder().id("a1").level(AlertLevel.error)
                 .title("Broker Down").acknowledged(false).build();
         when(alertRepository.findAlerts(null)).thenReturn(List.of(existing));
-        when(alertRepository.saveAlert(any(SystemAlertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(alertRepository.acknowledgeAlert(any(SystemAlertVO.class))).thenReturn(true);
 
         SystemAlertVO result = alertService.acknowledgeAlert("a1");
 
         assertThat(result.isAcknowledged()).isTrue();
-        verify(alertRepository).saveAlert(result);
+        verify(alertRepository).acknowledgeAlert(result);
         verify(operationAuditService).record(eq("ACKNOWLEDGE_SYSTEM_ALERT"), eq("SYSTEM_ALERT"), eq("a1"),
                 eq(null), eq("acknowledged=true"), eq("SUCCESS"), eq(null));
     }
@@ -582,6 +582,21 @@ class AlertServiceTest {
         assertThatThrownBy(() -> alertService.acknowledgeAlert("non-existent"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("System alert not found: non-existent");
+    }
+
+    @Test
+    void acknowledgeAlertShouldRejectConcurrentRemoval() {
+        SystemAlertVO existing = SystemAlertVO.builder().id("a1").level(AlertLevel.error)
+                .title("Broker Down").acknowledged(false).build();
+        when(alertRepository.findAlerts(null)).thenReturn(List.of(existing));
+        when(alertRepository.acknowledgeAlert(any(SystemAlertVO.class))).thenReturn(false);
+
+        assertThatThrownBy(() -> alertService.acknowledgeAlert("a1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("System alert not found: a1")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
+
+        verify(operationAuditService, never()).record(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -30,8 +30,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Locale;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -46,6 +48,22 @@ class MybatisPlusAlertRepositoryTest {
 
     @InjectMocks
     private MybatisPlusAlertRepository repository;
+
+    @Test
+    void acknowledgeAlertShouldReportUpdateOutcomeWithoutInserting() {
+        SystemAlertVO deleted = SystemAlertVO.builder().id("deleted").acknowledged(true).build();
+        SystemAlertVO existing = SystemAlertVO.builder().id("existing").acknowledged(true).build();
+        when(alertMapper.updateById(argThat((RmqSystemAlert entity) ->
+                entity != null && "deleted".equals(entity.getId()))))
+                .thenReturn(0);
+        when(alertMapper.updateById(argThat((RmqSystemAlert entity) ->
+                entity != null && "existing".equals(entity.getId()))))
+                .thenReturn(1);
+
+        assertThat(repository.acknowledgeAlert(deleted)).isFalse();
+        assertThat(repository.acknowledgeAlert(existing)).isTrue();
+        verify(alertMapper, never()).insert(any(RmqSystemAlert.class));
+    }
 
     @Test
     void findAlertsShouldNormalizeLevelIndependentlyOfDefaultLocale() {

--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -10,7 +10,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LangProvider } from '../../../i18n/LangContext';
-import { acknowledgeAlert, listSystemAlerts } from '../../../services/opsService';
+import {
+  acknowledgeAlert,
+  clearAcknowledgedAlerts,
+  listSystemAlerts,
+} from '../../../services/opsService';
 import SystemAlertsPage from '../systemAlerts';
 
 vi.mock('../../../services/opsService', () => ({
@@ -102,5 +106,39 @@ describe('SystemAlertsPage', () => {
       expect(acknowledgeButtons[0]).toHaveClass('ant-btn-loading');
       expect(acknowledgeButtons[1]).toHaveClass('ant-btn-loading');
     });
+  });
+
+  it('reloads canonical alerts after clearing a stale local acknowledgement snapshot', async () => {
+    vi.mocked(listSystemAlerts)
+      .mockResolvedValueOnce([
+        {
+          id: 'alert-a',
+          level: 'error',
+          title: 'Broker unavailable',
+          description: 'broker a',
+          time: '2026-08-10 01:00',
+          acknowledged: true,
+        },
+        {
+          id: 'alert-b',
+          level: 'warning',
+          title: 'Consumer lag',
+          description: 'consumer b',
+          time: '2026-08-10 01:01',
+          acknowledged: false,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    vi.mocked(clearAcknowledgedAlerts).mockResolvedValue(2);
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(await screen.findByText('Consumer lag')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /清除已确认/ }));
+
+    await waitFor(() => expect(listSystemAlerts).toHaveBeenCalledTimes(2));
+    expect(clearAcknowledgedAlerts).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Broker unavailable')).not.toBeInTheDocument();
+    expect(screen.queryByText('Consumer lag')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -90,6 +90,11 @@ const SystemAlertsPage = () => {
       await clearAcknowledgedAlerts();
       setAlerts((prev) => prev.filter((a) => !a.acknowledged));
       message.success(t('sysAlerts.cleared'));
+      try {
+        setAlerts(await listSystemAlerts());
+      } catch {
+        message.warning('已清理告警，但刷新列表失败，请重新加载页面');
+      }
     } catch {
       message.error('清理已确认告警失败，请稍后重试');
     } finally {
@@ -197,6 +202,7 @@ const SystemAlertsPage = () => {
                       icon={<CheckCircle size={14} />}
                       onClick={() => handleAck(alert.id)}
                       loading={acknowledgingIds.has(alert.id)}
+                      disabled={clearing}
                     >
                       {t('sysAlerts.acknowledge')}
                     </Button>


### PR DESCRIPTION
## Summary

- make system alert acknowledgement an update-only persistence operation
- return `404` when an alert is cleared concurrently instead of recreating it
- skip successful acknowledgement audit when no row was updated
- reload the canonical server alert list after clearing acknowledged records
- retain a safe local fallback if the follow-up refresh fails and block acknowledgements while clear is running
- cover stale cross-session acknowledgement state

Closes #2004
Closes #2014

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -Dtest=AlertServiceTest,MybatisPlusAlertRepositoryTest test`
- `npm test -- --run src/pages/ops/__tests__/SystemAlertsPage.test.tsx`
- `npx eslint src/pages/ops/systemAlerts.tsx src/pages/ops/__tests__/SystemAlertsPage.test.tsx`
- `npm run build`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -f server/pom.xml -DskipTests package`
- `git diff --check origin/rocketmq-studio...HEAD`
