### PR TITLE
fix: preserve ACL user update integrity

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclRepository.java
@@ -39,6 +39,11 @@ public interface AclRepository {
 
     AclUserVO saveUser(AclUserVO user);
 
+    /**
+     * Replaces an existing user without recreating a concurrently deleted identity.
+     */
+    Optional<AclUserVO> replaceUser(AclUserVO user);
+
     boolean deleteUser(String id);
 
     /**

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -134,7 +134,8 @@ public class AclService {
                 .clusters(user.getClusters() == null ? existing.getClusters() : user.getClusters())
                 .createdAt(existing.getCreatedAt())
                 .build();
-        AclUserVO saved = aclRepository.saveUser(merged);
+        AclUserVO saved = aclRepository.replaceUser(merged)
+                .orElseThrow(() -> new BusinessException(404, "ACL user not found: " + user.getId()));
         auditUser("UPDATE_ACL_USER", saved);
         return maskCredentials(saved);
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -112,6 +112,21 @@ public class MybatisPlusAclRepository implements AclRepository {
     }
 
     @Override
+    public Optional<AclUserVO> replaceUser(AclUserVO user) {
+        RmqAclUser existing = userMapper.selectById(user.getId());
+        if (existing == null) {
+            return Optional.empty();
+        }
+        RmqAclUser entity = toUserEntity(user);
+        entity.setCreatedAt(existing.getCreatedAt());
+        if (userMapper.updateById(entity) == 0) {
+            return Optional.empty();
+        }
+        user.setCreatedAt(existing.getCreatedAt());
+        return Optional.of(user);
+    }
+
+    @Override
     public boolean deleteUser(String id) {
         return userMapper.deleteById(id) > 0;
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -411,7 +411,8 @@ class AclServiceTest {
 
         ArgumentCaptor<AclUserVO> captor = ArgumentCaptor.forClass(AclUserVO.class);
         when(aclRepository.findUserById("user-1")).thenReturn(Optional.of(existingUser));
-        when(aclRepository.saveUser(any(AclUserVO.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(aclRepository.replaceUser(any(AclUserVO.class)))
+                .thenAnswer(inv -> Optional.of(inv.getArgument(0)));
 
         AclUserVO result = aclService.updateUser(input);
 
@@ -420,7 +421,7 @@ class AclServiceTest {
         assertThat(result.getAccessKey()).isEqualTo("acce****3456");
         assertThat(result.getSecretKey()).isEqualTo("secr****7654");
         assertThat(result.isAdmin()).isTrue();
-        verify(aclRepository).saveUser(captor.capture());
+        verify(aclRepository).replaceUser(captor.capture());
         assertThat(captor.getValue().getAccessKey()).isEqualTo("access-key-123456");
         assertThat(captor.getValue().getSecretKey()).isEqualTo("secret-key-987654");
         verify(operationAuditService).record(eq("UPDATE_ACL_USER"), eq("ACL_USER"), eq("user-1"), eq(null),
@@ -444,13 +445,14 @@ class AclServiceTest {
 
         ArgumentCaptor<AclUserVO> captor = ArgumentCaptor.forClass(AclUserVO.class);
         when(aclRepository.findUserById("user-1")).thenReturn(Optional.of(adminUser));
-        when(aclRepository.saveUser(any(AclUserVO.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(aclRepository.replaceUser(any(AclUserVO.class)))
+                .thenAnswer(inv -> Optional.of(inv.getArgument(0)));
 
         AclUserVO result = aclService.updateUser(input);
 
         assertThat(result.getUsername()).isEqualTo("renamed");
         assertThat(result.isAdmin()).isTrue();
-        verify(aclRepository).saveUser(captor.capture());
+        verify(aclRepository).replaceUser(captor.capture());
         assertThat(captor.getValue().isAdmin()).isTrue();
     }
 
@@ -466,7 +468,23 @@ class AclServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("ACL user not found: missing")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
-        verify(aclRepository, never()).saveUser(any(AclUserVO.class));
+        verify(aclRepository, never()).replaceUser(any(AclUserVO.class));
+    }
+
+    @Test
+    void updateUserShouldRejectConcurrentDeletion() {
+        UpdateAclUserDTO input = new UpdateAclUserDTO();
+        input.setId("user-1");
+        input.setUsername("renamed");
+        when(aclRepository.findUserById("user-1")).thenReturn(Optional.of(existingUser));
+        when(aclRepository.replaceUser(any(AclUserVO.class))).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> aclService.updateUser(input))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("ACL user not found: user-1")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
+
+        verify(operationAuditService, never()).record(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -517,6 +535,10 @@ class AclServiceTest {
         when(aclRepository.saveUser(any(AclUserVO.class))).thenAnswer(invocation -> {
             stored.set(invocation.getArgument(0));
             return invocation.getArgument(0);
+        });
+        when(aclRepository.replaceUser(any(AclUserVO.class))).thenAnswer(invocation -> {
+            stored.set(invocation.getArgument(0));
+            return Optional.of(invocation.getArgument(0));
         });
         when(aclRepository.findUserById(any())).thenAnswer(invocation -> Optional.ofNullable(stored.get()));
         when(aclRepository.findUsers()).thenAnswer(invocation -> List.of(stored.get()));

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
@@ -58,6 +58,25 @@ class MybatisPlusAclRepositoryTest {
     private MybatisPlusAclRepository repository;
 
     @Test
+    void replaceUserShouldNotRecreateAConcurrentlyDeletedUser() {
+        RmqAclUser existing = new RmqAclUser();
+        existing.setId("user-1");
+        existing.setCreatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+        when(userMapper.selectById("user-1")).thenReturn(existing);
+        when(userMapper.updateById(any(RmqAclUser.class))).thenReturn(0);
+        AclUserVO replacement = AclUserVO.builder()
+                .id("user-1")
+                .username("renamed")
+                .accessKey("access-key")
+                .secretKey("secret-key")
+                .build();
+
+        assertThat(repository.replaceUser(replacement)).isEmpty();
+
+        verify(userMapper, never()).insert(any(RmqAclUser.class));
+    }
+
+    @Test
     void upsertShouldAssignUniqueRuleIdPerPermission() {
         when(userMapper.selectOne(any(QueryWrapper.class))).thenReturn(null);
         when(userMapper.insert(any(RmqAclUser.class))).thenReturn(1);


### PR DESCRIPTION
## Summary

- add an update-only ACL user repository contract
- return `404` when an ACL user is deleted concurrently instead of recreating its identity and credentials
- retain the existing create-user insert path and credential masking behavior

This does not overlap #1881 (ACL rule replacement) or #1622 (frontend admin-switch request tracking).

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -f server/pom.xml -Dtest=AclServiceTest,MybatisPlusAclRepositoryTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -f server/pom.xml -DskipTests package`
- `git diff --check`

Closes #2006
