### PR TITLE
fix: ignore stale NameServer drift bootstrap results

### DIFF
--- a/web/src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx
@@ -39,6 +39,16 @@ vi.mock('../../../services/instanceService', () => ({
 const createObjectURL = vi.fn(() => 'blob:nameserver-config-drift');
 const revokeObjectURL = vi.fn();
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -186,5 +196,59 @@ describe('NameServerConfigDriftPage', () => {
 
     expect(await screen.findByText('暂无可检查的集群')).toBeInTheDocument();
     expect(getNameServerConfigDiff).not.toHaveBeenCalled();
+  });
+
+  it('ignores a stale bootstrap cluster response after the user selects another instance', async () => {
+    const user = userEvent.setup();
+    const instanceB = {
+      ...instance,
+      id: 'instance-b',
+      name: 'Backup instance',
+    };
+    const clusterB = {
+      ...cluster,
+      id: 'cluster-b',
+      name: 'Backup cluster',
+    };
+    const bootstrapClusters = deferred<ClusterInfo[]>();
+    vi.mocked(listInstances).mockResolvedValue([instance, instanceB]);
+    vi.mocked(listClusters).mockImplementation((instanceId) =>
+      instanceId === 'instance-a' ? bootstrapClusters.promise : Promise.resolve([clusterB]),
+    );
+    vi.mocked(getNameServerConfigDiff).mockResolvedValue({
+      ...driftResult,
+      cluster: 'cluster-b',
+      nodes: [
+        { address: 'ns-b:9876', reachable: true },
+        { address: 'ns-c:9876', reachable: true },
+      ],
+      differences: [
+        {
+          key: 'listenPort',
+          values: [
+            { address: 'ns-b:9876', configured: true, value: '29876' },
+            { address: 'ns-c:9876', configured: true, value: '39876' },
+          ],
+        },
+      ],
+    });
+
+    renderWithProviders(<NameServerConfigDriftPage />);
+
+    await user.click(await screen.findByRole('combobox', { name: 'NameServer drift instance' }));
+    await user.click(await screen.findByText('Backup instance'));
+
+    await waitFor(() => {
+      expect(listClusters).toHaveBeenCalledWith('instance-b');
+      expect(getNameServerConfigDiff).toHaveBeenCalledWith('cluster-b', 'instance-b');
+    });
+    expect(await screen.findByText('39876')).toBeInTheDocument();
+
+    bootstrapClusters.resolve([cluster]);
+
+    await waitFor(() => expect(listClusters).toHaveBeenCalledTimes(2));
+    expect(getNameServerConfigDiff).not.toHaveBeenCalledWith('cluster-a', 'instance-a');
+    expect(screen.getByText('39876')).toBeInTheDocument();
+    expect(screen.queryByText('19876')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/ops/nameServerConfigDrift.tsx
+++ b/web/src/pages/ops/nameServerConfigDrift.tsx
@@ -35,7 +35,8 @@ const { Text, Title } = Typography;
 const NameServerConfigDriftPage = () => {
   const { t } = useLang();
   const { message } = App.useApp();
-  const requestSequence = useRef(0);
+  const clusterRequestSequence = useRef(0);
+  const checkRequestSequence = useRef(0);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string>();
   const [clusters, setClusters] = useState<ClusterInfo[]>([]);
@@ -46,18 +47,18 @@ const NameServerConfigDriftPage = () => {
 
   const runCheck = useCallback(
     async (clusterId: string, instanceId: string) => {
-      const sequence = ++requestSequence.current;
+      const sequence = ++checkRequestSequence.current;
       setChecking(true);
       try {
         const nextResult = await getNameServerConfigDiff(clusterId, instanceId);
-        if (sequence === requestSequence.current) setResult(nextResult);
+        if (sequence === checkRequestSequence.current) setResult(nextResult);
       } catch {
-        if (sequence === requestSequence.current) {
+        if (sequence === checkRequestSequence.current) {
           setResult(undefined);
           message.error(t('nameServerDrift.checkFailed'));
         }
       } finally {
-        if (sequence === requestSequence.current) setChecking(false);
+        if (sequence === checkRequestSequence.current) setChecking(false);
       }
     },
     [message, t],
@@ -65,9 +66,10 @@ const NameServerConfigDriftPage = () => {
 
   useEffect(() => {
     let cancelled = false;
+    const sequence = ++clusterRequestSequence.current;
     void listInstances()
       .then(async (items) => {
-        if (cancelled) return;
+        if (cancelled || sequence !== clusterRequestSequence.current) return;
         const apacheInstances = items.filter((instance) => instance.vendor === 'APACHE');
         setInstances(apacheInstances);
         const firstInstanceId = apacheInstances[0]?.id;
@@ -77,42 +79,51 @@ const NameServerConfigDriftPage = () => {
           return;
         }
         const clustersForInstance = await listClusters(firstInstanceId);
-        if (cancelled) return;
+        if (cancelled || sequence !== clusterRequestSequence.current) return;
         setClusters(clustersForInstance);
         const firstClusterId = clustersForInstance[0]?.id;
         setSelectedClusterId(firstClusterId);
         if (firstClusterId) void runCheck(firstClusterId, firstInstanceId);
       })
       .catch(() => {
-        if (!cancelled) message.error(t('nameServerDrift.loadClustersFailed'));
+        if (!cancelled && sequence === clusterRequestSequence.current) {
+          message.error(t('nameServerDrift.loadClustersFailed'));
+        }
       })
       .finally(() => {
-        if (!cancelled) setClustersLoading(false);
+        if (!cancelled && sequence === clusterRequestSequence.current) {
+          setClustersLoading(false);
+        }
       });
     return () => {
       cancelled = true;
-      requestSequence.current += 1;
+      clusterRequestSequence.current += 1;
+      checkRequestSequence.current += 1;
     };
   }, [message, runCheck, t]);
 
   const selectInstance = async (instanceId: string) => {
-    const sequence = ++requestSequence.current;
+    const sequence = ++clusterRequestSequence.current;
+    checkRequestSequence.current += 1;
     setSelectedInstanceId(instanceId);
     setSelectedClusterId(undefined);
     setClusters([]);
     setResult(undefined);
     setClustersLoading(true);
+    setChecking(false);
     try {
       const nextClusters = await listClusters(instanceId);
-      if (sequence !== requestSequence.current) return;
+      if (sequence !== clusterRequestSequence.current) return;
       setClusters(nextClusters);
       const firstClusterId = nextClusters[0]?.id;
       setSelectedClusterId(firstClusterId);
       if (firstClusterId) void runCheck(firstClusterId, instanceId);
     } catch {
-      if (sequence === requestSequence.current) message.error(t('nameServerDrift.loadClustersFailed'));
+      if (sequence === clusterRequestSequence.current) {
+        message.error(t('nameServerDrift.loadClustersFailed'));
+      }
     } finally {
-      if (sequence === requestSequence.current) setClustersLoading(false);
+      if (sequence === clusterRequestSequence.current) setClustersLoading(false);
     }
   };
 


### PR DESCRIPTION
## Summary
- give bootstrap cluster loads explicit request ownership
- keep cluster loading and drift checks on independent request generations
- ignore stale bootstrap responses after a user switches instances

## Testing
- `npm test -- --run src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx`
- `npx eslint src/pages/ops/nameServerConfigDrift.tsx src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx`
- `npm run build`

Closes #2009