### PR TITLE
fix: ignore stale ACL diagnostic responses

### DIFF
--- a/web/src/pages/instance/__tests__/AclPage.test.tsx
+++ b/web/src/pages/instance/__tests__/AclPage.test.tsx
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { App } from 'antd';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { App, message } from 'antd';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -31,6 +31,7 @@ vi.mock('../../../services/aclService', () => ({
   createAndUpdatePlainAccessConfig: vi.fn(),
   deleteAclRule: vi.fn(),
   deleteAclUser: vi.fn(),
+  getAclUserCredentials: vi.fn(),
   examineBrokerClusterAclConfig: vi.fn(),
   listAclRules: vi.fn(),
   listAclUsers: vi.fn(),
@@ -65,6 +66,16 @@ const renderWithProviders = (ui: React.ReactElement) =>
       </LangProvider>
     </App>,
   );
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+};
 
 describe('ACL page', () => {
   beforeEach(() => {
@@ -360,6 +371,184 @@ describe('ACL page', () => {
     expect(await screen.findByText('rocketmq-admin')).toBeInTheDocument();
     expect(screen.getByText('ACL 2.0')).toBeInTheDocument();
     expect(aclService.examineBrokerClusterAclConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps cluster config ownership with the latest examine request', async () => {
+    const firstExamine =
+      deferred<Awaited<ReturnType<typeof aclService.examineBrokerClusterAclConfig>>>();
+    const secondExamine =
+      deferred<Awaited<ReturnType<typeof aclService.examineBrokerClusterAclConfig>>>();
+    const thirdExamine =
+      deferred<Awaited<ReturnType<typeof aclService.examineBrokerClusterAclConfig>>>();
+    const successSpy = vi.spyOn(message, 'success').mockImplementation(vi.fn());
+    const errorSpy = vi.spyOn(message, 'error').mockImplementation(vi.fn());
+    const user = userEvent.setup();
+    vi.mocked(aclService.examineBrokerClusterAclConfig)
+      .mockReturnValueOnce(firstExamine.promise)
+      .mockReturnValueOnce(secondExamine.promise)
+      .mockReturnValueOnce(thirdExamine.promise);
+    renderWithProviders(<AclPage />);
+
+    await user.click(await screen.findByText('集群 ACL 配置'));
+    const clusterInput = screen.getByPlaceholderText('请输入集群 ID');
+    const examineButton = screen.getByRole('button', { name: /检\s*查\s*配\s*置/ });
+
+    fireEvent.change(clusterInput, { target: { value: 'cluster-old-1' } });
+    await user.click(examineButton);
+    await waitFor(() =>
+      expect(aclService.examineBrokerClusterAclConfig).toHaveBeenNthCalledWith(1, 'cluster-old-1'),
+    );
+
+    await user.clear(clusterInput);
+    await user.type(clusterInput, 'cluster-old-2{enter}');
+    await waitFor(() =>
+      expect(aclService.examineBrokerClusterAclConfig).toHaveBeenNthCalledWith(2, 'cluster-old-2'),
+    );
+
+    await user.clear(clusterInput);
+    await user.type(clusterInput, 'cluster-latest{enter}');
+    await waitFor(() =>
+      expect(aclService.examineBrokerClusterAclConfig).toHaveBeenNthCalledWith(3, 'cluster-latest'),
+    );
+
+    await act(async () => {
+      firstExamine.resolve({
+        clusterId: 'cluster-old-1',
+        aclEnabled: true,
+        aclVersion: 'ACL stale-1',
+        globalWhiteRemoteAddresses: [],
+        accounts: [
+          {
+            accessKey: 'stale-account-1',
+            admin: true,
+            defaultTopicPerm: 'ALL',
+            defaultGroupPerm: 'ALL',
+            topicPerms: [],
+            groupPerms: [],
+          },
+        ],
+        accountCount: 1,
+      });
+    });
+
+    expect(screen.queryByText('stale-account-1')).not.toBeInTheDocument();
+    expect(successSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(examineButton).toHaveClass('ant-btn-loading');
+
+    await act(async () => {
+      secondExamine.reject(new Error('stale failure'));
+    });
+
+    expect(screen.queryByText('stale-account-1')).not.toBeInTheDocument();
+    expect(successSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(examineButton).toHaveClass('ant-btn-loading');
+
+    await act(async () => {
+      thirdExamine.resolve({
+        clusterId: 'cluster-latest',
+        aclEnabled: true,
+        aclVersion: 'ACL latest',
+        globalWhiteRemoteAddresses: ['10.0.0.0/8'],
+        accounts: [
+          {
+            accessKey: 'latest-account',
+            admin: false,
+            defaultTopicPerm: 'PUB',
+            defaultGroupPerm: 'SUB',
+            topicPerms: ['topic=PUB'],
+            groupPerms: ['group=SUB'],
+          },
+        ],
+        accountCount: 1,
+      });
+    });
+
+    expect(await screen.findByText('latest-account')).toBeInTheDocument();
+    expect(screen.getByText('ACL latest')).toBeInTheDocument();
+    await waitFor(() => expect(examineButton).not.toHaveClass('ant-btn-loading'));
+    expect(successSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps credential reveal ownership with the latest user generation', async () => {
+    type CredentialResponse = Awaited<ReturnType<typeof aclService.getAclUserCredentials>>;
+    const firstReveal = deferred<CredentialResponse>();
+    const secondReveal = deferred<CredentialResponse>();
+    const thirdReveal = deferred<CredentialResponse>();
+    const errorSpy = vi.spyOn(message, 'error').mockImplementation(vi.fn());
+    const user = userEvent.setup();
+    vi.mocked(aclService.getAclUserCredentials)
+      .mockReturnValueOnce(firstReveal.promise)
+      .mockReturnValueOnce(secondReveal.promise)
+      .mockReturnValueOnce(thirdReveal.promise);
+    renderWithProviders(<AclPage />);
+
+    await user.click(await screen.findByText('用户管理'));
+    const row = await screen.findByRole('row', { name: /remote-admin/ });
+    const secretCell = screen.getByText('••••••••••••').closest('td');
+    expect(secretCell).not.toBeNull();
+    const revealButton = within(secretCell as HTMLElement).getByRole('button');
+
+    await user.click(revealButton);
+    await waitFor(() => expect(aclService.getAclUserCredentials).toHaveBeenCalledTimes(1));
+    expect(within(row).getByText('加载中…')).toBeInTheDocument();
+
+    await user.click(revealButton);
+    expect(within(row).queryByText('加载中…')).not.toBeInTheDocument();
+
+    await user.click(revealButton);
+    await waitFor(() => expect(aclService.getAclUserCredentials).toHaveBeenCalledTimes(2));
+    expect(within(row).getByText('加载中…')).toBeInTheDocument();
+
+    await user.click(revealButton);
+    expect(within(row).queryByText('加载中…')).not.toBeInTheDocument();
+
+    await user.click(revealButton);
+    await waitFor(() => expect(aclService.getAclUserCredentials).toHaveBeenCalledTimes(3));
+    expect(within(row).getByText('加载中…')).toBeInTheDocument();
+
+    await act(async () => {
+      firstReveal.resolve({
+        id: 'user-remote',
+        username: 'remote-admin',
+        accessKey: 'stale-access-key',
+        secretKey: 'stale-secret-key',
+        admin: true,
+        clusters: ['cluster-a'],
+        createdAt: '2026-07-23T00:00:00Z',
+      });
+    });
+
+    expect(within(row).getByText('加载中…')).toBeInTheDocument();
+    expect(screen.queryByText('stale-secret-key')).not.toBeInTheDocument();
+    expect(screen.queryByText('stale-access-key')).not.toBeInTheDocument();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      secondReveal.reject(new Error('stale reveal failure'));
+    });
+
+    expect(within(row).getByText('加载中…')).toBeInTheDocument();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      thirdReveal.resolve({
+        id: 'user-remote',
+        username: 'remote-admin',
+        accessKey: 'latest-access-key',
+        secretKey: 'latest-secret-key',
+        admin: true,
+        clusters: ['cluster-a'],
+        createdAt: '2026-07-23T00:00:00Z',
+      });
+    });
+
+    expect(await within(row).findByText('latest-secret-key')).toBeInTheDocument();
+    expect(within(row).getByText('latest-access-key')).toBeInTheDocument();
+    expect(screen.queryByText('stale-secret-key')).not.toBeInTheDocument();
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
   it('creates a plain access account', async () => {

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -134,6 +134,7 @@ const AclPage = () => {
   const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set());
   const [adminUpdatingIds, setAdminUpdatingIds] = useState<Set<string>>(() => new Set());
   const adminUpdateInFlightRef = useRef<Set<string>>(new Set());
+  const revealRequestGenerationRef = useRef<Record<string, number>>({});
   const [credentialsByUser, setCredentialsByUser] = useState<
     Record<string, { accessKey: string; secretKey: string }>
   >({});
@@ -142,6 +143,7 @@ const AclPage = () => {
   const [clusterConfig, setClusterConfig] = useState<AclClusterConfig | null>(null);
   const [configLoading, setConfigLoading] = useState(false);
   const [clusterIdInput, setClusterIdInput] = useState('DefaultCluster');
+  const examineRequestGenerationRef = useRef(0);
 
   // Plain access config modal
   const [plainModalOpen, setPlainModalOpen] = useState(false);
@@ -272,6 +274,8 @@ const AclPage = () => {
   /* ─── User helpers ─── */
   const toggleRevealKey = async (userId: string) => {
     const revealing = !revealedKeys.has(userId);
+    const revealGeneration = (revealRequestGenerationRef.current[userId] ?? 0) + 1;
+    revealRequestGenerationRef.current[userId] = revealGeneration;
     setRevealedKeys((prev) => {
       const next = new Set(prev);
       if (next.has(userId)) {
@@ -284,6 +288,7 @@ const AclPage = () => {
     if (!revealing || credentialsByUser[userId]) return;
     try {
       const credentials = await getAclUserCredentials(userId);
+      if (revealRequestGenerationRef.current[userId] !== revealGeneration) return;
       setCredentialsByUser((prev) => ({
         ...prev,
         [userId]: {
@@ -292,6 +297,7 @@ const AclPage = () => {
         },
       }));
     } catch {
+      if (revealRequestGenerationRef.current[userId] !== revealGeneration) return;
       setRevealedKeys((prev) => {
         const next = new Set(prev);
         next.delete(userId);
@@ -393,15 +399,21 @@ const AclPage = () => {
       message.warning(t('acl.inputRequired', { field: t('acl.examineCluster') }));
       return;
     }
+    const requestGeneration = examineRequestGenerationRef.current + 1;
+    examineRequestGenerationRef.current = requestGeneration;
     try {
       setConfigLoading(true);
       const config = await examineBrokerClusterAclConfig(clusterId);
+      if (examineRequestGenerationRef.current !== requestGeneration) return;
       setClusterConfig(config);
       message.success(t('acl.configExamined'));
     } catch {
+      if (examineRequestGenerationRef.current !== requestGeneration) return;
       message.error(t('common.operationFailed'));
     } finally {
-      setConfigLoading(false);
+      if (examineRequestGenerationRef.current === requestGeneration) {
+        setConfigLoading(false);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- keep Broker ACL config examinations owned by the latest request
- invalidate credential reveal requests per user and per reveal generation
- prevent stale successes or failures from changing data, loading state, or notifications

## Testing
- `npm test -- --run src/pages/instance/__tests__/AclPage.test.tsx`
- `npx eslint src/pages/instance/acl.tsx src/pages/instance/__tests__/AclPage.test.tsx`
- `npm run build`

Closes #2008