### PR TITLE
fix: reconcile alerts after acknowledged cleanup

### DIFF
--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -10,7 +10,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LangProvider } from '../../../i18n/LangContext';
-import { acknowledgeAlert, listSystemAlerts } from '../../../services/opsService';
+import {
+  acknowledgeAlert,
+  clearAcknowledgedAlerts,
+  listSystemAlerts,
+} from '../../../services/opsService';
 import SystemAlertsPage from '../systemAlerts';
 
 vi.mock('../../../services/opsService', () => ({
@@ -102,5 +106,39 @@ describe('SystemAlertsPage', () => {
       expect(acknowledgeButtons[0]).toHaveClass('ant-btn-loading');
       expect(acknowledgeButtons[1]).toHaveClass('ant-btn-loading');
     });
+  });
+
+  it('reloads canonical alerts after clearing a stale local acknowledgement snapshot', async () => {
+    vi.mocked(listSystemAlerts)
+      .mockResolvedValueOnce([
+        {
+          id: 'alert-a',
+          level: 'error',
+          title: 'Broker unavailable',
+          description: 'broker a',
+          time: '2026-08-10 01:00',
+          acknowledged: true,
+        },
+        {
+          id: 'alert-b',
+          level: 'warning',
+          title: 'Consumer lag',
+          description: 'consumer b',
+          time: '2026-08-10 01:01',
+          acknowledged: false,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    vi.mocked(clearAcknowledgedAlerts).mockResolvedValue(2);
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(await screen.findByText('Consumer lag')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /清除已确认/ }));
+
+    await waitFor(() => expect(listSystemAlerts).toHaveBeenCalledTimes(2));
+    expect(clearAcknowledgedAlerts).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Broker unavailable')).not.toBeInTheDocument();
+    expect(screen.queryByText('Consumer lag')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -90,6 +90,11 @@ const SystemAlertsPage = () => {
       await clearAcknowledgedAlerts();
       setAlerts((prev) => prev.filter((a) => !a.acknowledged));
       message.success(t('sysAlerts.cleared'));
+      try {
+        setAlerts(await listSystemAlerts());
+      } catch {
+        message.warning('已清理告警，但刷新列表失败，请重新加载页面');
+      }
     } catch {
       message.error('清理已确认告警失败，请稍后重试');
     } finally {
@@ -197,6 +202,7 @@ const SystemAlertsPage = () => {
                       icon={<CheckCircle size={14} />}
                       onClick={() => handleAck(alert.id)}
                       loading={acknowledgingIds.has(alert.id)}
+                      disabled={clearing}
                     >
                       {t('sysAlerts.acknowledge')}
                     </Button>


### PR DESCRIPTION
## Summary
- reload the canonical server alert list after clearing acknowledged records
- keep a safe local fallback when the follow-up refresh fails
- prevent acknowledgement actions while a clear operation is running
- cover stale cross-session acknowledgement state

## Testing
- `npm test -- --run src/pages/ops/__tests__/SystemAlertsPage.test.tsx`
- `npx eslint src/pages/ops/systemAlerts.tsx src/pages/ops/__tests__/SystemAlertsPage.test.tsx`
- `npm run build`

Closes #2014