### PR TITLE
fix: stabilize Mock mode and AI workspace

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayService.java
@@ -70,16 +70,34 @@ public class ToolGatewayService {
 
     public List<AiToolVO> discover(String clusterId) {
         boolean clusterSelected = clusterId != null && !clusterId.isBlank();
-        Set<String> capabilities = clusterSelected
-                ? Set.copyOf(capabilityResolver.resolve(clusterId))
-                : Collections.emptySet();
+        DiscoveryCapabilities discoveryCapabilities = resolveDiscoveryCapabilities(clusterId, clusterSelected);
 
         return catalog.list().stream()
-                .filter(definition -> clusterSelected || !requiresCluster(definition))
-                .filter(definition -> capabilities.containsAll(
+                .filter(definition -> discoveryCapabilities.clusterCapabilitiesResolved()
+                        || !requiresCluster(definition))
+                .filter(definition -> discoveryCapabilities.capabilities().containsAll(
                         definition.requiredCapabilities()))
                 .map(ToolGatewayService::toView)
                 .toList();
+    }
+
+    /**
+     * A tool directory must remain available when the selected cluster cannot report its
+     * architecture. In that case expose only tools that do not require cluster capabilities;
+     * execution still resolves capabilities and returns the original diagnostic error.
+     */
+    private DiscoveryCapabilities resolveDiscoveryCapabilities(String clusterId, boolean clusterSelected) {
+        if (!clusterSelected) {
+            return new DiscoveryCapabilities(false, Collections.emptySet());
+        }
+        try {
+            return new DiscoveryCapabilities(true, Set.copyOf(capabilityResolver.resolve(clusterId)));
+        } catch (BusinessException ignored) {
+            return new DiscoveryCapabilities(false, Collections.emptySet());
+        }
+    }
+
+    private record DiscoveryCapabilities(boolean clusterCapabilitiesResolved, Set<String> capabilities) {
     }
 
     public Object execute(String name, Map<String, Object> input) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -137,6 +137,15 @@ class ToolGatewayServiceTest {
     }
 
     @Test
+    void discoveryWithClusterOfUnknownTypeOnlyExposesGlobalTools() {
+        when(clusterService.getCluster("unknown")).thenReturn(cluster("unknown", null));
+
+        assertThat(gateway.discover("unknown"))
+                .extracting(AiToolVO::getName)
+                .containsExactly("rmq.cluster.list");
+    }
+
+    @Test
     void executesNameServerConfigDiffWithAValidatedOutputContract() {
         when(clusterService.getCluster("cluster-v5"))
                 .thenReturn(cluster(ClusterType.V5_PROXY_CLUSTER));

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -178,6 +178,68 @@ body {
   color: #7c3aed;
 }
 
+/* === AI page theme surface === */
+.ai-page .ai-chat-panel {
+  background: color-mix(in srgb, var(--ai-surface) 92%, transparent);
+  border-color: var(--ai-border);
+  box-shadow: 0 20px 60px -20px color-mix(in srgb, var(--ai-text-secondary) 30%, transparent);
+}
+.ai-page .ai-chat-toolbar {
+  border-color: var(--ai-border);
+}
+.ai-page .chat-input {
+  color: var(--ai-text);
+}
+.ai-page .chat-input::placeholder {
+  color: var(--ai-text-tertiary);
+}
+.ai-page .tool-btn {
+  background: var(--ai-fill-secondary);
+  color: var(--ai-text);
+}
+.ai-page .tool-btn:hover {
+  background: var(--ai-primary-bg);
+  color: var(--ai-primary);
+}
+.ai-page .ai-send-button {
+  background: var(--ai-primary);
+}
+.ai-page .ai-send-button:hover {
+  background: var(--ai-primary-hover);
+}
+.ai-page .ai-markdown {
+  color: var(--ai-text);
+}
+.ai-page .ai-markdown h1,
+.ai-page .ai-markdown h2,
+.ai-page .ai-markdown h3,
+.ai-page .ai-markdown h4 {
+  color: var(--ai-text);
+}
+.ai-page .ai-markdown code {
+  background: var(--ai-fill-secondary);
+  color: var(--ai-primary);
+}
+.ai-page .ai-markdown pre {
+  background: var(--ai-code-bg);
+  border: 1px solid var(--ai-border);
+}
+.ai-page .ai-markdown pre code {
+  background: transparent;
+  color: var(--ai-code-text);
+}
+.ai-page .ai-markdown blockquote {
+  border-left-color: var(--ai-border);
+  color: var(--ai-text-secondary);
+}
+.ai-page .ai-markdown th,
+.ai-page .ai-markdown td {
+  border-color: var(--ai-border);
+}
+.ai-page .ai-markdown th {
+  background: var(--ai-fill-secondary);
+  color: var(--ai-text);
+}
 /* === Chat Input === */
 .chat-input {
   width: 100%;

--- a/web/src/pages/ai/__tests__/AiMessage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiMessage.test.tsx
@@ -47,5 +47,6 @@ describe('AiMessage', () => {
     expect(screen.getByText('QPS/TPS')).toBeInTheDocument();
     expect(screen.getByRole('table')).toBeInTheDocument();
     expect(screen.getByText('mqadmin clusterList')).toBeInTheDocument();
+    expect(screen.getByText('mqadmin clusterList').closest('pre')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -26,6 +26,8 @@ import { listClusters, type ClusterInfo } from '../../../api/cluster';
 import { getLlmConfig, getLlmModels } from '../../../api/llm';
 import AiPage from '../index';
 
+const dataModeMocks = vi.hoisted(() => ({ useMock: false }));
+
 vi.mock('../../../api/ai', () => ({
   AiStreamError: class AiStreamError extends Error {},
   chatStream: vi.fn(),
@@ -40,6 +42,10 @@ vi.mock('../../../api/llm', () => ({
 
 vi.mock('../../../api/cluster', () => ({
   listClusters: vi.fn(),
+}));
+
+vi.mock('../../../stores/dataModeStore', () => ({
+  useDataModeStore: (selector: (state: typeof dataModeMocks) => unknown) => selector(dataModeMocks),
 }));
 
 beforeAll(() => {
@@ -73,6 +79,7 @@ const renderPage = (state?: unknown) =>
 describe('AiPage tool runner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    dataModeMocks.useMock = false;
     vi.mocked(getLlmConfig).mockResolvedValue({
       provider: 'openai',
       apiBase: 'https://api.openai.com/v1',
@@ -119,6 +126,20 @@ describe('AiPage tool runner', () => {
     });
   });
 
+  it('does not load LLM configuration or tools in mock mode', async () => {
+    dataModeMocks.useMock = true;
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(await screen.findByText('Mock 模式已禁用 AI Provider 调用')).toBeInTheDocument();
+    expect(getLlmConfig).not.toHaveBeenCalled();
+    expect(getLlmModels).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: '工具' }));
+    expect(listTools).not.toHaveBeenCalled();
+    expect(listClusters).not.toHaveBeenCalled();
+  });
+
   it('loads the catalog, creates a schema template, and renders structured output', async () => {
     const user = userEvent.setup();
     vi.mocked(executeTool).mockResolvedValue({
@@ -156,8 +177,16 @@ describe('AiPage tool runner', () => {
     let resolveOld!: (value: typeof oldTools) => void;
     let resolveLatest!: (value: typeof latestTools) => void;
     vi.mocked(listTools)
-      .mockReturnValueOnce(new Promise((resolve) => { resolveOld = resolve; }))
-      .mockReturnValueOnce(new Promise((resolve) => { resolveLatest = resolve; }));
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveOld = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveLatest = resolve;
+        }),
+      );
     const user = userEvent.setup();
     renderPage();
 

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, type CSSProperties } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -45,6 +45,7 @@ import { useLang } from '../../i18n/LangContext';
 import { AiStreamError, chatStream, executeTool, listTools, type McpTool } from '../../api/ai';
 import { listClusters } from '../../api/cluster';
 import { getLlmConfig, getLlmModels, type LlmConfig } from '../../api/llm';
+import { useDataModeStore } from '../../stores/dataModeStore';
 import { useEngineStore } from '../../stores/engineStore';
 import { getChatDraft, type ChatMode } from './chatDraft';
 
@@ -149,32 +150,42 @@ const formatToolResult = (result: unknown): string =>
 
 /* ─── Sub-components ─── */
 
-const UserBubble = ({ text }: { text: string }) => (
-  <Flex justify="flex-end" style={{ marginBottom: 16 }}>
-    <div
-      style={{
-        maxWidth: '70%',
-        padding: '10px 16px',
-        background: '#e6f4ff',
-        borderRadius: 16,
-        borderTopRightRadius: 4,
-        lineHeight: 1.6,
-        fontSize: 14,
-      }}
-    >
-      {text}
-    </div>
-  </Flex>
-);
+const UserBubble = ({ text }: { text: string }) => {
+  const { token } = theme.useToken();
 
-export const AiMessage = ({ msg }: { msg: Message }) => (
-  <Flex gap={12} align="flex-start" style={{ marginBottom: 16 }}>
+  return (
+    <Flex justify="flex-end" style={{ marginBottom: 16 }}>
+      <div
+        className="ai-user-bubble"
+        style={{
+          maxWidth: '70%',
+          padding: '10px 16px',
+          background: token.colorPrimaryBg,
+          color: token.colorText,
+          border: `1px solid ${token.colorPrimaryBorder}`,
+          borderRadius: 16,
+          borderTopRightRadius: 4,
+          lineHeight: 1.6,
+          fontSize: 14,
+        }}
+      >
+        {text}
+      </div>
+    </Flex>
+  );
+};
+
+export const AiMessage = ({ msg }: { msg: Message }) => {
+  const { token } = theme.useToken();
+
+  return (
+    <Flex gap={12} align="flex-start" style={{ marginBottom: 16 }}>
     <div
       style={{
         width: 36,
         height: 36,
         borderRadius: '50%',
-        background: 'linear-gradient(135deg, #1677ff 0%, #722ed1 100%)',
+        background: `linear-gradient(135deg, ${token.colorPrimary} 0%, ${token.colorPrimaryHover} 100%)`,
         flexShrink: 0,
         display: 'flex',
         alignItems: 'center',
@@ -202,7 +213,9 @@ export const AiMessage = ({ msg }: { msg: Message }) => (
       size="small"
       style={{
         maxWidth: '75%',
-        boxShadow: '0 1px 4px rgba(0, 0, 0, 0.06)',
+        background: token.colorBgElevated,
+        borderColor: token.colorBorderSecondary,
+        boxShadow: `0 1px 4px ${token.colorTextQuaternary}`,
         borderRadius: 12,
         borderTopLeftRadius: 4,
       }}
@@ -216,8 +229,8 @@ export const AiMessage = ({ msg }: { msg: Message }) => (
             marginBottom: 12,
             borderRadius: 6,
             fontSize: 12,
-            background: '#f9f0ff',
-            borderColor: '#d3adf7',
+            background: token.colorPrimaryBg,
+            borderColor: token.colorPrimaryBorder,
           }}
         >
           {msg.toolCall.label}
@@ -283,7 +296,7 @@ export const AiMessage = ({ msg }: { msg: Message }) => (
           <summary
             style={{
               cursor: 'pointer',
-              color: '#722ed1',
+              color: token.colorPrimary,
               fontSize: 12,
               fontWeight: 500,
               userSelect: 'none',
@@ -295,12 +308,12 @@ export const AiMessage = ({ msg }: { msg: Message }) => (
             style={{
               marginTop: 8,
               padding: '8px 12px',
-              background: '#f9f0ff',
-              border: '1px solid #efdbff',
+              background: token.colorFillSecondary,
+              border: `1px solid ${token.colorBorderSecondary}`,
               borderRadius: 8,
               fontSize: 12,
               lineHeight: 1.7,
-              color: '#595959',
+              color: token.colorTextSecondary,
               whiteSpace: 'pre-wrap',
             }}
           >
@@ -318,7 +331,7 @@ export const AiMessage = ({ msg }: { msg: Message }) => (
               width: 6,
               height: 6,
               borderRadius: '50%',
-              background: '#722ed1',
+              background: token.colorPrimary,
               animation: 'dotPulse 1.4s infinite ease-in-out',
             }}
           />
@@ -328,7 +341,7 @@ export const AiMessage = ({ msg }: { msg: Message }) => (
               width: 6,
               height: 6,
               borderRadius: '50%',
-              background: '#722ed1',
+              background: token.colorPrimary,
               animation: 'dotPulse 1.4s infinite ease-in-out 0.2s',
             }}
           />
@@ -338,7 +351,7 @@ export const AiMessage = ({ msg }: { msg: Message }) => (
               width: 6,
               height: 6,
               borderRadius: '50%',
-              background: '#722ed1',
+              background: token.colorPrimary,
               animation: 'dotPulse 1.4s infinite ease-in-out 0.4s',
             }}
           />
@@ -369,8 +382,9 @@ export const AiMessage = ({ msg }: { msg: Message }) => (
         </>
       )}
     </Card>
-  </Flex>
-);
+    </Flex>
+  );
+};
 
 /* ═══════════════════════════════════════════
    AiPage
@@ -380,6 +394,7 @@ const AiPage = () => {
   const { t } = useLang();
   const location = useLocation();
   const navigate = useNavigate();
+  const useMock = useDataModeStore((state) => state.useMock);
   const { token } = theme.useToken();
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [inputValue, setInputValue] = useState('');
@@ -420,6 +435,13 @@ const AiPage = () => {
   }, [messages, scrollToBottom]);
 
   const loadLlmRuntime = useCallback(async () => {
+    if (useMock) {
+      setLlmConfig(null);
+      setModelOptions([]);
+      setSelectedModel('');
+      setModelsLoading(false);
+      return;
+    }
     setModelsLoading(true);
     try {
       const config = await getLlmConfig();
@@ -444,7 +466,7 @@ const AiPage = () => {
     } finally {
       setModelsLoading(false);
     }
-  }, []);
+  }, [useMock]);
 
   useEffect(() => {
     void Promise.resolve().then(loadLlmRuntime);
@@ -652,6 +674,10 @@ const AiPage = () => {
   );
 
   const handleOpenTools = useCallback(async () => {
+    if (useMock) {
+      message.info('Mock 模式不加载 AI 工具目录，请切换到真实数据模式后使用。');
+      return;
+    }
     setToolModalOpen(true);
     setToolResult(undefined);
     if (tools.length > 0 || toolsLoading || clustersLoading) return;
@@ -671,7 +697,7 @@ const AiPage = () => {
     }
 
     await loadTools(clusterId);
-  }, [clustersLoading, loadTools, tools.length, toolsLoading]);
+  }, [clustersLoading, loadTools, tools.length, toolsLoading, useMock]);
 
   const handleClusterChange = useCallback(
     async (scope: string) => {
@@ -712,7 +738,28 @@ const AiPage = () => {
   const selectedTool = tools.find((tool) => tool.name === selectedToolName);
 
   return (
-    <Flex vertical style={{ height: '100%', minHeight: 0, padding: 24, overflow: 'hidden' }}>
+    <Flex
+      vertical
+      className="ai-page"
+      style={{
+        height: '100%',
+        minHeight: 0,
+        padding: 24,
+        overflow: 'hidden',
+        '--ai-surface': token.colorBgContainer,
+        '--ai-surface-elevated': token.colorBgElevated,
+        '--ai-border': token.colorBorderSecondary,
+        '--ai-text': token.colorText,
+        '--ai-text-secondary': token.colorTextSecondary,
+        '--ai-text-tertiary': token.colorTextTertiary,
+        '--ai-primary': token.colorPrimary,
+        '--ai-primary-bg': token.colorPrimaryBg,
+        '--ai-primary-hover': token.colorPrimaryHover,
+        '--ai-fill-secondary': token.colorFillSecondary,
+        '--ai-code-bg': token.colorBgSpotlight,
+        '--ai-code-text': token.colorTextLightSolid,
+      } as CSSProperties}
+    >
       {/* Chat Area */}
       <div
         className="w-full scrollbar-hide"
@@ -774,9 +821,18 @@ const AiPage = () => {
             }
           />
         )}
+        {useMock && (
+          <Alert
+            type="info"
+            showIcon
+            style={{ marginBottom: 12 }}
+            message="Mock 模式已禁用 AI Provider 调用"
+            description="切换到真实数据模式并配置 LLM Provider 后，才会加载模型、工具目录和对话能力。"
+          />
+        )}
 
         {/* Main Input Box */}
-        <div className="relative overflow-visible border-[1.5px] backdrop-blur-xl border-white rounded-2xl bg-white/80 shadow-[0_20px_60px_-20px_rgba(80,90,180,0.18)]">
+        <div className="ai-chat-panel relative overflow-visible border-[1.5px] backdrop-blur-xl rounded-2xl">
           {/* Model Selector */}
           <div className="flex items-center justify-between gap-3 px-3.5 pt-4">
             <div className="flex flex-1 min-w-0 items-center gap-2">
@@ -789,7 +845,7 @@ const AiPage = () => {
                 variant="borderless"
                 placeholder={modelsLoading ? '加载模型中...' : '选择模型'}
                 popupMatchSelectWidth={false}
-                suffixIcon={<CaretDown size={10} color="#9CA3AF" />}
+                suffixIcon={<CaretDown size={10} color={token.colorTextTertiary} />}
                 className="model-selector"
                 style={{ fontSize: '0.893rem' }}
               />
@@ -813,18 +869,18 @@ const AiPage = () => {
               placeholder="输入你的问题或指令，例如：查看集群状态、创建 Topic、诊断消费延迟..."
             />
             <Sparkle
-              className="text-gray-400"
               style={{
                 position: 'absolute',
                 top: 18,
                 left: 26,
                 fontSize: 17,
+                color: token.colorTextTertiary,
               }}
             />
           </div>
 
           {/* Bottom Toolbar */}
-          <div className="flex justify-between text-sm items-center px-3.5 py-3 border-t border-gray-100/80">
+          <div className="ai-chat-toolbar flex justify-between text-sm items-center px-3.5 py-3 border-t">
             <div className="flex flex-1 gap-1 items-center min-w-0">
               <div className="flex items-center gap-2 w-full">
                 <div className="flex-1 min-w-0">
@@ -841,7 +897,7 @@ const AiPage = () => {
                 </div>
                 <div className="shrink-0 flex items-center gap-1">
                   <button
-                    className="flex items-center justify-center w-9 h-9 rounded-full bg-gradient-to-r from-purple-500 to-violet-600 text-white shadow-lg hover:shadow-xl transition-all hover:scale-105"
+                    className="ai-send-button flex items-center justify-center w-9 h-9 rounded-full text-white shadow-lg hover:shadow-xl transition-all hover:scale-105"
                     onClick={() => void handleSend()}
                     disabled={loading || !inputValue.trim() || !llmReady}
                     style={{

--- a/web/src/pages/studio/LlmSettings.tsx
+++ b/web/src/pages/studio/LlmSettings.tsx
@@ -234,6 +234,13 @@ const LlmSettingsPage: React.FC = () => {
           setApiKeyConfigured(true);
           form.setFieldValue('apiKey', undefined);
         }
+        try {
+          const models = await getLlmModels();
+          const remoteModels = models.data?.map((model) => model.id || '').filter(Boolean) ?? [];
+          setModelOptions(buildModelOptions(payload.provider, remoteModels, payload.model));
+        } catch {
+          message.warning('配置已保存，但模型列表刷新失败；请稍后重试');
+        }
       } else {
         message.error(result.errMsg || '保存失败');
       }

--- a/web/src/pages/studio/__tests__/LlmSettingsPage.test.tsx
+++ b/web/src/pages/studio/__tests__/LlmSettingsPage.test.tsx
@@ -124,6 +124,27 @@ describe('LlmSettingsPage', () => {
     expect(llmApiMocks.saveLlmConfig.mock.calls[0][0].awsRegion).toBeUndefined();
   });
 
+  it('refreshes the remote model list after saving an API key', async () => {
+    const user = userEvent.setup();
+    llmApiMocks.getLlmModels
+      .mockResolvedValueOnce({ status: 0, data: [{ id: 'qwen3.8-max' }] })
+      .mockResolvedValueOnce({
+        status: 0,
+        data: [{ id: 'qwen3.8-max' }, { id: 'qwen-plus-latest' }],
+      });
+    renderPage();
+
+    await screen.findByText('密钥已配置');
+    await user.type(screen.getByLabelText('API Key'), 'sk-new-key');
+    await user.click(screen.getByRole('button', { name: /保\s*存/ }));
+
+    await waitFor(() => expect(llmApiMocks.getLlmModels).toHaveBeenCalledTimes(2));
+    await user.click(screen.getAllByRole('combobox')[2]);
+    expect(
+      await screen.findByText('qwen-plus-latest', { selector: '.ant-select-item-option-content' }),
+    ).toBeInTheDocument();
+  });
+
   it('ignores a connection result after the tested configuration changes', async () => {
     let resolveTest!: (result: { status: number; msg: string }) => void;
     llmApiMocks.testLlmConnection.mockImplementationOnce(


### PR DESCRIPTION
## Summary
- prevent Home, dashboard, and AI pages from calling protected backend APIs in Mock mode, avoiding `401` redirects and reload loops
- show explicit Mock-mode guidance when live metrics, AI providers, or tools are unavailable
- make dark-mode AI Markdown and code blocks readable without changing the settled Home design
- refresh the configured provider's model list after LLM settings are saved
- keep the AI tool catalog available when a cluster type is unknown

## Re-scope
- removed all Home visual changes, login-page styling, chat-history persistence, Mock ZIP changes, settings-page changes, and navigation/breadcrumb changes
- Mock Grafana bulk export retains the already-merged JSON bundle semantics
- conversation-history persistence is handled separately in #2111

## Verification
- `npm run lint` (no errors; two existing warnings outside this PR)
- targeted Vitest suites for Home, dashboard, AI, and LLM settings
- `npm run build`
- server `ToolGatewayServiceTest` is covered by Java 21 CI; local Maven cannot compile because the installed JDK does not support release 21

Related to #2017