### PR TITLE
fix(web): prevent home page reload loop in Mock mode

### DIFF
--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -78,6 +78,18 @@ describe('HomePage LLM models', () => {
     expect(await screen.findByText('qwen3.8-max')).toBeInTheDocument();
   });
 
+  it('does not fetch LLM config in Mock mode', async () => {
+    const { useDataModeStore } = await import('../../../stores/dataModeStore');
+    useDataModeStore.getState().toggle();
+
+    renderHome();
+
+    expect(llmApiMocks.getLlmConfig).not.toHaveBeenCalled();
+    expect(await screen.findByText('qwen3.8-max')).toBeInTheDocument();
+
+    useDataModeStore.getState().toggle();
+  });
+
   it('submits the selected model and engine to the AI page', async () => {
     const user = userEvent.setup();
     renderHome();

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -34,6 +34,7 @@ import {
 } from '@phosphor-icons/react';
 import { getLlmConfig } from '../../api/llm';
 import { useEngineStore } from '../../stores/engineStore';
+import { useDataModeStore } from '../../stores/dataModeStore';
 import { useLang } from '../../i18n/LangContext';
 
 /* ─── Time-aware greeting key ─── */
@@ -98,6 +99,17 @@ const HomePage = () => {
     let cancelled = false;
 
     const loadModels = async () => {
+      const useMock = useDataModeStore.getState().useMock;
+      if (useMock) {
+        if (cancelled) return;
+        setModelOptions(
+          HOME_MODELS.map((value) => ({ value, recommended: value === RECOMMENDED_MODEL })),
+        );
+        setSelectedModel((current) =>
+          current && HOME_MODELS.includes(current) ? current : HOME_MODELS[0] || '',
+        );
+        return;
+      }
       const config = await getLlmConfig().catch(() => null);
       if (cancelled) return;
 


### PR DESCRIPTION
## What is the purpose of the change

Fix #2017.

When the runtime data-mode toggle is set to Mock, the Studio home page still requested GET /api/llm/config during mount. A local backend without a valid authenticated session responded with 401, the global Axios interceptor redirected to '/' and the page reloaded into the same request, producing a visible reload loop.

## Brief changelog

- HomePage: skip the LLM config fetch in Mock mode and render the default model list directly
- added a regression test asserting getLlmConfig is not called in Mock mode

## How was this patch verified

- npx vitest run src/pages/home/__tests__/HomePage.test.tsx (3 passed)
- npx tsc -b clean
- npx eslint . clean
