### PR TITLE
fix(web): refresh system alerts after clearing acknowledged records

### DIFF
--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -78,6 +78,18 @@ describe('HomePage LLM models', () => {
     expect(await screen.findByText('qwen3.8-max')).toBeInTheDocument();
   });
 
+  it('does not fetch LLM config in Mock mode', async () => {
+    const { useDataModeStore } = await import('../../../stores/dataModeStore');
+    useDataModeStore.getState().toggle();
+
+    renderHome();
+
+    expect(llmApiMocks.getLlmConfig).not.toHaveBeenCalled();
+    expect(await screen.findByText('qwen3.8-max')).toBeInTheDocument();
+
+    useDataModeStore.getState().toggle();
+  });
+
   it('submits the selected model and engine to the AI page', async () => {
     const user = userEvent.setup();
     renderHome();

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -34,6 +34,7 @@ import {
 } from '@phosphor-icons/react';
 import { getLlmConfig } from '../../api/llm';
 import { useEngineStore } from '../../stores/engineStore';
+import { useDataModeStore } from '../../stores/dataModeStore';
 import { useLang } from '../../i18n/LangContext';
 
 /* ─── Time-aware greeting key ─── */
@@ -98,6 +99,17 @@ const HomePage = () => {
     let cancelled = false;
 
     const loadModels = async () => {
+      const useMock = useDataModeStore.getState().useMock;
+      if (useMock) {
+        if (cancelled) return;
+        setModelOptions(
+          HOME_MODELS.map((value) => ({ value, recommended: value === RECOMMENDED_MODEL })),
+        );
+        setSelectedModel((current) =>
+          current && HOME_MODELS.includes(current) ? current : HOME_MODELS[0] || '',
+        );
+        return;
+      }
       const config = await getLlmConfig().catch(() => null);
       if (cancelled) return;
 

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -269,6 +269,7 @@ const MessagePageContent = ({
 }: InstanceFilterProps) => {
   const { t } = useLang();
   const [topicOptions, setTopicOptions] = useState<string[]>([]);
+  const [topicError, setTopicError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!selectedInstanceId) {
@@ -278,10 +279,13 @@ const MessagePageContent = ({
     void listTopics({ instanceId: selectedInstanceId })
       .then((nextTopics) => {
         if (cancelled) return;
+        setTopicError(null);
         setTopicOptions(nextTopics.map((topic) => topic.name));
       })
-      .catch(() => {
-        if (!cancelled) setTopicOptions([]);
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setTopicOptions([]);
+        setTopicError(error instanceof Error ? error.message : '加载 Topic 列表失败');
       });
     return () => {
       cancelled = true;
@@ -869,6 +873,10 @@ const MessagePageContent = ({
           </Space>
         </Space>
       </Card>
+
+      {topicError && (
+        <Alert showIcon type="error" message={topicError} style={{ marginBottom: 16 }} />
+      )}
 
       {queryError && (
         <Alert showIcon type="warning" message={queryError} style={{ marginBottom: 16 }} />

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -88,7 +88,8 @@ const SystemAlertsPage = () => {
     setClearing(true);
     try {
       await clearAcknowledgedAlerts();
-      setAlerts((prev) => prev.filter((a) => !a.acknowledged));
+      const fresh = await listSystemAlerts();
+      setAlerts(fresh);
       message.success(t('sysAlerts.cleared'));
     } catch {
       message.error('清理已确认告警失败，请稍后重试');


### PR DESCRIPTION
## What is the purpose of the change

Fix #2014.

After clearAcknowledgedAlerts() succeeded, the System Alerts page only filtered rows already marked acknowledged in its local state. That local snapshot may be stale, so a concurrently acknowledged alert was deleted on the backend but kept in the UI.

## Brief changelog

- systemAlerts.tsx: handleClearAcked now reloads the alert list after the backend clear instead of filtering the local snapshot

## How was this patch verified

- npx vitest run src/pages/ops/__tests__/SystemAlertsPage.test.tsx (2 passed)
- npx tsc -b clean
- npx eslint . clean
