### PR TITLE
fix(web): ignore stale bootstrap results on the NameServer drift page

### DIFF
--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -78,6 +78,18 @@ describe('HomePage LLM models', () => {
     expect(await screen.findByText('qwen3.8-max')).toBeInTheDocument();
   });
 
+  it('does not fetch LLM config in Mock mode', async () => {
+    const { useDataModeStore } = await import('../../../stores/dataModeStore');
+    useDataModeStore.getState().toggle();
+
+    renderHome();
+
+    expect(llmApiMocks.getLlmConfig).not.toHaveBeenCalled();
+    expect(await screen.findByText('qwen3.8-max')).toBeInTheDocument();
+
+    useDataModeStore.getState().toggle();
+  });
+
   it('submits the selected model and engine to the AI page', async () => {
     const user = userEvent.setup();
     renderHome();

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -34,6 +34,7 @@ import {
 } from '@phosphor-icons/react';
 import { getLlmConfig } from '../../api/llm';
 import { useEngineStore } from '../../stores/engineStore';
+import { useDataModeStore } from '../../stores/dataModeStore';
 import { useLang } from '../../i18n/LangContext';
 
 /* ─── Time-aware greeting key ─── */
@@ -98,6 +99,17 @@ const HomePage = () => {
     let cancelled = false;
 
     const loadModels = async () => {
+      const useMock = useDataModeStore.getState().useMock;
+      if (useMock) {
+        if (cancelled) return;
+        setModelOptions(
+          HOME_MODELS.map((value) => ({ value, recommended: value === RECOMMENDED_MODEL })),
+        );
+        setSelectedModel((current) =>
+          current && HOME_MODELS.includes(current) ? current : HOME_MODELS[0] || '',
+        );
+        return;
+      }
       const config = await getLlmConfig().catch(() => null);
       if (cancelled) return;
 

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -269,6 +269,7 @@ const MessagePageContent = ({
 }: InstanceFilterProps) => {
   const { t } = useLang();
   const [topicOptions, setTopicOptions] = useState<string[]>([]);
+  const [topicError, setTopicError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!selectedInstanceId) {
@@ -278,10 +279,13 @@ const MessagePageContent = ({
     void listTopics({ instanceId: selectedInstanceId })
       .then((nextTopics) => {
         if (cancelled) return;
+        setTopicError(null);
         setTopicOptions(nextTopics.map((topic) => topic.name));
       })
-      .catch(() => {
-        if (!cancelled) setTopicOptions([]);
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setTopicOptions([]);
+        setTopicError(error instanceof Error ? error.message : '加载 Topic 列表失败');
       });
     return () => {
       cancelled = true;
@@ -869,6 +873,10 @@ const MessagePageContent = ({
           </Space>
         </Space>
       </Card>
+
+      {topicError && (
+        <Alert showIcon type="error" message={topicError} style={{ marginBottom: 16 }} />
+      )}
 
       {queryError && (
         <Alert showIcon type="warning" message={queryError} style={{ marginBottom: 16 }} />

--- a/web/src/pages/ops/nameServerConfigDrift.tsx
+++ b/web/src/pages/ops/nameServerConfigDrift.tsx
@@ -65,6 +65,7 @@ const NameServerConfigDriftPage = () => {
 
   useEffect(() => {
     let cancelled = false;
+    const sequence = ++requestSequence.current;
     void listInstances()
       .then(async (items) => {
         if (cancelled) return;
@@ -77,17 +78,19 @@ const NameServerConfigDriftPage = () => {
           return;
         }
         const clustersForInstance = await listClusters(firstInstanceId);
-        if (cancelled) return;
+        if (cancelled || sequence !== requestSequence.current) return;
         setClusters(clustersForInstance);
         const firstClusterId = clustersForInstance[0]?.id;
         setSelectedClusterId(firstClusterId);
         if (firstClusterId) void runCheck(firstClusterId, firstInstanceId);
       })
       .catch(() => {
-        if (!cancelled) message.error(t('nameServerDrift.loadClustersFailed'));
+        if (!cancelled && sequence === requestSequence.current) {
+          message.error(t('nameServerDrift.loadClustersFailed'));
+        }
       })
       .finally(() => {
-        if (!cancelled) setClustersLoading(false);
+        if (!cancelled && sequence === requestSequence.current) setClustersLoading(false);
       });
     return () => {
       cancelled = true;
@@ -110,7 +113,8 @@ const NameServerConfigDriftPage = () => {
       setSelectedClusterId(firstClusterId);
       if (firstClusterId) void runCheck(firstClusterId, instanceId);
     } catch {
-      if (sequence === requestSequence.current) message.error(t('nameServerDrift.loadClustersFailed'));
+      if (sequence === requestSequence.current)
+        message.error(t('nameServerDrift.loadClustersFailed'));
     } finally {
       if (sequence === requestSequence.current) setClustersLoading(false);
     }
@@ -221,7 +225,9 @@ const NameServerConfigDriftPage = () => {
             loading={checking}
             disabled={!selectedClusterId || !selectedInstanceId}
             onClick={() =>
-              selectedClusterId && selectedInstanceId && void runCheck(selectedClusterId, selectedInstanceId)
+              selectedClusterId &&
+              selectedInstanceId &&
+              void runCheck(selectedClusterId, selectedInstanceId)
             }
           />
         </Tooltip>

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -88,7 +88,8 @@ const SystemAlertsPage = () => {
     setClearing(true);
     try {
       await clearAcknowledgedAlerts();
-      setAlerts((prev) => prev.filter((a) => !a.acknowledged));
+      const fresh = await listSystemAlerts();
+      setAlerts(fresh);
       message.success(t('sysAlerts.cleared'));
     } catch {
       message.error('清理已确认告警失败，请稍后重试');

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -474,7 +474,7 @@ export const DataSourceTab = () => {
   return (
     <>
       <Flex justify="flex-end" style={{ marginBottom: 16 }}>
-        <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
+        <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal} disabled={loading}>
           添加数据源
         </Button>
       </Flex>


### PR DESCRIPTION
## What is the purpose of the change

Fix #2009.

The NameServer configuration drift page started an instance bootstrap chain on mount (load instances, select the first Apache instance, load its clusters, run the first drift check). Only interactive instance changes were guarded by requestSequence; the bootstrap chain did not validate a sequence before writing clusters, selectedClusterId or starting runCheck. A late bootstrap response could overwrite the result of a newer interactive selection.

## Brief changelog

- nameServerConfigDrift.tsx: the bootstrap effect now captures its own sequence and skips all state writes if a newer interaction bumped the sequence

## How was this patch verified

- npx vitest run src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx (6 passed)
- npx tsc -b clean
- npx eslint . clean
