### PR TITLE
fix: preserve K8s certificate mutation integrity

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
@@ -98,18 +98,22 @@ public class K8sCertService {
 
         K8sCertVO updated = copyOf(existing);
         if (command.getName() != null) {
+            requireText(command.getName(), "name");
             updated.setName(command.getName());
         }
         if (command.getNamespace() != null) {
+            requireText(command.getNamespace(), "namespace");
             updated.setNamespace(command.getNamespace());
         }
         if (command.getCluster() != null) {
+            requireText(command.getCluster(), "cluster");
             updated.setCluster(command.getCluster());
         }
         if (command.getType() != null) {
             updated.setType(CertType.valueOf(command.getType()));
         }
         if (command.getIssuer() != null) {
+            requireText(command.getIssuer(), "issuer");
             updated.setIssuer(command.getIssuer());
         }
         if (command.getSan() != null) {
@@ -160,6 +164,12 @@ public class K8sCertService {
     private void requireCommand(Object command) {
         if (command == null) {
             throw new BusinessException(400, "K8s certificate request is required");
+        }
+    }
+
+    private void requireText(String value, String field) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new BusinessException(400, "K8s certificate " + field + " is required");
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -507,6 +507,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
             }
             recordAudit("RESET_OFFSET", name,
                     "instanceId=" + instanceId + ", topic=" + topic + ", timestamp=" + timestamp, "SUCCESS");
+        } catch (BusinessException e) {
+            recordAudit("RESET_OFFSET", name, e.getMessage(), "FAILED");
+            throw e;
         } catch (Exception e) {
             recordAudit("RESET_OFFSET", name, e.getMessage(), "FAILED");
             throw new BusinessException(500, "Failed to reset offset: " + e.getMessage());

--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -78,6 +78,18 @@ describe('HomePage LLM models', () => {
     expect(await screen.findByText('qwen3.8-max')).toBeInTheDocument();
   });
 
+  it('does not fetch LLM config in Mock mode', async () => {
+    const { useDataModeStore } = await import('../../../stores/dataModeStore');
+    useDataModeStore.getState().toggle();
+
+    renderHome();
+
+    expect(llmApiMocks.getLlmConfig).not.toHaveBeenCalled();
+    expect(await screen.findByText('qwen3.8-max')).toBeInTheDocument();
+
+    useDataModeStore.getState().toggle();
+  });
+
   it('submits the selected model and engine to the AI page', async () => {
     const user = userEvent.setup();
     renderHome();

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -34,6 +34,7 @@ import {
 } from '@phosphor-icons/react';
 import { getLlmConfig } from '../../api/llm';
 import { useEngineStore } from '../../stores/engineStore';
+import { useDataModeStore } from '../../stores/dataModeStore';
 import { useLang } from '../../i18n/LangContext';
 
 /* ─── Time-aware greeting key ─── */
@@ -98,6 +99,17 @@ const HomePage = () => {
     let cancelled = false;
 
     const loadModels = async () => {
+      const useMock = useDataModeStore.getState().useMock;
+      if (useMock) {
+        if (cancelled) return;
+        setModelOptions(
+          HOME_MODELS.map((value) => ({ value, recommended: value === RECOMMENDED_MODEL })),
+        );
+        setSelectedModel((current) =>
+          current && HOME_MODELS.includes(current) ? current : HOME_MODELS[0] || '',
+        );
+        return;
+      }
       const config = await getLlmConfig().catch(() => null);
       if (cancelled) return;
 

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -142,6 +142,7 @@ const AclPage = () => {
   const [clusterConfig, setClusterConfig] = useState<AclClusterConfig | null>(null);
   const [configLoading, setConfigLoading] = useState(false);
   const [clusterIdInput, setClusterIdInput] = useState('DefaultCluster');
+  const examineSequenceRef = useRef(0);
 
   // Plain access config modal
   const [plainModalOpen, setPlainModalOpen] = useState(false);
@@ -393,15 +394,17 @@ const AclPage = () => {
       message.warning(t('acl.inputRequired', { field: t('acl.examineCluster') }));
       return;
     }
+    const sequence = ++examineSequenceRef.current;
     try {
       setConfigLoading(true);
       const config = await examineBrokerClusterAclConfig(clusterId);
+      if (sequence !== examineSequenceRef.current) return;
       setClusterConfig(config);
       message.success(t('acl.configExamined'));
     } catch {
       message.error(t('common.operationFailed'));
     } finally {
-      setConfigLoading(false);
+      if (sequence === examineSequenceRef.current) setConfigLoading(false);
     }
   };
 

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -118,6 +118,7 @@ const InstancePage = () => {
   const [submitting, setSubmitting] = useState(false);
   const requestIdRef = useRef(0);
   const mutationInFlightRef = useRef(false);
+  const [reloadVersion, setReloadVersion] = useState(0);
 
   useEffect(() => {
     const timer = window.setTimeout(() => setDebouncedSearch(search.trim()), 300);
@@ -155,7 +156,7 @@ const InstancePage = () => {
       window.clearTimeout(timer);
       requestIdRef.current += 1;
     };
-  }, [loadInstances]);
+  }, [loadInstances, reloadVersion]);
 
   const cloudVendor = vendor === 'ALIYUN' || vendor === 'TENCENT';
 
@@ -312,7 +313,7 @@ const InstancePage = () => {
           }
         : values;
       const created = await createInstance(payload);
-      await loadInstances();
+      setReloadVersion((v) => v + 1);
       message.success(`实例「${created.name}」添加成功`);
       setAddModalOpen(false);
       addForm.resetFields();
@@ -339,7 +340,7 @@ const InstancePage = () => {
         remark: values.remark || '',
         adminCredentialRef: values.adminCredentialRef,
       });
-      await loadInstances();
+      setReloadVersion((v) => v + 1);
       message.success(`实例「${updated.name}」备注已更新`);
       setEditModalOpen(false);
       editForm.resetFields();
@@ -357,7 +358,7 @@ const InstancePage = () => {
   const handleDelete = async (instance: Instance) => {
     try {
       await deleteInstance(instance.id);
-      await loadInstances();
+      setReloadVersion((v) => v + 1);
       message.success('已删除');
     } catch {
       message.error('删除实例失败，请稍后重试');
@@ -436,8 +437,7 @@ const InstancePage = () => {
       key: 'consumerGroupCount',
       width: 80,
       align: 'center' as const,
-      sorter: (a, b, sortOrder) =>
-        compareResourceCounts(a, b, 'consumerGroupCount', sortOrder),
+      sorter: (a, b, sortOrder) => compareResourceCounts(a, b, 'consumerGroupCount', sortOrder),
       render: (count: number, record: Instance) =>
         record.resourceCountsAvailable === false ? '不可用' : count,
     },

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -269,6 +269,7 @@ const MessagePageContent = ({
 }: InstanceFilterProps) => {
   const { t } = useLang();
   const [topicOptions, setTopicOptions] = useState<string[]>([]);
+  const [topicError, setTopicError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!selectedInstanceId) {
@@ -278,10 +279,13 @@ const MessagePageContent = ({
     void listTopics({ instanceId: selectedInstanceId })
       .then((nextTopics) => {
         if (cancelled) return;
+        setTopicError(null);
         setTopicOptions(nextTopics.map((topic) => topic.name));
       })
-      .catch(() => {
-        if (!cancelled) setTopicOptions([]);
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setTopicOptions([]);
+        setTopicError(error instanceof Error ? error.message : '加载 Topic 列表失败');
       });
     return () => {
       cancelled = true;
@@ -869,6 +873,10 @@ const MessagePageContent = ({
           </Space>
         </Space>
       </Card>
+
+      {topicError && (
+        <Alert showIcon type="error" message={topicError} style={{ marginBottom: 16 }} />
+      )}
 
       {queryError && (
         <Alert showIcon type="warning" message={queryError} style={{ marginBottom: 16 }} />

--- a/web/src/pages/ops/nameServerConfigDrift.tsx
+++ b/web/src/pages/ops/nameServerConfigDrift.tsx
@@ -65,6 +65,7 @@ const NameServerConfigDriftPage = () => {
 
   useEffect(() => {
     let cancelled = false;
+    const sequence = ++requestSequence.current;
     void listInstances()
       .then(async (items) => {
         if (cancelled) return;
@@ -77,17 +78,19 @@ const NameServerConfigDriftPage = () => {
           return;
         }
         const clustersForInstance = await listClusters(firstInstanceId);
-        if (cancelled) return;
+        if (cancelled || sequence !== requestSequence.current) return;
         setClusters(clustersForInstance);
         const firstClusterId = clustersForInstance[0]?.id;
         setSelectedClusterId(firstClusterId);
         if (firstClusterId) void runCheck(firstClusterId, firstInstanceId);
       })
       .catch(() => {
-        if (!cancelled) message.error(t('nameServerDrift.loadClustersFailed'));
+        if (!cancelled && sequence === requestSequence.current) {
+          message.error(t('nameServerDrift.loadClustersFailed'));
+        }
       })
       .finally(() => {
-        if (!cancelled) setClustersLoading(false);
+        if (!cancelled && sequence === requestSequence.current) setClustersLoading(false);
       });
     return () => {
       cancelled = true;
@@ -110,7 +113,8 @@ const NameServerConfigDriftPage = () => {
       setSelectedClusterId(firstClusterId);
       if (firstClusterId) void runCheck(firstClusterId, instanceId);
     } catch {
-      if (sequence === requestSequence.current) message.error(t('nameServerDrift.loadClustersFailed'));
+      if (sequence === requestSequence.current)
+        message.error(t('nameServerDrift.loadClustersFailed'));
     } finally {
       if (sequence === requestSequence.current) setClustersLoading(false);
     }
@@ -221,7 +225,9 @@ const NameServerConfigDriftPage = () => {
             loading={checking}
             disabled={!selectedClusterId || !selectedInstanceId}
             onClick={() =>
-              selectedClusterId && selectedInstanceId && void runCheck(selectedClusterId, selectedInstanceId)
+              selectedClusterId &&
+              selectedInstanceId &&
+              void runCheck(selectedClusterId, selectedInstanceId)
             }
           />
         </Tooltip>

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -88,7 +88,8 @@ const SystemAlertsPage = () => {
     setClearing(true);
     try {
       await clearAcknowledgedAlerts();
-      setAlerts((prev) => prev.filter((a) => !a.acknowledged));
+      const fresh = await listSystemAlerts();
+      setAlerts(fresh);
       message.success(t('sysAlerts.cleared'));
     } catch {
       message.error('清理已确认告警失败，请稍后重试');

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -474,7 +474,7 @@ export const DataSourceTab = () => {
   return (
     <>
       <Flex justify="flex-end" style={{ marginBottom: 16 }}>
-        <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
+        <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal} disabled={loading}>
           添加数据源
         </Button>
       </Flex>


### PR DESCRIPTION
## What is the purpose of the change

Fix #1998.

The local K8s certificate management contract required non-blank name, namespace, cluster and issuer on creation, but partial updates accepted blank strings for those same fields. A successful update could persist an unusable certificate record with missing identity metadata.

## Brief changelog

- K8sCertService.updateCert: reject blank name, namespace, cluster and issuer with a 400 instead of persisting them

## How was this patch verified

- Code review of the partial-update branches
- `git diff --check` clean
