### PR TITLE
test: cover no-redirect HTTP request factories

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
@@ -23,7 +23,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
@@ -68,14 +67,7 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
     protected AbstractPrometheusCompatibleMetricsSource(RestClient.Builder restClientBuilder,
                                                          ObjectMapper objectMapper,
                                                          MetricsSourceSettings settings) {
-        // Disable redirect following to prevent SSRF bypass via HTTP redirect
-        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory() {
-            @Override
-            protected void prepareConnection(java.net.HttpURLConnection connection, String httpMethod) throws IOException {
-                super.prepareConnection(connection, httpMethod);
-                connection.setInstanceFollowRedirects(false);
-            }
-        };
+        NoRedirectClientHttpRequestFactory requestFactory = new NoRedirectClientHttpRequestFactory();
         requestFactory.setConnectTimeout(settings.getConnectTimeout());
         requestFactory.setReadTimeout(settings.getReadTimeout());
         this.restClient = restClientBuilder.requestFactory(requestFactory).build();

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/NoRedirectClientHttpRequestFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/NoRedirectClientHttpRequestFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+class NoRedirectClientHttpRequestFactory extends SimpleClientHttpRequestFactory {
+
+    @Override
+    protected void prepareConnection(HttpURLConnection connection, String httpMethod) throws IOException {
+        super.prepareConnection(connection, httpMethod);
+        connection.setInstanceFollowRedirects(false);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/NoRedirectClientHttpRequestFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/NoRedirectClientHttpRequestFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.proxy;
+
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+class NoRedirectClientHttpRequestFactory extends SimpleClientHttpRequestFactory {
+
+    @Override
+    protected void prepareConnection(HttpURLConnection connection, String httpMethod) throws IOException {
+        super.prepareConnection(connection, httpMethod);
+        connection.setInstanceFollowRedirects(false);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
@@ -21,13 +21,11 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
 import java.time.Duration;
 
 import java.util.ArrayList;
@@ -53,13 +51,7 @@ public class ProxyAddressService {
     private final RestTemplate restTemplate;
 
     public ProxyAddressService() {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory() {
-            @Override
-            protected void prepareConnection(java.net.HttpURLConnection connection, String httpMethod) throws IOException {
-                super.prepareConnection(connection, httpMethod);
-                connection.setInstanceFollowRedirects(false);
-            }
-        };
+        NoRedirectClientHttpRequestFactory factory = new NoRedirectClientHttpRequestFactory();
         factory.setConnectTimeout(Duration.ofSeconds(3));
         factory.setReadTimeout(Duration.ofSeconds(3));
         this.restTemplate = new RestTemplate(factory);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/NoRedirectClientHttpRequestFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/NoRedirectClientHttpRequestFactoryTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoRedirectClientHttpRequestFactoryTest {
+
+    @Test
+    void prepareConnectionShouldDisableRedirectsTest() throws Exception {
+        HttpURLConnection connection = (HttpURLConnection) URI.create("http://example.com")
+                .toURL().openConnection();
+        TestableNoRedirectClientHttpRequestFactory requestFactory =
+                new TestableNoRedirectClientHttpRequestFactory();
+
+        assertThat(connection.getInstanceFollowRedirects()).isTrue();
+
+        requestFactory.prepare(connection, HttpMethod.GET.name());
+
+        assertThat(connection.getInstanceFollowRedirects()).isFalse();
+        connection.disconnect();
+    }
+
+    private static class TestableNoRedirectClientHttpRequestFactory
+            extends NoRedirectClientHttpRequestFactory {
+
+        void prepare(HttpURLConnection connection, String httpMethod) throws Exception {
+            prepareConnection(connection, httpMethod);
+        }
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/NoRedirectClientHttpRequestFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/NoRedirectClientHttpRequestFactoryTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoRedirectClientHttpRequestFactoryTest {
+
+    @Test
+    void prepareConnectionShouldDisableRedirectsTest() throws Exception {
+        HttpURLConnection connection = (HttpURLConnection) URI.create("http://example.com")
+                .toURL().openConnection();
+        TestableNoRedirectClientHttpRequestFactory requestFactory =
+                new TestableNoRedirectClientHttpRequestFactory();
+
+        assertThat(connection.getInstanceFollowRedirects()).isTrue();
+
+        requestFactory.prepare(connection, HttpMethod.POST.name());
+
+        assertThat(connection.getInstanceFollowRedirects()).isFalse();
+        connection.disconnect();
+    }
+
+    private static class TestableNoRedirectClientHttpRequestFactory
+            extends NoRedirectClientHttpRequestFactory {
+
+        void prepare(HttpURLConnection connection, String httpMethod) throws Exception {
+            prepareConnection(connection, httpMethod);
+        }
+    }
+}


### PR DESCRIPTION
Adds direct regression coverage for the no-redirect HTTP request factories used by settings data-source checks, metrics queries, and proxy reloads.

The metrics and proxy implementations now use package-private factory classes instead of anonymous overrides, allowing tests to verify that each `HttpURLConnection` has redirect following disabled without changing the request behavior.

## Testing

```bash
cd server
mvn -DskipTests=false "-Dtest=DataSourceClientHttpRequestFactoryTest,org.apache.rocketmq.studio.cluster.metrics.NoRedirectClientHttpRequestFactoryTest,org.apache.rocketmq.studio.cluster.proxy.NoRedirectClientHttpRequestFactoryTest,ProxyAddressServiceTest" test
```

`BUILD SUCCESS` — 13 tests, 0 failures, 0 errors.
