### PR TITLE
test: cover early provider bug regressions

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemGroupFilterTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemGroupFilterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SystemGroupFilterTest {
+
+    @Test
+    void shouldRecognizeKnownSystemConsumerGroupPrefixesTest() {
+        assertThat(SystemGroupFilter.isSystem(null)).isTrue();
+        assertThat(SystemGroupFilter.isSystem("")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("CID_RMQ_SYS_TRANS")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("CID_ONSAPI_OWNER")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("CID_SYS_RMQ_TRANS")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("CID_HOUSEKEEPING")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("rmq_sys_TRACE_DATA")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("%RETRY%consumer-a")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("%DLQ%consumer-a")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("TOOLS_CONSUMER_monitor")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("FILTERSRV_CONSUMER_filter")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("SELF_TEST_GROUP")).isTrue();
+
+        assertThat(SystemGroupFilter.isSystem("order-service-consumer")).isFalse();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -227,6 +227,55 @@ class RocketMQDLQProviderTest {
     }
 
     @Test
+    void resendMessagesRetriesFromCorrectedOffsetAfterOffsetIllegal() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        MessageQueue queue = new MessageQueue(dlqTopic, "broker-a", 0);
+        MessageExt deadLetter = new MessageExt();
+        deadLetter.setMsgId("dlq-after-correction");
+        deadLetter.setTopic(dlqTopic);
+        deadLetter.setBody(new byte[] {1, 2, 3});
+        deadLetter.setStoreTimestamp(150L);
+        PullResult illegalOffset = new PullResult(PullStatus.OFFSET_ILLEGAL, 20L, 0L, 30L, null);
+        PullResult foundAfterCorrection = new PullResult(PullStatus.FOUND, 40L, 20L, 30L, List.of(deadLetter));
+        PullResult endOfQueue = new PullResult(PullStatus.NO_NEW_MSG, 50L, 40L, 40L, List.of());
+        SendResult sendResult = new SendResult();
+        sendResult.setSendStatus(SendStatus.SEND_OK);
+
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(Set.of(queue));
+                         when(consumer.searchOffset(queue, 100L)).thenReturn(10L);
+                         when(consumer.searchOffset(queue, 200L)).thenReturn(50L);
+                         when(consumer.pull(queue, "*", 10L, 32)).thenReturn(illegalOffset);
+                         when(consumer.pull(queue, "*", 20L, 32)).thenReturn(foundAfterCorrection);
+                         when(consumer.pull(queue, "*", 40L, 32)).thenReturn(endOfQueue);
+                         doNothing().when(consumer).shutdown();
+                     });
+             MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class, (producer, context) -> {
+                         doNothing().when(producer).start();
+                         when(producer.send(any(Message.class))).thenReturn(sendResult);
+                         doNothing().when(producer).shutdown();
+                     })) {
+            assertThat(provider.resendMessages("instance-a", "group-a", 100L, 200L, "orders"))
+                    .extracting("matched", "resent", "failed", "outcome")
+                    .containsExactly(1, 1, 0, "SUCCESS");
+
+            DefaultMQPullConsumer consumer = mockedConsumers.constructed().get(0);
+            verify(consumer).pull(queue, "*", 10L, 32);
+            verify(consumer).pull(queue, "*", 20L, 32);
+            verify(consumer).pull(queue, "*", 40L, 32);
+            verify(mockedProducers.constructed().get(0)).send(any(Message.class));
+        }
+        verify(auditService).record(
+                eq("RESEND_DLQ"),
+                eq("group-a"),
+                contains("matched=1, resent=1, failed=0"),
+                eq("SUCCESS"));
+    }
+
+    @Test
     void resendMessagesCountsNonSendOkResultsAsFailures() throws Exception {
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
         MessageQueue queue = new MessageQueue(dlqTopic, "broker-a", 0);

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -188,6 +188,41 @@ class RocketMQMessageProviderTest {
     }
 
     @Test
+    void queryByTopicRetriesFromCorrectedOffsetAfterOffsetIllegal() throws Exception {
+        MessageQueue queue = new MessageQueue("TopicA", "broker-a", 0);
+        MessageExt message = new MessageExt();
+        message.setMsgId("msg-after-correction");
+        message.setTopic("TopicA");
+        message.setBody("payload".getBytes(StandardCharsets.UTF_8));
+        message.setStoreTimestamp(150L);
+        PullResult illegalOffset = new PullResult(PullStatus.OFFSET_ILLEGAL, 20L, 0L, 30L, null);
+        PullResult foundAfterCorrection = new PullResult(PullStatus.FOUND, 40L, 20L, 30L, List.of(message));
+        PullResult endOfQueue = new PullResult(PullStatus.NO_NEW_MSG, 50L, 40L, 40L, List.of());
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues("TopicA")).thenReturn(Set.of(queue));
+                         when(consumer.searchOffset(queue, 100L)).thenReturn(10L);
+                         when(consumer.searchOffset(queue, 200L)).thenReturn(50L);
+                         when(consumer.pull(eq(queue), eq("*"), eq(10L), eq(32))).thenReturn(illegalOffset);
+                         when(consumer.pull(eq(queue), eq("*"), eq(20L), eq(32))).thenReturn(foundAfterCorrection);
+                         when(consumer.pull(eq(queue), eq("*"), eq(40L), eq(32))).thenReturn(endOfQueue);
+                         doNothing().when(consumer).shutdown();
+                     })) {
+            List<MessageRecordVO> messages = provider.queryMessages(
+                    "instance-a", "TopicA", null, null, null, 100L, 200L);
+
+            assertThat(messages).extracting(MessageRecordVO::getMsgId).containsExactly("msg-after-correction");
+            DefaultMQPullConsumer consumer = mockedConsumers.constructed().get(0);
+            verify(consumer).pull(queue, "*", 10L, 32);
+            verify(consumer).pull(queue, "*", 20L, 32);
+            verify(consumer).pull(queue, "*", 40L, 32);
+        }
+        verify(queryHistoryService).recordMessageQuery("instance-a", "TOPIC", "TopicA", null, null, null,
+                100L, 200L, 1);
+    }
+
+    @Test
     void toRecordVOBoundsMessageBodyAndProperties() {
         MessageExt message = new MessageExt();
         message.setMsgId("msg-1");


### PR DESCRIPTION
Adds regression tests for provider fixes that were already present but not directly covered:

- topic queries resume from the broker-provided offset after `OFFSET_ILLEGAL`;
- DLQ scans do the same instead of abandoning the queue;
- system consumer groups are filtered through the shared rules;
- dashboard topic and group counts are calculated per cluster.

## Testing

```bash
cd server
mvn -DskipTests=false "-Dtest=RocketMQMessageProviderTest#queryByTopicRetriesFromCorrectedOffsetAfterOffsetIllegal,RocketMQDLQProviderTest#resendMessagesRetriesFromCorrectedOffsetAfterOffsetIllegal,SystemGroupFilterTest,RocketMQDashboardProviderTest#dashboardShouldCountTopicsFromBrokerConfigWithoutPerTopicRouteRequests+dashboardShouldDeduplicateGroupsReportedByMultipleClusterBrokers" test
```

`BUILD SUCCESS` — 5 tests, 0 failures, 0 errors.
