### PR TITLE
test: cover alert and message query validation

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -351,6 +351,51 @@ class AlertServiceTest {
     }
 
     @Test
+    void exportPrometheusRulesYamlShouldPrefixAlertNamesStartingWithDigit() throws Exception {
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .name("5xx spike")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(1)
+                .enabled(true)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+
+        String result = alertService.exportPrometheusRulesYaml();
+
+        JsonNode exportedRule = new ObjectMapper(new YAMLFactory()).readTree(result)
+                .path("groups").get(0).path("rules").get(0);
+        assertThat(exportedRule.path("alert").asText()).isEqualTo("A_5xxspike");
+        assertThat(result).contains("# Rule 1: A_5xxspike");
+    }
+
+    @Test
+    void exportPrometheusRulesYamlShouldReplaceNonFiniteThresholds() throws Exception {
+        AlertRuleVO nanRule = AlertRuleVO.builder()
+                .name("Bad Threshold A")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(Double.NaN)
+                .enabled(true)
+                .build();
+        AlertRuleVO infinityRule = AlertRuleVO.builder()
+                .name("Bad Threshold B")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator("<")
+                .threshold(Double.POSITIVE_INFINITY)
+                .enabled(true)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(nanRule, infinityRule));
+
+        String result = alertService.exportPrometheusRulesYaml();
+
+        JsonNode rules = new ObjectMapper(new YAMLFactory()).readTree(result).path("groups").get(0).path("rules");
+        assertThat(rules.get(0).path("expr").asText()).isEqualTo("rocketmq_consumer_lag_messages > 0");
+        assertThat(rules.get(1).path("expr").asText()).isEqualTo("rocketmq_consumer_lag_messages < 0");
+        assertThat(result).doesNotContain("NaN", "Infinity");
+    }
+
+    @Test
     void exportPrometheusRulesYamlShouldExcludeDisabledRules() {
         AlertRuleVO enabled = AlertRuleVO.builder()
                 .name("Enabled Lag Alert")

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -111,6 +111,36 @@ class RocketMQMessageProviderTest {
     }
 
     @Test
+    void queryMessagesShouldRejectInvertedTimeRangeBeforeAdminLookup() throws Exception {
+        assertThatThrownBy(() -> provider.queryMessages(
+                "instance-a", "TopicA", null, null, null, 200L, 100L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Message query start time must be before end time")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+
+        verify(runtimeAdminClientResolver).resolveEndpoint("instance-a");
+        verify(runtimeAdminClientResolver).execute(eq("instance-a"), any());
+        verify(adminExt, never()).queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong());
+        verify(queryHistoryService, never()).recordMessageQuery(anyString(), anyString(), anyString(),
+                anyString(), anyString(), anyString(), any(), any(), anyInt());
+    }
+
+    @Test
+    void queryMessagesShouldRejectEqualTimeRangeBeforeAdminLookup() throws Exception {
+        assertThatThrownBy(() -> provider.queryMessages(
+                "instance-a", "TopicA", null, null, null, 100L, 100L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Message query start time must be before end time")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+
+        verify(runtimeAdminClientResolver).resolveEndpoint("instance-a");
+        verify(runtimeAdminClientResolver).execute(eq("instance-a"), any());
+        verify(adminExt, never()).queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong());
+        verify(queryHistoryService, never()).recordMessageQuery(anyString(), anyString(), anyString(),
+                anyString(), anyString(), anyString(), any(), any(), anyInt());
+    }
+
+    @Test
     void queryByKeySurfacesAdminFailure() throws Exception {
         when(adminExt.queryMessage("TopicA", "order-1", 64, 100L, 200L))
                 .thenThrow(new IllegalStateException("broker unavailable"));


### PR DESCRIPTION
Adds focused regression coverage for validation and result-normalization paths that are easy to break during provider changes:

- safe Prometheus alert names and finite threshold values;
- message-query time-range validation before broker access;
- DLQ resend outcomes for empty, failed, and partially scanned requests;
- TPS parsing with whitespace and values larger than the integer range.

## Testing

```bash
cd server
mvn -DskipTests=false "-Dtest=AlertServiceTest#exportPrometheusRulesYamlShouldPrefixAlertNamesStartingWithDigit+exportPrometheusRulesYamlShouldReplaceNonFiniteThresholds,RocketMQMessageProviderTest#queryMessagesShouldRejectInvertedTimeRangeBeforeAdminLookup+queryMessagesShouldRejectEqualTimeRangeBeforeAdminLookup,RocketMQDLQProviderTest#resendMessagesDoesNotPullWhenDlqQueueSetIsNull+resendMessagesCountsNonSendOkResultsAsFailures+resendMessagesMarksAResultPartialWhenOneDlqQueueCannotBeScanned,RocketMQClusterProviderTest#discoverClustersShouldParseRuntimeTpsWithExtraWhitespace+discoverClustersShouldKeepOneMinuteTpsAboveIntegerRange,RocketMQDashboardProviderTest#dashboardShouldKeepPerClusterTpsAboveIntegerRange" test
```

`BUILD SUCCESS` — 10 tests, 0 failures, 0 errors.
