### PR TITLE
test: cover reset offset and group list regressions

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -135,6 +135,18 @@ class RocketMQAdminClientImplTest {
     }
 
     @Test
+    void resetOffsetShouldRejectBlankTopicBeforeResolvingAdmin() {
+        assertThatThrownBy(() -> adminClient.resetOffset("instance-a", "cg-orders", 1784246400000L, " "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topic is required for offset reset")
+                .satisfies(exception -> assertThat(((BusinessException) exception).getCode()).isEqualTo(400));
+
+        verifyNoInteractions(runtimeAdminClientResolver);
+        verify(adminFactory, never()).execute(anyString(), any(), any());
+        verifyNoInteractions(auditService);
+    }
+
+    @Test
     void getConsumerGroupSurfacesAdminTimeout() throws Exception {
         when(adminExt.examineConsumerConnectionInfo("orders"))
                 .thenThrow(new RemotingTimeoutException("broker-0", 3_000));

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
@@ -54,6 +54,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -109,6 +110,31 @@ class RocketMQMetadataProviderTest {
 
         assertThat(groups).hasSize(1);
         assertThat(groups.get(0).getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
+    }
+
+    @Test
+    void listConsumerGroupsShouldNotFetchLiveAdminInfoForEachGroup() {
+        RmqGroup first = new RmqGroup();
+        first.setName("group-a");
+        first.setClusterId("cluster-1");
+        first.setConsumeType("CLUSTERING");
+        first.setMaxRetry(16);
+        RmqGroup second = new RmqGroup();
+        second.setName("group-b");
+        second.setClusterId("cluster-1");
+        second.setConsumeType("BROADCASTING");
+        second.setMaxRetry(3);
+        when(groupMapper.selectList(any())).thenReturn(List.of(first, second));
+
+        RocketMQMetadataProvider provider = newProvider();
+
+        List<ConsumerGroupVO> groups = provider.listConsumerGroups("cluster-1", null);
+
+        assertThat(groups).extracting(ConsumerGroupVO::getName).containsExactly("group-a", "group-b");
+        assertThat(groups).extracting(ConsumerGroupVO::getOnlineInstances).containsExactly(0, 0);
+        assertThat(groups).extracting(ConsumerGroupVO::getTotalLag).containsExactly(0L, 0L);
+        verify(groupMapper).selectList(any());
+        verifyNoInteractions(runtimeAdminClientResolver);
     }
 
     @Test


### PR DESCRIPTION
Adds regression coverage for three provider boundaries:

- offset reset rejects a blank topic before resolving an admin client;
- message sending rejects UTF-8 payloads above the 4 MiB limit while accepting the exact boundary;
- consumer-group listing uses stored metadata without an N+1 live-admin lookup for every group.

## Testing

```bash
cd server
mvn -DskipTests=false "-Dtest=RocketMQAdminClientImplTest#resetOffsetShouldRejectBlankTopicBeforeResolvingAdmin+sendMessageShouldRejectOversizedUtf8BodyBeforeResolvingEndpointOrCreatingProducer+sendMessageShouldAllowBodyAtMaximumSize,RocketMQMetadataProviderTest#listConsumerGroupsShouldNotFetchLiveAdminInfoForEachGroup+listConsumerGroupsReadsConsumeTypeColumn+listConsumerGroupsFallsBackToClusteringWhenConsumeTypeIsBlank" test
```

`BUILD SUCCESS` — 6 tests, 0 failures, 0 errors.
