### PR TITLE
test: cover K8s cert update type validation

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
@@ -216,6 +216,23 @@ class K8sCertControllerTest {
     }
 
     @Test
+    void updateCertShouldRejectUnsupportedType() throws Exception {
+        mockMvc.perform(post("/api/k8s-certs/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "id": "cert-1",
+                                    "type": "PEM"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("type must be one of TLS, mTLS, ServiceAccount"));
+
+        verifyNoInteractions(k8sCertService);
+    }
+
+    @Test
     void renewCertShouldRejectBlankId() throws Exception {
         mockMvc.perform(post("/api/k8s-certs/renew")
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
This PR added the missing MockMvc test for an unsupported certificate type on `/api/k8s-certs/update`. The test verifies the 400 response and confirms that validation prevents the service call.

The standalone PR was closed after the test moved alongside the K8s service fix. That complete service and controller coverage is now part of consolidated PR #2163, which replaces the closed #1827 branch.