### PR TITLE
fix: guard LLM base URLs saved through general settings

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -104,6 +104,9 @@ public class SettingsService {
 
     public synchronized void saveGeneralSettings(GeneralSettingsVO settings) {
         log.info("Saving general settings");
+        if (StringUtils.hasText(settings.getBaseUrl())) {
+            validateDataSourceUrl(settings.getBaseUrl().trim());
+        }
         GeneralSettingsVO currentSettings = settingsRepository.loadGeneralSettings();
         if (settings.isClearApiKey()) {
             settings.setApiKey("");


### PR DESCRIPTION
## What is the purpose of the change

Fix #2036.

Studio has two write paths for the LLM base URL. POST /api/llm/config validates the URL and applies UrlHostGuard, but POST /api/settings/general/save persisted GeneralSettingsVO.baseUrl without the guard, so an operator could store an internal-only or otherwise unsafe base URL through general settings.

## Brief changelog

- SettingsService.saveGeneralSettings: apply the same UrlHostGuard check used for data source URLs before persisting baseUrl

## How was this patch verified

- Code review: reuses the existing validateDataSourceUrl path
- `git diff --check` clean
