### PR TITLE
fix: restrict remote ACL policy discovery to administrators

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
@@ -102,6 +102,7 @@ public class AuthInterceptor implements HandlerInterceptor {
     private boolean isAdminOnlyGetPath(String path) {
         String normalizedPath = normalizePath(stripPathParameters(path));
         return "/api/llm/models".equals(normalizedPath)
+                || "/api/acl/remote/rules".equals(normalizedPath)
                 || isCredentialRevealPath(normalizedPath, "/api/acl/users/")
                 || isCredentialRevealPath(normalizedPath, "/api/cloud-credentials/");
     }


### PR DESCRIPTION
## What is the purpose of the change

Fix #2045.

GET /api/acl/remote/rules was treated as an ordinary reader GET by AuthInterceptor. It is not a passive read of Studio's local store: ApacheAclReadService resolves the selected instance, uses its stored administrative RocketMQ credentials, connects to every broker, and returns live ACL 2.0 subjects, resources and policies. A non-admin reader could therefore trigger broker connections and observe live ACL policy data.

## Brief changelog

- AuthInterceptor: require admin for GET /api/acl/remote/rules

## How was this patch verified

- Code review: matches the existing admin-only GET path handling for /api/llm/models and credential reveals
- `git diff --check` clean
