### PR TITLE
fix(web): preserve alert rule cluster and broker scope when editing

### DIFF
--- a/web/src/pages/studio/AlertManagement.tsx
+++ b/web/src/pages/studio/AlertManagement.tsx
@@ -247,15 +247,51 @@ function parseExpression(
   };
 }
 
+function parseScopeLabels(metric: string): {
+  metric: string;
+  clusterName?: string;
+  brokerName?: string;
+} {
+  const open = metric.indexOf('{');
+  if (open < 0) return { metric };
+  const metricName = metric.slice(0, open).trim();
+  const inner = metric.slice(open + 1, metric.lastIndexOf('}'));
+  let clusterName: string | undefined;
+  let brokerName: string | undefined;
+  const remaining: string[] = [];
+  for (const part of inner.split(',')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    const key = part.slice(0, eq).trim();
+    const raw = part.slice(eq + 1).trim();
+    const value = raw.replace(/^"|"$/g, '').replace(/\\\\/g, '\\').replace(/\\"/g, '"');
+    if (key === 'cluster') clusterName = value;
+    else if (key === 'broker') brokerName = value;
+    else remaining.push(part.trim());
+  }
+  // Rebuild the metric expression preserving every non-scope label.
+  const metricExpr =
+    remaining.length > 0
+      ? `${metricName}{${remaining.join(',')}}`
+      : clusterName || brokerName
+        ? metricName
+        : metric;
+  return { metric: metricExpr, clusterName, brokerName };
+}
+
 function toAlertRuleRequest(
   values: AlertRuleFormValues,
   editingRule: AlertRule | null,
 ): AlertRuleRequest {
   const expression = parseExpression(values.expr);
+  const scope = parseScopeLabels(expression.metric ?? '');
   return {
     id: editingRule?.id,
     name: values.alert.trim(),
     ...expression,
+    metric: scope.metric,
+    clusterName: scope.clusterName,
+    brokerName: scope.brokerName,
     duration: values.for,
     enabled: values.enabled ?? true,
     description: combineDescription(values.summary, values.description),


### PR DESCRIPTION
## What is the purpose of the change

Fix #1986.

The persisted alert-rule editor rendered clusterName and brokerName as a PromQL selector in the expression field, but toAlertRuleRequest later submitted the entire metric{labels} fragment as metric and omitted both scope fields. Editing and saving therefore dropped the cluster and broker scope.

## Brief changelog

- AlertManagement: parse cluster and broker labels out of the expression when building the update request and preserve them in clusterName/brokerName
- other labels (e.g. job) are kept in the metric expression

## How was this patch verified

- npx vitest run src/pages/studio/__tests__/AlertManagement.test.tsx (9 passed)
- npx tsc -b clean
- npx eslint . clean
