### PR TITLE
fix: do not recreate concurrently deleted ACL users

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclRepository.java
@@ -39,6 +39,12 @@ public interface AclRepository {
 
     AclUserVO saveUser(AclUserVO user);
 
+    /**
+     * Replaces an existing user atomically without creating a missing user.
+     * Returns empty when the user no longer exists.
+     */
+    Optional<AclUserVO> replaceUser(AclUserVO user);
+
     boolean deleteUser(String id);
 
     /**

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -134,7 +134,8 @@ public class AclService {
                 .clusters(user.getClusters() == null ? existing.getClusters() : user.getClusters())
                 .createdAt(existing.getCreatedAt())
                 .build();
-        AclUserVO saved = aclRepository.saveUser(merged);
+        AclUserVO saved = aclRepository.replaceUser(merged)
+                .orElseThrow(() -> new BusinessException(404, "ACL user not found: " + user.getId()));
         auditUser("UPDATE_ACL_USER", saved);
         return maskCredentials(saved);
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -112,6 +112,19 @@ public class MybatisPlusAclRepository implements AclRepository {
     }
 
     @Override
+    public Optional<AclUserVO> replaceUser(AclUserVO user) {
+        RmqAclUser existing = userMapper.selectById(user.getId());
+        if (existing == null) {
+            return Optional.empty();
+        }
+        RmqAclUser entity = toUserEntity(user);
+        entity.setCreatedAt(existing.getCreatedAt());
+        userMapper.updateById(entity);
+        user.setCreatedAt(existing.getCreatedAt());
+        return Optional.of(user);
+    }
+
+    @Override
     public boolean deleteUser(String id) {
         return userMapper.deleteById(id) > 0;
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -411,7 +411,7 @@ class AclServiceTest {
 
         ArgumentCaptor<AclUserVO> captor = ArgumentCaptor.forClass(AclUserVO.class);
         when(aclRepository.findUserById("user-1")).thenReturn(Optional.of(existingUser));
-        when(aclRepository.saveUser(any(AclUserVO.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(aclRepository.replaceUser(any(AclUserVO.class))).thenAnswer(inv -> Optional.of(inv.getArgument(0)));
 
         AclUserVO result = aclService.updateUser(input);
 
@@ -420,7 +420,7 @@ class AclServiceTest {
         assertThat(result.getAccessKey()).isEqualTo("acce****3456");
         assertThat(result.getSecretKey()).isEqualTo("secr****7654");
         assertThat(result.isAdmin()).isTrue();
-        verify(aclRepository).saveUser(captor.capture());
+        verify(aclRepository).replaceUser(captor.capture());
         assertThat(captor.getValue().getAccessKey()).isEqualTo("access-key-123456");
         assertThat(captor.getValue().getSecretKey()).isEqualTo("secret-key-987654");
         verify(operationAuditService).record(eq("UPDATE_ACL_USER"), eq("ACL_USER"), eq("user-1"), eq(null),
@@ -444,13 +444,13 @@ class AclServiceTest {
 
         ArgumentCaptor<AclUserVO> captor = ArgumentCaptor.forClass(AclUserVO.class);
         when(aclRepository.findUserById("user-1")).thenReturn(Optional.of(adminUser));
-        when(aclRepository.saveUser(any(AclUserVO.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(aclRepository.replaceUser(any(AclUserVO.class))).thenAnswer(inv -> Optional.of(inv.getArgument(0)));
 
         AclUserVO result = aclService.updateUser(input);
 
         assertThat(result.getUsername()).isEqualTo("renamed");
         assertThat(result.isAdmin()).isTrue();
-        verify(aclRepository).saveUser(captor.capture());
+        verify(aclRepository).replaceUser(captor.capture());
         assertThat(captor.getValue().isAdmin()).isTrue();
     }
 
@@ -519,6 +519,11 @@ class AclServiceTest {
             return invocation.getArgument(0);
         });
         when(aclRepository.findUserById(any())).thenAnswer(invocation -> Optional.ofNullable(stored.get()));
+        when(aclRepository.replaceUser(any(AclUserVO.class))).thenAnswer(invocation -> {
+            AclUserVO incoming = invocation.getArgument(0);
+            stored.set(incoming);
+            return Optional.of(incoming);
+        });
         when(aclRepository.findUsers()).thenAnswer(invocation -> List.of(stored.get()));
 
         AclUserVO created = aclService.createUser(AclUserVO.builder()


### PR DESCRIPTION
## What is the purpose of the change

Fix #2006.

AclService.updateUser loaded an existing ACL user, merged editable fields while preserving credentials, and called AclRepository.saveUser. The MyBatis implementation of saveUser performs a second existence check and inserts when the row is absent. If a delete request removed the user after updateUser read it, saveUser re-created the deleted user with the stale credentials.

## Brief changelog

- AclRepository: add replaceUser that updates an existing user without ever inserting a missing one (mirrors replaceRule)
- MybatisPlusAclRepository: implement replaceUser using the existing row's createdAt
- AclService.updateUser: use replaceUser and return 404 when the user no longer exists

## How was this patch verified

- Code review: matches the existing replaceRule pattern used for concurrent rule updates
- `git diff --check` clean
