### PR TITLE
fix: export selected alert rules and classify proxy metrics correctly

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -290,6 +290,9 @@ public class AlertService {
         if (!hasText(metric)) {
             return "broker";
         }
+        if (metric.contains("rocketmq_proxy") || metric.contains("proxy")) {
+            return "proxy";
+        }
         if (metric.contains("replication") || metric.contains("fall_behind") || metric.contains("slave")) {
             return "broker";
         }

--- a/web/src/pages/studio/AlertManagement.tsx
+++ b/web/src/pages/studio/AlertManagement.tsx
@@ -168,6 +168,44 @@ function parseYamlRules(yamlStr: string): AlertRule[] {
   return rules;
 }
 
+function escapeYamlText(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/** Builds a Prometheus-format YAML string for a specific set of alert rules. */
+function buildSelectedRulesYaml(rules: AlertRule[]): string {
+  if (rules.length === 0) return '';
+  const groups = new Map<string, AlertRule[]>();
+  for (const rule of rules) {
+    const group = rule.group || 'rules';
+    const list = groups.get(group) ?? [];
+    list.push(rule);
+    groups.set(group, list);
+  }
+  const lines: string[] = [];
+  let index = 0;
+  for (const [group, groupRules] of groups) {
+    lines.push('- name: ' + group);
+    lines.push('  rules:');
+    for (const rule of groupRules) {
+      index += 1;
+      lines.push(`    # Rule ${index}:`);
+      lines.push(`    - alert: ${rule.alert}`);
+      lines.push(`      expr: ${rule.expr}`);
+      lines.push(`      for: ${rule.for}`);
+      lines.push(`      labels:`);
+      lines.push(`        severity: ${rule.severity}`);
+      lines.push(`        team: ${rule.team}`);
+      lines.push(`      annotations:`);
+      lines.push(`        summary: "${escapeYamlText(rule.summary || rule.alert)}"`);
+      if (rule.description) {
+        lines.push(`        description: "${escapeYamlText(rule.description)}"`);
+      }
+    }
+  }
+  return lines.join('\n') + '\n';
+}
+
 function buildExpression(rule: PersistedAlertRule): string {
   const metric = scopedMetric(rule);
   const operator = rule.operator || '>';
@@ -443,6 +481,12 @@ const AlertManagementPage: React.FC = () => {
 
   const handleExportYaml = async () => {
     try {
+      if (selectedRuleKeys.length > 0) {
+        const rulesYaml = buildSelectedRulesYaml(selectedRules);
+        downloadBlob(new Blob([rulesYaml], { type: 'text/yaml' }), 'rocketmq-alert-rules.yaml');
+        message.success(t('alertMgmt.exportSuccess'));
+        return;
+      }
       const data = await exportAlertRulesYaml();
       downloadBlob(new Blob([data.rules], { type: 'text/yaml' }), 'rocketmq-alert-rules.yaml');
       message.success(t('alertMgmt.exportSuccess'));

--- a/web/src/pages/studio/__tests__/AlertManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/AlertManagement.test.tsx
@@ -183,7 +183,7 @@ describe('AlertManagementPage', () => {
     expect(within(brokerRow!).getAllByRole('button')[0]).toBeDisabled();
   });
 
-  it('exports the server-side YAML verbatim when rows are selected', async () => {
+  it('exports only the selected rows as YAML', async () => {
     const user = userEvent.setup();
     renderWithProviders(<AlertManagementPage />);
 
@@ -196,12 +196,13 @@ describe('AlertManagementPage', () => {
     await user.click(screen.getByRole('button', { name: '导出 YAML' }));
 
     await waitFor(() => {
-      expect(exportAlertRulesYaml).toHaveBeenCalledTimes(1);
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
     });
-    expect(createObjectURL).toHaveBeenCalledTimes(1);
     const blob = createObjectURL.mock.calls[0][0] as Blob;
     const yaml = await blob.text();
-    expect(yaml).toBe(rulesYaml);
+    expect(yaml).toContain('alert: BrokerDown');
+    expect(yaml).not.toContain('ConsumerLagHigh');
+    expect(exportAlertRulesYaml).not.toHaveBeenCalled();
     expect(clickSpy).toHaveBeenCalledTimes(1);
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:alert-rules');
   });
@@ -320,7 +321,7 @@ describe('AlertManagementPage', () => {
     expect(screen.queryByText('BrokerDown')).not.toBeInTheDocument();
   });
 
-  it('preserves selected rules while filtering the table', async () => {
+  it('exports the selected rows even when filtered out of the table', async () => {
     const user = userEvent.setup();
     renderWithProviders(<AlertManagementPage />);
 
@@ -338,6 +339,6 @@ describe('AlertManagementPage', () => {
     const blob = createObjectURL.mock.calls[0][0] as Blob;
     const yaml = await blob.text();
     expect(yaml).toContain('alert: BrokerDown');
-    expect(yaml).toContain('alert: ConsumerLagHigh');
+    expect(yaml).not.toContain('ConsumerLagHigh');
   });
 });


### PR DESCRIPTION
## What is the purpose of the change

Fix #1984.

The Studio alert-management page exposed row selection, but handleExportYaml ignored the selected rows and always called the unfiltered /api/alert-rules/export endpoint. Selecting one enabled rule therefore downloaded every enabled rule. The export path also inferred every custom rocketmq_proxy_* metric as the broker team.

## Brief changelog

- AlertManagement: when rows are selected, build the exported YAML from the selected rules only
- AlertService: classify rocketmq_proxy_* metrics as the proxy team

## How was this patch verified

- npx vitest run src/pages/studio/__tests__/AlertManagement.test.tsx (9 passed)
- npx tsc -b clean
- `git diff --check` clean
