### PR TITLE
fix: do not resurrect concurrently cleared system alerts

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
@@ -32,5 +32,8 @@ public interface AlertRepository {
 
     SystemAlertVO saveAlert(SystemAlertVO alert);
 
+    /** Updates an existing system alert without re-inserting a deleted one. */
+    boolean replaceAlert(SystemAlertVO alert);
+
     int deleteAcknowledgedAlerts();
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -155,10 +155,12 @@ public class AlertService {
                 .findFirst()
                 .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "System alert not found: " + id));
         alert.setAcknowledged(true);
-        SystemAlertVO saved = alertRepository.saveAlert(alert);
-        recordAudit("ACKNOWLEDGE_SYSTEM_ALERT", "SYSTEM_ALERT", saved.getId(), null,
+        if (!alertRepository.replaceAlert(alert)) {
+            throw new org.apache.rocketmq.studio.common.exception.BusinessException(404, "System alert not found: " + id);
+        }
+        recordAudit("ACKNOWLEDGE_SYSTEM_ALERT", "SYSTEM_ALERT", alert.getId(), null,
                 "acknowledged=true");
-        return saved;
+        return alert;
     }
 
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -98,6 +98,16 @@ public class MybatisPlusAlertRepository implements AlertRepository {
     }
 
     @Override
+    public boolean replaceAlert(SystemAlertVO alert) {
+        RmqSystemAlert existing = alertMapper.selectById(alert.getId());
+        if (existing == null) {
+            return false;
+        }
+        alertMapper.updateById(toAlertEntity(alert));
+        return true;
+    }
+
+    @Override
     public int deleteAcknowledgedAlerts() {
         return Math.toIntExact(alertMapper.delete(
                 new QueryWrapper<RmqSystemAlert>().eq("acknowledged", true)));

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -565,12 +565,12 @@ class AlertServiceTest {
         SystemAlertVO existing = SystemAlertVO.builder().id("a1").level(AlertLevel.error)
                 .title("Broker Down").acknowledged(false).build();
         when(alertRepository.findAlerts(null)).thenReturn(List.of(existing));
-        when(alertRepository.saveAlert(any(SystemAlertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(alertRepository.replaceAlert(any(SystemAlertVO.class))).thenReturn(true);
 
         SystemAlertVO result = alertService.acknowledgeAlert("a1");
 
         assertThat(result.isAcknowledged()).isTrue();
-        verify(alertRepository).saveAlert(result);
+        verify(alertRepository).replaceAlert(result);
         verify(operationAuditService).record(eq("ACKNOWLEDGE_SYSTEM_ALERT"), eq("SYSTEM_ALERT"), eq("a1"),
                 eq(null), eq("acknowledged=true"), eq("SUCCESS"), eq(null));
     }


### PR DESCRIPTION
## What is the purpose of the change

Fix #2004.

AlertService.acknowledgeAlert reads a system alert and then calls AlertRepository.saveAlert. The MyBatis repository implements saveAlert as an upsert: it selects by ID and inserts when the row is absent. If clearAcknowledged deletes the alert after the acknowledgement request read it but before saveAlert runs, the acknowledgement path re-inserts the deleted alert.

## Brief changelog

- AlertRepository: add replaceAlert that updates an existing alert without inserting a missing one
- MybatisPlusAlertRepository: implement replaceAlert
- AlertService.acknowledgeAlert: use replaceAlert and return 404 when the alert no longer exists

## How was this patch verified

- Code review: mirrors the replaceRule / replaceUser update-only patterns
- `git diff --check` clean
