### PR TITLE
fix: preserve instance admin credentials on NameServer drift reads

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffService.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 import org.apache.rocketmq.studio.cluster.broker.ClusterVO;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 
 import lombok.RequiredArgsConstructor;
@@ -70,19 +71,22 @@ public class NameServerConfigDiffService {
 
     private final ClusterService clusterService;
     private final MqAdminExtFactory adminFactory;
+    private final RuntimeAdminClientResolver adminClientResolver;
 
     public NameServerConfigDiffVO compare(String clusterId) {
         String normalizedClusterId = requireClusterId(clusterId);
-        return compare(normalizedClusterId, clusterService.getCluster(normalizedClusterId));
+        return compare(normalizedClusterId, clusterService.getCluster(normalizedClusterId), null);
     }
 
     public NameServerConfigDiffVO compare(String clusterId, String instanceId) {
         String normalizedClusterId = requireClusterId(clusterId);
         return compare(normalizedClusterId,
-                clusterService.getCluster(normalizedClusterId, normalizeInstanceId(instanceId)));
+                clusterService.getCluster(normalizedClusterId, normalizeInstanceId(instanceId)),
+                normalizeInstanceId(instanceId));
     }
 
-    private NameServerConfigDiffVO compare(String normalizedClusterId, ClusterVO cluster) {
+    private NameServerConfigDiffVO compare(String normalizedClusterId, ClusterVO cluster,
+                                           String instanceId) {
         List<String> addresses = collectNameServerAddresses(cluster);
         if (addresses.isEmpty()) {
             throw new BusinessException(409,
@@ -95,7 +99,7 @@ public class NameServerConfigDiffService {
 
         for (String address : addresses) {
             try {
-                Properties config = readConfig(connectionEndpoint, address);
+                Properties config = readConfig(connectionEndpoint, address, instanceId);
                 reachableConfigs.put(address, config);
                 nodes.add(NameServerConfigDiffVO.NodeStatusVO.builder()
                         .address(address)
@@ -124,7 +128,18 @@ public class NameServerConfigDiffService {
                 .build();
     }
 
-    private Properties readConfig(String connectionEndpoint, String address) {
+    private Properties readConfig(String connectionEndpoint, String address, String instanceId) {
+        if (instanceId != null) {
+            return adminClientResolver.execute(instanceId, admin -> {
+                Map<String, Properties> configs = admin.getNameServerConfig(List.of(address));
+                Properties config = configs == null ? null : configs.get(address);
+                if (config == null) {
+                    throw new BusinessException(502,
+                            "NameServer returned no configuration: " + address);
+                }
+                return config;
+            });
+        }
         return adminFactory.execute(connectionEndpoint, null, admin -> {
             Map<String, Properties> configs = admin.getNameServerConfig(List.of(address));
             Properties config = configs == null ? null : configs.get(address);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.nameserver;
 import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 import org.apache.rocketmq.studio.cluster.broker.ClusterVO;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -50,18 +52,34 @@ class NameServerConfigDiffServiceTest {
     private MqAdminExtFactory adminFactory;
 
     @Mock
+    private RuntimeAdminClientResolver adminClientResolver;
+
+    @Mock
     private MQAdminExt admin;
 
     private NameServerConfigDiffService service;
 
     @BeforeEach
     void setUp() {
-        service = new NameServerConfigDiffService(clusterService, adminFactory);
+        service = new NameServerConfigDiffService(clusterService, adminFactory, adminClientResolver);
     }
 
     private void stubAdminFactory() {
         when(adminFactory.execute(anyString(), isNull(), any())).thenAnswer(invocation -> {
             MqAdminExtFactory.AdminAction<Object> action = invocation.getArgument(2);
+            try {
+                return action.apply(admin);
+            } catch (BusinessException exception) {
+                throw exception;
+            } catch (Exception exception) {
+                throw new BusinessException(502, "RocketMQ admin call failed");
+            }
+        });
+    }
+
+    private void stubAdminResolver() {
+        when(adminClientResolver.execute(anyString(), any())).thenAnswer(invocation -> {
+            MqAdminExtFactory.AdminAction<Object> action = invocation.getArgument(1);
             try {
                 return action.apply(admin);
             } catch (BusinessException exception) {
@@ -111,7 +129,7 @@ class NameServerConfigDiffServiceTest {
 
     @Test
     void compareShouldResolveClusterThroughSelectedInstance() throws Exception {
-        stubAdminFactory();
+        stubAdminResolver();
         when(clusterService.getCluster("cluster-a", "instance-a")).thenReturn(cluster(
                 "ns-a:9876;ns-b:9876",
                 List.of(nameServer("ns-a:9876"), nameServer("ns-b:9876"))));
@@ -124,6 +142,7 @@ class NameServerConfigDiffServiceTest {
 
         assertThat(result.isComplete()).isTrue();
         verify(clusterService).getCluster("cluster-a", "instance-a");
+        verify(adminClientResolver, org.mockito.Mockito.times(2)).execute(eq("instance-a"), any());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Fix #1989.

Instance-scoped NameServer configuration drift reads created an anonymous MQAdminExt via adminFactory.execute(endpoint, null, ...), dropping the instance adminCredentialRef and its ACL hook. On ACL-enabled clusters the drift check marked NameServer nodes unreachable even though the selected instance had valid admin credentials.

## Brief changelog

- NameServerConfigDiffService: route instance-scoped reads through RuntimeAdminClientResolver so the selected instance endpoint and admin credentials are used; the non-instance path keeps the existing behaviour

## How was this patch verified

- Code review: mirrors how other instance-scoped providers use RuntimeAdminClientResolver
- `git diff --check` clean
