### PR TITLE
fix(web): guard null delivery status in message verification

### DIFF
--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -611,7 +611,7 @@ const MessagePageContent = ({
       dataIndex: 'deliveryStatus',
       key: 'deliveryStatus',
       render: (status: string) => {
-        const s = DELIVERY_STATUS_MAP[status.toLowerCase()] || {
+        const s = DELIVERY_STATUS_MAP[(status ?? '').toLowerCase()] || {
           label: status,
           color: 'default',
         };


### PR DESCRIPTION
## What is the purpose of the change

Fix #2065.

The message verification page called status.toLowerCase() on the backend deliveryStatus field, which is nullable. A null value threw TypeError and crashed the page.

## Brief changelog

- message.tsx: guard with (status ?? '').toLowerCase()

## How was this patch verified

- npx tsc -b clean
- npx eslint . clean
