### PR TITLE
fix(web): guard null alert level in system alerts

### DIFF
--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -142,7 +142,7 @@ const SystemAlertsPage = () => {
         {loading && <Card loading />}
         {!loading &&
           filtered.map((alert) => {
-            const normalizedLevel = alert.level.toLowerCase();
+            const normalizedLevel = (alert.level ?? '').toLowerCase();
             const cfg = alertLevelConfig[normalizedLevel] ?? {
               color: '#8c8c8c',
               bg: '#fafafa',


### PR DESCRIPTION
## What is the purpose of the change

Fix #2066.

The system alerts page called alert.level.toLowerCase() but the fallback below assumes level can be empty, so a null level throws before the fallback runs.

## Brief changelog

- systemAlerts.tsx: guard with (alert.level ?? '').toLowerCase()

## How was this patch verified

- npx vitest run src/pages/ops/__tests__/SystemAlertsPage.test.tsx (passed)
- npx tsc -b clean