### PR TITLE
fix(web): guard null cluster component lists in BrokerCluster

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -95,7 +95,7 @@ function mapClusters(clusters: ClusterInfo[]): {
   clusters.forEach((cluster) => {
     const clusterLabel = cluster.nsClusterName || cluster.name || cluster.id;
 
-    cluster.brokers.forEach((broker, index) => {
+    (cluster.brokers ?? []).forEach((broker, index) => {
       brokers.push({
         key: `${cluster.id}-broker-${broker.addr || index}`,
         clusterId: cluster.id,
@@ -110,7 +110,7 @@ function mapClusters(clusters: ClusterInfo[]): {
       });
     });
 
-    cluster.nameServers.forEach((nameServer, index) => {
+    (cluster.nameServers ?? []).forEach((nameServer, index) => {
       nameServers.push({
         key: `${cluster.id}-ns-${nameServer.addr || index}`,
         k8sCluster: clusterLabel,
@@ -122,7 +122,7 @@ function mapClusters(clusters: ClusterInfo[]): {
       });
     });
 
-    cluster.proxies.forEach((proxy, index) => {
+    (cluster.proxies ?? []).forEach((proxy, index) => {
       const host = hostOf(proxy.addr);
       proxies.push({
         key: `${cluster.id}-proxy-${proxy.addr || index}`,


### PR DESCRIPTION
## What is the purpose of the change

Fix #2067.

BrokerCluster page called cluster.brokers/nameServers/proxies .forEach without a null guard, while the backend can serialize these as null, crashing the page.

## Brief changelog

- BrokerCluster.tsx: use (cluster.brokers ?? []).forEach etc.

## How was this patch verified

- npx vitest run src/pages/studio/__tests__/BrokerCluster.test.tsx (passed)
- npx tsc -b clean