### PR TITLE
fix(web): guard null subscribedTopics in group management

### DIFF
--- a/web/src/pages/studio/GroupManagement.tsx
+++ b/web/src/pages/studio/GroupManagement.tsx
@@ -396,7 +396,7 @@ const GroupManagementPage = () => {
                             {t('groupMgmt.subscribedTopics')}
                           </div>
                           <div style={{ fontSize: 24, fontWeight: 600 }}>
-                            {selectedGroup.subscribedTopics.length}
+                            {(selectedGroup.subscribedTopics ?? []).length}
                           </div>
                         </Card>
                       </Col>
@@ -431,7 +431,7 @@ const GroupManagementPage = () => {
                         {selectedGroup.createdAt}
                       </Descriptions.Item>
                       <Descriptions.Item label={t('groupMgmt.subscribedTopics')} span={2}>
-                        {selectedGroup.subscribedTopics.join(', ')}
+                        {(selectedGroup.subscribedTopics ?? []).join(', ')}
                       </Descriptions.Item>
                     </Descriptions>
                     <h4 style={{ marginTop: 20, marginBottom: 12 }}>


### PR DESCRIPTION
## What is the purpose of the change

Fix #2068.

The group management detail dialog reads selectedGroup.subscribedTopics.length and .join without guarding the nullable backend list, crashing the dialog.

## Brief changelog

- GroupManagement.tsx: guard with (selectedGroup.subscribedTopics ?? [])

## How was this patch verified

- npx vitest run src/pages/studio/__tests__/GroupManagement.test.tsx (passed)
- npx tsc -b clean