### PR TITLE
fix(web): use build-provided metadata in About tab

### DIFF
--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -610,8 +610,8 @@ export const DataSourceTab = () => {
 const AboutTab = () => (
   <div style={{ maxWidth: 800 }}>
     <Descriptions column={1} bordered size="small">
-      <Descriptions.Item label="版本">0.1.0</Descriptions.Item>
-      <Descriptions.Item label="构建时间">2024-01-15 14:30:00</Descriptions.Item>
+      <Descriptions.Item label="版本">{__BUILD_COMMIT__}</Descriptions.Item>
+      <Descriptions.Item label="构建时间">{__BUILD_TIME__}</Descriptions.Item>
       <Descriptions.Item label="RocketMQ 支持版本">4.x / 5.x</Descriptions.Item>
       <Descriptions.Item label="前端框架">React 18 + Ant Design 5</Descriptions.Item>
       <Descriptions.Item label="后端框架">Spring Boot 3 + RocketMQ MCP Server</Descriptions.Item>


### PR DESCRIPTION
## What is the purpose of the change

Fix #2070.

The About tab hard-coded version 0.1.0 and a fixed build time while the build exposes __BUILD_TIME__ and __BUILD_COMMIT__ via vite define.

## Brief changelog

- settings About tab: render __BUILD_TIME__ and __BUILD_COMMIT__

## How was this patch verified

- npx vitest run src/pages/settings/__tests__ (passed)
- npx tsc -b clean