### PR TITLE
fix(web): guard consumer subscribedTopics and use stable row keys

### DIFF
--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -971,7 +971,7 @@ const ConsumerPageContent = ({
                   dataSource={
                     subscriptionsByGroup[diagnosticCacheKey(selectedInstanceId, record.name)] ?? []
                   }
-                  rowKey="topic"
+                  rowKey={(record) => `${record.topic}-${record.filterMode}-${record.expression}`}
                   loading={
                     subscriptionLoadingByGroup[diagnosticCacheKey(selectedInstanceId, record.name)]
                   }
@@ -1071,7 +1071,7 @@ const ConsumerPageContent = ({
                         >
                           <Statistic
                             title="订阅 Topic 数"
-                            value={selectedGroup.subscribedTopics.length}
+                            value={(selectedGroup.subscribedTopics ?? []).length}
                             prefix={<ListBullets size={18} color="#1677ff" />}
                             valueStyle={{ color: '#1677ff' }}
                           />
@@ -1129,7 +1129,7 @@ const ConsumerPageContent = ({
                       </Descriptions.Item>
                       <Descriptions.Item label="订阅 Topic" span={2}>
                         <Space size={4} wrap>
-                          {selectedGroup.subscribedTopics.map((t) => (
+                          {(selectedGroup.subscribedTopics ?? []).map((t) => (
                             <Tag key={t} color="blue">
                               {t}
                             </Tag>
@@ -1199,7 +1199,9 @@ const ConsumerPageContent = ({
                       <Table
                         columns={subscriptionSubColumns}
                         dataSource={visibleSubscriptions}
-                        rowKey="topic"
+                        rowKey={(record) =>
+                          `${record.topic}-${record.filterMode}-${record.expression}`
+                        }
                         loading={subscriptionLoadingByGroup[selectedDiagnosticKey]}
                         pagination={false}
                         size="small"


### PR DESCRIPTION
## What is the purpose of the change

Fix #2072 (and #2074).

The consumer detail dialog read selectedGroup.subscribedTopics.length and .map without guarding the nullable backend list, crashing the dialog. The subscription tables also used rowKey="topic" although one topic can have multiple subscription entries, causing React duplicate-key issues.

## Brief changelog

- consumer.tsx: guard subscribedTopics with ?? []
- consumer.tsx: use a composite row key of topic, filterMode and expression

## How was this patch verified

- npx vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx (13 passed)
- npx tsc -b clean