### PR TITLE
fix(web): guard null alert rule channels

### DIFF
--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -234,7 +234,7 @@ const AlertsPage = () => {
       title: t('alerts.channels'),
       render: (_, record) => (
         <Flex gap={4} wrap="wrap">
-          {record.channels.map((ch) => (
+          {(record.channels ?? []).map((ch) => (
             <Tag key={ch} color={channelColors[ch]}>
               {channelLabels[ch]}
             </Tag>


### PR DESCRIPTION
## What is the purpose of the change

Fix #2073.

The alerts page called record.channels.map without guarding the nullable backend list, crashing rules loaded from default YAML.

## Brief changelog

- alerts.tsx: use (record.channels ?? []).map

## How was this patch verified

- npx vitest run src/pages/ops/__tests__/AlertsPage.test.tsx (4 passed)
- npx tsc -b clean