### PR TITLE
fix(web): fall back cluster name in drift export filename

### DIFF
--- a/web/src/pages/ops/nameServerConfigDrift.tsx
+++ b/web/src/pages/ops/nameServerConfigDrift.tsx
@@ -154,7 +154,7 @@ const NameServerConfigDriftPage = () => {
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = `nameserver-config-drift-${result.cluster.replace(/[^a-zA-Z0-9._-]/g, '_')}.json`;
+    link.download = `nameserver-config-drift-${(result.cluster || 'unknown').replace(/[^a-zA-Z0-9._-]/g, '_')}.json`;
     link.click();
     URL.revokeObjectURL(url);
   };


### PR DESCRIPTION
## What is the purpose of the change

Fix #2078.

The NameServer drift export filename was built from result.cluster without a fallback, producing nameserver-config-drift-.json when cluster was empty.

## Brief changelog

- nameServerConfigDrift.tsx: fall back to 'unknown'

## How was this patch verified

- npx vitest run src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx (6 passed)
- npx tsc -b clean