### PR TITLE
fix(web): reuse formatDateTime for cert dates

### DIFF
--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -21,14 +21,9 @@ import type { ColumnsType } from 'antd/es/table';
 import PageHeader from '../../components/PageHeader';
 import type { K8sCertInfo } from '../../api/cluster';
 import { listK8sCerts } from '../../services/clusterService';
+import { formatDateTime } from '../../utils/format';
 
 const { Text } = Typography;
-
-const formatDateTime = (iso: string): string => {
-  const d = new Date(iso);
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
-};
 
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error && error.message ? error.message : '请求失败，请稍后重试';


### PR DESCRIPTION
## What is the purpose of the change

Fix #2080.

The K8s certificate page defined a local formatDateTime that rendered 'NaN-NaN-NaN NaN:NaN:NaN' for null/invalid notAfter, duplicating utils/format.ts formatDateTime which already returns a safe value.

## Brief changelog

- certs.tsx: remove the local formatDateTime and reuse utils/format.ts formatDateTime

## How was this patch verified

- npx vitest run src/pages/cluster/__tests__/K8sCertsPage.test.tsx (7 passed)
- npx tsc -b clean
- npx eslint . clean
