### PR TITLE
fix(web): render dash for zero consume time

### DIFF
--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -119,6 +119,7 @@ const formatSize = (bytes: number): string => {
 };
 
 const formatTimeMs = (value: number | string): string => {
+  if (!value) return '-';
   const d = new Date(value);
   const pad = (n: number, len = 2) => String(n).padStart(len, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`;


### PR DESCRIPTION
## What is the purpose of the change

Fix #2081.

formatTimeMs(0) rendered the epoch (1970-01-01) for an unconsumed message because the backend serializes consumeTime as 0.

## Brief changelog

- message.tsx: formatTimeMs returns '-' for zero or falsy values

## How was this patch verified

- npx vitest run src/pages/instance/__tests__/MessagePage.test.tsx src/pages/instance/__tests__/MessagePageAsyncState.test.tsx (24 passed)
- npx tsc -b clean
- npx eslint . clean
