### PR TITLE
fix(web): surface AI tool execution errors

### DIFF
--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -702,8 +702,8 @@ const AiPage = () => {
     try {
       setToolResult(await executeTool(selectedToolName, parsedInput));
       message.success('工具执行成功');
-    } catch {
-      message.error('工具执行失败');
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '工具执行失败');
     } finally {
       setToolExecuting(false);
     }


### PR DESCRIPTION
## What is the purpose of the change

Fix #2083.

The AI tool execution handler showed a generic error and dropped the server's specific message.

## Brief changelog

- ai/index.tsx: surface error instanceof Error ? error.message when a tool execution fails

## How was this patch verified

- npx vitest run src/pages/ai/__tests__/AiPage.test.tsx (passed)
- npx tsc -b clean
- npx eslint . clean
