### PR TITLE
fix(web): localize home placeholder and footer text

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -519,6 +519,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'home.docs': { zh: '文档中心', en: 'Documentation' },
   'home.community': { zh: 'RocketMQ 社区', en: 'RocketMQ Community' },
   'home.brand': { zh: 'RocketMQ Studio 出品', en: 'Powered by RocketMQ Studio' },
+  'home.version': { zh: '当前版本', en: 'Version' },
 
   // ─── AI Page (additional) ───
   'ai.recommended': { zh: '推荐', en: 'Rec.' },

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -424,7 +424,7 @@ const HomePage = () => {
                   <textarea
                     ref={textareaRef}
                     className="chat-input"
-                    placeholder="向 RocketMQ Bot 提问，全程加密、安全、可信"
+                    placeholder={t('home.placeholder')}
                     value={inputValue}
                     onChange={(event) => setInputValue(event.target.value)}
                     onKeyDown={handleKeyDown}
@@ -516,7 +516,7 @@ const HomePage = () => {
               className="transition-colors hover:text-purple-500"
               style={{ textDecoration: 'none' }}
             >
-              文档中心
+              {t('home.docs')}
             </a>
             <span style={{ margin: '0 4px' }}>｜</span>
             <a
@@ -524,13 +524,13 @@ const HomePage = () => {
               className="transition-colors hover:text-purple-500"
               style={{ textDecoration: 'none' }}
             >
-              RocketMQ 社区
+              {t('home.community')}
             </a>
             <span style={{ margin: '0 4px' }}>｜</span>
-            <span>RocketMQ Studio 出品</span>
+            <span>{t('home.brand')}</span>
             <span style={{ margin: '0 4px' }}>｜</span>
             <span>
-              当前版本 {__BUILD_TIME__} build({__BUILD_COMMIT__})
+              {t('home.version')} {__BUILD_TIME__} build({__BUILD_COMMIT__})
             </span>
           </span>
         </footer>


### PR DESCRIPTION
## What is the purpose of the change

Fix #2071.

The home page input placeholder and footer text were hard-coded Chinese while the rest of the page uses i18n.

## Brief changelog

- home/index.tsx: render home.placeholder, home.docs, home.community, home.brand and home.version from translations
- translations.ts: add home.version key

## How was this patch verified

- npx vitest run src/pages/home/__tests__/HomePage.test.tsx (3 passed)
- npx tsc -b clean
- npx eslint . clean
