### PR TITLE
fix: validate instance name on creation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/CreateInstanceDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/CreateInstanceDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.instance;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
@@ -23,6 +24,7 @@ import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 @Data
 public class CreateInstanceDTO {
 
+    @NotBlank(message = "name is required")
     private String name;
 
     private InstanceType type;


### PR DESCRIPTION
## What is the purpose of the change

Fix #2075.

CreateInstanceDTO had no validation annotations, unlike sibling DTOs, so invalid payloads reached the service layer.

## Brief changelog

- CreateInstanceDTO: add @NotBlank on name

## How was this patch verified

- InstanceController already applies @Valid; cloud create path unaffected (endpoint/type/vendor stay optional)
- git diff --check clean