### PR TITLE
fix: validate login credentials at the DTO layer

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthController.java
@@ -21,6 +21,7 @@ import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.apache.rocketmq.studio.settings.SettingsRepository;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
@@ -62,7 +63,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public Result<LoginVO> login(@RequestBody(required = false) LoginDTO request) {
+    public Result<LoginVO> login(@Valid @RequestBody(required = false) LoginDTO request) {
         if (request == null) {
             throw new BusinessException(400, "Login request is required");
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/LoginDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/LoginDTO.java
@@ -17,12 +17,15 @@
 
 package org.apache.rocketmq.studio.auth;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import lombok.ToString;
 
 @Data
 public class LoginDTO {
+    @NotBlank(message = "username is required")
     private String username;
+    @NotBlank(message = "password is required")
     @ToString.Exclude
     private String password;
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix #2076.

LoginDTO had no validation annotations; null/blank credentials were only rejected in AuthService.

## Brief changelog

- LoginDTO: add @NotBlank on username and password
- AuthController.login: apply @Valid

## How was this patch verified

- Code review against sibling DTO validation style
- git diff --check clean