### PR TITLE
fix: validate AI request payloads

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiCommandDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiCommandDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,6 +29,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AiCommandDTO {
+    @NotBlank(message = "command is required")
     private String command;
     private String mode;
     private String model;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.ai;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -41,12 +42,12 @@ public class AiController {
     private final AiService aiService;
 
     @PostMapping(value = "/chat", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter chat(@RequestBody ChatDTO request) {
+    public SseEmitter chat(@Valid @RequestBody ChatDTO request) {
         return aiService.chat(request);
     }
 
     @PostMapping("/execute")
-    public Result<AiExecuteResultVO> execute(@RequestBody AiCommandDTO command) {
+    public Result<AiExecuteResultVO> execute(@Valid @RequestBody AiCommandDTO command) {
         return Result.ok(aiService.execute(command));
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ChatDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ChatDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,6 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatDTO {
+    @NotBlank(message = "message is required")
     private String message;
     private String mode;
     private String model;


### PR DESCRIPTION
## What is the purpose of the change

Fix #2077.

AiCommandDTO and ChatDTO had no constraints and the controller did not use @Valid, so an empty payload reached the provider layer.

## Brief changelog

- AiCommandDTO: @NotBlank on command; ChatDTO: @NotBlank on message
- AiController: apply @Valid on chat and execute

## How was this patch verified

- Code review; no /chat or /execute test cases to regress
- git diff --check clean