### PR TITLE
fix(web): localize clients sampled warning

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -184,6 +184,10 @@ const translations: Record<string, Record<Lang, string>> = {
   'dlq.title': { zh: '死信队列', en: 'Dead Letter Queue' },
 
   // ─── Client Connections ───
+  'clients.sampledWarning': {
+    zh: '由于达到 Topic 扫描上限，Producer 连接为采样展示',
+    en: 'Producer connections are sampled because the topic scan limit was reached.',
+  },
   'clients.title': { zh: '客户端连接', en: 'Client Connections' },
   'clients.clientId': { zh: 'Client ID', en: 'Client ID' },
   'clients.groupOrTopic': { zh: 'Group/Topic', en: 'Group/Topic' },

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -407,7 +407,7 @@ const ClientsPage = () => {
         <Alert
           showIcon
           type="warning"
-          message="Producer connections are sampled because the topic scan limit was reached."
+          message={t('clients.sampledWarning')}
           style={{ marginBottom: 16 }}
         />
       )}


### PR DESCRIPTION
## What is the purpose of the change

Fix #2079.

The clients page showed a sampled-connections warning in English while the rest of the page uses i18n.

## Brief changelog

- clients.tsx: render t('clients.sampledWarning')
- translations.ts: add clients.sampledWarning key

## How was this patch verified

- npx vitest run src/pages/cluster/__tests__/ClientsPage.test.tsx (10 passed)
- npx tsc -b clean
- npx eslint . clean
