### PR TITLE
fix(web): guard null principal and resource in ACL rule search

### DIFF
--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -185,8 +185,8 @@ const AclPage = () => {
     const aclVersion = String(r.aclVersion);
     const matchSearch =
       !ruleSearch ||
-      r.principal.toLowerCase().includes(ruleSearch.toLowerCase()) ||
-      r.resource.toLowerCase().includes(ruleSearch.toLowerCase());
+      r.principal?.toLowerCase().includes(ruleSearch.toLowerCase()) ||
+      r.resource?.toLowerCase().includes(ruleSearch.toLowerCase());
     const matchVersion = ruleVersionFilter === 'all' || aclVersion === ruleVersionFilter;
     const matchDecision = ruleDecisionFilter === 'all' || r.decision === ruleDecisionFilter;
     return matchSearch && matchVersion && matchDecision;


### PR DESCRIPTION
## What is the purpose of the change

Fix #2104.

The ACL rules filter called r.principal.toLowerCase() and r.resource.toLowerCase() without guarding null values from the backend, crashing when a rule has no principal/resource.

## Brief changelog

- acl.tsx: use r.principal?.toLowerCase() and r.resource?.toLowerCase()

## How was this patch verified

- npx vitest run src/pages/instance/__tests__/AclPage.test.tsx (13 passed)
- npx tsc -b clean
- npx eslint . clean
