### PR TITLE
fix(web): guard null alert level in system alerts

### DIFF
--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -29,7 +29,7 @@ import type { SystemAlert } from '../../api/ops';
 
 const { Text } = Typography;
 
-const normalizeAlertLevel = (level: string) => level.toLowerCase();
+const normalizeAlertLevel = (level?: string | null) => (level ?? '').toLowerCase();
 
 const SystemAlertsPage = () => {
   const { t } = useLang();


### PR DESCRIPTION
## What is the purpose of the change

Fix #2066.

The system alerts page called normalizeAlertLevel(alert.level) which did alert.level.toLowerCase() without guarding null, crashing when a backend alert has no level.

## Brief changelog

- systemAlerts.tsx: normalizeAlertLevel guards with (level ?? '')

## How was this patch verified

- npx vitest run src/pages/ops/__tests__/SystemAlertsPage.test.tsx (passed)
- npx tsc -b clean
- npx eslint . clean
