### PR TITLE
feat(ai): preserve bounded conversation history

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -18,6 +18,7 @@
 import axios from 'axios';
 import { message } from 'antd';
 import { clearAuthSession, TOKEN_STORAGE_KEY } from '../stores/authStorage';
+import { clearAiChatHistories } from '../stores/aiChatHistoryStore';
 import { API_BASE_URL } from '../config';
 
 const SUCCESS_BUSINESS_CODES = new Set([0, 200]);
@@ -88,6 +89,7 @@ client.interceptors.response.use(
   },
   (error) => {
     if (error.response?.status === 401 && !isPublicAuthRequest(error.config?.url)) {
+      clearAiChatHistories();
       clearAuthSession();
       window.location.href = '/';
     }

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -306,6 +306,16 @@ const translations: Record<string, Record<Lang, string>> = {
   // ─── AI Page ───
   'ai.title': { zh: 'AI 交互', en: 'AI Chat' },
   'ai.commonCommands': { zh: '常用指令', en: 'Common Commands' },
+  'ai.history.title': { zh: 'AI 对话历史', en: 'AI conversation history' },
+  'ai.history.empty': { zh: '当前模式暂无对话记录', en: 'No conversations in this mode' },
+  'ai.history.justNow': { zh: '刚刚', en: 'Just now' },
+  'ai.history.minutesAgo': { zh: '{count} 分钟前', en: '{count} min ago' },
+  'ai.responseStopped': { zh: '回答已停止。', en: 'Response stopped.' },
+  'ai.requestFailed': { zh: 'AI 请求失败', en: 'AI request failed' },
+  'ai.runtimeLoadFailed': { zh: 'AI 配置加载失败', en: 'Failed to load AI configuration' },
+  'ai.providerRequired': { zh: '请先配置并启用 LLM Provider', en: 'Configure and enable an LLM provider first' },
+  'ai.toolCatalogLoadFailed': { zh: 'AI 工具目录加载失败', en: 'Failed to load the AI tool catalog' },
+  'ai.clusterListLoadFailed': { zh: '集群列表加载失败，已显示全局工具', en: 'Failed to load clusters; showing global tools' },
 
   // ─── Home Page ───
   'home.banner': {

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -45,6 +45,7 @@ import { useLang } from '../i18n/LangContext';
 import { useTheme } from '../theme/useTheme';
 import { logout as requestLogout } from '../api/auth';
 import useAuthStore from '../stores/authStore';
+import { clearAiChatHistories } from '../stores/aiChatHistoryStore';
 import {
   filterNavigationEntries,
   isNavigationSearchShortcut,
@@ -85,6 +86,7 @@ const MainLayout = () => {
     } catch {
       message.warning('服务端退出失败，已清除本地登录状态');
     } finally {
+      clearAiChatHistories();
       clearAuth();
       navigate('/login', { replace: true });
     }

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -24,6 +24,7 @@ import { LangProvider } from '../../../i18n/LangContext';
 import { chatStream, executeTool, listTools } from '../../../api/ai';
 import { listClusters, type ClusterInfo } from '../../../api/cluster';
 import { getLlmConfig, getLlmModels } from '../../../api/llm';
+import { useAiChatHistoryStore } from '../../../stores/aiChatHistoryStore';
 import AiPage from '../index';
 
 vi.mock('../../../api/ai', () => ({
@@ -73,6 +74,13 @@ const renderPage = (state?: unknown) =>
 describe('AiPage tool runner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sessionStorage.clear();
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: { conversations: [], activeConversationId: null },
+      },
+    });
     vi.mocked(getLlmConfig).mockResolvedValue({
       provider: 'openai',
       apiBase: 'https://api.openai.com/v1',
@@ -117,6 +125,146 @@ describe('AiPage tool runner', () => {
         expect.any(Function),
       );
     });
+  });
+
+  it('starts a new conversation when the home-page draft requests it', async () => {
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: {
+          conversations: [
+            {
+              id: 'previous-conversation',
+              messages: [{ id: 'previous', role: 'user', text: 'Previous conversation' }],
+              updatedAt: new Date(2026, 7, 13, 9, 45).getTime(),
+            },
+          ],
+          activeConversationId: 'previous-conversation',
+        },
+      },
+    });
+    vi.mocked(chatStream).mockResolvedValue(undefined);
+
+    renderPage({ prompt: 'New conversation', newConversation: true });
+
+    await waitFor(() => {
+      expect(chatStream).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'New conversation' }),
+        expect.any(Function),
+        expect.any(AbortSignal),
+        expect.any(Function),
+      );
+    });
+    expect(useAiChatHistoryStore.getState().histories.real.conversations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          messages: expect.arrayContaining([expect.objectContaining({ text: 'Previous conversation' })]),
+        }),
+      ]),
+    );
+  });
+
+  it('uses the conversation update time for legacy messages without message timestamps', async () => {
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: {
+          conversations: [
+            {
+              id: 'previous-conversation',
+              messages: [{ id: 'previous', role: 'user', text: 'Previous conversation' }],
+              updatedAt: new Date(2026, 7, 13, 9, 45).getTime(),
+            },
+          ],
+          activeConversationId: null,
+        },
+      },
+    });
+
+    renderPage({ conversationId: 'previous-conversation' });
+
+    expect(await screen.findByText('Previous conversation')).toBeInTheDocument();
+    expect(screen.getByText('09:45')).toBeInTheDocument();
+    expect(chatStream).not.toHaveBeenCalled();
+  });
+
+  it('switches conversations from the AI-page history drawer without sending a request', async () => {
+    const now = Date.now();
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: {
+          conversations: [
+            {
+              id: 'active',
+              messages: [{ id: 'active-message', role: 'user', text: 'Active conversation' }],
+              updatedAt: now,
+            },
+            {
+              id: 'previous',
+              messages: [{ id: 'previous-message', role: 'user', text: 'Previous conversation' }],
+              updatedAt: now - 5 * 60_000,
+            },
+          ],
+          activeConversationId: 'active',
+        },
+      },
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: 'AI 对话历史' }));
+    expect(screen.getByText('刚刚')).toBeInTheDocument();
+    expect(screen.getByText('5 分钟前')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Previous conversation5 分钟前$/ })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /^Previous conversation/ }));
+
+    expect(
+      await screen.findByText('Previous conversation', { selector: 'div[style*="max-width"]' }),
+    ).toBeInTheDocument();
+    expect(useAiChatHistoryStore.getState().histories.real.activeConversationId).toBe('previous');
+    expect(chatStream).not.toHaveBeenCalled();
+  });
+
+  it('stops an in-flight response before switching conversations', async () => {
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: {
+          conversations: [
+            {
+              id: 'previous',
+              messages: [{ id: 'previous-message', role: 'user', text: 'Previous conversation' }],
+              updatedAt: Date.now() - 60_000,
+            },
+          ],
+          activeConversationId: 'previous',
+        },
+      },
+    });
+    let requestSignal: AbortSignal | undefined;
+    vi.mocked(chatStream).mockImplementation(
+      (_request, _onChunk, signal) =>
+        new Promise<void>((resolve) => {
+          requestSignal = signal;
+          if (signal) {
+            signal.addEventListener('abort', () => resolve());
+          } else {
+            resolve();
+          }
+        }),
+    );
+    const user = userEvent.setup();
+    renderPage({ prompt: 'Start streaming', newConversation: true });
+
+    await waitFor(() => expect(requestSignal).toBeDefined());
+    await user.click(screen.getByRole('button', { name: 'AI 对话历史' }));
+    const historyDrawer = await screen.findByRole('dialog', { name: 'AI 对话历史' });
+    await user.click(within(historyDrawer).getByRole('button', { name: /^Previous conversation/ }));
+
+    expect(requestSignal?.aborted).toBe(true);
+    expect(useAiChatHistoryStore.getState().histories.real.activeConversationId).toBe('previous');
+    await waitFor(() => expect(screen.queryByRole('button', { name: '停止' })).not.toBeInTheDocument());
   });
 
   it('loads the catalog, creates a schema template, and renders structured output', async () => {

--- a/web/src/pages/ai/chatDraft.ts
+++ b/web/src/pages/ai/chatDraft.ts
@@ -24,12 +24,19 @@ export interface ChatDraft {
   model?: string;
   mode?: ChatMode;
   enhance?: boolean;
+  newConversation?: boolean;
+  conversationId?: string;
 }
 
 export function getChatDraft(state: unknown): ChatDraft | null {
   if (typeof state !== 'object' || state === null) return null;
   const candidate = state as Record<string, unknown>;
-  if (typeof candidate.prompt !== 'string' || !candidate.prompt.trim()) return null;
+  const prompt = typeof candidate.prompt === 'string' ? candidate.prompt.trim() : '';
+  const conversationId =
+    typeof candidate.conversationId === 'string' && candidate.conversationId.trim()
+      ? candidate.conversationId
+      : undefined;
+  if (!prompt && !conversationId) return null;
   const model = typeof candidate.model === 'string' ? candidate.model.trim() : '';
   const mode =
     typeof candidate.mode === 'string' && CHAT_MODES.has(candidate.mode as ChatMode)
@@ -37,9 +44,11 @@ export function getChatDraft(state: unknown): ChatDraft | null {
       : undefined;
 
   return {
-    prompt: candidate.prompt.trim(),
+    prompt,
     ...(model ? { model } : {}),
     ...(mode ? { mode } : {}),
     ...(candidate.enhance === true ? { enhance: true } : {}),
+    ...(candidate.newConversation === true ? { newConversation: true } : {}),
+    ...(conversationId ? { conversationId } : {}),
   };
 }

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -31,6 +31,8 @@ import {
   Descriptions,
   Flex,
   Divider,
+  Drawer,
+  Empty,
   Select,
   Alert,
   Input,
@@ -39,13 +41,26 @@ import {
   theme,
   message,
 } from 'antd';
-import { ArrowUp, Sparkle, SlidersHorizontal, CaretDown } from '@phosphor-icons/react';
+import {
+  ArrowUp,
+  CaretDown,
+  ClockCounterClockwise,
+  SlidersHorizontal,
+  Sparkle,
+} from '@phosphor-icons/react';
 import type { ColumnsType } from 'antd/es/table';
 import { useLang } from '../../i18n/LangContext';
 import { AiStreamError, chatStream, executeTool, listTools, type McpTool } from '../../api/ai';
 import { listClusters } from '../../api/cluster';
 import { getLlmConfig, getLlmModels, type LlmConfig } from '../../api/llm';
+import { formatRelativeTime, formatTimeOfDay } from '../../utils/format';
+import { useDataModeStore } from '../../stores/dataModeStore';
 import { useEngineStore } from '../../stores/engineStore';
+import {
+  getRecentAiChatConversations,
+  type AiChatDataMode,
+  useAiChatHistoryStore,
+} from '../../stores/aiChatHistoryStore';
 import { getChatDraft, type ChatMode } from './chatDraft';
 
 const { Text } = Typography;
@@ -79,6 +94,7 @@ interface DescriptionItem {
 interface Message {
   id: string;
   role: 'user' | 'ai';
+  createdAt?: number;
   text?: string;
   toolCall?: ToolCallTag;
   tableData?: TopicRow[];
@@ -92,8 +108,6 @@ interface Message {
 }
 
 /* ─── Mock Data ─── */
-
-const initialMessages: Message[] = [];
 
 /* ─── Quick Actions ─── */
 
@@ -149,7 +163,7 @@ const formatToolResult = (result: unknown): string =>
 
 /* ─── Sub-components ─── */
 
-const UserBubble = ({ text }: { text: string }) => (
+const UserBubble = ({ text, createdAt }: Pick<Message, 'text' | 'createdAt'>) => (
   <Flex justify="flex-end" style={{ marginBottom: 16 }}>
     <div
       style={{
@@ -163,6 +177,11 @@ const UserBubble = ({ text }: { text: string }) => (
       }}
     >
       {text}
+      {createdAt && (
+        <div style={{ marginTop: 4, color: '#8c8c8c', fontSize: 11, textAlign: 'right' }}>
+          {formatTimeOfDay(createdAt)}
+        </div>
+      )}
     </div>
   </Flex>
 );
@@ -368,6 +387,12 @@ export const AiMessage = ({ msg }: { msg: Message }) => (
           </Flex>
         </>
       )}
+
+      {msg.createdAt && (
+        <div style={{ marginTop: 8, color: '#8c8c8c', fontSize: 11 }}>
+          {formatTimeOfDay(msg.createdAt)}
+        </div>
+      )}
     </Card>
   </Flex>
 );
@@ -377,11 +402,23 @@ export const AiMessage = ({ msg }: { msg: Message }) => (
    ═══════════════════════════════════════════ */
 
 const AiPage = () => {
-  const { t } = useLang();
+  const { t, lang } = useLang();
   const location = useLocation();
   const navigate = useNavigate();
+  const useMock = useDataModeStore((state) => state.useMock);
+  const chatMode: AiChatDataMode = useMock ? 'mock' : 'real';
   const { token } = theme.useToken();
-  const [messages, setMessages] = useState<Message[]>(initialMessages);
+  const history = useAiChatHistoryStore((state) => state.histories[chatMode]);
+  const activeConversation = useMemo(
+    () => history.conversations.find((item) => item.id === history.activeConversationId),
+    [history],
+  );
+  const messages = useMemo(() => activeConversation?.messages ?? [], [activeConversation]);
+  const legacyMessageTimestamp = activeConversation?.updatedAt || undefined;
+  const updateMessages = useAiChatHistoryStore((state) => state.setMessages);
+  const startConversation = useAiChatHistoryStore((state) => state.startConversation);
+  const selectConversation = useAiChatHistoryStore((state) => state.selectConversation);
+  const [historyOpen, setHistoryOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [loading, setLoading] = useState(false);
   const [llmConfig, setLlmConfig] = useState<LlmConfig | null>(null);
@@ -401,7 +438,8 @@ const AiPage = () => {
   const chatEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
-  const conversationIdRef = useRef<string | null>(null);
+  const streamRequestIdRef = useRef(0);
+  const conversationIdRef = useRef<string | null>(history.activeConversationId);
   const toolLoadRequestRef = useRef(0);
   const consumedDraftRef = useRef(false);
   const pendingAutoSendRef = useRef<{
@@ -418,6 +456,10 @@ const AiPage = () => {
   useEffect(() => {
     scrollToBottom();
   }, [messages, scrollToBottom]);
+
+  useEffect(() => {
+    conversationIdRef.current = useAiChatHistoryStore.getState().histories[chatMode].activeConversationId;
+  }, [chatMode, history.activeConversationId]);
 
   const loadLlmRuntime = useCallback(async () => {
     setModelsLoading(true);
@@ -440,11 +482,11 @@ const AiPage = () => {
         setModelOptions([{ value: config.model, label: config.model }]);
       }
     } catch (error) {
-      message.error(error instanceof Error ? error.message : 'AI 配置加载失败');
+      message.error(error instanceof Error ? error.message : t('ai.runtimeLoadFailed'));
     } finally {
       setModelsLoading(false);
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     void Promise.resolve().then(loadLlmRuntime);
@@ -456,7 +498,15 @@ const AiPage = () => {
     consumedDraftRef.current = true;
 
     void Promise.resolve().then(() => {
-      setInputValue(draft.prompt);
+      if (draft.newConversation) {
+        const newConversationId = `conversation-${Date.now()}`;
+        startConversation(chatMode, newConversationId);
+        conversationIdRef.current = newConversationId;
+      } else if (draft.conversationId) {
+        selectConversation(chatMode, draft.conversationId);
+        conversationIdRef.current = draft.conversationId;
+      }
+      if (draft.prompt) setInputValue(draft.prompt);
       const draftModel = draft.model;
       if (draftModel) {
         setSelectedModel(draftModel);
@@ -466,15 +516,17 @@ const AiPage = () => {
             : [{ value: draftModel, label: draftModel }, ...options],
         );
       }
-      pendingAutoSendRef.current = {
-        prompt: draft.prompt,
-        model: draft.model,
-        mode: draft.mode,
-        enhance: draft.enhance,
-      };
+      if (draft.prompt) {
+        pendingAutoSendRef.current = {
+          prompt: draft.prompt,
+          model: draft.model,
+          mode: draft.mode,
+          enhance: draft.enhance,
+        };
+      }
       navigate('/ai', { replace: true, state: null });
     });
-  }, [location.state, navigate]);
+  }, [chatMode, location.state, navigate, selectConversation, startConversation]);
 
   /* ─── Auto-resize textarea ─── */
   useEffect(() => {
@@ -505,25 +557,30 @@ const AiPage = () => {
       const model = modelOverride ?? selectedModel;
       if (!text || loading) return;
       if (!llmReady) {
-        message.warning('请先配置并启用 LLM Provider');
+        message.warning(t('ai.providerRequired'));
         return;
       }
 
       if (!conversationIdRef.current) {
         conversationIdRef.current = `conversation-${Date.now()}`;
+        startConversation(chatMode, conversationIdRef.current);
       }
 
+      const conversationId = conversationIdRef.current;
+      const requestId = ++streamRequestIdRef.current;
+      const createdAt = Date.now();
       const userMsg: Message = {
-        id: `user-${Date.now()}`,
+        id: `user-${createdAt}`,
         role: 'user',
         text,
+        createdAt,
       };
 
       const responseId = `ai-${Date.now()}`;
-      setMessages((prev) => [
+      updateMessages(chatMode, conversationId, (prev) => [
         ...prev,
         userMsg,
-        { id: responseId, role: 'ai', summary: '', pending: true },
+        { id: responseId, role: 'ai', summary: '', pending: true, createdAt },
       ]);
       setInputValue('');
       if (textareaRef.current) {
@@ -541,10 +598,10 @@ const AiPage = () => {
             model,
             engine: useEngineStore.getState().engine,
             enhance,
-            conversationId: conversationIdRef.current,
+            conversationId,
           },
           (chunk) => {
-            setMessages((prev) =>
+            updateMessages(chatMode, conversationId, (prev) =>
               prev.map((item) =>
                 item.id === responseId
                   ? { ...item, summary: `${item.summary ?? ''}${chunk}` }
@@ -554,7 +611,7 @@ const AiPage = () => {
           },
           controller.signal,
           (enhanceDelta) => {
-            setMessages((prev) =>
+            updateMessages(chatMode, conversationId, (prev) =>
               prev.map((item) =>
                 item.id === responseId
                   ? { ...item, thinking: `${item.thinking ?? ''}${enhanceDelta}` }
@@ -565,29 +622,29 @@ const AiPage = () => {
         );
       } catch (error) {
         if (controller.signal.aborted) {
-          setMessages((prev) =>
+          updateMessages(chatMode, conversationId, (prev) =>
             prev.map((item) =>
-              item.id === responseId && !item.summary ? { ...item, summary: '回答已停止。' } : item,
+              item.id === responseId && !item.summary ? { ...item, summary: t('ai.responseStopped') } : item,
             ),
           );
         } else {
-          const errorMessage = error instanceof Error ? error.message : 'AI 请求失败';
+          const errorMessage = error instanceof Error ? error.message : t('ai.requestFailed');
           const errorHint = error instanceof AiStreamError && error.hint ? error.hint : '';
           const summary = errorHint ? `${errorMessage}\n\n> ${errorHint}` : errorMessage;
-          setMessages((prev) =>
+          updateMessages(chatMode, conversationId, (prev) =>
             prev.map((item) => (item.id === responseId ? { ...item, summary } : item)),
           );
           message.error(errorMessage);
         }
       } finally {
         if (abortControllerRef.current === controller) abortControllerRef.current = null;
-        setMessages((prev) =>
+        updateMessages(chatMode, conversationId, (prev) =>
           prev.map((item) => (item.id === responseId ? { ...item, pending: false } : item)),
         );
-        setLoading(false);
+        if (streamRequestIdRef.current === requestId) setLoading(false);
       }
     },
-    [inputValue, llmReady, loading, selectedModel],
+    [chatMode, inputValue, llmReady, loading, selectedModel, startConversation, t, updateMessages],
   );
 
   /* ─── Auto-send the draft from the home page as soon as runtime is ready ─── */
@@ -617,6 +674,18 @@ const AiPage = () => {
     textareaRef.current?.focus();
   }, []);
 
+  const recentConversations = getRecentAiChatConversations(history.conversations);
+
+  const handleConversationSelect = (conversationId: string) => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    streamRequestIdRef.current += 1;
+    setLoading(false);
+    selectConversation(chatMode, conversationId);
+    conversationIdRef.current = conversationId;
+    setHistoryOpen(false);
+  };
+
   const selectTool = useCallback(
     (name: string, availableTools: McpTool[] = tools, clusterId: string = selectedClusterId) => {
       const tool = availableTools.find((item) => item.name === name);
@@ -624,7 +693,7 @@ const AiPage = () => {
       setToolInput(tool ? buildToolInputTemplate(tool, clusterId) : '{}');
       setToolResult(undefined);
     },
-    [selectedClusterId, tools],
+    [selectedClusterId, setSelectedToolName, setToolInput, setToolResult, tools],
   );
 
   const loadTools = useCallback(
@@ -642,13 +711,13 @@ const AiPage = () => {
       } catch {
         if (requestId === toolLoadRequestRef.current) {
           setTools([]);
-          message.error('AI 工具目录加载失败');
+          message.error(t('ai.toolCatalogLoadFailed'));
         }
       } finally {
         if (requestId === toolLoadRequestRef.current) setToolsLoading(false);
       }
     },
-    [selectTool],
+    [selectTool, t],
   );
 
   const handleOpenTools = useCallback(async () => {
@@ -665,13 +734,24 @@ const AiPage = () => {
       clusterId = options[0]?.value ?? '';
       setSelectedClusterId(clusterId);
     } catch {
-      message.warning('集群列表加载失败，已显示全局工具');
+      message.warning(t('ai.clusterListLoadFailed'));
     } finally {
       setClustersLoading(false);
     }
 
     await loadTools(clusterId);
-  }, [clustersLoading, loadTools, tools.length, toolsLoading]);
+  }, [
+    clustersLoading,
+    loadTools,
+    setClusterOptions,
+    setClustersLoading,
+    setSelectedClusterId,
+    setToolModalOpen,
+    setToolResult,
+    t,
+    tools.length,
+    toolsLoading,
+  ]);
 
   const handleClusterChange = useCallback(
     async (scope: string) => {
@@ -726,9 +806,16 @@ const AiPage = () => {
       >
         {messages.map((msg) =>
           msg.role === 'user' ? (
-            <UserBubble key={msg.id} text={msg.text!} />
+            <UserBubble
+              key={msg.id}
+              text={msg.text!}
+              createdAt={msg.createdAt ?? legacyMessageTimestamp}
+            />
           ) : (
-            <AiMessage key={msg.id} msg={msg} />
+            <AiMessage
+              key={msg.id}
+              msg={msg.createdAt || !legacyMessageTimestamp ? msg : { ...msg, createdAt: legacyMessageTimestamp }}
+            />
           ),
         )}
         <div ref={chatEndRef} />
@@ -800,6 +887,15 @@ const AiPage = () => {
                 </Tag>
               )}
             </div>
+            <button
+              type="button"
+              className="p-1 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-50 transition-colors"
+              aria-label="AI 对话历史"
+              title="AI 对话历史"
+              onClick={() => setHistoryOpen(true)}
+            >
+              <ClockCounterClockwise size={20} />
+            </button>
           </div>
 
           {/* Textarea */}
@@ -863,6 +959,50 @@ const AiPage = () => {
           </div>
         </div>
       </div>
+
+      <Drawer
+        title={t('ai.history.title')}
+        placement="right"
+        width={360}
+        open={historyOpen}
+        onClose={() => setHistoryOpen(false)}
+      >
+        {recentConversations.length === 0 ? (
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('ai.history.empty')} />
+        ) : (
+          <div className="flex flex-col gap-2">
+            {recentConversations.map((conversation) => (
+              <button
+                key={conversation.id}
+                type="button"
+                onClick={() => handleConversationSelect(conversation.id)}
+                className={`w-full rounded-md border px-3 py-2 text-left text-sm transition-colors ${
+                  conversation.id === history.activeConversationId
+                    ? 'border-blue-400 bg-blue-50 text-blue-700'
+                    : 'border-gray-200 bg-white text-gray-700 hover:border-blue-300 hover:bg-blue-50'
+                }`}
+              >
+                <span style={{ display: 'flex', alignItems: 'center', gap: 12, minWidth: 0 }}>
+                  <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {conversation.prompt}
+                  </span>
+                  <span
+                    style={{
+                      flexShrink: 0,
+                      color: token.colorTextSecondary,
+                      fontSize: 12,
+                      fontWeight: 500,
+                      lineHeight: 1.5,
+                    }}
+                  >
+                    {formatRelativeTime(conversation.updatedAt, lang, t)}
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+      </Drawer>
 
       <Modal
         title="AI 工具"

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -58,6 +58,7 @@ import { useDataModeStore } from '../../stores/dataModeStore';
 import { useEngineStore } from '../../stores/engineStore';
 import {
   getRecentAiChatConversations,
+  flushAiChatHistoryPersistence,
   type AiChatDataMode,
   useAiChatHistoryStore,
 } from '../../stores/aiChatHistoryStore';
@@ -121,6 +122,9 @@ const quickActions = [
 ];
 
 const GLOBAL_TOOL_SCOPE = '__global__';
+
+const newConversationId = (): string =>
+  `conversation-${typeof crypto?.randomUUID === 'function' ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`}`;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -439,6 +443,7 @@ const AiPage = () => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const streamRequestIdRef = useRef(0);
+  const previousChatModeRef = useRef(chatMode);
   const conversationIdRef = useRef<string | null>(history.activeConversationId);
   const toolLoadRequestRef = useRef(0);
   const consumedDraftRef = useRef(false);
@@ -458,6 +463,13 @@ const AiPage = () => {
   }, [messages, scrollToBottom]);
 
   useEffect(() => {
+    if (previousChatModeRef.current !== chatMode) {
+      abortControllerRef.current?.abort();
+      abortControllerRef.current = null;
+      streamRequestIdRef.current += 1;
+      setLoading(false);
+      previousChatModeRef.current = chatMode;
+    }
     conversationIdRef.current = useAiChatHistoryStore.getState().histories[chatMode].activeConversationId;
   }, [chatMode, history.activeConversationId]);
 
@@ -499,9 +511,9 @@ const AiPage = () => {
 
     void Promise.resolve().then(() => {
       if (draft.newConversation) {
-        const newConversationId = `conversation-${Date.now()}`;
-        startConversation(chatMode, newConversationId);
-        conversationIdRef.current = newConversationId;
+        const nextConversationId = newConversationId();
+        startConversation(chatMode, nextConversationId);
+        conversationIdRef.current = nextConversationId;
       } else if (draft.conversationId) {
         selectConversation(chatMode, draft.conversationId);
         conversationIdRef.current = draft.conversationId;
@@ -562,7 +574,7 @@ const AiPage = () => {
       }
 
       if (!conversationIdRef.current) {
-        conversationIdRef.current = `conversation-${Date.now()}`;
+        conversationIdRef.current = newConversationId();
         startConversation(chatMode, conversationIdRef.current);
       }
 
@@ -601,6 +613,7 @@ const AiPage = () => {
             conversationId,
           },
           (chunk) => {
+            if (streamRequestIdRef.current !== requestId || controller.signal.aborted) return;
             updateMessages(chatMode, conversationId, (prev) =>
               prev.map((item) =>
                 item.id === responseId
@@ -611,6 +624,7 @@ const AiPage = () => {
           },
           controller.signal,
           (enhanceDelta) => {
+            if (streamRequestIdRef.current !== requestId || controller.signal.aborted) return;
             updateMessages(chatMode, conversationId, (prev) =>
               prev.map((item) =>
                 item.id === responseId
@@ -641,6 +655,7 @@ const AiPage = () => {
         updateMessages(chatMode, conversationId, (prev) =>
           prev.map((item) => (item.id === responseId ? { ...item, pending: false } : item)),
         );
+        flushAiChatHistoryPersistence();
         if (streamRequestIdRef.current === requestId) setLoading(false);
       }
     },

--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -20,6 +20,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
+import { useAiChatHistoryStore } from '../../../stores/aiChatHistoryStore';
 import HomePage from '../index';
 
 const navigateMock = vi.hoisted(() => vi.fn());
@@ -51,6 +52,13 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  sessionStorage.clear();
+  useAiChatHistoryStore.setState({
+    histories: {
+      mock: { conversations: [], activeConversationId: null },
+      real: { conversations: [], activeConversationId: null },
+    },
+  });
   llmApiMocks.getLlmConfig.mockResolvedValue({
     provider: 'tongyi',
     apiBase: 'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',
@@ -107,8 +115,82 @@ describe('HomePage LLM models', () => {
           model: 'qwen3.8-max',
           engine: 'claude-code',
           mode: 'chat',
+          newConversation: true,
         },
       });
     });
+  });
+
+  it('shows only the current data mode history and opens the conversation', async () => {
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: {
+          conversations: [
+            {
+              id: 'mock-conversation',
+              messages: [{ id: 'mock-1', role: 'user', text: 'Mock conversation' }],
+              updatedAt: 1,
+            },
+          ],
+          activeConversationId: 'mock-conversation',
+        },
+        real: {
+          conversations: [
+            {
+              id: 'real-conversation',
+              messages: [{ id: 'real-1', role: 'user', text: 'Real conversation' }],
+              updatedAt: 1,
+            },
+          ],
+          activeConversationId: 'real-conversation',
+        },
+      },
+    });
+    const user = userEvent.setup();
+    renderHome();
+
+    await user.click(await screen.findByRole('button', { name: 'AI 对话历史' }));
+    expect(screen.getByText('Real conversation')).toBeInTheDocument();
+    expect(screen.queryByText('Mock conversation')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^Real conversation/ }));
+    expect(navigateMock).toHaveBeenCalledWith('/ai', { state: { conversationId: 'real-conversation' } });
+  });
+
+  it('lists multiple conversations instead of flattening their messages', async () => {
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: {
+          conversations: [
+            {
+              id: 'latest',
+              messages: [{ id: 'latest-message', role: 'user', text: 'Latest conversation' }],
+              updatedAt: 2,
+            },
+            {
+              id: 'previous',
+              messages: [{ id: 'previous-message', role: 'user', text: 'Previous conversation' }],
+              updatedAt: 1,
+            },
+          ],
+          activeConversationId: 'latest',
+        },
+      },
+    });
+    const user = userEvent.setup();
+    renderHome();
+
+    await user.click(await screen.findByRole('button', { name: 'AI 对话历史' }));
+    expect(screen.getByRole('button', { name: /^Latest conversation/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Previous conversation/ })).toBeInTheDocument();
+  });
+
+  it('shows an explicit empty state when the current data mode has no history', async () => {
+    const user = userEvent.setup();
+    renderHome();
+
+    await user.click(await screen.findByRole('button', { name: 'AI 对话历史' }));
+    expect(screen.getByText('当前模式暂无对话记录')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -18,7 +18,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { RobotOutlined } from '@ant-design/icons';
-import { Select, ConfigProvider, theme } from 'antd';
+import { Drawer, Empty, Select, ConfigProvider, theme } from 'antd';
 import {
   Stethoscope,
   ChatCircleDots,
@@ -35,7 +35,13 @@ import {
 import { getLlmConfig } from '../../api/llm';
 import { useEngineStore } from '../../stores/engineStore';
 import { useDataModeStore } from '../../stores/dataModeStore';
+import {
+  getRecentAiChatConversations,
+  type AiChatDataMode,
+  useAiChatHistoryStore,
+} from '../../stores/aiChatHistoryStore';
 import { useLang } from '../../i18n/LangContext';
+import { formatRelativeTime } from '../../utils/format';
 
 /* ─── Time-aware greeting key ─── */
 function getGreetingKey(): string {
@@ -87,7 +93,11 @@ const HomePage = () => {
   const [selectedModel, setSelectedModel] = useState('');
   const engine = useEngineStore((s) => s.engine);
   const setEnginePreference = useEngineStore((s) => s.setEngine);
+  const useMock = useDataModeStore((state) => state.useMock);
+  const chatMode: AiChatDataMode = useMock ? 'mock' : 'real';
+  const conversations = useAiChatHistoryStore((state) => state.histories[chatMode].conversations);
   const [promoteOn, setPromoteOn] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [indicatorStyle, setIndicatorStyle] = useState({ width: 83, left: 6 });
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -205,10 +215,18 @@ const HomePage = () => {
             ...(selectedModel ? { model: selectedModel } : {}),
             engine,
             mode: activeMode,
+            newConversation: true,
             ...(promoteOn ? { enhance: true } : {}),
           }
         : null,
     });
+  };
+
+  const recentConversations = getRecentAiChatConversations(conversations);
+
+  const openConversation = (conversationId: string) => {
+    setHistoryOpen(false);
+    navigate('/ai', { state: { conversationId } });
   };
 
   return (
@@ -413,7 +431,13 @@ const HomePage = () => {
                     />
                   </div>
                   <div className="flex shrink-0 items-center gap-1">
-                    <button className="p-1 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-50 transition-colors">
+                    <button
+                      type="button"
+                      className="p-1 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-50 transition-colors"
+                      aria-label={t('ai.history.title')}
+                      title={t('ai.history.title')}
+                      onClick={() => setHistoryOpen(true)}
+                    >
                       <ClockCounterClockwise size={20} />
                     </button>
                   </div>
@@ -535,6 +559,38 @@ const HomePage = () => {
           </span>
         </footer>
       </div>
+      <Drawer
+        title={t('ai.history.title')}
+        placement="right"
+        width={360}
+        open={historyOpen}
+        onClose={() => setHistoryOpen(false)}
+      >
+        {recentConversations.length === 0 ? (
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description={t('ai.history.empty')}
+          />
+        ) : (
+          <div className="flex flex-col gap-2">
+            {recentConversations.map((conversation) => (
+              <button
+                key={conversation.id}
+                type="button"
+                onClick={() => openConversation(conversation.id)}
+                className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-left text-sm text-gray-700 transition-colors hover:border-blue-300 hover:bg-blue-50"
+              >
+                <span className="flex items-center justify-between gap-3">
+                  <span className="min-w-0 truncate">{conversation.prompt}</span>
+                  <span className="shrink-0 text-xs text-gray-400">
+                    {formatRelativeTime(conversation.updatedAt, lang, t)}
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+      </Drawer>
     </ConfigProvider>
   );
 };

--- a/web/src/stores/aiChatHistoryStore.test.ts
+++ b/web/src/stores/aiChatHistoryStore.test.ts
@@ -25,6 +25,7 @@ async function loadStore(persisted?: object) {
 
 describe('aiChatHistoryStore', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.resetModules();
     sessionStorage.clear();
   });
@@ -86,6 +87,39 @@ describe('aiChatHistoryStore', () => {
     expect(conversations[0]?.id).toBe('conversation-20');
     expect(conversations[0]?.messages).toHaveLength(100);
     expect(conversations[0]?.messages[0]?.id).toBe('message-1');
+  });
+
+  it('rejects malformed persisted conversation data instead of failing hydration', async () => {
+    const store = await loadStore({
+      histories: { real: { conversations: { invalid: true }, activeConversationId: 'missing' } },
+    });
+
+    expect(store.getState().histories.real).toEqual({ conversations: [], activeConversationId: null });
+  });
+
+  it('bounds a persisted message field before it can exhaust session storage', async () => {
+    const { MAX_AI_CHAT_MESSAGE_FIELD_LENGTH } = await import('./aiChatHistoryStore');
+    const store = await loadStore();
+    store.getState().setMessages('real', 'conversation-1', [{
+      id: 'answer',
+      role: 'ai',
+      summary: 'x'.repeat(MAX_AI_CHAT_MESSAGE_FIELD_LENGTH + 100),
+    }]);
+
+    expect(store.getState().histories.real.conversations[0]?.messages[0]?.summary).toHaveLength(
+      MAX_AI_CHAT_MESSAGE_FIELD_LENGTH + '\n\n[Truncated]'.length,
+    );
+  });
+
+  it('clears pending throttled persistence when histories are cleared', async () => {
+    vi.useFakeTimers();
+    const store = await loadStore();
+    const { clearAiChatHistories, flushAiChatHistoryPersistence } = await import('./aiChatHistoryStore');
+    store.getState().setMessages('real', 'conversation-1', [{ id: 'message', role: 'user', text: 'secret' }]);
+    clearAiChatHistories();
+    flushAiChatHistoryPersistence();
+
+    expect(sessionStorage.getItem(STORAGE_KEY)).toContain('"conversations":[]');
   });
 
   it('derives recent conversations from the first user message', async () => {

--- a/web/src/stores/aiChatHistoryStore.test.ts
+++ b/web/src/stores/aiChatHistoryStore.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const STORAGE_KEY = 'rocketmq-studio-ai-chat-history';
+
+async function loadStore(persisted?: object) {
+  vi.resetModules();
+  if (persisted) sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ state: persisted, version: 0 }));
+  return (await import('./aiChatHistoryStore')).useAiChatHistoryStore;
+}
+
+describe('aiChatHistoryStore', () => {
+  afterEach(() => {
+    vi.resetModules();
+    sessionStorage.clear();
+  });
+
+  it('keeps multiple conversations independently for each data mode', async () => {
+    const store = await loadStore();
+    store.getState().startConversation('real', 'real-1');
+    store.getState().setMessages('real', 'real-1', [{ id: 'r1', role: 'user', text: 'First' }]);
+    store.getState().startConversation('real', 'real-2');
+    store.getState().setMessages('real', 'real-2', [{ id: 'r2', role: 'user', text: 'Second' }]);
+    store.getState().startConversation('mock', 'mock-1');
+    store.getState().setMessages('mock', 'mock-1', [{ id: 'm1', role: 'user', text: 'Mock' }]);
+
+    const real = store.getState().histories.real;
+    expect(real.conversations.map((conversation) => conversation.id)).toEqual(['real-2', 'real-1']);
+    expect(real.conversations[1].messages[0]?.text).toBe('First');
+    expect(store.getState().histories.mock.conversations).toHaveLength(1);
+  });
+
+  it('migrates the previous current conversation to the Real conversation list', async () => {
+    const store = await loadStore({
+      conversationId: 'conversation-2',
+      messages: [{ id: 'message-2', role: 'ai', summary: '', pending: true }],
+    });
+
+    expect(store.getState().histories.mock).toEqual({ conversations: [], activeConversationId: null });
+    expect(store.getState().histories.real.activeConversationId).toBe('conversation-2');
+    expect(store.getState().histories.real.conversations[0]).toMatchObject({
+      id: 'conversation-2',
+      messages: [{ id: 'message-2', role: 'ai', summary: '', pending: false }],
+    });
+  });
+
+  it('selects a previous conversation without deleting newer conversations', async () => {
+    const store = await loadStore();
+    store.getState().startConversation('real', 'first');
+    store.getState().startConversation('real', 'second');
+
+    store.getState().selectConversation('real', 'first');
+
+    expect(store.getState().histories.real.activeConversationId).toBe('first');
+    expect(store.getState().histories.real.conversations).toHaveLength(2);
+  });
+
+  it('bounds persisted conversations and messages', async () => {
+    const store = await loadStore();
+    for (let index = 0; index < 21; index += 1) {
+      store.getState().startConversation('real', `conversation-${index}`);
+    }
+    const messages = Array.from({ length: 101 }, (_, index) => ({
+      id: `message-${index}`,
+      role: 'user' as const,
+      text: `Message ${index}`,
+    }));
+    store.getState().setMessages('real', 'conversation-20', messages);
+
+    const conversations = store.getState().histories.real.conversations;
+    expect(conversations).toHaveLength(20);
+    expect(conversations[0]?.id).toBe('conversation-20');
+    expect(conversations[0]?.messages).toHaveLength(100);
+    expect(conversations[0]?.messages[0]?.id).toBe('message-1');
+  });
+
+  it('derives recent conversations from the first user message', async () => {
+    const { getRecentAiChatConversations } = await import('./aiChatHistoryStore');
+    const recent = getRecentAiChatConversations([
+      { id: 'empty', messages: [], updatedAt: 3 },
+      { id: 'prompt', messages: [{ id: 'p', role: 'user', text: 'Inspect lag' }], updatedAt: 2 },
+    ]);
+
+    expect(recent).toEqual([expect.objectContaining({ id: 'prompt', prompt: 'Inspect lag' })]);
+  });
+});

--- a/web/src/stores/aiChatHistoryStore.ts
+++ b/web/src/stores/aiChatHistoryStore.ts
@@ -14,7 +14,7 @@
  */
 
 import { create } from 'zustand';
-import { createJSONStorage, persist } from 'zustand/middleware';
+import { createJSONStorage, persist, type StateStorage } from 'zustand/middleware';
 
 export interface AiChatMessage {
   id: string;
@@ -45,6 +45,11 @@ export interface RecentAiChatConversation extends AiChatConversation {
 
 export const MAX_AI_CHAT_CONVERSATIONS = 20;
 export const MAX_AI_CHAT_MESSAGES = 100;
+export const MAX_AI_CHAT_HISTORY_BYTES = 512 * 1024;
+export const MAX_AI_CHAT_MESSAGE_FIELD_LENGTH = 16 * 1024;
+
+const AI_CHAT_HISTORY_STORAGE_KEY = 'rocketmq-studio-ai-chat-history';
+const AI_CHAT_HISTORY_PERSIST_INTERVAL_MS = 250;
 
 interface AiChatHistoryState {
   histories: Record<AiChatDataMode, AiChatHistory>;
@@ -55,14 +60,64 @@ interface AiChatHistoryState {
     conversationId: string,
     messages: AiChatMessage[] | ((messages: AiChatMessage[]) => AiChatMessage[]),
   ) => void;
+  clearHistories: () => void;
 }
 
 const emptyHistory = (): AiChatHistory => ({ conversations: [], activeConversationId: null });
 
-const restoreMessages = (messages?: AiChatMessage[]): AiChatMessage[] =>
-  (messages ?? [])
-    .slice(-MAX_AI_CHAT_MESSAGES)
-    .map((message) => (message.pending ? { ...message, pending: false } : message));
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const truncateMessageField = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  return value.length <= MAX_AI_CHAT_MESSAGE_FIELD_LENGTH
+    ? value
+    : `${value.slice(0, MAX_AI_CHAT_MESSAGE_FIELD_LENGTH)}\n\n[Truncated]`;
+};
+
+const boundMessageFields = (messages: AiChatMessage[]): AiChatMessage[] =>
+  messages.slice(-MAX_AI_CHAT_MESSAGES).map((message) => ({
+    ...message,
+    text: truncateMessageField(message.text),
+    summary: truncateMessageField(message.summary),
+    thinking: truncateMessageField(message.thinking),
+  }));
+
+const restoreMessages = (messages: unknown): AiChatMessage[] =>
+  (Array.isArray(messages) ? messages : [])
+    .filter(isRecord)
+    .flatMap((message) => {
+      if (typeof message.id !== 'string' || (message.role !== 'user' && message.role !== 'ai')) return [];
+      return [{
+        id: message.id,
+        role: message.role as AiChatMessage['role'],
+        createdAt: typeof message.createdAt === 'number' ? message.createdAt : undefined,
+        text: truncateMessageField(message.text),
+        summary: truncateMessageField(message.summary),
+        thinking: truncateMessageField(message.thinking),
+        pending: false,
+      }];
+    })
+    .slice(-MAX_AI_CHAT_MESSAGES);
+
+const limitHistorySize = (history: AiChatHistory): AiChatHistory => {
+  const conversations = history.conversations.map((conversation) => ({ ...conversation, messages: [...conversation.messages] }));
+  while (conversations.length > 0 && JSON.stringify({ conversations }).length > MAX_AI_CHAT_HISTORY_BYTES) {
+    const oldestIndex = conversations.length - 1;
+    const oldest = conversations[oldestIndex];
+    if (oldest.messages.length > 1) {
+      conversations[oldestIndex] = { ...oldest, messages: oldest.messages.slice(1) };
+    } else {
+      conversations.pop();
+    }
+  }
+  return {
+    conversations,
+    activeConversationId: conversations.some((item) => item.id === history.activeConversationId)
+      ? history.activeConversationId
+      : conversations[0]?.id ?? null,
+  };
+};
 
 export const getRecentAiChatConversations = (
   conversations: AiChatConversation[],
@@ -77,27 +132,66 @@ export const getRecentAiChatConversations = (
     .slice(0, limit);
 
 const restoreHistory = (history?: Partial<AiChatHistory> & { messages?: AiChatMessage[]; conversationId?: string | null }): AiChatHistory => {
-  if (history?.conversations) {
-    const conversations = history.conversations.slice(0, MAX_AI_CHAT_CONVERSATIONS).map((conversation) => ({
-        ...conversation,
+  if (Array.isArray(history?.conversations)) {
+    const conversations = history.conversations
+      .filter((conversation): conversation is AiChatConversation => isRecord(conversation) && typeof conversation.id === 'string')
+      .slice(0, MAX_AI_CHAT_CONVERSATIONS)
+      .map((conversation) => ({
+        id: conversation.id,
         messages: restoreMessages(conversation.messages),
+        updatedAt: typeof conversation.updatedAt === 'number' ? conversation.updatedAt : 0,
       }));
-    return {
+    return limitHistorySize({
       conversations,
       activeConversationId: conversations.some((item) => item.id === history.activeConversationId)
         ? history.activeConversationId ?? null
         : conversations[0]?.id ?? null,
-    };
+    });
   }
 
   if (history?.conversationId || history?.messages?.length) {
     const id = history.conversationId ?? 'legacy-conversation';
-    return {
+    return limitHistorySize({
       conversations: [{ id, messages: restoreMessages(history.messages), updatedAt: 0 }],
       activeConversationId: id,
-    };
+    });
   }
   return emptyHistory();
+};
+
+let pendingPersist: { name: string; value: string } | null = null;
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const flushAiChatHistoryPersistence = (): void => {
+  if (persistTimer) {
+    clearTimeout(persistTimer);
+    persistTimer = null;
+  }
+  const pending = pendingPersist;
+  pendingPersist = null;
+  if (!pending) return;
+  try {
+    sessionStorage.setItem(pending.name, pending.value);
+  } catch {
+    // The in-memory conversation remains available if browser storage is unavailable.
+  }
+};
+
+const throttledHistoryStorage: StateStorage = {
+  getItem: (name) => sessionStorage.getItem(name),
+  setItem: (name, value) => {
+    pendingPersist = { name, value };
+    if (persistTimer) return;
+    persistTimer = setTimeout(flushAiChatHistoryPersistence, AI_CHAT_HISTORY_PERSIST_INTERVAL_MS);
+  },
+  removeItem: (name) => {
+    if (persistTimer) {
+      clearTimeout(persistTimer);
+      persistTimer = null;
+    }
+    pendingPersist = null;
+    sessionStorage.removeItem(name);
+  },
 };
 
 export const useAiChatHistoryStore = create<AiChatHistoryState>()(
@@ -108,18 +202,19 @@ export const useAiChatHistoryStore = create<AiChatHistoryState>()(
         set((state) => {
           const history = state.histories[mode];
           const exists = history.conversations.some((item) => item.id === conversationId);
+          const nextHistory = limitHistorySize({
+            conversations: exists
+              ? history.conversations
+              : [
+                  { id: conversationId, messages: [], updatedAt: Date.now() },
+                  ...history.conversations,
+                ].slice(0, MAX_AI_CHAT_CONVERSATIONS),
+            activeConversationId: conversationId,
+          });
           return {
             histories: {
               ...state.histories,
-              [mode]: {
-                conversations: exists
-                  ? history.conversations
-                  : [
-                      { id: conversationId, messages: [], updatedAt: Date.now() },
-                      ...history.conversations,
-                    ].slice(0, MAX_AI_CHAT_CONVERSATIONS),
-                activeConversationId: conversationId,
-              },
+              [mode]: nextHistory,
             },
           };
         }),
@@ -134,27 +229,29 @@ export const useAiChatHistoryStore = create<AiChatHistoryState>()(
         set((state) => {
           const history = state.histories[mode];
           const conversation = history.conversations.find((item) => item.id === conversationId);
-          const nextMessages = (
-            typeof messages === 'function' ? messages(conversation?.messages ?? []) : messages
-          ).slice(-MAX_AI_CHAT_MESSAGES);
+          const nextMessages = boundMessageFields(
+            typeof messages === 'function' ? messages(conversation?.messages ?? []) : messages,
+          );
           const updatedConversation = { id: conversationId, messages: nextMessages, updatedAt: Date.now() };
+          const nextHistory = limitHistorySize({
+            conversations: [updatedConversation, ...history.conversations.filter((item) => item.id !== conversationId)].slice(
+              0,
+              MAX_AI_CHAT_CONVERSATIONS,
+            ),
+            activeConversationId: history.activeConversationId ?? conversationId,
+          });
           return {
             histories: {
               ...state.histories,
-              [mode]: {
-                conversations: [updatedConversation, ...history.conversations.filter((item) => item.id !== conversationId)].slice(
-                  0,
-                  MAX_AI_CHAT_CONVERSATIONS,
-                ),
-                activeConversationId: history.activeConversationId ?? conversationId,
-              },
+              [mode]: nextHistory,
             },
           };
         }),
+      clearHistories: () => set({ histories: { mock: emptyHistory(), real: emptyHistory() } }),
     }),
     {
-      name: 'rocketmq-studio-ai-chat-history',
-      storage: createJSONStorage(() => sessionStorage),
+      name: AI_CHAT_HISTORY_STORAGE_KEY,
+      storage: createJSONStorage(() => throttledHistoryStorage),
       partialize: (state) => ({ histories: state.histories }),
       merge: (persisted, current) => {
         const saved = persisted as Partial<AiChatHistoryState> & { messages?: AiChatMessage[]; conversationId?: string | null };
@@ -169,3 +266,8 @@ export const useAiChatHistoryStore = create<AiChatHistoryState>()(
     },
   ),
 );
+
+export const clearAiChatHistories = (): void => {
+  useAiChatHistoryStore.getState().clearHistories();
+  flushAiChatHistoryPersistence();
+};

--- a/web/src/stores/aiChatHistoryStore.ts
+++ b/web/src/stores/aiChatHistoryStore.ts
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+export interface AiChatMessage {
+  id: string;
+  role: 'user' | 'ai';
+  createdAt?: number;
+  text?: string;
+  summary?: string;
+  thinking?: string;
+  pending?: boolean;
+}
+
+export type AiChatDataMode = 'mock' | 'real';
+
+export interface AiChatConversation {
+  id: string;
+  messages: AiChatMessage[];
+  updatedAt: number;
+}
+
+export interface AiChatHistory {
+  conversations: AiChatConversation[];
+  activeConversationId: string | null;
+}
+
+export interface RecentAiChatConversation extends AiChatConversation {
+  prompt: string;
+}
+
+export const MAX_AI_CHAT_CONVERSATIONS = 20;
+export const MAX_AI_CHAT_MESSAGES = 100;
+
+interface AiChatHistoryState {
+  histories: Record<AiChatDataMode, AiChatHistory>;
+  startConversation: (mode: AiChatDataMode, conversationId: string) => void;
+  selectConversation: (mode: AiChatDataMode, conversationId: string) => void;
+  setMessages: (
+    mode: AiChatDataMode,
+    conversationId: string,
+    messages: AiChatMessage[] | ((messages: AiChatMessage[]) => AiChatMessage[]),
+  ) => void;
+}
+
+const emptyHistory = (): AiChatHistory => ({ conversations: [], activeConversationId: null });
+
+const restoreMessages = (messages?: AiChatMessage[]): AiChatMessage[] =>
+  (messages ?? [])
+    .slice(-MAX_AI_CHAT_MESSAGES)
+    .map((message) => (message.pending ? { ...message, pending: false } : message));
+
+export const getRecentAiChatConversations = (
+  conversations: AiChatConversation[],
+  limit = 8,
+): RecentAiChatConversation[] =>
+  conversations
+    .map((conversation) => ({
+      ...conversation,
+      prompt: conversation.messages.find((item) => item.role === 'user' && item.text?.trim())?.text,
+    }))
+    .filter((conversation): conversation is RecentAiChatConversation => Boolean(conversation.prompt))
+    .slice(0, limit);
+
+const restoreHistory = (history?: Partial<AiChatHistory> & { messages?: AiChatMessage[]; conversationId?: string | null }): AiChatHistory => {
+  if (history?.conversations) {
+    const conversations = history.conversations.slice(0, MAX_AI_CHAT_CONVERSATIONS).map((conversation) => ({
+        ...conversation,
+        messages: restoreMessages(conversation.messages),
+      }));
+    return {
+      conversations,
+      activeConversationId: conversations.some((item) => item.id === history.activeConversationId)
+        ? history.activeConversationId ?? null
+        : conversations[0]?.id ?? null,
+    };
+  }
+
+  if (history?.conversationId || history?.messages?.length) {
+    const id = history.conversationId ?? 'legacy-conversation';
+    return {
+      conversations: [{ id, messages: restoreMessages(history.messages), updatedAt: 0 }],
+      activeConversationId: id,
+    };
+  }
+  return emptyHistory();
+};
+
+export const useAiChatHistoryStore = create<AiChatHistoryState>()(
+  persist(
+    (set) => ({
+      histories: { mock: emptyHistory(), real: emptyHistory() },
+      startConversation: (mode, conversationId) =>
+        set((state) => {
+          const history = state.histories[mode];
+          const exists = history.conversations.some((item) => item.id === conversationId);
+          return {
+            histories: {
+              ...state.histories,
+              [mode]: {
+                conversations: exists
+                  ? history.conversations
+                  : [
+                      { id: conversationId, messages: [], updatedAt: Date.now() },
+                      ...history.conversations,
+                    ].slice(0, MAX_AI_CHAT_CONVERSATIONS),
+                activeConversationId: conversationId,
+              },
+            },
+          };
+        }),
+      selectConversation: (mode, conversationId) =>
+        set((state) => ({
+          histories: {
+            ...state.histories,
+            [mode]: { ...state.histories[mode], activeConversationId: conversationId },
+          },
+        })),
+      setMessages: (mode, conversationId, messages) =>
+        set((state) => {
+          const history = state.histories[mode];
+          const conversation = history.conversations.find((item) => item.id === conversationId);
+          const nextMessages = (
+            typeof messages === 'function' ? messages(conversation?.messages ?? []) : messages
+          ).slice(-MAX_AI_CHAT_MESSAGES);
+          const updatedConversation = { id: conversationId, messages: nextMessages, updatedAt: Date.now() };
+          return {
+            histories: {
+              ...state.histories,
+              [mode]: {
+                conversations: [updatedConversation, ...history.conversations.filter((item) => item.id !== conversationId)].slice(
+                  0,
+                  MAX_AI_CHAT_CONVERSATIONS,
+                ),
+                activeConversationId: history.activeConversationId ?? conversationId,
+              },
+            },
+          };
+        }),
+    }),
+    {
+      name: 'rocketmq-studio-ai-chat-history',
+      storage: createJSONStorage(() => sessionStorage),
+      partialize: (state) => ({ histories: state.histories }),
+      merge: (persisted, current) => {
+        const saved = persisted as Partial<AiChatHistoryState> & { messages?: AiChatMessage[]; conversationId?: string | null };
+        return {
+          ...current,
+          histories: {
+            mock: restoreHistory(saved.histories?.mock),
+            real: restoreHistory(saved.histories?.real ?? saved),
+          },
+        };
+      },
+    },
+  ),
+);

--- a/web/src/utils/format.test.ts
+++ b/web/src/utils/format.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
-import { formatBytes } from './format';
+import { formatBytes, formatRelativeTime, formatTimeOfDay } from './format';
 
 describe('formatBytes', () => {
   it('formats zero', () => {
@@ -22,5 +22,19 @@ describe('formatBytes', () => {
     expect(formatBytes(Number.NaN)).toBe('-');
     expect(formatBytes(Number.POSITIVE_INFINITY)).toBe('-');
     expect(formatBytes(Number.NEGATIVE_INFINITY)).toBe('-');
+  });
+
+  it('formats recent timestamps for compact conversation history', () => {
+    const now = new Date(2026, 7, 13, 15, 30).getTime();
+    const zh = (key: string, params?: Record<string, string | number>) =>
+      key === 'ai.history.justNow' ? '刚刚' : `${params?.count} 分钟前`;
+    const en = (key: string, params?: Record<string, string | number>) =>
+      key === 'ai.history.justNow' ? 'Just now' : `${params?.count} min ago`;
+
+    expect(formatRelativeTime(now, 'zh', zh, now)).toBe('刚刚');
+    expect(formatRelativeTime(now - 5 * 60_000, 'zh', zh, now)).toBe('5 分钟前');
+    expect(formatRelativeTime(now - 5 * 60_000, 'en', en, now)).toBe('5 min ago');
+    expect(formatRelativeTime(now - 2 * 60 * 60_000, 'zh', zh, now)).toBe('13:30');
+    expect(formatTimeOfDay(now)).toBe('15:30');
   });
 });

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -40,6 +40,41 @@ export function formatDate(date: string | Date | null | undefined): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
+type RelativeTimeTranslator = (key: string, params?: Record<string, string | number>) => string;
+
+/**
+ * Format a recent timestamp for compact conversation history entries.
+ */
+export function formatRelativeTime(
+  timestamp: number,
+  lang: 'zh' | 'en',
+  t: RelativeTimeTranslator,
+  now = Date.now(),
+): string {
+  if (!timestamp) return t('ai.history.justNow');
+
+  const elapsed = Math.max(0, now - timestamp);
+  const minutes = Math.floor(elapsed / 60_000);
+  if (minutes < 1) return t('ai.history.justNow');
+  if (minutes < 60) return t('ai.history.minutesAgo', { count: minutes });
+
+  const updatedAt = new Date(timestamp);
+  const current = new Date(now);
+  const locale = lang === 'zh' ? 'zh-CN' : 'en-US';
+  if (updatedAt.toDateString() === current.toDateString()) {
+    return new Intl.DateTimeFormat(locale, { hour: '2-digit', minute: '2-digit', hour12: false }).format(updatedAt);
+  }
+  return new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric' }).format(updatedAt);
+}
+
+/**
+ * Format a message timestamp for a compact chat bubble footer.
+ */
+export function formatTimeOfDay(timestamp: number): string {
+  const date = new Date(timestamp);
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
 /**
  * Format bytes into human-readable string (1024-based).
  * e.g. 1536 → '1.5 KB', 1048576 → '1 MB'


### PR DESCRIPTION
## Summary
- preserve AI conversations across Studio home and `/ai` navigation, separated by mock/real data mode
- provide a shared recent-conversation selector for the home and AI history drawers
- bound session storage to 20 conversations and 100 messages per conversation
- cancel in-flight streams before switching conversations and keep the selected conversation active
- localize history labels and relative timestamps through the translation catalog

## Verification
- `npm run lint` (two existing warnings remain outside this PR: `MainLayout.tsx` and `instance/topic.tsx`)
- `npm test -- --run src/pages/ai/__tests__/AiPage.test.tsx src/pages/home/__tests__/HomePage.test.tsx src/stores/aiChatHistoryStore.test.ts src/utils/format.test.ts` (25 tests)
- `npm run build`