### PR TITLE
fix(alerts): use existence-checked updates for bulk rule toggles

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -160,10 +160,15 @@ public class AlertService {
             }
             try {
                 rule.setEnabled(enabled);
-                AlertRuleVO saved = alertRepository.saveRule(rule);
-                auditRule("TOGGLE_ALERT_RULE", saved, "enabled=" + enabled + ", bulk=true");
+                // replaceRule performs an existence-checked update; a rule deleted between the
+                // snapshot load and this call is reported as a failure instead of being recreated.
+                if (!alertRepository.replaceRule(rule)) {
+                    failures.put(id, "Alert rule not found");
+                    continue;
+                }
+                auditRule("TOGGLE_ALERT_RULE", rule, "enabled=" + enabled + ", bulk=true");
                 succeeded.add(id);
-                updated.add(saved);
+                updated.add(rule);
             } catch (RuntimeException failure) {
                 failures.put(id, failure.getMessage() == null ? "Update failed" : failure.getMessage());
             }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -601,8 +601,7 @@ class AlertServiceTest {
     void bulkToggleShouldDeduplicateIdsAndReportMissingRules() {
         AlertRuleVO rule = AlertRuleVO.builder().id("rule-1").name("High CPU").enabled(false).build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
-        when(alertRepository.saveRule(any(AlertRuleVO.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(true);
 
         AlertRuleBulkResultVO result = alertService.bulkToggleRules(
                 List.of("rule-1", "missing", "rule-1"), true);
@@ -611,7 +610,21 @@ class AlertServiceTest {
         assertThat(result.getFailures()).containsEntry("missing", "Alert rule not found");
         assertThat(result.getUpdatedRules()).singleElement()
                 .extracting(AlertRuleVO::isEnabled).isEqualTo(true);
-        verify(alertRepository).saveRule(rule);
+        verify(alertRepository).replaceRule(rule);
+    }
+
+    @Test
+    void bulkToggleShouldReportRulesDeletedConcurrentlyInsteadOfRecreatingThem() {
+        AlertRuleVO rule = AlertRuleVO.builder().id("rule-1").name("High CPU").enabled(false).build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+        when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(false);
+
+        AlertRuleBulkResultVO result = alertService.bulkToggleRules(List.of("rule-1"), true);
+
+        assertThat(result.getSucceededIds()).isEmpty();
+        assertThat(result.getFailures()).containsEntry("rule-1", "Alert rule not found");
+        assertThat(result.getUpdatedRules()).isEmpty();
+        verify(alertRepository, never()).saveRule(any(AlertRuleVO.class));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #1920: bulkToggleRules used the upsert-style saveRule, so a rule deleted between the snapshot load and the update was silently recreated. Switch to replaceRule (existence-checked update), report concurrently deleted rules as failures, and add a regression test. Verified: AlertServiceTest + AlertRuleControllerTest 61/61 green.