### PR TITLE
[Studio] fix: release AdminClients by credential identity

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
@@ -132,6 +132,25 @@ public class MqAdminExtFactory {
         log.info("Released RocketMQ admin clients for namesrv {}", normalizedNamesrvAddr);
     }
 
+    /** Stops one credential-scoped client without interrupting other identities on the endpoint. */
+    public void release(String namesrvAddr, String authenticationIdentity) {
+        if (namesrvAddr == null || namesrvAddr.isBlank()) {
+            return;
+        }
+        String normalizedNamesrvAddr = normalizeNamesrvAddr(namesrvAddr);
+        if (normalizedNamesrvAddr.isEmpty()) {
+            return;
+        }
+        AdminClientCacheKey key = new AdminClientCacheKey(normalizedNamesrvAddr,
+                normalizeAuthenticationIdentity(authenticationIdentity));
+        DefaultMQAdminExt admin = cache.remove(key);
+        if (admin != null) {
+            safeShutdown(admin);
+            log.info("Released RocketMQ admin client for namesrv {} and identity {}",
+                    normalizedNamesrvAddr, key.authenticationIdentity());
+        }
+    }
+
     private DefaultMQAdminExt createAndStart(String namesrvAddr, RPCHook rpcHook) {
         DefaultMQAdminExt admin = newAdmin(rpcHook);
         admin.setNamesrvAddr(namesrvAddr);

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -321,7 +321,7 @@ public class InstanceService {
         if (vendor != InstanceVendor.APACHE) {
             return;
         }
-        releaseEndpointIfUnused(existing.getEndpoint(), currentEndpoint, existing.getId());
+        releaseOldClientIfUnused(existing, currentEndpoint, null, existing.getId());
     }
 
     private void releaseApacheClientIfChanged(InstanceVO existing, InstanceVO saved) {
@@ -329,25 +329,32 @@ public class InstanceService {
         if (vendor != InstanceVendor.APACHE) {
             return;
         }
-        if (!Objects.equals(normalizeCredentialRef(existing.getAdminCredentialRef()),
-                normalizeCredentialRef(saved.getAdminCredentialRef()))
-                && Objects.equals(normalizeEndpoint(existing.getEndpoint()), normalizeEndpoint(saved.getEndpoint()))) {
-            adminFactory.release(existing.getEndpoint());
-            return;
-        }
-        releaseEndpointIfUnused(existing.getEndpoint(), saved.getEndpoint(), existing.getId());
+        releaseOldClientIfUnused(existing, saved.getEndpoint(), saved.getAdminCredentialRef(), existing.getId());
     }
 
-    private void releaseEndpointIfUnused(String previousEndpoint, String currentEndpoint, String excludedInstanceId) {
-        String oldEndpoint = normalizeEndpoint(previousEndpoint);
-        if (oldEndpoint == null || oldEndpoint.equals(normalizeEndpoint(currentEndpoint))) {
+    private void releaseOldClientIfUnused(InstanceVO existing, String currentEndpoint,
+                                          String currentCredentialRef, String excludedInstanceId) {
+        String oldEndpoint = normalizeEndpoint(existing.getEndpoint());
+        String oldCredentialRef = normalizeCredentialRef(existing.getAdminCredentialRef());
+        if (oldEndpoint == null || (oldEndpoint.equals(normalizeEndpoint(currentEndpoint))
+                && Objects.equals(oldCredentialRef, normalizeCredentialRef(currentCredentialRef)))) {
             return;
         }
-        boolean stillReferenced = instanceRepository.findAll().stream()
-                .anyMatch(instance -> !excludedInstanceId.equals(instance.getId())
-                        && oldEndpoint.equals(normalizeEndpoint(instance.getEndpoint())));
-        if (!stillReferenced) {
+        List<InstanceVO> remaining = instanceRepository.findAll().stream()
+                .filter(instance -> !excludedInstanceId.equals(instance.getId()))
+                .toList();
+        boolean endpointReferenced = remaining.stream()
+                .anyMatch(instance -> oldEndpoint.equals(normalizeEndpoint(instance.getEndpoint())));
+        if (!endpointReferenced) {
             adminFactory.release(oldEndpoint);
+            return;
+        }
+        boolean identityReferenced = remaining.stream()
+                .anyMatch(instance -> !excludedInstanceId.equals(instance.getId())
+                        && oldEndpoint.equals(normalizeEndpoint(instance.getEndpoint()))
+                        && Objects.equals(oldCredentialRef, normalizeCredentialRef(instance.getAdminCredentialRef())));
+        if (!identityReferenced) {
+            adminFactory.release(oldEndpoint, oldCredentialRef);
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
@@ -85,6 +85,22 @@ class MqAdminExtFactoryTest {
     }
 
     @Test
+    void releaseShouldEvictOnlyMatchingCredentialIdentity() throws Exception {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+
+        factory.execute("10.0.0.1:9876", null, "credential-a", ignored -> null);
+        factory.execute("10.0.0.1:9876", null, "credential-b", ignored -> null);
+        factory.release("10.0.0.1:9876", "credential-a");
+        factory.execute("10.0.0.1:9876", null, "credential-b", ignored -> null);
+        factory.execute("10.0.0.1:9876", null, "credential-a", ignored -> null);
+
+        assertThat(factory.created.get()).isEqualTo(3);
+        verify(admin, times(3)).start();
+        verify(admin).shutdown();
+    }
+
+    @Test
     void releaseShouldEvictClientUsingEquivalentNameServerAddressList() throws Exception {
         DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
         RecordingFactory factory = new RecordingFactory(admin);


### PR DESCRIPTION
## Summary\n\n- add credential-scoped AdminClient eviction\n- retain shared endpoint and identity clients while referenced\n- release the old identity on instance update or deletion\n- add focused cache regression coverage\n\nCloses #1754\n\n## Verification\n\ngit diff --check passed. Maven compile was attempted but dependency resolution was blocked by Maven Central HTTP 403 before source compilation.\n\n## Base\n\nrocketmq-studio at 737a7b4d