### PR TITLE
[Studio] fix: remove deleted instances from metrics bindings

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -29,9 +29,12 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.CloudInstanceDetailVO;
 import org.apache.rocketmq.studio.provider.InstanceProvider;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
+import org.apache.rocketmq.studio.settings.DataSourceVO;
+import org.apache.rocketmq.studio.settings.SettingsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -48,6 +51,7 @@ public class InstanceService {
     private final InstanceProviderRegistry providerRegistry;
     private final MqAdminExtFactory adminFactory;
     private final OperationAuditService operationAuditService;
+    private final SettingsRepository settingsRepository;
 
     public List<InstanceVO> listInstances(InstanceType type, String search) {
         log.debug("Listing instances, type={}, search={}", type, search);
@@ -260,6 +264,7 @@ public class InstanceService {
         return saved;
     }
 
+    @Transactional
     public void deleteInstance(String id) {
         log.info("Deleting instance: {}", id);
 
@@ -280,9 +285,26 @@ public class InstanceService {
                     topicCount, consumerGroupCount));
         }
         instanceRepository.deleteById(id);
+        removeDataSourceBindings(id);
         releaseApacheEndpointIfUnused(existing, null);
         recordAudit("DELETE_INSTANCE", "INSTANCE", id, null,
                 instanceAuditDetail(existing));
+    }
+
+    private void removeDataSourceBindings(String instanceId) {
+        for (DataSourceVO dataSource : settingsRepository.findAllDataSources()) {
+            List<String> instanceIds = dataSource.getInstanceIds();
+            if (instanceIds == null || !instanceIds.contains(instanceId)) {
+                continue;
+            }
+            dataSource.setInstanceIds(instanceIds.stream()
+                    .filter(candidate -> !instanceId.equals(candidate))
+                    .toList());
+            if (!settingsRepository.replaceDataSource(dataSource)) {
+                log.warn("Metrics data source {} disappeared while removing instance binding {}",
+                        dataSource.getKey(), instanceId);
+            }
+        }
     }
 
     private void requireInstance(InstanceVO instance) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -28,6 +28,8 @@ import org.apache.rocketmq.studio.provider.CloudCatalogProvider;
 import org.apache.rocketmq.studio.provider.CloudInstanceDetailVO;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
 import org.apache.rocketmq.studio.provider.InstanceProvider;
+import org.apache.rocketmq.studio.settings.DataSourceVO;
+import org.apache.rocketmq.studio.settings.SettingsRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -70,6 +72,9 @@ class InstanceServiceTest {
 
     @Mock
     private OperationAuditService operationAuditService;
+
+    @Mock
+    private SettingsRepository settingsRepository;
 
     @InjectMocks
     private InstanceService instanceService;
@@ -715,6 +720,23 @@ class InstanceServiceTest {
 
         verify(instanceRepository).deleteById("inst-1");
         verify(adminFactory).release("namesrv:9876");
+    }
+
+    @Test
+    void deleteInstanceShouldRemoveMetricsDataSourceBinding() {
+        InstanceVO existing = InstanceVO.builder().name("to-delete").build();
+        existing.setId("inst-1");
+        DataSourceVO dataSource = DataSourceVO.builder().key("prometheus")
+                .instanceIds(List.of("inst-1", "inst-2")).build();
+        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(settingsRepository.findAllDataSources()).thenReturn(List.of(dataSource));
+        when(settingsRepository.replaceDataSource(dataSource)).thenReturn(true);
+
+        instanceService.deleteInstance("inst-1");
+
+        assertThat(dataSource.getInstanceIds()).containsExactly("inst-2");
+        verify(settingsRepository).replaceDataSource(dataSource);
     }
 
     @Test


### PR DESCRIPTION
## Summary\n\n- remove a deleted instance ID from every metrics data source binding\n- preserve empty bindings as global availability\n- make deletion and binding cleanup transactional\n- cover the lifecycle contract\n\nCloses #1264\n\n## Verification\n\ngit diff --check passed. Maven compile was attempted but dependency resolution was blocked by Maven Central HTTP 403 before source compilation.\n\n## Base\n\nrocketmq-studio at 737a7b4d