### PR TITLE
[Studio] fix: surface Message Explorer Topic loading failures

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -118,7 +118,7 @@ describe('Message page query history', () => {
     const queryButton = screen.getByRole('button', { name: /^search查询$/ });
 
     expect(queryButton).toBeDisabled();
-    expect(queryButton).toHaveAttribute('title', '请选择 Topic');
+    await waitFor(() => expect(queryButton).toHaveAttribute('title', '请选择 Topic'));
 
     await user.click(lastElement(screen.getAllByRole('combobox')));
     await user.click(lastElement(await screen.findAllByText('order-create')));
@@ -165,6 +165,23 @@ describe('Message page query history', () => {
         instanceId: 'instance-a',
       });
     });
+  });
+
+  it('surfaces Topic loading failures and retries without changing instance', async () => {
+    const user = userEvent.setup();
+    topicServiceMocks.listTopics
+      .mockReset()
+      .mockRejectedValueOnce(new Error('NameServer unavailable'))
+      .mockResolvedValueOnce([{ name: 'orders' }]);
+
+    renderWithProviders(<MessagePage />);
+
+    expect(await screen.findByText('Topic 列表加载失败')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^search查询$/ })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: /重\s*试/ }));
+    await waitFor(() => expect(topicServiceMocks.listTopics).toHaveBeenCalledTimes(2));
+    await user.click(lastElement(screen.getAllByRole('combobox')));
+    expect(await screen.findAllByText('orders')).not.toHaveLength(0);
   });
 
   it('requires a topic even when a key or message ID is present', async () => {

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
   Card,
@@ -272,27 +272,38 @@ const MessagePageContent = ({
   const { t } = useLang();
   const [topicOptions, setTopicOptions] = useState<string[]>([]);
   const [topicError, setTopicError] = useState<string | null>(null);
+  const [topicLoading, setTopicLoading] = useState(false);
+  const topicRequestId = useRef(0);
 
-  useEffect(() => {
+  const loadTopicOptions = useCallback(async () => {
     if (!selectedInstanceId) {
+      setTopicOptions([]);
+      setTopicError(null);
+      setTopicLoading(false);
       return;
     }
-    let cancelled = false;
-    void listTopics({ instanceId: selectedInstanceId })
-      .then((nextTopics) => {
-        if (cancelled) return;
-        setTopicError(null);
-        setTopicOptions(nextTopics.map((topic) => topic.name));
-      })
-      .catch((error: unknown) => {
-        if (cancelled) return;
-        setTopicOptions([]);
-        setTopicError(error instanceof Error ? error.message : '加载 Topic 列表失败');
-      });
-    return () => {
-      cancelled = true;
-    };
+    const requestId = ++topicRequestId.current;
+    setTopicLoading(true);
+    setTopicError(null);
+    setTopicOptions([]);
+    try {
+      const nextTopics = await listTopics({ instanceId: selectedInstanceId });
+      if (requestId !== topicRequestId.current) return;
+      setTopicOptions(nextTopics.map((topic) => topic.name));
+    } catch (error: unknown) {
+      if (requestId !== topicRequestId.current) return;
+      setTopicError(error instanceof Error ? error.message : '加载 Topic 列表失败');
+    } finally {
+      if (requestId === topicRequestId.current) setTopicLoading(false);
+    }
   }, [selectedInstanceId]);
+
+  useEffect(() => {
+    void Promise.resolve().then(loadTopicOptions);
+    return () => {
+      topicRequestId.current += 1;
+    };
+  }, [loadTopicOptions]);
   const [queryMode, setQueryMode] = useState<QueryMode>('topic');
   const [selectedTopic, setSelectedTopic] = useState<string | undefined>();
   const [dateRange, setDateRange] = useState<[Dayjs, Dayjs]>(getDefaultRange);
@@ -327,7 +338,13 @@ const MessagePageContent = ({
         ? { topic: selectedTopic, key: keyInput || undefined }
         : { topic: selectedTopic, msgId: msgIdInput || undefined };
   const queryValidationError = getQueryValidationError(queryMode, currentQueryParams);
-  const queryDisabledReason = !selectedInstanceId ? '请先选择实例' : queryValidationError;
+  const queryDisabledReason = !selectedInstanceId
+    ? '请先选择实例'
+    : topicLoading
+      ? '正在加载 Topic 列表'
+      : topicError
+        ? 'Topic 列表加载失败，请先重试'
+        : queryValidationError;
 
   /* ─── Handlers ─── */
   const handleReset = () => {
@@ -781,6 +798,8 @@ const MessagePageContent = ({
                   onChange={setSelectedTopic}
                   allowClear
                   showSearch
+                  loading={topicLoading}
+                  disabled={topicLoading || Boolean(topicError)}
                   options={topicOptions.map((t) => ({
                     value: t,
                     label: t,
@@ -808,6 +827,8 @@ const MessagePageContent = ({
                   onChange={setSelectedTopic}
                   allowClear
                   showSearch
+                  loading={topicLoading}
+                  disabled={topicLoading || Boolean(topicError)}
                   options={topicOptions.map((t) => ({
                     value: t,
                     label: t,
@@ -831,6 +852,8 @@ const MessagePageContent = ({
                   onChange={setSelectedTopic}
                   allowClear
                   showSearch
+                  loading={topicLoading}
+                  disabled={topicLoading || Boolean(topicError)}
                   options={topicOptions.map((t) => ({
                     value: t,
                     label: t,
@@ -879,7 +902,18 @@ const MessagePageContent = ({
       </Card>
 
       {topicError && (
-        <Alert showIcon type="error" message={topicError} style={{ marginBottom: 16 }} />
+        <Alert
+          showIcon
+          type="error"
+          message="Topic 列表加载失败"
+          description={topicError}
+          action={
+            <Button size="small" onClick={() => void loadTopicOptions()}>
+              重试
+            </Button>
+          }
+          style={{ marginBottom: 16 }}
+        />
       )}
       <MessageQueryHistoryDrawer
         open={historyDrawerOpen}


### PR DESCRIPTION
## Summary\n\n- distinguish Topic loading, failure, and successful empty states\n- disable queries while Topic options are unavailable\n- expose an in-place retry action with request sequencing\n- add frontend regression coverage\n\nCloses #2016\n\n## Verification\n\nnpm run build passed. Targeted ESLint passed. Vitest passed: 2 files, 25 tests.\n\n## Base\n\nrocketmq-studio at 737a7b4d