### PR TITLE
[Studio] fix: record provider-neutral message query history

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -34,14 +34,17 @@ public class MessageService {
 
     private final MessageProvider messageProvider;
     private final InstanceProviderRegistry providerRegistry;
+    private final QueryHistoryService queryHistoryService;
 
     public List<MessageRecordVO> queryMessages(
             String instanceId, String topic, String msgId, String tag, String key, Long startTime, Long endTime) {
         validateTopicQueryWindow(topic, msgId, key, startTime, endTime);
         log.info("Querying messages: topic={}, msgId={}, tag={}, key={}", topic, msgId, tag, key);
-        return providerRegistry.byInstanceId(instanceId)
+        List<MessageRecordVO> result = providerRegistry.byInstanceId(instanceId)
                 .map(provider -> provider.queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime))
                 .orElseGet(() -> messageProvider.queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime));
+        recordMessageQuery(instanceId, topic, msgId, tag, key, startTime, endTime, result.size());
+        return result;
     }
 
     public TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic) {
@@ -49,9 +52,33 @@ public class MessageService {
             throw new BusinessException(400, "msgId is required");
         }
         log.info("Getting message trace: msgId={}, topic={}", msgId, topic);
-        return providerRegistry.byInstanceId(instanceId)
+        TraceRecordVO result = providerRegistry.byInstanceId(instanceId)
                 .map(provider -> provider.getMessageTrace(instanceId, msgId, topic))
                 .orElseGet(() -> messageProvider.getMessageTrace(instanceId, msgId, topic));
+        recordTraceQuery(instanceId, msgId, topic, result);
+        return result;
+    }
+
+    private void recordMessageQuery(String instanceId, String topic, String msgId, String tag,
+                                    String key, Long startTime, Long endTime, int resultCount) {
+        String queryType = StringUtils.hasText(msgId) ? "MSG_ID" : StringUtils.hasText(key) ? "KEY" : "TOPIC";
+        try {
+            queryHistoryService.recordMessageQuery(instanceId, queryType, topic, msgId, tag, key,
+                    startTime, endTime, resultCount);
+        } catch (RuntimeException failure) {
+            log.warn("Failed to record message query history: {}", failure.getMessage());
+        }
+    }
+
+    private void recordTraceQuery(String instanceId, String msgId, String topic, TraceRecordVO result) {
+        int nodeCount = result == null || result.getNodes() == null ? 0 : result.getNodes().size();
+        int consumerCount = result == null || result.getConsumerStatus() == null ? 0
+                : result.getConsumerStatus().size();
+        try {
+            queryHistoryService.recordTraceQuery(instanceId, msgId, topic, nodeCount, consumerCount);
+        } catch (RuntimeException failure) {
+            log.warn("Failed to record trace query history: {}", failure.getMessage());
+        }
     }
 
     private void validateTopicQueryWindow(String topic, String msgId, String key, Long startTime, Long endTime) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -33,7 +33,6 @@ import org.apache.rocketmq.studio.instance.message.MessageProvider;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
 import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
 import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
-import org.apache.rocketmq.studio.instance.message.QueryHistoryService;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.apache.rocketmq.tools.admin.api.MessageTrack;
 import org.apache.rocketmq.tools.admin.api.TrackType;
@@ -83,7 +82,6 @@ public class RocketMQMessageProvider implements MessageProvider {
     private static final int MAX_CONSECUTIVE_OFFSET_ILLEGAL = 3;
 
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
-    private final QueryHistoryService queryHistoryService;
 
     @Override
     public List<MessageRecordVO> queryMessages(String instanceId, String topic, String msgId, String tag, String key,
@@ -105,22 +103,17 @@ public class RocketMQMessageProvider implements MessageProvider {
         }
 
         List<MessageRecordVO> result;
-        String queryType;
         if (StringUtils.hasText(msgId)) {
-            queryType = "MSG_ID";
             result = queryByMsgId(adminExt, topic, msgId);
         } else if (StringUtils.hasText(topic) && StringUtils.hasText(key)) {
-            queryType = "KEY";
             result = queryByKey(adminExt, topic, key, tag, begin, end);
         } else if (StringUtils.hasText(topic)) {
-            queryType = "TOPIC";
             result = queryByTopic(endpoint, topic, tag, begin, end, DEFAULT_TOPIC_LIMIT);
         } else {
             log.warn("queryMessages requires at least one of msgId/topic, returning empty list");
             return Collections.emptyList();
         }
 
-        recordMessageQuery(instanceId, queryType, topic, msgId, tag, key, startTime, endTime, result.size());
         return result;
     }
 
@@ -308,7 +301,6 @@ public class RocketMQMessageProvider implements MessageProvider {
             throw new BusinessException(502, "Failed to query message trace: " + e.getMessage());
         }
 
-        recordTraceQuery(instanceId, msgId, null, nodes.size(), consumerStatus.size());
         return TraceRecordVO.builder()
                 .nodes(nodes)
                 .consumerStatus(consumerStatus)
@@ -561,24 +553,6 @@ public class RocketMQMessageProvider implements MessageProvider {
         consumer.setInstanceName(ShortLivedClientName.next(groupPrefix));
         consumer.setNamesrvAddr(endpoint);
         return consumer;
-    }
-
-    private void recordMessageQuery(String instanceId, String queryType, String topic, String msgId, String tag, String key,
-                                    Long startTime, Long endTime, int resultCount) {
-        try {
-            queryHistoryService.recordMessageQuery(instanceId, queryType, topic, msgId, tag, key,
-                    startTime, endTime, resultCount);
-        } catch (Exception e) {
-            log.warn("Failed to record message query history: {}", e.getMessage());
-        }
-    }
-
-    private void recordTraceQuery(String instanceId, String msgId, String topic, int nodeCount, int consumerCount) {
-        try {
-            queryHistoryService.recordTraceQuery(instanceId, msgId, topic, nodeCount, consumerCount);
-        } catch (Exception e) {
-            log.warn("Failed to record trace query history: {}", e.getMessage());
-        }
     }
 
     private static TraceRecordVO emptyTrace() {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -12,11 +12,17 @@ package org.apache.rocketmq.studio.instance.message;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
+import org.apache.rocketmq.studio.provider.InstanceProvider;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class MessageServiceTest {
 
@@ -24,7 +30,7 @@ class MessageServiceTest {
     void rejectsKeyQueryWithoutTopicBeforeCallingProvider() {
         MessageProvider provider = mock(MessageProvider.class);
         InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
-        MessageService service = new MessageService(provider, registry);
+        MessageService service = new MessageService(provider, registry, mock(QueryHistoryService.class));
 
         assertThatThrownBy(() -> service.queryMessages(null, null, null, null, "order-1", null, null))
                 .isInstanceOf(BusinessException.class)
@@ -37,7 +43,7 @@ class MessageServiceTest {
     void rejectsMessageIdQueryWithoutTopicBeforeCallingProvider() {
         MessageProvider provider = mock(MessageProvider.class);
         InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
-        MessageService service = new MessageService(provider, registry);
+        MessageService service = new MessageService(provider, registry, mock(QueryHistoryService.class));
 
         assertThatThrownBy(() -> service.queryMessages(null, null, "msg-001", null, null, null, null))
                 .isInstanceOf(BusinessException.class)
@@ -50,7 +56,7 @@ class MessageServiceTest {
     void rejectsBlankMessageTraceIdBeforeCallingProvider() {
         MessageProvider provider = mock(MessageProvider.class);
         InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
-        MessageService service = new MessageService(provider, registry);
+        MessageService service = new MessageService(provider, registry, mock(QueryHistoryService.class));
 
         assertThatThrownBy(() -> service.getMessageTrace("instance-a", "  ", null))
                 .isInstanceOf(BusinessException.class)
@@ -63,7 +69,7 @@ class MessageServiceTest {
     void rejectsReversedTopicQueryWindowBeforeCallingProvider() {
         MessageProvider provider = mock(MessageProvider.class);
         InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
-        MessageService service = new MessageService(provider, registry);
+        MessageService service = new MessageService(provider, registry, mock(QueryHistoryService.class));
 
         assertThatThrownBy(() -> service.queryMessages("instance-a", "TopicA", null, null, null, 200L, 100L))
                 .isInstanceOf(BusinessException.class)
@@ -76,7 +82,7 @@ class MessageServiceTest {
     void rejectsTopicQueryWindowLongerThanSevenDaysBeforeCallingProvider() {
         MessageProvider provider = mock(MessageProvider.class);
         InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
-        MessageService service = new MessageService(provider, registry);
+        MessageService service = new MessageService(provider, registry, mock(QueryHistoryService.class));
 
         assertThatThrownBy(() -> service.queryMessages("instance-a", "TopicA", null, null, null, 0L,
                 8L * 24 * 60 * 60 * 1000))
@@ -84,5 +90,23 @@ class MessageServiceTest {
                 .hasMessage("topic query time range must not exceed 7 days");
 
         verifyNoInteractions(provider);
+    }
+
+    @Test
+    void recordsProviderNeutralMessageQueryHistory() {
+        MessageProvider fallback = mock(MessageProvider.class);
+        InstanceProvider provider = mock(InstanceProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        QueryHistoryService history = mock(QueryHistoryService.class);
+        MessageService service = new MessageService(fallback, registry, history);
+        when(registry.byInstanceId("cloud-instance")).thenReturn(Optional.of(provider));
+        when(provider.queryMessages("cloud-instance", "orders", null, null, "ORDER-1", null, null))
+                .thenReturn(List.of(MessageRecordVO.builder().msgId("msg-1").build()));
+
+        service.queryMessages("cloud-instance", "orders", null, null, "ORDER-1", null, null);
+
+        verify(history).recordMessageQuery("cloud-instance", "KEY", "orders", null, null,
+                "ORDER-1", null, null, 1);
+        verifyNoInteractions(fallback);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -30,7 +30,6 @@ import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
 import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
 import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
-import org.apache.rocketmq.studio.instance.message.QueryHistoryService;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,9 +69,6 @@ class RocketMQMessageProviderTest {
     @Mock
     private RuntimeAdminClientResolver runtimeAdminClientResolver;
 
-    @Mock
-    private QueryHistoryService queryHistoryService;
-
     private RocketMQMessageProvider provider;
 
     @BeforeEach
@@ -82,7 +78,7 @@ class RocketMQMessageProviderTest {
             MqAdminExtFactory.AdminAction<Object> action = invocation.getArgument(1);
             return action == null ? null : action.apply(adminExt);
         });
-        provider = new RocketMQMessageProvider(runtimeAdminClientResolver, queryHistoryService);
+        provider = new RocketMQMessageProvider(runtimeAdminClientResolver);
     }
 
     @Test
@@ -106,8 +102,6 @@ class RocketMQMessageProviderTest {
         }
         verify(runtimeAdminClientResolver).resolveEndpoint("instance-a");
         verify(runtimeAdminClientResolver).execute(eq("instance-a"), any());
-        verify(queryHistoryService).recordMessageQuery("instance-a", "TOPIC", "TopicA", null, null, null,
-                100L, 200L, 0);
     }
 
     @Test
@@ -257,7 +251,6 @@ class RocketMQMessageProviderTest {
         TraceRecordVO record = provider.getMessageTrace("instance-a", "msg-123", "orders");
 
         assertThat(record.getNodes()).hasSize(2);
-        verify(queryHistoryService).recordTraceQuery(eq("instance-a"), eq("msg-123"), eq(null), eq(2), eq(1));
         TraceNodeVO produce = record.getNodes().get(0);
         assertThat(produce.getTitle()).isEqualTo("produce");
         assertThat(produce.getStatus()).isEqualTo("finish");
@@ -308,7 +301,6 @@ class RocketMQMessageProviderTest {
                 .hasMessage("Failed to query message trace: broker unavailable")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
 
-        verify(queryHistoryService, never()).recordTraceQuery(anyString(), anyString(), any(), anyInt(), anyInt());
     }
 
     private static String traceContext(String... fields) {


### PR DESCRIPTION
## Summary\n\n- move query-history recording to MessageService\n- cover Apache, Aliyun, Tencent, and fallback query paths uniformly\n- preserve Topic context for trace history\n- keep successful queries successful when history persistence fails\n\nCloses #2114\n\n## Verification\n\ngit diff --check passed. Maven compile was attempted but dependency resolution was blocked by Maven Central HTTP 403 before source compilation.\n\n## Base\n\nrocketmq-studio at 737a7b4d