### PR TITLE
[Studio] fix: preserve singular alert mutation integrity

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
@@ -32,5 +32,7 @@ public interface AlertRepository {
 
     SystemAlertVO saveAlert(SystemAlertVO alert);
 
+    boolean replaceAlert(SystemAlertVO alert);
+
     int deleteAcknowledgedAlerts();
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -128,9 +128,11 @@ public class AlertService {
                 .findFirst()
                 .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "Alert rule not found: " + id));
         rule.setEnabled(enabled);
-        AlertRuleVO saved = alertRepository.saveRule(rule);
-        auditRule("TOGGLE_ALERT_RULE", saved, "enabled=" + enabled);
-        return saved;
+        if (!alertRepository.replaceRule(rule)) {
+            throw ruleNotFound(id);
+        }
+        auditRule("TOGGLE_ALERT_RULE", rule, "enabled=" + enabled);
+        return rule;
     }
 
 
@@ -231,10 +233,12 @@ public class AlertService {
                 .findFirst()
                 .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "System alert not found: " + id));
         alert.setAcknowledged(true);
-        SystemAlertVO saved = alertRepository.saveAlert(alert);
-        recordAudit("ACKNOWLEDGE_SYSTEM_ALERT", "SYSTEM_ALERT", saved.getId(), null,
+        if (!alertRepository.replaceAlert(alert)) {
+            throw new BusinessException(404, "System alert not found: " + id);
+        }
+        recordAudit("ACKNOWLEDGE_SYSTEM_ALERT", "SYSTEM_ALERT", alert.getId(), null,
                 "acknowledged=true");
-        return saved;
+        return alert;
     }
 
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -97,6 +97,11 @@ public class MybatisPlusAlertRepository implements AlertRepository {
     }
 
     @Override
+    public boolean replaceAlert(SystemAlertVO alert) {
+        return alertMapper.updateById(toAlertEntity(alert)) > 0;
+    }
+
+    @Override
     public int deleteAcknowledgedAlerts() {
         return Math.toIntExact(alertMapper.delete(
                 new QueryWrapper<RmqSystemAlert>().eq("acknowledged", true)));

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -518,12 +518,12 @@ class AlertServiceTest {
     void toggleRuleShouldEnableRule() {
         AlertRuleVO existing = AlertRuleVO.builder().id("rule-1").name("CPU Alert").enabled(false).build();
         when(alertRepository.findAllRules()).thenReturn(List.of(existing));
-        when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(true);
 
         AlertRuleVO result = alertService.toggleRule("rule-1", true);
 
         assertThat(result.isEnabled()).isTrue();
-        verify(alertRepository).saveRule(result);
+        verify(alertRepository).replaceRule(result);
         verify(operationAuditService).record(eq("TOGGLE_ALERT_RULE"), eq("ALERT_RULE"), eq("rule-1"),
                 eq(null), eq("enabled=true"), eq("SUCCESS"), eq(null));
     }
@@ -532,11 +532,24 @@ class AlertServiceTest {
     void toggleRuleShouldDisableRule() {
         AlertRuleVO existing = AlertRuleVO.builder().id("rule-1").name("CPU Alert").enabled(true).build();
         when(alertRepository.findAllRules()).thenReturn(List.of(existing));
-        when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(true);
 
         AlertRuleVO result = alertService.toggleRule("rule-1", false);
 
         assertThat(result.isEnabled()).isFalse();
+    }
+
+    @Test
+    void toggleRuleShouldNotRecreateConcurrentlyDeletedRule() {
+        AlertRuleVO existing = AlertRuleVO.builder().id("rule-1").enabled(false).build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(existing));
+        when(alertRepository.replaceRule(existing)).thenReturn(false);
+
+        assertThatThrownBy(() -> alertService.toggleRule("rule-1", true))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert rule not found: rule-1");
+
+        verify(alertRepository, never()).saveRule(any());
     }
 
     @Test
@@ -678,12 +691,12 @@ class AlertServiceTest {
         SystemAlertVO existing = SystemAlertVO.builder().id("a1").level(AlertLevel.error)
                 .title("Broker Down").acknowledged(false).build();
         when(alertRepository.findAlerts(null)).thenReturn(List.of(existing));
-        when(alertRepository.saveAlert(any(SystemAlertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(alertRepository.replaceAlert(any(SystemAlertVO.class))).thenReturn(true);
 
         SystemAlertVO result = alertService.acknowledgeAlert("a1");
 
         assertThat(result.isAcknowledged()).isTrue();
-        verify(alertRepository).saveAlert(result);
+        verify(alertRepository).replaceAlert(result);
         verify(operationAuditService).record(eq("ACKNOWLEDGE_SYSTEM_ALERT"), eq("SYSTEM_ALERT"), eq("a1"),
                 eq(null), eq("acknowledged=true"), eq("SUCCESS"), eq(null));
     }


### PR DESCRIPTION
## Summary\n\n- use update-only persistence for singular rule toggles\n- use update-only persistence for system alert acknowledgement\n- return not found when a concurrent delete wins\n- avoid recording successful audit events for missing rows\n\nCloses #2115\n\n## Verification\n\ngit diff --check passed. Maven compile was attempted but dependency resolution was blocked by Maven Central HTTP 403 before source compilation.\n\n## Base\n\nrocketmq-studio at 737a7b4d