### PR TITLE
[Studio] fix: prevent deleted cloud credential recreation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialRepository.java
@@ -31,5 +31,7 @@ public interface CloudCredentialRepository {
 
     CloudCredentialVO save(CloudCredentialVO credential);
 
+    boolean replace(CloudCredentialVO credential);
+
     boolean deleteById(String id);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
@@ -99,11 +99,13 @@ public class CloudCredentialService {
             existing.setRemark(request.getRemark());
         }
         existing.setUpdatedAt(LocalDateTime.now());
-        CloudCredentialVO saved = credentialRepository.save(existing);
-        invalidateCloudClients(saved);
-        recordAudit("UPDATE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", saved.getId(), null,
-                credentialAuditDetail(saved));
-        return maskAccessKey(saved);
+        if (!credentialRepository.replace(existing)) {
+            throw new BusinessException(404, "Cloud credential not found: " + request.getId());
+        }
+        invalidateCloudClients(existing);
+        recordAudit("UPDATE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", existing.getId(), null,
+                credentialAuditDetail(existing));
+        return maskAccessKey(existing);
     }
 
     public void delete(String id) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
@@ -79,6 +79,11 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
     }
 
     @Override
+    public boolean replace(CloudCredentialVO credential) {
+        return credentialMapper.updateById(toEntity(credential)) > 0;
+    }
+
+    @Override
     public boolean deleteById(String id) {
         return credentialMapper.deleteById(id) > 0;
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
@@ -161,8 +161,7 @@ class CloudCredentialServiceTest {
         stored.setAccessKey("LTAI5tUpdateKey000000001");
         stored.setSecretKey("old-secret");
         when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
-        when(credentialRepository.save(any(CloudCredentialVO.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(credentialRepository.replace(any(CloudCredentialVO.class))).thenReturn(true);
 
         UpdateCloudCredentialDTO request = new UpdateCloudCredentialDTO();
         request.setId("cred-1");
@@ -173,6 +172,25 @@ class CloudCredentialServiceTest {
         verify(aliyunClientFactory).invalidateCredential("cred-1");
         verify(operationAuditService).record(eq("UPDATE_CLOUD_CREDENTIAL"), eq("CLOUD_CREDENTIAL"),
                 eq("cred-1"), eq(null), eq("name=null, vendor=ALIYUN"), eq("SUCCESS"), eq(null));
+    }
+
+    @Test
+    void updateShouldNotRecreateConcurrentlyDeletedCredentialTest() {
+        CloudCredentialVO stored = new CloudCredentialVO();
+        stored.setId("cred-1");
+        stored.setVendor(InstanceVendor.TENCENT);
+        stored.setAccessKey("AKIDexample");
+        when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
+        when(credentialRepository.replace(stored)).thenReturn(false);
+        UpdateCloudCredentialDTO request = new UpdateCloudCredentialDTO();
+        request.setId("cred-1");
+        request.setName("renamed");
+
+        assertThatThrownBy(() -> service.update(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Cloud credential not found: cred-1");
+
+        verify(tencentClientFactory, never()).invalidateCredential(any());
     }
 
     @Test


### PR DESCRIPTION
## Summary\n\n- add an update-only cloud credential repository operation\n- return not found when the credential disappears concurrently\n- invalidate cloud clients only after an applied update\n- add focused service regression coverage\n\nCloses #2116\n\n## Verification\n\ngit diff --check passed. Maven compile was attempted but dependency resolution was blocked by Maven Central HTTP 403 before source compilation.\n\n## Base\n\nrocketmq-studio at 737a7b4d