### PR TITLE
[Studio] fix: validate message query time bounds safely

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -72,10 +72,14 @@ public class MessageService {
         }
         long end = endTime == null ? System.currentTimeMillis() : endTime;
         long start = startTime == null ? end - 60 * 60 * 1000L : startTime;
-        if (start > end) {
-            throw new BusinessException(400, "startTime must not be after endTime");
+        if (start < 0 || end < 0) {
+            throw new BusinessException(400, "message query timestamps must not be negative");
         }
-        if (end - start > MAX_TOPIC_QUERY_WINDOW_MILLIS) {
+        if (start >= end) {
+            throw new BusinessException(400, "startTime must be before endTime");
+        }
+        // Compare without subtracting untrusted endpoints; end - start can overflow long.
+        if (start < end - MAX_TOPIC_QUERY_WINDOW_MILLIS) {
             throw new BusinessException(400, "topic query time range must not exceed 7 days");
         }
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -67,7 +67,7 @@ class MessageServiceTest {
 
         assertThatThrownBy(() -> service.queryMessages("instance-a", "TopicA", null, null, null, 200L, 100L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("startTime must not be after endTime");
+                .hasMessage("startTime must be before endTime");
 
         verifyNoInteractions(provider);
     }
@@ -84,5 +84,19 @@ class MessageServiceTest {
                 .hasMessage("topic query time range must not exceed 7 days");
 
         verifyNoInteractions(provider);
+    }
+
+    @Test
+    void rejectsOverflowingTopicQueryWindowBeforeCallingProvider() {
+        MessageProvider provider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(provider, registry);
+
+        assertThatThrownBy(() -> service.queryMessages("instance-a", "TopicA", null, null, null,
+                0L, Long.MAX_VALUE))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topic query time range must not exceed 7 days");
+
+        verifyNoInteractions(provider, registry);
     }
 }


### PR DESCRIPTION
## Summary\n\n- reject negative and non-increasing Topic query timestamps\n- enforce the seven-day window without long subtraction overflow\n- keep validation at the provider-neutral boundary\n- add extreme-value regression coverage\n\nCloses #2117\n\n## Verification\n\ngit diff --check passed. Maven compile was attempted but dependency resolution was blocked by Maven Central HTTP 403 before source compilation.\n\n## Base\n\nrocketmq-studio at 737a7b4d