### PR TITLE
[Studio] fix: flag incomplete dashboard broker topology

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -112,6 +112,23 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             totalClusters = clusterAddrTable.size();
             totalBrokers = brokerAddrTable.size();
 
+            Set<String> topologyUnavailableClusters = new HashSet<>();
+            for (Map.Entry<String, Set<String>> clusterEntry : clusterAddrTable.entrySet()) {
+                Set<String> brokerNames = clusterEntry.getValue();
+                if (brokerNames == null || brokerNames.isEmpty()) {
+                    topologyUnavailableClusters.add(clusterEntry.getKey());
+                    continue;
+                }
+                boolean incomplete = brokerNames.stream().anyMatch(brokerName -> {
+                    BrokerData brokerData = brokerAddrTable.get(brokerName);
+                    return brokerData == null || brokerData.getBrokerAddrs() == null
+                            || brokerData.getBrokerAddrs().get(0L) == null;
+                });
+                if (incomplete) {
+                    topologyUnavailableClusters.add(clusterEntry.getKey());
+                }
+            }
+
             // Collect all unique broker addresses (master only, brokerId=0)
             Set<String> masterAddrs = new HashSet<>();
 
@@ -232,7 +249,8 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 long clusterTpsIn = 0;
                 long clusterTpsOut = 0;
                 String version = "unknown";
-                boolean runtimeMetricsUnavailable = topicCountsUnavailableClusters.contains(clusterName)
+                boolean runtimeMetricsUnavailable = topologyUnavailableClusters.contains(clusterName)
+                        || topicCountsUnavailableClusters.contains(clusterName)
                         || groupCountsUnavailableClusters.contains(clusterName);
 
                 for (String brokerName : brokerNames) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -284,6 +284,7 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getStats()).isNotNull();
         assertThat(dashboard.getClusters()).hasSize(1);
         assertThat(dashboard.getClusters().get(0).getBrokers()).isZero();
+        assertThat(dashboard.getClusters().get(0).getStatus()).isEqualTo(ClusterStatus.warning);
     }
 
     @Test
@@ -306,6 +307,7 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getClusters().get(0).getBrokers()).isZero();
         assertThat(dashboard.getStats().getTotalClusters()).isEqualTo(1);
         assertThat(dashboard.getStats().getTotalBrokers()).isZero();
+        assertThat(dashboard.getStats().getHealthyClusters()).isZero();
     }
 
     @Test
@@ -381,6 +383,7 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getClusters()).singleElement().satisfies(cluster -> {
             assertThat(cluster.getName()).isEqualTo("cluster-without-members");
             assertThat(cluster.getBrokers()).isZero();
+            assertThat(cluster.getStatus()).isEqualTo(ClusterStatus.warning);
         });
     }
 


### PR DESCRIPTION
## Summary\n\n- detect missing cluster membership, BrokerData, address tables, and masters\n- render affected clusters with warning status\n- exclude incomplete topology from healthy-cluster totals\n- extend dashboard regression assertions\n\nCloses #2118\n\n## Verification\n\ngit diff --check passed. Maven compile was attempted but dependency resolution was blocked by Maven Central HTTP 403 before source compilation.\n\n## Base\n\nrocketmq-studio at 737a7b4d