### PR TITLE
[Studio] fix: clear stale query history after load failures

### DIFF
--- a/web/src/components/MessageQueryHistoryDrawer.tsx
+++ b/web/src/components/MessageQueryHistoryDrawer.tsx
@@ -5,7 +5,7 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Alert, Drawer, Flex, Input, Statistic, Table, Tabs, Tag } from 'antd';
+import { Alert, Button, Drawer, Flex, Input, Statistic, Table, Tabs, Tag } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import {
   getQueryHistorySummary,
@@ -23,7 +23,11 @@ interface Props {
 }
 
 const PAGE_SIZE = 20;
-const formatTime = (value?: string) => (value ? new Date(value).toLocaleString() : '-');
+const formatTime = (value?: string) => {
+  if (!value) return '-';
+  const timestamp = new Date(value);
+  return Number.isNaN(timestamp.getTime()) ? '-' : timestamp.toLocaleString();
+};
 
 const MessageQueryHistoryDrawer = ({ open, clusterId, onClose }: Props) => {
   const [tab, setTab] = useState<'messages' | 'traces'>('messages');
@@ -42,6 +46,10 @@ const MessageQueryHistoryDrawer = ({ open, clusterId, onClose }: Props) => {
     const id = ++requestId.current;
     setLoading(true);
     setError('');
+    setSummary(undefined);
+    setMessageRows([]);
+    setTraceRows([]);
+    setTotal(0);
     try {
       const [nextSummary, result] = await Promise.all([
         getQueryHistorySummary(clusterId),
@@ -115,7 +123,16 @@ const MessageQueryHistoryDrawer = ({ open, clusterId, onClose }: Props) => {
         }}
         style={{ marginBottom: 12, width: 420 }}
       />
-      {error && <Alert type="error" showIcon message={error} style={{ marginBottom: 12 }} />}
+      {error && (
+        <Alert
+          type="error"
+          showIcon
+          message="查询历史加载失败"
+          description={error}
+          action={<Button size="small" onClick={() => void load()}>重试</Button>}
+          style={{ marginBottom: 12 }}
+        />
+      )}
       <Tabs
         activeKey={tab}
         onChange={(key) => {

--- a/web/src/components/__tests__/MessageQueryHistoryDrawer.test.tsx
+++ b/web/src/components/__tests__/MessageQueryHistoryDrawer.test.tsx
@@ -88,4 +88,24 @@ describe('MessageQueryHistoryDrawer', () => {
     expect(await screen.findByText('msg-1')).toBeInTheDocument();
     await waitFor(() => expect(listTraceQueryHistory).toHaveBeenCalled());
   });
+
+  it('clears stale rows and offers retry when a new instance load fails', async () => {
+    const view = render(
+      <App>
+        <MessageQueryHistoryDrawer open clusterId="instance-a" onClose={vi.fn()} />
+      </App>,
+    );
+    expect(await screen.findByText('order-1')).toBeInTheDocument();
+    vi.mocked(getQueryHistorySummary).mockRejectedValueOnce(new Error('network unavailable'));
+
+    view.rerender(
+      <App>
+        <MessageQueryHistoryDrawer open clusterId="instance-b" onClose={vi.fn()} />
+      </App>,
+    );
+
+    expect(await screen.findByText('查询历史加载失败')).toBeInTheDocument();
+    expect(screen.queryByText('order-1')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /重\s*试/ })).toBeEnabled();
+  });
 });


### PR DESCRIPTION
## Summary\n\n- clear rows and summary when history context changes\n- keep failed contexts from displaying previous instance data\n- add an in-place retry action and safe timestamp formatting\n- add focused frontend regression coverage\n\nCloses #2119\n\n## Verification\n\nnpm run build passed. Targeted ESLint passed. Vitest passed: 1 file, 2 tests.\n\n## Base\n\nrocketmq-studio at 737a7b4d