### PR TITLE
[Studio] fix(web): localize client sampling warning

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -193,6 +193,10 @@ const translations: Record<string, Record<Lang, string>> = {
   'clients.allClusters': { zh: '全部集群', en: 'All Clusters' },
   'clients.searchPlaceholder': { zh: '搜索 Client ID 或地址', en: 'Search Client ID or address' },
   'clients.detailTitle': { zh: '客户端详情 - {id}', en: 'Client Detail - {id}' },
+  'clients.sampledConnectionsWarning': {
+    zh: '由于已达到 Topic 扫描上限，生产者连接结果为采样数据。',
+    en: 'Producer connections are sampled because the topic scan limit was reached.',
+  },
 
   // ─── Alert Rules ───
   'alerts.title': { zh: '告警规则管理', en: 'Alert Rules' },

--- a/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
@@ -83,6 +83,11 @@ const connections: ClientConnection[] = [
   },
 ];
 
+const partialConnection: ClientConnection = {
+  ...connection,
+  partial: true,
+};
+
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -208,6 +213,18 @@ describe('Clients page', () => {
     expect(
       within(screen.getByTestId('language-version-distribution')).getByText('暂无数据'),
     ).toBeInTheDocument();
+  });
+
+  it('localizes the sampled producer connection warning', async () => {
+    vi.mocked(connectionsService.listConnections).mockResolvedValue([partialConnection]);
+    renderWithProviders(<ClientsPage />);
+
+    expect(
+      await screen.findByText('由于已达到 Topic 扫描上限，生产者连接结果为采样数据。'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Producer connections are sampled because the topic scan limit was reached.'),
+    ).not.toBeInTheDocument();
   });
 
   it('surfaces unavailable provider errors from the client API', async () => {

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -407,7 +407,7 @@ const ClientsPage = () => {
         <Alert
           showIcon
           type="warning"
-          message="Producer connections are sampled because the topic scan limit was reached."
+          message={t('clients.sampledConnectionsWarning')}
           style={{ marginBottom: 16 }}
         />
       )}


### PR DESCRIPTION
## What changed
- move the sampled producer-connection warning into the shared i18n catalog
- render the warning through the active language translator
- add a Clients page regression test for the Chinese warning

## Why
The Clients page showed this warning only in English, even when Studio was using Chinese. This created a mixed-language operator experience.

Fixes #2079.

## Validation
- `node node_modules/vitest/vitest.mjs run src/pages/cluster/__tests__/ClientsPage.test.tsx --pool=threads --maxWorkers=1 --reporter=dot` — 11 passed
- ESLint passed for the changed page, translation catalog, and test
- Full TypeScript check was attempted but exceeded the local 90-second command limit on the current upstream dependency tree.