### PR TITLE
[Studio] fix: honor metrics authentication mode

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/AbstractPrometheusCompatibleMetricsSource.java
@@ -39,6 +39,7 @@ import java.net.URI;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.StreamSupport;
 
@@ -202,18 +203,29 @@ public abstract class AbstractPrometheusCompatibleMetricsSource implements Metri
     }
 
     private void applyAuthentication(HttpHeaders headers) {
-        if (StringUtils.hasText(settings.getBearerToken())) {
-            headers.setBearerAuth(settings.getBearerToken());
-            return;
-        }
-        boolean hasUsername = StringUtils.hasText(settings.getUsername());
-        boolean hasPassword = StringUtils.hasText(settings.getPassword());
-        if (hasUsername != hasPassword) {
-            throw new PrometheusException(HttpStatus.SERVICE_UNAVAILABLE.value(),
-                    backendLabel() + " basic authentication is incomplete");
-        }
-        if (hasUsername) {
-            headers.setBasicAuth(settings.getUsername(), settings.getPassword());
+        String authType = StringUtils.hasText(settings.getAuthType())
+                ? settings.getAuthType().strip().toLowerCase(Locale.ROOT)
+                : "none";
+        switch (authType) {
+            case "none" -> {
+                // Credentials may remain after changing modes; none must never send them.
+            }
+            case "basic" -> {
+                if (!StringUtils.hasText(settings.getUsername()) || !StringUtils.hasText(settings.getPassword())) {
+                    throw new PrometheusException(HttpStatus.SERVICE_UNAVAILABLE.value(),
+                            backendLabel() + " basic authentication is incomplete");
+                }
+                headers.setBasicAuth(settings.getUsername(), settings.getPassword());
+            }
+            case "bearer" -> {
+                if (!StringUtils.hasText(settings.getBearerToken())) {
+                    throw new PrometheusException(HttpStatus.SERVICE_UNAVAILABLE.value(),
+                            backendLabel() + " bearer authentication is incomplete");
+                }
+                headers.setBearerAuth(settings.getBearerToken());
+            }
+            default -> throw new PrometheusException(HttpStatus.SERVICE_UNAVAILABLE.value(),
+                    "Unsupported " + backendLabel() + " authentication mode: " + settings.getAuthType());
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsSourceFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsSourceFactory.java
@@ -45,6 +45,7 @@ public class MetricsSourceFactory {
                 .baseUrl(config.getUrl())
                 .connectTimeout(Duration.ofSeconds(3))
                 .readTimeout(Duration.ofSeconds(10))
+                .authType(config.getAuthType())
                 .username(config.getUsername())
                 .password(config.getPassword())
                 .bearerToken(config.getBearerToken())

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsSourceSettings.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsSourceSettings.java
@@ -40,6 +40,8 @@ public class MetricsSourceSettings {
     private final Duration connectTimeout = Duration.ofSeconds(3);
     @Builder.Default
     private final Duration readTimeout = Duration.ofSeconds(10);
+    @Builder.Default
+    private final String authType = "none";
     private final String username;
     private final String password;
     private final String bearerToken;

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusMetricsSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/PrometheusMetricsSource.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.metrics;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -49,9 +50,20 @@ public class PrometheusMetricsSource extends AbstractPrometheusCompatibleMetrics
                 .baseUrl(properties.getBaseUrl())
                 .connectTimeout(properties.getConnectTimeout())
                 .readTimeout(properties.getReadTimeout())
+                .authType(legacyAuthType(properties))
                 .username(properties.getUsername())
                 .password(properties.getPassword())
                 .bearerToken(properties.getBearerToken())
                 .build();
+    }
+
+    private static String legacyAuthType(PrometheusProperties properties) {
+        if (StringUtils.hasText(properties.getBearerToken())) {
+            return "bearer";
+        }
+        if (StringUtils.hasText(properties.getUsername()) || StringUtils.hasText(properties.getPassword())) {
+            return "basic";
+        }
+        return "none";
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MultiBackendMetricsSourceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MultiBackendMetricsSourceTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class MultiBackendMetricsSourceTest {
 
@@ -137,6 +138,71 @@ class MultiBackendMetricsSourceTest {
         config.setProviderType("does-not-exist");
         config.setUrl(baseUrl);
         assertThat(factory.create(config)).isInstanceOf(PrometheusMetricsSource.class);
+    }
+
+    @Test
+    void noneAuthenticationShouldIgnoreConfiguredCredentials() {
+        assertAuthorization("none", "user", "password", "token", null);
+    }
+
+    @Test
+    void basicAuthenticationShouldTakePrecedenceOverAnUnrelatedBearerToken() {
+        assertAuthorization("basic", "user", "password", "token", "Basic dXNlcjpwYXNzd29yZA==");
+    }
+
+    @Test
+    void bearerAuthenticationShouldIgnoreConfiguredBasicCredentials() {
+        assertAuthorization("bearer", "user", "password", "token", "Bearer token");
+    }
+
+    @Test
+    void authenticationModeShouldRejectMissingRequiredCredentials() {
+        assertAuthenticationFailure("basic", "user", null, null,
+                "Prometheus basic authentication is incomplete");
+        assertAuthenticationFailure("bearer", null, null, null,
+                "Prometheus bearer authentication is incomplete");
+    }
+
+    @Test
+    void unsupportedAuthenticationModeShouldBeRejected() {
+        assertAuthenticationFailure("digest", "user", "password", "token",
+                "Unsupported Prometheus authentication mode: digest");
+    }
+
+    private void assertAuthorization(String authType, String username, String password,
+                                     String bearerToken, String expectedAuthorization) {
+        AtomicReference<String> authorization = new AtomicReference<>();
+        server.createContext(MetricsBackendType.PROMETHEUS.getQueryPath(), exchange -> {
+            authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            respond(exchange, 200, """
+                    {"status":"success","data":{"resultType":"matrix","result":[]}}
+                    """);
+        });
+
+        factory.create(configWithAuth(authType, username, password, bearerToken)).query(query());
+
+        assertThat(authorization.get()).isEqualTo(expectedAuthorization);
+    }
+
+    private void assertAuthenticationFailure(String authType, String username, String password,
+                                             String bearerToken, String message) {
+        assertThatExceptionOfType(PrometheusException.class)
+                .isThrownBy(() -> factory.create(configWithAuth(authType, username, password, bearerToken))
+                        .query(query()))
+                .satisfies(exception -> {
+                    assertThat(exception.getStatusCode()).isEqualTo(503);
+                    assertThat(exception.getMessage()).isEqualTo(message);
+                });
+    }
+
+    private MetricsDataSourceConfig configWithAuth(String authType, String username,
+                                                   String password, String bearerToken) {
+        MetricsDataSourceConfig config = configFor(MetricsBackendType.PROMETHEUS);
+        config.setAuthType(authType);
+        config.setUsername(username);
+        config.setPassword(password);
+        config.setBearerToken(bearerToken);
+        return config;
     }
 
     private MetricsDataSourceConfig configFor(MetricsBackendType backendType) {


### PR DESCRIPTION
## Summary

- propagate authType through the dynamic metrics source factory
- apply none, basic, and bearer without credential-based guessing
- reject missing credentials and unsupported modes before sending requests

Fixes #2141

## Validation

- MetricsServiceTest, MultiBackendMetricsSourceTest, and PrometheusMetricsSourceTest: 55 passed
- Maven Checkstyle: 0 violations
- scope check: 117 changed lines

## Compatibility

The static Prometheus configuration path keeps its legacy credential inference for compatibility.

## Base

rocketmq-studio at 737a7b4d8b6ddf53d4c6dde581e821e6eac66529