### PR TITLE
[Studio] fix: preserve Broker config editor integrity

### DIFF
--- a/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { App, message, Modal } from 'antd';
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -262,6 +262,52 @@ describe('Cluster page', () => {
     expect(within(dialog).getByText('1,842')).toBeInTheDocument();
     expect(within(dialog).getByText('8081')).toBeInTheDocument();
     expect(within(dialog).getByText('8080')).toBeInTheDocument();
+  });
+
+  it('preserves a fractional MiB message size when another config field changes', async () => {
+    const cluster = buildCluster();
+    cluster.config.maxMessageSize = 4.5 * 1024 * 1024;
+    clusterServiceMocks.listClusters.mockResolvedValue([cluster]);
+    const user = userEvent.setup();
+    renderWithProviders(<ClusterPage />);
+
+    const brokerRow = await screen.findByRole('row', { name: /10\.101\.2\.11:10911/ });
+    await user.click(within(brokerRow).getByRole('button', { name: /配置/ }));
+    const dialog = await screen.findByRole('dialog', { name: /配置 - rocketmq-prod/ });
+    expect(within(dialog).getByRole('spinbutton', { name: '最大消息大小 (MB)' })).toHaveValue(
+      '4.5',
+    );
+
+    await user.click(within(dialog).getByRole('radio', { name: '异步刷盘' }));
+    await user.click(within(dialog).getByRole('button', { name: 'OK' }));
+
+    await waitFor(() => expect(clusterServiceMocks.updateClusterConfig).toHaveBeenCalledTimes(1));
+    expect(clusterServiceMocks.updateClusterConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flushDiskType: 'ASYNC_FLUSH',
+        maxMessageSize: 4.5 * 1024 * 1024,
+      }),
+    );
+  });
+
+  it('requires equal integer read and write queue counts before updating config', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ClusterPage />);
+
+    const brokerRow = await screen.findByRole('row', { name: /10\.101\.2\.11:10911/ });
+    await user.click(within(brokerRow).getByRole('button', { name: /配置/ }));
+    const dialog = await screen.findByRole('dialog', { name: /配置 - rocketmq-prod/ });
+    const writeQueues = within(dialog).getByRole('spinbutton', { name: '写队列数' });
+    const readQueues = within(dialog).getByRole('spinbutton', { name: '读队列数' });
+
+    expect(writeQueues).toHaveAttribute('step', '1');
+    expect(readQueues).toHaveAttribute('step', '1');
+    await user.clear(readQueues);
+    await user.type(readQueues, '4');
+    await user.click(within(dialog).getByRole('button', { name: 'OK' }));
+
+    expect(await within(dialog).findByText('读写队列数必须相等')).toBeInTheDocument();
+    expect(clusterServiceMocks.updateClusterConfig).not.toHaveBeenCalled();
   });
 
   it('keeps cluster tabs usable when address fields are missing', async () => {

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -336,7 +336,7 @@ const ClusterPage = () => {
       flushDiskType: cfg.flushDiskType ?? 'ASYNC_FLUSH',
       autoCreateTopicEnable: cfg.autoCreateTopicEnable ?? false,
       autoCreateSubscriptionGroup: cfg.autoCreateSubscriptionGroup ?? false,
-      maxMessageSizeMB: Math.round((cfg.maxMessageSize ?? 4194304) / 1048576),
+      maxMessageSizeMB: (cfg.maxMessageSize ?? 4194304) / 1048576,
       fileReservedTime: cfg.fileReservedTime ?? 72,
       writeQueueNums: cfg.writeQueueNums ?? 8,
       readQueueNums: cfg.readQueueNums ?? 8,
@@ -570,42 +570,45 @@ const ClusterPage = () => {
             open={configModalOpen}
             onCancel={() => setConfigModalOpen(false)}
             onOk={() => {
-              configForm.validateFields().then(async (values) => {
-                if (!selectedCluster) return;
-                try {
-                  const { maxMessageSizeMB, ...configValues } = values;
-                  const nextConfig: ClusterConfig = {
-                    ...(selectedCluster.config ?? {}),
-                    ...configValues,
-                    maxMessageSize: maxMessageSizeMB * 1048576,
-                  };
-                  const result = await updateClusterConfig({
-                    id: selectedCluster.id,
-                    instanceId: selectedInstanceIdRef.current || undefined,
-                    ...nextConfig,
-                  });
-                  if (result.status === 'SUCCESS') {
-                    await requestRefresh('operation');
-                    message.success(t('cluster.configUpdated'));
-                    setConfigModalOpen(false);
-                    return;
-                  }
+              void configForm.validateFields().then(
+                async (values) => {
+                  if (!selectedCluster) return;
+                  try {
+                    const { maxMessageSizeMB, ...configValues } = values;
+                    const nextConfig: ClusterConfig = {
+                      ...(selectedCluster.config ?? {}),
+                      ...configValues,
+                      maxMessageSize: Math.round(maxMessageSizeMB * 1048576),
+                    };
+                    const result = await updateClusterConfig({
+                      id: selectedCluster.id,
+                      instanceId: selectedInstanceIdRef.current || undefined,
+                      ...nextConfig,
+                    });
+                    if (result.status === 'SUCCESS') {
+                      await requestRefresh('operation');
+                      message.success(t('cluster.configUpdated'));
+                      setConfigModalOpen(false);
+                      return;
+                    }
 
-                  const failedAddresses = result.failedBrokers
-                    .map((failure) => failure.address)
-                    .join(', ');
-                  if (result.status === 'PARTIAL') {
-                    await requestRefresh('operation');
-                    message.warning(
-                      t('cluster.configPartiallyUpdated', { brokers: failedAddresses }),
-                    );
-                    return;
+                    const failedAddresses = result.failedBrokers
+                      .map((failure) => failure.address)
+                      .join(', ');
+                    if (result.status === 'PARTIAL') {
+                      await requestRefresh('operation');
+                      message.warning(
+                        t('cluster.configPartiallyUpdated', { brokers: failedAddresses }),
+                      );
+                      return;
+                    }
+                    message.error(t('cluster.configUpdateFailed', { brokers: failedAddresses }));
+                  } catch {
+                    message.error(t('cluster.configUpdateFailed', { brokers: '' }));
                   }
-                  message.error(t('cluster.configUpdateFailed', { brokers: failedAddresses }));
-                } catch {
-                  message.error(t('cluster.configUpdateFailed', { brokers: '' }));
-                }
-              });
+                },
+                () => undefined,
+              );
             }}
             width={560}
           >
@@ -631,23 +634,35 @@ const ClusterPage = () => {
                 <Switch />
               </Form.Item>
               <Form.Item label={t('cluster.maxMessageSize')} name="maxMessageSizeMB">
-                <InputNumber min={1} max={128} style={{ width: '100%' }} />
+                <InputNumber min={1} max={128} step={0.5} style={{ width: '100%' }} />
               </Form.Item>
               <Form.Item label={t('cluster.fileReservedTime')} name="fileReservedTime">
-                <InputNumber min={1} max={720} style={{ width: '100%' }} />
+                <InputNumber min={1} max={720} step={1} precision={0} style={{ width: '100%' }} />
               </Form.Item>
               <Form.Item label={t('cluster.writeQueues')} name="writeQueueNums">
-                <InputNumber min={1} max={256} style={{ width: '100%' }} />
+                <InputNumber min={1} max={256} step={1} precision={0} style={{ width: '100%' }} />
               </Form.Item>
-              <Form.Item label={t('cluster.readQueues')} name="readQueueNums">
-                <InputNumber min={1} max={256} style={{ width: '100%' }} />
+              <Form.Item
+                label={t('cluster.readQueues')}
+                name="readQueueNums"
+                dependencies={['writeQueueNums']}
+                rules={[
+                  ({ getFieldValue }) => ({
+                    validator(_, value) {
+                      if (value === getFieldValue('writeQueueNums')) return Promise.resolve();
+                      return Promise.reject(new Error('读写队列数必须相等'));
+                    },
+                  }),
+                ]}
+              >
+                <InputNumber min={1} max={256} step={1} precision={0} style={{ width: '100%' }} />
               </Form.Item>
               <Text type="secondary" style={{ display: 'block', marginTop: -16, marginBottom: 16 }}>
                 RocketMQ Broker uses one default Topic queue count; read and write values must
                 match.
               </Text>
               <Form.Item label={t('cluster.brokerPermission')} name="brokerPermission">
-                <InputNumber min={0} max={7} style={{ width: '100%' }} />
+                <InputNumber min={0} max={7} step={1} precision={0} style={{ width: '100%' }} />
               </Form.Item>
             </Form>
           </Modal>


### PR DESCRIPTION
## Summary

- round-trip fractional MiB message sizes without rewriting unrelated configuration
- enforce equal read and write queue counts
- constrain Broker integer settings to integer input and handle form rejection

Fixes #2142

## Validation

- ClusterPage.test.tsx: 16 passed
- targeted Prettier and ESLint passed
- scope check: 145 changed lines

## Base

rocketmq-studio at 737a7b4d8b6ddf53d4c6dde581e821e6eac66529