### PR TITLE
[Studio] fix: preserve prompt submission integrity

### DIFF
--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -119,6 +119,36 @@ describe('AiPage tool runner', () => {
     });
   });
 
+  it('does not send while an input method composition is being confirmed', async () => {
+    renderPage();
+    const input = await screen.findByPlaceholderText(
+      '输入你的问题或指令，例如：查看集群状态、创建 Topic、诊断消费延迟...',
+    );
+    await waitFor(() => expect(getLlmModels).toHaveBeenCalled());
+
+    fireEvent.change(input, { target: { value: '检查集群状态' } });
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+
+    expect(chatStream).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates prompt submissions before loading state is rendered', async () => {
+    vi.mocked(chatStream).mockReturnValue(new Promise(() => {}));
+    renderPage();
+    const input = await screen.findByPlaceholderText(
+      '输入你的问题或指令，例如：查看集群状态、创建 Topic、诊断消费延迟...',
+    );
+    await waitFor(() => expect(getLlmModels).toHaveBeenCalled());
+    fireEvent.change(input, { target: { value: '检查集群状态' } });
+
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+
+    expect(chatStream).toHaveBeenCalledTimes(1);
+  });
+
   it('loads the catalog, creates a schema template, and renders structured output', async () => {
     const user = userEvent.setup();
     vi.mocked(executeTool).mockResolvedValue({
@@ -156,8 +186,16 @@ describe('AiPage tool runner', () => {
     let resolveOld!: (value: typeof oldTools) => void;
     let resolveLatest!: (value: typeof latestTools) => void;
     vi.mocked(listTools)
-      .mockReturnValueOnce(new Promise((resolve) => { resolveOld = resolve; }))
-      .mockReturnValueOnce(new Promise((resolve) => { resolveLatest = resolve; }));
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveOld = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveLatest = resolve;
+        }),
+      );
     const user = userEvent.setup();
     renderPage();
 

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -401,6 +401,7 @@ const AiPage = () => {
   const chatEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const chatInFlightRef = useRef(false);
   const conversationIdRef = useRef<string | null>(null);
   const toolLoadRequestRef = useRef(0);
   const consumedDraftRef = useRef(false);
@@ -503,11 +504,12 @@ const AiPage = () => {
     ) => {
       const text = (textOverride ?? inputValue).trim();
       const model = modelOverride ?? selectedModel;
-      if (!text || loading) return;
+      if (!text || loading || chatInFlightRef.current) return;
       if (!llmReady) {
         message.warning('请先配置并启用 LLM Provider');
         return;
       }
+      chatInFlightRef.current = true;
 
       if (!conversationIdRef.current) {
         conversationIdRef.current = `conversation-${Date.now()}`;
@@ -580,6 +582,7 @@ const AiPage = () => {
           message.error(errorMessage);
         }
       } finally {
+        chatInFlightRef.current = false;
         if (abortControllerRef.current === controller) abortControllerRef.current = null;
         setMessages((prev) =>
           prev.map((item) => (item.id === responseId ? { ...item, pending: false } : item)),
@@ -604,6 +607,7 @@ const AiPage = () => {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.nativeEvent.isComposing) return;
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         handleSend();

--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
@@ -110,5 +110,16 @@ describe('HomePage LLM models', () => {
         },
       });
     });
+  });
+
+  it('does not submit while an input method composition is being confirmed', async () => {
+    renderHome();
+    await screen.findByText('qwen3.8-max');
+    const input = screen.getByPlaceholderText('向 RocketMQ Bot 提问，全程加密、安全、可信');
+
+    fireEvent.change(input, { target: { value: '查看集群状态' } });
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -186,6 +186,7 @@ const HomePage = () => {
 
   /* ─── Keyboard shortcut: Enter to send ─── */
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.nativeEvent.isComposing) return;
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handlePromptSubmit();


### PR DESCRIPTION
## Summary

- ignore Enter while Home and AI inputs are composing IME text
- guard AI streaming with a synchronous in-flight reference
- release the guard after every stream completion path

Fixes #2143

## Validation

- HomePage.test.tsx and AiPage.test.tsx: 11 passed
- targeted Prettier and ESLint passed
- scope check: 62 changed lines

## Base

rocketmq-studio at 737a7b4d8b6ddf53d4c6dde581e821e6eac66529