### PR TITLE
[Studio] fix: preserve CSV import round-trip semantics

### DIFF
--- a/web/src/utils/resourceCsvImport.test.ts
+++ b/web/src/utils/resourceCsvImport.test.ts
@@ -67,6 +67,23 @@ describe('resourceCsvImport', () => {
     });
   });
 
+  it.each(['\t', '\r', '\n'])('restores exported control-prefixed cells for %j', (prefix) => {
+    const records = parseCsvTable(`"Name","Remark"\n"'${prefix}topic-a","ok"`);
+
+    expect(records[0].values.Name).toBe('topic-a');
+  });
+
+  it('tracks lone carriage returns inside quoted fields when reporting row errors', () => {
+    const content = [
+      '"Name","Remark"',
+      '"topic-a","line1\rline2"',
+      '"topic-b","ok"',
+      '"topic-c","too","many"',
+    ].join('\r\n');
+
+    expect(() => parseCsvTable(content)).toThrow('第 5 行字段数超过表头字段数');
+  });
+
   it('validates topic fields and duplicate names before import calls', () => {
     const records = parseCsvTable(
       [

--- a/web/src/utils/resourceCsvImport.ts
+++ b/web/src/utils/resourceCsvImport.ts
@@ -43,7 +43,7 @@ interface ParsedCsvRow {
   cells: string[];
 }
 
-const FORMULA_SAFE_PREFIX_PATTERN = /^'(?=[=+\-@])/;
+const FORMULA_SAFE_PREFIX_PATTERN = /^'(?=[=+\-@\t\r\n])/;
 const TOPIC_NAME_PATTERN = /^[a-zA-Z0-9_\-/*]+$/;
 const GROUP_NAME_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
 
@@ -122,7 +122,7 @@ const readCsvRows = (content: string): ParsedCsvRow[] => {
           quoteJustClosed = true;
         }
       } else {
-        if (char === '\n') lineNumber += 1;
+        if (char === '\n' || (char === '\r' && next !== '\n')) lineNumber += 1;
         cell += char;
       }
       continue;


### PR DESCRIPTION
## Summary

- restore apostrophe-protected tab, CR, and LF prefixes emitted by resource export
- count lone carriage returns inside quoted fields
- keep later CSV validation errors aligned with physical source lines

Fixes #2144

## Validation

- resourceCsvImport.test.ts: 9 passed
- targeted Prettier and ESLint passed
- scope check: 21 changed lines

## Base

rocketmq-studio at 737a7b4d8b6ddf53d4c6dde581e821e6eac66529