### PR TITLE
[Studio] fix: normalize producer connection summary identity

### DIFF
--- a/web/src/api/producer.test.ts
+++ b/web/src/api/producer.test.ts
@@ -169,4 +169,26 @@ describe('Producer API', () => {
     expect(result.duplicateClientIds).toEqual(['producer-a']);
     expect(result.warnings).toEqual(['DUPLICATE_CLIENT_ID', 'MIXED_CLIENT_VERSION']);
   });
+
+  it('normalizes client identifiers and addresses consistently in summary counts', () => {
+    const result = buildProducerConnectionSummary([
+      {
+        clientId: 'producer-a',
+        clientAddr: '10.0.0.1',
+        language: 'Java',
+        versionDesc: '5.1.0',
+      },
+      {
+        clientId: ' producer-a ',
+        clientAddr: ' 10.0.0.1 ',
+        language: 'Java',
+        versionDesc: '5.1.0',
+      },
+    ]);
+
+    expect(result.uniqueClientCount).toBe(1);
+    expect(result.uniqueAddressCount).toBe(1);
+    expect(result.duplicateClientIds).toEqual(['producer-a']);
+    expect(result.warnings).toContain('DUPLICATE_CLIENT_ID');
+  });
 });

--- a/web/src/api/producer.ts
+++ b/web/src/api/producer.ts
@@ -76,7 +76,13 @@ const normalizeDimension = (value?: string | null) => (hasText(value) ? value!.t
 const countDistinct = (
   connections: ProducerConnection[],
   extractor: (connection: ProducerConnection) => string,
-) => new Set(connections.map(extractor).filter(hasText)).size;
+) =>
+  new Set(
+    connections
+      .map(extractor)
+      .filter(hasText)
+      .map((value) => value.trim()),
+  ).size;
 
 const distribution = (
   connections: ProducerConnection[],


### PR DESCRIPTION
## Summary

- trim accepted client IDs before distinct counting
- trim accepted addresses before distinct counting
- keep unique counts consistent with distributions and duplicate detection

Fixes #2145

## Validation

- producer.test.ts: 9 passed
- targeted Prettier and ESLint passed
- scope check: 30 changed lines

## Base

rocketmq-studio at 737a7b4d8b6ddf53d4c6dde581e821e6eac66529