### PR TITLE
[Studio] fix: clear stale BrokerCluster topology on instance change

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -160,29 +160,34 @@ const BrokerClusterPage = () => {
     setProxyData([]);
   }, []);
 
-  const loadData = useCallback(async () => {
-    if (!selectedInstanceId) {
-      clearData();
-      return;
-    }
-    const requestId = ++loadRequestId.current;
-    setLoading(true);
-    try {
-      const clusters = await listClusters(selectedInstanceId);
-      if (requestId !== loadRequestId.current) return;
-      const mapped = mapClusters(clusters);
-      setBrokerData(mapped.brokers);
-      setNameServerData(mapped.nameServers);
-      setProxyData(mapped.proxies);
-    } catch {
-      if (requestId !== loadRequestId.current) return;
-      message.error(t('common.refreshFailed'));
-    } finally {
-      if (requestId === loadRequestId.current) {
-        setLoading(false);
+  const loadData = useCallback(
+    async (clearExisting = false) => {
+      if (!selectedInstanceId) {
+        clearData();
+        return;
       }
-    }
-  }, [clearData, message, selectedInstanceId, t]);
+      const requestId = ++loadRequestId.current;
+      if (clearExisting) clearData();
+      setLoading(true);
+      try {
+        const clusters = await listClusters(selectedInstanceId);
+        if (requestId !== loadRequestId.current) return;
+        const mapped = mapClusters(clusters);
+        setBrokerData(mapped.brokers);
+        setNameServerData(mapped.nameServers);
+        setProxyData(mapped.proxies);
+      } catch {
+        if (requestId !== loadRequestId.current) return;
+        clearData();
+        message.error(t('common.refreshFailed'));
+      } finally {
+        if (requestId === loadRequestId.current) {
+          setLoading(false);
+        }
+      }
+    },
+    [clearData, message, selectedInstanceId, t],
+  );
 
   useEffect(() => {
     let active = true;
@@ -206,7 +211,7 @@ const BrokerClusterPage = () => {
     const requestId = loadRequestId.current;
     // The state updates are performed by the asynchronous cluster API request, not by this effect itself.
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    void loadData();
+    void loadData(true);
     return () => {
       loadRequestId.current = requestId + 1;
     };

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -123,10 +123,12 @@ const renderWithProviders = (ui: React.ReactElement) => {
 
 const createDeferred = <T,>() => {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 };
 
 describe('BrokerCluster Page', () => {
@@ -229,6 +231,49 @@ describe('BrokerCluster Page', () => {
     expect(screen.queryByText('broker-b')).not.toBeInTheDocument();
     expect(screen.queryByText('nameserver-a')).not.toBeInTheDocument();
     expect(screen.queryByText('proxy-a')).not.toBeInTheDocument();
+  });
+
+  it('clears the previous topology while a newly selected instance loads or fails', async () => {
+    const nextInstance = createDeferred<ClusterInfo[]>();
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'instance-1',
+        name: 'instance-1',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '10.0.1.20:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+      {
+        id: 'instance-2',
+        name: 'instance-2',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '10.0.2.20:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
+    vi.mocked(listClusters)
+      .mockResolvedValueOnce(clusterFixture)
+      .mockReturnValueOnce(nextInstance.promise);
+    const user = userEvent.setup();
+    renderWithProviders(<BrokerCluster />);
+    await screen.findByText('broker-api-a');
+
+    await user.click(screen.getByRole('combobox', { name: '选择实例' }));
+    const instanceTwoOptions = await screen.findAllByText('instance-2');
+    await user.click(instanceTwoOptions[instanceTwoOptions.length - 1]);
+
+    await waitFor(() => expect(screen.queryByText('broker-api-a')).not.toBeInTheDocument());
+    await act(async () => nextInstance.reject(new Error('instance-2 unavailable')));
+    expect(screen.queryByText('broker-api-a')).not.toBeInTheDocument();
+    expect(listClusters).toHaveBeenLastCalledWith('instance-2');
   });
 
   it('polls only while live refresh is enabled', async () => {


### PR DESCRIPTION
## Summary

- clear Broker, NameServer, and Proxy rows when instance scope changes
- clear the active scope when its cluster request fails
- preserve request sequencing so older responses cannot repopulate stale data

Fixes #2151

## Validation

- BrokerCluster.test.tsx: 14 passed
- npm run build passed
- targeted Prettier and ESLint passed
- scope check: 100 changed lines

## Base

rocketmq-studio at 737a7b4d8b6ddf53d4c6dde581e821e6eac66529