### PR TITLE
[Studio] fix: order metrics samples by timestamp

### DIFF
--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -59,8 +59,10 @@ interface NumericSample {
 
 const toNumericSamples = (series: MetricSeries): NumericSample[] =>
   series.values
-    .map((sample) => ({ timestamp: sample.timestamp, value: Number(sample.value) }))
-    .filter((sample) => Number.isFinite(sample.timestamp) && Number.isFinite(sample.value));
+    .map((sample, index) => ({ timestamp: sample.timestamp, value: Number(sample.value), index }))
+    .filter((sample) => Number.isFinite(sample.timestamp) && Number.isFinite(sample.value))
+    .sort((left, right) => left.timestamp - right.timestamp || left.index - right.index)
+    .map(({ timestamp, value }) => ({ timestamp, value }));
 
 const seriesLabel = (series: MetricSeries, fallback: string) => {
   const labels = Object.entries(series.labels)

--- a/web/src/components/__tests__/MetricsExplorer.test.tsx
+++ b/web/src/components/__tests__/MetricsExplorer.test.tsx
@@ -147,6 +147,29 @@ describe('MetricsExplorer', () => {
     expect(screen.getByText('42 messages/s')).toBeInTheDocument();
   });
 
+  it('sorts provider samples before drawing and selecting the latest value', async () => {
+    vi.mocked(queryMetrics).mockResolvedValue({
+      ...metricData,
+      series: [
+        {
+          ...metricData.series[0],
+          values: [
+            { timestamp: 1_800_000_000, value: '42' },
+            { timestamp: 1_799_996_400, value: '40' },
+          ],
+        },
+      ],
+    });
+
+    renderWithProviders(<MetricsExplorer />);
+
+    expect(await screen.findByText('42 messages/s')).toBeInTheDocument();
+    const chart = screen.getByRole('img', { name: 'Message In TPS time series' });
+    const points = chart.querySelector('polyline')?.getAttribute('points')?.split(' ') ?? [];
+    const xCoordinates = points.map((point) => Number(point.split(',')[0]));
+    expect(xCoordinates).toEqual([...xCoordinates].sort((left, right) => left - right));
+  });
+
   it('updates the query window when the range changes', async () => {
     const user = userEvent.setup();
     renderWithProviders(<MetricsExplorer />);


### PR DESCRIPTION
## Summary

- stably sort finite metric samples by timestamp
- draw chart points from oldest to newest
- derive the displayed latest value from the chronologically latest sample

Fixes #2152

## Validation

- MetricsExplorer.test.tsx: 11 passed
- targeted Prettier and ESLint passed
- scope check: 29 changed lines

## Base

rocketmq-studio at 737a7b4d8b6ddf53d4c6dde581e821e6eac66529