### PR TITLE
[Studio] fix: use instance IDs in NameServer drift selector

### DIFF
--- a/web/src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx
@@ -118,6 +118,36 @@ describe('NameServerConfigDriftPage', () => {
     expect(screen.getByText('listenPort')).toBeInTheDocument();
     expect(screen.getByText('19876')).toBeInTheDocument();
     expect(screen.getByText('ns-a:9876 · 可达')).toBeInTheDocument();
+    expect(screen.getByText('Production instance')).toBeInTheDocument();
+    expect(screen.queryByText('instance-a')).not.toBeInTheDocument();
+  });
+
+  it('keeps instance identifiers stable when selecting another instance', async () => {
+    const secondInstance = {
+      id: 'instance-b',
+      name: 'Staging instance',
+      vendor: 'APACHE',
+    } as Instance;
+    vi.mocked(listInstances).mockResolvedValue([instance, secondInstance]);
+    const stagingCluster = { id: 'cluster-b', name: 'Staging' } as ClusterInfo;
+    vi.mocked(listClusters).mockImplementation(async (instanceId) =>
+      instanceId === 'instance-b' ? [stagingCluster] : [cluster],
+    );
+    const user = userEvent.setup();
+
+    renderWithProviders(<NameServerConfigDriftPage />);
+    const selector = await screen.findByRole('combobox', { name: 'NameServer drift instance' });
+    await user.click(selector);
+    await user.click(
+      await screen.findByText('Staging instance', {
+        selector: '.ant-select-item-option-content',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(listClusters).toHaveBeenCalledWith('instance-b');
+      expect(getNameServerConfigDiff).toHaveBeenCalledWith('cluster-b', 'instance-b');
+    });
   });
 
   it('reports a consistent result when no safe configuration differs', async () => {

--- a/web/src/pages/ops/nameServerConfigDrift.tsx
+++ b/web/src/pages/ops/nameServerConfigDrift.tsx
@@ -203,7 +203,7 @@ const NameServerConfigDriftPage = () => {
           value={selectedInstanceId}
           onChange={(instanceId) => void selectInstance(instanceId)}
           placeholder={t('common.selectInstance')}
-          options={instances.map((instance) => ({ label: instance.name, value: instance.name }))}
+          options={instances.map((instance) => ({ label: instance.name, value: instance.id }))}
           style={{ width: 'min(100%, 280px)' }}
         />
         <Select


### PR DESCRIPTION
## Summary

- use instance IDs as Select option values
- keep instance names as user-facing labels
- send the selected ID consistently to cluster and drift APIs

Fixes #2153

## Validation

- NameServerConfigDriftPage.test.tsx: 7 passed
- targeted Prettier and ESLint passed
- scope check: 32 changed lines

## Base

rocketmq-studio at 737a7b4d8b6ddf53d4c6dde581e821e6eac66529