### PR TITLE
[Studio] fix: validate pasted message properties

### DIFF
--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -22,6 +22,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
 import type { Topic } from '../../../api/metadata';
+import { parseMessageProperties } from '../../../utils/messageProperties';
 import TopicPage from '../topic';
 
 const topicServiceMocks = vi.hoisted(() => ({
@@ -456,6 +457,20 @@ describe('TopicPage', () => {
     await waitFor(() => expect(document.querySelector('.ant-spin-spinning')).toBeNull());
     expect(screen.getByRole('button', { name: /导入/ })).toBeDisabled();
     expect(screen.getByRole('button', { name: /创建 Topic/ })).toBeDisabled();
+  });
+
+  it('rejects malformed or duplicate batch message properties without sending', () => {
+    expect(parseMessageProperties('traceId=abc\ntenant\ntraceId=duplicate')).toEqual({
+      properties: { traceId: 'abc' },
+      errors: ['“tenant”应使用 key=value 格式', '属性名“traceId”重复'],
+    });
+  });
+
+  it('preserves equals signs in valid batch message property values', () => {
+    expect(parseMessageProperties('signature=part-a=part-b')).toEqual({
+      properties: { signature: 'part-a=part-b' },
+      errors: [],
+    });
   });
 
   it('renders unavailable Topic consumer metrics distinctly from zero', async () => {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -72,6 +72,7 @@ import {
   validateTopicCsvImport,
   type ResourceImportRow,
 } from '../../utils/resourceCsvImport';
+import { parseMessageProperties } from '../../utils/messageProperties';
 
 const { Text } = Typography;
 
@@ -263,19 +264,6 @@ const RANDOM_BODY_GENERATORS = [
 // ─── Format helpers ───────────────────────────────────────────────
 const formatNumber = (n: number) => n.toLocaleString('zh-CN');
 
-// 解析批量粘贴的用户属性串：key=value 按换行或逗号分隔，等号只取第一个
-const parsePropsText = (text: string): Record<string, string> => {
-  const props: Record<string, string> = {};
-  for (const line of text.split(/[\n,]+/)) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    const eqIndex = trimmed.indexOf('=');
-    if (eqIndex <= 0) continue;
-    const key = trimmed.slice(0, eqIndex).trim();
-    if (key) props[key] = trimmed.slice(eqIndex + 1).trim();
-  }
-  return props;
-};
 const formatDateTime = (iso?: string): string => {
   if (!iso) return '-';
   const d = new Date(iso);
@@ -856,7 +844,12 @@ const TopicPage = () => {
       // Build properties: batch-paste text mode or key-value form rows
       let props: Record<string, string> = {};
       if (propsMode === 'text') {
-        props = parsePropsText(values.propsText || '');
+        const parsed = parseMessageProperties(values.propsText || '');
+        if (parsed.errors.length > 0) {
+          message.error(`消息属性格式错误：${parsed.errors.join('；')}`);
+          return;
+        }
+        props = parsed.properties;
       } else if (values.properties && Array.isArray(values.properties)) {
         values.properties.forEach((p: { key?: string; value?: string }) => {
           if (p.key) props[p.key] = p.value || '';

--- a/web/src/utils/messageProperties.ts
+++ b/web/src/utils/messageProperties.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface ParsedProperties {
+  properties: Record<string, string>;
+  errors: string[];
+}
+
+// 解析批量粘贴的用户属性串：key=value 按换行或逗号分隔，等号只取第一个
+export const parseMessageProperties = (text: string): ParsedProperties => {
+  const properties: Record<string, string> = {};
+  const errors: string[] = [];
+  for (const line of text.split(/[\n,]+/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex <= 0) {
+      errors.push(`“${trimmed}”应使用 key=value 格式`);
+      continue;
+    }
+    const key = trimmed.slice(0, eqIndex).trim();
+    if (!key) {
+      errors.push(`“${trimmed}”的属性名不能为空`);
+    } else if (Object.prototype.hasOwnProperty.call(properties, key)) {
+      errors.push(`属性名“${key}”重复`);
+    } else {
+      properties[key] = trimmed.slice(eqIndex + 1).trim();
+    }
+  }
+  return { properties, errors };
+};


### PR DESCRIPTION
## Summary

- report malformed and empty-key batch property tokens
- reject duplicate property names instead of overwriting values
- preserve valid values after the first equals sign and block sending on parse errors

Fixes #2154

## Validation

- TopicPage.test.tsx: 13 passed
- npm run build passed
- targeted Prettier and ESLint passed
- scope check: 81 changed lines

## Base

rocketmq-studio at 737a7b4d8b6ddf53d4c6dde581e821e6eac66529