### PR TITLE
[Studio] fix: report DLQ resend hard-cap truncation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -178,9 +178,10 @@ public class RocketMQDLQProvider implements DLQProvider {
 
         String outcome = classifyOutcome(deadLetters.size(), resent, failed, scanResult.scanIncomplete());
         String detail = String.format("instanceId=%s, group=%s, dlqTopic=%s, targetTopic=%s, matched=%d, resent=%d, "
-                        + "failed=%d, scanIncomplete=%s, scanFailedQueues=%d",
+                        + "failed=%d, scanIncomplete=%s, scanTruncated=%s, scanFailedQueues=%d",
                 instanceId, groupName, dlqTopic, StringUtils.hasText(targetTopic) ? targetTopic : "<original>",
-                deadLetters.size(), resent, failed, scanResult.scanIncomplete(), scanResult.failedQueueCount());
+                deadLetters.size(), resent, failed, scanResult.scanIncomplete(), scanResult.truncated(),
+                scanResult.failedQueueCount());
         recordAudit(groupName, detail, outcome);
         log.info("DLQ resend completed: {}", detail);
         return DLQResendResultVO.builder()
@@ -197,11 +198,12 @@ public class RocketMQDLQProvider implements DLQProvider {
         DefaultMQPullConsumer consumer = newPullConsumer(endpoint);
         List<MessageExt> result = new ArrayList<>();
         int failedQueueCount = 0;
+        boolean truncated = false;
         try {
             consumer.start();
             Set<MessageQueue> queues = consumer.fetchSubscribeMessageQueues(dlqTopic);
             if (queues == null || queues.isEmpty()) {
-                return new DeadLetterScanResult(result, 0);
+                return new DeadLetterScanResult(result, 0, false);
             }
             outer:
             for (MessageQueue queue : queues) {
@@ -213,6 +215,7 @@ public class RocketMQDLQProvider implements DLQProvider {
                     int consecutiveIllegalOffsets = 0;
                     for (long offset = minOffset; offset <= maxOffset; ) {
                         if (result.size() >= RESEND_HARD_CAP) {
+                            truncated = true;
                             break outer;
                         }
                         PullResult pullResult = consumer.pull(queue, "*", offset, 32);
@@ -255,6 +258,7 @@ public class RocketMQDLQProvider implements DLQProvider {
                                     && messageExt.getStoreTimestamp() <= end) {
                                 result.add(messageExt);
                                 if (result.size() >= RESEND_HARD_CAP) {
+                                    truncated = true;
                                     break outer;
                                 }
                             }
@@ -277,7 +281,7 @@ public class RocketMQDLQProvider implements DLQProvider {
         } finally {
             consumer.shutdown();
         }
-        return new DeadLetterScanResult(result, failedQueueCount);
+        return new DeadLetterScanResult(result, failedQueueCount, truncated);
     }
 
     private boolean resendOne(DefaultMQProducer producer, MessageExt deadLetter, String targetTopic) {
@@ -385,9 +389,9 @@ public class RocketMQDLQProvider implements DLQProvider {
         }
     }
 
-    private record DeadLetterScanResult(List<MessageExt> messages, int failedQueueCount) {
+    private record DeadLetterScanResult(List<MessageExt> messages, int failedQueueCount, boolean truncated) {
         boolean scanIncomplete() {
-            return failedQueueCount > 0;
+            return failedQueueCount > 0 || truncated;
         }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -45,6 +45,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -267,6 +268,52 @@ class RocketMQDLQProviderTest {
                 eq("group-a"),
                 contains("matched=1, resent=0, failed=1"),
                 eq("FAILED"));
+    }
+
+    @Test
+    void resendMessagesMarksAResultPartialWhenScanReachesHardCap() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        MessageQueue queue = new MessageQueue(dlqTopic, "broker-a", 0);
+        List<MessageExt> deadLetters = IntStream.range(0, 5001)
+                .mapToObj(index -> {
+                    MessageExt deadLetter = new MessageExt();
+                    deadLetter.setMsgId("msg-" + index);
+                    deadLetter.setTopic(dlqTopic);
+                    deadLetter.setBody(new byte[] {1});
+                    deadLetter.setStoreTimestamp(150L);
+                    return deadLetter;
+                })
+                .toList();
+        PullResult pullResult = new PullResult(PullStatus.FOUND, 5001L, 0L, 5000L, deadLetters);
+        SendResult sendResult = new SendResult();
+        sendResult.setSendStatus(SendStatus.SEND_OK);
+
+        try (MockedConstruction<DefaultMQPullConsumer> mockedConsumers =
+                     mockConstruction(DefaultMQPullConsumer.class, (consumer, context) -> {
+                         doNothing().when(consumer).start();
+                         when(consumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(Set.of(queue));
+                         when(consumer.searchOffset(queue, 100L)).thenReturn(0L);
+                         when(consumer.searchOffset(queue, 200L)).thenReturn(5001L);
+                         when(consumer.pull(queue, "*", 0L, 32)).thenReturn(pullResult);
+                         doNothing().when(consumer).shutdown();
+                     });
+             MockedConstruction<DefaultMQProducer> mockedProducers =
+                     mockConstruction(DefaultMQProducer.class, (producer, context) -> {
+                         doNothing().when(producer).start();
+                         when(producer.send(any(Message.class))).thenReturn(sendResult);
+                         doNothing().when(producer).shutdown();
+                     })) {
+            assertThat(provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic"))
+                    .extracting("matched", "resent", "failed", "outcome", "scanIncomplete", "failedQueueCount")
+                    .containsExactly(5000, 5000, 0, "PARTIAL", true, 0);
+
+            verify(mockedProducers.constructed().get(0), times(5000)).send(any(Message.class));
+        }
+        verify(auditService).record(
+                eq("RESEND_DLQ"),
+                eq("group-a"),
+                contains("scanTruncated=true"),
+                eq("PARTIAL"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- mark DLQ scans truncated when the 5000-message hard cap is reached
- treat truncated scans as incomplete and classify the outcome as PARTIAL
- include scanTruncated in audit details without changing the public result schema

Fixes #2155

## Validation

- RocketMQDLQProviderTest and DLQServiceTest: 17 passed
- Maven Checkstyle passed
- scope check: 63 changed lines

## Base

rocketmq-studio at 737a7b4d8b6ddf53d4c6dde581e821e6eac66529