### PR TITLE
feat(auth): add persistent Studio user management

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -25,7 +25,7 @@
 >
 > Base URL: `/api`
 > Content-Type: `application/json`
-> 认证方式: `Authorization: Bearer <token>`
+> 浏览器认证方式: `HttpOnly` 会话 Cookie。自动化 API 客户端可在登录时显式请求 bearer token，后续使用 `Authorization: Bearer <token>`。
 
 ## 接口设计风格
 
@@ -168,11 +168,17 @@ POST /api/auth/login
 | `username` | `string` | 是 | 用户名 |
 | `password` | `string` | 是 | 密码 |
 
+**可选 Request Header：**
+
+| Header | 值 | 说明 |
+|--------|----|------|
+| `X-RocketMQ-Studio-Session-Delivery` | `bearer` | 仅供非浏览器 API 客户端使用。响应 `data.token` 返回 bearer token，且不设置 Cookie。省略时使用 `HttpOnly` 会话 Cookie，响应不包含 token。 |
+
 **Response `data`:**
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `token` | `string` | JWT Token |
+| `token` | `string` | 仅当请求 `X-RocketMQ-Studio-Session-Delivery: bearer` 时返回的会话 token |
 | `expiresIn` | `number` | 过期时间（秒） |
 | `user` | `object` | 用户信息 |
 | `user.username` | `string` | 用户名 |

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthController.java
@@ -34,6 +34,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -47,9 +48,12 @@ public class AuthController {
     @GetMapping("/status")
     public ResponseEntity<Result<AuthStatusVO>> status(
             HttpServletRequest request) {
+        Optional<LoginVO.UserInfo> user = authService.getAuthenticatedUser(
+                AuthCookie.authorization(request, authProperties));
         AuthStatusVO status = AuthStatusVO.builder()
                 .loginRequired(isLoginRequired())
-                .authenticated(authService.isAuthenticated(AuthCookie.authorization(request, authProperties)))
+                .authenticated(user.isPresent())
+                .user(user.orElse(null))
                 .build();
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noStore())

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthController.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -73,6 +74,19 @@ public class AuthController {
     public Result<Void> logout(@RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false)
                                String authorization) {
         authService.logout(authorization);
+        return Result.ok();
+    }
+
+    @PostMapping("/password")
+    public Result<Void> changePassword(
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization,
+            @Valid @RequestBody ChangePasswordDTO request) {
+        LoginVO.UserInfo user = authService.getAuthenticatedUser(authorization)
+                .orElseThrow(() -> new BusinessException(401, "Unauthorized"));
+        if (user.getUserId() == null) {
+            throw new BusinessException(503, "Studio user management is not initialized");
+        }
+        authService.changePassword(user.getUserId(), request.getCurrentPassword(), request.getNewPassword(), true);
         return Result.ok();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthController.java
@@ -66,12 +66,17 @@ public class AuthController {
 
     @PostMapping("/login")
     public Result<LoginVO> login(@RequestBody(required = false) LoginDTO request,
+                                 HttpServletRequest servletRequest,
                                  HttpServletResponse response) {
         if (request == null) {
             throw new BusinessException(400, "Login request is required");
         }
         LoginVO login = authService.login(request);
+        if (AuthCookie.requestsBearerToken(servletRequest)) {
+            return Result.ok(login);
+        }
         AuthCookie.write(response, authProperties, login.getToken(), Duration.ofSeconds(login.getExpiresIn()));
+        login.setToken(null);
         return Result.ok(login);
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthController.java
@@ -17,21 +17,23 @@
 
 package org.apache.rocketmq.studio.auth;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.apache.rocketmq.studio.settings.SettingsRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.CacheControl;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import jakarta.validation.Valid;
+
+import java.time.Duration;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -44,10 +46,10 @@ public class AuthController {
 
     @GetMapping("/status")
     public ResponseEntity<Result<AuthStatusVO>> status(
-            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization) {
+            HttpServletRequest request) {
         AuthStatusVO status = AuthStatusVO.builder()
                 .loginRequired(isLoginRequired())
-                .authenticated(authService.isAuthenticated(authorization))
+                .authenticated(authService.isAuthenticated(AuthCookie.authorization(request, authProperties)))
                 .build();
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noStore())
@@ -63,25 +65,28 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public Result<LoginVO> login(@RequestBody(required = false) LoginDTO request) {
+    public Result<LoginVO> login(@RequestBody(required = false) LoginDTO request,
+                                 HttpServletResponse response) {
         if (request == null) {
             throw new BusinessException(400, "Login request is required");
         }
-        return Result.ok(authService.login(request));
+        LoginVO login = authService.login(request);
+        AuthCookie.write(response, authProperties, login.getToken(), Duration.ofSeconds(login.getExpiresIn()));
+        return Result.ok(login);
     }
 
     @PostMapping("/logout")
-    public Result<Void> logout(@RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false)
-                               String authorization) {
-        authService.logout(authorization);
+    public Result<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        authService.logout(AuthCookie.authorization(request, authProperties));
+        AuthCookie.clear(response, authProperties);
         return Result.ok();
     }
 
     @PostMapping("/password")
     public Result<Void> changePassword(
-            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization,
+            HttpServletRequest servletRequest,
             @Valid @RequestBody ChangePasswordDTO request) {
-        LoginVO.UserInfo user = authService.getAuthenticatedUser(authorization)
+        LoginVO.UserInfo user = authService.getAuthenticatedUser(AuthCookie.authorization(servletRequest, authProperties))
                 .orElseThrow(() -> new BusinessException(401, "Unauthorized"));
         if (user.getUserId() == null) {
             throw new BusinessException(503, "Studio user management is not initialized");

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthCookie.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthCookie.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.auth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+import java.time.Duration;
+
+final class AuthCookie {
+
+    private static final String TOKEN_PREFIX = "Bearer ";
+    private static final String DEFAULT_COOKIE_NAME = "rmq_studio_session";
+    private static final String DEFAULT_SAME_SITE = "Strict";
+
+    private AuthCookie() {
+    }
+
+    static String authorization(HttpServletRequest request, AuthProperties properties) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookieName(properties).equals(cookie.getName())
+                        && !cookie.getValue().isBlank()) {
+                    return TOKEN_PREFIX + cookie.getValue();
+                }
+            }
+        }
+        // Keep non-browser callers compatible while browser clients use HttpOnly cookies.
+        return request.getHeader(HttpHeaders.AUTHORIZATION);
+    }
+
+    static void write(HttpServletResponse response, AuthProperties properties, String token,
+                      Duration maxAge) {
+        response.addHeader(HttpHeaders.SET_COOKIE, ResponseCookie.from(cookieName(properties), token)
+                .httpOnly(true)
+                .secure(properties.isSessionCookieSecure())
+                .sameSite(sameSite(properties))
+                .path("/")
+                .maxAge(maxAge)
+                .build()
+                .toString());
+    }
+
+    static void clear(HttpServletResponse response, AuthProperties properties) {
+        write(response, properties, "", Duration.ZERO);
+    }
+
+    private static String cookieName(AuthProperties properties) {
+        String name = properties.getSessionCookieName();
+        return name == null || name.isBlank() ? DEFAULT_COOKIE_NAME : name;
+    }
+
+    private static String sameSite(AuthProperties properties) {
+        String sameSite = properties.getSessionCookieSameSite();
+        return sameSite == null || sameSite.isBlank() ? DEFAULT_SAME_SITE : sameSite;
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthCookie.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthCookie.java
@@ -29,6 +29,8 @@ final class AuthCookie {
     private static final String TOKEN_PREFIX = "Bearer ";
     private static final String DEFAULT_COOKIE_NAME = "rmq_studio_session";
     private static final String DEFAULT_SAME_SITE = "Strict";
+    static final String SESSION_DELIVERY_HEADER = "X-RocketMQ-Studio-Session-Delivery";
+    private static final String BEARER_SESSION_DELIVERY = "bearer";
 
     private AuthCookie() {
     }
@@ -43,8 +45,12 @@ final class AuthCookie {
                 }
             }
         }
-        // Keep non-browser callers compatible while browser clients use HttpOnly cookies.
+        // API clients that explicitly requested a bearer token at login authenticate with this header.
         return request.getHeader(HttpHeaders.AUTHORIZATION);
+    }
+
+    static boolean requestsBearerToken(HttpServletRequest request) {
+        return BEARER_SESSION_DELIVERY.equalsIgnoreCase(request.getHeader(SESSION_DELIVERY_HEADER));
     }
 
     static void write(HttpServletResponse response, AuthProperties properties, String token,

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
@@ -22,7 +22,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.apache.rocketmq.studio.settings.SettingsRepository;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -55,7 +54,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             // enforcement, matching the documented AuthWebConfig behaviour.
             return true;
         }
-        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String authorization = AuthCookie.authorization(request, authProperties);
         if (!authService.isAuthenticated(authorization)) {
             writeError(response, HttpStatus.UNAUTHORIZED, "Unauthorized");
             return false;

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
@@ -36,6 +36,7 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     private static final Set<String> READER_POST_PATHS = Set.of(
             "/api/auth/logout",
+            "/api/auth/password",
             "/api/ai/chat",
             "/api/metrics/query",
             "/api/metrics/query/datasource");
@@ -60,7 +61,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             return false;
         }
         authService.getAuthenticatedUser(authorization)
-                .ifPresent(user -> AuthenticatedUserContext.setUsername(user.getUsername()));
+                .ifPresent(user -> AuthenticatedUserContext.setUser(user.getUserId(), user.getUsername()));
         if (requiresAdmin(request, requestPath(request)) && !authService.isAdmin(authorization)) {
             writeError(response, HttpStatus.FORBIDDEN, "Admin permission required");
             return false;
@@ -102,6 +103,7 @@ public class AuthInterceptor implements HandlerInterceptor {
     private boolean isAdminOnlyGetPath(String path) {
         String normalizedPath = normalizePath(stripPathParameters(path));
         return "/api/llm/models".equals(normalizedPath)
+                || "/api/studio-users".equals(normalizedPath)
                 || isCloudCatalogPath(normalizedPath)
                 || "/api/acl/remote/rules".equals(normalizedPath)
                 || isCredentialRevealPath(normalizedPath, "/api/acl/users/")

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthProperties.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthProperties.java
@@ -32,6 +32,9 @@ import java.util.List;
 @ConfigurationProperties(prefix = "studio.auth")
 public class AuthProperties {
     private boolean loginRequired;
+    private String sessionCookieName = "rmq_studio_session";
+    private boolean sessionCookieSecure = true;
+    private String sessionCookieSameSite = "Strict";
     private List<User> users = new ArrayList<>();
 
     public List<User> configuredUsers() {

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
@@ -17,21 +17,44 @@
 
 package org.apache.rocketmq.studio.auth;
 
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.persistence.entity.RmqStudioSession;
+import org.apache.rocketmq.studio.persistence.entity.RmqStudioUser;
+import org.apache.rocketmq.studio.persistence.mapper.RmqStudioSessionMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqStudioUserMapper;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.apache.rocketmq.studio.settings.SettingsRepository;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
 import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Authenticates Studio users and owns bearer session lifecycle.
+ *
+ * <p>The configuration users remain a bootstrap mechanism for a fresh database only. Once a
+ * Studio user has been created, the database is the source of truth for credentials and account
+ * status.</p>
+ */
 @Slf4j
 @Service
 public class AuthService {
@@ -40,52 +63,48 @@ public class AuthService {
     private static final int MIN_SESSION_TIMEOUT_MINUTES = 5;
     private static final int MAX_SESSION_TIMEOUT_MINUTES = 1440;
     private static final String TOKEN_PREFIX = "Bearer ";
+    private static final SecureRandom TOKEN_RANDOM = new SecureRandom();
 
     private final AuthProperties authProperties;
     private final SettingsRepository settingsRepository;
     private final Clock clock;
+    private final RmqStudioUserMapper userMapper;
+    private final RmqStudioSessionMapper sessionMapper;
+    private final PasswordHasher passwordHasher;
+
+    // Retained only for narrow unit tests that construct the legacy service directly.
     private final Map<String, AuthSession> activeTokens = new ConcurrentHashMap<>();
 
     @Autowired
+    public AuthService(AuthProperties authProperties, SettingsRepository settingsRepository,
+                       RmqStudioUserMapper userMapper, RmqStudioSessionMapper sessionMapper,
+                       PasswordHasher passwordHasher) {
+        this(authProperties, settingsRepository, Clock.systemUTC(), userMapper, sessionMapper,
+                passwordHasher);
+    }
+
     public AuthService(AuthProperties authProperties, SettingsRepository settingsRepository) {
         this(authProperties, settingsRepository, Clock.systemUTC());
     }
 
     AuthService(AuthProperties authProperties, SettingsRepository settingsRepository, Clock clock) {
+        this(authProperties, settingsRepository, clock, null, null, new PasswordHasher());
+    }
+
+    AuthService(AuthProperties authProperties, SettingsRepository settingsRepository, Clock clock,
+                RmqStudioUserMapper userMapper, RmqStudioSessionMapper sessionMapper,
+                PasswordHasher passwordHasher) {
         this.authProperties = authProperties;
         this.settingsRepository = settingsRepository;
         this.clock = clock;
+        this.userMapper = userMapper;
+        this.sessionMapper = sessionMapper;
+        this.passwordHasher = passwordHasher;
     }
 
     public LoginVO login(LoginDTO request) {
-        if (request == null) {
-            throw new BusinessException(400, "Login request is required");
-        }
-
-        log.info("Login attempt for user: {}", request.getUsername());
-
-        if (request.getUsername() == null || request.getUsername().isBlank()) {
-            throw new BusinessException(400, "Username is required");
-        }
-        if (request.getPassword() == null || request.getPassword().isBlank()) {
-            throw new BusinessException(400, "Password is required");
-        }
-
-        LoginVO.UserInfo user = authenticate(request);
-        long now = clock.millis();
-        purgeExpiredSessions(now);
-        int tokenTtlSeconds = sessionTimeoutSeconds();
-        String token = "studio-jwt-" + UUID.randomUUID();
-        activeTokens.put(token, new AuthSession(user, now + tokenTtlSeconds * 1000L));
-
-        LoginVO response = LoginVO.builder()
-                .token(token)
-                .expiresIn(tokenTtlSeconds)
-                .user(user)
-                .build();
-
-        log.info("User {} logged in successfully, admin={}", user.getUsername(), user.isAdmin());
-        return response;
+        validateLogin(request);
+        return databaseBacked() ? loginDatabaseUser(request) : loginConfiguredUser(request);
     }
 
     public boolean isAuthenticated(String authorization) {
@@ -97,42 +116,254 @@ public class AuthService {
         if (token.isEmpty()) {
             return Optional.empty();
         }
-        AuthSession session = activeTokens.get(token.get());
+        return databaseBacked() ? databaseUserForToken(token.get()) : inMemoryUserForToken(token.get());
+    }
+
+    public boolean isAdmin(String authorization) {
+        return getAuthenticatedUser(authorization).map(LoginVO.UserInfo::isAdmin).orElse(false);
+    }
+
+    public void logout(String authorization) {
+        tokenFromAuthorization(authorization).ifPresent(token -> {
+            if (databaseBacked()) {
+                sessionMapper.update(null, new UpdateWrapper<RmqStudioSession>()
+                        .eq("token_hash", tokenHash(token))
+                        .isNull("revoked_at")
+                        .set("revoked_at", now()));
+            } else {
+                activeTokens.remove(token);
+            }
+        });
+    }
+
+    public List<RmqStudioUser> listUsers() {
+        requireDatabaseBacked();
+        return userMapper.selectList(new QueryWrapper<RmqStudioUser>().orderByAsc("username"));
+    }
+
+    public RmqStudioUser createUser(String username, String password, boolean admin) {
+        requireDatabaseBacked();
+        validateUsername(username);
+        validatePassword(password);
+        if (findUserByUsername(username).isPresent()) {
+            throw new BusinessException(409, "Username is already in use");
+        }
+        RmqStudioUser user = new RmqStudioUser();
+        user.setId(UUID.randomUUID().toString());
+        user.setUsername(username.trim());
+        user.setPasswordHash(passwordHasher.hash(password));
+        user.setAdmin(admin);
+        user.setEnabled(true);
+        user.setPasswordChangedAt(now());
+        userMapper.insert(user);
+        return user;
+    }
+
+    public RmqStudioUser setUserEnabled(String userId, boolean enabled) {
+        requireDatabaseBacked();
+        RmqStudioUser user = getUser(userId);
+        if (!enabled && Boolean.TRUE.equals(user.getAdmin()) && enabledAdminCount() <= 1) {
+            throw new BusinessException(409, "The last enabled administrator cannot be disabled");
+        }
+        userMapper.updateById(userWithEnabled(user, enabled));
+        if (!enabled) {
+            revokeUserSessions(user.getId());
+        }
+        user.setEnabled(enabled);
+        return user;
+    }
+
+    public void changePassword(String userId, String currentPassword, String newPassword,
+                               boolean requireCurrentPassword) {
+        requireDatabaseBacked();
+        RmqStudioUser user = getUser(userId);
+        if (requireCurrentPassword && !passwordHasher.matches(currentPassword, user.getPasswordHash())) {
+            throw new BusinessException(401, "Current password is incorrect");
+        }
+        validatePassword(newPassword);
+        userMapper.update(null, new UpdateWrapper<RmqStudioUser>()
+                .eq("id", user.getId())
+                .set("password_hash", passwordHasher.hash(newPassword))
+                .set("password_changed_at", now()));
+        revokeUserSessions(user.getId());
+    }
+
+    @Scheduled(fixedDelayString = "${studio.auth.session-cleanup-interval:PT5M}")
+    public void purgeExpiredSessions() {
+        if (databaseBacked()) {
+            sessionMapper.delete(new QueryWrapper<RmqStudioSession>().lt("expires_at", now()));
+        } else {
+            purgeExpiredSessions(clock.millis());
+        }
+    }
+
+    private LoginVO loginDatabaseUser(LoginDTO request) {
+        ensureBootstrapUsers();
+        RmqStudioUser user = findUserByUsername(request.getUsername())
+                .orElseThrow(() -> new BusinessException(401, "Invalid username or password"));
+        if (!Boolean.TRUE.equals(user.getEnabled())) {
+            throw new BusinessException(403, "User account is disabled");
+        }
+        if (!passwordHasher.matches(request.getPassword(), user.getPasswordHash())) {
+            throw new BusinessException(401, "Invalid username or password");
+        }
+        int tokenTtlSeconds = sessionTimeoutSeconds();
+        String token = newBearerToken();
+        LocalDateTime current = now();
+        RmqStudioSession session = new RmqStudioSession();
+        session.setId(UUID.randomUUID().toString());
+        session.setUserId(user.getId());
+        session.setTokenHash(tokenHash(token));
+        session.setCreatedAt(current);
+        session.setLastSeenAt(current);
+        session.setExpiresAt(current.plusSeconds(tokenTtlSeconds));
+        sessionMapper.insert(session);
+        return loginResponse(userInfo(user), token, tokenTtlSeconds);
+    }
+
+    private LoginVO loginConfiguredUser(LoginDTO request) {
+        LoginVO.UserInfo user = authenticateConfiguredUser(request);
+        long current = clock.millis();
+        purgeExpiredSessions(current);
+        int tokenTtlSeconds = sessionTimeoutSeconds();
+        String token = "studio-jwt-" + UUID.randomUUID();
+        activeTokens.put(token, new AuthSession(user, current + tokenTtlSeconds * 1000L));
+        return loginResponse(user, token, tokenTtlSeconds);
+    }
+
+    private LoginVO loginResponse(LoginVO.UserInfo user, String token, int tokenTtlSeconds) {
+        log.info("User {} logged in successfully, admin={}", user.getUsername(), user.isAdmin());
+        return LoginVO.builder().token(token).expiresIn(tokenTtlSeconds).user(user).build();
+    }
+
+    private Optional<LoginVO.UserInfo> databaseUserForToken(String token) {
+        RmqStudioSession session = sessionMapper.selectOne(new QueryWrapper<RmqStudioSession>()
+                .eq("token_hash", tokenHash(token)));
+        if (session == null || session.getRevokedAt() != null || !session.getExpiresAt().isAfter(now())) {
+            return Optional.empty();
+        }
+        RmqStudioUser user = userMapper.selectById(session.getUserId());
+        if (user == null || !Boolean.TRUE.equals(user.getEnabled())) {
+            return Optional.empty();
+        }
+        sessionMapper.update(null, new UpdateWrapper<RmqStudioSession>()
+                .eq("id", session.getId())
+                .set("last_seen_at", now()));
+        return Optional.of(userInfo(user));
+    }
+
+    private Optional<LoginVO.UserInfo> inMemoryUserForToken(String token) {
+        AuthSession session = activeTokens.get(token);
         if (session == null) {
             return Optional.empty();
         }
         if (session.expiresAtMillis() <= clock.millis()) {
-            activeTokens.remove(token.get());
+            activeTokens.remove(token);
             return Optional.empty();
         }
         return Optional.of(session.user());
     }
 
-    public boolean isAdmin(String authorization) {
-        Optional<String> token = tokenFromAuthorization(authorization);
-        if (token.isEmpty()) {
-            return false;
+    private void ensureBootstrapUsers() {
+        if (userMapper.selectCount(null) > 0) {
+            return;
         }
-        AuthSession session = activeTokens.get(token.get());
-        if (session == null || session.expiresAtMillis() <= clock.millis()) {
-            activeTokens.remove(token.get());
-            return false;
+        if (authProperties.configuredUsers().isEmpty()) {
+            throw new BusinessException(503, "No Studio users are configured");
         }
-        return session.user().isAdmin();
+        Set<String> seeded = new HashSet<>();
+        for (AuthProperties.User configuredUser : authProperties.configuredUsers()) {
+            if (!seeded.add(configuredUser.getUsername())) {
+                log.warn("Skipping duplicate bootstrap username: {}", configuredUser.getUsername());
+                continue;
+            }
+            RmqStudioUser user = new RmqStudioUser();
+            user.setId(UUID.randomUUID().toString());
+            user.setUsername(configuredUser.getUsername());
+            user.setPasswordHash(passwordHasher.hash(configuredUser.getPassword()));
+            user.setAdmin(configuredUser.isAdmin());
+            user.setEnabled(true);
+            user.setPasswordChangedAt(now());
+            userMapper.insert(user);
+        }
     }
 
-    public void logout(String authorization) {
-        tokenFromAuthorization(authorization).ifPresent(activeTokens::remove);
-        log.info("User logged out");
+    private Optional<RmqStudioUser> findUserByUsername(String username) {
+        return Optional.ofNullable(userMapper.selectOne(new QueryWrapper<RmqStudioUser>()
+                .eq("username", username.trim())));
     }
 
-    @Scheduled(fixedDelayString = "${studio.auth.session-cleanup-interval:PT5M}")
-    public void purgeExpiredSessions() {
-        purgeExpiredSessions(clock.millis());
+    private RmqStudioUser getUser(String userId) {
+        RmqStudioUser user = userMapper.selectById(userId);
+        if (user == null) {
+            throw new BusinessException(404, "User not found");
+        }
+        return user;
     }
 
-    private void purgeExpiredSessions(long now) {
-        activeTokens.entrySet().removeIf(entry -> entry.getValue().expiresAtMillis() <= now);
+    private RmqStudioUser userWithEnabled(RmqStudioUser user, boolean enabled) {
+        RmqStudioUser update = new RmqStudioUser();
+        update.setId(user.getId());
+        update.setEnabled(enabled);
+        return update;
+    }
+
+    private long enabledAdminCount() {
+        return userMapper.selectCount(new QueryWrapper<RmqStudioUser>()
+                .eq("admin", true)
+                .eq("enabled", true));
+    }
+
+    private void revokeUserSessions(String userId) {
+        sessionMapper.update(null, new UpdateWrapper<RmqStudioSession>()
+                .eq("user_id", userId)
+                .isNull("revoked_at")
+                .set("revoked_at", now()));
+    }
+
+    private void validateLogin(LoginDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "Login request is required");
+        }
+        if (request.getUsername() == null || request.getUsername().isBlank()) {
+            throw new BusinessException(400, "Username is required");
+        }
+        if (request.getPassword() == null || request.getPassword().isBlank()) {
+            throw new BusinessException(400, "Password is required");
+        }
+    }
+
+    private void validateUsername(String username) {
+        if (username == null || username.isBlank() || username.trim().length() > 128) {
+            throw new BusinessException(400, "Username must contain 1 to 128 characters");
+        }
+    }
+
+    private void validatePassword(String password) {
+        if (password == null || password.length() < 8 || password.length() > 256) {
+            throw new BusinessException(400, "Password must contain 8 to 256 characters");
+        }
+    }
+
+    private LoginVO.UserInfo authenticateConfiguredUser(LoginDTO request) {
+        var configuredUsers = authProperties.configuredUsers();
+        if (configuredUsers.isEmpty()) {
+            throw new BusinessException(503, "No valid login users are configured");
+        }
+        return configuredUsers.stream()
+                .filter(user -> user.getUsername().equals(request.getUsername()))
+                .filter(user -> user.getPassword().equals(request.getPassword()))
+                .findFirst()
+                .map(user -> userInfo(null, user.getUsername(), user.isAdmin()))
+                .orElseThrow(() -> new BusinessException(401, "Invalid username or password"));
+    }
+
+    private LoginVO.UserInfo userInfo(RmqStudioUser user) {
+        return userInfo(user.getId(), user.getUsername(), Boolean.TRUE.equals(user.getAdmin()));
+    }
+
+    private LoginVO.UserInfo userInfo(String userId, String username, boolean admin) {
+        return LoginVO.UserInfo.builder().userId(userId).username(username).admin(admin).build();
     }
 
     private int sessionTimeoutSeconds() {
@@ -145,25 +376,23 @@ public class AuthService {
         return Math.toIntExact(Duration.ofMinutes(minutes).toSeconds());
     }
 
-    private LoginVO.UserInfo authenticate(LoginDTO request) {
-        var configuredUsers = authProperties.configuredUsers();
-        if (configuredUsers.isEmpty()) {
-            throw new BusinessException(503, "No valid login users are configured");
-        }
-
-        return configuredUsers.stream()
-                .filter(user -> user.getUsername().equals(request.getUsername()))
-                .filter(user -> user.getPassword().equals(request.getPassword()))
-                .findFirst()
-                .map(user -> userInfo(user.getUsername(), user.isAdmin()))
-                .orElseThrow(() -> new BusinessException(401, "Invalid username or password"));
+    private LocalDateTime now() {
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(clock.millis()), ZoneOffset.UTC);
     }
 
-    private LoginVO.UserInfo userInfo(String username, boolean admin) {
-        return LoginVO.UserInfo.builder()
-                .username(username)
-                .admin(admin)
-                .build();
+    private String newBearerToken() {
+        byte[] bytes = new byte[32];
+        TOKEN_RANDOM.nextBytes(bytes);
+        return "studio-jwt-" + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private String tokenHash(String token) {
+        try {
+            return java.util.HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256")
+                    .digest(token.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception exception) {
+            throw new IllegalStateException("Unable to hash session token", exception);
+        }
     }
 
     private Optional<String> tokenFromAuthorization(String authorization) {
@@ -173,6 +402,20 @@ public class AuthService {
         }
         String token = authorization.substring(TOKEN_PREFIX.length()).trim();
         return token.isBlank() ? Optional.empty() : Optional.of(token);
+    }
+
+    private void purgeExpiredSessions(long current) {
+        activeTokens.entrySet().removeIf(entry -> entry.getValue().expiresAtMillis() <= current);
+    }
+
+    private boolean databaseBacked() {
+        return userMapper != null && sessionMapper != null;
+    }
+
+    private void requireDatabaseBacked() {
+        if (!databaseBacked()) {
+            throw new IllegalStateException("Studio user management requires database persistence");
+        }
     }
 
     private record AuthSession(LoginVO.UserInfo user, long expiresAtMillis) {

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
@@ -28,6 +28,7 @@ import org.apache.rocketmq.studio.persistence.mapper.RmqStudioUserMapper;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.apache.rocketmq.studio.settings.SettingsRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -62,6 +63,7 @@ public class AuthService {
     private static final int DEFAULT_SESSION_TIMEOUT_MINUTES = 30;
     private static final int MIN_SESSION_TIMEOUT_MINUTES = 5;
     private static final int MAX_SESSION_TIMEOUT_MINUTES = 1440;
+    private static final Duration LAST_SEEN_UPDATE_INTERVAL = Duration.ofMinutes(5);
     private static final String TOKEN_PREFIX = "Bearer ";
     private static final SecureRandom TOKEN_RANDOM = new SecureRandom();
 
@@ -246,9 +248,13 @@ public class AuthService {
         if (user == null || !Boolean.TRUE.equals(user.getEnabled())) {
             return Optional.empty();
         }
-        sessionMapper.update(null, new UpdateWrapper<RmqStudioSession>()
-                .eq("id", session.getId())
-                .set("last_seen_at", now()));
+        LocalDateTime current = now();
+        if (session.getLastSeenAt() == null
+                || !session.getLastSeenAt().plus(LAST_SEEN_UPDATE_INTERVAL).isAfter(current)) {
+            sessionMapper.update(null, new UpdateWrapper<RmqStudioSession>()
+                    .eq("id", session.getId())
+                    .set("last_seen_at", current));
+        }
         return Optional.of(userInfo(user));
     }
 
@@ -284,7 +290,12 @@ public class AuthService {
             user.setAdmin(configuredUser.isAdmin());
             user.setEnabled(true);
             user.setPasswordChangedAt(now());
-            userMapper.insert(user);
+            try {
+                userMapper.insert(user);
+            } catch (DuplicateKeyException exception) {
+                // Another Studio instance can initialize the same configured user concurrently.
+                log.debug("Bootstrap user {} was created concurrently", configuredUser.getUsername());
+            }
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthStatusVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthStatusVO.java
@@ -29,4 +29,5 @@ import lombok.NoArgsConstructor;
 public class AuthStatusVO {
     private boolean loginRequired;
     private boolean authenticated;
+    private LoginVO.UserInfo user;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthenticatedUserContext.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthenticatedUserContext.java
@@ -18,13 +18,14 @@
 package org.apache.rocketmq.studio.auth;
 
 /**
- * Holds the authenticated username for the current request thread.
+ * Holds the authenticated Studio principal for the current request thread.
  */
 public final class AuthenticatedUserContext {
 
     public static final String SYSTEM_ACTOR = "system";
 
     private static final ThreadLocal<String> CURRENT_USERNAME = new ThreadLocal<>();
+    private static final ThreadLocal<String> CURRENT_USER_ID = new ThreadLocal<>();
 
     private AuthenticatedUserContext() {
     }
@@ -37,6 +38,19 @@ public final class AuthenticatedUserContext {
         CURRENT_USERNAME.set(username);
     }
 
+    public static void setUser(String userId, String username) {
+        setUsername(username);
+        if (userId == null || userId.isBlank()) {
+            CURRENT_USER_ID.remove();
+        } else {
+            CURRENT_USER_ID.set(userId);
+        }
+    }
+
+    public static String currentUserId() {
+        return CURRENT_USER_ID.get();
+    }
+
     public static String currentUsernameOrSystem() {
         String username = CURRENT_USERNAME.get();
         return username == null ? SYSTEM_ACTOR : username;
@@ -44,5 +58,6 @@ public final class AuthenticatedUserContext {
 
     public static void clear() {
         CURRENT_USERNAME.remove();
+        CURRENT_USER_ID.remove();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/ChangePasswordDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/ChangePasswordDTO.java
@@ -14,32 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.rocketmq.studio.auth;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class LoginVO {
-    @ToString.Exclude
-    private String token;
-    private int expiresIn;
-    private UserInfo user;
+public class ChangePasswordDTO {
 
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class UserInfo {
-        private String userId;
-        private String username;
-        private boolean admin;
-    }
+    @NotBlank(message = "Current password is required")
+    @ToString.Exclude
+    private String currentPassword;
+
+    @NotBlank(message = "New password is required")
+    @Size(min = 8, max = 256, message = "New password must contain 8 to 256 characters")
+    @ToString.Exclude
+    private String newPassword;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/CreateStudioUserDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/CreateStudioUserDTO.java
@@ -14,32 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.rocketmq.studio.auth;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class LoginVO {
-    @ToString.Exclude
-    private String token;
-    private int expiresIn;
-    private UserInfo user;
+public class CreateStudioUserDTO {
 
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class UserInfo {
-        private String userId;
-        private String username;
-        private boolean admin;
-    }
+    @NotBlank(message = "Username is required")
+    @Size(max = 128, message = "Username must not exceed 128 characters")
+    private String username;
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 8, max = 256, message = "Password must contain 8 to 256 characters")
+    @ToString.Exclude
+    private String password;
+
+    private boolean admin;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/LoginVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/LoginVO.java
@@ -17,7 +17,7 @@
 
 package org.apache.rocketmq.studio.auth;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -30,7 +30,7 @@ import lombok.ToString;
 @AllArgsConstructor
 public class LoginVO {
     @ToString.Exclude
-    @JsonIgnore
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String token;
     private int expiresIn;
     private UserInfo user;

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/LoginVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/LoginVO.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.studio.auth;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -29,6 +30,7 @@ import lombok.ToString;
 @AllArgsConstructor
 public class LoginVO {
     @ToString.Exclude
+    @JsonIgnore
     private String token;
     private int expiresIn;
     private UserInfo user;

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/PasswordHasher.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/PasswordHasher.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.rocketmq.studio.auth;
+
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class PasswordHasher {
+
+    private static final String ALGORITHM = "PBKDF2WithHmacSHA256";
+    private static final int ITERATIONS = 210_000;
+    private static final int KEY_LENGTH = 256;
+    private static final int SALT_LENGTH = 16;
+    private static final int MIN_ITERATIONS = 100_000;
+    private static final int MAX_ITERATIONS = 1_000_000;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public String hash(String password) {
+        byte[] salt = new byte[SALT_LENGTH];
+        secureRandom.nextBytes(salt);
+        byte[] digest = derive(password.toCharArray(), salt, ITERATIONS);
+        return "pbkdf2$" + ITERATIONS + "$" + Base64.getEncoder().encodeToString(salt)
+                + "$" + Base64.getEncoder().encodeToString(digest);
+    }
+
+    public boolean matches(String password, String storedHash) {
+        if (password == null || storedHash == null) {
+            return false;
+        }
+        String[] parts = storedHash.split("\\$", -1);
+        if (parts.length != 4 || !"pbkdf2".equals(parts[0])) {
+            return false;
+        }
+        try {
+            int iterations = Integer.parseInt(parts[1]);
+            if (iterations < MIN_ITERATIONS || iterations > MAX_ITERATIONS) {
+                return false;
+            }
+            byte[] salt = Base64.getDecoder().decode(parts[2]);
+            byte[] expected = Base64.getDecoder().decode(parts[3]);
+            return MessageDigest.isEqual(expected, derive(password.toCharArray(), salt, iterations));
+        } catch (IllegalArgumentException exception) {
+            return false;
+        }
+    }
+
+    private byte[] derive(char[] password, byte[] salt, int iterations) {
+        PBEKeySpec keySpec = new PBEKeySpec(password, salt, iterations, KEY_LENGTH);
+        try {
+            return SecretKeyFactory.getInstance(ALGORITHM).generateSecret(keySpec).getEncoded();
+        } catch (Exception exception) {
+            throw new IllegalStateException("Unable to hash password", exception);
+        } finally {
+            keySpec.clearPassword();
+        }
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/ResetPasswordDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/ResetPasswordDTO.java
@@ -14,32 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.rocketmq.studio.auth;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class LoginVO {
-    @ToString.Exclude
-    private String token;
-    private int expiresIn;
-    private UserInfo user;
+public class ResetPasswordDTO {
 
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class UserInfo {
-        private String userId;
-        private String username;
-        private boolean admin;
-    }
+    @NotBlank(message = "New password is required")
+    @Size(min = 8, max = 256, message = "New password must contain 8 to 256 characters")
+    @ToString.Exclude
+    private String newPassword;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/StudioUserController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/StudioUserController.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.auth;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/studio-users")
+@RequiredArgsConstructor
+public class StudioUserController {
+
+    private final AuthService authService;
+
+    @GetMapping
+    public Result<List<StudioUserVO>> list() {
+        return Result.ok(authService.listUsers().stream().map(StudioUserVO::from).toList());
+    }
+
+    @PostMapping
+    public Result<StudioUserVO> create(@Valid @RequestBody CreateStudioUserDTO request) {
+        return Result.ok(StudioUserVO.from(authService.createUser(
+                request.getUsername(), request.getPassword(), request.isAdmin())));
+    }
+
+    @PostMapping("/{userId}/status")
+    public Result<StudioUserVO> updateStatus(@PathVariable String userId,
+                                              @Valid @RequestBody UpdateStudioUserStatusDTO request) {
+        return Result.ok(StudioUserVO.from(authService.setUserEnabled(userId, request.getEnabled())));
+    }
+
+    @PostMapping("/{userId}/password")
+    public Result<Void> resetPassword(@PathVariable String userId,
+                                      @Valid @RequestBody ResetPasswordDTO request) {
+        authService.changePassword(userId, null, request.getNewPassword(), false);
+        return Result.ok();
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/StudioUserVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/StudioUserVO.java
@@ -14,32 +14,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.rocketmq.studio.auth;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import org.apache.rocketmq.studio.persistence.entity.RmqStudioUser;
+
+import java.time.LocalDateTime;
 
 @Data
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class LoginVO {
-    @ToString.Exclude
-    private String token;
-    private int expiresIn;
-    private UserInfo user;
+public class StudioUserVO {
+    private String id;
+    private String username;
+    private boolean admin;
+    private boolean enabled;
+    private LocalDateTime passwordChangedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class UserInfo {
-        private String userId;
-        private String username;
-        private boolean admin;
+    public static StudioUserVO from(RmqStudioUser user) {
+        return StudioUserVO.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .admin(Boolean.TRUE.equals(user.getAdmin()))
+                .enabled(Boolean.TRUE.equals(user.getEnabled()))
+                .passwordChangedAt(user.getPasswordChangedAt())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/UpdateStudioUserStatusDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/UpdateStudioUserStatusDTO.java
@@ -14,32 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.rocketmq.studio.auth;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class LoginVO {
-    @ToString.Exclude
-    private String token;
-    private int expiresIn;
-    private UserInfo user;
+public class UpdateStudioUserStatusDTO {
 
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class UserInfo {
-        private String userId;
-        private String username;
-        private boolean admin;
-    }
+    @NotNull(message = "Enabled is required")
+    private Boolean enabled;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/common/config/CorsConfig.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/config/CorsConfig.java
@@ -16,6 +16,9 @@
  */
 package org.apache.rocketmq.studio.common.config;
 
+import java.util.Arrays;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -23,11 +26,22 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
+    private final String[] allowedOrigins;
+
+    public CorsConfig(@Value("${studio.cors.allowed-origins:http://localhost:5173,http://127.0.0.1:5173}")
+                      String allowedOrigins) {
+        this.allowedOrigins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(origin -> !origin.isEmpty())
+                .toArray(String[]::new);
+    }
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("*");
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqStudioSession.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqStudioSession.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.rocketmq.studio.persistence.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("rmq_studio_session")
+public class RmqStudioSession {
+
+    @TableId(type = IdType.INPUT)
+    private String id;
+
+    private String userId;
+
+    private String tokenHash;
+
+    private LocalDateTime expiresAt;
+
+    private LocalDateTime revokedAt;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime lastSeenAt;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqStudioUser.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqStudioUser.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.rocketmq.studio.persistence.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("rmq_studio_user")
+public class RmqStudioUser {
+
+    @TableId(type = IdType.INPUT)
+    private String id;
+
+    private String username;
+
+    @ToString.Exclude
+    private String passwordHash;
+
+    private Boolean admin;
+
+    private Boolean enabled;
+
+    private LocalDateTime passwordChangedAt;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqStudioSessionMapper.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqStudioSessionMapper.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.rocketmq.studio.persistence.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.rocketmq.studio.persistence.entity.RmqStudioSession;
+
+public interface RmqStudioSessionMapper extends BaseMapper<RmqStudioSession> {
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqStudioUserMapper.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqStudioUserMapper.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.rocketmq.studio.persistence.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.rocketmq.studio.persistence.entity.RmqStudioUser;
+
+public interface RmqStudioUserMapper extends BaseMapper<RmqStudioUser> {
+}

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -14,6 +14,11 @@ spring:
       enabled: true
       path: /h2-console
 
+studio:
+  auth:
+    # Browsers do not send Secure cookies over local HTTP.
+    session-cookie-secure: false
+
 logging:
   level:
     org.apache.rocketmq.studio: INFO

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -33,7 +33,7 @@ studio:
     allowed-origins: ${STUDIO_CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173}
   auth:
     login-required: ${STUDIO_AUTH_LOGIN_REQUIRED:true}
-    # Keep Secure enabled in production. Set STUDIO_AUTH_SESSION_COOKIE_SECURE=false only for local HTTP development.
+    # Production defaults. The dev profile disables Secure so local HTTP works without extra environment variables.
     session-cookie-name: ${STUDIO_AUTH_SESSION_COOKIE_NAME:rmq_studio_session}
     session-cookie-secure: ${STUDIO_AUTH_SESSION_COOKIE_SECURE:true}
     session-cookie-same-site: ${STUDIO_AUTH_SESSION_COOKIE_SAME_SITE:Strict}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -29,8 +29,14 @@ springdoc:
     path: /swagger-ui.html
 
 studio:
+  cors:
+    allowed-origins: ${STUDIO_CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173}
   auth:
     login-required: ${STUDIO_AUTH_LOGIN_REQUIRED:true}
+    # Keep Secure enabled in production. Set STUDIO_AUTH_SESSION_COOKIE_SECURE=false only for local HTTP development.
+    session-cookie-name: ${STUDIO_AUTH_SESSION_COOKIE_NAME:rmq_studio_session}
+    session-cookie-secure: ${STUDIO_AUTH_SESSION_COOKIE_SECURE:true}
+    session-cookie-same-site: ${STUDIO_AUTH_SESSION_COOKIE_SAME_SITE:Strict}
     users:
       - username: ${STUDIO_AUTH_ADMIN_USERNAME:}
         password: ${STUDIO_AUTH_ADMIN_PASSWORD:}

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -6,7 +6,34 @@
 -- 固定连接编码，防止 mysql 客户端以 latin1 解释 UTF-8 字节导致中文双重编码
 SET NAMES utf8mb4;
 
--- 1. NameServer / 集群地址注册表
+-- 1. Studio console users. This is distinct from RocketMQ ACL users below.
+CREATE TABLE IF NOT EXISTS rmq_studio_user (
+  id CHAR(36) PRIMARY KEY COMMENT 'Immutable Studio user ID',
+  username VARCHAR(128) NOT NULL,
+  password_hash VARCHAR(512) NOT NULL COMMENT 'PBKDF2 password hash; never store plaintext',
+  admin TINYINT(1) NOT NULL DEFAULT 0,
+  enabled TINYINT(1) NOT NULL DEFAULT 1,
+  password_changed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uk_studio_user_username (username)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 2. Persisted bearer-token sessions. token_hash is SHA-256(token), never the bearer token itself.
+CREATE TABLE IF NOT EXISTS rmq_studio_session (
+  id CHAR(36) PRIMARY KEY,
+  user_id CHAR(36) NOT NULL,
+  token_hash CHAR(64) NOT NULL,
+  expires_at DATETIME NOT NULL,
+  revoked_at DATETIME NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  last_seen_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uk_studio_session_token_hash (token_hash),
+  INDEX idx_studio_session_user (user_id),
+  INDEX idx_studio_session_expiry (expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 3. NameServer / 集群地址注册表
 CREATE TABLE IF NOT EXISTS rmq_nameserver (
   id VARCHAR(64) PRIMARY KEY,
   name VARCHAR(128) NOT NULL,

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthControllerTest.java
@@ -29,6 +29,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Optional;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -63,7 +65,7 @@ class AuthControllerTest {
     @Test
     void statusShouldReportDisabledLoginProtection() throws Exception {
         when(authProperties.isLoginRequired()).thenReturn(false);
-        when(authService.isAuthenticated(null)).thenReturn(false);
+        when(authService.getAuthenticatedUser(null)).thenReturn(Optional.empty());
 
         mockMvc.perform(get("/api/auth/status"))
                 .andExpect(status().isOk())
@@ -79,7 +81,7 @@ class AuthControllerTest {
         when(settingsRepository.loadGeneralSettings()).thenReturn(GeneralSettingsVO.builder()
                 .requireLogin(true)
                 .build());
-        when(authService.isAuthenticated(null)).thenReturn(false);
+        when(authService.getAuthenticatedUser(null)).thenReturn(Optional.empty());
 
         mockMvc.perform(get("/api/auth/status"))
                 .andExpect(status().isOk())
@@ -90,7 +92,7 @@ class AuthControllerTest {
     @Test
     void statusShouldReportUnauthenticatedWhenTokenIsMissing() throws Exception {
         when(authProperties.isLoginRequired()).thenReturn(true);
-        when(authService.isAuthenticated(null)).thenReturn(false);
+        when(authService.getAuthenticatedUser(null)).thenReturn(Optional.empty());
 
         mockMvc.perform(get("/api/auth/status"))
                 .andExpect(status().isOk())
@@ -101,13 +103,19 @@ class AuthControllerTest {
     @Test
     void statusShouldReportAuthenticatedForActiveToken() throws Exception {
         when(authProperties.isLoginRequired()).thenReturn(true);
-        when(authService.isAuthenticated("Bearer token-1")).thenReturn(true);
+        when(authService.getAuthenticatedUser("Bearer token-1")).thenReturn(Optional.of(LoginVO.UserInfo.builder()
+                .userId("user-1")
+                .username("studio-admin")
+                .admin(true)
+                .build()));
 
         mockMvc.perform(get("/api/auth/status")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer token-1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.loginRequired").value(true))
-                .andExpect(jsonPath("$.data.authenticated").value(true));
+                .andExpect(jsonPath("$.data.authenticated").value(true))
+                .andExpect(jsonPath("$.data.user.userId").value("user-1"))
+                .andExpect(jsonPath("$.data.user.username").value("studio-admin"));
     }
 
     @Test
@@ -206,6 +214,11 @@ class AuthControllerTest {
     void logoutShouldReturnSuccess() throws Exception {
         doNothing().when(authService).logout("Bearer token-1");
         when(authService.isAuthenticated("Bearer token-1")).thenReturn(true);
+        when(authService.getAuthenticatedUser("Bearer token-1")).thenReturn(Optional.of(LoginVO.UserInfo.builder()
+                .userId("user-1")
+                .username("studio-admin")
+                .admin(true)
+                .build()));
 
         mockMvc.perform(post("/api/auth/logout")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer token-1"))

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthControllerTest.java
@@ -111,7 +111,7 @@ class AuthControllerTest {
     }
 
     @Test
-    void loginShouldReturnTokenOnValidRequest() throws Exception {
+    void loginShouldSetHttpOnlySessionCookieOnValidRequest() throws Exception {
         LoginVO mockResponse = LoginVO.builder()
                 .token("mock-jwt-abc123")
                 .expiresIn(86400)
@@ -133,7 +133,12 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.data.token").value("mock-jwt-abc123"))
+                .andExpect(header().string(HttpHeaders.SET_COOKIE,
+                        org.hamcrest.Matchers.allOf(
+                                org.hamcrest.Matchers.containsString("rmq_studio_session=mock-jwt-abc123"),
+                                org.hamcrest.Matchers.containsString("HttpOnly"),
+                                org.hamcrest.Matchers.containsString("SameSite=Strict"))))
+                .andExpect(jsonPath("$.data.token").doesNotExist())
                 .andExpect(jsonPath("$.data.expiresIn").value(86400))
                 .andExpect(jsonPath("$.data.user.username").value("testuser"))
                 .andExpect(jsonPath("$.data.user.admin").value(false));

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthControllerTest.java
@@ -170,6 +170,28 @@ class AuthControllerTest {
     }
 
     @Test
+    void loginShouldReturnBearerTokenOnlyWhenExplicitlyRequested() throws Exception {
+        LoginVO mockResponse = LoginVO.builder()
+                .token("mock-jwt-api-client")
+                .expiresIn(86400)
+                .user(LoginVO.UserInfo.builder().username("automation").build())
+                .build();
+        when(authService.login(any(LoginDTO.class))).thenReturn(mockResponse);
+
+        LoginDTO request = new LoginDTO();
+        request.setUsername("automation");
+        request.setPassword("testpass");
+
+        mockMvc.perform(post("/api/auth/login")
+                        .header(AuthCookie.SESSION_DELIVERY_HEADER, "bearer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist(HttpHeaders.SET_COOKIE))
+                .andExpect(jsonPath("$.data.token").value("mock-jwt-api-client"));
+    }
+
+    @Test
     void loginShouldRejectMissingRequestBody() throws Exception {
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON))

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCookieProfileTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCookieProfileTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.auth;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+class AuthCookieProfileTest {
+
+    @Autowired
+    private AuthProperties authProperties;
+
+    @Test
+    void devProfileShouldAllowLocalHttpCookies() {
+        assertThat(authProperties.isSessionCookieSecure()).isFalse();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCookieTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCookieTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.auth;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthCookieTest {
+
+    @Test
+    void usesHttpOnlySecureCookieAndPrefersItOverAuthorizationHeader() {
+        AuthProperties properties = new AuthProperties();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("rmq_studio_session", "cookie-token"));
+        request.addHeader("Authorization", "Bearer header-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        AuthCookie.write(response, properties, "cookie-token", Duration.ofMinutes(30));
+
+        assertThat(AuthCookie.authorization(request, properties)).isEqualTo("Bearer cookie-token");
+        assertThat(response.getHeader("Set-Cookie"))
+                .contains("HttpOnly")
+                .contains("Secure")
+                .contains("SameSite=Strict");
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceDatabaseTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceDatabaseTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.auth;
+
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.persistence.entity.RmqStudioSession;
+import org.apache.rocketmq.studio.persistence.entity.RmqStudioUser;
+import org.apache.rocketmq.studio.persistence.mapper.RmqStudioSessionMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqStudioUserMapper;
+import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
+import org.apache.rocketmq.studio.settings.SettingsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AuthServiceDatabaseTest {
+
+    private AuthService authService;
+    private RmqStudioUserMapper userMapper;
+    private RmqStudioSessionMapper sessionMapper;
+    private PasswordHasher passwordHasher;
+
+    @BeforeEach
+    void setUp() {
+        AuthProperties authProperties = new AuthProperties();
+        SettingsRepository settingsRepository = mock(SettingsRepository.class);
+        GeneralSettingsVO settings = GeneralSettingsVO.builder().sessionTimeout(30).build();
+        when(settingsRepository.loadGeneralSettings()).thenReturn(settings);
+        userMapper = mock(RmqStudioUserMapper.class);
+        sessionMapper = mock(RmqStudioSessionMapper.class);
+        passwordHasher = new PasswordHasher();
+        authService = new AuthService(authProperties, settingsRepository,
+                Clock.fixed(Instant.parse("2026-08-13T00:00:00Z"), ZoneOffset.UTC), userMapper,
+                sessionMapper, passwordHasher);
+    }
+
+    @Test
+    void databaseLoginPersistsOnlyTokenHashAndReturnsImmutableUserId() {
+        RmqStudioUser user = user("id-1", "operator", true, true, "password-1");
+        when(userMapper.selectCount(isNull())).thenReturn(1L);
+        when(userMapper.selectOne(any(Wrapper.class))).thenReturn(user);
+
+        LoginDTO request = new LoginDTO();
+        request.setUsername("operator");
+        request.setPassword("password-1");
+
+        LoginVO result = authService.login(request);
+
+        assertThat(result.getUser().getUserId()).isEqualTo("id-1");
+        assertThat(result.getToken()).startsWith("studio-jwt-");
+        org.mockito.ArgumentCaptor<RmqStudioSession> captor =
+                org.mockito.ArgumentCaptor.forClass(RmqStudioSession.class);
+        verify(sessionMapper).insert(captor.capture());
+        assertThat(captor.getValue().getUserId()).isEqualTo("id-1");
+        assertThat(captor.getValue().getTokenHash()).doesNotContain(result.getToken());
+        assertThat(captor.getValue().getTokenHash()).hasSize(64);
+    }
+
+    @Test
+    void passwordChangeRevokesExistingSessions() {
+        RmqStudioUser user = user("id-1", "operator", false, true, "password-1");
+        when(userMapper.selectById("id-1")).thenReturn(user);
+
+        authService.changePassword("id-1", "password-1", "password-2", true);
+
+        verify(userMapper).update(isNull(), any(Wrapper.class));
+        verify(sessionMapper).update(isNull(), any(Wrapper.class));
+    }
+
+    @Test
+    void disablingLastEnabledAdministratorIsRejected() {
+        RmqStudioUser user = user("id-1", "admin", true, true, "password-1");
+        when(userMapper.selectById("id-1")).thenReturn(user);
+        when(userMapper.selectCount(any(Wrapper.class))).thenReturn(1L);
+
+        assertThatThrownBy(() -> authService.setUserEnabled("id-1", false))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("The last enabled administrator cannot be disabled");
+    }
+
+    private RmqStudioUser user(String id, String username, boolean admin, boolean enabled, String password) {
+        RmqStudioUser user = new RmqStudioUser();
+        user.setId(id);
+        user.setUsername(username);
+        user.setAdmin(admin);
+        user.setEnabled(enabled);
+        user.setPasswordHash(passwordHasher.hash(password));
+        return user;
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceDatabaseTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceDatabaseTest.java
@@ -29,13 +29,16 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -102,6 +105,67 @@ class AuthServiceDatabaseTest {
         assertThatThrownBy(() -> authService.setUserEnabled("id-1", false))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("The last enabled administrator cannot be disabled");
+    }
+
+    @Test
+    void databaseAuthenticationThrottlesLastSeenWrites() {
+        RmqStudioUser user = user("id-1", "operator", false, true, "password-1");
+        RmqStudioSession session = activeSession("session-1", "id-1",
+                LocalDateTime.parse("2026-08-13T00:00:00"));
+        when(sessionMapper.selectOne(any(Wrapper.class))).thenReturn(session);
+        when(userMapper.selectById("id-1")).thenReturn(user);
+
+        assertThat(authService.isAuthenticated("Bearer token-1")).isTrue();
+
+        verify(sessionMapper, never()).update(isNull(), any(Wrapper.class));
+    }
+
+    @Test
+    void databaseAuthenticationUpdatesStaleLastSeenTimestamp() {
+        RmqStudioUser user = user("id-1", "operator", false, true, "password-1");
+        RmqStudioSession session = activeSession("session-1", "id-1",
+                LocalDateTime.parse("2026-08-12T23:54:59"));
+        when(sessionMapper.selectOne(any(Wrapper.class))).thenReturn(session);
+        when(userMapper.selectById("id-1")).thenReturn(user);
+
+        assertThat(authService.isAuthenticated("Bearer token-1")).isTrue();
+
+        verify(sessionMapper).update(isNull(), any(Wrapper.class));
+    }
+
+    @Test
+    void databaseBootstrapIgnoresConcurrentUserCreation() {
+        AuthProperties.User configuredUser = new AuthProperties.User();
+        configuredUser.setUsername("operator");
+        configuredUser.setPassword("password-1");
+        AuthProperties properties = new AuthProperties();
+        properties.setUsers(List.of(configuredUser));
+        RmqStudioUser user = user("id-1", "operator", false, true, "password-1");
+        when(userMapper.selectCount(isNull())).thenReturn(0L);
+        when(userMapper.selectOne(any(Wrapper.class))).thenReturn(user);
+        when(userMapper.insert(any(RmqStudioUser.class)))
+                .thenThrow(new org.springframework.dao.DuplicateKeyException("duplicate username"));
+        SettingsRepository databaseSettingsRepository = mock(SettingsRepository.class);
+        when(databaseSettingsRepository.loadGeneralSettings())
+                .thenReturn(GeneralSettingsVO.builder().sessionTimeout(30).build());
+        authService = new AuthService(properties, databaseSettingsRepository,
+                Clock.fixed(Instant.parse("2026-08-13T00:00:00Z"), ZoneOffset.UTC), userMapper,
+                sessionMapper, passwordHasher);
+
+        LoginDTO request = new LoginDTO();
+        request.setUsername("operator");
+        request.setPassword("password-1");
+
+        assertThat(authService.login(request).getUser().getUsername()).isEqualTo("operator");
+    }
+
+    private RmqStudioSession activeSession(String id, String userId, LocalDateTime lastSeenAt) {
+        RmqStudioSession session = new RmqStudioSession();
+        session.setId(id);
+        session.setUserId(userId);
+        session.setLastSeenAt(lastSeenAt);
+        session.setExpiresAt(LocalDateTime.parse("2026-08-14T00:00:00"));
+        return session;
     }
 
     private RmqStudioUser user(String id, String username, boolean admin, boolean enabled, String password) {

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/PasswordHasherTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/PasswordHasherTest.java
@@ -14,32 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.rocketmq.studio.auth;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import org.junit.jupiter.api.Test;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class LoginVO {
-    @ToString.Exclude
-    private String token;
-    private int expiresIn;
-    private UserInfo user;
+import static org.assertj.core.api.Assertions.assertThat;
 
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class UserInfo {
-        private String userId;
-        private String username;
-        private boolean admin;
+class PasswordHasherTest {
+
+    @Test
+    void hashesPasswordsWithSaltAndVerifiesOnlyTheMatchingPassword() {
+        PasswordHasher hasher = new PasswordHasher();
+
+        String firstHash = hasher.hash("a-long-enough-password");
+        String secondHash = hasher.hash("a-long-enough-password");
+
+        assertThat(firstHash).startsWith("pbkdf2$");
+        assertThat(firstHash).isNotEqualTo(secondHash);
+        assertThat(hasher.matches("a-long-enough-password", firstHash)).isTrue();
+        assertThat(hasher.matches("different-password", firstHash)).isFalse();
     }
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getAuthStatus } from './api/auth';
 import { AuthGate, LazyRouteOutlet } from './App';
 import { LangProvider } from './i18n/LangContext';
+import useAuthStore from './stores/authStore';
 
 vi.mock('./api/auth', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./api/auth')>();
@@ -90,6 +91,7 @@ describe('AuthGate', () => {
     dataModeMocks.isMockMode.mockReturnValue(false);
     localStorage.setItem('token', 'stale-token');
     localStorage.setItem('rocketmq-studio-user', 'admin');
+    useAuthStore.setState({ user: 'admin', userId: 'stale-user', admin: false });
   });
 
   afterEach(() => {
@@ -115,11 +117,16 @@ describe('AuthGate', () => {
   });
 
   it('allows protected routes for an authenticated session', async () => {
-    mockedGetAuthStatus.mockResolvedValue({ loginRequired: true, authenticated: true });
+    mockedGetAuthStatus.mockResolvedValue({
+      loginRequired: true,
+      authenticated: true,
+      user: { userId: 'user-1', username: 'studio-admin', admin: true },
+    });
 
     renderGate();
 
     expect(await screen.findByText('protected content')).toBeInTheDocument();
+    expect(useAuthStore.getState()).toMatchObject({ user: 'studio-admin', userId: 'user-1', admin: true });
   });
 
   it('clears an invalid session and redirects to login', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -60,6 +60,7 @@ type AuthGateState = 'checking' | 'allowed' | 'denied' | 'error';
 export function AuthGate() {
   const { t } = useLang();
   const clearAuth = useAuthStore((state) => state.logout);
+  const syncAuth = useAuthStore((state) => state.login);
   const [gateState, setGateState] = useState<AuthGateState>(isMockMode() ? 'allowed' : 'checking');
   const [attempt, setAttempt] = useState(0);
 
@@ -70,6 +71,9 @@ export function AuthGate() {
     void getAuthStatus()
       .then((status) => {
         if (cancelled) return;
+        if (status.authenticated && status.user) {
+          syncAuth(status.user.username, status.user.userId, status.user.admin);
+        }
         if (!status.loginRequired || status.authenticated) {
           setGateState('allowed');
           return;
@@ -84,7 +88,7 @@ export function AuthGate() {
     return () => {
       cancelled = true;
     };
-  }, [attempt, clearAuth]);
+  }, [attempt, clearAuth, syncAuth]);
 
   const retry = useCallback(() => {
     setGateState('checking');

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -53,6 +53,7 @@ const GrafanaDashboardsPage = lazy(() => import('./pages/studio/GrafanaDashboard
 const ProducerPage = lazy(() => import('./pages/studio/Producer'));
 const OpsPage = lazy(() => import('./pages/studio/Ops'));
 const AlertRuleAssetsPage = lazy(() => import('./pages/studio/AlertRuleAssets'));
+const UserManagementPage = lazy(() => import('./pages/studio/UserManagement'));
 
 type AuthGateState = 'checking' | 'allowed' | 'denied' | 'error';
 
@@ -195,6 +196,7 @@ function App() {
             <Route path="studio/alert-management" element={<Navigate to="/ops/alerts" replace />} />
             <Route path="studio/producer" element={<ProducerPage />} />
             <Route path="studio/ops" element={<OpsPage />} />
+            <Route path="studio/users" element={<UserManagementPage />} />
             <Route path="ops/alert-rule-templates" element={<AlertRuleAssetsPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Route>

--- a/web/src/api/ai.test.ts
+++ b/web/src/api/ai.test.ts
@@ -45,11 +45,6 @@ function streamResponse(chunks: string[], onCancel?: () => void): Response {
 describe('AI API', () => {
   beforeEach(() => {
     mock.reset();
-    vi.stubGlobal('localStorage', {
-      getItem: vi.fn().mockReturnValue('test-token'),
-      setItem: vi.fn(),
-      removeItem: vi.fn(),
-    });
   });
 
   afterEach(() => {
@@ -58,10 +53,7 @@ describe('AI API', () => {
   });
 
   describe('chatStream (SSE)', () => {
-    it('continues without auth when browser storage is unavailable', async () => {
-      vi.mocked(localStorage.getItem).mockImplementation(() => {
-        throw new DOMException('storage disabled', 'SecurityError');
-      });
+    it('sends browser cookies without reading browser storage', async () => {
       const fetchMock = vi.fn().mockResolvedValue(streamResponse(['data: [DONE]\n\n']));
       vi.stubGlobal('fetch', fetchMock);
 
@@ -72,6 +64,7 @@ describe('AI API', () => {
       expect(fetchMock).toHaveBeenCalledWith(
         '/api/ai/chat',
         expect.objectContaining({
+          credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
         }),
       );

--- a/web/src/api/ai.ts
+++ b/web/src/api/ai.ts
@@ -16,7 +16,6 @@
  */
 
 import client from './client';
-import { readAuthSession } from '../stores/authStorage';
 
 const MAX_SSE_EVENT_CHARS = 1024 * 1024;
 
@@ -161,12 +160,11 @@ export async function chatStream(
   signal?: AbortSignal,
   onEnhance?: (prompt: string) => void,
 ) {
-  const token = readAuthSession().token;
   const response = await fetch('/api/ai/chat', {
     method: 'POST',
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     body: JSON.stringify(data),
     signal,

--- a/web/src/api/auth.test.ts
+++ b/web/src/api/auth.test.ts
@@ -38,7 +38,11 @@ describe('Auth API', () => {
   });
 
   it('status should return the login requirement and session state', async () => {
-    const authStatus = { loginRequired: true, authenticated: false };
+    const authStatus = {
+      loginRequired: true,
+      authenticated: true,
+      user: { userId: 'user-1', username: 'studio-admin', admin: true },
+    };
     mock.onGet('/auth/status').reply(200, { data: authStatus });
 
     await expect(getAuthStatus()).resolves.toEqual(authStatus);

--- a/web/src/api/auth.test.ts
+++ b/web/src/api/auth.test.ts
@@ -46,7 +46,6 @@ describe('Auth API', () => {
 
   it('login should post credentials and return token data', async () => {
     const mockResponse = {
-      token: 'jwt-token-123',
       expiresIn: 86400,
       user: {
         userId: 'user-1',
@@ -60,7 +59,6 @@ describe('Auth API', () => {
 
     const result = await login('admin', 'secret');
     expect(result).toEqual(mockResponse);
-    expect(result.token).toBe('jwt-token-123');
     expect(result.expiresIn).toBe(86400);
     expect(result.user.username).toBe('admin');
     expect(result.user.userId).toBe('user-1');

--- a/web/src/api/auth.test.ts
+++ b/web/src/api/auth.test.ts
@@ -49,6 +49,7 @@ describe('Auth API', () => {
       token: 'jwt-token-123',
       expiresIn: 86400,
       user: {
+        userId: 'user-1',
         username: 'admin',
         admin: true,
       },
@@ -62,6 +63,7 @@ describe('Auth API', () => {
     expect(result.token).toBe('jwt-token-123');
     expect(result.expiresIn).toBe(86400);
     expect(result.user.username).toBe('admin');
+    expect(result.user.userId).toBe('user-1');
     expect(result.user.admin).toBe(true);
   });
 

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -27,6 +27,7 @@ export interface LoginResponse {
   token: string;
   expiresIn: number;
   user: {
+    userId: string;
     username: string;
     admin: boolean;
   };
@@ -50,4 +51,8 @@ export async function login(username: string, password: string) {
 
 export async function logout() {
   await client.post('/auth/logout');
+}
+
+export async function changePassword(currentPassword: string, newPassword: string) {
+  await client.post('/auth/password', { currentPassword, newPassword });
 }

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -25,16 +25,19 @@ export interface LoginRequest {
 
 export interface LoginResponse {
   expiresIn: number;
-  user: {
-    userId: string;
-    username: string;
-    admin: boolean;
-  };
+  user: AuthenticatedUser;
+}
+
+export interface AuthenticatedUser {
+  userId: string | null;
+  username: string;
+  admin: boolean;
 }
 
 export interface AuthStatus {
   loginRequired: boolean;
   authenticated: boolean;
+  user?: AuthenticatedUser;
 }
 
 // ─── Auth ───────────────────────────────────────────────────────

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -24,7 +24,6 @@ export interface LoginRequest {
 }
 
 export interface LoginResponse {
-  token: string;
   expiresIn: number;
   user: {
     userId: string;

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -110,10 +110,10 @@ describe('API client response contract', () => {
     expect(message.error).not.toHaveBeenCalled();
   });
 
-  it('attaches the stored bearer token to outgoing requests', async () => {
-    localStorage.setItem('token', 'test-token');
+  it('uses credentials without attaching a client-readable bearer token', async () => {
     mock.onGet('/clusters').reply((config) => {
-      expect(config.headers?.Authorization).toBe('Bearer test-token');
+      expect(config.headers?.Authorization).toBeUndefined();
+      expect(config.withCredentials).toBe(true);
       return [200, { code: 200, message: 'success', data: [] }];
     });
 
@@ -123,38 +123,33 @@ describe('API client response contract', () => {
   it.each(['/auth/login', '/auth/status'])(
     'does not clear the current session when public auth request %s returns 401',
     async (path) => {
-      localStorage.setItem('token', 'current-token');
       localStorage.setItem('rocketmq-studio-user', 'admin');
       localStorage.setItem('rocketmq-studio-user-admin', 'true');
       mock.onAny(path).reply(401, { code: 401, message: 'Unauthorized', data: null });
 
       await expect(client.get(path)).rejects.toMatchObject({ response: { status: 401 } });
 
-      expect(localStorage.getItem('token')).toBe('current-token');
+      expect(localStorage.getItem('token')).toBeNull();
       expect(localStorage.getItem('rocketmq-studio-user')).toBe('admin');
       expect(localStorage.getItem('rocketmq-studio-user-admin')).toBe('true');
     },
   );
 
   it('clears the current session when a protected API request returns 401', async () => {
-    localStorage.setItem('token', 'expired-token');
     localStorage.setItem('rocketmq-studio-user', 'admin');
     localStorage.setItem('rocketmq-studio-user-admin', 'true');
     mock.onGet('/clusters').reply(401, { code: 401, message: 'Unauthorized', data: null });
 
     await expect(client.get('/clusters')).rejects.toMatchObject({ response: { status: 401 } });
 
-    expect(localStorage.getItem('token')).toBeNull();
     expect(localStorage.getItem('rocketmq-studio-user')).toBeNull();
     expect(localStorage.getItem('rocketmq-studio-user-admin')).toBeNull();
   });
 
   it('preserves the original 401 error when the request URL is malformed', async () => {
-    localStorage.setItem('token', 'expired-token');
     mock.onGet('http://[').reply(401, { code: 401, message: 'Unauthorized', data: null });
 
     await expect(client.get('http://[')).rejects.toMatchObject({ response: { status: 401 } });
 
-    expect(localStorage.getItem('token')).toBeNull();
   });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -17,7 +17,7 @@
 
 import axios from 'axios';
 import { message } from 'antd';
-import { clearAuthSession, TOKEN_STORAGE_KEY } from '../stores/authStorage';
+import { clearAuthSession } from '../stores/authStorage';
 import { API_BASE_URL } from '../config';
 
 const SUCCESS_BUSINESS_CODES = new Set([0, 200]);
@@ -62,19 +62,8 @@ function isPublicAuthRequest(url?: string): boolean {
 const client = axios.create({
   baseURL: API_BASE_URL,
   timeout: 30000,
+  withCredentials: true,
 });
-
-// Request interceptor: attach Authorization header
-client.interceptors.request.use(
-  (config) => {
-    const token = localStorage.getItem(TOKEN_STORAGE_KEY);
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => Promise.reject(error),
-);
 
 // Response interceptor: check business code and handle 401
 client.interceptors.response.use(

--- a/web/src/api/studioUsers.ts
+++ b/web/src/api/studioUsers.ts
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import client from './client';
+
+export interface StudioUser {
+  id: string;
+  username: string;
+  admin: boolean;
+  enabled: boolean;
+  passwordChangedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function listStudioUsers() {
+  const response = await client.get<{ data: StudioUser[] }>('/studio-users');
+  return response.data.data;
+}
+
+export async function createStudioUser(request: { username: string; password: string; admin: boolean }) {
+  const response = await client.post<{ data: StudioUser }>('/studio-users', request);
+  return response.data.data;
+}
+
+export async function setStudioUserEnabled(userId: string, enabled: boolean) {
+  const response = await client.post<{ data: StudioUser }>(`/studio-users/${userId}/status`, { enabled });
+  return response.data.data;
+}
+
+export async function resetStudioUserPassword(userId: string, newPassword: string) {
+  await client.post(`/studio-users/${userId}/password`, { newPassword });
+}

--- a/web/src/layouts/MainLayout.test.tsx
+++ b/web/src/layouts/MainLayout.test.tsx
@@ -73,7 +73,7 @@ describe('MainLayout authentication navigation', () => {
   beforeEach(() => {
     localStorage.clear();
     vi.mocked(logout).mockReset().mockResolvedValue(undefined);
-    useAuthStore.getState().login('test-token', 'admin', 'user-1', true);
+    useAuthStore.getState().login('admin', 'user-1', true);
   });
 
   it('replaces a protected route with the login page after logout', async () => {

--- a/web/src/layouts/MainLayout.test.tsx
+++ b/web/src/layouts/MainLayout.test.tsx
@@ -73,7 +73,7 @@ describe('MainLayout authentication navigation', () => {
   beforeEach(() => {
     localStorage.clear();
     vi.mocked(logout).mockReset().mockResolvedValue(undefined);
-    useAuthStore.getState().login('test-token', 'admin', true);
+    useAuthStore.getState().login('test-token', 'admin', 'user-1', true);
   });
 
   it('replaces a protected route with the login page after logout', async () => {

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -64,6 +64,7 @@ const MainLayout = () => {
   const [searchText, setSearchText] = useState('');
   const { lang, setLang, t } = useLang();
   const clearAuth = useAuthStore((state) => state.logout);
+  const admin = useAuthStore((state) => state.admin);
   const useMock = useDataModeStore((state) => state.useMock);
   const toggleDataMode = useDataModeStore((state) => state.toggle);
 
@@ -76,6 +77,10 @@ const MainLayout = () => {
   const handleUserMenuClick = async ({ key }: { key: string }) => {
     if (key === 'profile') {
       navigate('/settings');
+      return;
+    }
+    if (key === 'users') {
+      navigate('/studio/users');
       return;
     }
     if (key !== 'logout') return;
@@ -198,6 +203,7 @@ const MainLayout = () => {
       '/ops/alert-rule-templates': t('nav.alertRuleAssets'),
       '/ai': t('nav.ai'),
       '/settings': t('nav.settings'),
+      '/studio/users': '用户管理',
     }),
     [t],
   );
@@ -242,6 +248,7 @@ const MainLayout = () => {
     onClick: handleUserMenuClick,
     items: [
       { key: 'profile', icon: <UserGear size={14} />, label: t('user.profile') },
+      ...(admin ? [{ key: 'users', icon: <UserGear size={14} />, label: '用户管理' }] : []),
       { type: 'divider' as const },
       { key: 'logout', label: t('user.logout'), danger: true },
     ],

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -41,7 +41,7 @@ const LoginPage = () => {
     setLoading(true);
     try {
       const data = await loginApi(values.username, values.password);
-      authLogin(data.token, data.user.username, data.user.admin);
+      authLogin(data.token, data.user.username, data.user.userId, data.user.admin);
       message.success(t('login.success'));
       navigate('/', { replace: true });
     } catch (err: unknown) {

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -41,7 +41,7 @@ const LoginPage = () => {
     setLoading(true);
     try {
       const data = await loginApi(values.username, values.password);
-      authLogin(data.token, data.user.username, data.user.userId, data.user.admin);
+      authLogin(data.user.username, data.user.userId, data.user.admin);
       message.success(t('login.success'));
       navigate('/', { replace: true });
     } catch (err: unknown) {

--- a/web/src/pages/studio/Ops.tsx
+++ b/web/src/pages/studio/Ops.tsx
@@ -44,7 +44,7 @@ const OpsPage: React.FC = () => {
   const { t } = useLang();
   const { message } = App.useApp();
   const fetchFailedMessage = t('ops.fetchFailed');
-  const token = useAuthStore((state) => state.token);
+  const userId = useAuthStore((state) => state.userId);
   const admin = useAuthStore((state) => state.admin);
 
   const [namesrvAddrList, setNamesrvAddrList] = useState<string[]>([]);
@@ -61,7 +61,7 @@ const OpsPage: React.FC = () => {
   const tlsUpdateInFlight = useRef(false);
   const [configurationAvailable, setConfigurationAvailable] = useState(false);
   const [unavailableReason, setUnavailableReason] = useState('');
-  const writeOperationEnabled = configurationAvailable && (!token || admin === true);
+  const writeOperationEnabled = configurationAvailable && (!userId || admin === true);
   const deleteNameServerDisabled =
     !selectedNamesrv || selectedNamesrv === currentNamesrv || namesrvAddrList.length <= 1;
 

--- a/web/src/pages/studio/UserManagement.tsx
+++ b/web/src/pages/studio/UserManagement.tsx
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { Alert, Button, Card, Form, Input, Modal, Space, Switch, Table, Tag, message } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { Key, Plus } from '@phosphor-icons/react';
+import PageHeader from '../../components/PageHeader';
+import { changePassword } from '../../api/auth';
+import {
+  createStudioUser,
+  listStudioUsers,
+  resetStudioUserPassword,
+  setStudioUserEnabled,
+  type StudioUser,
+} from '../../api/studioUsers';
+import useAuthStore from '../../stores/authStore';
+
+interface CreateFormValues {
+  username: string;
+  password: string;
+  admin: boolean;
+}
+
+interface PasswordFormValues {
+  currentPassword?: string;
+  newPassword: string;
+}
+
+const dateTime = (value?: string) => (value ? new Date(value).toLocaleString() : '-');
+
+const UserManagementPage = () => {
+  const admin = useAuthStore((state) => state.admin);
+  const userId = useAuthStore((state) => state.userId);
+  const [users, setUsers] = useState<StudioUser[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [passwordTarget, setPasswordTarget] = useState<StudioUser | null>(null);
+  const [createForm] = Form.useForm<CreateFormValues>();
+  const [passwordForm] = Form.useForm<PasswordFormValues>();
+
+  const loadUsers = useCallback(async () => {
+    if (!admin) return;
+    setLoading(true);
+    try {
+      setUsers(await listStudioUsers());
+    } catch {
+      message.error('加载用户列表失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [admin]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void loadUsers();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [loadUsers]);
+
+  const createUser = async () => {
+    const values = await createForm.validateFields();
+    try {
+      await createStudioUser(values);
+      message.success('用户已创建');
+      setCreateOpen(false);
+      createForm.resetFields();
+      await loadUsers();
+    } catch {
+      message.error('创建用户失败');
+    }
+  };
+
+  const setEnabled = async (record: StudioUser, enabled: boolean) => {
+    try {
+      await setStudioUserEnabled(record.id, enabled);
+      message.success(enabled ? '用户已启用' : '用户已禁用，全部会话已注销');
+      await loadUsers();
+    } catch {
+      message.error('更新用户状态失败');
+    }
+  };
+
+  const updatePassword = async () => {
+    if (!passwordTarget) return;
+    const values = await passwordForm.validateFields();
+    try {
+      if (passwordTarget.id === userId) {
+        await changePassword(values.currentPassword ?? '', values.newPassword);
+        message.success('密码已修改，请使用新密码重新登录');
+      } else {
+        await resetStudioUserPassword(passwordTarget.id, values.newPassword);
+        message.success('密码已重置，用户的现有会话已注销');
+      }
+      setPasswordTarget(null);
+      passwordForm.resetFields();
+    } catch {
+      message.error('修改密码失败');
+    }
+  };
+
+  const columns: ColumnsType<StudioUser> = [
+    { title: '用户名', dataIndex: 'username' },
+    { title: '用户 ID', dataIndex: 'id', ellipsis: true, width: 270 },
+    {
+      title: '权限',
+      dataIndex: 'admin',
+      render: (value: boolean) => (value ? <Tag color="blue">管理员</Tag> : <Tag>普通用户</Tag>),
+    },
+    {
+      title: '状态',
+      dataIndex: 'enabled',
+      render: (value: boolean) => (value ? <Tag color="green">已启用</Tag> : <Tag color="default">已禁用</Tag>),
+    },
+    { title: '创建时间', dataIndex: 'createdAt', render: dateTime },
+    {
+      title: '操作',
+      key: 'actions',
+      render: (_, record) => (
+        <Space>
+          <Button size="small" icon={<Key size={14} />} onClick={() => setPasswordTarget(record)}>
+            改密
+          </Button>
+          <Switch
+            checked={record.enabled}
+            checkedChildren="启用"
+            unCheckedChildren="禁用"
+            onChange={(enabled) => void setEnabled(record, enabled)}
+          />
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div style={{ padding: 24 }}>
+      <PageHeader
+        title="用户管理"
+        subtitle="Studio 本地账号、会话与密码管理"
+        extra={
+          admin ? (
+            <Button type="primary" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>
+              新建用户
+            </Button>
+          ) : undefined
+        }
+      />
+      {!admin && (
+        <Alert
+          type="info"
+          showIcon
+          message="当前账号不是管理员"
+          description="你可以修改自己的密码；用户列表和账号状态仅对管理员开放。"
+          style={{ marginBottom: 16 }}
+        />
+      )}
+      <Card title="我的账号" style={{ marginBottom: 16 }}>
+        <Button
+          icon={<Key size={16} />}
+          disabled={!userId}
+          onClick={() =>
+            setPasswordTarget({
+              id: userId ?? '',
+              username: '',
+              admin: !!admin,
+              enabled: true,
+              passwordChangedAt: '',
+              createdAt: '',
+              updatedAt: '',
+            })
+          }
+        >
+          修改我的密码
+        </Button>
+      </Card>
+      {admin && <Table rowKey="id" loading={loading} columns={columns} dataSource={users} />}
+
+      <Modal title="新建 Studio 用户" open={createOpen} onOk={() => void createUser()} onCancel={() => setCreateOpen(false)}>
+        <Form form={createForm} layout="vertical" initialValues={{ admin: false }}>
+          <Form.Item name="username" label="用户名" rules={[{ required: true }, { max: 128 }]}>
+            <Input autoComplete="username" />
+          </Form.Item>
+          <Form.Item name="password" label="初始密码" rules={[{ required: true }, { min: 8, message: '密码至少 8 位' }]}>
+            <Input.Password autoComplete="new-password" />
+          </Form.Item>
+          <Form.Item name="admin" label="管理员权限" valuePropName="checked">
+            <Switch checkedChildren="管理员" unCheckedChildren="普通用户" />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal
+        title={passwordTarget?.id === userId ? '修改我的密码' : `重置 ${passwordTarget?.username ?? ''} 的密码`}
+        open={passwordTarget !== null}
+        onOk={() => void updatePassword()}
+        onCancel={() => {
+          setPasswordTarget(null);
+          passwordForm.resetFields();
+        }}
+      >
+        <Form form={passwordForm} layout="vertical">
+          {passwordTarget?.id === userId && (
+            <Form.Item name="currentPassword" label="当前密码" rules={[{ required: true }]}>
+              <Input.Password autoComplete="current-password" />
+            </Form.Item>
+          )}
+          <Form.Item name="newPassword" label="新密码" rules={[{ required: true }, { min: 8, message: '密码至少 8 位' }]}>
+            <Input.Password autoComplete="new-password" />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+};
+
+export default UserManagementPage;

--- a/web/src/pages/studio/__tests__/Ops.test.tsx
+++ b/web/src/pages/studio/__tests__/Ops.test.tsx
@@ -63,7 +63,7 @@ describe('OpsPage', () => {
     vi.clearAllMocks();
     localStorage.clear();
     sessionStorage.clear();
-    useAuthStore.setState({ token: null, user: null, admin: null });
+    useAuthStore.setState({ user: null, userId: null, admin: null });
     vi.mocked(queryOpsHomePage).mockResolvedValue({
       namesvrAddrList: ['127.0.0.1:9876', '127.0.0.2:9876'],
       configurationAvailable: true,
@@ -122,7 +122,7 @@ describe('OpsPage', () => {
   });
 
   it('hides write controls for read-only users', async () => {
-    useAuthStore.setState({ token: 'token-reader', user: 'reader', admin: false });
+    useAuthStore.setState({ user: 'reader', userId: 'reader-1', admin: false });
 
     renderWithProviders(<OpsPage />);
 
@@ -135,7 +135,7 @@ describe('OpsPage', () => {
   });
 
   it('keeps write controls visible for admin users', async () => {
-    useAuthStore.setState({ token: 'token-admin', user: 'admin', admin: true });
+    useAuthStore.setState({ user: 'admin', userId: 'admin-1', admin: true });
 
     renderWithProviders(<OpsPage />);
 

--- a/web/src/stores/authStorage.test.ts
+++ b/web/src/stores/authStorage.test.ts
@@ -22,6 +22,7 @@ import {
   readAuthSession,
   TOKEN_STORAGE_KEY,
   USER_ADMIN_STORAGE_KEY,
+  USER_ID_STORAGE_KEY,
   USER_STORAGE_KEY,
 } from './authStorage';
 
@@ -31,31 +32,32 @@ describe('auth session storage', () => {
   });
 
   it('persists the token and user together', () => {
-    persistAuthSession('token-1', 'studio-admin', true);
+    persistAuthSession('token-1', 'studio-admin', 'user-1', true);
 
-    expect(readAuthSession()).toEqual({ token: 'token-1', user: 'studio-admin', admin: true });
+    expect(readAuthSession()).toEqual({ token: 'token-1', user: 'studio-admin', userId: 'user-1', admin: true });
   });
 
   it('does not restore an orphaned user without a token', () => {
     localStorage.setItem(USER_STORAGE_KEY, 'studio-admin');
     localStorage.setItem(USER_ADMIN_STORAGE_KEY, 'true');
 
-    expect(readAuthSession()).toEqual({ token: null, user: null, admin: null });
+    expect(readAuthSession()).toEqual({ token: null, user: null, userId: null, admin: null });
   });
 
   it('does not infer admin permissions from legacy sessions', () => {
     localStorage.setItem(TOKEN_STORAGE_KEY, 'token-1');
     localStorage.setItem(USER_STORAGE_KEY, 'studio-admin');
 
-    expect(readAuthSession()).toEqual({ token: 'token-1', user: 'studio-admin', admin: null });
+    expect(readAuthSession()).toEqual({ token: 'token-1', user: 'studio-admin', userId: null, admin: null });
   });
 
   it('clears every persisted session key', () => {
-    persistAuthSession('token-1', 'studio-admin', true);
+    persistAuthSession('token-1', 'studio-admin', 'user-1', true);
     clearAuthSession();
 
     expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
     expect(localStorage.getItem(USER_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(USER_ID_STORAGE_KEY)).toBeNull();
     expect(localStorage.getItem(USER_ADMIN_STORAGE_KEY)).toBeNull();
   });
 });

--- a/web/src/stores/authStorage.test.ts
+++ b/web/src/stores/authStorage.test.ts
@@ -20,7 +20,6 @@ import {
   clearAuthSession,
   persistAuthSession,
   readAuthSession,
-  TOKEN_STORAGE_KEY,
   USER_ADMIN_STORAGE_KEY,
   USER_ID_STORAGE_KEY,
   USER_STORAGE_KEY,
@@ -31,31 +30,33 @@ describe('auth session storage', () => {
     localStorage.clear();
   });
 
-  it('persists the token and user together', () => {
-    persistAuthSession('token-1', 'studio-admin', 'user-1', true);
+  it('persists display identity without a bearer token', () => {
+    persistAuthSession('studio-admin', 'user-1', true);
 
-    expect(readAuthSession()).toEqual({ token: 'token-1', user: 'studio-admin', userId: 'user-1', admin: true });
+    expect(readAuthSession()).toEqual({ user: 'studio-admin', userId: 'user-1', admin: true });
+    expect(localStorage.getItem('token')).toBeNull();
   });
 
-  it('does not restore an orphaned user without a token', () => {
+  it('restores display identity independently from the HttpOnly session cookie', () => {
     localStorage.setItem(USER_STORAGE_KEY, 'studio-admin');
+    localStorage.setItem(USER_ID_STORAGE_KEY, 'user-1');
     localStorage.setItem(USER_ADMIN_STORAGE_KEY, 'true');
 
-    expect(readAuthSession()).toEqual({ token: null, user: null, userId: null, admin: null });
+    expect(readAuthSession()).toEqual({ user: 'studio-admin', userId: 'user-1', admin: true });
   });
 
-  it('does not infer admin permissions from legacy sessions', () => {
-    localStorage.setItem(TOKEN_STORAGE_KEY, 'token-1');
+  it('does not infer admin permissions when the display flag is absent', () => {
     localStorage.setItem(USER_STORAGE_KEY, 'studio-admin');
 
-    expect(readAuthSession()).toEqual({ token: 'token-1', user: 'studio-admin', userId: null, admin: null });
+    expect(readAuthSession()).toEqual({ user: 'studio-admin', userId: null, admin: null });
   });
 
   it('clears every persisted session key', () => {
-    persistAuthSession('token-1', 'studio-admin', 'user-1', true);
+    localStorage.setItem('token', 'legacy-token');
+    persistAuthSession('studio-admin', 'user-1', true);
     clearAuthSession();
 
-    expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem('token')).toBeNull();
     expect(localStorage.getItem(USER_STORAGE_KEY)).toBeNull();
     expect(localStorage.getItem(USER_ID_STORAGE_KEY)).toBeNull();
     expect(localStorage.getItem(USER_ADMIN_STORAGE_KEY)).toBeNull();

--- a/web/src/stores/authStorage.ts
+++ b/web/src/stores/authStorage.ts
@@ -17,11 +17,13 @@
 
 export const TOKEN_STORAGE_KEY = 'token';
 export const USER_STORAGE_KEY = 'rocketmq-studio-user';
+export const USER_ID_STORAGE_KEY = 'rocketmq-studio-user-id';
 export const USER_ADMIN_STORAGE_KEY = 'rocketmq-studio-user-admin';
 
 export interface AuthSession {
   token: string | null;
   user: string | null;
+  userId: string | null;
   admin: boolean | null;
 }
 
@@ -32,17 +34,19 @@ export function readAuthSession(): AuthSession {
     return {
       token,
       user: token ? localStorage.getItem(USER_STORAGE_KEY) : null,
+      userId: token ? localStorage.getItem(USER_ID_STORAGE_KEY) : null,
       admin: token && admin != null ? admin === 'true' : null,
     };
   } catch {
-    return { token: null, user: null, admin: null };
+    return { token: null, user: null, userId: null, admin: null };
   }
 }
 
-export function persistAuthSession(token: string, user: string, admin: boolean): void {
+export function persistAuthSession(token: string, user: string, userId: string, admin: boolean): void {
   try {
     localStorage.setItem(TOKEN_STORAGE_KEY, token);
     localStorage.setItem(USER_STORAGE_KEY, user);
+    localStorage.setItem(USER_ID_STORAGE_KEY, userId);
     localStorage.setItem(USER_ADMIN_STORAGE_KEY, String(admin));
   } catch {
     // The in-memory store remains usable when browser storage is unavailable.
@@ -53,6 +57,7 @@ export function clearAuthSession(): void {
   try {
     localStorage.removeItem(TOKEN_STORAGE_KEY);
     localStorage.removeItem(USER_STORAGE_KEY);
+    localStorage.removeItem(USER_ID_STORAGE_KEY);
     localStorage.removeItem(USER_ADMIN_STORAGE_KEY);
   } catch {
     // The caller still clears the in-memory store.

--- a/web/src/stores/authStorage.ts
+++ b/web/src/stores/authStorage.ts
@@ -15,13 +15,11 @@
  * limitations under the License.
  */
 
-export const TOKEN_STORAGE_KEY = 'token';
 export const USER_STORAGE_KEY = 'rocketmq-studio-user';
 export const USER_ID_STORAGE_KEY = 'rocketmq-studio-user-id';
 export const USER_ADMIN_STORAGE_KEY = 'rocketmq-studio-user-admin';
 
 export interface AuthSession {
-  token: string | null;
   user: string | null;
   userId: string | null;
   admin: boolean | null;
@@ -29,22 +27,19 @@ export interface AuthSession {
 
 export function readAuthSession(): AuthSession {
   try {
-    const token = localStorage.getItem(TOKEN_STORAGE_KEY);
     const admin = localStorage.getItem(USER_ADMIN_STORAGE_KEY);
     return {
-      token,
-      user: token ? localStorage.getItem(USER_STORAGE_KEY) : null,
-      userId: token ? localStorage.getItem(USER_ID_STORAGE_KEY) : null,
-      admin: token && admin != null ? admin === 'true' : null,
+      user: localStorage.getItem(USER_STORAGE_KEY),
+      userId: localStorage.getItem(USER_ID_STORAGE_KEY),
+      admin: admin != null ? admin === 'true' : null,
     };
   } catch {
-    return { token: null, user: null, userId: null, admin: null };
+    return { user: null, userId: null, admin: null };
   }
 }
 
-export function persistAuthSession(token: string, user: string, userId: string, admin: boolean): void {
+export function persistAuthSession(user: string, userId: string, admin: boolean): void {
   try {
-    localStorage.setItem(TOKEN_STORAGE_KEY, token);
     localStorage.setItem(USER_STORAGE_KEY, user);
     localStorage.setItem(USER_ID_STORAGE_KEY, userId);
     localStorage.setItem(USER_ADMIN_STORAGE_KEY, String(admin));
@@ -55,7 +50,7 @@ export function persistAuthSession(token: string, user: string, userId: string, 
 
 export function clearAuthSession(): void {
   try {
-    localStorage.removeItem(TOKEN_STORAGE_KEY);
+    localStorage.removeItem('token');
     localStorage.removeItem(USER_STORAGE_KEY);
     localStorage.removeItem(USER_ID_STORAGE_KEY);
     localStorage.removeItem(USER_ADMIN_STORAGE_KEY);

--- a/web/src/stores/authStorage.ts
+++ b/web/src/stores/authStorage.ts
@@ -38,10 +38,14 @@ export function readAuthSession(): AuthSession {
   }
 }
 
-export function persistAuthSession(user: string, userId: string, admin: boolean): void {
+export function persistAuthSession(user: string, userId: string | null, admin: boolean): void {
   try {
     localStorage.setItem(USER_STORAGE_KEY, user);
-    localStorage.setItem(USER_ID_STORAGE_KEY, userId);
+    if (userId) {
+      localStorage.setItem(USER_ID_STORAGE_KEY, userId);
+    } else {
+      localStorage.removeItem(USER_ID_STORAGE_KEY);
+    }
     localStorage.setItem(USER_ADMIN_STORAGE_KEY, String(admin));
   } catch {
     // The in-memory store remains usable when browser storage is unavailable.

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -20,9 +20,10 @@ import { clearAuthSession, persistAuthSession, readAuthSession } from './authSto
 
 interface AuthState {
   user: string | null;
+  userId: string | null;
   token: string | null;
   admin: boolean | null;
-  login: (token: string, user: string, admin: boolean) => void;
+  login: (token: string, user: string, userId: string, admin: boolean) => void;
   logout: () => void;
 }
 
@@ -30,15 +31,16 @@ const initialSession = readAuthSession();
 
 const useAuthStore = create<AuthState>((set) => ({
   user: initialSession.user,
+  userId: initialSession.userId,
   token: initialSession.token,
   admin: initialSession.admin,
-  login: (token: string, user: string, admin: boolean) => {
-    persistAuthSession(token, user, admin);
-    set({ token, user, admin });
+  login: (token: string, user: string, userId: string, admin: boolean) => {
+    persistAuthSession(token, user, userId, admin);
+    set({ token, user, userId, admin });
   },
   logout: () => {
     clearAuthSession();
-    set({ token: null, user: null, admin: null });
+    set({ token: null, user: null, userId: null, admin: null });
   },
 }));
 

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -21,9 +21,8 @@ import { clearAuthSession, persistAuthSession, readAuthSession } from './authSto
 interface AuthState {
   user: string | null;
   userId: string | null;
-  token: string | null;
   admin: boolean | null;
-  login: (token: string, user: string, userId: string, admin: boolean) => void;
+  login: (user: string, userId: string, admin: boolean) => void;
   logout: () => void;
 }
 
@@ -32,15 +31,14 @@ const initialSession = readAuthSession();
 const useAuthStore = create<AuthState>((set) => ({
   user: initialSession.user,
   userId: initialSession.userId,
-  token: initialSession.token,
   admin: initialSession.admin,
-  login: (token: string, user: string, userId: string, admin: boolean) => {
-    persistAuthSession(token, user, userId, admin);
-    set({ token, user, userId, admin });
+  login: (user: string, userId: string, admin: boolean) => {
+    persistAuthSession(user, userId, admin);
+    set({ user, userId, admin });
   },
   logout: () => {
     clearAuthSession();
-    set({ token: null, user: null, userId: null, admin: null });
+    set({ user: null, userId: null, admin: null });
   },
 }));
 

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -22,7 +22,7 @@ interface AuthState {
   user: string | null;
   userId: string | null;
   admin: boolean | null;
-  login: (user: string, userId: string, admin: boolean) => void;
+  login: (user: string, userId: string | null, admin: boolean) => void;
   logout: () => void;
 }
 
@@ -32,7 +32,7 @@ const useAuthStore = create<AuthState>((set) => ({
   user: initialSession.user,
   userId: initialSession.userId,
   admin: initialSession.admin,
-  login: (user: string, userId: string, admin: boolean) => {
+  login: (user: string, userId: string | null, admin: boolean) => {
     persistAuthSession(user, userId, admin);
     set({ user, userId, admin });
   },


### PR DESCRIPTION
## Summary
- add `rmq_studio_user` and `rmq_studio_session` schema plus MyBatis entities/mappers
- use immutable user IDs, PBKDF2 password hashes, and SHA-256 token hashes for persisted sessions
- bootstrap initial database users from existing `studio.auth.users` only when no Studio user exists
- add admin user list/create/enable/disable/password-reset APIs and a minimal UI
- add self-service password change; disable and password changes revoke all active sessions
- deliver browser sessions in a `HttpOnly`, `Secure`, `SameSite` cookie; browser JavaScript no longer receives or stores the token
- retain Authorization-header support for non-browser API clients

## Scope
This deliberately excludes roles beyond the existing admin flag, organizations/tenants, and SSO/OIDC.

Closes #2161

## Configuration
- `STUDIO_AUTH_SESSION_COOKIE_NAME` defaults to `rmq_studio_session`.
- Production defaults to `Secure=true` and `SameSite=Strict`.
- The `dev` profile automatically uses `session-cookie-secure=false` so local HTTP works without environment configuration.
- When the frontend uses a different origin, configure `STUDIO_CORS_ALLOWED_ORIGINS` and keep credentialed requests enabled.

## Verification
- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) mvn -Dtest=AuthCookieTest,AuthCookieProfileTest,AuthControllerTest,AuthInterceptorTest,AuthServiceTest,AuthServiceDatabaseTest,PasswordHasherTest test` (64 tests)
- `npm run lint` (one pre-existing `MainLayout` hooks warning remains)
- `npm test -- --run src/App.test.tsx src/layouts/MainLayout.test.tsx src/api/client.test.ts src/api/auth.test.ts src/api/ai.test.ts src/stores/authStorage.test.ts src/pages/studio/__tests__/Ops.test.tsx` (48 tests)
- `npm run build`