### PR TITLE
fix(ai): reject unsupported provider config tests

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
@@ -134,12 +134,16 @@ public class LlmConfigService {
         if (!LlmConfigVO.ENGINE_HTTP.equalsIgnoreCase(normalized.normalizeEngine())) {
             return testCliEngine(normalized.normalizeEngine());
         }
-        if (llmClient.supports(normalized)) {
-            try {
-                llmClient.listModels(normalized);
-            } catch (LlmGatewayException exception) {
-                return LlmOperationResultVO.failure(exception.getCode(), exception.getMessage(), exception.getHint());
-            }
+        if (!llmClient.supports(normalized)) {
+            return LlmOperationResultVO.failure(
+                    "llm.config.unsupported_provider",
+                    "LLM provider is not supported by the OpenAI-compatible gateway",
+                    "Use one of: openai, deepseek, tongyi, ollama.");
+        }
+        try {
+            llmClient.listModels(normalized);
+        } catch (LlmGatewayException exception) {
+            return LlmOperationResultVO.failure(exception.getCode(), exception.getMessage(), exception.getHint());
         }
         return LlmOperationResultVO.success("Connection successful");
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
@@ -327,6 +327,8 @@ class LlmConfigServiceTest {
 
     @Test
     void testConfigShouldAllowOllamaWithoutApiKey() {
+        when(llmClient.supports(org.mockito.ArgumentMatchers.any())).thenReturn(true);
+
         LlmOperationResultVO result = llmConfigService.testConfig(LlmConfigVO.builder()
                 .provider("ollama")
                 .engine("http")
@@ -408,6 +410,27 @@ class LlmConfigServiceTest {
         assertThat(result.getCode()).isEqualTo("llm.provider.upstream_error");
         assertThat(result.getErrMsg()).contains("401");
         assertThat(result.getHint()).contains("credentials");
+    }
+
+    @Test
+    void testConfigShouldRejectUnsupportedHttpProvider() {
+        when(llmClient.supports(org.mockito.ArgumentMatchers.any())).thenReturn(false);
+
+        LlmOperationResultVO result = llmConfigService.testConfig(LlmConfigVO.builder()
+                .provider("bedrock")
+                .engine("http")
+                .apiKey("bedrock-key")
+                .apiBase("https://bedrock-runtime.us-east-1.amazonaws.com")
+                .model("anthropic.claude-3-sonnet")
+                .maxTokens(2048)
+                .temperature(1.0)
+                .build());
+
+        assertThat(result.getStatus()).isEqualTo(1);
+        assertThat(result.getCode()).isEqualTo("llm.config.unsupported_provider");
+        assertThat(result.getErrMsg()).contains("not supported");
+        assertThat(result.getHint()).contains("openai").contains("ollama");
+        verify(llmClient, never()).listModels(org.mockito.ArgumentMatchers.any());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- fail HTTP configuration tests when the selected provider is unsupported by the active gateway
- return the same structured `llm.config.unsupported_provider` result used by runtime requests
- add a regression test while preserving valid Ollama connection tests

## Root cause

`testConfig` only called the provider probe when `llmClient.supports()` returned true. A false result fell through to `Connection successful` without any network request, so Azure and Bedrock configurations could appear usable even though the current OpenAI-compatible gateway rejects them.

This is narrower than the earlier provider-visibility work in #809/#810: it does not hide or remove provider-specific settings. It only keeps the connection-test response consistent with the runtime gateway.

Closes #2172.

## Validation

- `mvn -Dtest=LlmConfigServiceTest test` (27 tests passed)
- Maven Checkstyle validation (0 violations)
- `git diff --check`
- both changed paths checked against all open PRs targeting `rocketmq-studio` (no matches)