### PR TITLE
fix(metrics): validate Prometheus duration order

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
@@ -40,7 +40,7 @@ public class MetricsService {
     private static final long MAX_RANGE_SECONDS = 31L * 24 * 60 * 60;
     private static final long MAX_SAMPLE_POINTS = 11_000L;
     private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+(?:\\.\\d+)?");
-    private static final Pattern DURATION_PART_PATTERN = Pattern.compile("(\\d+(?:\\.\\d+)?)(ms|s|m|h|d|w|y)");
+    private static final Pattern DURATION_PART_PATTERN = Pattern.compile("(\\d+)(ms|s|m|h|d|w|y)");
     private static final Map<String, BigDecimal> UNIT_TO_MILLIS = Map.of(
             "ms", BigDecimal.ONE,
             "s", BigDecimal.valueOf(1_000L),
@@ -49,6 +49,15 @@ public class MetricsService {
             "d", BigDecimal.valueOf(86_400_000L),
             "w", BigDecimal.valueOf(604_800_000L),
             "y", BigDecimal.valueOf(31_536_000_000L)
+    );
+    private static final Map<String, Integer> UNIT_ORDER = Map.of(
+            "y", 0,
+            "w", 1,
+            "d", 2,
+            "h", 3,
+            "m", 4,
+            "s", 5,
+            "ms", 6
     );
 
     private final MetricsSource metricsSource;
@@ -188,13 +197,20 @@ public class MetricsService {
         Matcher matcher = DURATION_PART_PATTERN.matcher(value);
         BigDecimal millis = BigDecimal.ZERO;
         int position = 0;
+        int previousUnitOrder = -1;
         while (matcher.find()) {
             if (matcher.start() != position) {
                 throw badRequest("Metric query step is invalid");
             }
+            String unit = matcher.group(2);
+            int unitOrder = UNIT_ORDER.get(unit);
+            if (unitOrder <= previousUnitOrder) {
+                throw badRequest("Metric query step is invalid");
+            }
             BigDecimal amount = new BigDecimal(matcher.group(1));
-            millis = millis.add(amount.multiply(UNIT_TO_MILLIS.get(matcher.group(2))));
+            millis = millis.add(amount.multiply(UNIT_TO_MILLIS.get(unit)));
             position = matcher.end();
+            previousUnitOrder = unitOrder;
         }
         if (position != value.length()) {
             throw badRequest("Metric query step is invalid");

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
@@ -271,6 +271,36 @@ class MetricsServiceTest {
     }
 
     @Test
+    void queryShouldRejectInvalidPrometheusDurationCombinations() {
+        for (String step : List.of("1s1h", "1m1m", "1ms1s", "1.5h")) {
+            MetricQueryDTO query = MetricQueryDTO.builder()
+                    .metric("rocketmq_messages_in_total")
+                    .start(1700000000L)
+                    .end(1700003600L)
+                    .step(step)
+                    .build();
+
+            assertBadRequest(query, "Metric query step is invalid");
+        }
+        verifyNoInteractions(metricsSource);
+    }
+
+    @Test
+    void queryShouldAcceptOrderedPrometheusDurationCombinations() {
+        MetricQueryDTO query = MetricQueryDTO.builder()
+                .metric("rocketmq_messages_in_total")
+                .start(1700000000L)
+                .end(1700003600L)
+                .step("1h30m15s500ms")
+                .build();
+        when(metricsSource.query(query)).thenReturn(emptyMetricData());
+
+        metricsService.query(query);
+
+        verify(metricsSource).query(query);
+    }
+
+    @Test
     void queryShouldRejectTooManySamples() {
         MetricQueryDTO query = MetricQueryDTO.builder()
                 .metric("rocketmq_messages_in_total")


### PR DESCRIPTION
## Summary

- require suffixed Prometheus duration parts to use integer values
- enforce longest-to-shortest unit order and reject repeated units
- retain support for bare numeric seconds and valid combined durations

## Root cause

The local step parser summed every matched duration part independently. As a result, inputs such as `1s1h`, `1m1m`, and `1.5h` passed local validation even though Prometheus rejects them, moving a client error downstream to the data source.

Closes #2174.

## Validation

- `mvn -Dtest=MetricsServiceTest test` (22 tests passed)
- Maven Checkstyle validation (0 violations)
- `git diff --check`
- both changed paths checked against all open PRs targeting `rocketmq-studio` (no matches)

The accepted grammar follows the Prometheus duration rule that combined units are ordered longest to shortest and each unit appears at most once.