### PR TITLE
fix(tencent): skip null catalog instances

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
@@ -94,6 +94,9 @@ public class TencentCatalogService implements CloudCatalogProvider {
                 break;
             }
             for (InstanceItem item : data) {
+                if (item == null) {
+                    continue;
+                }
                 CloudInstanceOptionVO option = toInstanceOption(item, regionId);
                 if (matchesSearch(search, option)) {
                     instances.add(option);

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
@@ -86,6 +86,22 @@ class TencentCatalogServiceTest {
     }
 
     @Test
+    void listCloudInstancesShouldSkipNullItemsTest() {
+        InstanceItem item = new InstanceItem();
+        item.setInstanceId("rmq-valid");
+        item.setInstanceName("chengdu-prod");
+        DescribeInstanceListResponse response = new DescribeInstanceListResponse();
+        response.setData(new InstanceItem[]{null, item});
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any())).thenReturn(response);
+
+        List<CloudInstanceOptionVO> instances = service.listCloudInstances(CREDENTIAL_ID, REGION, null);
+
+        assertThat(instances).singleElement()
+                .extracting(CloudInstanceOptionVO::getInstanceId)
+                .isEqualTo("rmq-valid");
+    }
+
+    @Test
     void getCloudInstanceShouldMapOnlyOpenEndpointsTest() {
         Endpoint vpc = endpoint("VPC", "OPEN", "vpc.tencent:8080");
         Endpoint publicEndpoint = endpoint("PUBLIC", "OPEN", "public.tencent:8080");


### PR DESCRIPTION
## Summary

- skip null records returned in Tencent Cloud instance pages
- continue mapping and filtering valid instances from the same response
- cover a mixed null/valid SDK response with a regression test

## Root cause

The Tencent SDK models the page payload as an `InstanceItem[]`, and the catalog loop assumed every array element was non-null. A single null record therefore raised a `NullPointerException` and discarded all valid instances in that page.

Closes #2176.

## Validation

- `mvn -f server/pom.xml -Dtest=TencentCatalogServiceTest test` (4 tests passed)
- Maven Checkstyle validation (0 violations)
- `git diff --check`
- both changed paths checked against all open PRs targeting `rocketmq-studio` (no matches)