### PR TITLE
fix(ai): surface SSE error envelopes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -428,6 +428,12 @@ public class OpenAiCompatibleLlmClient {
     private String parseDelta(String body) {
         try {
             JsonNode root = objectMapper.readTree(body);
+            String errorMessage = root.path("error").path("message").asText();
+            if (StringUtils.hasText(errorMessage)) {
+                throw new LlmGatewayException(502, "llm.provider.stream_error",
+                        "LLM provider stream failed: " + errorMessage,
+                        "Check the provider credentials, model name, and account quota.");
+            }
             return root.path("choices").path(0).path("delta").path("content").asText("");
         } catch (JsonProcessingException exception) {
             throw new LlmGatewayException(502, "llm.provider.malformed_stream_event",

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
@@ -153,6 +153,27 @@ class OpenAiCompatibleLlmClientTest {
     }
 
     @Test
+    void streamShouldExposeErrorEnvelopeFromSuccessfulResponse() {
+        server.createContext("/v1/chat/completions", exchange -> respond(exchange, 200, """
+                data: {"error":{"message":"quota exceeded"}}
+
+                data: [DONE]
+
+                """, "text/event-stream"));
+
+        assertThatThrownBy(() -> client.stream(
+                config("openai", "sk-test"), "hello", null, token -> { }))
+                .isInstanceOf(LlmGatewayException.class)
+                .hasMessage("LLM provider stream failed: quota exceeded")
+                .satisfies(exception -> {
+                    LlmGatewayException gatewayException = (LlmGatewayException) exception;
+                    assertThat(gatewayException.getStatusCode()).isEqualTo(502);
+                    assertThat(gatewayException.getCode()).isEqualTo("llm.provider.stream_error");
+                    assertThat(gatewayException.getHint()).contains("account quota");
+                });
+    }
+
+    @Test
     void streamShouldEnforceTimeoutWhileReadingResponseBody() {
         OpenAiCompatibleLlmClient timeoutClient = new OpenAiCompatibleLlmClient(
                 objectMapper,


### PR DESCRIPTION
## Summary

- detect explicit `error.message` objects in provider SSE data events
- preserve the upstream message in a structured gateway error
- keep valid tokenless events, including usage metadata, unchanged

## Root cause

The stream parser extracted only `choices[0].delta.content`. When a provider encoded a quota or credential failure inside an HTTP 200 SSE event, the missing delta became an empty string and the event was silently ignored.

This concerns content-level failures after a successful response header. It is separate from HTTP 4xx/5xx response-body handling, stream timeouts, size limits, and browser-side SSE framing.

Closes #2178.

## Validation

- `mvn -Dtest=OpenAiCompatibleLlmClientTest test` (19 tests passed)
- Maven Checkstyle validation (0 violations)
- `git diff --check`
- both changed paths checked against all open PRs targeting `rocketmq-studio` (no matches)