### PR TITLE
[studio][ISSUE #2167] Add localized not-found route

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -20,8 +20,9 @@ import { lazy, type ComponentType } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getAuthStatus } from './api/auth';
-import { AuthGate, LazyRouteOutlet } from './App';
+import { AuthGate, LazyRouteOutlet, NotFoundPage } from './App';
 import { LangProvider } from './i18n/LangContext';
+import { LANGUAGE_STORAGE_KEY } from './i18n/languagePreference';
 
 vi.mock('./api/auth', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./api/auth')>();
@@ -66,6 +67,45 @@ describe('LazyRouteOutlet', () => {
 
     expect(await screen.findByText('lazy page loaded')).toBeInTheDocument();
     expect(screen.queryByRole('status', { name: '加载中' })).not.toBeInTheDocument();
+  });
+});
+
+describe('NotFoundPage', () => {
+  afterEach(() => cleanup());
+
+  it('explains an unknown route and navigates back home', () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en');
+
+    render(
+      <LangProvider>
+        <MemoryRouter initialEntries={['/missing']}>
+          <Routes>
+            <Route path="/" element={<div>home page</div>} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Routes>
+        </MemoryRouter>
+      </LangProvider>,
+    );
+
+    expect(screen.getByText('Page not found')).toBeInTheDocument();
+    expect(screen.getByText(/link may be outdated/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to home' }));
+
+    expect(screen.getByText('home page')).toBeInTheDocument();
+  });
+
+  it('uses Chinese copy by default', () => {
+    render(
+      <LangProvider>
+        <MemoryRouter>
+          <NotFoundPage />
+        </MemoryRouter>
+      </LangProvider>,
+    );
+
+    expect(screen.getByText('页面不存在')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '返回首页' })).toBeInTheDocument();
   });
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,7 +17,7 @@
 
 import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 import { Button, Result, Spin } from 'antd';
-import { Routes, Route, Navigate, Outlet } from 'react-router-dom';
+import { Routes, Route, Navigate, Outlet, useNavigate } from 'react-router-dom';
 import { getAuthStatus } from './api/auth';
 import { isMockMode } from './services/dataMode';
 import { useLang } from './i18n/LangContext';
@@ -138,6 +138,42 @@ export function LazyRouteOutlet() {
   );
 }
 
+export function NotFoundPage() {
+  const { lang } = useLang();
+  const navigate = useNavigate();
+  const copy =
+    lang === 'zh'
+      ? {
+          title: '页面不存在',
+          description: '此链接可能已失效，或页面地址输入有误。',
+          action: '返回首页',
+        }
+      : {
+          title: 'Page not found',
+          description: 'This link may be outdated, or the page address may be incorrect.',
+          action: 'Back to home',
+        };
+
+  return (
+    <Result
+      status="404"
+      title="404"
+      subTitle={
+        <span>
+          <strong>{copy.title}</strong>
+          <br />
+          {copy.description}
+        </span>
+      }
+      extra={
+        <Button type="primary" onClick={() => navigate('/')}>
+          {copy.action}
+        </Button>
+      }
+    />
+  );
+}
+
 function App() {
   return (
     <Routes>
@@ -196,7 +232,7 @@ function App() {
             <Route path="studio/producer" element={<ProducerPage />} />
             <Route path="studio/ops" element={<OpsPage />} />
             <Route path="ops/alert-rule-templates" element={<AlertRuleAssetsPage />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
+            <Route path="*" element={<NotFoundPage />} />
           </Route>
         </Route>
       </Route>


### PR DESCRIPTION
## Summary

- replace silent wildcard redirects with an explicit 404 result inside the Studio layout
- provide English and Chinese explanations using the active language preference
- add a one-click route back to the Studio home page
- cover both localized rendering and navigation behavior

## Testing

- npx vitest run src/App.test.tsx -t NotFoundPage --pool=threads --maxWorkers=1 --no-file-parallelism
- npx eslint src/App.tsx src/App.test.tsx
- npm run build

Closes #2167