### PR TITLE
[studio][ISSUE #2168] Surface recently used instances

### DIFF
--- a/web/src/components/InstanceSelect.tsx
+++ b/web/src/components/InstanceSelect.tsx
@@ -16,7 +16,33 @@
  */
 
 import { Select } from 'antd';
+import { useEffect, useMemo, useState } from 'react';
 import type { CSSProperties } from 'react';
+import { useLang } from '../i18n/LangContext';
+
+export const INSTANCE_RECENTS_STORAGE_KEY = 'rocketmq-studio-recent-instances';
+const RECENT_INSTANCE_LIMIT = 5;
+
+function readRecentInstances(): string[] {
+  try {
+    const parsed: unknown = JSON.parse(localStorage.getItem(INSTANCE_RECENTS_STORAGE_KEY) ?? '[]');
+    if (!Array.isArray(parsed)) return [];
+    return [...new Set(parsed.filter((value): value is string => typeof value === 'string'))].slice(
+      0,
+      RECENT_INSTANCE_LIMIT,
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeRecentInstances(values: string[]): void {
+  try {
+    localStorage.setItem(INSTANCE_RECENTS_STORAGE_KEY, JSON.stringify(values));
+  } catch {
+    // Instance selection still works when browser storage is unavailable.
+  }
+}
 
 export interface InstanceOption {
   value: string;
@@ -42,6 +68,49 @@ export function InstanceSelect({
   style,
   placeholder = '选择实例',
 }: InstanceSelectProps) {
+  const { lang } = useLang();
+  const [recentValues, setRecentValues] = useState(readRecentInstances);
+
+  const validRecentValues = useMemo(() => {
+    const available = new Set(options.map((option) => option.value));
+    return recentValues.filter((recent) => available.has(recent));
+  }, [options, recentValues]);
+
+  useEffect(() => {
+    if (validRecentValues.length !== recentValues.length) {
+      writeRecentInstances(validRecentValues);
+    }
+  }, [recentValues.length, validRecentValues]);
+
+  const selectOptions = useMemo(() => {
+    const recentSet = new Set(validRecentValues);
+    const recent = validRecentValues
+      .map((recentValue) => options.find((option) => option.value === recentValue))
+      .filter((option): option is InstanceOption => Boolean(option));
+
+    if (recent.length === 0) return options;
+
+    return [
+      { label: lang === 'zh' ? '最近使用' : 'Recent', options: recent },
+      {
+        label: lang === 'zh' ? '全部实例' : 'All instances',
+        options: options.filter((option) => !recentSet.has(option.value)),
+      },
+    ];
+  }, [lang, options, validRecentValues]);
+
+  const remember = (selectedValue: string) => {
+    const available = new Set(options.map((option) => option.value));
+    setRecentValues((current) => {
+      const next = [
+        selectedValue,
+        ...current.filter((item) => item !== selectedValue && available.has(item)),
+      ].slice(0, RECENT_INSTANCE_LIMIT);
+      writeRecentInstances(next);
+      return next;
+    });
+  };
+
   return (
     <Select
       showSearch
@@ -52,13 +121,15 @@ export function InstanceSelect({
         if (next === undefined || next === null) {
           const first = options[0]?.value;
           if (first) {
+            remember(first);
             onChange(first);
           }
           return;
         }
+        remember(next);
         onChange(next, option);
       }}
-      options={options}
+      options={selectOptions}
       optionFilterProp="label"
       filterOption={(input, option) =>
         String(option?.label ?? '')

--- a/web/src/components/__tests__/InstanceSelect.test.tsx
+++ b/web/src/components/__tests__/InstanceSelect.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LangProvider } from '../../i18n/LangContext';
+import { LANGUAGE_STORAGE_KEY } from '../../i18n/languagePreference';
+import InstanceSelect, { INSTANCE_RECENTS_STORAGE_KEY } from '../InstanceSelect';
+
+const options = [
+  { value: 'cluster-a', label: 'Cluster A' },
+  { value: 'cluster-b', label: 'Cluster B' },
+  { value: 'cluster-c', label: 'Cluster C' },
+];
+
+function openSelect() {
+  fireEvent.mouseDown(screen.getByRole('combobox'));
+}
+
+describe('InstanceSelect recent instances', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('persists a selection and groups it first on the next render', async () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en');
+    const onChange = vi.fn();
+    const firstRender = render(
+      <LangProvider>
+        <InstanceSelect options={options} onChange={onChange} />
+      </LangProvider>,
+    );
+
+    openSelect();
+    fireEvent.click(screen.getByText('Cluster B'));
+
+    expect(onChange).toHaveBeenCalledWith('cluster-b', expect.anything());
+    expect(JSON.parse(localStorage.getItem(INSTANCE_RECENTS_STORAGE_KEY) ?? '[]')).toEqual([
+      'cluster-b',
+    ]);
+
+    firstRender.unmount();
+    render(
+      <LangProvider>
+        <InstanceSelect options={options} onChange={vi.fn()} />
+      </LangProvider>,
+    );
+    openSelect();
+
+    expect(await screen.findByText('Recent')).toBeInTheDocument();
+    expect(screen.getByText('All instances')).toBeInTheDocument();
+  });
+
+  it('prunes instances that are no longer available', async () => {
+    localStorage.setItem(
+      INSTANCE_RECENTS_STORAGE_KEY,
+      JSON.stringify(['deleted-cluster', 'cluster-a']),
+    );
+
+    render(<InstanceSelect options={options} onChange={vi.fn()} />);
+
+    await waitFor(() =>
+      expect(JSON.parse(localStorage.getItem(INSTANCE_RECENTS_STORAGE_KEY) ?? '[]')).toEqual([
+        'cluster-a',
+      ]),
+    );
+    openSelect();
+    expect(screen.queryByText('deleted-cluster')).not.toBeInTheDocument();
+  });
+
+  it('keeps selection usable when browser storage is unavailable', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage blocked');
+    });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage blocked');
+    });
+    const onChange = vi.fn();
+
+    render(<InstanceSelect options={options} onChange={onChange} />);
+    openSelect();
+    fireEvent.click(screen.getByText('Cluster C'));
+
+    expect(onChange).toHaveBeenCalledWith('cluster-c', expect.anything());
+  });
+});


### PR DESCRIPTION
## Summary

- persist up to five recently selected instance IDs in browser-local storage
- group valid recent instances ahead of the remaining options in English and Chinese
- prune removed instances and tolerate unavailable browser storage
- preserve existing search, clear, and onChange behavior
- add focused persistence, pruning, and failure-mode tests

## Testing

- npx vitest run src/components/__tests__/InstanceSelect.test.tsx --pool=threads --maxWorkers=1 --no-file-parallelism
- npx eslint src/components/InstanceSelect.tsx src/components/__tests__/InstanceSelect.test.tsx
- npm run build

Closes #2168