### PR TITLE
[studio][ISSUE #2169] Expose accessible MiniLine summaries

### DIFF
--- a/web/src/components/MiniLine.tsx
+++ b/web/src/components/MiniLine.tsx
@@ -34,6 +34,8 @@ interface MiniLineProps {
   animated?: boolean;
   /** Make SVG responsive (width=100%, preserves aspect ratio) */
   responsive?: boolean;
+  /** Optional context prepended to the accessible sample summary */
+  ariaLabel?: string;
 }
 
 const MiniLine = ({
@@ -46,6 +48,7 @@ const MiniLine = ({
   showDot = true,
   animated = true,
   responsive = false,
+  ariaLabel,
 }: MiniLineProps) => {
   const max = Math.max(...data, 1);
   const min = Math.min(...data, 0);
@@ -59,6 +62,9 @@ const MiniLine = ({
   const glowId = useMemo(() => `ml-glow-${++_lineId}`, []);
 
   if (data.length < 2) return null;
+
+  const sampleSummary = data.join(' → ');
+  const accessibleSummary = ariaLabel ? `${ariaLabel}: ${sampleSummary}` : sampleSummary;
 
   // Build smooth Catmull-Rom → Bezier control points
   const points = data.map((v, i) => ({
@@ -91,13 +97,15 @@ const MiniLine = ({
 
   return (
     <svg
+      role="img"
+      aria-label={accessibleSummary}
       width={responsive ? '100%' : width}
       height={height}
       viewBox={responsive ? `0 0 ${width} ${height}` : undefined}
       preserveAspectRatio={responsive ? 'none' : undefined}
       style={{ display: 'block', overflow: 'visible' }}
     >
-      {' '}
+      <title>{accessibleSummary}</title>
       <defs>
         <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor={color} stopOpacity={0.3} />

--- a/web/src/components/__tests__/MiniLine.test.tsx
+++ b/web/src/components/__tests__/MiniLine.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import MiniLine from '../MiniLine';
+
+describe('MiniLine accessibility', () => {
+  it('exposes samples in order to assistive technology and native hover', () => {
+    const { container } = render(<MiniLine data={[12, 8, 15]} animated={false} />);
+
+    expect(screen.getByRole('img', { name: '12 → 8 → 15' })).toBeInTheDocument();
+    expect(container.querySelector('title')).toHaveTextContent('12 → 8 → 15');
+  });
+
+  it('prefixes the summary with caller-provided context', () => {
+    render(<MiniLine data={[1.5, 2.5]} ariaLabel="Send TPS" />);
+
+    expect(screen.getByRole('img', { name: 'Send TPS: 1.5 → 2.5' })).toBeInTheDocument();
+  });
+
+  it('does not expose misleading metadata when there is no chart', () => {
+    const { container } = render(<MiniLine data={[1]} ariaLabel="Send TPS" />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- expose non-empty MiniLine charts as accessible images
- summarize samples in display order through an SVG title and accessible name
- allow callers to prepend domain-specific context
- keep the existing empty-series behavior
- add focused accessibility tests

## Testing

- npx vitest run src/components/__tests__/MiniLine.test.tsx --pool=threads --maxWorkers=1 --no-file-parallelism
- npx eslint src/components/MiniLine.tsx src/components/__tests__/MiniLine.test.tsx
- npm run build

Closes #2169