### PR TITLE
[studio][ISSUE #2170] Synchronize PageHeader document titles

### DIFF
--- a/web/src/components/PageHeader.tsx
+++ b/web/src/components/PageHeader.tsx
@@ -16,7 +16,7 @@
  */
 
 import { Flex, Typography } from 'antd';
-import type { ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
 
 const { Title, Text } = Typography;
 
@@ -25,22 +25,43 @@ interface PageHeaderProps {
   subtitle?: ReactNode;
   extra?: ReactNode;
   headingLevel?: 1 | 2 | 3 | 4 | 5;
+  /** Override the browser-tab title, or set to false to leave it unchanged. */
+  documentTitle?: string | false;
 }
 
-const PageHeader = ({ title, subtitle, extra, headingLevel = 1 }: PageHeaderProps) => (
-  <Flex justify="space-between" align="center" style={{ marginBottom: 24 }}>
-    <Flex align="center" gap={12}>
-      <Title level={headingLevel} style={{ margin: 0, fontSize: 20, fontWeight: 600 }}>
-        {title}
-      </Title>
-      {subtitle && (
-        <Text type="secondary" style={{ fontSize: 13 }}>
-          {subtitle}
-        </Text>
-      )}
+const PageHeader = ({
+  title,
+  subtitle,
+  extra,
+  headingLevel = 1,
+  documentTitle,
+}: PageHeaderProps) => {
+  useEffect(() => {
+    if (documentTitle === false) return;
+
+    const previousTitle = document.title;
+    document.title = `${documentTitle ?? title} | RocketMQ Studio`;
+
+    return () => {
+      document.title = previousTitle;
+    };
+  }, [documentTitle, title]);
+
+  return (
+    <Flex justify="space-between" align="center" style={{ marginBottom: 24 }}>
+      <Flex align="center" gap={12}>
+        <Title level={headingLevel} style={{ margin: 0, fontSize: 20, fontWeight: 600 }}>
+          {title}
+        </Title>
+        {subtitle && (
+          <Text type="secondary" style={{ fontSize: 13 }}>
+            {subtitle}
+          </Text>
+        )}
+      </Flex>
+      {extra && <Flex gap={8}>{extra}</Flex>}
     </Flex>
-    {extra && <Flex gap={8}>{extra}</Flex>}
-  </Flex>
-);
+  );
+};
 
 export default PageHeader;

--- a/web/src/components/__tests__/PageHeader.test.tsx
+++ b/web/src/components/__tests__/PageHeader.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import PageHeader from '../PageHeader';
+
+describe('PageHeader document title', () => {
+  const initialTitle = 'RocketMQ Studio';
+
+  afterEach(() => {
+    document.title = initialTitle;
+  });
+
+  it('synchronizes the browser tab and restores the previous title', () => {
+    document.title = initialTitle;
+    const view = render(<PageHeader title="Topics" />);
+
+    expect(screen.getByRole('heading', { name: 'Topics' })).toBeInTheDocument();
+    expect(document.title).toBe('Topics | RocketMQ Studio');
+
+    view.unmount();
+    expect(document.title).toBe(initialTitle);
+  });
+
+  it('supports a title override', () => {
+    render(<PageHeader title="主题" documentTitle="Topics" />);
+
+    expect(document.title).toBe('Topics | RocketMQ Studio');
+  });
+
+  it('can leave the existing document title unchanged', () => {
+    document.title = 'Managed by parent';
+    render(<PageHeader title="Topics" documentTitle={false} />);
+
+    expect(document.title).toBe('Managed by parent');
+  });
+});


### PR DESCRIPTION
## Summary

- derive descriptive browser-tab titles from the shared PageHeader
- retain RocketMQ Studio as a stable product suffix
- support explicit overrides and an opt-out for parent-managed titles
- restore the previous title when a header unmounts
- cover default, override, opt-out, and cleanup behavior

## Testing

- npx vitest run src/components/__tests__/PageHeader.test.tsx --pool=threads --maxWorkers=1 --no-file-parallelism
- npx eslint src/components/PageHeader.tsx src/components/__tests__/PageHeader.test.tsx
- npm run build

Closes #2170