### PR TITLE
fix(tencent): preserve partial ACL updates

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentAclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentAclService.java
@@ -150,27 +150,58 @@ public class TencentAclService {
 
     public AclUserVO updateUser(String instanceId, AclUserVO user) {
         Context context = resolve(instanceId);
-        if (!StringUtils.hasText(user.getUsername())) {
-            throw new BusinessException(400, "ACL username is required");
+        String roleName = StringUtils.hasText(user.getId()) ? user.getId() : user.getUsername();
+        if (!StringUtils.hasText(roleName)) {
+            throw new BusinessException(400, "ACL user id is required");
         }
+        RoleItem existing = user.getPermRead() == null || user.getPermWrite() == null
+                ? findRole(context, roleName) : null;
+        boolean permRead = user.getPermRead() == null
+                ? Boolean.TRUE.equals(existing.getPermRead()) : user.getPermRead();
+        boolean permWrite = user.getPermWrite() == null
+                ? Boolean.TRUE.equals(existing.getPermWrite()) : user.getPermWrite();
         ModifyRoleRequest request = new ModifyRoleRequest();
         request.setInstanceId(context.cloudInstanceId());
-        request.setRole(user.getUsername());
-        request.setPermRead(user.getPermRead() == null || user.getPermRead());
-        request.setPermWrite(user.getPermWrite() == null || user.getPermWrite());
+        request.setRole(roleName);
+        request.setPermRead(permRead);
+        request.setPermWrite(permWrite);
         clientFactory.call(context.credentialId(), context.regionId(),
                 client -> client.ModifyRole(request));
         return AclUserVO.builder()
-                .id(user.getUsername())
-                .username(user.getUsername())
+                .id(roleName)
+                .username(roleName)
                 .accessKey(null)
                 .secretKey(null)
                 .admin(false)
-                .permRead(user.getPermRead() == null || user.getPermRead())
-                .permWrite(user.getPermWrite() == null || user.getPermWrite())
+                .permRead(permRead)
+                .permWrite(permWrite)
                 .clusters(context.cloudInstanceId() == null ? List.of() : List.of(context.cloudInstanceId()))
                 .createdAt(user.getCreatedAt())
                 .build();
+    }
+
+    private RoleItem findRole(Context context, String roleName) {
+        for (int page = 0; page < MAX_PAGES; page++) {
+            DescribeRoleListRequest request = new DescribeRoleListRequest();
+            request.setInstanceId(context.cloudInstanceId());
+            request.setOffset((long) page * PAGE_SIZE);
+            request.setLimit((long) PAGE_SIZE);
+            DescribeRoleListResponse response = clientFactory.call(context.credentialId(),
+                    context.regionId(), client -> client.DescribeRoleList(request));
+            RoleItem[] data = response == null ? null : response.getData();
+            if (data == null || data.length == 0) {
+                break;
+            }
+            for (RoleItem role : data) {
+                if (role != null && roleName.equals(role.getRoleName())) {
+                    return role;
+                }
+            }
+            if (data.length < PAGE_SIZE) {
+                break;
+            }
+        }
+        throw new BusinessException(404, "ACL user not found: " + roleName);
     }
 
     public void deleteUser(String instanceId, String username) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentAclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentAclServiceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.tencent;
+
+import com.tencentcloudapi.trocket.v20230308.TrocketClient;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeRoleListResponse;
+import com.tencentcloudapi.trocket.v20230308.models.ModifyRoleRequest;
+import com.tencentcloudapi.trocket.v20230308.models.RoleItem;
+import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.instance.acl.AclUserVO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TencentAclServiceTest {
+
+    private static final String INSTANCE_ID = "instance-1";
+    private static final String CLOUD_INSTANCE_ID = "rmq-abc";
+    private static final String CREDENTIAL_ID = "credential-1";
+    private static final String REGION = "ap-guangzhou";
+
+    @Mock
+    private TencentClientFactory clientFactory;
+    @Mock
+    private InstanceRepository instanceRepository;
+    @Mock
+    private TrocketClient client;
+
+    private TencentAclService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TencentAclService(clientFactory, instanceRepository);
+        when(instanceRepository.findById(INSTANCE_ID)).thenReturn(Optional.of(InstanceVO.builder()
+                .cloudInstanceId(CLOUD_INSTANCE_ID)
+                .credentialId(CREDENTIAL_ID)
+                .regionId(REGION)
+                .build()));
+        lenient().when(clientFactory.call(anyString(), anyString(), any())).thenAnswer(invocation -> {
+            TencentClientFactory.TencentCall<Object> action = invocation.getArgument(2);
+            return action.execute(client);
+        });
+    }
+
+    @Test
+    void updateUserShouldUseIdWhenUsernameIsOmittedTest() throws Exception {
+        AclUserVO updated = service.updateUser(INSTANCE_ID, AclUserVO.builder()
+                .id("reader-role")
+                .permRead(false)
+                .permWrite(true)
+                .build());
+
+        ArgumentCaptor<ModifyRoleRequest> requestCaptor = ArgumentCaptor.forClass(ModifyRoleRequest.class);
+        verify(client).ModifyRole(requestCaptor.capture());
+        ModifyRoleRequest request = requestCaptor.getValue();
+        assertThat(request.getRole()).isEqualTo("reader-role");
+        assertThat(request.getPermRead()).isFalse();
+        assertThat(request.getPermWrite()).isTrue();
+        assertThat(updated.getId()).isEqualTo("reader-role");
+        assertThat(updated.getUsername()).isEqualTo("reader-role");
+    }
+
+    @Test
+    void updateUserShouldPreserveOmittedPermissionsTest() throws Exception {
+        RoleItem role = new RoleItem();
+        role.setRoleName("reader-role");
+        role.setPermRead(false);
+        role.setPermWrite(false);
+        DescribeRoleListResponse response = new DescribeRoleListResponse();
+        response.setData(new RoleItem[]{role});
+        when(client.DescribeRoleList(any())).thenReturn(response);
+
+        AclUserVO updated = service.updateUser(INSTANCE_ID, AclUserVO.builder()
+                .id("reader-role")
+                .build());
+
+        ArgumentCaptor<ModifyRoleRequest> requestCaptor = ArgumentCaptor.forClass(ModifyRoleRequest.class);
+        verify(client).ModifyRole(requestCaptor.capture());
+        ModifyRoleRequest request = requestCaptor.getValue();
+        assertThat(request.getPermRead()).isFalse();
+        assertThat(request.getPermWrite()).isFalse();
+        assertThat(updated.getPermRead()).isFalse();
+        assertThat(updated.getPermWrite()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- resolve Tencent ACL updates with the required role id
- load the existing role only when a permission field is omitted
- preserve each omitted permission instead of defaulting it to true
- return the effective role and permission values after the update

## Root cause

`UpdateAclUserDTO` models a partial update: `id` is required while `username`, `permRead`, and `permWrite` are optional. The Tencent adapter required the optional username and converted null permissions to true, rejecting valid id-only requests and unexpectedly enabling omitted permissions.

Closes #2185.

## Validation

- `mvn -Dtest=TencentAclServiceTest test` (2 tests passed)
- `mvn -DskipTests checkstyle:check` (0 violations)
- `git diff --check`
- both changed paths checked against all open PRs targeting `rocketmq-studio` (no matches)