### PR TITLE
fix(metrics): use availability for broker health

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricProfileService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricProfileService.java
@@ -100,9 +100,9 @@ public class MetricProfileService {
                 mapping(SemanticMetric.CONSUMER_LAG_LATENCY, "rocketmq_consumer_lag_latency",
                         "max(rocketmq_consumer_lag_latency) by (cluster, topic, consumer_group)",
                         "cluster", "topic", "consumer_group"),
-                mapping(SemanticMetric.BROKER_HEALTH, "rocketmq_processor_watermark",
-                        "max(rocketmq_processor_watermark) by (cluster, node_id, processor)",
-                        "cluster", "node_id", "processor")
+                mapping(SemanticMetric.BROKER_HEALTH, "up",
+                        "min(up{job=~\".*rocketmq.*\"}) by (job, instance)",
+                        "job", "instance")
         );
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricProfileServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricProfileServiceTest.java
@@ -53,8 +53,12 @@ class MetricProfileServiceTest {
                         "sum(rate(rocketmq_messages_in_total[1m])) by (cluster, node_id)");
         assertThat(mapping(profile, SemanticMetric.CONSUMER_LAG_MESSAGES).getPrometheusMetric())
                 .isEqualTo("rocketmq_consumer_lag_messages");
-        assertThat(mapping(profile, SemanticMetric.BROKER_HEALTH).getPrometheusMetric())
-                .isEqualTo("rocketmq_processor_watermark");
+        assertThat(mapping(profile, SemanticMetric.BROKER_HEALTH))
+                .extracting(MetricProfileVO.MetricMappingVO::getPrometheusMetric,
+                        MetricProfileVO.MetricMappingVO::getPromql,
+                        MetricProfileVO.MetricMappingVO::getLabels)
+                .containsExactly("up", "min(up{job=~\".*rocketmq.*\"}) by (job, instance)",
+                        List.of("job", "instance"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- map RocketMQ 5 broker health to Prometheus scrape availability
- use the existing RocketMQ target filter and stable job/instance labels
- verify the metric name, PromQL, and labels in the profile test

## Root cause

`rocketmq_processor_watermark` measures request-processor queue watermarks. It is a load signal rather than a binary availability signal, so it cannot represent the `broker_health` semantic metric correctly. A healthy idle broker can have a zero watermark while a busy broker has a positive value.

Closes #2188.

## Validation

- `mvn -Dtest=MetricProfileServiceTest test` (7 tests passed)
- `mvn -DskipTests checkstyle:check` (0 violations)
- `git diff --check`
- final GraphQL scan of all open PR files targeting `rocketmq-studio`, including large-PR pagination (no path matches)