### PR TITLE
fix(provider): parse long jstack thread names

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProvider.java
@@ -49,7 +49,7 @@ import java.util.regex.Pattern;
 public class RocketMQConsumerDiagnosticsProvider implements ConsumerDiagnosticsProvider {
 
     private static final Pattern THREAD_HEADER =
-            Pattern.compile("^(?<name>.+?)\\s+TID:\\s+(?<id>\\d+)\\s+STATE:\\s+(?<state>\\S+)\\s*$");
+            Pattern.compile("^(?<name>.+?)TID:\\s+(?<id>\\d+)\\s+STATE:\\s+(?<state>\\S+)\\s*$");
 
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
     private final MqAdminExtFactory adminFactory;

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProviderTest.java
@@ -99,6 +99,25 @@ class RocketMQConsumerDiagnosticsProviderTest {
     }
 
     @Test
+    void getConsumerStackShouldParseThreadNamesLongerThanJstackColumnWidth() throws Exception {
+        String threadName = "ConsumeMessageThreadWithANameLongerThanFortyCharacters";
+        ConsumerRunningInfo runningInfo = new ConsumerRunningInfo();
+        runningInfo.setJstack(String.format(
+                "%-40sTID: 42 STATE: RUNNABLE%n%-40scom.example.Listener.consume(Listener.java:10)%n",
+                threadName, threadName));
+        when(adminExt.getConsumerRunningInfo("cg-orders", "client-1", true)).thenReturn(runningInfo);
+
+        ConsumerStackTraceVO result = provider.getConsumerStack("instance-a", "cg-orders", "client-1");
+
+        assertThat(result.getThreadCount()).isEqualTo(1);
+        assertThat(result.getThreads().get(0).getThreadName()).isEqualTo(threadName);
+        assertThat(result.getThreads().get(0).getThreadId()).isEqualTo(42);
+        assertThat(result.getThreads().get(0).getState()).isEqualTo("RUNNABLE");
+        assertThat(result.getThreads().get(0).getStackTrace())
+                .containsExactly("com.example.Listener.consume(Listener.java:10)");
+    }
+
+    @Test
     void getConsumerStackShouldUseDefaultNameServerWhenInstanceIsBlank() throws Exception {
         ConsumerRunningInfo runningInfo = new ConsumerRunningInfo();
         runningInfo.setJstack("");


### PR DESCRIPTION
## Summary

- parse RocketMQ jstack headers at the stable `TID:` marker
- support thread names that consume or exceed the 40-character display column
- verify the full thread name, id, state, and frame list

## Root cause

RocketMQ formats thread names with `%-40s`. Short names receive padding, but names of 40 characters or more are immediately followed by `TID:`. The diagnostics regex required at least one whitespace character at that boundary, so those threads were omitted.

Closes #2190.

## Validation

- `mvn -Dtest=RocketMQConsumerDiagnosticsProviderTest test` (6 tests passed)
- `mvn -DskipTests checkstyle:check` (0 violations)
- `git diff --check`
- final GraphQL scan of all open PR files targeting `rocketmq-studio`, including large-PR pagination (no path matches)