### PR TITLE
fix(alerting): export assets as attachments

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -65,7 +66,9 @@ public class AlertRuleAssetController {
         String yaml = alertRuleAssetService.getAssetYaml(name);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.parseMediaType("application/x-yaml"));
-        headers.setContentDispositionFormData("attachment", name + ".yaml");
+        headers.setContentDisposition(ContentDisposition.attachment()
+                .filename(name + ".yaml")
+                .build());
         return new ResponseEntity<>(yaml.getBytes(StandardCharsets.UTF_8), headers, HttpStatus.OK);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetControllerTest.java
@@ -76,6 +76,6 @@ class AlertRuleAssetControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(header().string("Content-Type", "application/x-yaml"))
                 .andExpect(header().string("Content-Disposition",
-                        "form-data; name=\"attachment\"; filename=\"rocketmq-broker-down.yaml\""));
+                        "attachment; filename=\"rocketmq-broker-down.yaml\""));
     }
 }


### PR DESCRIPTION
## Summary

- return alert rule YAML exports with an attachment content disposition
- preserve the generated filename in the download response
- update the controller regression test for the expected header

## Root cause

`setContentDispositionFormData` emits multipart form-data semantics intended for a multipart body part. This endpoint returns a normal file response, so clients could fail to recognize the YAML as a download.

Closes #2192

## Validation

- `mvn -pl server -Dtest=AlertRuleAssetControllerTest test` (3 tests)
- `mvn -pl server checkstyle:check`
- `git diff --check`
- verified the changed paths against all open PRs targeting `rocketmq-studio`