### PR TITLE
[ISSUE #2142] Fix cluster administration UI integrity

### DIFF
--- a/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { App, message, Modal } from 'antd';
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -262,6 +262,52 @@ describe('Cluster page', () => {
     expect(within(dialog).getByText('1,842')).toBeInTheDocument();
     expect(within(dialog).getByText('8081')).toBeInTheDocument();
     expect(within(dialog).getByText('8080')).toBeInTheDocument();
+  });
+
+  it('preserves a fractional MiB message size when another config field changes', async () => {
+    const cluster = buildCluster();
+    cluster.config.maxMessageSize = 4.5 * 1024 * 1024;
+    clusterServiceMocks.listClusters.mockResolvedValue([cluster]);
+    const user = userEvent.setup();
+    renderWithProviders(<ClusterPage />);
+
+    const brokerRow = await screen.findByRole('row', { name: /10\.101\.2\.11:10911/ });
+    await user.click(within(brokerRow).getByRole('button', { name: /配置/ }));
+    const dialog = await screen.findByRole('dialog', { name: /配置 - rocketmq-prod/ });
+    expect(within(dialog).getByRole('spinbutton', { name: '最大消息大小 (MB)' })).toHaveValue(
+      '4.5',
+    );
+
+    await user.click(within(dialog).getByRole('radio', { name: '异步刷盘' }));
+    await user.click(within(dialog).getByRole('button', { name: 'OK' }));
+
+    await waitFor(() => expect(clusterServiceMocks.updateClusterConfig).toHaveBeenCalledTimes(1));
+    expect(clusterServiceMocks.updateClusterConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flushDiskType: 'ASYNC_FLUSH',
+        maxMessageSize: 4.5 * 1024 * 1024,
+      }),
+    );
+  });
+
+  it('requires equal integer read and write queue counts before updating config', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ClusterPage />);
+
+    const brokerRow = await screen.findByRole('row', { name: /10\.101\.2\.11:10911/ });
+    await user.click(within(brokerRow).getByRole('button', { name: /配置/ }));
+    const dialog = await screen.findByRole('dialog', { name: /配置 - rocketmq-prod/ });
+    const writeQueues = within(dialog).getByRole('spinbutton', { name: '写队列数' });
+    const readQueues = within(dialog).getByRole('spinbutton', { name: '读队列数' });
+
+    expect(writeQueues).toHaveAttribute('step', '1');
+    expect(readQueues).toHaveAttribute('step', '1');
+    await user.clear(readQueues);
+    await user.type(readQueues, '4');
+    await user.click(within(dialog).getByRole('button', { name: 'OK' }));
+
+    expect(await within(dialog).findByText('读写队列数必须相等')).toBeInTheDocument();
+    expect(clusterServiceMocks.updateClusterConfig).not.toHaveBeenCalled();
   });
 
   it('keeps cluster tabs usable when address fields are missing', async () => {

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -336,7 +336,7 @@ const ClusterPage = () => {
       flushDiskType: cfg.flushDiskType ?? 'ASYNC_FLUSH',
       autoCreateTopicEnable: cfg.autoCreateTopicEnable ?? false,
       autoCreateSubscriptionGroup: cfg.autoCreateSubscriptionGroup ?? false,
-      maxMessageSizeMB: Math.round((cfg.maxMessageSize ?? 4194304) / 1048576),
+      maxMessageSizeMB: (cfg.maxMessageSize ?? 4194304) / 1048576,
       fileReservedTime: cfg.fileReservedTime ?? 72,
       writeQueueNums: cfg.writeQueueNums ?? 8,
       readQueueNums: cfg.readQueueNums ?? 8,
@@ -570,42 +570,45 @@ const ClusterPage = () => {
             open={configModalOpen}
             onCancel={() => setConfigModalOpen(false)}
             onOk={() => {
-              configForm.validateFields().then(async (values) => {
-                if (!selectedCluster) return;
-                try {
-                  const { maxMessageSizeMB, ...configValues } = values;
-                  const nextConfig: ClusterConfig = {
-                    ...(selectedCluster.config ?? {}),
-                    ...configValues,
-                    maxMessageSize: maxMessageSizeMB * 1048576,
-                  };
-                  const result = await updateClusterConfig({
-                    id: selectedCluster.id,
-                    instanceId: selectedInstanceIdRef.current || undefined,
-                    ...nextConfig,
-                  });
-                  if (result.status === 'SUCCESS') {
-                    await requestRefresh('operation');
-                    message.success(t('cluster.configUpdated'));
-                    setConfigModalOpen(false);
-                    return;
-                  }
+              void configForm.validateFields().then(
+                async (values) => {
+                  if (!selectedCluster) return;
+                  try {
+                    const { maxMessageSizeMB, ...configValues } = values;
+                    const nextConfig: ClusterConfig = {
+                      ...(selectedCluster.config ?? {}),
+                      ...configValues,
+                      maxMessageSize: Math.round(maxMessageSizeMB * 1048576),
+                    };
+                    const result = await updateClusterConfig({
+                      id: selectedCluster.id,
+                      instanceId: selectedInstanceIdRef.current || undefined,
+                      ...nextConfig,
+                    });
+                    if (result.status === 'SUCCESS') {
+                      await requestRefresh('operation');
+                      message.success(t('cluster.configUpdated'));
+                      setConfigModalOpen(false);
+                      return;
+                    }
 
-                  const failedAddresses = result.failedBrokers
-                    .map((failure) => failure.address)
-                    .join(', ');
-                  if (result.status === 'PARTIAL') {
-                    await requestRefresh('operation');
-                    message.warning(
-                      t('cluster.configPartiallyUpdated', { brokers: failedAddresses }),
-                    );
-                    return;
+                    const failedAddresses = result.failedBrokers
+                      .map((failure) => failure.address)
+                      .join(', ');
+                    if (result.status === 'PARTIAL') {
+                      await requestRefresh('operation');
+                      message.warning(
+                        t('cluster.configPartiallyUpdated', { brokers: failedAddresses }),
+                      );
+                      return;
+                    }
+                    message.error(t('cluster.configUpdateFailed', { brokers: failedAddresses }));
+                  } catch {
+                    message.error(t('cluster.configUpdateFailed', { brokers: '' }));
                   }
-                  message.error(t('cluster.configUpdateFailed', { brokers: failedAddresses }));
-                } catch {
-                  message.error(t('cluster.configUpdateFailed', { brokers: '' }));
-                }
-              });
+                },
+                () => undefined,
+              );
             }}
             width={560}
           >
@@ -631,23 +634,35 @@ const ClusterPage = () => {
                 <Switch />
               </Form.Item>
               <Form.Item label={t('cluster.maxMessageSize')} name="maxMessageSizeMB">
-                <InputNumber min={1} max={128} style={{ width: '100%' }} />
+                <InputNumber min={1} max={128} step={0.5} style={{ width: '100%' }} />
               </Form.Item>
               <Form.Item label={t('cluster.fileReservedTime')} name="fileReservedTime">
-                <InputNumber min={1} max={720} style={{ width: '100%' }} />
+                <InputNumber min={1} max={720} step={1} precision={0} style={{ width: '100%' }} />
               </Form.Item>
               <Form.Item label={t('cluster.writeQueues')} name="writeQueueNums">
-                <InputNumber min={1} max={256} style={{ width: '100%' }} />
+                <InputNumber min={1} max={256} step={1} precision={0} style={{ width: '100%' }} />
               </Form.Item>
-              <Form.Item label={t('cluster.readQueues')} name="readQueueNums">
-                <InputNumber min={1} max={256} style={{ width: '100%' }} />
+              <Form.Item
+                label={t('cluster.readQueues')}
+                name="readQueueNums"
+                dependencies={['writeQueueNums']}
+                rules={[
+                  ({ getFieldValue }) => ({
+                    validator(_, value) {
+                      if (value === getFieldValue('writeQueueNums')) return Promise.resolve();
+                      return Promise.reject(new Error('读写队列数必须相等'));
+                    },
+                  }),
+                ]}
+              >
+                <InputNumber min={1} max={256} step={1} precision={0} style={{ width: '100%' }} />
               </Form.Item>
               <Text type="secondary" style={{ display: 'block', marginTop: -16, marginBottom: 16 }}>
                 RocketMQ Broker uses one default Topic queue count; read and write values must
                 match.
               </Text>
               <Form.Item label={t('cluster.brokerPermission')} name="brokerPermission">
-                <InputNumber min={0} max={7} style={{ width: '100%' }} />
+                <InputNumber min={0} max={7} step={1} precision={0} style={{ width: '100%' }} />
               </Form.Item>
             </Form>
           </Modal>

--- a/web/src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx
@@ -118,6 +118,36 @@ describe('NameServerConfigDriftPage', () => {
     expect(screen.getByText('listenPort')).toBeInTheDocument();
     expect(screen.getByText('19876')).toBeInTheDocument();
     expect(screen.getByText('ns-a:9876 · 可达')).toBeInTheDocument();
+    expect(screen.getByText('Production instance')).toBeInTheDocument();
+    expect(screen.queryByText('instance-a')).not.toBeInTheDocument();
+  });
+
+  it('keeps instance identifiers stable when selecting another instance', async () => {
+    const secondInstance = {
+      id: 'instance-b',
+      name: 'Staging instance',
+      vendor: 'APACHE',
+    } as Instance;
+    vi.mocked(listInstances).mockResolvedValue([instance, secondInstance]);
+    const stagingCluster = { id: 'cluster-b', name: 'Staging' } as ClusterInfo;
+    vi.mocked(listClusters).mockImplementation(async (instanceId) =>
+      instanceId === 'instance-b' ? [stagingCluster] : [cluster],
+    );
+    const user = userEvent.setup();
+
+    renderWithProviders(<NameServerConfigDriftPage />);
+    const selector = await screen.findByRole('combobox', { name: 'NameServer drift instance' });
+    await user.click(selector);
+    await user.click(
+      await screen.findByText('Staging instance', {
+        selector: '.ant-select-item-option-content',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(listClusters).toHaveBeenCalledWith('instance-b');
+      expect(getNameServerConfigDiff).toHaveBeenCalledWith('cluster-b', 'instance-b');
+    });
   });
 
   it('reports a consistent result when no safe configuration differs', async () => {

--- a/web/src/pages/ops/nameServerConfigDrift.tsx
+++ b/web/src/pages/ops/nameServerConfigDrift.tsx
@@ -203,7 +203,7 @@ const NameServerConfigDriftPage = () => {
           value={selectedInstanceId}
           onChange={(instanceId) => void selectInstance(instanceId)}
           placeholder={t('common.selectInstance')}
-          options={instances.map((instance) => ({ label: instance.name, value: instance.name }))}
+          options={instances.map((instance) => ({ label: instance.name, value: instance.id }))}
           style={{ width: 'min(100%, 280px)' }}
         />
         <Select

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -162,29 +162,34 @@ const BrokerClusterPage = () => {
     setProxyData([]);
   }, []);
 
-  const loadData = useCallback(async () => {
-    if (!selectedInstanceId) {
-      clearData();
-      return;
-    }
-    const requestId = ++loadRequestId.current;
-    setLoading(true);
-    try {
-      const clusters = await listClusters(selectedInstanceId);
-      if (!mountedRef.current || requestId !== loadRequestId.current) return;
-      const mapped = mapClusters(clusters);
-      setBrokerData(mapped.brokers);
-      setNameServerData(mapped.nameServers);
-      setProxyData(mapped.proxies);
-    } catch {
-      if (!mountedRef.current || requestId !== loadRequestId.current) return;
-      message.error(t('common.refreshFailed'));
-    } finally {
-      if (mountedRef.current && requestId === loadRequestId.current) {
-        setLoading(false);
+  const loadData = useCallback(
+    async (clearExisting = false) => {
+      if (!selectedInstanceId) {
+        clearData();
+        return;
       }
-    }
-  }, [clearData, message, selectedInstanceId, t]);
+      const requestId = ++loadRequestId.current;
+      if (clearExisting) clearData();
+      setLoading(true);
+      try {
+        const clusters = await listClusters(selectedInstanceId);
+        if (!mountedRef.current || requestId !== loadRequestId.current) return;
+        const mapped = mapClusters(clusters);
+        setBrokerData(mapped.brokers);
+        setNameServerData(mapped.nameServers);
+        setProxyData(mapped.proxies);
+      } catch {
+        if (!mountedRef.current || requestId !== loadRequestId.current) return;
+        clearData();
+        message.error(t('common.refreshFailed'));
+      } finally {
+        if (mountedRef.current && requestId === loadRequestId.current) {
+          setLoading(false);
+        }
+      }
+    },
+    [clearData, message, selectedInstanceId, t],
+  );
 
   useEffect(() => {
     let active = true;
@@ -207,7 +212,7 @@ const BrokerClusterPage = () => {
   useEffect(() => {
     mountedRef.current = true;
     const requestId = loadRequestId.current;
-    const timeoutId = window.setTimeout(() => void loadData());
+    const timeoutId = window.setTimeout(() => void loadData(true));
     return () => {
       window.clearTimeout(timeoutId);
       loadRequestId.current = requestId + 1;

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -477,7 +477,10 @@ const BrokerClusterPage = () => {
       </div>
 
       <Spin spinning={loading} tip={t('common.loading')}>
-        <Card variant="borderless" style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}>
+        <Card
+          variant="borderless"
+          style={{ borderRadius: 8, boxShadow: '0 1px 6px rgba(0,0,0,0.04)' }}
+        >
           <Tabs
             activeKey={activeTab}
             onChange={setActiveTab}

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -123,10 +123,12 @@ const renderWithProviders = (ui: React.ReactElement) => {
 
 const createDeferred = <T,>() => {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 };
 
 describe('BrokerCluster Page', () => {
@@ -230,6 +232,49 @@ describe('BrokerCluster Page', () => {
     expect(screen.queryByText('broker-b')).not.toBeInTheDocument();
     expect(screen.queryByText('nameserver-a')).not.toBeInTheDocument();
     expect(screen.queryByText('proxy-a')).not.toBeInTheDocument();
+  });
+
+  it('clears the previous topology while a newly selected instance loads or fails', async () => {
+    const nextInstance = createDeferred<ClusterInfo[]>();
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 'instance-1',
+        name: 'instance-1',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '10.0.1.20:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+      {
+        id: 'instance-2',
+        name: 'instance-2',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '10.0.2.20:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ]);
+    vi.mocked(listClusters)
+      .mockResolvedValueOnce(clusterFixture)
+      .mockReturnValueOnce(nextInstance.promise);
+    const user = userEvent.setup();
+    renderWithProviders(<BrokerCluster />);
+    await screen.findByText('broker-api-a');
+
+    await user.click(screen.getByRole('combobox', { name: '选择实例' }));
+    const instanceTwoOptions = await screen.findAllByText('instance-2');
+    await user.click(instanceTwoOptions[instanceTwoOptions.length - 1]);
+
+    await waitFor(() => expect(screen.queryByText('broker-api-a')).not.toBeInTheDocument());
+    await act(async () => nextInstance.reject(new Error('instance-2 unavailable')));
+    expect(screen.queryByText('broker-api-a')).not.toBeInTheDocument();
+    expect(listClusters).toHaveBeenLastCalledWith('instance-2');
   });
 
   it('polls only while live refresh is enabled and the document is visible', async () => {

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -278,9 +278,7 @@ describe('BrokerCluster Page', () => {
   });
 
   it('polls only while live refresh is enabled and the document is visible', async () => {
-    const visibilityState = vi
-      .spyOn(document, 'visibilityState', 'get')
-      .mockReturnValue('hidden');
+    const visibilityState = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
     renderWithProviders(<BrokerCluster />);
 
     await screen.findByText('broker-api-a');


### PR DESCRIPTION
## What is the purpose of the change

This PR consolidates three related cluster administration UI integrity fixes, following the maintainer guidance in #2107. It replaces the closed one-off PRs #2147, #2156, and #2158 without reopening them.

The broker configuration editor can silently round valid message-size values and submit mismatched read/write queue counts. The BrokerCluster page can display topology from the previously selected instance while a new request is loading or after it fails. The NameServer drift selector also mixes instance names and IDs, leaving its controlled value outside the option domain.

## Brief changelog

- preserve exact broker message-size values and validate paired queue counts before submission
- clear instance-scoped topology during instance changes and active-request failures while preserving request ordering and visibility-aware polling
- use instance IDs consistently in the NameServer drift selector and downstream requests
- add regression tests for configuration round trips, stale topology, request ordering, and selector identity

## Verifying this change

- `npm test -- --run src/pages/cluster/__tests__/ClusterPage.test.tsx src/pages/studio/__tests__/BrokerCluster.test.tsx src/pages/ops/__tests__/NameServerConfigDriftPage.test.tsx` (37 tests passed)
- ESLint and Prettier checks passed for all changed files
- `npm run build` passed
- `git diff --check` passed

Fixes #2142
Fixes #2151
Fixes #2153

