### PR TITLE
fix: allow explicit removal of unreachable instances

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/domain/Result.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/domain/Result.java
@@ -16,31 +16,39 @@
  */
 package org.apache.rocketmq.studio.common.domain;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
 @Getter
 public class Result<T> {
     private int code;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String errorCode;
     private String message;
     private T data;
 
     private Result() {}
 
-    private Result(int code, String message, T data) {
+    private Result(int code, String errorCode, String message, T data) {
         this.code = code;
+        this.errorCode = errorCode;
         this.message = message;
         this.data = data;
     }
 
     public static <T> Result<T> ok(T data) {
-        return new Result<>(200, "success", data);
+        return new Result<>(200, null, "success", data);
     }
 
     public static <T> Result<T> ok() {
-        return new Result<>(200, "success", null);
+        return new Result<>(200, null, "success", null);
     }
 
     public static <T> Result<T> error(int code, String message) {
-        return new Result<>(code, message, null);
+        return error(code, null, message);
+    }
+
+    public static <T> Result<T> error(int code, String errorCode, String message) {
+        return new Result<>(code, errorCode, message, null);
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandler.java
@@ -41,7 +41,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Result<?>> handleBusinessException(BusinessException ex) {
         log.warn("Business exception: {}", ex.getMessage());
         return ResponseEntity.status(ex.getCode())
-                .body(Result.error(ex.getCode(), ex.getMessage()));
+                .body(Result.error(ex.getCode(), ex.getErrorCode(), ex.getMessage()));
     }
 
     @ExceptionHandler(UnsupportedOperationException.class)

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/DeleteInstanceRequest.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/DeleteInstanceRequest.java
@@ -14,22 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.rocketmq.studio.common.exception;
+package org.apache.rocketmq.studio.instance;
 
-import lombok.Getter;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
 
-@Getter
-public class BusinessException extends RuntimeException {
-    private final int code;
-    private final String errorCode;
+/** Request dedicated to the instance deletion safety contract. */
+@Data
+public class DeleteInstanceRequest {
 
-    public BusinessException(int code, String message) {
-        this(code, null, message);
-    }
+    @NotBlank(message = "id is required")
+    private String id;
 
-    public BusinessException(int code, String errorCode, String message) {
-        super(message);
-        this.code = code;
-        this.errorCode = errorCode;
-    }
+    /**
+     * Allows removal of the Studio registration only when the remote resource
+     * preflight cannot determine whether managed resources still exist.
+     */
+    private boolean force;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
@@ -17,7 +17,6 @@
 
 package org.apache.rocketmq.studio.instance;
 
-import org.apache.rocketmq.studio.common.domain.DeleteRequestDTO;
 import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import jakarta.validation.Valid;
@@ -71,8 +70,9 @@ public class InstanceController {
     }
 
     @PostMapping("/delete")
-    public Result<Void> deleteInstance(@Valid @RequestBody DeleteRequestDTO request) {
-        instanceService.deleteInstance(instanceService.resolveInstanceId(request.getId()));
+    public Result<Void> deleteInstance(@Valid @RequestBody DeleteInstanceRequest request) {
+        Long instanceId = instanceService.resolveInstanceId(request.getId());
+        instanceService.deleteInstance(instanceId, request.isForce());
         return Result.ok();
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceDeleteErrorCodes.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceDeleteErrorCodes.java
@@ -14,22 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.rocketmq.studio.common.exception;
+package org.apache.rocketmq.studio.instance;
 
-import lombok.Getter;
+public final class InstanceDeleteErrorCodes {
 
-@Getter
-public class BusinessException extends RuntimeException {
-    private final int code;
-    private final String errorCode;
+    public static final String MANAGED_RESOURCES_PRESENT = "instance.delete.managed_resources_present";
+    public static final String PREFLIGHT_UNAVAILABLE = "instance.delete.preflight_unavailable";
 
-    public BusinessException(int code, String message) {
-        this(code, null, message);
-    }
-
-    public BusinessException(int code, String errorCode, String message) {
-        super(message);
-        this.code = code;
-        this.errorCode = errorCode;
+    private InstanceDeleteErrorCodes() {
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceDeletionPreflight.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceDeletionPreflight.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+/** Result of checking remote managed resources before deleting an instance registration. */
+final class InstanceDeletionPreflight {
+
+    private final int topicCount;
+    private final int consumerGroupCount;
+    private final String failureSummary;
+
+    private InstanceDeletionPreflight(int topicCount, int consumerGroupCount, String failureSummary) {
+        this.topicCount = topicCount;
+        this.consumerGroupCount = consumerGroupCount;
+        this.failureSummary = failureSummary;
+    }
+
+    static InstanceDeletionPreflight verified(int topicCount, int consumerGroupCount) {
+        return new InstanceDeletionPreflight(topicCount, consumerGroupCount, null);
+    }
+
+    static InstanceDeletionPreflight unavailable(RuntimeException failure) {
+        return new InstanceDeletionPreflight(0, 0, summarizeFailure(failure));
+    }
+
+    boolean isUnavailable() {
+        return failureSummary != null;
+    }
+
+    boolean hasManagedResources() {
+        return !isUnavailable() && (topicCount > 0 || consumerGroupCount > 0);
+    }
+
+    int topicCount() {
+        return topicCount;
+    }
+
+    int consumerGroupCount() {
+        return consumerGroupCount;
+    }
+
+    String failureSummary() {
+        return failureSummary;
+    }
+
+    private static String summarizeFailure(RuntimeException failure) {
+        String type = failure.getClass().getSimpleName();
+        return type.isBlank() ? RuntimeException.class.getSimpleName() : type;
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -439,7 +439,12 @@ public class InstanceService {
 
     @Transactional
     public void deleteInstance(Long id) {
-        log.info("Deleting instance: {}", id);
+        deleteInstance(id, false);
+    }
+
+    @Transactional
+    public void deleteInstance(Long id, boolean force) {
+        log.info("Deleting instance: {}, force={}", id, force);
 
         if (id == null) {
             throw new BusinessException(400, "InstanceVO ID is required");
@@ -448,24 +453,68 @@ public class InstanceService {
         InstanceVO existing = instanceRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(404, "InstanceVO not found: " + id));
 
-        InstanceVendor vendor = existing.getVendor() == null ? InstanceVendor.APACHE : existing.getVendor();
-        if (vendor == InstanceVendor.APACHE) {
-            InstanceProvider provider = providerRegistry.forVendor(InstanceVendor.APACHE);
-            int topicCount = provider.countTopics(String.valueOf(id));
-            int consumerGroupCount = provider.countGroups(String.valueOf(id));
-            if (topicCount > 0 || consumerGroupCount > 0) {
-                throw new BusinessException(409, String.format(
-                        "Cannot delete instance with managed resources: topics=%d, consumerGroups=%d",
-                        topicCount, consumerGroupCount));
-            }
+        InstanceDeletionPreflight preflight = inspectDeletionPreflight(existing, id);
+        if (preflight.hasManagedResources()) {
+            throw new BusinessException(409, InstanceDeleteErrorCodes.MANAGED_RESOURCES_PRESENT, String.format(
+                    "Cannot delete instance with managed resources: topics=%d, consumerGroups=%d",
+                    preflight.topicCount(), preflight.consumerGroupCount()));
+        }
+        if (preflight.isUnavailable() && !force) {
+            throw new BusinessException(503, InstanceDeleteErrorCodes.PREFLIGHT_UNAVAILABLE,
+                    "Unable to verify managed resources before deleting the instance");
         }
         if (!instanceRepository.deleteById(id)) {
             throw new BusinessException(404, "InstanceVO not found: " + id);
         }
         removeDataSourceBindings(existing.getName());
         releaseApacheEndpointIfUnused(existing, null);
+        String auditDetail = instanceAuditDetail(existing);
+        if (preflight.isUnavailable()) {
+            auditDetail += ", forced=true, preflight=unavailable, failure=" + preflight.failureSummary();
+        }
         recordAudit("DELETE_INSTANCE", "INSTANCE", String.valueOf(id), null,
-                instanceAuditDetail(existing));
+                auditDetail);
+    }
+
+    private InstanceDeletionPreflight inspectDeletionPreflight(InstanceVO existing, Long id) {
+        InstanceProvider provider;
+        try {
+            provider = providerRegistry.forVendor(
+                    existing.getVendor() == null ? InstanceVendor.APACHE : existing.getVendor());
+        } catch (RuntimeException ex) {
+            InstanceDeletionPreflight unavailable = InstanceDeletionPreflight.unavailable(ex);
+            log.warn("Unable to verify managed resources for instance {}: {}", id,
+                    unavailable.failureSummary());
+            return unavailable;
+        }
+
+        String providerInstanceId = String.valueOf(id);
+        RuntimeException failure = null;
+        int topicCount = 0;
+        int consumerGroupCount = 0;
+        try {
+            topicCount = provider.countTopics(providerInstanceId);
+        } catch (RuntimeException ex) {
+            failure = ex;
+        }
+        try {
+            consumerGroupCount = provider.countGroups(providerInstanceId);
+        } catch (RuntimeException ex) {
+            if (failure == null) {
+                failure = ex;
+            }
+        }
+
+        if (topicCount > 0 || consumerGroupCount > 0) {
+            return InstanceDeletionPreflight.verified(topicCount, consumerGroupCount);
+        }
+        if (failure != null) {
+            InstanceDeletionPreflight unavailable = InstanceDeletionPreflight.unavailable(failure);
+            log.warn("Unable to verify managed resources for instance {}: {}", id,
+                    unavailable.failureSummary());
+            return unavailable;
+        }
+        return InstanceDeletionPreflight.verified(topicCount, consumerGroupCount);
     }
 
     /**

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
@@ -212,7 +212,7 @@ class InstanceControllerTest {
     @Test
     void deleteInstanceShouldReturnSuccess() throws Exception {
         when(instanceService.resolveInstanceId("instance-1")).thenReturn(1L);
-        doNothing().when(instanceService).deleteInstance(1L);
+        doNothing().when(instanceService).deleteInstance(1L, false);
 
         Map<String, String> body = Map.of("id", "instance-1");
 
@@ -223,25 +223,65 @@ class InstanceControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success"));
 
-        verify(instanceService).deleteInstance(1L);
+        verify(instanceService).resolveInstanceId("instance-1");
+        verify(instanceService).deleteInstance(1L, false);
+    }
+
+    @Test
+    void deleteInstanceShouldBindExplicitForceRemoval() throws Exception {
+        when(instanceService.resolveInstanceId("instance-1")).thenReturn(1L);
+        doNothing().when(instanceService).deleteInstance(1L, true);
+
+        mockMvc.perform(post("/api/instances/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", "instance-1", "force", true))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(instanceService).resolveInstanceId("instance-1");
+        verify(instanceService).deleteInstance(1L, true);
     }
 
     @Test
     void deleteInstanceShouldReturnConflictWhenManagedResourcesExist() throws Exception {
         when(instanceService.resolveInstanceId("instance-1")).thenReturn(1L);
-        doThrow(new BusinessException(409,
+        doThrow(new BusinessException(409, InstanceDeleteErrorCodes.MANAGED_RESOURCES_PRESENT,
                 "Cannot delete instance with managed resources: topics=2, consumerGroups=1"))
-                .when(instanceService).deleteInstance(1L);
+                .when(instanceService).deleteInstance(1L, false);
 
         mockMvc.perform(post("/api/instances/delete")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(Map.of("id", "instance-1"))))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value(409))
+                .andExpect(jsonPath("$.errorCode")
+                        .value(InstanceDeleteErrorCodes.MANAGED_RESOURCES_PRESENT))
                 .andExpect(jsonPath("$.message")
                         .value("Cannot delete instance with managed resources: topics=2, consumerGroups=1"));
 
-        verify(instanceService).deleteInstance(1L);
+        verify(instanceService).resolveInstanceId("instance-1");
+        verify(instanceService).deleteInstance(1L, false);
+    }
+
+    @Test
+    void deleteInstanceShouldReturnMachineReadablePreflightUnavailableError() throws Exception {
+        when(instanceService.resolveInstanceId("instance-1")).thenReturn(1L);
+        doThrow(new BusinessException(503, InstanceDeleteErrorCodes.PREFLIGHT_UNAVAILABLE,
+                "Unable to verify managed resources before deleting the instance"))
+                .when(instanceService).deleteInstance(1L, false);
+
+        mockMvc.perform(post("/api/instances/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("id", "instance-1"))))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.code").value(503))
+                .andExpect(jsonPath("$.errorCode")
+                        .value(InstanceDeleteErrorCodes.PREFLIGHT_UNAVAILABLE))
+                .andExpect(jsonPath("$.message")
+                        .value("Unable to verify managed resources before deleting the instance"));
+
+        verify(instanceService).resolveInstanceId("instance-1");
+        verify(instanceService).deleteInstance(1L, false);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceDeletionPreflightTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceDeletionPreflightTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InstanceDeletionPreflightTest {
+
+    @Test
+    void unavailableShouldNotCopyProviderMessagesIntoAuditDetails() {
+        InstanceDeletionPreflight preflight = InstanceDeletionPreflight.unavailable(
+                new IllegalStateException("request to https://user:pass@broker failed\n"
+                        + "token=top-secret password: hunter2"));
+
+        assertThat(preflight.failureSummary()).isEqualTo("IllegalStateException");
+    }
+
+    @Test
+    void unavailableShouldUseABoundedFallbackForAnonymousExceptions() {
+        InstanceDeletionPreflight preflight = InstanceDeletionPreflight.unavailable(
+                new RuntimeException("secret provider text") { });
+
+        assertThat(preflight.failureSummary()).isEqualTo("RuntimeException");
+    }
+
+    @Test
+    void verifiedShouldExposeManagedResourceCounts() {
+        InstanceDeletionPreflight preflight = InstanceDeletionPreflight.verified(2, 3);
+
+        assertThat(preflight.isUnavailable()).isFalse();
+        assertThat(preflight.hasManagedResources()).isTrue();
+        assertThat(preflight.topicCount()).isEqualTo(2);
+        assertThat(preflight.consumerGroupCount()).isEqualTo(3);
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -722,12 +722,16 @@ class InstanceServiceTest {
         InstanceVO existing = InstanceVO.builder().name("cloud-inst").vendor(InstanceVendor.ALIYUN).build();
         existing.setId(2L);
         when(instanceRepository.findById(2L)).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("2")).thenReturn(0);
+        when(instanceProvider.countGroups("2")).thenReturn(0);
         when(instanceRepository.deleteById(2L)).thenReturn(true);
 
         instanceService.deleteInstance(2L);
 
         verify(instanceRepository).deleteById(2L);
-        verifyNoInteractions(providerRegistry);
+        verify(instanceProvider).countTopics("2");
+        verify(instanceProvider).countGroups("2");
     }
 
     @Test
@@ -795,6 +799,135 @@ class InstanceServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(409));
 
         verify(instanceRepository, never()).deleteById(1L);
+    }
+
+    @Test
+    void deleteInstanceShouldReturnStructuredErrorWhenResourcePreflightFails() {
+        InstanceVO existing = InstanceVO.builder().name("unreachable").build();
+        existing.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("1"))
+                .thenThrow(new IllegalStateException("broker unavailable"));
+
+        assertThatThrownBy(() -> instanceService.deleteInstance(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Unable to verify managed resources before deleting the instance")
+                .satisfies(error -> {
+                    BusinessException businessError = (BusinessException) error;
+                    assertThat(businessError.getCode()).isEqualTo(503);
+                    assertThat(businessError.getErrorCode())
+                            .isEqualTo(InstanceDeleteErrorCodes.PREFLIGHT_UNAVAILABLE);
+                });
+
+        verify(instanceRepository, never()).deleteById(1L);
+        verifyNoInteractions(operationAuditService);
+    }
+
+    @Test
+    void deleteInstanceShouldForceRemoveRegistrationWhenResourcePreflightFails() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("unreachable")
+                .vendor(InstanceVendor.ALIYUN)
+                .build();
+        existing.setId(1L);
+        DataSourceVO dataSource = DataSourceVO.builder().key("prometheus")
+                .instanceIds(List.of("unreachable", "other-instance")).build();
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("1"))
+                .thenThrow(new IllegalStateException("endpoint unavailable"));
+        when(instanceRepository.deleteById(1L)).thenReturn(true);
+        when(settingsRepository.findAllDataSources()).thenReturn(List.of(dataSource));
+        when(settingsRepository.replaceDataSource(dataSource)).thenReturn(true);
+
+        instanceService.deleteInstance(1L, true);
+
+        verify(instanceRepository).deleteById(1L);
+        assertThat(dataSource.getInstanceIds()).containsExactly("other-instance");
+        verify(settingsRepository).replaceDataSource(dataSource);
+        verify(operationAuditService).record(eq("DELETE_INSTANCE"), eq("INSTANCE"), eq("1"), eq(null),
+                eq("name=unreachable, vendor=ALIYUN, type=null, forced=true, preflight=unavailable, "
+                        + "failure=IllegalStateException"),
+                eq("SUCCESS"), eq(null));
+    }
+
+    @Test
+    void deleteInstanceShouldNotForceDeleteKnownManagedResources() {
+        InstanceVO existing = InstanceVO.builder().name("managed").build();
+        existing.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("1")).thenReturn(1);
+        when(instanceProvider.countGroups("1"))
+                .thenThrow(new IllegalStateException("group inventory unavailable"));
+
+        assertThatThrownBy(() -> instanceService.deleteInstance(1L, true))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Cannot delete instance with managed resources: topics=1, consumerGroups=0")
+                .satisfies(error -> assertThat(((BusinessException) error).getErrorCode())
+                        .isEqualTo(InstanceDeleteErrorCodes.MANAGED_RESOURCES_PRESENT));
+
+        verify(instanceProvider).countGroups("1");
+        verify(instanceRepository, never()).deleteById(1L);
+        verifyNoInteractions(operationAuditService);
+    }
+
+    @Test
+    void deleteInstanceShouldTreatForceRequestAsNormalWhenPreflightIsSafe() {
+        InstanceVO existing = InstanceVO.builder().name("empty").build();
+        existing.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("1")).thenReturn(0);
+        when(instanceProvider.countGroups("1")).thenReturn(0);
+        when(instanceRepository.deleteById(1L)).thenReturn(true);
+
+        instanceService.deleteInstance(1L, true);
+
+        verify(operationAuditService).record(eq("DELETE_INSTANCE"), eq("INSTANCE"), eq("1"), eq(null),
+                eq("name=empty, vendor=APACHE, type=null"), eq("SUCCESS"), eq(null));
+    }
+
+    @Test
+    void deleteInstanceShouldReleaseUnusedApacheEndpointAfterForcedRemoval() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("unreachable")
+                .endpoint("namesrv:9876")
+                .build();
+        existing.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(instanceRepository.findAll()).thenReturn(List.of());
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("1"))
+                .thenThrow(new IllegalStateException("connection refused"));
+        when(instanceRepository.deleteById(1L)).thenReturn(true);
+
+        instanceService.deleteInstance(1L, true);
+
+        verify(adminFactory).release("namesrv:9876");
+    }
+
+    @Test
+    void deleteInstanceShouldRejectConcurrentForcedRemovalBeforeSideEffects() {
+        InstanceVO existing = InstanceVO.builder()
+                .name("unreachable")
+                .endpoint("namesrv:9876")
+                .build();
+        existing.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("1"))
+                .thenThrow(new IllegalStateException("connection refused"));
+        when(instanceRepository.deleteById(1L)).thenReturn(false);
+
+        assertThatThrownBy(() -> instanceService.deleteInstance(1L, true))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("InstanceVO not found: 1")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
+
+        verify(adminFactory, never()).release(any());
+        verifyNoInteractions(operationAuditService);
     }
 
     @Test

--- a/web/src/api/instance.test.ts
+++ b/web/src/api/instance.test.ts
@@ -22,6 +22,7 @@ import {
   createInstance,
   deleteInstance,
   getInstanceCapabilities,
+  isInstanceDeletePreflightUnavailable,
   listInstances,
   supportsApacheRuntime,
   updateInstance,
@@ -85,9 +86,9 @@ describe('instance API', () => {
     await expect(listInstances({ search: '   ' })).resolves.toEqual([instance]);
   });
 
-  it('sends the instance ID when deleting', async () => {
+  it('sends the instance name and normal preflight mode when deleting', async () => {
     mock.onPost('/instances/delete').reply((config) => {
-      expect(JSON.parse(config.data)).toEqual({ id: instance.name });
+      expect(JSON.parse(config.data)).toEqual({ id: instance.name, force: false });
       return [200, { code: 200, data: null }];
     });
 
@@ -114,5 +115,28 @@ describe('instance API', () => {
     expect(supportsApacheRuntime({})).toBe(true);
     expect(supportsApacheRuntime({ vendor: 'ALIYUN' })).toBe(false);
     expect(supportsApacheRuntime({ vendor: 'TENCENT' })).toBe(false);
+  });
+
+  it('serializes an explicit force-removal request', async () => {
+    mock.onPost('/instances/delete').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ id: instance.name, force: true });
+      return [200, { code: 200, data: null }];
+    });
+
+    await expect(deleteInstance(instance.name, true)).resolves.toBeUndefined();
+  });
+
+  it('recognizes only the stable unavailable-preflight error identifier', () => {
+    expect(
+      isInstanceDeletePreflightUnavailable({
+        response: { data: { errorCode: 'instance.delete.preflight_unavailable' } },
+      }),
+    ).toBe(true);
+    expect(
+      isInstanceDeletePreflightUnavailable({
+        response: { data: { errorCode: 'instance.delete.managed_resources_present' } },
+      }),
+    ).toBe(false);
+    expect(isInstanceDeletePreflightUnavailable(new Error('preflight unavailable'))).toBe(false);
   });
 });

--- a/web/src/api/instance.ts
+++ b/web/src/api/instance.ts
@@ -85,6 +85,23 @@ export interface InstanceCapabilities {
   capabilities: InstanceCapability[];
 }
 
+export const INSTANCE_DELETE_PREFLIGHT_UNAVAILABLE = 'instance.delete.preflight_unavailable';
+
+interface InstanceDeleteErrorLike {
+  response?: {
+    data?: {
+      errorCode?: unknown;
+    };
+  };
+}
+
+export function isInstanceDeletePreflightUnavailable(error: unknown): boolean {
+  return (
+    (error as InstanceDeleteErrorLike)?.response?.data?.errorCode ===
+    INSTANCE_DELETE_PREFLIGHT_UNAVAILABLE
+  );
+}
+
 // ─── Instance CRUD ──────────────────────────────────────────────
 export async function listInstances(query: InstanceQuery = {}) {
   const search = query.search?.trim();
@@ -120,8 +137,8 @@ export interface CloudImportResult {
   failed: string[];
 }
 
-export async function deleteInstance(instanceId: string) {
-  await client.post('/instances/delete', { id: instanceId });
+export async function deleteInstance(instanceId: string, force = false) {
+  await client.post('/instances/delete', { id: instanceId, force });
 }
 
 export interface BatchDeleteResult {

--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -368,7 +368,7 @@ describe('InstancePage', () => {
     const proxyName = await screen.findByText('production-proxy');
     await user.click(within(proxyName.closest('tr')!).getByRole('button', { name: /删除/ }));
     await waitFor(() =>
-      expect(instanceService.deleteInstance).toHaveBeenCalledWith('production-proxy'),
+      expect(instanceService.deleteInstance).toHaveBeenCalledWith('production-proxy', false),
     );
 
     const typeSelect = screen.getByRole('combobox');
@@ -384,6 +384,62 @@ describe('InstancePage', () => {
 
     await waitFor(() => expect(instanceService.listInstances).toHaveBeenCalledTimes(3));
     expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' });
+    confirmSpy.mockRestore();
+  });
+
+  it('offers force removal only after the deletion preflight is unavailable', async () => {
+    const user = userEvent.setup();
+    vi.mocked(instanceService.deleteInstance)
+      .mockRejectedValueOnce({
+        response: {
+          data: { errorCode: 'instance.delete.preflight_unavailable' },
+        },
+      })
+      .mockResolvedValueOnce();
+    const confirmations: Array<Parameters<typeof Modal.confirm>[0]> = [];
+    const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
+      confirmations.push(config);
+      void config.onOk?.();
+      return { destroy: vi.fn(), update: vi.fn() } as unknown as ReturnType<typeof Modal.confirm>;
+    });
+    renderPage();
+
+    const proxyName = await screen.findByText('production-proxy');
+    await user.click(within(proxyName.closest('tr')!).getByRole('button', { name: /删除/ }));
+
+    await waitFor(() =>
+      expect(instanceService.deleteInstance).toHaveBeenNthCalledWith(1, 'production-proxy', false),
+    );
+    await waitFor(() =>
+      expect(instanceService.deleteInstance).toHaveBeenNthCalledWith(2, 'production-proxy', true),
+    );
+    expect(confirmations).toHaveLength(2);
+    expect(confirmations[1].title).toContain('无法验证');
+    expect(confirmations[1].content).toContain('只会移除 Studio 中的实例记录');
+    confirmSpy.mockRestore();
+  });
+
+  it('does not expose force removal for a managed-resource conflict', async () => {
+    const user = userEvent.setup();
+    vi.mocked(instanceService.deleteInstance).mockRejectedValue({
+      response: {
+        data: { errorCode: 'instance.delete.managed_resources_present' },
+      },
+    });
+    const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
+      void config.onOk?.();
+      return { destroy: vi.fn(), update: vi.fn() } as unknown as ReturnType<typeof Modal.confirm>;
+    });
+    renderPage();
+
+    const proxyName = await screen.findByText('production-proxy');
+    await user.click(within(proxyName.closest('tr')!).getByRole('button', { name: /删除/ }));
+
+    await waitFor(() =>
+      expect(instanceService.deleteInstance).toHaveBeenCalledWith('production-proxy', false),
+    );
+    expect(instanceService.deleteInstance).toHaveBeenCalledTimes(1);
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
     confirmSpy.mockRestore();
   });
 

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -38,7 +38,11 @@ import { Plus, MagnifyingGlass } from '@phosphor-icons/react';
 import { EditOutlined, DeleteOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import type { SortOrder } from 'antd/es/table/interface';
-import type { Instance, InstanceQuery } from '../../api/instance';
+import {
+  isInstanceDeletePreflightUnavailable,
+  type Instance,
+  type InstanceQuery,
+} from '../../api/instance';
 import { listCloudCredentials, type CloudCredential } from '../../api/cloudCredential';
 import {
   listAliyunInstances,
@@ -405,10 +409,29 @@ const InstancePage = () => {
 
   const handleDelete = async (instance: Instance) => {
     try {
-      await deleteInstance(instance.name);
+      await deleteInstance(instance.name, false);
       await loadInstances();
       message.success('已删除');
     } catch (error) {
+      if (isInstanceDeletePreflightUnavailable(error)) {
+        Modal.confirm({
+          title: `无法验证 "${instance.name}" 的远端资源`,
+          content:
+            'Studio 无法确认该实例是否仍有 Topic 或消费组。只有在远端实例已停用、不可达或凭据失效时，才应继续。继续操作只会移除 Studio 中的实例记录，不会删除或验证远端 RocketMQ 资源。',
+          okText: '仅移除 Studio 记录',
+          okButtonProps: { danger: true },
+          onOk: async () => {
+            try {
+              await deleteInstance(instance.name, true);
+              await loadInstances();
+              message.success('已移除 Studio 实例记录');
+            } catch {
+              message.error('强制移除实例记录失败，请稍后重试');
+            }
+          },
+        });
+        return;
+      }
       message.error(describeApiError(error, '删除实例失败，请稍后重试'));
     }
   };

--- a/web/src/services/instanceService.ts
+++ b/web/src/services/instanceService.ts
@@ -145,12 +145,12 @@ export async function updateInstance(data: UpdateInstanceRequest): Promise<Insta
   return instanceApi.updateInstance(data);
 }
 
-export async function deleteInstance(instanceId: string): Promise<void> {
+export async function deleteInstance(instanceId: string, force = false): Promise<void> {
   if (isMockMode()) {
     const idx = mockInstances.findIndex((i) => i.name === instanceId);
     if (idx < 0) throw new Error(`Instance not found: ${instanceId}`);
     mockInstances.splice(idx, 1);
     return;
   }
-  return instanceApi.deleteInstance(instanceId);
+  return instanceApi.deleteInstance(instanceId, force);
 }


### PR DESCRIPTION
## Why

Studio protects instance deletion by querying the selected provider for current Topic and Consumer Group counts. That is the right default, but it also means a registration cannot be removed after its endpoint is decommissioned, its cloud instance is deleted, credentials expire, or the provider API is unavailable: the count call fails before the local repository delete is reached.

This change adds an explicit recovery path without weakening the managed-resource guard. It closes #2210.

## Rebase and identifier contract

The branch is rebased onto current `rocketmq-studio` trunk `c0bdaab9`.

The deletion flow follows the current trunk model:

- the frontend sends the instance's globally unique string `name`;
- `InstanceController` resolves that boundary identifier through `resolveInstanceId`;
- `InstanceService` and `InstanceRepository` continue to use the numeric `Long` primary key;
- successful normal and forced removals retain `removeDataSourceBindings(existing.getName())` before endpoint cleanup and audit.

No direct String primary-key access is reintroduced.

## Backend contract

Instance deletion uses an instance-specific request containing `id` and `force`. Here `id` is the external name-based identifier resolved by the controller before service invocation.

Every request, including `force=true`, still performs the provider preflight:

- verified zero Topics and zero Consumer Groups: delete normally;
- any confirmed managed resources: return HTTP 409 with `instance.delete.managed_resources_present`; force cannot bypass this result, even if the other inventory call is unavailable;
- unavailable preflight with a normal request: return HTTP 503 with `instance.delete.preflight_unavailable`;
- unavailable preflight with `force=true`: remove only the Studio registration.

The stable `errorCode` is added to business-error responses so clients do not parse English messages. Existing business errors continue to use the same HTTP/status code and message and omit `errorCode` when none is supplied.

Forced removals keep the repository race check, metrics data-source binding cleanup, and Apache AdminClient release path. Their successful audit detail includes:

- `forced=true`
- `preflight=unavailable`
- a bounded failure category based only on the exception class

Provider exception messages are intentionally not copied into the audit record or warning log because they may contain credentials, endpoint user-info, tokens, or unbounded SDK text.

## Frontend behavior

The instance API always serializes the deletion mode and always uses the instance's unique string name. The instance page first sends `force=false` after the existing confirmation.

Only an exact `instance.delete.preflight_unavailable` response opens a second destructive confirmation. The warning states that Studio could not verify remote resources and that continuing removes only the Studio record; it does not delete or validate the remote RocketMQ instance. Confirming sends `force=true` with the same name-based identifier.

Managed-resource conflicts and unrelated failures never expose the force path.

## Size

Production code and production-facing API/UI changes, excluding tests:

- 253 additions
- 24 deletions

The complete rebased PR, including regression tests:

- 561 additions
- 32 deletions

## Verification

Backend focused suite:

```text
mvn -Dtest=InstanceServiceTest,InstanceControllerTest,InstanceDeletionPreflightTest test
79 tests
0 failures
0 errors
BUILD SUCCESS
Checkstyle: 0 violations
```

Backend full suite:

```text
mvn test
1,479 tests
0 failures
0 errors
BUILD SUCCESS
Checkstyle: 0 violations
```

Frontend focused suite:

```text
npm test -- --run src/api/instance.test.ts src/pages/instance/__tests__/InstancePage.test.tsx src/services/instanceService.test.ts
3 test files
29 tests
all passed
```

Frontend full verification:

```text
npm test
94 test files
628 tests
all passed

npm run build
success

npm run lint
0 errors
1 pre-existing react-hooks warning in src/pages/instance/topic.tsx
```

`git diff --check` also passes.

The tests are deterministic unit/controller/UI tests. No live Broker, cloud-provider, or browser session is claimed.
