### PR TITLE
fix(cluster): isolate nested repository snapshots

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
@@ -70,7 +70,7 @@ public class ClusterRepositoryImpl implements ClusterRepository {
         // observe a partially updated snapshot (new config, old updatedAt).
         store.computeIfPresent(clusterId, (id, cluster) -> {
             ClusterVO updated = defensiveCopy(cluster);
-            updated.setConfig(config);
+            updated.setConfig(copyConfig(config));
             updated.setUpdatedAt(LocalDateTime.now());
             log.info("Config updated for cluster: {}", clusterId);
             return updated;
@@ -89,11 +89,15 @@ public class ClusterRepositoryImpl implements ClusterRepository {
                 .endpoint(cluster.getEndpoint())
                 .status(cluster.getStatus())
                 .version(cluster.getVersion())
-                // new ArrayList forces a fresh list even when the source is already immutable
-                // (List.copyOf would return the source reference for immutable inputs).
-                .brokers(cluster.getBrokers() == null ? null : new ArrayList<>(cluster.getBrokers()))
-                .proxies(cluster.getProxies() == null ? null : new ArrayList<>(cluster.getProxies()))
-                .nameServers(cluster.getNameServers() == null ? null : new ArrayList<>(cluster.getNameServers()))
+                .brokers(cluster.getBrokers() == null ? null : new ArrayList<>(cluster.getBrokers().stream()
+                        .map(this::copyBroker)
+                        .toList()))
+                .proxies(cluster.getProxies() == null ? null : new ArrayList<>(cluster.getProxies().stream()
+                        .map(this::copyProxy)
+                        .toList()))
+                .nameServers(cluster.getNameServers() == null ? null : new ArrayList<>(cluster.getNameServers().stream()
+                        .map(this::copyNameServer)
+                        .toList()))
                 .config(copyConfig(cluster.getConfig()))
                 .topicCount(cluster.getTopicCount())
                 .groupCount(cluster.getGroupCount())
@@ -103,6 +107,45 @@ public class ClusterRepositoryImpl implements ClusterRepository {
         copy.setCreatedAt(cluster.getCreatedAt());
         copy.setUpdatedAt(cluster.getUpdatedAt());
         return copy;
+    }
+
+    private BrokerVO copyBroker(BrokerVO broker) {
+        if (broker == null) {
+            return null;
+        }
+        return BrokerVO.builder()
+                .name(broker.getName())
+                .addr(broker.getAddr())
+                .version(broker.getVersion())
+                .status(broker.getStatus())
+                .diskUsage(broker.getDiskUsage())
+                .tpsIn(broker.getTpsIn())
+                .tpsOut(broker.getTpsOut())
+                .runtimeStatsAvailable(broker.isRuntimeStatsAvailable())
+                .build();
+    }
+
+    private ProxyVO copyProxy(ProxyVO proxy) {
+        if (proxy == null) {
+            return null;
+        }
+        return ProxyVO.builder()
+                .addr(proxy.getAddr())
+                .status(proxy.getStatus())
+                .connections(proxy.getConnections())
+                .grpcPort(proxy.getGrpcPort())
+                .remotingPort(proxy.getRemotingPort())
+                .build();
+    }
+
+    private NameServerVO copyNameServer(NameServerVO nameServer) {
+        if (nameServer == null) {
+            return null;
+        }
+        return NameServerVO.builder()
+                .addr(nameServer.getAddr())
+                .status(nameServer.getStatus())
+                .build();
     }
 
     private ClusterConfigVO copyConfig(ClusterConfigVO config) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.cluster.broker;
 
+import org.apache.rocketmq.studio.cluster.config.ClusterConfigVO;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -48,13 +49,37 @@ class ClusterRepositoryImplTest {
         ClusterVO first = repository.findById("cluster-001").orElseThrow();
         first.setName("mutated");
         first.getConfig().setFileReservedTime(1);
+        first.getBrokers().get(0).setName("mutated-broker");
+        first.getProxies().get(0).setAddr("mutated-proxy");
+        first.getNameServers().get(0).setAddr("mutated-nameserver");
+        first.getTpsHistory().set(0, 999);
 
         ClusterVO second = repository.findById("cluster-001").orElseThrow();
 
         // Mutating the returned copy must not affect the cached cluster.
         assertThat(second.getName()).isEqualTo("rmq-cluster-prod");
         assertThat(first.getBrokers()).isNotSameAs(second.getBrokers());
+        assertThat(first.getBrokers().get(0)).isNotSameAs(second.getBrokers().get(0));
+        assertThat(second.getBrokers().get(0).getName()).isEqualTo("broker-a");
+        assertThat(second.getProxies().get(0).getAddr()).isEqualTo("10.0.0.10:8081");
+        assertThat(second.getNameServers().get(0).getAddr()).isEqualTo("10.0.0.20:9876");
+        assertThat(first.getTpsHistory()).isNotSameAs(second.getTpsHistory());
+        assertThat(second.getTpsHistory().get(0)).isEqualTo(1200);
         assertThat(second.getConfig()).isNotSameAs(first.getConfig());
         assertThat(second.getConfig().getFileReservedTime()).isEqualTo(72);
+    }
+
+    @Test
+    void updateConfigShouldNotRetainCallerOwnedObject() {
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(true);
+        ClusterConfigVO config = ClusterConfigVO.builder()
+                .fileReservedTime(24)
+                .build();
+
+        repository.updateConfig("cluster-001", config);
+        config.setFileReservedTime(1);
+
+        assertThat(repository.findById("cluster-001").orElseThrow().getConfig().getFileReservedTime())
+                .isEqualTo(24);
     }
 }


### PR DESCRIPTION
## Summary

- deep-copy broker, proxy, and NameServer objects when returning cluster snapshots
- copy incoming cluster configuration before storing it
- cover nested read mutation, TPS history isolation, and update-input aliasing with regression tests

## Root cause

`ClusterRepositoryImpl` created fresh list containers but reused their mutable elements. It also assigned the caller-owned `ClusterConfigVO` directly during updates. Callers could therefore change cached repository state without invoking another repository operation.

This complements #1528/#1531, which isolated configuration objects returned by reads; it does not change that earlier fix.

## Validation

- `mvn -f server/pom.xml -Dtest=ClusterRepositoryImplTest test` — 4 tests passed
- Maven validate lifecycle — 0 Checkstyle violations

Closes #2212