### PR TITLE
fix(provider): reject duplicate vendor registrations

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProviderRegistry.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProviderRegistry.java
@@ -37,9 +37,21 @@ public class InstanceProviderRegistry {
     public InstanceProviderRegistry(List<InstanceProvider> providerList,
                                     List<CloudCatalogProvider> catalogList,
                                     InstanceRepository instanceRepository) {
-        providerList.forEach(provider -> providers.put(provider.vendor(), provider));
-        catalogList.forEach(catalog -> catalogs.put(catalog.vendor(), catalog));
+        providerList.forEach(provider -> registerProvider(provider.vendor(), provider));
+        catalogList.forEach(catalog -> registerCatalog(catalog.vendor(), catalog));
         this.instanceRepository = instanceRepository;
+    }
+
+    private void registerProvider(InstanceVendor vendor, InstanceProvider provider) {
+        if (providers.putIfAbsent(vendor, provider) != null) {
+            throw new IllegalStateException("Duplicate instance provider registered for vendor " + vendor);
+        }
+    }
+
+    private void registerCatalog(InstanceVendor vendor, CloudCatalogProvider catalog) {
+        if (catalogs.putIfAbsent(vendor, catalog) != null) {
+            throw new IllegalStateException("Duplicate cloud catalog provider registered for vendor " + vendor);
+        }
     }
 
     public InstanceProvider forVendor(InstanceVendor vendor) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/InstanceProviderRegistryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/InstanceProviderRegistryTest.java
@@ -101,9 +101,44 @@ class InstanceProviderRegistryTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
     }
 
+    @Test
+    void constructorShouldRejectDuplicateProvidersForVendorTest() {
+        InstanceProvider duplicate = stubProvider(InstanceVendor.APACHE);
+
+        assertThatThrownBy(() -> new InstanceProviderRegistry(
+                List.of(apacheProvider, duplicate), List.of(), instanceRepository))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Duplicate instance provider registered for vendor APACHE");
+    }
+
+    @Test
+    void constructorShouldRejectDuplicateCatalogsForVendorTest() {
+        CloudCatalogProvider first = stubCatalog(InstanceVendor.ALIYUN);
+        CloudCatalogProvider duplicate = stubCatalog(InstanceVendor.ALIYUN);
+
+        assertThatThrownBy(() -> new InstanceProviderRegistry(
+                List.of(apacheProvider), List.of(first, duplicate), instanceRepository))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Duplicate cloud catalog provider registered for vendor ALIYUN");
+    }
+
+    @Test
+    void catalogForShouldReturnRegisteredCatalogTest() {
+        CloudCatalogProvider catalog = stubCatalog(InstanceVendor.ALIYUN);
+        registry = new InstanceProviderRegistry(List.of(apacheProvider), List.of(catalog), instanceRepository);
+
+        assertThat(registry.catalogFor(InstanceVendor.ALIYUN)).isSameAs(catalog);
+    }
+
     private InstanceProvider stubProvider(InstanceVendor vendor) {
         InstanceProvider provider = mock(InstanceProvider.class);
         when(provider.vendor()).thenReturn(vendor);
         return provider;
+    }
+
+    private CloudCatalogProvider stubCatalog(InstanceVendor vendor) {
+        CloudCatalogProvider catalog = mock(CloudCatalogProvider.class);
+        when(catalog.vendor()).thenReturn(vendor);
+        return catalog;
     }
 }


### PR DESCRIPTION
## Summary

- reject duplicate `InstanceProvider` registrations for the same vendor
- apply the same startup validation to `CloudCatalogProvider` registrations
- report stable error messages that identify the conflicting vendor
- test normal catalog lookup and both duplicate-registration paths

## Root cause

The registry populated `EnumMap` instances with unconditional `put` calls. When multiple Spring beans declared the same vendor, the last injected bean silently won, making provider selection depend on injection order and hiding an invalid application configuration.

## Validation

- `mvn -f server/pom.xml -Dtest=InstanceProviderRegistryTest test` — 10 tests passed
- Maven validate lifecycle — 0 Checkstyle violations

Closes #2213