### PR TITLE
fix(cluster): tolerate malformed topology entries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProvider.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -110,15 +111,24 @@ public class RealClusterProvider implements ClusterProvider {
                 clusterInfo.getClusterAddrTable() == null ? Map.of() : clusterInfo.getClusterAddrTable();
 
         if (clusterAddrTable.isEmpty()) {
-            return List.of(toClusterVO(namesrvAddr, "DefaultCluster", brokerAddrTable.values()));
+            List<BrokerData> brokers = brokerAddrTable.values().stream()
+                    .filter(Objects::nonNull)
+                    .toList();
+            return brokers.isEmpty()
+                    ? List.of()
+                    : List.of(toClusterVO(namesrvAddr, "DefaultCluster", brokers));
         }
 
         return clusterAddrTable.entrySet().stream()
+                .filter(entry -> entry.getKey() != null && !entry.getKey().isBlank())
+                .filter(entry -> entry.getValue() != null)
                 .sorted(Map.Entry.comparingByKey())
                 .map(entry -> toClusterVO(namesrvAddr, entry.getKey(), entry.getValue().stream()
+                        .filter(Objects::nonNull)
                         .map(brokerAddrTable::get)
-                        .filter(java.util.Objects::nonNull)
+                        .filter(Objects::nonNull)
                         .toList()))
+                .filter(cluster -> !cluster.getBrokers().isEmpty())
                 .toList();
     }
 
@@ -158,7 +168,10 @@ public class RealClusterProvider implements ClusterProvider {
         if (data.getBrokerAddrs() != null) {
             addr = data.getBrokerAddrs().get(MixAll.MASTER_ID);
             if (addr == null) {
-                addr = data.getBrokerAddrs().values().stream().findFirst().orElse(null);
+                addr = data.getBrokerAddrs().values().stream()
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .orElse(null);
             }
         }
         return BrokerVO.builder()

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProviderTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -131,6 +132,45 @@ class RealClusterProviderTest {
     @Test
     void describeClustersShouldTolerateNullClusterInfo() throws Exception {
         stubClusterInfo("10.0.0.1:9876", null);
+
+        assertThat(provider.describeClusters("10.0.0.1:9876")).isEmpty();
+    }
+
+    @Test
+    void describeClustersShouldSkipMalformedTopologyEntries() throws Exception {
+        ClusterInfo info = new ClusterInfo();
+        HashMap<String, BrokerData> brokers = new HashMap<>();
+        brokers.put("broker-a", new BrokerData("ValidCluster", "broker-a",
+                new HashMap<>(java.util.Map.of(0L, "10.0.0.11:10911"))));
+        brokers.put("broken", null);
+        info.setBrokerAddrTable(brokers);
+
+        HashSet<String> brokerNames = new HashSet<>();
+        brokerNames.add("broker-a");
+        brokerNames.add("missing");
+        brokerNames.add(null);
+        HashMap<String, Set<String>> clusters = new HashMap<>();
+        clusters.put("ValidCluster", brokerNames);
+        clusters.put("NullSetCluster", null);
+        clusters.put(null, Set.of("broker-a"));
+        info.setClusterAddrTable(clusters);
+        stubClusterInfo("10.0.0.1:9876", info);
+
+        List<ClusterVO> result = provider.describeClusters("10.0.0.1:9876");
+
+        assertThat(result).extracting(ClusterVO::getName).containsExactly("ValidCluster");
+        assertThat(result.get(0).getBrokers()).extracting(BrokerVO::getName)
+                .containsExactly("broker-a");
+    }
+
+    @Test
+    void describeClustersShouldReturnEmptyWhenTopologyHasNoValidBrokers() throws Exception {
+        ClusterInfo info = new ClusterInfo();
+        HashMap<String, BrokerData> brokers = new HashMap<>();
+        brokers.put("broken", null);
+        info.setBrokerAddrTable(brokers);
+        info.setClusterAddrTable(new HashMap<>());
+        stubClusterInfo("10.0.0.1:9876", info);
 
         assertThat(provider.describeClusters("10.0.0.1:9876")).isEmpty();
     }


### PR DESCRIPTION
## Summary

Cluster discovery now tolerates malformed entries in a NameServer topology response without losing valid clusters. Null cluster keys/sets, null or missing broker references, and null fallback addresses are skipped at the response boundary.

When a response contains no valid broker topology, discovery returns an empty result instead of constructing a misleading empty cluster or throwing a runtime exception.

## Testing

- `mvn -Dtest=RealClusterProviderTest test` (9 tests passed)
- Maven Checkstyle validation (0 violations)

Fixes #2219
