### PR TITLE
[ISSUE #2118] Mark incomplete dashboard topology unavailable

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -112,6 +112,23 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             totalClusters = clusterAddrTable.size();
             totalBrokers = brokerAddrTable.size();
 
+            Set<String> topologyUnavailableClusters = new HashSet<>();
+            for (Map.Entry<String, Set<String>> clusterEntry : clusterAddrTable.entrySet()) {
+                Set<String> brokerNames = clusterEntry.getValue();
+                if (brokerNames == null || brokerNames.isEmpty()) {
+                    topologyUnavailableClusters.add(clusterEntry.getKey());
+                    continue;
+                }
+                boolean incomplete = brokerNames.stream().anyMatch(brokerName -> {
+                    BrokerData brokerData = brokerAddrTable.get(brokerName);
+                    return brokerData == null || brokerData.getBrokerAddrs() == null
+                            || brokerData.getBrokerAddrs().get(0L) == null;
+                });
+                if (incomplete) {
+                    topologyUnavailableClusters.add(clusterEntry.getKey());
+                }
+            }
+
             // Collect all unique broker addresses (master only, brokerId=0)
             Set<String> masterAddrs = new HashSet<>();
 
@@ -242,7 +259,8 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 long clusterTpsIn = 0;
                 long clusterTpsOut = 0;
                 String version = "unknown";
-                boolean runtimeMetricsUnavailable = topicCountsUnavailableClusters.contains(clusterName)
+                boolean runtimeMetricsUnavailable = topologyUnavailableClusters.contains(clusterName)
+                        || topicCountsUnavailableClusters.contains(clusterName)
                         || groupCountsUnavailableClusters.contains(clusterName);
 
                 for (String brokerName : brokerNames) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -331,6 +331,7 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getStats()).isNotNull();
         assertThat(dashboard.getClusters()).hasSize(1);
         assertThat(dashboard.getClusters().get(0).getBrokers()).isZero();
+        assertThat(dashboard.getClusters().get(0).getStatus()).isEqualTo(ClusterStatus.warning);
     }
 
     @Test
@@ -353,6 +354,7 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getClusters().get(0).getBrokers()).isZero();
         assertThat(dashboard.getStats().getTotalClusters()).isEqualTo(1);
         assertThat(dashboard.getStats().getTotalBrokers()).isZero();
+        assertThat(dashboard.getStats().getHealthyClusters()).isZero();
     }
 
     @Test
@@ -428,6 +430,7 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getClusters()).singleElement().satisfies(cluster -> {
             assertThat(cluster.getName()).isEqualTo("cluster-without-members");
             assertThat(cluster.getBrokers()).isZero();
+            assertThat(cluster.getStatus()).isEqualTo(ClusterStatus.warning);
         });
     }
 


### PR DESCRIPTION
## Summary

Dashboard health now treats a cluster as unavailable when topology discovery is incomplete, including empty broker membership, missing broker metadata, and missing master addresses. The total and unavailable counts therefore no longer report a partially discovered cluster as healthy.

## Verification

- `mvn -Dtest=RocketMQDashboardProviderTest test`
- `mvn -DskipTests checkstyle:check`
- `git diff --check`

Fixes #2118
