### PR TITLE
[ISSUE #1972] Fix remote deployment bootstrap integrity

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -12,6 +12,12 @@ REMOTE_PATH=/opt/rocketmq-studio
 # Frontend public port
 PUBLIC_PORT=6789
 
+# Remote server deployments require an explicit persistent datasource.
+SPRING_DATASOURCE_URL=jdbc:mysql://mysql-host:3306/rocketmq?useSSL=false&serverTimezone=UTC
+SPRING_DATASOURCE_USERNAME=rocketmq
+SPRING_DATASOURCE_PASSWORD=change-me
+STUDIO_ROCKETMQ_NAMESRV_ADDR=nameserver-host:9876
+
 # Login protection is disabled by default for local development.
 # Set STUDIO_AUTH_LOGIN_REQUIRED=true and provide credentials in shared environments.
 STUDIO_AUTH_LOGIN_REQUIRED=false

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,9 +24,17 @@ PUBLIC_PORT=8080
 # 可选：自定义宿主机 Maven 缓存和构建镜像
 MAVEN_CACHE_DIR=/home/your-user/.m2
 MAVEN_IMAGE=maven:3.9.9-eclipse-temurin-21
+
+# Required for remote server deployment: use a persistent database.
+SPRING_DATASOURCE_URL=jdbc:mysql://mysql-host:3306/rocketmq?useSSL=false&serverTimezone=UTC
+SPRING_DATASOURCE_USERNAME=rocketmq
+SPRING_DATASOURCE_PASSWORD=change-me
+STUDIO_ROCKETMQ_NAMESRV_ADDR=nameserver-host:9876
 ```
 
 `MAVEN_CACHE_DIR` 默认为当前用户的 `~/.m2`。如果其中存在 `settings.xml`，构建容器也会自动使用该配置。
+`server` 与 `all` 远程部署会强制启用 `prod` profile，并在构建前校验数据库配置，避免容器误用
+开发环境的内存数据库。仅部署 `web` 时不要求数据库变量。
 
 ## 本地 Docker Compose
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -51,6 +51,12 @@ check_prereqs() {
   log "前置条件通过"
 }
 
+validate_server_config() {
+  [[ -n "${SPRING_DATASOURCE_URL:-}" ]] || err "SPRING_DATASOURCE_URL 未配置，远程后端必须使用持久化数据库"
+  [[ -n "${SPRING_DATASOURCE_USERNAME:-}" ]] || err "SPRING_DATASOURCE_USERNAME 未配置"
+  [[ -n "${SPRING_DATASOURCE_PASSWORD:-}" ]] || err "SPRING_DATASOURCE_PASSWORD 未配置"
+}
+
 # ─── 构建镜像 ───
 build_server() {
   info "在 Maven 容器中构建 server（复用宿主机缓存: $MAVEN_CACHE_DIR）..."
@@ -135,6 +141,11 @@ deploy_remote() {
         --name rocketmq-server \
         --network $NETWORK \
         --restart unless-stopped \
+        -e SPRING_PROFILES_ACTIVE=prod \
+        -e SPRING_DATASOURCE_URL="${SPRING_DATASOURCE_URL}" \
+        -e SPRING_DATASOURCE_USERNAME="${SPRING_DATASOURCE_USERNAME}" \
+        -e SPRING_DATASOURCE_PASSWORD="${SPRING_DATASOURCE_PASSWORD}" \
+        -e STUDIO_ROCKETMQ_NAMESRV_ADDR="${STUDIO_ROCKETMQ_NAMESRV_ADDR:-}" \
         -e STUDIO_AUTH_LOGIN_REQUIRED=\"${STUDIO_AUTH_LOGIN_REQUIRED:-true}\" \
         -e STUDIO_AUTH_ADMIN_USERNAME=\"${STUDIO_AUTH_ADMIN_USERNAME:-}\" \
         -e STUDIO_AUTH_ADMIN_PASSWORD=\"${STUDIO_AUTH_ADMIN_PASSWORD:-}\" \
@@ -197,6 +208,10 @@ main() {
   echo "═══════════════════════════════════════════"
   echo ""
 
+  if [[ "$TARGET" == "all" || "$TARGET" == "server" ]]; then
+    validate_server_config
+  fi
+
   check_prereqs
 
   case "$TARGET" in
@@ -212,5 +227,7 @@ main() {
   cleanup
 }
 
-trap cleanup EXIT
-main
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  trap cleanup EXIT
+  main "$@"
+fi

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -182,17 +182,30 @@ verify() {
   status=$(ssh "$REMOTE" "podman ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'" 2>&1)
   echo "$status"
 
-  echo ""
-  local http_code
-  http_code=$(ssh "$REMOTE" "curl -sf -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:${PUBLIC_PORT:-6789}" 2>/dev/null || echo "000")
-  if [[ "$http_code" == "200" ]]; then
+  if [[ "$TARGET" == "all" || "$TARGET" == "server" ]]; then
+    echo ""
+    ssh "$REMOTE" \
+      "podman exec rocketmq-server curl -fsS --max-time 5 http://localhost:8888/actuator/health >/dev/null" \
+      || err "后端健康检查失败"
+    log "后端健康检查通过"
+  fi
+
+  if [[ "$TARGET" == "all" || "$TARGET" == "web" ]]; then
+    echo ""
+    local http_code
+    http_code=$(ssh "$REMOTE" \
+      "curl -sf -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:${PUBLIC_PORT:-6789}" \
+      2>/dev/null || echo "000")
+    [[ "$http_code" == "200" ]] || err "前端返回 HTTP $http_code"
     log "前端响应正常 (HTTP $http_code)"
-  else
-    warn "前端返回 HTTP $http_code"
   fi
 
   echo ""
-  log "部署完成 → http://${REMOTE_HOST}:${PUBLIC_PORT:-6789}"
+  if [[ "$TARGET" == "server" ]]; then
+    log "后端部署完成"
+  else
+    log "部署完成 → http://${REMOTE_HOST}:${PUBLIC_PORT:-6789}"
+  fi
 }
 
 # ─── 清理临时文件 ───

--- a/deploy/deploy_test.sh
+++ b/deploy/deploy_test.sh
@@ -19,4 +19,34 @@ SPRING_DATASOURCE_USERNAME=rocketmq
 SPRING_DATASOURCE_PASSWORD=secret
 validate_server_config
 
+sleep() { :; }
+ssh() {
+  local command="${*: -1}"
+  if [[ "$command" == *"podman ps"* ]]; then
+    echo "rocketmq-server Up"
+  elif [[ "$command" == *"actuator/health"* ]]; then
+    return "${SERVER_HEALTH_EXIT:-0}"
+  elif [[ "$command" == *"curl -sf -o"* ]]; then
+    printf '%s' "${WEB_HTTP_CODE:-200}"
+  fi
+}
+
+TARGET=server
+SERVER_HEALTH_EXIT=0
+verify >/dev/null
+
+if (SERVER_HEALTH_EXIT=1; verify >/dev/null 2>&1); then
+  echo "expected failed server health check to fail deployment verification" >&2
+  exit 1
+fi
+
+TARGET=web
+WEB_HTTP_CODE=200
+verify >/dev/null
+
+if (WEB_HTTP_CODE=503; verify >/dev/null 2>&1); then
+  echo "expected non-200 web response to fail deployment verification" >&2
+  exit 1
+fi
+
 echo "deploy configuration validation passed"

--- a/deploy/deploy_test.sh
+++ b/deploy/deploy_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Provide the minimum target configuration needed to source the script.
+REMOTE_HOST=test-host
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/deploy.sh"
+
+if (unset SPRING_DATASOURCE_URL SPRING_DATASOURCE_USERNAME SPRING_DATASOURCE_PASSWORD
+    validate_server_config >/dev/null 2>&1); then
+  echo "expected missing datasource configuration to fail" >&2
+  exit 1
+fi
+
+SPRING_DATASOURCE_URL=jdbc:mysql://db:3306/rocketmq
+SPRING_DATASOURCE_USERNAME=rocketmq
+SPRING_DATASOURCE_PASSWORD=secret
+validate_server_config
+
+echo "deploy configuration validation passed"

--- a/deploy/rocketmq/README.md
+++ b/deploy/rocketmq/README.md
@@ -30,6 +30,8 @@ cd deploy/rocketmq
 ./build.sh
 
 # 2. 拉起集群与收发客户端
+# 此 Compose 项目会自动创建名为 rocketmq_net 的共享网络；Studio 的 Compose
+# 配置会以 external 网络方式加入它，因此首次启动无需手工执行 docker network create。
 docker compose up -d
 
 # 3. 观察收发日志（1 TPS）

--- a/deploy/rocketmq/docker-compose.yml
+++ b/deploy/rocketmq/docker-compose.yml
@@ -111,7 +111,6 @@ services:
 networks:
   default:
     name: rocketmq_net
-    external: true
 
 volumes:
   broker-0-store:


### PR DESCRIPTION
## Summary

- require persistent datasource configuration for remote server deployments
- let the RocketMQ Compose project create its named network on a fresh host
- verify only the selected deployment target and return non-zero on failed health checks
- avoid reporting a frontend URL after a server-only deployment
- add shell regression coverage for server and web target verification

The changes form one deployment bootstrap and verification contract, consolidated in line with #2107.

## Verification

- `bash -n deploy/deploy.sh deploy/deploy_test.sh`
- `bash deploy/deploy_test.sh`
- `docker compose -f deploy/rocketmq/docker-compose.yml config --quiet`
- `git diff --check`

Fixes #1972
