### PR TITLE
[ISSUE #2226] Clear stale LiteTopic quota on refresh failure

### DIFF
--- a/web/src/pages/studio/LiteTopic.tsx
+++ b/web/src/pages/studio/LiteTopic.tsx
@@ -166,6 +166,9 @@ const LiteTopicPage: React.FC = () => {
 
       if (quotaResult.status === 'fulfilled') {
         setQuota(quotaResult.value);
+      } else {
+        setQuota(null);
+        messageRef.current.warning(translationRef.current('liteTopic.fetchQuotaFailed'));
       }
 
       if (listResult.status === 'fulfilled') {

--- a/web/src/pages/studio/__tests__/LiteTopic.test.tsx
+++ b/web/src/pages/studio/__tests__/LiteTopic.test.tsx
@@ -465,4 +465,25 @@ describe('LiteTopic Page', () => {
     expect(screen.queryByText('old-*')).not.toBeInTheDocument();
     expect(screen.queryByText('90 / 100')).not.toBeInTheDocument();
   });
+
+  it('clears stale quota while preserving a successfully refreshed topic list', async () => {
+    apiMocks.queryLiteTopicQuota
+      .mockResolvedValueOnce(createQuota(90))
+      .mockRejectedValueOnce(new Error('quota unavailable'));
+    apiMocks.queryLiteTopicList
+      .mockResolvedValueOnce([{ namespace: 'default', topicPattern: 'old-*' }])
+      .mockResolvedValueOnce([{ namespace: 'default', topicPattern: 'fresh-*' }]);
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(await screen.findByText('old-*')).toBeInTheDocument();
+    expect(screen.getByText('90 / 100')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /刷新/ }));
+
+    expect(await screen.findByText('fresh-*')).toBeInTheDocument();
+    expect(screen.queryByText('old-*')).not.toBeInTheDocument();
+    expect(screen.queryByText('90 / 100')).not.toBeInTheDocument();
+    expect(await screen.findByText('获取配额信息失败')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

When a LiteTopic refresh gets a fresh Topic list but the quota request fails, the page now clears the previous quota and displays the existing localized quota warning. The successfully refreshed Topic list remains available, so partial failure no longer combines fresh resources with stale quota data.

## Verification

- `npm test -- src/pages/studio/__tests__/LiteTopic.test.tsx`
- targeted ESLint and Prettier checks
- `git diff --check`

Fixes #2226
