### PR TITLE
[ISSUE #2172] Reject unsupported LLM test providers

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
@@ -134,12 +134,16 @@ public class LlmConfigService {
         if (!LlmConfigVO.ENGINE_HTTP.equalsIgnoreCase(normalized.normalizeEngine())) {
             return testCliEngine(normalized.normalizeEngine());
         }
-        if (llmClient.supports(normalized)) {
-            try {
-                llmClient.listModels(normalized);
-            } catch (LlmGatewayException exception) {
-                return LlmOperationResultVO.failure(exception.getCode(), exception.getMessage(), exception.getHint());
-            }
+        if (!llmClient.supports(normalized)) {
+            return LlmOperationResultVO.failure(
+                    "llm.config.unsupported_provider",
+                    "LLM provider is not supported by the OpenAI-compatible gateway",
+                    "Use one of: openai, deepseek, tongyi, ollama.");
+        }
+        try {
+            llmClient.listModels(normalized);
+        } catch (LlmGatewayException exception) {
+            return LlmOperationResultVO.failure(exception.getCode(), exception.getMessage(), exception.getHint());
         }
         return LlmOperationResultVO.success("Connection successful");
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
@@ -327,6 +327,8 @@ class LlmConfigServiceTest {
 
     @Test
     void testConfigShouldAllowOllamaWithoutApiKey() {
+        when(llmClient.supports(any())).thenReturn(true);
+
         LlmOperationResultVO result = llmConfigService.testConfig(LlmConfigVO.builder()
                 .provider("ollama")
                 .engine("http")
@@ -336,6 +338,31 @@ class LlmConfigServiceTest {
 
         assertThat(result.getStatus()).isZero();
         assertThat(result.getMsg()).isEqualTo("Connection successful");
+    }
+
+    @Test
+    void testConfigShouldRejectHttpProvidersUnsupportedByRuntimeGateway() {
+        LlmOperationResultVO azure = llmConfigService.testConfig(LlmConfigVO.builder()
+                .provider("azure")
+                .engine("http")
+                .apiKey("azure-key")
+                .apiBase("https://example.openai.azure.com")
+                .deploymentName("production-gpt")
+                .model("gpt-4o")
+                .build());
+        LlmOperationResultVO bedrock = llmConfigService.testConfig(LlmConfigVO.builder()
+                .provider("bedrock")
+                .engine("http")
+                .apiKey("bedrock-key")
+                .apiBase("https://bedrock-runtime.us-east-1.amazonaws.com")
+                .model("anthropic.claude-3-sonnet")
+                .build());
+
+        assertThat(azure.getStatus()).isEqualTo(1);
+        assertThat(azure.getCode()).isEqualTo("llm.config.unsupported_provider");
+        assertThat(bedrock.getStatus()).isEqualTo(1);
+        assertThat(bedrock.getCode()).isEqualTo("llm.config.unsupported_provider");
+        verify(llmClient, never()).listModels(any());
     }
 
     @Test


### PR DESCRIPTION
## Summary

LLM configuration tests now reject HTTP providers that the runtime OpenAI-compatible gateway does not support. Azure OpenAI and Amazon Bedrock can no longer pass a connectivity probe and be saved as apparently valid configurations that later fail every runtime request.

Supported providers keep the existing model-list connectivity check and structured error mapping.

## Verification

- `mvn -Dtest=LlmConfigServiceTest test`
- `mvn -DskipTests checkstyle:check`
- `git diff --check`

Fixes #2172
