### PR TITLE
[ISSUE #2227] Tolerate null Aliyun collection rows

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
@@ -158,6 +158,9 @@ public class AliyunInstanceProvider implements InstanceProvider {
         }
         List<TopicVO> topics = new ArrayList<>();
         for (ListTopicsResponseBody.List item : all) {
+            if (item == null) {
+                continue;
+            }
             TopicVO vo = AliyunConverters.toTopicVO(item, instanceId);
             if (matchesType(type, vo)) {
                 topics.add(vo);
@@ -230,6 +233,9 @@ public class AliyunInstanceProvider implements InstanceProvider {
             return consumers;
         }
         for (ListTopicSubscriptionsResponseBody.Data item : data) {
+            if (item == null) {
+                continue;
+            }
             consumers.add(AliyunConverters.toTopicConsumerVO(item));
         }
         return consumers;
@@ -263,6 +269,9 @@ public class AliyunInstanceProvider implements InstanceProvider {
         }
         List<ConsumerGroupVO> groups = new ArrayList<>();
         for (ListConsumerGroupsResponseBody.List item : all) {
+            if (item == null) {
+                continue;
+            }
             groups.add(AliyunConverters.toConsumerGroupVO(item, instanceId));
         }
         return groups;
@@ -359,6 +368,9 @@ public class AliyunInstanceProvider implements InstanceProvider {
             return subscriptions;
         }
         for (ListConsumerGroupSubscriptionsResponseBody.Data item : data) {
+            if (item == null) {
+                continue;
+            }
             subscriptions.add(AliyunConverters.toSubscriptionEntry(item));
         }
         return subscriptions;
@@ -418,6 +430,9 @@ public class AliyunInstanceProvider implements InstanceProvider {
                 break;
             }
             for (ListMessagesResponseBody.List item : list) {
+                if (item == null) {
+                    continue;
+                }
                 MessageRecordVO vo = AliyunConverters.toMessageRecord(item);
                 if (!StringUtils.hasText(tag) || tag.equals(vo.getTag())) {
                     records.add(vo);

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -101,6 +101,7 @@ class AliyunInstanceProviderTest {
         stubCallThrough();
         ListTopicsResponse response = topicsResponse(
                 topicRow("topic-normal", "NORMAL"),
+                null,
                 topicRow("topic-fifo", "FIFO"),
                 topicRow("topic-mystery", "MYSTERY"));
         when(asyncClient.listTopics(any(ListTopicsRequest.class)))
@@ -131,12 +132,13 @@ class AliyunInstanceProviderTest {
                 .statusCode(200)
                 .body(ListConsumerGroupsResponseBody.builder()
                         .data(ListConsumerGroupsResponseBody.Data.builder()
-                                .list(List.of(ListConsumerGroupsResponseBody.List.builder()
-                                        .consumerGroupId("GID_test")
-                                        .messageModel("Clustering")
-                                        .status("RUNNING")
-                                        .remark("test group")
-                                        .build()))
+                                .list(java.util.Arrays.asList(null,
+                                        ListConsumerGroupsResponseBody.List.builder()
+                                                .consumerGroupId("GID_test")
+                                                .messageModel("Clustering")
+                                                .status("RUNNING")
+                                                .remark("test group")
+                                                .build()))
                                 .pageNumber(1L)
                                 .pageSize(100L)
                                 .totalCount(1L)
@@ -198,7 +200,8 @@ class AliyunInstanceProviderTest {
                 .statusCode(200)
                 .body(ListMessagesResponseBody.builder()
                         .data(ListMessagesResponseBody.Data.builder()
-                                .list(List.of(
+                                .list(java.util.Arrays.asList(
+                                        null,
                                         ListMessagesResponseBody.List.builder()
                                                 .messageId("msg-1")
                                                 .topicName("topic-a")
@@ -455,7 +458,7 @@ class AliyunInstanceProviderTest {
                 .statusCode(200)
                 .body(ListTopicsResponseBody.builder()
                         .data(ListTopicsResponseBody.Data.builder()
-                                .list(List.of(rows))
+                                .list(java.util.Arrays.asList(rows))
                                 .pageNumber(1L)
                                 .pageSize(100L)
                                 .totalCount((long) rows.length)


### PR DESCRIPTION
## Summary

Aliyun provider collection boundaries now skip null SDK rows consistently across Topic lists, Topic consumers, Consumer Groups, subscriptions, and message query results. Valid neighboring entries preserve their original order and conversion.

## Verification

- `mvn -Dtest=AliyunInstanceProviderTest test`
- `mvn -DskipTests checkstyle:check`
- `git diff --check`

Fixes #2227
