### PR TITLE
[ISSUE #2229] Prevent stale Producer connection queries

### DIFF
--- a/web/src/pages/studio/Producer.tsx
+++ b/web/src/pages/studio/Producer.tsx
@@ -64,6 +64,7 @@ const ProducerPage = () => {
   const { message } = App.useApp();
   const fetchTopicFailedMessage = t('producer.fetchTopicFailed');
   const queryRequestIdRef = useRef(0);
+  const queryInFlightRef = useRef<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -87,6 +88,7 @@ const ProducerPage = () => {
 
   const handleInstanceChange = (instanceId: string) => {
     queryRequestIdRef.current += 1;
+    queryInFlightRef.current = null;
     setSelectedInstanceId(instanceId);
     setTopicList([]);
     setProducerGroups([]);
@@ -152,11 +154,15 @@ const ProducerPage = () => {
   }, [selectedInstanceId]);
 
   const onFinish = async (values: { selectedTopic: string; producerGroup: string }) => {
+    if (queryInFlightRef.current !== null) return;
     if (!selectedInstanceId) {
       message.error('Select an instance before querying producer connections.');
       return;
     }
     const requestId = ++queryRequestIdRef.current;
+    queryInFlightRef.current = requestId;
+    setConnectionList([]);
+    setConnectionSummary(null);
     setLoading(true);
     try {
       const result = await queryProducerConnection(
@@ -176,6 +182,9 @@ const ProducerPage = () => {
         message.error(t('producer.fetchConnectionFailed'));
       }
     } finally {
+      if (queryInFlightRef.current === requestId) {
+        queryInFlightRef.current = null;
+      }
       if (requestId === queryRequestIdRef.current) {
         setLoading(false);
       }

--- a/web/src/pages/studio/__tests__/Producer.test.tsx
+++ b/web/src/pages/studio/__tests__/Producer.test.tsx
@@ -319,4 +319,66 @@ describe('ProducerPage', () => {
     expect(within(container).queryByText('producer-1')).not.toBeInTheDocument();
     expect(within(container).queryByText('order-events')).not.toBeInTheDocument();
   });
+
+  it('clears stale results when a new producer query fails', async () => {
+    const user = userEvent.setup();
+    vi.mocked(queryProducerConnection)
+      .mockResolvedValueOnce(
+        producerResult([
+          {
+            clientId: 'producer-1',
+            clientAddr: '192.168.1.10',
+            language: 'JAVA',
+            versionDesc: '5.1.0',
+          },
+        ]),
+      )
+      .mockRejectedValueOnce(new Error('broker unavailable'));
+    renderWithProviders(<ProducerPage />);
+
+    await waitFor(() => expect(fetchTopicList).toHaveBeenCalledTimes(1));
+    const [, topicSelect, groupInput] = screen.getAllByRole('combobox');
+    fireEvent.mouseDown(topicSelect.parentElement!);
+    await user.click(
+      await screen.findByText('order-events', { selector: '.ant-select-item-option-content' }),
+    );
+    await user.type(groupInput, 'order-producer');
+    const search = screen.getByRole('button', { name: /搜索/ });
+    await user.click(search);
+    expect(await screen.findByText('producer-1')).toBeInTheDocument();
+
+    await user.click(search);
+
+    await waitFor(() => expect(queryProducerConnection).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByText('producer-1')).not.toBeInTheDocument());
+    expect(screen.queryByText('生产者连接健康')).not.toBeInTheDocument();
+  });
+
+  it('ignores duplicate producer queries while the first request is pending', async () => {
+    const user = userEvent.setup();
+    let resolveQuery: ((value: ProducerConnectionResult) => void) | undefined;
+    vi.mocked(queryProducerConnection).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveQuery = resolve;
+        }),
+    );
+    renderWithProviders(<ProducerPage />);
+
+    await waitFor(() => expect(fetchTopicList).toHaveBeenCalledTimes(1));
+    const [, topicSelect, groupInput] = screen.getAllByRole('combobox');
+    fireEvent.mouseDown(topicSelect.parentElement!);
+    await user.click(
+      await screen.findByText('order-events', { selector: '.ant-select-item-option-content' }),
+    );
+    await user.type(groupInput, 'order-producer');
+    const search = screen.getByRole('button', { name: /搜索/ });
+    await user.click(search);
+    await waitFor(() => expect(queryProducerConnection).toHaveBeenCalledTimes(1));
+    fireEvent.click(search);
+
+    expect(queryProducerConnection).toHaveBeenCalledTimes(1);
+    resolveQuery?.(producerResult([]));
+    await waitFor(() => expect(search).not.toHaveClass('ant-btn-loading'));
+  });
 });


### PR DESCRIPTION
## Summary

- clear previous Producer connection rows and summary when a new query starts
- prevent failed queries from leaving results from earlier criteria visible
- guard same-tick duplicate submissions with a synchronous in-flight request identity
- allow only the active request to release query state

## Verification

- `npm test -- src/pages/studio/__tests__/Producer.test.tsx`
- targeted ESLint and Prettier checks
- `git diff --check`

Fixes #2229
