### PR TITLE
[Studio] fix: preserve user topics that resemble system names

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/SystemTopicFilter.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/SystemTopicFilter.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.common.util;
 
 import java.util.Set;
+import org.apache.rocketmq.common.topic.TopicValidator;
 
 /**
  * Shared utility for identifying RocketMQ system topics.
@@ -27,16 +28,8 @@ import java.util.Set;
  */
 public final class SystemTopicFilter {
 
-    private static final Set<String> SYSTEM_TOPIC_PREFIXES = Set.of(
-            "RMQ_SYS_", "rmq_sys_", "SCHEDULE_TOPIC_", "%RETRY%", "%DLQ%",
-            "CID_", "broker_", "BenchmarkTest"
-    );
-
-    private static final Set<String> SYSTEM_TOPICS = Set.of(
-            "TBW102", "SELF_TEST_TOPIC", "DefaultCluster", "OFFSET_MOVED_EVENT",
-            "broker", "SCHEDULE_TOPIC_XXXX", "RMQ_SYS_TRANS_HALF_TOPIC",
-            "RMQ_SYS_TRACE_TOPIC", "RMQ_SYS_TRANS_OP_HALF_TOPIC"
-    );
+    private static final String RETRY_TOPIC_PREFIX = "%RETRY%";
+    private static final String DEAD_LETTER_TOPIC_PREFIX = "%DLQ%";
 
     private SystemTopicFilter() {
     }
@@ -54,15 +47,10 @@ public final class SystemTopicFilter {
         if (topicName == null || topicName.isEmpty()) {
             return true;
         }
-        if (SYSTEM_TOPICS.contains(topicName)) {
-            return true;
-        }
-        for (String prefix : SYSTEM_TOPIC_PREFIXES) {
-            if (topicName.startsWith(prefix)) {
-                return true;
-            }
-        }
-        return brokerNames != null && brokerNames.contains(topicName);
+        return TopicValidator.isSystemTopic(topicName)
+                || topicName.startsWith(RETRY_TOPIC_PREFIX)
+                || topicName.startsWith(DEAD_LETTER_TOPIC_PREFIX)
+                || brokerNames != null && brokerNames.contains(topicName);
     }
 
     /**

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemTopicFilterTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemTopicFilterTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SystemTopicFilterTest {
 
     @Test
-    void shouldRecognizeSharedSystemTopicPrefixesAndBrokerNamesTest() {
+    void shouldRecognizeCanonicalSystemTopicsAndBrokerNamesTest() {
         Set<String> brokerNames = Set.of("broker-prod-a", "broker-prod-b");
 
         assertThat(SystemTopicFilter.isSystem(null, brokerNames)).isTrue();
@@ -35,14 +35,20 @@ class SystemTopicFilterTest {
         assertThat(SystemTopicFilter.isSystem("SCHEDULE_TOPIC_XXXX", brokerNames)).isTrue();
         assertThat(SystemTopicFilter.isSystem("%RETRY%consumer-a", brokerNames)).isTrue();
         assertThat(SystemTopicFilter.isSystem("%DLQ%consumer-a", brokerNames)).isTrue();
-        assertThat(SystemTopicFilter.isSystem("CID_RMQ_SYS_TRANS", brokerNames)).isTrue();
-        assertThat(SystemTopicFilter.isSystem("broker_config", brokerNames)).isTrue();
-        assertThat(SystemTopicFilter.isSystem("BenchmarkTestTopic", brokerNames)).isTrue();
         assertThat(SystemTopicFilter.isSystem("TBW102", brokerNames)).isTrue();
         assertThat(SystemTopicFilter.isSystem("SELF_TEST_TOPIC", brokerNames)).isTrue();
         assertThat(SystemTopicFilter.isSystem("OFFSET_MOVED_EVENT", brokerNames)).isTrue();
         assertThat(SystemTopicFilter.isSystem("broker-prod-a", brokerNames)).isTrue();
 
         assertThat(SystemTopicFilter.isSystem("orders", brokerNames)).isFalse();
+    }
+
+    @Test
+    void shouldNotHideUserTopicsThatOnlyResembleSystemTopicsTest() {
+        assertThat(SystemTopicFilter.isSystem("CID_orders")).isFalse();
+        assertThat(SystemTopicFilter.isSystem("broker_events")).isFalse();
+        assertThat(SystemTopicFilter.isSystem("BenchmarkTestOrders")).isFalse();
+        assertThat(SystemTopicFilter.isSystem("SCHEDULE_TOPIC_orders")).isFalse();
+        assertThat(SystemTopicFilter.isSystem("RMQ_SYS_orders")).isFalse();
     }
 }


### PR DESCRIPTION
## Summary

- delegate Apache system-topic classification to RocketMQ's canonical `TopicValidator`
- preserve retry, dead-letter, and exact live-broker topic filtering
- keep valid user topics whose names only resemble historical system prefixes
- add regression coverage for canonical and lookalike names

## Problem

The shared filter classified several broad prefixes as system topics. Names such as `CID_orders`, `broker_events`, and `BenchmarkTestOrders` are valid ordinary topics according to current RocketMQ rules, but Studio removed them from topic lists and dashboard totals.

## Verification

- `mvn -Dtest=SystemTopicFilterTest,RocketMQDashboardProviderTest,RocketMQMetadataProviderTest test` (37 tests passed)
- `mvn checkstyle:check` (0 violations)
- `git diff --check`

Closes #2244
