### PR TITLE
[Studio] fix: decode inherited topic route permissions

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.provider.apache;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import org.apache.rocketmq.common.constant.PermName;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.remoting.protocol.admin.ConsumeStats;
@@ -482,14 +483,13 @@ public class RocketMQMetadataProvider implements MetadataProvider {
     }
 
     private TopicPerm mapPerm(int perm) {
-        // RocketMQ perm: 6=RW, 4=R, 2=W
-        if (perm == 6) {
-            return TopicPerm.RW;
-        } else if (perm == 4) {
-            return TopicPerm.RO;
-        } else if (perm == 2) {
+        if (PermName.isReadable(perm)) {
+            return PermName.isWriteable(perm) ? TopicPerm.RW : TopicPerm.RO;
+        }
+        if (PermName.isWriteable(perm)) {
             return TopicPerm.WO;
         }
+        // TopicPerm has no inaccessible value; retain the historical fallback for invalid masks.
         return TopicPerm.RW;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
@@ -21,6 +21,10 @@ import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.remoting.protocol.admin.ConsumeStats;
 import org.apache.rocketmq.remoting.protocol.admin.OffsetWrapper;
 import org.apache.rocketmq.remoting.protocol.body.GroupList;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.route.QueueData;
+import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
+import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -38,9 +42,12 @@ import org.apache.rocketmq.studio.persistence.mapper.RmqGroupMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqTopicMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.LinkedHashMap;
@@ -164,6 +171,42 @@ class RocketMQMetadataProviderTest {
 
         assertThat(provider.getTopicRoutes("instance-a", "orders")).containsExactlyElementsOf(routes);
         verify(runtimeAdminClientResolver).execute(eq("instance-a"), any());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "0, RW",
+        "2, WO",
+        "3, WO",
+        "4, RO",
+        "5, RO",
+        "6, RW",
+        "7, RW"
+    })
+    void getTopicRoutesShouldInterpretPermissionBits(int permission, TopicPerm expected) throws Exception {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        QueueData queueData = new QueueData();
+        queueData.setBrokerName("broker-a");
+        queueData.setReadQueueNums(4);
+        queueData.setWriteQueueNums(2);
+        queueData.setPerm(permission);
+        BrokerData brokerData = new BrokerData();
+        brokerData.setBrokerName("broker-a");
+        brokerData.setBrokerAddrs(new HashMap<>(Map.of(0L, "10.0.0.1:10911")));
+        TopicRouteData routeData = new TopicRouteData();
+        routeData.setQueueDatas(List.of(queueData));
+        routeData.setBrokerDatas(List.of(brokerData));
+        when(admin.examineTopicRouteInfo("TopicA")).thenReturn(routeData);
+
+        List<BrokerRouteVO> routes = newLiveProvider(admin).getTopicRoutes(null, "TopicA");
+
+        assertThat(routes).singleElement().satisfies(route -> {
+            assertThat(route.getBrokerName()).isEqualTo("broker-a");
+            assertThat(route.getBrokerAddr()).isEqualTo("10.0.0.1:10911");
+            assertThat(route.getReadQueues()).isEqualTo(4);
+            assertThat(route.getWriteQueues()).isEqualTo(2);
+            assertThat(route.getPerm()).isEqualTo(expected);
+        });
     }
 
     @Test


### PR DESCRIPTION
## Summary

- decode QueueData permissions with RocketMQ's official bit helpers
- report READ|INHERIT and WRITE|INHERIT as RO and WO instead of RW
- preserve the existing fallback for masks without read/write bits
- add route-level parameterized coverage for permissions and mapped fields

## Problem

Studio compared route permission integers only with 6, 4, and 2. Valid masks that also carry the INHERIT bit, such as 5 and 3, missed those exact comparisons and fell through to RW.

## Verification

- `mvn -Dtest=RocketMQMetadataProviderTest test` (22 tests passed)
- `mvn checkstyle:check` (0 violations)
- `mvn -DskipTests package` (BUILD SUCCESS)
- `git diff --check`

Closes #2248
