### PR TITLE
[Studio] fix: scope mock client connections by instance

### DIFF
--- a/web/src/mock/clients.ts
+++ b/web/src/mock/clients.ts
@@ -31,6 +31,15 @@ export interface ClientConnection {
 
 /* ─── Mock Data ─── */
 
+/**
+ * Associates mock client inventories with the Studio instances that own them. The real endpoint
+ * is instance-scoped, so mock mode must not expose every cluster for every selection.
+ */
+export const mockClientClusterByInstance: Readonly<Record<string, string>> = {
+  'instance-direct-1': 'ns-prod',
+  'instance-direct-2': 'ns-pre',
+};
+
 export const mockClients: ClientConnection[] = [
   {
     clientId: 'order-svc-0@10.0.1.12:49152',

--- a/web/src/services/connectionsService.test.ts
+++ b/web/src/services/connectionsService.test.ts
@@ -25,9 +25,31 @@ vi.mock('../config', () => ({
 import { listConnections } from './connectionsService';
 
 describe('connectionsService mock connections', () => {
-  it('returns defensive copies after applying filters', async () => {
+  it('isolates client inventories by the required instance id', async () => {
+    const production = await listConnections({ instanceId: 'instance-direct-1' });
+    const preproduction = await listConnections({ instanceId: 'instance-direct-2' });
+
+    expect(production).not.toHaveLength(0);
+    expect(preproduction).not.toHaveLength(0);
+    expect(production.every((connection) => connection.clusterName === 'ns-prod')).toBe(true);
+    expect(preproduction.every((connection) => connection.clusterName === 'ns-pre')).toBe(true);
+    expect(new Set(production.map((connection) => connection.clientId))).not.toEqual(
+      new Set(preproduction.map((connection) => connection.clientId)),
+    );
+  });
+
+  it('returns an empty inventory for an unknown instance', async () => {
+    await expect(listConnections({ instanceId: 'missing-instance' })).resolves.toEqual([]);
+  });
+
+  it('requires the same instance parameter as the real endpoint', async () => {
+    await expect(listConnections()).rejects.toThrow('instanceId is required');
+    await expect(listConnections({ instanceId: '  ' })).rejects.toThrow('instanceId is required');
+  });
+
+  it('returns defensive copies after applying instance, cluster, and type filters', async () => {
     const connections = await listConnections({
-      instanceId: 'instance-1',
+      instanceId: 'instance-direct-1',
       clusterId: 'ns-prod',
       type: 'Consumer',
     });
@@ -38,7 +60,7 @@ describe('connectionsService mock connections', () => {
     connections[0].address = '127.0.0.1:8081';
 
     const fresh = await listConnections({
-      instanceId: 'instance-1',
+      instanceId: 'instance-direct-1',
       clusterId: 'ns-prod',
       type: 'Consumer',
     });
@@ -48,5 +70,11 @@ describe('connectionsService mock connections', () => {
     expect(fresh[0]).not.toBe(connections[0]);
     expect(fresh.every((connection) => connection.clusterName === 'ns-prod')).toBe(true);
     expect(fresh.every((connection) => connection.type === 'Consumer')).toBe(true);
+  });
+
+  it('does not leak another instance when a conflicting cluster filter is supplied', async () => {
+    await expect(
+      listConnections({ instanceId: 'instance-direct-1', clusterId: 'ns-pre' }),
+    ).resolves.toEqual([]);
   });
 });

--- a/web/src/services/connectionsService.ts
+++ b/web/src/services/connectionsService.ts
@@ -1,7 +1,7 @@
 import { isMockMode } from './dataMode';
 import * as connApi from '../api/connections';
 import type { ClientConnection, ClientConnectionQuery } from '../api/connections';
-import { mockClients } from '../mock/clients';
+import { mockClientClusterByInstance, mockClients } from '../mock/clients';
 
 function copyConnection(connection: ClientConnection): ClientConnection {
   return { ...connection };
@@ -9,7 +9,14 @@ function copyConnection(connection: ClientConnection): ClientConnection {
 
 export async function listConnections(params?: ClientConnectionQuery): Promise<ClientConnection[]> {
   if (isMockMode()) {
-    let result = [...mockClients];
+    const instanceId = params?.instanceId?.trim();
+    if (!instanceId) {
+      throw new Error('instanceId is required');
+    }
+    const instanceCluster = mockClientClusterByInstance[instanceId];
+    if (!instanceCluster) return [];
+
+    let result = mockClients.filter((connection) => connection.clusterName === instanceCluster);
     if (params?.clusterId)
       result = result.filter((connection) => connection.clusterName === params.clusterId);
     if (params?.type) result = result.filter((c) => c.type === params.type);


### PR DESCRIPTION
## Summary

- declare ownership of mock client inventories by Studio instance
- enforce the real endpoint's required instance scope in mock mode
- layer cluster and type filters after instance isolation
- retain defensive copies and add isolation/contract regression coverage

## Problem

Mock mode ignored `instanceId` and returned the global client inventory. Switching instances could therefore show connections from another instance, while missing and unknown instances still exposed unrelated fixture data.

## Verification

- `npm test -- src/services/connectionsService.test.ts src/api/connections.test.ts` (6 tests passed)
- `npx eslint src/mock/clients.ts src/services/connectionsService.ts src/services/connectionsService.test.ts`
- `npx prettier --check src/mock/clients.ts src/services/connectionsService.ts src/services/connectionsService.test.ts`
- `npm run build`
- `git diff --check`

Closes #2250
