### PR TITLE
[Studio] fix: mask credentials on Unicode boundaries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/CredentialUtils.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/CredentialUtils.java
@@ -61,18 +61,42 @@ public final class CredentialUtils {
     }
 
     /**
-     * Keeps the first and last few characters visible, hides everything else; short values are
-     * fully masked.
+     * Keeps the first and last few Unicode code points visible and hides everything else. Short
+     * values and malformed UTF-16 input are fully masked. Using code-point boundaries prevents a
+     * supplementary character from being split into an isolated surrogate in API responses.
      */
     public static String mask(String value) {
         if (value == null || value.isEmpty()) {
             return value;
         }
-        if (value.length() < MIN_PARTIALLY_MASKED_CREDENTIAL_CHARS) {
+        if (hasUnpairedSurrogate(value)) {
             return CREDENTIAL_MASK;
         }
-        return value.substring(0, VISIBLE_CREDENTIAL_CHARS)
+        int codePointCount = value.codePointCount(0, value.length());
+        if (codePointCount < MIN_PARTIALLY_MASKED_CREDENTIAL_CHARS) {
+            return CREDENTIAL_MASK;
+        }
+        int visiblePrefixEnd = value.offsetByCodePoints(0, VISIBLE_CREDENTIAL_CHARS);
+        int visibleSuffixStart = value.offsetByCodePoints(
+                0, codePointCount - VISIBLE_CREDENTIAL_CHARS);
+        return value.substring(0, visiblePrefixEnd)
                 + CREDENTIAL_MASK
-                + value.substring(value.length() - VISIBLE_CREDENTIAL_CHARS);
+                + value.substring(visibleSuffixStart);
+    }
+
+    private static boolean hasUnpairedSurrogate(String value) {
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            if (Character.isHighSurrogate(current)) {
+                if (index + 1 >= value.length()
+                        || !Character.isLowSurrogate(value.charAt(index + 1))) {
+                    return true;
+                }
+                index++;
+            } else if (Character.isLowSurrogate(current)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/CredentialUtilsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/CredentialUtilsTest.java
@@ -30,4 +30,68 @@ class CredentialUtilsTest {
 
         assertThat(CredentialUtils.decodeBase64(legacyValue)).isEqualTo(legacyValue);
     }
+
+    @Test
+    void maskShouldPreserveAsciiBehavior() {
+        assertThat(CredentialUtils.mask("abcdefghijklmnopq"))
+                .isEqualTo("abcd****nopq");
+        assertThat(CredentialUtils.mask("abcdefghijklmnop"))
+                .isEqualTo("****");
+    }
+
+    @Test
+    void maskShouldUseSupplementaryCodePointBoundaries() {
+        String value = "abc🚀" + "123456789" + "🛰xyz";
+
+        String masked = CredentialUtils.mask(value);
+
+        assertThat(masked).isEqualTo("abc🚀****🛰xyz");
+        assertThat(hasIsolatedSurrogate(masked)).isFalse();
+    }
+
+    @Test
+    void maskShouldKeepFourCodePointsAtEachEnd() {
+        String value = "🚀abc" + "123456789" + "xyz🛰";
+
+        assertThat(CredentialUtils.mask(value)).isEqualTo("🚀abc****xyz🛰");
+    }
+
+    @Test
+    void maskShouldMeasureShortValuesInCodePoints() {
+        assertThat(CredentialUtils.mask("🚀".repeat(16))).isEqualTo("****");
+        assertThat(CredentialUtils.mask("🚀".repeat(17)))
+                .isEqualTo("🚀".repeat(4) + "****" + "🚀".repeat(4));
+    }
+
+    @Test
+    void maskShouldPreserveNullAndEmptyValues() {
+        assertThat(CredentialUtils.mask(null)).isNull();
+        assertThat(CredentialUtils.mask("")).isEmpty();
+    }
+
+    @Test
+    void maskShouldFullyHideMalformedUtf16WithoutLeakingSurrogates() {
+        String malformed = "abcd" + '\uD83D' + "1234567890123456";
+
+        String masked = CredentialUtils.mask(malformed);
+
+        assertThat(masked).isEqualTo("****");
+        assertThat(hasIsolatedSurrogate(masked)).isFalse();
+    }
+
+    private static boolean hasIsolatedSurrogate(String value) {
+        for (int index = 0; index < value.length(); index++) {
+            char current = value.charAt(index);
+            if (Character.isHighSurrogate(current)) {
+                if (index + 1 >= value.length()
+                        || !Character.isLowSurrogate(value.charAt(index + 1))) {
+                    return true;
+                }
+                index++;
+            } else if (Character.isLowSurrogate(current)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary

- measure credential masking thresholds by Unicode code point instead of UTF-16 code unit
- preserve complete supplementary characters at the four-code-point prefix and suffix boundaries
- fail closed for malformed UTF-16 so masked API responses never expose isolated surrogates
- preserve the existing null, empty, short-value, and ASCII behavior

## Problem

`CredentialUtils.mask` sliced credentials at fixed UTF-16 offsets. A supplementary character at a visibility boundary could therefore be split, producing malformed Unicode in an API response. Supplementary characters also counted twice toward the partial-mask threshold.

## Verification

- `CredentialUtilsTest`: 7 tests passed
- related ACL and credential suites: 75 tests passed
- Maven Checkstyle: 0 violations
- main/test compilation: 400 main and 140 test sources compiled successfully
- `git diff --check`

Closes #2252
