### PR TITLE
[Studio] fix: normalize Kubernetes certificate SAN entries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/CreateCertDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/CreateCertDTO.java
@@ -41,5 +41,5 @@ public class CreateCertDTO {
     private String type;
     @NotBlank(message = "issuer is required")
     private String issuer;
-    private List<String> san;
+    private List<@NotBlank(message = "san must not contain blank values") String> san;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -150,7 +150,7 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
             if (san == null) {
                 throw invalidPersistedValue(certificateId, "SAN JSON", json);
             }
-            return san;
+            return normalizeSan(san);
         } catch (JsonProcessingException exception) {
             throw invalidPersistedValue(certificateId, "SAN JSON", json);
         }
@@ -166,9 +166,17 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
             return null;
         }
         try {
-            return objectMapper.writeValueAsString(san);
+            return objectMapper.writeValueAsString(normalizeSan(san));
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException("Failed to serialize certificate SAN values", exception);
         }
+    }
+
+    private List<String> normalizeSan(List<String> san) {
+        return san.stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .distinct()
+                .toList();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/UpdateCertDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/UpdateCertDTO.java
@@ -38,5 +38,5 @@ public class UpdateCertDTO {
     @Pattern(regexp = "TLS|mTLS|ServiceAccount", message = "type must be one of TLS, mTLS, ServiceAccount")
     private String type;
     private String issuer;
-    private List<String> san;
+    private List<@NotBlank(message = "san must not contain blank values") String> san;
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertDTOTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.k8s;
+
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class K8sCertDTOTest {
+
+    @Test
+    void createShouldRejectNullAndBlankSanValues() {
+        CreateCertDTO command = CreateCertDTO.builder()
+                .name("broker")
+                .namespace("rocketmq")
+                .cluster("production")
+                .type("TLS")
+                .issuer("cluster-ca")
+                .san(Arrays.asList(null, " "))
+                .build();
+
+        try (ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            assertThat(validatorFactory.getValidator().validate(command))
+                    .extracting(violation -> violation.getMessage())
+                    .containsOnly("san must not contain blank values");
+        }
+    }
+
+    @Test
+    void updateShouldRejectBlankSanValues() {
+        UpdateCertDTO command = UpdateCertDTO.builder()
+                .id("cert-1")
+                .san(List.of("broker.example", ""))
+                .build();
+
+        try (ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            assertThat(validatorFactory.getValidator().validate(command))
+                    .extracting(violation -> violation.getMessage())
+                    .containsExactly("san must not contain blank values");
+        }
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
@@ -21,11 +21,16 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.persistence.entity.RmqK8sCertificate;
 import org.apache.rocketmq.studio.persistence.mapper.RmqK8sCertificateMapper;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MybatisPlusK8sCertRepositoryTest {
@@ -108,6 +113,33 @@ class MybatisPlusK8sCertRepositoryTest {
         assertThatThrownBy(() -> repository(mapper).findById("cert-1"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("SAN JSON");
+    }
+
+    @Test
+    void findByIdNormalizesLegacySanValues() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        RmqK8sCertificate entity = certificate();
+        entity.setSan("[\" broker.example \",null,\"\",\"broker.example\",\"api.example\"]");
+        when(mapper.selectById("cert-1")).thenReturn(entity);
+
+        assertThat(repository(mapper).findById("cert-1")).get()
+                .extracting(K8sCertVO::getSan)
+                .isEqualTo(List.of("broker.example", "api.example"));
+    }
+
+    @Test
+    void saveNormalizesSanValuesBeforePersistence() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        K8sCertVO cert = K8sCertVO.builder()
+                .name("broker")
+                .san(Arrays.asList(" broker.example ", null, "", "broker.example", "api.example"))
+                .build();
+
+        repository(mapper).save(cert);
+
+        ArgumentCaptor<RmqK8sCertificate> entity = ArgumentCaptor.forClass(RmqK8sCertificate.class);
+        verify(mapper).insert(entity.capture());
+        assertThat(entity.getValue().getSan()).isEqualTo("[\"broker.example\",\"api.example\"]");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- validate every SAN entry on Kubernetes certificate create and update requests
- normalize SAN values on persistence writes by trimming, dropping blanks, and stable-deduplicating entries
- normalize legacy SAN JSON on reads so existing null or blank values cannot break certificate consumers
- cover request validation and both persistence boundaries with focused tests

## Problem

Certificate SAN lists accepted null, blank, whitespace-padded, and duplicate entries. Those values were persisted and returned unchanged; a legacy null entry could then break client-side certificate search when the UI applies string operations to every SAN value.

## Verification

- `K8sCertDTOTest,MybatisPlusK8sCertRepositoryTest`: 11 tests passed
- `mvn -B -ntp -DskipTests package`: passed
- Maven Checkstyle: 0 violations
- `git diff --check`

Closes #2254
