### PR TITLE
[Studio] fix: isolate malformed remote ACL rows

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadService.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.instance.acl;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.remoting.protocol.body.AclInfo;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
@@ -26,6 +27,7 @@ import org.springframework.stereotype.Service;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -46,15 +48,23 @@ public class ApacheAclReadService {
                     continue;
                 }
                 try {
-                    policies.put(address, admin.listAcl(address, subject, resource).stream()
-                            .map(RemoteAclPolicyVO::from)
-                            .toList());
+                    policies.put(address, mapPolicies(admin.listAcl(address, subject, resource)));
                 } catch (Exception ex) {
                     failures.put(address, rootMessage(ex));
                 }
             }
             return result(policies, failures);
         });
+    }
+
+    private List<RemoteAclPolicyVO> mapPolicies(List<AclInfo> brokerPolicies) {
+        if (brokerPolicies == null) {
+            return List.of();
+        }
+        return brokerPolicies.stream()
+                .filter(Objects::nonNull)
+                .map(RemoteAclPolicyVO::from)
+                .toList();
     }
 
     private RemoteAclReadResult result(Map<String, List<RemoteAclPolicyVO>> policies,

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/RemoteAclPolicyVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/RemoteAclPolicyVO.java
@@ -19,12 +19,14 @@ package org.apache.rocketmq.studio.instance.acl;
 import org.apache.rocketmq.remoting.protocol.body.AclInfo;
 
 import java.util.List;
+import java.util.Objects;
 
 /** REST representation of an Apache ACL 2.0 policy. */
 public record RemoteAclPolicyVO(String subject, List<PolicyGroupVO> policies) {
 
     public static RemoteAclPolicyVO from(AclInfo policy) {
         List<PolicyGroupVO> groups = policy.getPolicies() == null ? List.of() : policy.getPolicies().stream()
+                .filter(Objects::nonNull)
                 .map(PolicyGroupVO::from)
                 .toList();
         return new RemoteAclPolicyVO(policy.getSubject(), groups);
@@ -33,6 +35,7 @@ public record RemoteAclPolicyVO(String subject, List<PolicyGroupVO> policies) {
     public record PolicyGroupVO(String policyType, List<PolicyEntryVO> entries) {
         private static PolicyGroupVO from(AclInfo.PolicyInfo policy) {
             List<PolicyEntryVO> policyEntries = policy.getEntries() == null ? List.of() : policy.getEntries().stream()
+                    .filter(Objects::nonNull)
                     .map(PolicyEntryVO::from)
                     .toList();
             return new PolicyGroupVO(policy.getPolicyType(), policyEntries);
@@ -46,7 +49,9 @@ public record RemoteAclPolicyVO(String subject, List<PolicyGroupVO> policies) {
         }
 
         private static List<String> listOrEmpty(List<String> values) {
-            return values == null ? List.of() : List.copyOf(values);
+            return values == null ? List.of() : values.stream()
+                    .filter(Objects::nonNull)
+                    .toList();
         }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.instance.acl;
 
+import org.apache.rocketmq.remoting.protocol.body.AclInfo;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
@@ -23,8 +24,9 @@ import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,5 +59,68 @@ class ApacheAclReadServiceTest {
         assertThat(result.getPoliciesByBroker()).containsKey("broker-a:10911");
         assertThat(result.getFailuresByBroker()).containsEntry("broker-b:10911", "unavailable");
         assertThat(result.isPartial()).isTrue();
+    }
+
+    @Test
+    void treatsNullBrokerPolicyListAsEmptySuccess() throws Exception {
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        MQAdminExt admin = mock(MQAdminExt.class);
+        when(admin.examineBrokerClusterInfo()).thenReturn(clusterInfo("broker-a:10911"));
+        when(admin.listAcl("broker-a:10911", null, null)).thenReturn(null);
+        executeWith(resolver, admin);
+
+        RemoteAclReadResult result = new ApacheAclReadService(resolver).listRules("instance-1", null, null);
+
+        assertThat(result.getPoliciesByBroker()).containsEntry("broker-a:10911", List.of());
+        assertThat(result.getFailuresByBroker()).isEmpty();
+        assertThat(result.isPartial()).isFalse();
+    }
+
+    @Test
+    void retainsValidPoliciesWhenResponseContainsNullRows() throws Exception {
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        MQAdminExt admin = mock(MQAdminExt.class);
+        AclInfo.PolicyEntryInfo entry = AclInfo.PolicyEntryInfo.of(
+                "Topic:orders", Arrays.asList("PUB", null), List.of("10.0.0.0/8"), "ALLOW");
+        AclInfo.PolicyInfo group = new AclInfo.PolicyInfo();
+        group.setPolicyType("CUSTOM");
+        group.setEntries(Arrays.asList(entry, null));
+        AclInfo policy = new AclInfo();
+        policy.setSubject("User:alice");
+        policy.setPolicies(Arrays.asList(group, null));
+        when(admin.examineBrokerClusterInfo()).thenReturn(clusterInfo("broker-a:10911"));
+        when(admin.listAcl("broker-a:10911", null, null)).thenReturn(Arrays.asList(policy, null));
+        executeWith(resolver, admin);
+
+        RemoteAclReadResult result = new ApacheAclReadService(resolver).listRules("instance-1", null, null);
+
+        assertThat(result.getFailuresByBroker()).isEmpty();
+        assertThat(result.getPoliciesByBroker().get("broker-a:10911"))
+                .singleElement()
+                .satisfies(remotePolicy -> {
+                    assertThat(remotePolicy.subject()).isEqualTo("User:alice");
+                    assertThat(remotePolicy.policies()).singleElement().satisfies(remoteGroup -> {
+                        assertThat(remoteGroup.policyType()).isEqualTo("CUSTOM");
+                        assertThat(remoteGroup.entries()).singleElement().satisfies(remoteEntry -> {
+                            assertThat(remoteEntry.resource()).isEqualTo("Topic:orders");
+                            assertThat(remoteEntry.actions()).containsExactly("PUB");
+                        });
+                    });
+                });
+    }
+
+    private ClusterInfo clusterInfo(String address) {
+        BrokerData broker = new BrokerData();
+        broker.setBrokerAddrs(new HashMap<>(Map.of(0L, address)));
+        ClusterInfo clusterInfo = new ClusterInfo();
+        clusterInfo.setBrokerAddrTable(Map.of("broker", broker));
+        return clusterInfo;
+    }
+
+    private void executeWith(RuntimeAdminClientResolver resolver, MQAdminExt admin) throws Exception {
+        when(resolver.execute(eq("instance-1"), any())).thenAnswer(invocation -> {
+            MqAdminExtFactory.AdminAction<?> action = invocation.getArgument(1);
+            return action.apply(admin);
+        });
     }
 }


### PR DESCRIPTION
## Summary

- treat a null broker ACL list as an empty successful result
- skip null policy, group, and entry rows without discarding valid siblings
- remove null action and source-IP values while producing immutable response lists
- verify both null top-level responses and mixed valid/malformed nested responses

## Problem

The Apache ACL reader streamed the broker result and every nested list without isolating null rows. One malformed optional row raised an exception that was caught at the broker boundary, causing all valid policies from that broker to disappear and the broker to be reported as failed.

## Verification

- `ApacheAclReadServiceTest`: 3 tests passed
- `mvn -B -ntp -DskipTests package`: passed
- Maven Checkstyle: 0 violations
- `git diff --check`

Closes #2256
