### PR TITLE
[Studio] fix: canonicalize alert channel entries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTO.java
@@ -34,7 +34,7 @@ public class AlertRuleRequestDTO {
     private String thresholdUnit;
     @Pattern(regexp = "(?:[0-9]+(?:ms|s|m|h|d|w|y))+", message = "duration is invalid")
     private String duration;
-    private List<String> channels;
+    private List<@NotBlank(message = "channel must not be blank") String> channels;
     private boolean enabled;
     private String description;
     private String brokerName;
@@ -52,12 +52,23 @@ public class AlertRuleRequestDTO {
                 .threshold(threshold)
                 .thresholdUnit(thresholdUnit)
                 .duration(duration)
-                .channels(channels)
+                .channels(normalizeChannels(channels))
                 .enabled(enabled)
                 .description(description)
                 .brokerName(brokerName)
                 .clusterName(clusterName)
                 .severity(severity)
                 .build();
+    }
+
+    private static List<String> normalizeChannels(List<String> values) {
+        if (values == null) {
+            return null;
+        }
+        return values.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(String::trim)
+                .distinct()
+                .toList();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -126,7 +126,9 @@ public class MybatisPlusAlertRepository implements AlertRepository {
         entity.setThreshold(rule.getThreshold());
         entity.setThresholdUnit(rule.getThresholdUnit());
         entity.setDuration(rule.getDuration());
-        entity.setChannels(rule.getChannels() == null ? null : String.join(",", rule.getChannels()));
+        entity.setChannels(rule.getChannels() == null
+                ? null
+                : String.join(",", normalizeChannels(rule.getChannels())));
         entity.setEnabled(rule.isEnabled());
         entity.setLastTriggered(rule.getLastTriggered());
         entity.setDescription(rule.getDescription());
@@ -175,9 +177,14 @@ public class MybatisPlusAlertRepository implements AlertRepository {
         if (!StringUtils.hasText(value)) {
             return List.of();
         }
-        return Arrays.stream(value.split(","))
+        return normalizeChannels(Arrays.asList(value.split(",")));
+    }
+
+    private static List<String> normalizeChannels(List<String> channels) {
+        return channels.stream()
+                .filter(StringUtils::hasText)
                 .map(String::trim)
-                .filter(part -> !part.isEmpty())
-                .collect(Collectors.toList());
+                .distinct()
+                .toList();
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTOTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlertRuleRequestDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void channelsShouldRejectNullAndBlankElements() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName("High Lag");
+        request.setChannels(Arrays.asList("email", null, " "));
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsOnly("channel must not be blank");
+    }
+
+    @Test
+    void toAlertRuleVOShouldTrimAndDeduplicateChannelsInInputOrder() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName("High Lag");
+        request.setChannels(List.of(" email ", "sms", "email", " sms "));
+
+        assertThat(request.toAlertRuleVO().getChannels()).containsExactly("email", "sms");
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -28,6 +28,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -68,6 +69,32 @@ class MybatisPlusAlertRepositoryTest {
         assertThat(repository.findAlerts(null)).singleElement()
                 .satisfies(alert -> assertThat(alert.getLevel()).isEqualTo(
                         org.apache.rocketmq.studio.common.domain.enums.AlertLevel.warning));
+    }
+
+    @Test
+    void saveRuleShouldCanonicalizeChannelsBeforePersistence() {
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .id("rule-1")
+                .name("Lag")
+                .channels(Arrays.asList(" email ", null, "", "sms", "email", " sms "))
+                .build();
+
+        repository.saveRule(rule);
+
+        verify(ruleMapper).insert(argThat((RmqAlertRule entity) ->
+                entity != null && "email,sms".equals(entity.getChannels())));
+    }
+
+    @Test
+    void findAllRulesShouldCanonicalizeLegacyStoredChannels() {
+        RmqAlertRule entity = new RmqAlertRule();
+        entity.setId("rule-1");
+        entity.setName("Lag");
+        entity.setChannels(" email ,,sms,email, sms ");
+        when(ruleMapper.selectList(any())).thenReturn(List.of(entity));
+
+        assertThat(repository.findAllRules()).singleElement()
+                .satisfies(rule -> assertThat(rule.getChannels()).containsExactly("email", "sms"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- reject null and blank notification-channel entries at the alert rule request boundary
- trim and stable-deduplicate channels during DTO-to-domain conversion
- defensively canonicalize channel lists before persistence for internal callers
- normalize legacy comma-separated channel rows when loading alert rules

## Problem

Alert rule channels were accepted as unconstrained string-list elements. A null element reached `String.join` and caused a server error, while blank, padded, and duplicate values were stored unchanged and could represent repeated notification destinations.

## Verification

- `AlertRuleRequestDTOTest,MybatisPlusAlertRepositoryTest,AlertRuleControllerTest,AlertServiceTest`: 72 tests passed
- `mvn -DskipTests package`: passed
- Maven Checkstyle: 0 violations
- `git diff --check`

Closes #2258
