### PR TITLE
fix(web): derive and localize static page metadata

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -541,6 +541,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'home.docs': { zh: '文档中心', en: 'Documentation' },
   'home.community': { zh: 'RocketMQ 社区', en: 'RocketMQ Community' },
   'home.brand': { zh: 'RocketMQ Studio 出品', en: 'Powered by RocketMQ Studio' },
+  'home.version': { zh: '当前版本', en: 'Version' },
 
   // ─── AI Page (additional) ───
   'ai.recommended': { zh: '推荐', en: 'Rec.' },

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -424,7 +424,7 @@ const HomePage = () => {
                   <textarea
                     ref={textareaRef}
                     className="chat-input"
-                    placeholder="向 RocketMQ Bot 提问，全程加密、安全、可信"
+                    placeholder={t('home.placeholder')}
                     value={inputValue}
                     onChange={(event) => setInputValue(event.target.value)}
                     onKeyDown={handleKeyDown}
@@ -516,7 +516,7 @@ const HomePage = () => {
               className="transition-colors hover:text-purple-500"
               style={{ textDecoration: 'none' }}
             >
-              文档中心
+              {t('home.docs')}
             </a>
             <span style={{ margin: '0 4px' }}>｜</span>
             <a
@@ -524,13 +524,13 @@ const HomePage = () => {
               className="transition-colors hover:text-purple-500"
               style={{ textDecoration: 'none' }}
             >
-              RocketMQ 社区
+              {t('home.community')}
             </a>
             <span style={{ margin: '0 4px' }}>｜</span>
-            <span>RocketMQ Studio 出品</span>
+            <span>{t('home.brand')}</span>
             <span style={{ margin: '0 4px' }}>｜</span>
             <span>
-              当前版本 {__BUILD_TIME__} build({__BUILD_COMMIT__})
+              {t('home.version')} {__BUILD_TIME__} build({__BUILD_COMMIT__})
             </span>
           </span>
         </footer>

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -592,8 +592,8 @@ export const DataSourceTab = () => {
 const AboutTab = () => (
   <div style={{ maxWidth: 800 }}>
     <Descriptions column={1} bordered size="small">
-      <Descriptions.Item label="版本">0.1.0</Descriptions.Item>
-      <Descriptions.Item label="构建时间">2024-01-15 14:30:00</Descriptions.Item>
+      <Descriptions.Item label="版本">{__BUILD_COMMIT__}</Descriptions.Item>
+      <Descriptions.Item label="构建时间">{__BUILD_TIME__}</Descriptions.Item>
       <Descriptions.Item label="RocketMQ 支持版本">4.x / 5.x</Descriptions.Item>
       <Descriptions.Item label="前端框架">React 18 + Ant Design 5</Descriptions.Item>
       <Descriptions.Item label="后端框架">Spring Boot 3 + RocketMQ MCP Server</Descriptions.Item>


### PR DESCRIPTION
## Problem

The About tab displays stale hard-coded build metadata, while several visible strings on the home page bypass the translation catalog. This makes deployed builds report misleading version/date information and leaves mixed-language content when the locale changes.

## Root cause

The settings page used literal metadata values instead of the build-time constants, and the home page embedded placeholder, footer, community, brand, and version strings directly in the component.

## Changes

- derive About version and build time from `__BUILD_COMMIT__` and `__BUILD_TIME__`
- route the affected home-page strings through the existing i18n catalog
- add a localized `home.version` entry

This consolidates the related static-content fixes from closed PRs #2089 and #2099 into one cohesive PR, following the maintainer guidance in #2107.

## Impact

Operators see metadata for the build they are actually running, and the home page consistently follows the selected locale.

## Validation

- `npm test -- src/pages/home/__tests__/HomePage.test.tsx src/pages/settings/__tests__` (15 tests passed)
- ESLint on all changed files
- `npm run build`
- `git diff --check`

Closes #2070.
Closes #2071.
