### PR TITLE
fix(web): harden nullable collection rendering

### DIFF
--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -971,7 +971,7 @@ const ConsumerPageContent = ({
                   dataSource={
                     subscriptionsByGroup[diagnosticCacheKey(selectedInstanceId, record.name)] ?? []
                   }
-                  rowKey="topic"
+                  rowKey={(record) => `${record.topic}-${record.filterMode}-${record.expression}`}
                   loading={
                     subscriptionLoadingByGroup[diagnosticCacheKey(selectedInstanceId, record.name)]
                   }
@@ -1071,7 +1071,7 @@ const ConsumerPageContent = ({
                         >
                           <Statistic
                             title="订阅 Topic 数"
-                            value={selectedGroup.subscribedTopics.length}
+                            value={(selectedGroup.subscribedTopics ?? []).length}
                             prefix={<ListBullets size={18} color="#1677ff" />}
                             valueStyle={{ color: '#1677ff' }}
                           />
@@ -1129,7 +1129,7 @@ const ConsumerPageContent = ({
                       </Descriptions.Item>
                       <Descriptions.Item label="订阅 Topic" span={2}>
                         <Space size={4} wrap>
-                          {selectedGroup.subscribedTopics.map((t) => (
+                          {(selectedGroup.subscribedTopics ?? []).map((t) => (
                             <Tag key={t} color="blue">
                               {t}
                             </Tag>
@@ -1199,7 +1199,9 @@ const ConsumerPageContent = ({
                       <Table
                         columns={subscriptionSubColumns}
                         dataSource={visibleSubscriptions}
-                        rowKey="topic"
+                        rowKey={(record) =>
+                          `${record.topic}-${record.filterMode}-${record.expression}`
+                        }
                         loading={subscriptionLoadingByGroup[selectedDiagnosticKey]}
                         pagination={false}
                         size="small"

--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -256,7 +256,7 @@ const AlertsPage = () => {
       title: t('alerts.channels'),
       render: (_, record) => (
         <Flex gap={4} wrap="wrap">
-          {record.channels.map((ch) => (
+          {(record.channels ?? []).map((ch) => (
             <Tag key={ch} color={channelColors[ch]}>
               {channelLabels[ch]}
             </Tag>


### PR DESCRIPTION
## Problem

Consumer and alert views assume nullable API collections are always present. The same consumer topic can also appear with different filter expressions while the tables use only the topic name as their React row key.

## Root cause

Rendering calls `.length` and `.map` directly on optional collections, and the subscription tables use a non-unique key for rows that are distinct by filter mode and expression.

## Changes

- normalize missing `subscribedTopics` and alert `channels` to empty arrays while rendering
- use a composite subscription key of topic, filter mode, and expression in both tables

This consolidates the related defensive-rendering fixes from closed PRs #2090 and #2091 into one cohesive PR, following the maintainer guidance in #2107.

## Impact

The affected views no longer crash on valid nullable responses, and React can reconcile distinct subscription rows reliably.

## Validation

- `npm test -- src/pages/instance/__tests__/ConsumerPage.test.tsx src/pages/ops/__tests__/AlertsPage.test.tsx` (18 tests passed)
- ESLint on all changed files
- `npm run build`
- `git diff --check`

Closes #2072.
Closes #2073.
Closes #2074.
