### PR TITLE
fix(api): validate request DTOs at controller boundaries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthController.java
@@ -21,6 +21,7 @@ import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.apache.rocketmq.studio.settings.SettingsRepository;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
@@ -62,7 +63,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public Result<LoginVO> login(@RequestBody(required = false) LoginDTO request) {
+    public Result<LoginVO> login(@Valid @RequestBody(required = false) LoginDTO request) {
         if (request == null) {
             throw new BusinessException(400, "Login request is required");
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/LoginDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/LoginDTO.java
@@ -17,12 +17,15 @@
 
 package org.apache.rocketmq.studio.auth;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import lombok.ToString;
 
 @Data
 public class LoginDTO {
+    @NotBlank(message = "username is required")
     private String username;
+    @NotBlank(message = "password is required")
     @ToString.Exclude
     private String password;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/CreateInstanceDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/CreateInstanceDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.instance;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
@@ -23,6 +24,7 @@ import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 @Data
 public class CreateInstanceDTO {
 
+    @NotBlank(message = "name is required")
     private String name;
 
     private InstanceType type;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiCommandDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiCommandDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,6 +29,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AiCommandDTO {
+    @NotBlank(message = "command is required")
     private String command;
     private String mode;
     private String model;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AiController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.ai;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -41,12 +42,12 @@ public class AiController {
     private final AiService aiService;
 
     @PostMapping(value = "/chat", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter chat(@RequestBody ChatDTO request) {
+    public SseEmitter chat(@Valid @RequestBody ChatDTO request) {
         return aiService.chat(request);
     }
 
     @PostMapping("/execute")
-    public Result<AiExecuteResultVO> execute(@RequestBody AiCommandDTO command) {
+    public Result<AiExecuteResultVO> execute(@Valid @RequestBody AiCommandDTO command) {
         return Result.ok(aiService.execute(command));
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ChatDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ChatDTO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,6 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatDTO {
+    @NotBlank(message = "message is required")
     private String message;
     private String mode;
     private String model;

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthControllerTest.java
@@ -176,6 +176,19 @@ class AuthControllerTest {
     }
 
     @Test
+    void loginShouldRejectBlankCredentials() throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"username":" ","password":""}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400));
+
+        verify(authService, never()).login(any(LoginDTO.class));
+    }
+
+    @Test
     void logoutShouldReturnSuccess() throws Exception {
         doNothing().when(authService).logout("Bearer token-1");
         when(authService.isAuthenticated("Bearer token-1")).thenReturn(true);

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
@@ -148,6 +148,19 @@ class InstanceControllerTest {
     }
 
     @Test
+    void createInstanceShouldRejectBlankName() throws Exception {
+        mockMvc.perform(post("/api/instances/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":" ","type":"DIRECT","endpoint":"10.0.2.1:8080"}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400));
+
+        verifyNoInteractions(instanceService);
+    }
+
+    @Test
     void updateInstanceShouldReturnUpdatedInstance() throws Exception {
         InstanceVO update = InstanceVO.builder()
                 .name("updated-name")

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiControllerTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.ops.ai;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -45,7 +47,11 @@ class AiControllerTest {
     @BeforeEach
     void setUp() {
         aiService = mock(AiService.class);
-        mockMvc = MockMvcBuilders.standaloneSetup(new AiController(aiService)).build();
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+        mockMvc = MockMvcBuilders.standaloneSetup(new AiController(aiService))
+                .setValidator(validator)
+                .build();
 
         when(aiService.catalogVersion()).thenReturn("1.0.0");
         when(aiService.catalogDigest()).thenReturn(DIGEST);
@@ -124,5 +130,29 @@ class AiControllerTest {
                 .andExpect(jsonPath("$.data").isArray());
 
         verify(aiService).executeTool("rmq.cluster.list", Collections.emptyMap());
+    }
+
+    @Test
+    void chatRejectsBlankMessage() throws Exception {
+        mockMvc.perform(post("/api/ai/chat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"message":" "}
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verify(aiService, never()).chat(org.mockito.ArgumentMatchers.any(ChatDTO.class));
+    }
+
+    @Test
+    void executeRejectsBlankCommand() throws Exception {
+        mockMvc.perform(post("/api/ai/execute")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"command":""}
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verify(aiService, never()).execute(org.mockito.ArgumentMatchers.any(AiCommandDTO.class));
     }
 }


### PR DESCRIPTION
## Problem

Instance creation, login, and AI endpoints accept empty required fields and pass malformed requests into service logic.

## Root cause

The request DTOs do not declare non-blank constraints, and the login and AI controller boundaries do not trigger Bean Validation.

## Changes

- require non-blank instance names, login credentials, AI commands, and chat messages
- enable `@Valid` processing on login, chat, and execute request bodies
- add controller regression tests proving invalid requests return HTTP 400 without invoking the service layer

This consolidates the related request-boundary fixes from closed PRs #2100, #2101, and #2102 into one cohesive PR, following the maintainer guidance in #2107.

## Impact

Clients receive a deterministic validation error at the HTTP boundary, and downstream services are protected from incomplete requests.

## Validation

- targeted controller suite: 27 tests passed
- full server suite excluding the two local external-CLI tests: 1196 tests passed
- Maven Checkstyle: 0 violations
- `git diff --check`

Closes #2075.
Closes #2076.
Closes #2077.
