### PR TITLE
fix: scope query history to authenticated subject

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
@@ -100,8 +100,10 @@ public class QueryHistoryService {
     public PageResult<MessageQueryHistoryVO> listMessageQueries(String clusterId, String queryType,
                                                                  String search, int page, int pageSize) {
         String pattern = escapeLike(search);
+        String queriedBy = AuthenticatedUserContext.currentUsernameOrSystem();
         QueryWrapper<RmqMessageQuery> query = new QueryWrapper<RmqMessageQuery>()
                 .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
+                .eq("queried_by", queriedBy)
                 .eq(StringUtils.hasText(queryType), "query_type", queryType)
                 .and(StringUtils.hasText(search), nested -> nested
                         .like("topic", pattern)
@@ -118,8 +120,10 @@ public class QueryHistoryService {
     public PageResult<TraceQueryHistoryVO> listTraceQueries(String clusterId, String search,
                                                              int page, int pageSize) {
         String pattern = escapeLike(search);
+        String queriedBy = AuthenticatedUserContext.currentUsernameOrSystem();
         QueryWrapper<RmqTraceQuery> query = new QueryWrapper<RmqTraceQuery>()
                 .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
+                .eq("queried_by", queriedBy)
                 .and(StringUtils.hasText(search), nested -> nested
                         .like("topic", pattern)
                         .or().like("msg_id", pattern)
@@ -132,19 +136,24 @@ public class QueryHistoryService {
     }
 
     public QueryHistorySummaryVO summarize(String clusterId) {
+        String queriedBy = AuthenticatedUserContext.currentUsernameOrSystem();
         QueryWrapper<RmqMessageQuery> messageFilter = new QueryWrapper<RmqMessageQuery>()
-                .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId);
+                .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
+                .eq("queried_by", queriedBy);
         QueryWrapper<RmqTraceQuery> traceFilter = new QueryWrapper<RmqTraceQuery>()
-                .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId);
+                .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
+                .eq("queried_by", queriedBy);
         long messageCount = messageQueryMapper.selectCount(messageFilter);
         long traceCount = traceQueryMapper.selectCount(traceFilter);
         RmqMessageQuery latestMessage = messageQueryMapper.selectOne(
                 new QueryWrapper<RmqMessageQuery>()
                         .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
+                        .eq("queried_by", queriedBy)
                         .orderByDesc("gmt_create", "id").last("LIMIT 1"));
         RmqTraceQuery latestTrace = traceQueryMapper.selectOne(
                 new QueryWrapper<RmqTraceQuery>()
                         .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
+                        .eq("queried_by", queriedBy)
                         .orderByDesc("gmt_create", "id").last("LIMIT 1"));
         LocalDateTime latest = latestOf(
                 latestMessage == null ? null : latestMessage.getGmtCreate(),

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
@@ -107,6 +107,7 @@ class QueryHistoryServiceTest {
 
     @Test
     void listsMessageHistoryAsNewestFirstPage() {
+        AuthenticatedUserContext.setUsername("alice");
         RmqMessageQuery entity = new RmqMessageQuery();
         entity.setId(9L);
         entity.setQueryType("KEY");
@@ -132,10 +133,15 @@ class QueryHistoryServiceTest {
             assertThat(item.getMessageKey()).isEqualTo("order-1");
             assertThat(item.getQueriedBy()).isEqualTo("alice");
         });
+
+        ArgumentCaptor<Wrapper<RmqMessageQuery>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(messageQueryMapper).selectPage(any(Page.class), queryCaptor.capture());
+        assertThat(queryCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
     }
 
     @Test
     void summarizesBothHistoryStreams() {
+        AuthenticatedUserContext.setUsername("alice");
         RmqMessageQuery message = new RmqMessageQuery();
         message.setGmtCreate(LocalDateTime.of(2026, 8, 5, 10, 0));
         RmqTraceQuery trace = new RmqTraceQuery();
@@ -150,5 +156,12 @@ class QueryHistoryServiceTest {
         assertThat(summary.getMessageQueries()).isEqualTo(7);
         assertThat(summary.getTraceQueries()).isEqualTo(4);
         assertThat(summary.getLatestQueryAt()).isEqualTo(LocalDateTime.of(2026, 8, 5, 12, 0));
+
+        ArgumentCaptor<Wrapper<RmqMessageQuery>> messageCountCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        ArgumentCaptor<Wrapper<RmqTraceQuery>> traceCountCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(messageQueryMapper).selectCount(messageCountCaptor.capture());
+        verify(traceQueryMapper).selectCount(traceCountCaptor.capture());
+        assertThat(messageCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
+        assertThat(traceCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
     }
 }


### PR DESCRIPTION
## Summary
- scope message and trace history reads to the authenticated subject
- scope per-instance history summaries and latest-record lookups consistently
- retain deterministic `system` ownership when no request identity exists

## Verification
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -B -ntp -Dtest=QueryHistoryServiceTest,QueryHistoryControllerTest test`
- `git diff --check`

Closes #2265