### PR TITLE
fix: stabilize persisted audit queries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
@@ -29,6 +29,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /** MySQL-backed audit repository (rmq_operation_audit). */
@@ -36,7 +37,10 @@ import java.util.stream.Collectors;
 @Repository
 public class MybatisPlusAuditRepository implements AuditRepository {
 
+    private static final long FILTER_OPTIONS_CACHE_TTL_NANOS = TimeUnit.SECONDS.toNanos(30);
+
     private final RmqOperationAuditMapper auditMapper;
+    private volatile CachedFilterOptions cachedFilterOptions;
 
     @Override
     public PageResult<AuditRecordVO> findPage(String search, String operationType,
@@ -54,7 +58,7 @@ public class MybatisPlusAuditRepository implements AuditRepository {
                 .ge(startDate != null, "operated_at", startDate)
                 .le(endDate != null, "operated_at", endDate)
                 .eq(StringUtils.hasText(result), "result", result)
-                .orderByDesc("operated_at");
+                .orderByDesc("operated_at", "id");
         Page<RmqOperationAudit> resultPage = auditMapper.selectPage(
                 new Page<>(page, pageSize), query);
         List<AuditRecordVO> records = resultPage.getRecords().stream()
@@ -65,6 +69,23 @@ public class MybatisPlusAuditRepository implements AuditRepository {
 
     @Override
     public AuditFilterOptionsVO findFilterOptions() {
+        long now = System.nanoTime();
+        CachedFilterOptions cached = cachedFilterOptions;
+        if (isCacheValid(cached, now)) {
+            return cached.options();
+        }
+        synchronized (this) {
+            cached = cachedFilterOptions;
+            if (isCacheValid(cached, now)) {
+                return cached.options();
+            }
+            AuditFilterOptionsVO options = loadFilterOptions();
+            cachedFilterOptions = new CachedFilterOptions(options, now);
+            return options;
+        }
+    }
+
+    private AuditFilterOptionsVO loadFilterOptions() {
         List<Map<String, Object>> values = auditMapper.selectMaps(
                 new QueryWrapper<RmqOperationAudit>()
                         .select("operation", "resource_type", "cluster_id", "result")
@@ -90,6 +111,14 @@ public class MybatisPlusAuditRepository implements AuditRepository {
         entity.setOperator(record.getOperator());
         entity.setOperatedAt(record.getTimestamp() == null ? LocalDateTime.now() : record.getTimestamp());
         auditMapper.insert(entity);
+        cachedFilterOptions = null;
+    }
+
+    private static boolean isCacheValid(CachedFilterOptions cached, long now) {
+        return cached != null && now - cached.createdAtNanos() < FILTER_OPTIONS_CACHE_TTL_NANOS;
+    }
+
+    private record CachedFilterOptions(AuditFilterOptionsVO options, long createdAtNanos) {
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
@@ -80,11 +80,11 @@ class MybatisPlusAuditRepositoryTest {
         assertThat(record.getClusterId()).isEqualTo("prod-cn");
         assertThat(record.getErrorMessage()).isEqualTo("denied");
         assertThat(queryCaptor.getValue().getSqlSegment())
-                .contains("operation", "resource_type", "cluster_id", "result");
+                .contains("operation", "resource_type", "cluster_id", "result", "operated_at", "id");
     }
 
     @Test
-    void findFilterOptionsPreservesPersistedValuesFromOneQuery() {
+    void findFilterOptionsPreservesPersistedValuesAndCachesTheResult() {
         when(auditMapper.selectMaps(any(Wrapper.class))).thenReturn(List.of(
                 Map.of("operation", "DELETE_TOPIC", "resource_type", "TOPIC",
                         "cluster_id", "prod-cn", "result", "SUCCESS"),
@@ -94,17 +94,31 @@ class MybatisPlusAuditRepositoryTest {
                         "cluster_id", "", "result", "PARTIAL")));
 
         AuditFilterOptionsVO options = repository.findFilterOptions();
+        AuditFilterOptionsVO cachedOptions = repository.findFilterOptions();
 
         assertThat(options.getOperationTypes()).containsExactly(" CREATE_TOPIC ", "DELETE_TOPIC");
         assertThat(options.getResourceTypes()).containsExactly("GROUP", "TOPIC");
         assertThat(options.getClusterIds()).containsExactly("prod-cn", "prod-sh");
         assertThat(options.getResults()).containsExactly("FAILED", "PARTIAL", "SUCCESS");
+        assertThat(cachedOptions).isSameAs(options);
         ArgumentCaptor<Wrapper<RmqOperationAudit>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
         verify(auditMapper).selectMaps(queryCaptor.capture());
         assertThat(((QueryWrapper<RmqOperationAudit>) queryCaptor.getValue()).getSqlSelect())
                 .contains("operation", "resource_type", "cluster_id", "result");
         assertThat(queryCaptor.getValue().getSqlSegment())
                 .contains("GROUP BY operation,resource_type,cluster_id,result");
+    }
+
+    @Test
+    void saveInvalidatesCachedFilterOptions() {
+        when(auditMapper.selectMaps(any(Wrapper.class))).thenReturn(List.of());
+
+        repository.findFilterOptions();
+        repository.save(AuditRecordVO.builder().operationType("CREATE_TOPIC").build());
+        repository.findFilterOptions();
+
+        verify(auditMapper, org.mockito.Mockito.times(2)).selectMaps(any(Wrapper.class));
+        verify(auditMapper).insert(any(RmqOperationAudit.class));
     }
 
 }


### PR DESCRIPTION
## Summary
- use audit IDs as a deterministic tie-breaker for equal timestamps
- cache dynamic audit filter options for 30 seconds
- invalidate the cache after successful audit writes

## Verification
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -B -ntp -Dtest=MybatisPlusAuditRepositoryTest test`
- `git diff --check`

Closes #2269