### PR TITLE
fix: use targeted lookups for alert mutations

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
@@ -18,9 +18,14 @@ package org.apache.rocketmq.studio.ops.alert;
 
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AlertRepository {
     List<AlertRuleVO> findAllRules();
+
+    Optional<AlertRuleVO> findRuleById(String id);
+
+    List<AlertRuleVO> findRulesByIds(List<String> ids);
 
     AlertRuleVO saveRule(AlertRuleVO rule);
 
@@ -29,6 +34,8 @@ public interface AlertRepository {
     boolean deleteRule(String id);
 
     List<SystemAlertVO> findAlerts(String level);
+
+    Optional<SystemAlertVO> findAlertById(String id);
 
     boolean acknowledgeAlert(SystemAlertVO alert);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -122,11 +121,8 @@ public class AlertService {
     public AlertRuleVO toggleRule(String id, boolean enabled) {
         log.info("Toggling alert rule id={}, enabled={}", id, enabled);
         validateRuleId(id);
-        List<AlertRuleVO> rules = alertRepository.findAllRules();
-        AlertRuleVO rule = rules.stream()
-                .filter(r -> Objects.equals(r.getId(), id))
-                .findFirst()
-                .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "Alert rule not found: " + id));
+        AlertRuleVO rule = alertRepository.findRuleById(id)
+                .orElseThrow(() -> ruleNotFound(id));
         rule.setEnabled(enabled);
         AlertRuleVO saved = alertRepository.saveRule(rule);
         auditRule("TOGGLE_ALERT_RULE", saved, "enabled=" + enabled);
@@ -146,7 +142,7 @@ public class AlertService {
     public AlertRuleBulkResultVO bulkToggleRules(List<String> ids, boolean enabled) {
         List<String> normalizedIds = normalizeBulkIds(ids);
         Map<String, AlertRuleVO> rulesById = new LinkedHashMap<>();
-        for (AlertRuleVO rule : alertRepository.findAllRules()) {
+        for (AlertRuleVO rule : alertRepository.findRulesByIds(normalizedIds)) {
             rulesById.put(rule.getId(), rule);
         }
         List<String> succeeded = new ArrayList<>();
@@ -225,11 +221,9 @@ public class AlertService {
         if (id == null || id.isBlank()) {
             throw new BusinessException(400, "System alert ID is required");
         }
-        List<SystemAlertVO> alerts = alertRepository.findAlerts(null);
-        SystemAlertVO alert = alerts.stream()
-                .filter(a -> Objects.equals(a.getId(), id))
-                .findFirst()
-                .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "System alert not found: " + id));
+        SystemAlertVO alert = alertRepository.findAlertById(id)
+                .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404,
+                        "System alert not found: " + id));
         alert.setAcknowledged(true);
         if (!alertRepository.acknowledgeAlert(alert)) {
             throw new BusinessException(404, "System alert not found: " + id);

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -31,6 +31,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -46,6 +47,22 @@ public class MybatisPlusAlertRepository implements AlertRepository {
     @Override
     public List<AlertRuleVO> findAllRules() {
         return ruleMapper.selectList(new QueryWrapper<RmqAlertRule>().orderByAsc("name")).stream()
+                .map(MybatisPlusAlertRepository::toRuleVO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<AlertRuleVO> findRuleById(String id) {
+        return Optional.ofNullable(ruleMapper.selectById(id))
+                .map(MybatisPlusAlertRepository::toRuleVO);
+    }
+
+    @Override
+    public List<AlertRuleVO> findRulesByIds(List<String> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        return ruleMapper.selectBatchIds(ids).stream()
                 .map(MybatisPlusAlertRepository::toRuleVO)
                 .collect(Collectors.toList());
     }
@@ -83,6 +100,12 @@ public class MybatisPlusAlertRepository implements AlertRepository {
         return alertMapper.selectList(query).stream()
                 .map(MybatisPlusAlertRepository::toAlertVO)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<SystemAlertVO> findAlertById(String id) {
+        return Optional.ofNullable(alertMapper.selectById(id))
+                .map(MybatisPlusAlertRepository::toAlertVO);
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -562,13 +563,14 @@ class AlertServiceTest {
     @Test
     void toggleRuleShouldEnableRule() {
         AlertRuleVO existing = AlertRuleVO.builder().id("rule-1").name("CPU Alert").enabled(false).build();
-        when(alertRepository.findAllRules()).thenReturn(List.of(existing));
+        when(alertRepository.findRuleById("rule-1")).thenReturn(Optional.of(existing));
         when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         AlertRuleVO result = alertService.toggleRule("rule-1", true);
 
         assertThat(result.isEnabled()).isTrue();
         verify(alertRepository).saveRule(result);
+        verify(alertRepository, never()).findAllRules();
         verify(operationAuditService).record(eq("TOGGLE_ALERT_RULE"), eq("ALERT_RULE"), eq("rule-1"),
                 eq(null), eq("enabled=true"), eq("SUCCESS"), eq(null));
     }
@@ -576,7 +578,7 @@ class AlertServiceTest {
     @Test
     void toggleRuleShouldDisableRule() {
         AlertRuleVO existing = AlertRuleVO.builder().id("rule-1").name("CPU Alert").enabled(true).build();
-        when(alertRepository.findAllRules()).thenReturn(List.of(existing));
+        when(alertRepository.findRuleById("rule-1")).thenReturn(Optional.of(existing));
         when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         AlertRuleVO result = alertService.toggleRule("rule-1", false);
@@ -591,21 +593,12 @@ class AlertServiceTest {
                 .hasMessage("Alert rule ID is required")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
 
-        verify(alertRepository, never()).findAllRules();
-    }
-
-    @Test
-    void toggleRuleShouldIgnorePersistedRulesWithNullIds() {
-        when(alertRepository.findAllRules()).thenReturn(List.of(AlertRuleVO.builder().name("corrupt").build()));
-
-        assertThatThrownBy(() -> alertService.toggleRule("missing", true))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("Alert rule not found: missing");
+        verify(alertRepository, never()).findRuleById(any());
     }
 
     @Test
     void toggleRuleShouldThrowWhenRuleNotFound() {
-        when(alertRepository.findAllRules()).thenReturn(Collections.emptyList());
+        when(alertRepository.findRuleById("non-existent")).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> alertService.toggleRule("non-existent", true))
                 .isInstanceOf(BusinessException.class)
@@ -645,7 +638,7 @@ class AlertServiceTest {
     @Test
     void bulkToggleShouldDeduplicateIdsAndReportMissingRules() {
         AlertRuleVO rule = AlertRuleVO.builder().id("rule-1").name("High CPU").enabled(false).build();
-        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+        when(alertRepository.findRulesByIds(List.of("rule-1", "missing"))).thenReturn(List.of(rule));
         when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(true);
 
         AlertRuleBulkResultVO result = alertService.bulkToggleRules(
@@ -656,12 +649,13 @@ class AlertServiceTest {
         assertThat(result.getUpdatedRules()).singleElement()
                 .extracting(AlertRuleVO::isEnabled).isEqualTo(true);
         verify(alertRepository).replaceRule(rule);
+        verify(alertRepository, never()).findAllRules();
     }
 
     @Test
     void bulkToggleShouldReportRulesDeletedConcurrentlyInsteadOfRecreatingThem() {
         AlertRuleVO rule = AlertRuleVO.builder().id("rule-1").name("High CPU").enabled(false).build();
-        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+        when(alertRepository.findRulesByIds(List.of("rule-1"))).thenReturn(List.of(rule));
         when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(false);
 
         AlertRuleBulkResultVO result = alertService.bulkToggleRules(List.of("rule-1"), true);
@@ -722,13 +716,14 @@ class AlertServiceTest {
     void acknowledgeAlertShouldSetAcknowledgedTrue() {
         SystemAlertVO existing = SystemAlertVO.builder().id("a1").level(AlertLevel.error)
                 .title("Broker Down").acknowledged(false).build();
-        when(alertRepository.findAlerts(null)).thenReturn(List.of(existing));
+        when(alertRepository.findAlertById("a1")).thenReturn(Optional.of(existing));
         when(alertRepository.acknowledgeAlert(any(SystemAlertVO.class))).thenReturn(true);
 
         SystemAlertVO result = alertService.acknowledgeAlert("a1");
 
         assertThat(result.isAcknowledged()).isTrue();
         verify(alertRepository).acknowledgeAlert(result);
+        verify(alertRepository, never()).findAlerts(any());
         verify(operationAuditService).record(eq("ACKNOWLEDGE_SYSTEM_ALERT"), eq("SYSTEM_ALERT"), eq("a1"),
                 eq(null), eq("acknowledged=true"), eq("SUCCESS"), eq(null));
     }
@@ -740,21 +735,12 @@ class AlertServiceTest {
                 .hasMessage("System alert ID is required")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
 
-        verify(alertRepository, never()).findAlerts(any());
-    }
-
-    @Test
-    void acknowledgeAlertShouldIgnorePersistedAlertsWithNullIds() {
-        when(alertRepository.findAlerts(null)).thenReturn(List.of(SystemAlertVO.builder().title("corrupt").build()));
-
-        assertThatThrownBy(() -> alertService.acknowledgeAlert("missing"))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("System alert not found: missing");
+        verify(alertRepository, never()).findAlertById(any());
     }
 
     @Test
     void acknowledgeAlertShouldThrowWhenAlertNotFound() {
-        when(alertRepository.findAlerts(null)).thenReturn(Collections.emptyList());
+        when(alertRepository.findAlertById("non-existent")).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> alertService.acknowledgeAlert("non-existent"))
                 .isInstanceOf(BusinessException.class)
@@ -765,7 +751,7 @@ class AlertServiceTest {
     void acknowledgeAlertShouldRejectConcurrentRemoval() {
         SystemAlertVO existing = SystemAlertVO.builder().id("a1").level(AlertLevel.error)
                 .title("Broker Down").acknowledged(false).build();
-        when(alertRepository.findAlerts(null)).thenReturn(List.of(existing));
+        when(alertRepository.findAlertById("a1")).thenReturn(Optional.of(existing));
         when(alertRepository.acknowledgeAlert(any(SystemAlertVO.class))).thenReturn(false);
 
         assertThatThrownBy(() -> alertService.acknowledgeAlert("a1"))

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,6 +69,27 @@ class MybatisPlusAlertRepositoryTest {
         assertThat(repository.findAlerts(null)).singleElement()
                 .satisfies(alert -> assertThat(alert.getLevel()).isEqualTo(
                         org.apache.rocketmq.studio.common.domain.enums.AlertLevel.warning));
+    }
+
+    @Test
+    void findAlertByIdShouldMapOnlyTheRequestedAlert() {
+        RmqSystemAlert entity = new RmqSystemAlert();
+        entity.setId("alert-1");
+        entity.setLevel("error");
+        when(alertMapper.selectById("alert-1")).thenReturn(entity);
+
+        Optional<SystemAlertVO> result = repository.findAlertById("alert-1");
+
+        assertThat(result).map(SystemAlertVO::getId).contains("alert-1");
+        verify(alertMapper).selectById("alert-1");
+        verify(alertMapper, never()).selectList(any());
+    }
+
+    @Test
+    void findRulesByIdsShouldSkipDatabaseLookupForAnEmptySelection() {
+        assertThat(repository.findRulesByIds(List.of())).isEmpty();
+
+        verify(ruleMapper, never()).selectBatchIds(any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- use direct repository lookups for single alert-rule toggles and system-alert acknowledgements
- load only selected rules for bulk toggles instead of reading the entire rule table
- add repository and service regression coverage for the targeted paths

## Verification
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home PATH="$JAVA_HOME/bin:$PATH" mvn -q -B -ntp -Dtest=AlertServiceTest,MybatisPlusAlertRepositoryTest test`

Closes #2271
