### PR TITLE
fix: harden persisted plain ACL integrity

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -32,8 +32,10 @@ import lombok.RequiredArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -164,8 +166,13 @@ public class MybatisPlusAclRepository implements AclRepository {
     @Override
     @Transactional
     public PlainAccessConfigVO createAndUpdatePlainAccessConfig(PlainAccessConfigVO config) {
-        RmqAclUser existing = userMapper.selectOne(
+        List<RmqAclUser> existingAccounts = userMapper.selectList(
                 new QueryWrapper<RmqAclUser>().eq("access_key", config.getAccessKey()));
+        if (existingAccounts.size() > 1) {
+            throw new BusinessException(409, "Multiple plain access accounts use accessKey: "
+                    + config.getAccessKey());
+        }
+        RmqAclUser existing = existingAccounts.isEmpty() ? null : existingAccounts.get(0);
         boolean secretProvided = StringUtils.hasText(config.getSecretKey());
         if (!secretProvided && existing == null) {
             throw new BusinessException(400, "secretKey is required for a new plain access account");
@@ -289,7 +296,7 @@ public class MybatisPlusAclRepository implements AclRepository {
         String defaultTopicPerm = null;
         String defaultGroupPerm = null;
         for (AclRuleVO rule : userRules) {
-            String actions = rule.getActions() == null ? "" : String.join(",", rule.getActions());
+            String actions = joinNormalizedCsv(rule.getActions());
             if ("Topic".equals(rule.getResourceType())) {
                 topicPerms.add(rule.getResource() + "=" + actions);
             } else if ("Group".equals(rule.getResourceType())) {
@@ -352,7 +359,7 @@ public class MybatisPlusAclRepository implements AclRepository {
         entity.setResource(rule.getResource());
         entity.setResourceType(rule.getResourceType());
         entity.setResourcePattern(rule.getResourcePattern());
-        entity.setActions(rule.getActions() == null ? null : String.join(",", rule.getActions()));
+        entity.setActions(joinNormalizedCsv(rule.getActions()));
         entity.setDecision(rule.getDecision());
         entity.setScope(rule.getScope());
         entity.setAclVersion(rule.getAclVersion());
@@ -381,7 +388,7 @@ public class MybatisPlusAclRepository implements AclRepository {
         entity.setAccessKey(user.getAccessKey());
         entity.setSecretKey(CredentialUtils.encodeBase64(user.getSecretKey()));
         entity.setAdmin(user.isAdmin());
-        entity.setClusters(user.getClusters() == null ? null : String.join(",", user.getClusters()));
+        entity.setClusters(joinNormalizedCsv(user.getClusters()));
         entity.setCreatedAt(user.getCreatedAt());
         entity.setUpdatedAt(LocalDateTime.now());
         return entity;
@@ -394,6 +401,20 @@ public class MybatisPlusAclRepository implements AclRepository {
         return Arrays.stream(value.split(","))
                 .map(String::trim)
                 .filter(part -> !part.isEmpty())
+                .distinct()
                 .collect(Collectors.toList());
+    }
+
+    private static String joinNormalizedCsv(List<String> values) {
+        if (values == null) {
+            return null;
+        }
+        Set<String> normalized = new LinkedHashSet<>();
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                normalized.add(value.trim());
+            }
+        }
+        return normalized.isEmpty() ? null : String.join(",", normalized);
     }
 }

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -178,7 +178,8 @@ CREATE TABLE IF NOT EXISTS rmq_acl_user (
   white_remote_address VARCHAR(255) COMMENT 'plain access 账号 IP 白名单，空表示不限制',
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  UNIQUE KEY uk_username (username)
+  UNIQUE KEY uk_username (username),
+  UNIQUE KEY uk_access_key (access_key)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 13. 告警规则

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
@@ -34,6 +34,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,7 +77,7 @@ class MybatisPlusAclRepositoryTest {
 
     @Test
     void upsertShouldAssignUniqueRuleIdPerPermission() {
-        when(userMapper.selectOne(any(QueryWrapper.class))).thenReturn(null);
+        when(userMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of());
         when(userMapper.insert(any(RmqAclUser.class))).thenReturn(1);
         when(ruleMapper.delete(any(QueryWrapper.class))).thenReturn(0);
         when(ruleMapper.insert(any(RmqAclRule.class))).thenReturn(1);
@@ -108,7 +109,7 @@ class MybatisPlusAclRepositoryTest {
 
     @Test
     void upsertShouldReplacePreviousRulesBeforeInsertingNewOnes() {
-        when(userMapper.selectOne(any(QueryWrapper.class))).thenReturn(null);
+        when(userMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of());
         when(userMapper.insert(any(RmqAclUser.class))).thenReturn(1);
         when(ruleMapper.delete(any(QueryWrapper.class))).thenReturn(2);
         when(ruleMapper.insert(any(RmqAclRule.class))).thenReturn(1);
@@ -128,7 +129,7 @@ class MybatisPlusAclRepositoryTest {
 
     @Test
     void createShouldRejectBlankSecretForNewAccount() {
-        when(userMapper.selectOne(any(QueryWrapper.class))).thenReturn(null);
+        when(userMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of());
 
         PlainAccessConfigVO config = PlainAccessConfigVO.builder()
                 .accessKey("svc-new")
@@ -147,7 +148,7 @@ class MybatisPlusAclRepositoryTest {
     void updateWithBlankSecretShouldKeepStoredSecret() {
         RmqAclUser existing = userEntity("plain-svc-x", "svc-x",
                 CredentialUtils.encodeBase64("kept-secret-value"));
-        when(userMapper.selectOne(any(QueryWrapper.class))).thenReturn(existing);
+        when(userMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of(existing));
         when(userMapper.updateById(any(RmqAclUser.class))).thenReturn(1);
         when(ruleMapper.delete(any(QueryWrapper.class))).thenReturn(0);
 
@@ -169,7 +170,7 @@ class MybatisPlusAclRepositoryTest {
 
     @Test
     void createShouldPersistWhiteRemoteAddressAndTrimBlanks() {
-        when(userMapper.selectOne(any(QueryWrapper.class))).thenReturn(null);
+        when(userMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of());
         when(userMapper.insert(any(RmqAclUser.class))).thenReturn(1);
         when(ruleMapper.delete(any(QueryWrapper.class))).thenReturn(0);
 
@@ -189,7 +190,7 @@ class MybatisPlusAclRepositoryTest {
 
     @Test
     void createShouldStoreBlankWhiteRemoteAddressAsNull() {
-        when(userMapper.selectOne(any(QueryWrapper.class))).thenReturn(null);
+        when(userMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of());
         when(userMapper.insert(any(RmqAclUser.class))).thenReturn(1);
         when(ruleMapper.delete(any(QueryWrapper.class))).thenReturn(0);
 
@@ -211,7 +212,7 @@ class MybatisPlusAclRepositoryTest {
         RmqAclUser existing = userEntity("plain-svc-x", "svc-x",
                 CredentialUtils.encodeBase64("kept-secret-value"));
         existing.setWhiteRemoteAddress("10.0.1.0/24");
-        when(userMapper.selectOne(any(QueryWrapper.class))).thenReturn(existing);
+        when(userMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of(existing));
         when(userMapper.updateById(any(RmqAclUser.class))).thenReturn(1);
         when(userMapper.update(isNull(), any(UpdateWrapper.class))).thenReturn(1);
         when(ruleMapper.delete(any(QueryWrapper.class))).thenReturn(0);
@@ -269,6 +270,53 @@ class MybatisPlusAclRepositoryTest {
                 .containsExactly("svc-a", "svc-g");
         assertThat(config.getAccountCount()).isEqualTo(2);
         assertThat(config.isAclEnabled()).isTrue();
+    }
+
+    @Test
+    void plainAccessUpsertShouldRejectDuplicateAccessKeys() {
+        RmqAclUser first = userEntity("plain-first", "svc-duplicate", CredentialUtils.encodeBase64("secret-a"));
+        RmqAclUser second = userEntity("plain-second", "svc-duplicate", CredentialUtils.encodeBase64("secret-b"));
+        when(userMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of(first, second));
+
+        assertThatThrownBy(() -> repository.createAndUpdatePlainAccessConfig(PlainAccessConfigVO.builder()
+                        .accessKey("svc-duplicate")
+                        .secretKey("replacement")
+                        .build()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(409));
+
+        verify(userMapper, never()).insert(any(RmqAclUser.class));
+        verify(userMapper, never()).updateById(any(RmqAclUser.class));
+    }
+
+    @Test
+    void saveRuleShouldNormalizeActionCollectionsBeforePersistence() {
+        when(ruleMapper.selectById("rule-a")).thenReturn(null);
+        when(ruleMapper.insert(any(RmqAclRule.class))).thenReturn(1);
+        AclRuleVO rule = AclRuleVO.builder().id("rule-a").principal("svc-a").resource("orders")
+                .actions(Arrays.asList(" PUB ", null, "", "SUB", "PUB"))
+                .build();
+
+        repository.saveRule(rule);
+
+        ArgumentCaptor<RmqAclRule> captor = ArgumentCaptor.forClass(RmqAclRule.class);
+        verify(ruleMapper).insert(captor.capture());
+        assertThat(captor.getValue().getActions()).isEqualTo("PUB,SUB");
+    }
+
+    @Test
+    void saveUserShouldNormalizeClusterCollectionsBeforePersistence() {
+        when(userMapper.selectById("user-a")).thenReturn(null);
+        when(userMapper.insert(any(RmqAclUser.class))).thenReturn(1);
+        AclUserVO user = AclUserVO.builder().id("user-a").username("svc-a").accessKey("svc-a")
+                .secretKey("secret").clusters(Arrays.asList(" cluster-a ", null, "", "cluster-b", "cluster-a"))
+                .build();
+
+        repository.saveUser(user);
+
+        ArgumentCaptor<RmqAclUser> captor = ArgumentCaptor.forClass(RmqAclUser.class);
+        verify(userMapper).insert(captor.capture());
+        assertThat(captor.getValue().getClusters()).isEqualTo("cluster-a,cluster-b");
     }
 
     private static RmqAclUser userEntity(String id, String accessKey, String encodedSecret) {


### PR DESCRIPTION
## Summary
- add a unique `access_key` constraint for new local ACL schemas
- detect legacy duplicate access keys and return a structured conflict instead of relying on `selectOne`
- normalize local ACL action and cluster CSV values before persistence

## Verification
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home PATH="$JAVA_HOME/bin:$PATH" mvn -q -B -ntp -Dtest=MybatisPlusAclRepositoryTest test`

Closes #2273
