### PR TITLE
feat: paginate and filter K8s certificate inventory

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertController.java
@@ -17,16 +17,16 @@
 package org.apache.rocketmq.studio.cluster.k8s;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/k8s-certs")
@@ -36,8 +36,15 @@ public class K8sCertController {
     private final K8sCertService k8sCertService;
 
     @GetMapping
-    public Result<List<K8sCertVO>> listCerts() {
-        return Result.ok(k8sCertService.listCerts());
+    public Result<PageResult<K8sCertVO>> listCerts(
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String cluster,
+            @RequestParam(required = false) String namespace,
+            @RequestParam(required = false) String type,
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return Result.ok(k8sCertService.listCerts(search, cluster, namespace, type, status, page, pageSize));
     }
 
     @PostMapping("/create")

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertRepository.java
@@ -17,12 +17,14 @@
 package org.apache.rocketmq.studio.cluster.k8s;
 
 
-import java.util.List;
+import org.apache.rocketmq.studio.common.domain.PageResult;
+
 import java.util.Optional;
 
 public interface K8sCertRepository {
 
-    List<K8sCertVO> findAll();
+    PageResult<K8sCertVO> findPage(String search, String cluster, String namespace, String type, String status,
+                                   int page, int pageSize);
 
     Optional<K8sCertVO> findById(Long id);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.k8s;
 
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import lombok.extern.slf4j.Slf4j;
@@ -59,12 +60,19 @@ public class K8sCertService {
         this.clock = clock;
     }
 
-    public List<K8sCertVO> listCerts() {
-        log.info("Listing all K8s certificates");
+    public PageResult<K8sCertVO> listCerts(String search, String cluster, String namespace, String type, String status,
+                                            int page, int pageSize) {
+        validatePage(page, pageSize);
+        String normalizedStatus = normalizeStatus(status);
+        log.info("Listing K8s certificates search={}, cluster={}, namespace={}, type={}, status={}, page={}, pageSize={}",
+                search, cluster, namespace, type, normalizedStatus, page, pageSize);
         LocalDateTime now = LocalDateTime.now(clock);
-        return k8sCertRepository.findAll().stream()
+        PageResult<K8sCertVO> result = k8sCertRepository.findPage(search, cluster, namespace, type, normalizedStatus,
+                page, pageSize);
+        List<K8sCertVO> certificates = result.getItems().stream()
                 .map(cert -> refreshExpirationState(cert, now))
                 .collect(Collectors.toCollection(ArrayList::new));
+        return PageResult.of(certificates, result.getTotal(), page, pageSize);
     }
 
     public K8sCertVO createCert(CreateCertDTO command) {
@@ -177,6 +185,26 @@ public class K8sCertService {
     private void requireCommand(Object command) {
         if (command == null) {
             throw new BusinessException(400, "K8s certificate request is required");
+        }
+    }
+
+    private void validatePage(int page, int pageSize) {
+        if (page < 1) {
+            throw new BusinessException(400, "page must be greater than 0");
+        }
+        if (pageSize < 1 || pageSize > 100) {
+            throw new BusinessException(400, "pageSize must be between 1 and 100");
+        }
+    }
+
+    private String normalizeStatus(String status) {
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+        try {
+            return CertStatus.valueOf(status.trim().toLowerCase()).name();
+        } catch (IllegalArgumentException exception) {
+            throw new BusinessException(400, "Unsupported certificate status: " + status);
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -17,11 +17,13 @@
 package org.apache.rocketmq.studio.cluster.k8s;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.persistence.entity.RmqK8sCertificate;
 import org.apache.rocketmq.studio.persistence.mapper.RmqK8sCertificateMapper;
@@ -48,10 +50,23 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
     private final ObjectMapper objectMapper;
 
     @Override
-    public List<K8sCertVO> findAll() {
-        return certMapper.selectList(new QueryWrapper<RmqK8sCertificate>().orderByAsc("name")).stream()
+    public PageResult<K8sCertVO> findPage(String search, String cluster, String namespace, String type, String status,
+                                          int page, int pageSize) {
+        QueryWrapper<RmqK8sCertificate> query = new QueryWrapper<RmqK8sCertificate>()
+                .and(StringUtils.hasText(search), wrapper -> wrapper.like("name", search)
+                        .or().like("cluster", search)
+                        .or().like("namespace", search)
+                        .or().like("san", search))
+                .eq(StringUtils.hasText(cluster), "cluster", cluster)
+                .eq(StringUtils.hasText(namespace), "namespace", namespace)
+                .eq(StringUtils.hasText(type), "cert_type", type)
+                .eq(StringUtils.hasText(status), "status", status)
+                .orderByAsc("name", "id");
+        Page<RmqK8sCertificate> resultPage = certMapper.selectPage(new Page<>(page, pageSize), query);
+        List<K8sCertVO> certificates = resultPage.getRecords().stream()
                 .map(this::toVO)
                 .collect(Collectors.toList());
+        return PageResult.of(certificates, resultPage.getTotal(), page, pageSize);
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.k8s;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -29,7 +30,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -54,34 +54,36 @@ class K8sCertControllerTest {
     private K8sCertService k8sCertService;
 
     @Test
-    void listCertsShouldReturnAllCerts() throws Exception {
+    void listCertsShouldReturnAPageOfCertificates() throws Exception {
         K8sCertVO cert1 = buildCert(1L, "rocketmq-tls", CertType.TLS, CertStatus.valid);
         K8sCertVO cert2 = buildCert(2L, "broker-mtls", CertType.mTLS, CertStatus.expiring);
-        when(k8sCertService.listCerts()).thenReturn(Arrays.asList(cert1, cert2));
+        when(k8sCertService.listCerts(null, null, null, null, null, 1, 20))
+                .thenReturn(PageResult.of(Arrays.asList(cert1, cert2), 2, 1, 20));
 
         mockMvc.perform(get("/api/k8s-certs"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].id").value(1))
-                .andExpect(jsonPath("$.data[0].name").value("rocketmq-tls"))
-                .andExpect(jsonPath("$.data[0].type").value("TLS"))
-                .andExpect(jsonPath("$.data[0].status").value("valid"))
-                .andExpect(jsonPath("$.data[1].id").value(2))
-                .andExpect(jsonPath("$.data[1].name").value("broker-mtls"));
+                .andExpect(jsonPath("$.data.total").value(2))
+                .andExpect(jsonPath("$.data.items.length()").value(2))
+                .andExpect(jsonPath("$.data.items[0].id").value(1))
+                .andExpect(jsonPath("$.data.items[0].name").value("rocketmq-tls"))
+                .andExpect(jsonPath("$.data.items[0].type").value("TLS"))
+                .andExpect(jsonPath("$.data.items[0].status").value("valid"))
+                .andExpect(jsonPath("$.data.items[1].id").value(2))
+                .andExpect(jsonPath("$.data.items[1].name").value("broker-mtls"));
     }
 
     @Test
-    void listCertsShouldReturnEmptyArrayWhenNoCerts() throws Exception {
-        when(k8sCertService.listCerts()).thenReturn(Collections.emptyList());
+    void listCertsShouldReturnAnEmptyPageWhenNoCerts() throws Exception {
+        when(k8sCertService.listCerts(null, null, null, null, null, 1, 20))
+                .thenReturn(PageResult.empty(1, 20));
 
         mockMvc.perform(get("/api/k8s-certs"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data.length()").value(0));
+                .andExpect(jsonPath("$.data.items").isArray())
+                .andExpect(jsonPath("$.data.items.length()").value(0));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.k8s;
 
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +33,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -91,25 +91,27 @@ class K8sCertServiceTest {
                 .build();
         secondCert.setId(2L);
 
-        when(k8sCertRepository.findAll()).thenReturn(Arrays.asList(sampleCert, secondCert));
+        when(k8sCertRepository.findPage(null, null, null, null, null, 1, 20))
+                .thenReturn(PageResult.of(Arrays.asList(sampleCert, secondCert), 2, 1, 20));
 
-        List<K8sCertVO> result = k8sCertService.listCerts();
+        PageResult<K8sCertVO> result = k8sCertService.listCerts(null, null, null, null, null, 1, 20);
 
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getName()).isEqualTo("rocketmq-tls");
-        assertThat(result.get(0).getType()).isEqualTo(CertType.TLS);
-        assertThat(result.get(1).getName()).isEqualTo("broker-mtls");
-        assertThat(result.get(1).getType()).isEqualTo(CertType.mTLS);
-        verify(k8sCertRepository).findAll();
+        assertThat(result.getItems()).hasSize(2);
+        assertThat(result.getItems().get(0).getName()).isEqualTo("rocketmq-tls");
+        assertThat(result.getItems().get(0).getType()).isEqualTo(CertType.TLS);
+        assertThat(result.getItems().get(1).getName()).isEqualTo("broker-mtls");
+        assertThat(result.getItems().get(1).getType()).isEqualTo(CertType.mTLS);
+        verify(k8sCertRepository).findPage(null, null, null, null, null, 1, 20);
     }
 
     @Test
     void listCertsShouldReturnEmptyListWhenNoCerts() {
-        when(k8sCertRepository.findAll()).thenReturn(Collections.emptyList());
+        when(k8sCertRepository.findPage(null, null, null, null, null, 1, 20))
+                .thenReturn(PageResult.empty(1, 20));
 
-        List<K8sCertVO> result = k8sCertService.listCerts();
+        PageResult<K8sCertVO> result = k8sCertService.listCerts(null, null, null, null, null, 1, 20);
 
-        assertThat(result).isEmpty();
+        assertThat(result.getItems()).isEmpty();
     }
 
     @Test
@@ -124,10 +126,10 @@ class K8sCertServiceTest {
                 CertStatus.expired, -1);
         K8sCertVO validCert = copyWithExpiry(5L, now.plusDays(31),
                 CertStatus.expired, -1);
-        when(k8sCertRepository.findAll())
-                .thenReturn(List.of(sampleCert, expiresNowCert, expiringCert, validCert));
+        when(k8sCertRepository.findPage(null, null, null, null, null, 1, 20))
+                .thenReturn(PageResult.of(List.of(sampleCert, expiresNowCert, expiringCert, validCert), 4, 1, 20));
 
-        List<K8sCertVO> result = k8sCertService.listCerts();
+        List<K8sCertVO> result = k8sCertService.listCerts(null, null, null, null, null, 1, 20).getItems();
 
         assertThat(result).extracting(K8sCertVO::getStatus)
                 .containsExactly(CertStatus.expired, CertStatus.expired,

--- a/web/src/api/cluster.test.ts
+++ b/web/src/api/cluster.test.ts
@@ -63,9 +63,11 @@ describe('K8s certificate API', () => {
   });
 
   it('loads and unwraps certificate records', async () => {
-    mock.onGet('/k8s-certs').reply(200, { code: 200, message: 'success', data: [cert] });
+    const page = { items: [cert], total: 1, page: 2, size: 50 };
+    mock.onGet('/k8s-certs', { params: { page: 2, pageSize: 50, status: 'expiring' } })
+      .reply(200, { code: 200, message: 'success', data: page });
 
-    await expect(listK8sCerts()).resolves.toEqual([cert]);
+    await expect(listK8sCerts({ page: 2, pageSize: 50, status: 'expiring' })).resolves.toEqual(page);
   });
 
   it('returns the certificate created by the backend', async () => {

--- a/web/src/api/cluster.ts
+++ b/web/src/api/cluster.ts
@@ -113,6 +113,23 @@ export interface K8sCertInfo {
   keyPem?: string;
 }
 
+export interface K8sCertQuery {
+  search?: string;
+  cluster?: string;
+  namespace?: string;
+  type?: string;
+  status?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface K8sCertPage {
+  items: K8sCertInfo[];
+  total: number;
+  page: number;
+  size: number;
+}
+
 export interface NameServerConfigValue {
   address: string;
   configured: boolean;
@@ -216,8 +233,8 @@ export async function restartProxy(data: { clusterId: string; addr: string }) {
 }
 
 // ─── K8s Certs ──────────────────────────────────────────────────
-export async function listK8sCerts() {
-  const res = await client.get<{ data: K8sCertInfo[] }>('/k8s-certs');
+export async function listK8sCerts(params: K8sCertQuery = {}) {
+  const res = await client.get<{ data: K8sCertPage }>('/k8s-certs', { params });
   return res.data.data;
 }
 

--- a/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
@@ -16,17 +16,15 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import type { K8sCertInfo } from '../../../api/cluster';
-import { listK8sCerts, createK8sCert, deleteK8sCert } from '../../../services/clusterService';
+import { listK8sCerts } from '../../../services/clusterService';
 import K8sCertsPage from '../certs';
 
 vi.mock('../../../services/clusterService', () => ({
   listK8sCerts: vi.fn(),
-  createK8sCert: vi.fn(),
-  deleteK8sCert: vi.fn(),
 }));
 
 const certs: K8sCertInfo[] = [
@@ -76,7 +74,20 @@ beforeAll(() => {
 describe('K8sCertsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(listK8sCerts).mockResolvedValue(certs);
+    vi.mocked(listK8sCerts).mockImplementation(async (query = {}) => {
+      const search = query.search?.trim().toLowerCase();
+      const items = certs.filter(
+        (cert) =>
+          (!search ||
+            [cert.name, cert.cluster, ...(cert.san ?? [])].some((value) =>
+              value.toLowerCase().includes(search),
+            )) &&
+          (!query.cluster || cert.cluster === query.cluster) &&
+          (!query.type || cert.type === query.type) &&
+          (!query.status || cert.status === query.status),
+      );
+      return { items, total: items.length, page: query.page ?? 1, size: query.pageSize ?? 20 };
+    });
   });
 
   const renderPage = () =>
@@ -86,15 +97,13 @@ describe('K8sCertsPage', () => {
       </App>,
     );
 
-  it('displays certificate metadata without SAN or namespace columns', async () => {
+  it('displays certificate SAN metadata', async () => {
     renderPage();
 
     await screen.findByText('rocketmq-prod-tls');
 
-    expect(screen.getByText('prod-cluster')).toBeInTheDocument();
-    expect(screen.queryByText('broker.prod.example.com')).not.toBeInTheDocument();
-    expect(screen.queryByText('命名空间')).not.toBeInTheDocument();
-    expect(screen.queryByText('SAN')).not.toBeInTheDocument();
+    expect(screen.getByText('broker.prod.example.com')).toBeInTheDocument();
+    expect(screen.getByText('-')).toBeInTheDocument();
   });
 
   it('explains that certificate records are Studio-local metadata', async () => {
@@ -107,65 +116,43 @@ describe('K8sCertsPage', () => {
 
   it.each([
     ['staging-cluster', 'rocketmq-staging-tls', 'rocketmq-prod-tls'],
-    ['prod-tls', 'rocketmq-prod-tls', 'rocketmq-staging-tls'],
+    ['broker.prod.example.com', 'rocketmq-prod-tls', 'rocketmq-staging-tls'],
   ])('searches certificate metadata by %s', async (query, expected, hidden) => {
     const user = userEvent.setup();
     renderPage();
 
     await screen.findByText('rocketmq-prod-tls');
-    await user.type(screen.getByPlaceholderText('搜索证书名称或集群'), `${query}{enter}`);
+    await user.type(
+      screen.getByPlaceholderText('搜索证书名称、集群或 SAN'),
+      `${query}{enter}`,
+    );
 
     expect(screen.getByText(expected)).toBeInTheDocument();
     expect(screen.queryByText(hidden)).not.toBeInTheDocument();
   });
 
-  it('creates a certificate with PEM content through the modal', async () => {
-    vi.mocked(createK8sCert).mockResolvedValue({
-      ...certs[0],
-      id: 3,
-      name: 'kubernetes-admin-client',
-      cluster: 'kubernetes',
-    });
-    const user = userEvent.setup();
+  it('does not expose local metadata mutations as Kubernetes certificate operations', async () => {
     renderPage();
 
     await screen.findByText('rocketmq-prod-tls');
-    await user.click(screen.getByRole('button', { name: /新增证书/ }));
 
-    await user.type(
-      screen.getByPlaceholderText('例如：kubernetes-admin-client'),
-      'kubernetes-admin-client',
-    );
-    await user.type(
-      screen.getByPlaceholderText('例如：kubernetes（120.26.99.191:6443）'),
-      'kubernetes',
-    );
-    await user.click(screen.getByRole('button', { name: /添\s*加/ }));
-
-    await waitFor(() =>
-      expect(createK8sCert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'kubernetes-admin-client',
-          cluster: 'kubernetes',
-          type: 'TLS',
-        }),
-      ),
-    );
-    expect(await screen.findByText('kubernetes-admin-client')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '添加证书' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '编辑' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '续期' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '删除' })).not.toBeInTheDocument();
   });
 
-  it('deletes a certificate after confirmation', async () => {
-    vi.mocked(deleteK8sCert).mockResolvedValue();
+  it('trims certificate search text before filtering', async () => {
     const user = userEvent.setup();
     renderPage();
 
     await screen.findByText('rocketmq-prod-tls');
-    const deleteButtons = screen.getAllByRole('button', { name: /删\s*除/ });
-    await user.click(deleteButtons[0]);
-    const confirmButtons = await screen.findAllByRole('button', { name: /删\s*除/ });
-    await user.click(confirmButtons[confirmButtons.length - 1]);
+    await user.type(
+      screen.getByPlaceholderText('搜索证书名称、集群或 SAN'),
+      '  prod-cluster  {enter}',
+    );
 
-    await waitFor(() => expect(deleteK8sCert).toHaveBeenCalledWith(1));
-    await waitFor(() => expect(screen.queryByText('rocketmq-prod-tls')).not.toBeInTheDocument());
+    expect(screen.getByText('rocketmq-prod-tls')).toBeInTheDocument();
+    expect(screen.queryByText('rocketmq-staging-tls')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -16,27 +16,11 @@
  */
 
 import { useEffect, useState } from 'react';
-import {
-  Table,
-  Tag,
-  Input,
-  Select,
-  Flex,
-  Space,
-  Typography,
-  Card,
-  Button,
-  Modal,
-  Form,
-  Popconfirm,
-  message,
-} from 'antd';
-import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import { Table, Tag, Input, Select, Flex, Space, Typography, Card, Alert, message } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import PageHeader from '../../components/PageHeader';
-import InfoBanner from '../../components/InfoBanner';
 import type { K8sCertInfo } from '../../api/cluster';
-import { listK8sCerts, createK8sCert, deleteK8sCert } from '../../services/clusterService';
+import { listK8sCerts } from '../../services/clusterService';
 import { formatDateTime } from '../../utils/format';
 
 const { Text } = Typography;
@@ -44,29 +28,33 @@ const { Text } = Typography;
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error && error.message ? error.message : '请求失败，请稍后重试';
 
-interface CreateCertFormValues {
-  name: string;
-  cluster: string;
-  type: string;
-  certPem?: string;
-  keyPem?: string;
-}
-
 const K8sCertsPage = () => {
   const [certs, setCerts] = useState<K8sCertInfo[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
   const [loading, setLoading] = useState(true);
   const [certSearch, setCertSearch] = useState('');
+  const [certClusterFilter, setCertClusterFilter] = useState('');
   const [certTypeFilter, setCertTypeFilter] = useState<string>('');
-  const [createModalOpen, setCreateModalOpen] = useState(false);
-  const [creating, setCreating] = useState(false);
-  const [deletingId, setDeletingId] = useState<number | null>(null);
-  const [createForm] = Form.useForm<CreateCertFormValues>();
+  const [certStatusFilter, setCertStatusFilter] = useState<string>('');
 
   useEffect(() => {
     let active = true;
-    listK8sCerts()
+    setLoading(true);
+    listK8sCerts({
+      search: certSearch.trim() || undefined,
+      cluster: certClusterFilter || undefined,
+      type: certTypeFilter || undefined,
+      status: certStatusFilter || undefined,
+      page,
+      pageSize,
+    })
       .then((data) => {
-        if (active) setCerts(data);
+        if (active) {
+          setCerts(data.items);
+          setTotal(data.total);
+        }
       })
       .catch((error: unknown) => {
         if (active) message.error(getErrorMessage(error));
@@ -77,55 +65,11 @@ const K8sCertsPage = () => {
     return () => {
       active = false;
     };
-  }, []);
+  }, [certSearch, certClusterFilter, certTypeFilter, certStatusFilter, page, pageSize]);
 
-  const normalizedCertSearch = certSearch.trim().toLowerCase();
-  const filteredCerts = certs.filter((cert) => {
-    const matchSearch =
-      !normalizedCertSearch ||
-      [cert.name, cert.cluster].some((value) => value.toLowerCase().includes(normalizedCertSearch));
-    const matchType = !certTypeFilter || cert.type === certTypeFilter;
-    return matchSearch && matchType;
-  });
-
-  const handleCreate = async () => {
-    let values: CreateCertFormValues;
-    try {
-      values = await createForm.validateFields();
-    } catch {
-      return;
-    }
-    setCreating(true);
-    try {
-      const created = await createK8sCert({
-        name: values.name.trim(),
-        cluster: values.cluster.trim(),
-        type: values.type,
-        certPem: values.certPem?.trim() || undefined,
-        keyPem: values.keyPem?.trim() || undefined,
-      });
-      setCerts((previous) => [...previous, created]);
-      message.success(`证书「${created.name}」已添加`);
-      setCreateModalOpen(false);
-      createForm.resetFields();
-    } catch (error: unknown) {
-      message.error(getErrorMessage(error));
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  const handleDelete = async (cert: K8sCertInfo) => {
-    setDeletingId(cert.id);
-    try {
-      await deleteK8sCert(cert.id);
-      setCerts((previous) => previous.filter((item) => item.id !== cert.id));
-      message.success(`证书「${cert.name}」已删除`);
-    } catch (error: unknown) {
-      message.error(getErrorMessage(error));
-    } finally {
-      setDeletingId(null);
-    }
+  const resetToFirstPage = (setFilter: (value: string) => void) => (value: string) => {
+    setFilter(value);
+    setPage(1);
   };
 
   const certColumns: ColumnsType<K8sCertInfo> = [
@@ -133,8 +77,7 @@ const K8sCertsPage = () => {
       title: 'K8s 集群名称',
       dataIndex: 'cluster',
       key: 'cluster',
-      width: 260,
-      ellipsis: true,
+      width: 160,
       sorter: (a, b) => a.cluster.localeCompare(b.cluster),
       render: (name: string) => <Text strong>{name}</Text>,
     },
@@ -142,17 +85,33 @@ const K8sCertsPage = () => {
       title: '证书名称',
       dataIndex: 'name',
       key: 'name',
-      width: 240,
+      width: 280,
       sorter: (a, b) => a.name.localeCompare(b.name),
       render: (name: string) => (
-        <Text style={{ fontFamily: 'monospace', fontSize: 14 }}>{name}</Text>
+        <Text style={{ fontFamily: 'monospace', fontSize: 13 }}>{name}</Text>
       ),
+    },
+    {
+      title: 'SAN',
+      dataIndex: 'san',
+      key: 'san',
+      width: 260,
+      render: (san: string[] | null) =>
+        san?.length ? (
+          <Flex wrap gap={4}>
+            {san.map((value) => (
+              <Tag key={value}>{value}</Tag>
+            ))}
+          </Flex>
+        ) : (
+          <Text type="secondary">-</Text>
+        ),
     },
     {
       title: '类型',
       dataIndex: 'type',
       key: 'type',
-      width: 110,
+      width: 130,
       sorter: (a, b) => a.type.localeCompare(b.type),
       render: (type: string) => {
         const colorMap: Record<string, string> = {
@@ -167,9 +126,8 @@ const K8sCertsPage = () => {
       title: '签发者',
       dataIndex: 'issuer',
       key: 'issuer',
-      width: 180,
+      width: 130,
       sorter: (a, b) => a.issuer.localeCompare(b.issuer),
-      ellipsis: true,
     },
     {
       title: '到期时间',
@@ -178,7 +136,7 @@ const K8sCertsPage = () => {
       width: 170,
       sorter: (a, b) => new Date(a.notAfter).getTime() - new Date(b.notAfter).getTime(),
       render: (iso: string) => (
-        <Text type="secondary" style={{ fontSize: 14 }}>
+        <Text type="secondary" style={{ fontSize: 13 }}>
           {formatDateTime(iso)}
         </Text>
       ),
@@ -216,137 +174,83 @@ const K8sCertsPage = () => {
         return <Tag color={cfg.color}>{cfg.label}</Tag>;
       },
     },
-    {
-      title: '操作',
-      key: 'action',
-      width: 90,
-      fixed: 'right',
-      render: (_: unknown, cert: K8sCertInfo) => (
-        <Popconfirm
-          title={`确定要删除证书「${cert.name}」吗？`}
-          onConfirm={() => void handleDelete(cert)}
-          okText="删除"
-          cancelText="取消"
-          okButtonProps={{ danger: true }}
-        >
-          <Button
-            type="link"
-            size="small"
-            danger
-            icon={<DeleteOutlined />}
-            loading={deletingId === cert.id}
-          >
-            删除
-          </Button>
-        </Popconfirm>
-      ),
-    },
   ];
 
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader title="K8s 证书管理" subtitle={`共 ${filteredCerts.length} 个证书`} />
-      <InfoBanner
+      <PageHeader title="K8s 证书管理" subtitle={`共 ${total} 个证书`} />
+      <Alert
         data-testid="k8s-cert-local-metadata-notice"
-        title="当前证书记录仅保存为 Studio 本地元数据"
+        type="warning"
+        showIcon
+        message="当前证书记录仅保存为 Studio 本地元数据"
         description="创建、续期和删除操作尚不会应用到 Kubernetes 集群或 cert-manager。请在集群侧管理实际证书，直到 Kubernetes Provider 接入完成。"
+        style={{ marginBottom: 16 }}
       />
       <Flex justify="space-between" style={{ marginBottom: 16 }}>
         <Space>
           <Input.Search
-            placeholder="搜索证书名称或集群"
+            placeholder="搜索证书名称、集群或 SAN"
             allowClear
-            onSearch={setCertSearch}
-            onChange={(e) => !e.target.value && setCertSearch('')}
-            style={{ width: 320 }}
+            value={certSearch}
+            onChange={(event) => resetToFirstPage(setCertSearch)(event.target.value)}
+            style={{ width: 280 }}
+          />
+          <Input
+            aria-label="按 K8s 集群筛选"
+            placeholder="K8s 集群名称"
+            allowClear
+            value={certClusterFilter}
+            onChange={(event) => resetToFirstPage(setCertClusterFilter)(event.target.value)}
+            style={{ width: 180 }}
           />
           <Select
+            aria-label="按证书类型筛选"
             value={certTypeFilter}
-            onChange={setCertTypeFilter}
-            style={{ width: 160 }}
+            onChange={resetToFirstPage(setCertTypeFilter)}
+            style={{ width: 140 }}
             options={[
-              { value: '', label: '全部' },
+              { value: '', label: '全部类型' },
               { value: 'TLS', label: 'TLS' },
               { value: 'mTLS', label: 'mTLS' },
               { value: 'ServiceAccount', label: 'ServiceAccount' },
             ]}
           />
+          <Select
+            aria-label="按状态筛选"
+            value={certStatusFilter}
+            onChange={resetToFirstPage(setCertStatusFilter)}
+            style={{ width: 160 }}
+            options={[
+              { value: '', label: '全部状态' },
+              { value: 'valid', label: '有效' },
+              { value: 'expiring', label: '即将过期' },
+              { value: 'expired', label: '已过期' },
+            ]}
+          />
         </Space>
-        <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
-          新增证书
-        </Button>
       </Flex>
       <Card styles={{ body: { padding: 0 } }}>
         <Table
           columns={certColumns}
-          dataSource={filteredCerts}
+          dataSource={certs}
           rowKey="id"
           loading={loading}
-          pagination={{ pageSize: 20 }}
+          pagination={{
+            current: page,
+            pageSize,
+            total,
+            showSizeChanger: true,
+            pageSizeOptions: [20, 50, 100],
+            onChange: (nextPage, nextPageSize) => {
+              setPage(nextPage);
+              setPageSize(nextPageSize);
+            },
+          }}
           size="small"
-          scroll={{ x: 1400 }}
+          scroll={{ x: 1600 }}
         />
       </Card>
-
-      <Modal
-        title="新增证书"
-        open={createModalOpen}
-        onCancel={() => {
-          setCreateModalOpen(false);
-          createForm.resetFields();
-        }}
-        onOk={() => void handleCreate()}
-        confirmLoading={creating}
-        okText="添加"
-        cancelText="取消"
-        width={640}
-        destroyOnHidden
-      >
-        <Form form={createForm} layout="vertical" preserve={false}>
-          <Form.Item
-            label="证书名称"
-            name="name"
-            rules={[{ required: true, message: '请输入证书名称' }]}
-          >
-            <Input placeholder="例如：kubernetes-admin-client" />
-          </Form.Item>
-          <Form.Item
-            label="K8s 集群名称"
-            name="cluster"
-            rules={[{ required: true, message: '请输入集群名称' }]}
-          >
-            <Input placeholder="例如：kubernetes（120.26.99.191:6443）" />
-          </Form.Item>
-          <Form.Item label="类型" name="type" initialValue="TLS">
-            <Select
-              virtual={false}
-              options={[
-                { value: 'TLS', label: 'TLS' },
-                { value: 'mTLS', label: 'mTLS' },
-                { value: 'ServiceAccount', label: 'ServiceAccount' },
-              ]}
-            />
-          </Form.Item>
-          <Form.Item
-            label="证书内容（PEM）"
-            name="certPem"
-            extra="粘贴 PEM 格式证书，签发者、有效期与 SAN 将自动解析；留空时有效期按一年占位"
-          >
-            <Input.TextArea
-              rows={6}
-              placeholder="-----BEGIN CERTIFICATE-----..."
-              style={{ fontFamily: 'monospace' }}
-            />
-          </Form.Item>
-          <Form.Item label="私钥内容（PEM）" name="keyPem" extra="仅保存，不会在页面展示或返回">
-            <Input.TextArea
-              rows={6}
-              placeholder="-----BEGIN PRIVATE KEY-----..."
-              style={{ fontFamily: 'monospace' }}
-            />
-          </Form.Item>
-        </Form>
-      </Modal>
     </div>
   );
 };

--- a/web/src/services/clusterService.test.ts
+++ b/web/src/services/clusterService.test.ts
@@ -154,7 +154,7 @@ describe('clusterService mock clusters', () => {
     try {
       san.push('mutated-create.example.com');
 
-      let stored = (await listK8sCerts()).find((cert) => cert.id === created.id);
+      let stored = (await listK8sCerts()).items.find((cert) => cert.id === created.id);
       expect(stored?.san).toEqual(['proxy.example.com']);
 
       const nextSan = ['proxy-next.example.com'];
@@ -164,7 +164,7 @@ describe('clusterService mock clusters', () => {
       });
       nextSan.push('mutated-update.example.com');
 
-      stored = (await listK8sCerts()).find((cert) => cert.id === created.id);
+      stored = (await listK8sCerts()).items.find((cert) => cert.id === created.id);
       expect(stored?.san).toEqual(['proxy-next.example.com']);
     } finally {
       await deleteK8sCert(created.id);

--- a/web/src/services/clusterService.ts
+++ b/web/src/services/clusterService.ts
@@ -6,6 +6,8 @@ import type {
   ClusterInfo,
   ClusterProbeResult,
   K8sCertInfo,
+  K8sCertPage,
+  K8sCertQuery,
   NameServerConfigDiffResult,
 } from '../api/cluster';
 import clusters, { mockK8sCerts } from '../mock/clusters';
@@ -105,9 +107,27 @@ export async function getNameServerConfigDiff(
   };
 }
 
-export async function listK8sCerts(): Promise<K8sCertInfo[]> {
-  if (isMockMode()) return mockCertStore.map((cert) => ({ ...cert, san: [...cert.san] }));
-  return clusterApi.listK8sCerts();
+export async function listK8sCerts(query: K8sCertQuery = {}): Promise<K8sCertPage> {
+  if (!isMockMode()) return clusterApi.listK8sCerts(query);
+
+  const page = query.page ?? 1;
+  const pageSize = query.pageSize ?? 20;
+  const matches = mockCertStore.filter((cert) =>
+    (!query.search ||
+      [cert.name, cert.cluster, ...(cert.san ?? [])].some((value) =>
+        value.toLowerCase().includes(query.search!.trim().toLowerCase()),
+      )) &&
+    (!query.cluster || cert.cluster === query.cluster) &&
+    (!query.type || cert.type === query.type) &&
+    (!query.status || cert.status === query.status),
+  );
+  const start = (page - 1) * pageSize;
+  return {
+    items: matches.slice(start, start + pageSize).map((cert) => ({ ...cert, san: [...cert.san] })),
+    total: matches.length,
+    page,
+    size: pageSize,
+  };
 }
 
 export async function createK8sCert(data: Partial<K8sCertInfo>): Promise<K8sCertInfo> {


### PR DESCRIPTION
## Summary
- paginate the local K8s certificate inventory with bounded page sizes
- filter server-side by keyword, cluster, namespace, type, and status
- refresh expiration state only for returned records and update the UI to request server pages

## Verification
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home PATH="$JAVA_HOME/bin:$PATH" mvn -q -B -ntp -Dtest=K8sCertControllerTest,K8sCertServiceTest,MybatisPlusK8sCertRepositoryTest test`
- `npm run build`
- `npm test -- --run src/api/cluster.test.ts src/services/clusterService.test.ts src/pages/cluster/__tests__/K8sCertsPage.test.tsx`

Closes #2275
