### PR TITLE
feat: paginate system alert inventory

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
@@ -18,9 +18,14 @@ package org.apache.rocketmq.studio.ops.alert;
 
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AlertRepository {
     List<AlertRuleVO> findAllRules();
+
+    Optional<AlertRuleVO> findRuleById(String id);
+
+    List<AlertRuleVO> findRulesByIds(List<String> ids);
 
     AlertRuleVO saveRule(AlertRuleVO rule);
 
@@ -29,6 +34,8 @@ public interface AlertRepository {
     boolean deleteRule(String id);
 
     List<SystemAlertVO> findAlerts(String level);
+
+    Optional<SystemAlertVO> findAlertById(String id);
 
     boolean acknowledgeAlert(SystemAlertVO alert);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
@@ -17,6 +17,8 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 
+import org.apache.rocketmq.studio.common.domain.PageResult;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -33,7 +35,7 @@ public interface AlertRepository {
 
     boolean deleteRule(String id);
 
-    List<SystemAlertVO> findAlerts(String level);
+    PageResult<SystemAlertVO> findAlerts(String level, int page, int pageSize);
 
     Optional<SystemAlertVO> findAlertById(String id);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -122,11 +121,8 @@ public class AlertService {
     public AlertRuleVO toggleRule(String id, boolean enabled) {
         log.info("Toggling alert rule id={}, enabled={}", id, enabled);
         validateRuleId(id);
-        List<AlertRuleVO> rules = alertRepository.findAllRules();
-        AlertRuleVO rule = rules.stream()
-                .filter(r -> Objects.equals(r.getId(), id))
-                .findFirst()
-                .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "Alert rule not found: " + id));
+        AlertRuleVO rule = alertRepository.findRuleById(id)
+                .orElseThrow(() -> ruleNotFound(id));
         rule.setEnabled(enabled);
         AlertRuleVO saved = alertRepository.saveRule(rule);
         auditRule("TOGGLE_ALERT_RULE", saved, "enabled=" + enabled);
@@ -146,7 +142,7 @@ public class AlertService {
     public AlertRuleBulkResultVO bulkToggleRules(List<String> ids, boolean enabled) {
         List<String> normalizedIds = normalizeBulkIds(ids);
         Map<String, AlertRuleVO> rulesById = new LinkedHashMap<>();
-        for (AlertRuleVO rule : alertRepository.findAllRules()) {
+        for (AlertRuleVO rule : alertRepository.findRulesByIds(normalizedIds)) {
             rulesById.put(rule.getId(), rule);
         }
         List<String> succeeded = new ArrayList<>();
@@ -225,11 +221,9 @@ public class AlertService {
         if (id == null || id.isBlank()) {
             throw new BusinessException(400, "System alert ID is required");
         }
-        List<SystemAlertVO> alerts = alertRepository.findAlerts(null);
-        SystemAlertVO alert = alerts.stream()
-                .filter(a -> Objects.equals(a.getId(), id))
-                .findFirst()
-                .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "System alert not found: " + id));
+        SystemAlertVO alert = alertRepository.findAlertById(id)
+                .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404,
+                        "System alert not found: " + id));
         alert.setAcknowledged(true);
         if (!alertRepository.acknowledgeAlert(alert)) {
             throw new BusinessException(404, "System alert not found: " + id);

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -210,9 +211,10 @@ public class AlertService {
     }
 
 
-    public List<SystemAlertVO> listAlerts(String level) {
-        log.info("Listing system alerts, level={}", level);
-        return alertRepository.findAlerts(level);
+    public PageResult<SystemAlertVO> listAlerts(String level, int page, int pageSize) {
+        validateAlertPagination(page, pageSize);
+        log.info("Listing system alerts, level={}, page={}, pageSize={}", level, page, pageSize);
+        return alertRepository.findAlerts(level, page, pageSize);
     }
 
 
@@ -240,6 +242,15 @@ public class AlertService {
         recordAudit("CLEAR_ACKNOWLEDGED_SYSTEM_ALERTS", "SYSTEM_ALERT", null, null,
                 "deleted=" + deleted);
         return deleted;
+    }
+
+    private void validateAlertPagination(int page, int pageSize) {
+        if (page < 1) {
+            throw new BusinessException(400, "page must be greater than 0");
+        }
+        if (pageSize < 1 || pageSize > 100) {
+            throw new BusinessException(400, "pageSize must be between 1 and 100");
+        }
     }
 
     private List<PrometheusAlertRule> defaultPrometheusRules() {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -31,6 +31,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -46,6 +47,22 @@ public class MybatisPlusAlertRepository implements AlertRepository {
     @Override
     public List<AlertRuleVO> findAllRules() {
         return ruleMapper.selectList(new QueryWrapper<RmqAlertRule>().orderByAsc("name")).stream()
+                .map(MybatisPlusAlertRepository::toRuleVO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<AlertRuleVO> findRuleById(String id) {
+        return Optional.ofNullable(ruleMapper.selectById(id))
+                .map(MybatisPlusAlertRepository::toRuleVO);
+    }
+
+    @Override
+    public List<AlertRuleVO> findRulesByIds(List<String> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        return ruleMapper.selectBatchIds(ids).stream()
                 .map(MybatisPlusAlertRepository::toRuleVO)
                 .collect(Collectors.toList());
     }
@@ -83,6 +100,12 @@ public class MybatisPlusAlertRepository implements AlertRepository {
         return alertMapper.selectList(query).stream()
                 .map(MybatisPlusAlertRepository::toAlertVO)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<SystemAlertVO> findAlertById(String id) {
+        return Optional.ofNullable(alertMapper.selectById(id))
+                .map(MybatisPlusAlertRepository::toAlertVO);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -17,6 +17,8 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.AlertLevel;
 import org.apache.rocketmq.studio.persistence.entity.RmqAlertRule;
 import org.apache.rocketmq.studio.persistence.entity.RmqSystemAlert;
@@ -93,13 +95,15 @@ public class MybatisPlusAlertRepository implements AlertRepository {
     }
 
     @Override
-    public List<SystemAlertVO> findAlerts(String level) {
+    public PageResult<SystemAlertVO> findAlerts(String level, int page, int pageSize) {
         QueryWrapper<RmqSystemAlert> query = new QueryWrapper<RmqSystemAlert>()
                 .eq(StringUtils.hasText(level), "level", level == null ? null : level.toLowerCase(Locale.ROOT))
-                .orderByDesc("time");
-        return alertMapper.selectList(query).stream()
+                .orderByDesc("time", "id");
+        Page<RmqSystemAlert> resultPage = alertMapper.selectPage(new Page<>(page, pageSize), query);
+        List<SystemAlertVO> alerts = resultPage.getRecords().stream()
                 .map(MybatisPlusAlertRepository::toAlertVO)
                 .collect(Collectors.toList());
+        return PageResult.of(alerts, resultPage.getTotal(), page, pageSize);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -38,9 +38,11 @@ public class SystemAlertController {
     private final AlertService alertService;
 
     @GetMapping
-    public Result<List<SystemAlertVO>> listAlerts(
-            @RequestParam(required = false) String level) {
-        return Result.ok(alertService.listAlerts(level));
+    public Result<PageResult<SystemAlertVO>> listAlerts(
+            @RequestParam(required = false) String level,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return Result.ok(alertService.listAlerts(level, page, pageSize));
     }
 
     @PostMapping("/acknowledge")

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.apache.rocketmq.studio.common.domain.enums.AlertLevel;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +37,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -689,27 +691,28 @@ class AlertServiceTest {
                 .title("Broker Down").acknowledged(false).build();
         SystemAlertVO alert2 = SystemAlertVO.builder().id("a2").level(AlertLevel.error)
                 .title("High Latency").acknowledged(false).build();
-        when(alertRepository.findAlerts("error")).thenReturn(Arrays.asList(alert1, alert2));
+        when(alertRepository.findAlerts("error", 1, 20))
+                .thenReturn(PageResult.of(Arrays.asList(alert1, alert2), 2, 1, 20));
 
-        List<SystemAlertVO> result = alertService.listAlerts("error");
+        PageResult<SystemAlertVO> result = alertService.listAlerts("error", 1, 20);
 
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getLevel()).isEqualTo(AlertLevel.error);
-        assertThat(result.get(0).getTitle()).isEqualTo("Broker Down");
-        verify(alertRepository).findAlerts("error");
+        assertThat(result.getItems()).hasSize(2);
+        assertThat(result.getItems().get(0).getLevel()).isEqualTo(AlertLevel.error);
+        assertThat(result.getItems().get(0).getTitle()).isEqualTo("Broker Down");
+        verify(alertRepository).findAlerts("error", 1, 20);
     }
 
     @Test
     void listAlertsShouldReturnAllAlertsWhenLevelIsNull() {
         SystemAlertVO alert = SystemAlertVO.builder().id("a1").level(AlertLevel.warning)
                 .title("Slow Consumer").build();
-        when(alertRepository.findAlerts(null)).thenReturn(List.of(alert));
+        when(alertRepository.findAlerts(null, 1, 20)).thenReturn(PageResult.of(List.of(alert), 1, 1, 20));
 
-        List<SystemAlertVO> result = alertService.listAlerts(null);
+        PageResult<SystemAlertVO> result = alertService.listAlerts(null, 1, 20);
 
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getLevel()).isEqualTo(AlertLevel.warning);
-        verify(alertRepository).findAlerts(null);
+        assertThat(result.getItems()).hasSize(1);
+        assertThat(result.getItems().get(0).getLevel()).isEqualTo(AlertLevel.warning);
+        verify(alertRepository).findAlerts(null, 1, 20);
     }
 
     @Test
@@ -723,7 +726,7 @@ class AlertServiceTest {
 
         assertThat(result.isAcknowledged()).isTrue();
         verify(alertRepository).acknowledgeAlert(result);
-        verify(alertRepository, never()).findAlerts(any());
+        verify(alertRepository, never()).findAlerts(any(), anyInt(), anyInt());
         verify(operationAuditService).record(eq("ACKNOWLEDGE_SYSTEM_ALERT"), eq("SYSTEM_ALERT"), eq("a1"),
                 eq(null), eq("acknowledged=true"), eq("SUCCESS"), eq(null));
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -562,13 +563,14 @@ class AlertServiceTest {
     @Test
     void toggleRuleShouldEnableRule() {
         AlertRuleVO existing = AlertRuleVO.builder().id("rule-1").name("CPU Alert").enabled(false).build();
-        when(alertRepository.findAllRules()).thenReturn(List.of(existing));
+        when(alertRepository.findRuleById("rule-1")).thenReturn(Optional.of(existing));
         when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         AlertRuleVO result = alertService.toggleRule("rule-1", true);
 
         assertThat(result.isEnabled()).isTrue();
         verify(alertRepository).saveRule(result);
+        verify(alertRepository, never()).findAllRules();
         verify(operationAuditService).record(eq("TOGGLE_ALERT_RULE"), eq("ALERT_RULE"), eq("rule-1"),
                 eq(null), eq("enabled=true"), eq("SUCCESS"), eq(null));
     }
@@ -576,7 +578,7 @@ class AlertServiceTest {
     @Test
     void toggleRuleShouldDisableRule() {
         AlertRuleVO existing = AlertRuleVO.builder().id("rule-1").name("CPU Alert").enabled(true).build();
-        when(alertRepository.findAllRules()).thenReturn(List.of(existing));
+        when(alertRepository.findRuleById("rule-1")).thenReturn(Optional.of(existing));
         when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         AlertRuleVO result = alertService.toggleRule("rule-1", false);
@@ -591,21 +593,12 @@ class AlertServiceTest {
                 .hasMessage("Alert rule ID is required")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
 
-        verify(alertRepository, never()).findAllRules();
-    }
-
-    @Test
-    void toggleRuleShouldIgnorePersistedRulesWithNullIds() {
-        when(alertRepository.findAllRules()).thenReturn(List.of(AlertRuleVO.builder().name("corrupt").build()));
-
-        assertThatThrownBy(() -> alertService.toggleRule("missing", true))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("Alert rule not found: missing");
+        verify(alertRepository, never()).findRuleById(any());
     }
 
     @Test
     void toggleRuleShouldThrowWhenRuleNotFound() {
-        when(alertRepository.findAllRules()).thenReturn(Collections.emptyList());
+        when(alertRepository.findRuleById("non-existent")).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> alertService.toggleRule("non-existent", true))
                 .isInstanceOf(BusinessException.class)
@@ -645,7 +638,7 @@ class AlertServiceTest {
     @Test
     void bulkToggleShouldDeduplicateIdsAndReportMissingRules() {
         AlertRuleVO rule = AlertRuleVO.builder().id("rule-1").name("High CPU").enabled(false).build();
-        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+        when(alertRepository.findRulesByIds(List.of("rule-1", "missing"))).thenReturn(List.of(rule));
         when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(true);
 
         AlertRuleBulkResultVO result = alertService.bulkToggleRules(
@@ -656,12 +649,13 @@ class AlertServiceTest {
         assertThat(result.getUpdatedRules()).singleElement()
                 .extracting(AlertRuleVO::isEnabled).isEqualTo(true);
         verify(alertRepository).replaceRule(rule);
+        verify(alertRepository, never()).findAllRules();
     }
 
     @Test
     void bulkToggleShouldReportRulesDeletedConcurrentlyInsteadOfRecreatingThem() {
         AlertRuleVO rule = AlertRuleVO.builder().id("rule-1").name("High CPU").enabled(false).build();
-        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+        when(alertRepository.findRulesByIds(List.of("rule-1"))).thenReturn(List.of(rule));
         when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(false);
 
         AlertRuleBulkResultVO result = alertService.bulkToggleRules(List.of("rule-1"), true);
@@ -722,13 +716,14 @@ class AlertServiceTest {
     void acknowledgeAlertShouldSetAcknowledgedTrue() {
         SystemAlertVO existing = SystemAlertVO.builder().id("a1").level(AlertLevel.error)
                 .title("Broker Down").acknowledged(false).build();
-        when(alertRepository.findAlerts(null)).thenReturn(List.of(existing));
+        when(alertRepository.findAlertById("a1")).thenReturn(Optional.of(existing));
         when(alertRepository.acknowledgeAlert(any(SystemAlertVO.class))).thenReturn(true);
 
         SystemAlertVO result = alertService.acknowledgeAlert("a1");
 
         assertThat(result.isAcknowledged()).isTrue();
         verify(alertRepository).acknowledgeAlert(result);
+        verify(alertRepository, never()).findAlerts(any());
         verify(operationAuditService).record(eq("ACKNOWLEDGE_SYSTEM_ALERT"), eq("SYSTEM_ALERT"), eq("a1"),
                 eq(null), eq("acknowledged=true"), eq("SUCCESS"), eq(null));
     }
@@ -740,21 +735,12 @@ class AlertServiceTest {
                 .hasMessage("System alert ID is required")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
 
-        verify(alertRepository, never()).findAlerts(any());
-    }
-
-    @Test
-    void acknowledgeAlertShouldIgnorePersistedAlertsWithNullIds() {
-        when(alertRepository.findAlerts(null)).thenReturn(List.of(SystemAlertVO.builder().title("corrupt").build()));
-
-        assertThatThrownBy(() -> alertService.acknowledgeAlert("missing"))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("System alert not found: missing");
+        verify(alertRepository, never()).findAlertById(any());
     }
 
     @Test
     void acknowledgeAlertShouldThrowWhenAlertNotFound() {
-        when(alertRepository.findAlerts(null)).thenReturn(Collections.emptyList());
+        when(alertRepository.findAlertById("non-existent")).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> alertService.acknowledgeAlert("non-existent"))
                 .isInstanceOf(BusinessException.class)
@@ -765,7 +751,7 @@ class AlertServiceTest {
     void acknowledgeAlertShouldRejectConcurrentRemoval() {
         SystemAlertVO existing = SystemAlertVO.builder().id("a1").level(AlertLevel.error)
                 .title("Broker Down").acknowledged(false).build();
-        when(alertRepository.findAlerts(null)).thenReturn(List.of(existing));
+        when(alertRepository.findAlertById("a1")).thenReturn(Optional.of(existing));
         when(alertRepository.acknowledgeAlert(any(SystemAlertVO.class))).thenReturn(false);
 
         assertThatThrownBy(() -> alertService.acknowledgeAlert("a1"))

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.ops.alert;
 
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.apache.rocketmq.studio.persistence.entity.RmqAlertRule;
 import org.apache.rocketmq.studio.persistence.entity.RmqSystemAlert;
 import org.apache.rocketmq.studio.persistence.mapper.RmqAlertRuleMapper;
@@ -64,9 +65,12 @@ class MybatisPlusAlertRepositoryTest {
     void findAlertsShouldNormalizeStoredLevelValues() {
         RmqSystemAlert entity = new RmqSystemAlert();
         entity.setLevel(" WARNING ");
-        when(alertMapper.selectList(any())).thenReturn(List.of(entity));
+        Page<RmqSystemAlert> page = new Page<>(1, 20);
+        page.setRecords(List.of(entity));
+        page.setTotal(1);
+        when(alertMapper.selectPage(any(Page.class), any())).thenReturn(page);
 
-        assertThat(repository.findAlerts(null)).singleElement()
+        assertThat(repository.findAlerts(null, 1, 20).getItems()).singleElement()
                 .satisfies(alert -> assertThat(alert.getLevel()).isEqualTo(
                         org.apache.rocketmq.studio.common.domain.enums.AlertLevel.warning));
     }
@@ -110,17 +114,20 @@ class MybatisPlusAlertRepositoryTest {
 
     @Test
     void findAlertsShouldNormalizeLevelIndependentlyOfDefaultLocale() {
-        when(alertMapper.selectList(any())).thenReturn(List.of());
+        Page<RmqSystemAlert> page = new Page<>(1, 20);
+        page.setRecords(List.of());
+        when(alertMapper.selectPage(any(Page.class), any())).thenReturn(page);
         Locale originalLocale = Locale.getDefault();
 
         try {
             Locale.setDefault(Locale.forLanguageTag("tr-TR"));
-            repository.findAlerts("INFO");
+            repository.findAlerts("INFO", 1, 20);
         } finally {
             Locale.setDefault(originalLocale);
         }
 
-        verify(alertMapper).selectList(argThat(MybatisPlusAlertRepositoryTest::hasInfoLevelParameter));
+        verify(alertMapper).selectPage(any(Page.class),
+                argThat(MybatisPlusAlertRepositoryTest::hasInfoLevelParameter));
     }
 
     private static boolean hasInfoLevelParameter(Wrapper<RmqSystemAlert> query) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,6 +69,27 @@ class MybatisPlusAlertRepositoryTest {
         assertThat(repository.findAlerts(null)).singleElement()
                 .satisfies(alert -> assertThat(alert.getLevel()).isEqualTo(
                         org.apache.rocketmq.studio.common.domain.enums.AlertLevel.warning));
+    }
+
+    @Test
+    void findAlertByIdShouldMapOnlyTheRequestedAlert() {
+        RmqSystemAlert entity = new RmqSystemAlert();
+        entity.setId("alert-1");
+        entity.setLevel("error");
+        when(alertMapper.selectById("alert-1")).thenReturn(entity);
+
+        Optional<SystemAlertVO> result = repository.findAlertById("alert-1");
+
+        assertThat(result).map(SystemAlertVO::getId).contains("alert-1");
+        verify(alertMapper).selectById("alert-1");
+        verify(alertMapper, never()).selectList(any());
+    }
+
+    @Test
+    void findRulesByIdsShouldSkipDatabaseLookupForAnEmptySelection() {
+        assertThat(repository.findRulesByIds(List.of())).isEmpty();
+
+        verify(ruleMapper, never()).selectBatchIds(any());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.ops.alert;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.domain.enums.AlertLevel;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -58,16 +59,16 @@ class SystemAlertControllerTest {
                 .title("Broker Down")
                 .acknowledged(false)
                 .build();
-        when(alertService.listAlerts("error")).thenReturn(List.of(alert));
+        when(alertService.listAlerts("error", 1, 20)).thenReturn(PageResult.of(List.of(alert), 1, 1, 20));
 
         mockMvc.perform(get("/api/system-alerts").param("level", "error"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data[0].id").value("alert-1"))
-                .andExpect(jsonPath("$.data[0].level").value("error"))
-                .andExpect(jsonPath("$.data[0].acknowledged").value(false));
+                .andExpect(jsonPath("$.data.items[0].id").value("alert-1"))
+                .andExpect(jsonPath("$.data.items[0].level").value("error"))
+                .andExpect(jsonPath("$.data.items[0].acknowledged").value(false));
 
-        verify(alertService).listAlerts("error");
+        verify(alertService).listAlerts("error", 1, 20);
     }
 
     @Test

--- a/web/src/api/ops.test.ts
+++ b/web/src/api/ops.test.ts
@@ -209,9 +209,8 @@ describe('Ops API - System Alerts & Audit', () => {
   });
 
   it('lists system alerts', async () => {
-    mock.onGet('/system-alerts').reply(200, {
-      code: 200,
-      data: [
+    const page = {
+      items: [
         {
           id: 'a1',
           level: 'critical',
@@ -221,9 +220,16 @@ describe('Ops API - System Alerts & Audit', () => {
           acknowledged: false,
         },
       ],
+      total: 1,
+      page: 1,
+      size: 20,
+    };
+    mock.onGet('/system-alerts').reply(200, {
+      code: 200,
+      data: page,
     });
     const result = await listSystemAlerts();
-    expect(result[0].level).toBe('critical');
+    expect(result.items[0].level).toBe('critical');
   });
 
   it('acknowledges an alert', async () => {

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -64,6 +64,12 @@ export interface AuditQuery {
   result?: string;
 }
 
+export interface SystemAlertQuery {
+  level?: string;
+  page?: number;
+  pageSize?: number;
+}
+
 // ─── Alert Rules ────────────────────────────────────────────────
 export async function listAlertRules() {
   const res = await client.get<{ data: AlertRule[] }>('/alert-rules');
@@ -103,8 +109,8 @@ export async function bulkDeleteAlertRules(ids: string[]) {
 }
 
 // ─── System Alerts ──────────────────────────────────────────────
-export async function listSystemAlerts() {
-  const res = await client.get<{ data: SystemAlert[] }>('/system-alerts');
+export async function listSystemAlerts(params: SystemAlertQuery = {}) {
+  const res = await client.get<{ data: PageResult<SystemAlert> }>('/system-alerts', { params });
   return res.data.data;
 }
 

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -273,8 +273,8 @@ const translations: Record<string, Record<Lang, string>> = {
   'sysAlerts.acknowledged': { zh: '告警已确认', en: 'Alert Acknowledged' },
   'sysAlerts.cleared': { zh: '已清除所有已确认告警', en: 'Cleared all acknowledged alerts' },
   'sysAlerts.subtitle': {
-    zh: '集群运行告警监控，当前 {n} 条未确认',
-    en: 'Cluster alert monitoring, {n} unacknowledged',
+    zh: '集群运行告警监控，共 {n} 条',
+    en: 'Cluster alert monitoring, {n} alerts',
   },
 
   // ─── Audit Log ───

--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -47,37 +47,47 @@ const renderPage = () =>
 describe('SystemAlertsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(listSystemAlerts).mockResolvedValue([
-      {
-        id: 'alert-a',
-        level: 'error',
-        title: 'Broker unavailable',
-        description: 'broker a',
-        time: '2026-08-10 01:00',
-        acknowledged: false,
-      },
-      {
-        id: 'alert-b',
-        level: 'warning',
-        title: 'Consumer lag',
-        description: 'consumer b',
-        time: '2026-08-10 01:01',
-        acknowledged: false,
-      },
-    ]);
+    vi.mocked(listSystemAlerts).mockResolvedValue({
+      items: [
+        {
+          id: 'alert-a',
+          level: 'error',
+          title: 'Broker unavailable',
+          description: 'broker a',
+          time: '2026-08-10 01:00',
+          acknowledged: false,
+        },
+        {
+          id: 'alert-b',
+          level: 'warning',
+          title: 'Consumer lag',
+          description: 'consumer b',
+          time: '2026-08-10 01:01',
+          acknowledged: false,
+        },
+      ],
+      total: 2,
+      page: 1,
+      size: 20,
+    });
   });
 
   it('renders an alert with an unknown backend level', async () => {
-    vi.mocked(listSystemAlerts).mockResolvedValue([
-      {
-        id: 'alert-critical',
-        level: 'critical',
-        title: 'Critical broker condition',
-        description: 'A newer backend emitted this level',
-        time: '2026-08-10 01:00',
-        acknowledged: false,
-      },
-    ]);
+    vi.mocked(listSystemAlerts).mockResolvedValue({
+      items: [
+        {
+          id: 'alert-critical',
+          level: 'critical',
+          title: 'Critical broker condition',
+          description: 'A newer backend emitted this level',
+          time: '2026-08-10 01:00',
+          acknowledged: false,
+        },
+      ],
+      total: 1,
+      page: 1,
+      size: 20,
+    });
 
     renderPage();
 
@@ -87,29 +97,27 @@ describe('SystemAlertsPage', () => {
   });
 
   it('filters backend alert levels case-insensitively', async () => {
-    vi.mocked(listSystemAlerts).mockResolvedValue([
-      {
-        id: 'alert-error',
-        level: 'Error',
-        title: 'Mixed-case error',
-        description: 'error',
-        time: '2026-08-10 01:00',
-        acknowledged: false,
-      },
-      {
-        id: 'alert-warning',
-        level: 'WARNING',
-        title: 'Mixed-case warning',
-        description: 'warning',
-        time: '2026-08-10 01:01',
-        acknowledged: false,
-      },
-    ]);
+    vi.mocked(listSystemAlerts).mockImplementation(async (query = {}) => {
+      const alerts = [
+        {
+          id: 'alert-error', level: 'Error', title: 'Mixed-case error', description: 'error',
+          time: '2026-08-10 01:00', acknowledged: false,
+        },
+        {
+          id: 'alert-warning', level: 'WARNING', title: 'Mixed-case warning', description: 'warning',
+          time: '2026-08-10 01:01', acknowledged: false,
+        },
+      ];
+      const items = query.level
+        ? alerts.filter((alert) => alert.level.toLowerCase() === query.level?.toLowerCase())
+        : alerts;
+      return { items, total: items.length, page: query.page ?? 1, size: query.pageSize ?? 20 };
+    });
     const user = userEvent.setup();
     renderPage();
     await screen.findByText('Mixed-case error');
 
-    await user.click(screen.getByRole('button', { name: /严重/ }));
+    await user.click(screen.getByRole('button', { name: /严\s*重/ }));
 
     expect(screen.getByText('Mixed-case error')).toBeInTheDocument();
     expect(screen.queryByText('Mixed-case warning')).not.toBeInTheDocument();

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Card, Tag, Flex, Typography, Badge, Button, message } from 'antd';
+import { Card, Tag, Flex, Typography, Button, message, Pagination } from 'antd';
 import { CheckCircle, Trash } from '@phosphor-icons/react';
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
@@ -41,6 +41,9 @@ const SystemAlertsPage = () => {
   };
 
   const [alerts, setAlerts] = useState<SystemAlert[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
   const [levelFilter, setLevelFilter] = useState<string>('all');
   const [loading, setLoading] = useState(true);
   const [acknowledgingIds, setAcknowledgingIds] = useState<Set<string>>(() => new Set());
@@ -49,9 +52,17 @@ const SystemAlertsPage = () => {
   useEffect(() => {
     let cancelled = false;
 
-    void listSystemAlerts()
+    setLoading(true);
+    void listSystemAlerts({
+      level: levelFilter === 'all' ? undefined : levelFilter,
+      page,
+      pageSize,
+    })
       .then((data) => {
-        if (!cancelled) setAlerts(data);
+        if (!cancelled) {
+          setAlerts(data.items);
+          setTotal(data.total);
+        }
       })
       .catch(() => {
         if (!cancelled) message.error('系统告警加载失败，请稍后重试');
@@ -63,14 +74,7 @@ const SystemAlertsPage = () => {
     return () => {
       cancelled = true;
     };
-  }, []);
-
-  const filtered =
-    levelFilter === 'all'
-      ? alerts
-      : alerts.filter((a) => normalizeAlertLevel(a.level) === levelFilter);
-
-  const unackCount = alerts.filter((a) => !a.acknowledged).length;
+  }, [levelFilter, page, pageSize]);
 
   const handleAck = async (id: string) => {
     setAcknowledgingIds((current) => new Set(current).add(id));
@@ -93,8 +97,17 @@ const SystemAlertsPage = () => {
     setClearing(true);
     try {
       await clearAcknowledgedAlerts();
-      const fresh = await listSystemAlerts();
-      setAlerts(fresh);
+      const fresh = await listSystemAlerts({
+        level: levelFilter === 'all' ? undefined : levelFilter,
+        page,
+        pageSize,
+      });
+      if (fresh.items.length === 0 && fresh.total > 0 && page > 1) {
+        setPage(page - 1);
+      } else {
+        setAlerts(fresh.items);
+        setTotal(fresh.total);
+      }
       message.success(t('sysAlerts.cleared'));
     } catch {
       message.error('清理已确认告警失败，请稍后重试');
@@ -107,7 +120,7 @@ const SystemAlertsPage = () => {
     <div style={{ padding: 24 }}>
       <PageHeader
         title={t('sysAlerts.title')}
-        subtitle={t('sysAlerts.subtitle', { n: unackCount })}
+        subtitle={t('sysAlerts.subtitle', { n: total })}
         extra={
           <Button
             icon={<Trash size={14} />}
@@ -126,20 +139,12 @@ const SystemAlertsPage = () => {
             key={level}
             type={levelFilter === level ? 'primary' : 'default'}
             size="small"
-            onClick={() => setLevelFilter(level)}
+            onClick={() => {
+              setLevelFilter(level);
+              setPage(1);
+            }}
           >
             {level === 'all' ? t('common.all') : alertLevelConfig[level]?.label}
-            {level !== 'all' && (
-              <Badge
-                count={alerts.filter((a) => normalizeAlertLevel(a.level) === level).length}
-                style={{
-                  marginLeft: 4,
-                  backgroundColor:
-                    level === 'error' ? '#ff4d4f' : level === 'warning' ? '#fa8c16' : '#1677ff',
-                }}
-                size="small"
-              />
-            )}
           </Button>
         ))}
       </Flex>
@@ -147,7 +152,7 @@ const SystemAlertsPage = () => {
       <Flex vertical gap={12}>
         {loading && <Card loading />}
         {!loading &&
-          filtered.map((alert) => {
+          alerts.map((alert) => {
             const normalizedLevel = normalizeAlertLevel(alert.level);
             const cfg = alertLevelConfig[normalizedLevel] ?? {
               color: '#8c8c8c',
@@ -211,7 +216,7 @@ const SystemAlertsPage = () => {
               </div>
             );
           })}
-        {!loading && filtered.length === 0 && (
+        {!loading && alerts.length === 0 && (
           <Card>
             <Flex justify="center" style={{ padding: 40 }}>
               <Text type="secondary">{t('sysAlerts.noAlerts')}</Text>
@@ -219,6 +224,21 @@ const SystemAlertsPage = () => {
           </Card>
         )}
       </Flex>
+      {total > 0 && (
+        <Flex justify="end" style={{ marginTop: 16 }}>
+          <Pagination
+            current={page}
+            pageSize={pageSize}
+            total={total}
+            showSizeChanger
+            pageSizeOptions={[20, 50, 100]}
+            onChange={(nextPage, nextPageSize) => {
+              setPage(nextPage);
+              setPageSize(nextPageSize);
+            }}
+          />
+        </Flex>
+      )}
     </div>
   );
 };

--- a/web/src/services/opsService.test.ts
+++ b/web/src/services/opsService.test.ts
@@ -102,12 +102,12 @@ describe('ops service mock data', () => {
 
   it('returns copied system alert rows', async () => {
     const first = await listSystemAlerts();
-    const originalTitle = first[0].title;
-    first[0].title = 'mutated-alert';
+    const originalTitle = first.items[0].title;
+    first.items[0].title = 'mutated-alert';
 
     const second = await listSystemAlerts();
-    expect(second[0].title).toBe(originalTitle);
-    expect(second[0]).not.toBe(first[0]);
+    expect(second.items[0].title).toBe(originalTitle);
+    expect(second.items[0]).not.toBe(first.items[0]);
   });
 
   it('returns copied audit records', async () => {

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -6,6 +6,7 @@ import type {
   AlertRule,
   AlertRuleBulkResult,
   SystemAlert,
+  SystemAlertQuery,
   AuditQuery,
   AuditRecord,
   PageResult,
@@ -190,9 +191,17 @@ export async function bulkDeleteAlertRules(ids: string[]): Promise<AlertRuleBulk
   return { succeededIds, failures, updatedRules: [] };
 }
 
-export async function listSystemAlerts(): Promise<SystemAlert[]> {
-  if (isMockMode()) return (mockSystemAlerts as unknown as SystemAlert[]).map(copySystemAlert);
-  return opsApi.listSystemAlerts();
+export async function listSystemAlerts(
+  query: SystemAlertQuery = {},
+): Promise<PageResult<SystemAlert>> {
+  if (!isMockMode()) return opsApi.listSystemAlerts(query);
+  const page = query.page ?? 1;
+  const pageSize = query.pageSize ?? 20;
+  const alerts = (mockSystemAlerts as unknown as SystemAlert[])
+    .filter((alert) => !query.level || alert.level.toLowerCase() === query.level.toLowerCase())
+    .map(copySystemAlert);
+  const start = (page - 1) * pageSize;
+  return { items: alerts.slice(start, start + pageSize), total: alerts.length, page, size: pageSize };
 }
 
 export async function acknowledgeAlert(id: string): Promise<void> {


### PR DESCRIPTION
## Summary
- paginate persisted system-alert queries with optional level filtering and stable ordering
- update the API and UI to render server pages with bounded page sizes
- preserve acknowledgement and clear behavior while refreshing the active page

## Dependency
This branch builds on #2272, which supplies the targeted point lookups used by alert mutations.

## Verification
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home PATH="$JAVA_HOME/bin:$PATH" mvn -q -B -ntp -Dtest=AlertServiceTest,MybatisPlusAlertRepositoryTest,SystemAlertControllerTest test`
- `npm run build`
- `npm test -- --run src/api/ops.test.ts src/services/opsService.test.ts src/pages/ops/__tests__/SystemAlertsPage.test.tsx`

Closes #2277
