### PR TITLE
feat: paginate client connection listings

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientController.java
@@ -17,13 +17,12 @@
 package org.apache.rocketmq.studio.cluster.client;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/clients")
@@ -33,10 +32,12 @@ public class ClientController {
     private final ClientService clientService;
 
     @GetMapping
-    public Result<List<ClientConnectionVO>> listConnections(
+    public Result<PageResult<ClientConnectionVO>> listConnections(
             @RequestParam String instanceId,
             @RequestParam(required = false) String clusterId,
-            @RequestParam(required = false) String type) {
-        return Result.ok(clientService.listConnections(instanceId, clusterId, type));
+            @RequestParam(required = false) String type,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return Result.ok(clientService.listConnections(instanceId, clusterId, type, page, pageSize));
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientService.java
@@ -18,10 +18,12 @@ package org.apache.rocketmq.studio.cluster.client;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Slf4j
@@ -31,9 +33,28 @@ public class ClientService {
 
     private final ClientProvider clientProvider;
 
-    public List<ClientConnectionVO> listConnections(String instanceId, String clusterId, String type) {
-        log.info("Listing client connections, instanceId={}, clusterId={}, type={}", instanceId, clusterId, type);
-        return clientProvider.findConnections(requireInstanceId(instanceId), normalizeFilter(clusterId), normalizeFilter(type));
+    private static final int MAX_PAGE_SIZE = 100;
+    private static final Comparator<ClientConnectionVO> CONNECTION_ORDER = Comparator
+            .comparing(ClientConnectionVO::getClusterName, Comparator.nullsFirst(String::compareTo))
+            .thenComparing(connection -> connection.getType() == null ? null : connection.getType().name(),
+                    Comparator.nullsFirst(String::compareTo))
+            .thenComparing(ClientConnectionVO::getGroupOrTopic, Comparator.nullsFirst(String::compareTo))
+            .thenComparing(ClientConnectionVO::getClientId, Comparator.nullsFirst(String::compareTo))
+            .thenComparing(ClientConnectionVO::getAddress, Comparator.nullsFirst(String::compareTo));
+
+    public PageResult<ClientConnectionVO> listConnections(String instanceId, String clusterId, String type,
+                                                           int page, int pageSize) {
+        validatePage(page, pageSize);
+        log.info("Listing client connections, instanceId={}, clusterId={}, type={}, page={}, pageSize={}",
+                instanceId, clusterId, type, page, pageSize);
+        List<ClientConnectionVO> connections = clientProvider.findConnections(
+                        requireInstanceId(instanceId), normalizeFilter(clusterId), normalizeFilter(type)).stream()
+                .sorted(CONNECTION_ORDER)
+                .toList();
+        int total = connections.size();
+        int from = Math.min((page - 1) * pageSize, total);
+        int to = Math.min(from + pageSize, total);
+        return PageResult.of(connections.subList(from, to), total, page, pageSize);
     }
 
     private String requireInstanceId(String instanceId) {
@@ -45,5 +66,14 @@ public class ClientService {
 
     private String normalizeFilter(String value) {
         return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private void validatePage(int page, int pageSize) {
+        if (page < 1) {
+            throw new BusinessException(400, "page must be greater than 0");
+        }
+        if (pageSize < 1 || pageSize > MAX_PAGE_SIZE) {
+            throw new BusinessException(400, "pageSize must be between 1 and " + MAX_PAGE_SIZE);
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientControllerTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.client;
 import org.apache.rocketmq.studio.common.domain.enums.ClientLanguage;
 import org.apache.rocketmq.studio.common.domain.enums.ClientType;
 import org.apache.rocketmq.studio.common.domain.enums.Protocol;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -69,27 +70,29 @@ class ClientControllerTest {
                 .connectedAt(LocalDateTime.of(2026, 1, 1, 12, 5))
                 .clusterName("production-cluster")
                 .build();
-        when(clientService.listConnections("instance-1", null, null)).thenReturn(List.of(grpcClient, remotingClient));
+        when(clientService.listConnections("instance-1", null, null, 1, 20))
+                .thenReturn(PageResult.of(List.of(grpcClient, remotingClient), 2, 1, 20));
 
         mockMvc.perform(get("/api/clients").param("instanceId", "instance-1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data[0].clientId").value("grpc-client-001"))
-                .andExpect(jsonPath("$.data[0].type").value("Consumer"))
-                .andExpect(jsonPath("$.data[0].protocol").value("gRPC"))
-                .andExpect(jsonPath("$.data[0].language").value("Java"))
-                .andExpect(jsonPath("$.data[0].version").value("5.1.0"))
-                .andExpect(jsonPath("$.data[1].clientId").value("remoting-client-001"))
-                .andExpect(jsonPath("$.data[1].type").value("Producer"))
-                .andExpect(jsonPath("$.data[1].protocol").value("Remoting"));
+                .andExpect(jsonPath("$.data.total").value(2))
+                .andExpect(jsonPath("$.data.items[0].clientId").value("grpc-client-001"))
+                .andExpect(jsonPath("$.data.items[0].type").value("Consumer"))
+                .andExpect(jsonPath("$.data.items[0].protocol").value("gRPC"))
+                .andExpect(jsonPath("$.data.items[0].language").value("Java"))
+                .andExpect(jsonPath("$.data.items[0].version").value("5.1.0"))
+                .andExpect(jsonPath("$.data.items[1].clientId").value("remoting-client-001"))
+                .andExpect(jsonPath("$.data.items[1].type").value("Producer"))
+                .andExpect(jsonPath("$.data.items[1].protocol").value("Remoting"));
 
-        verify(clientService).listConnections("instance-1", null, null);
+        verify(clientService).listConnections("instance-1", null, null, 1, 20);
     }
 
     @Test
     void listConnectionsShouldPassClusterAndTypeFilters() throws Exception {
-        when(clientService.listConnections("instance-1", "production-cluster", "Consumer")).thenReturn(List.of());
+        when(clientService.listConnections("instance-1", "production-cluster", "Consumer", 1, 20))
+                .thenReturn(PageResult.empty(1, 20));
 
         mockMvc.perform(get("/api/clients")
                         .param("instanceId", "instance-1")
@@ -97,9 +100,9 @@ class ClientControllerTest {
                         .param("type", "Consumer"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data").isEmpty());
+                .andExpect(jsonPath("$.data.items").isArray())
+                .andExpect(jsonPath("$.data.items").isEmpty());
 
-        verify(clientService).listConnections("instance-1", "production-cluster", "Consumer");
+        verify(clientService).listConnections("instance-1", "production-cluster", "Consumer", 1, 20);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.cluster.client;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,9 +49,10 @@ class ClientServiceTest {
                 .build();
         when(clientProvider.findConnections("instance-1", "production-cluster", "Producer")).thenReturn(List.of(connection));
 
-        List<ClientConnectionVO> result = clientService.listConnections(" instance-1 ", " production-cluster ", " Producer ");
+        PageResult<ClientConnectionVO> result = clientService.listConnections(
+                " instance-1 ", " production-cluster ", " Producer ", 1, 20);
 
-        assertThat(result).containsExactly(connection);
+        assertThat(result.getItems()).containsExactly(connection);
         verify(clientProvider).findConnections("instance-1", "production-cluster", "Producer");
     }
 
@@ -58,18 +60,34 @@ class ClientServiceTest {
     void listConnectionsShouldTreatBlankOptionalFiltersAsUnspecified() {
         when(clientProvider.findConnections("instance-1", null, null)).thenReturn(List.of());
 
-        List<ClientConnectionVO> result = clientService.listConnections("instance-1", " ", "\t");
+        PageResult<ClientConnectionVO> result = clientService.listConnections("instance-1", " ", "\t", 1, 20);
 
-        assertThat(result).isEmpty();
+        assertThat(result.getItems()).isEmpty();
         verify(clientProvider).findConnections("instance-1", null, null);
     }
 
     @Test
     void listConnectionsShouldRejectBlankInstanceIdBeforeQueryingProvider() {
-        assertThatThrownBy(() -> clientService.listConnections(" ", null, null))
+        assertThatThrownBy(() -> clientService.listConnections(" ", null, null, 1, 20))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("instanceId is required");
 
         verifyNoInteractions(clientProvider);
+    }
+
+    @Test
+    void listConnectionsShouldSortAndPageConnections() {
+        ClientConnectionVO later = ClientConnectionVO.builder()
+                .clusterName("cluster-b").type(org.apache.rocketmq.studio.common.domain.enums.ClientType.Consumer)
+                .groupOrTopic("group-b").clientId("client-b").address("10.0.0.2").build();
+        ClientConnectionVO first = ClientConnectionVO.builder()
+                .clusterName("cluster-a").type(org.apache.rocketmq.studio.common.domain.enums.ClientType.Producer)
+                .groupOrTopic("group-a").clientId("client-a").address("10.0.0.1").build();
+        when(clientProvider.findConnections("instance-1", null, null)).thenReturn(List.of(later, first));
+
+        PageResult<ClientConnectionVO> result = clientService.listConnections("instance-1", null, null, 1, 1);
+
+        assertThat(result.getTotal()).isEqualTo(2);
+        assertThat(result.getItems()).containsExactly(first);
     }
 }

--- a/web/src/api/connections.test.ts
+++ b/web/src/api/connections.test.ts
@@ -52,7 +52,7 @@ describe('client connections API', () => {
         clusterId: 'production-cluster',
         type: 'Producer',
       });
-      return [200, { code: 200, data: [connection] }];
+      return [200, { code: 200, data: { items: [connection], total: 1, page: 1, size: 20 } }];
     });
 
     await expect(
@@ -61,6 +61,6 @@ describe('client connections API', () => {
         clusterId: 'production-cluster',
         type: 'Producer',
       }),
-    ).resolves.toEqual([connection]);
+    ).resolves.toEqual({ items: [connection], total: 1, page: 1, size: 20 });
   });
 });

--- a/web/src/api/connections.ts
+++ b/web/src/api/connections.ts
@@ -18,9 +18,18 @@ export interface ClientConnectionQuery {
   instanceId: string;
   clusterId?: string;
   type?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface ClientConnectionPage {
+  items: ClientConnection[];
+  total: number;
+  page: number;
+  size: number;
 }
 
 export async function listConnections(params?: ClientConnectionQuery) {
-  const res = await client.get<{ data: ClientConnection[] }>('/clients', { params });
+  const res = await client.get<{ data: ClientConnectionPage }>('/clients', { params });
   return res.data.data;
 }

--- a/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
@@ -83,6 +83,8 @@ const connections: ClientConnection[] = [
   },
 ];
 
+const pageOf = (items: ClientConnection[]) => ({ items, total: items.length, page: 1, size: 20 });
+
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -100,7 +102,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  vi.mocked(connectionsService.listConnections).mockResolvedValue([connection]);
+  vi.mocked(connectionsService.listConnections).mockResolvedValue(pageOf([connection]));
 });
 
 afterEach(() => {
@@ -119,11 +121,11 @@ describe('Clients page', () => {
     renderWithProviders(<ClientsPage />);
 
     await screen.findByText('order-svc-0@10.0.1.12:49152');
-    expect(connectionsService.listConnections).toHaveBeenCalledWith({ instanceId: 'instance-1' });
+    expect(connectionsService.listConnections).toHaveBeenCalledWith({ instanceId: 'instance-1', page: 1, pageSize: 20 });
   });
 
   it('summarizes connection types, protocols, and language versions', async () => {
-    vi.mocked(connectionsService.listConnections).mockResolvedValue(connections);
+    vi.mocked(connectionsService.listConnections).mockResolvedValue(pageOf(connections));
     renderWithProviders(<ClientsPage />);
 
     await waitFor(() => {
@@ -144,7 +146,10 @@ describe('Clients page', () => {
 
   it('updates statistics when the selected cluster changes', async () => {
     const user = userEvent.setup();
-    vi.mocked(connectionsService.listConnections).mockResolvedValue(connections);
+    vi.mocked(connectionsService.listConnections).mockImplementation(async (query) => {
+      const items = query.clusterId ? connections.filter((connection) => connection.clusterName === query.clusterId) : connections;
+      return pageOf(items);
+    });
     renderWithProviders(<ClientsPage />);
 
     await screen.findByText('audit-svc-0@10.0.2.10:49154');
@@ -174,7 +179,7 @@ describe('Clients page', () => {
 
   it('keeps cluster statistics stable when text search narrows the table', async () => {
     const user = userEvent.setup();
-    vi.mocked(connectionsService.listConnections).mockResolvedValue(connections);
+    vi.mocked(connectionsService.listConnections).mockResolvedValue(pageOf(connections));
     renderWithProviders(<ClientsPage />);
 
     await screen.findByText('audit-svc-0@10.0.2.10:49154');
@@ -194,7 +199,7 @@ describe('Clients page', () => {
   });
 
   it('renders empty distributions when no connections are available', async () => {
-    vi.mocked(connectionsService.listConnections).mockResolvedValue([]);
+    vi.mocked(connectionsService.listConnections).mockResolvedValue(pageOf([]));
     renderWithProviders(<ClientsPage />);
 
     expect(
@@ -225,7 +230,7 @@ describe('Clients page', () => {
   it('retries the current instance connection query after a runtime failure', async () => {
     vi.mocked(connectionsService.listConnections)
       .mockRejectedValueOnce(new Error('Client connection provider is not configured'))
-      .mockResolvedValueOnce([connection]);
+      .mockResolvedValueOnce(pageOf([connection]));
     const user = userEvent.setup();
     renderWithProviders(<ClientsPage />);
 
@@ -239,7 +244,7 @@ describe('Clients page', () => {
     expect(await screen.findByText('order-svc-0@10.0.1.12:49152')).toBeInTheDocument();
     expect(connectionsService.listConnections).toHaveBeenCalledTimes(2);
     expect(connectionsService.listConnections).toHaveBeenLastCalledWith({
-      instanceId: 'instance-1',
+      instanceId: 'instance-1', page: 1, pageSize: 20,
     });
   });
 
@@ -270,7 +275,7 @@ describe('Clients page', () => {
     ]);
     vi.mocked(connectionsService.listConnections).mockImplementation((query) =>
       query?.instanceId === 'instance-1'
-        ? Promise.resolve([connection])
+        ? Promise.resolve(pageOf([connection]))
         : Promise.reject(new Error('Instance 2 is unavailable')),
     );
     const user = userEvent.setup();
@@ -311,7 +316,7 @@ describe('Clients page', () => {
 
     await user.click(screen.getByRole('button', { name: /重\s*试/ }));
     await screen.findByText('order-svc-0@10.0.1.12:49152');
-    expect(connectionsService.listConnections).toHaveBeenCalledWith({ instanceId: 'instance-1' });
+    expect(connectionsService.listConnections).toHaveBeenCalledWith({ instanceId: 'instance-1', page: 1, pageSize: 20 });
   });
 
   it('opens a client detail dialog from the connection table', async () => {

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -107,6 +107,9 @@ const ClientsPage = () => {
   const { t } = useLang();
   const { token } = theme.useToken();
   const [connections, setConnections] = useState<ClientConnection[]>([]);
+  const [totalConnections, setTotalConnections] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState('');
   const [loading, setLoading] = useState(true);
@@ -120,6 +123,8 @@ const ClientsPage = () => {
   const handleInstanceChange = (instanceId: string) => {
     setSelectedInstanceId(instanceId);
     setConnections([]);
+    setTotalConnections(0);
+    setPage(1);
     setClusterFilter('ALL');
     setSelectedConnection(null);
     setLoadError(null);
@@ -160,10 +165,16 @@ const ClientsPage = () => {
       };
     }
 
-    void listConnections({ instanceId: selectedInstanceId })
-      .then((nextConnections) => {
+    void listConnections({
+      instanceId: selectedInstanceId,
+      clusterId: clusterFilter === 'ALL' ? undefined : clusterFilter,
+      page,
+      pageSize,
+    })
+      .then((result) => {
         if (!cancelled) {
-          setConnections(nextConnections);
+          setConnections(result.items);
+          setTotalConnections(result.total);
           setLoadError(null);
         }
       })
@@ -182,7 +193,7 @@ const ClientsPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [connectionLoadKey, selectedInstanceId]);
+  }, [clusterFilter, connectionLoadKey, page, pageSize, selectedInstanceId]);
 
   /* ─── Cluster options using nsClusterName ─── */
   const clusterOptions = useMemo(() => {
@@ -379,7 +390,7 @@ const ClientsPage = () => {
       {/* ─── Header ─── */}
       <PageHeader
         title={t('clients.title')}
-        subtitle={`${t('clients.title')} — ${filtered.length} connections`}
+        subtitle={`${t('clients.title')} — ${totalConnections} connections`}
       />
 
       {loadError && (
@@ -426,7 +437,10 @@ const ClientsPage = () => {
           <Select
             aria-label={t('clients.cluster')}
             value={clusterFilter}
-            onChange={setClusterFilter}
+            onChange={(value) => {
+              setClusterFilter(value);
+              setPage(1);
+            }}
             style={{ width: 180 }}
             options={clusterOptions}
           />
@@ -514,9 +528,16 @@ const ClientsPage = () => {
           loading={loading}
           scroll={{ x: 1320 }}
           pagination={{
-            pageSize: 20,
+            current: page,
+            pageSize,
+            total: totalConnections,
             showSizeChanger: true,
+            pageSizeOptions: [20, 50, 100],
             showTotal: (total) => `${t('common.total')} ${total}`,
+            onChange: (nextPage, nextPageSize) => {
+              setPage(nextPage);
+              setPageSize(nextPageSize);
+            },
           }}
           size="small"
         />

--- a/web/src/services/connectionsService.test.ts
+++ b/web/src/services/connectionsService.test.ts
@@ -31,11 +31,11 @@ describe('connectionsService mock connections', () => {
       clusterId: 'ns-prod',
       type: 'Consumer',
     });
-    const originalClientId = connections[0].clientId;
-    const originalAddress = connections[0].address;
+    const originalClientId = connections.items[0].clientId;
+    const originalAddress = connections.items[0].address;
 
-    connections[0].clientId = 'mutated-client';
-    connections[0].address = '127.0.0.1:8081';
+    connections.items[0].clientId = 'mutated-client';
+    connections.items[0].address = '127.0.0.1:8081';
 
     const fresh = await listConnections({
       instanceId: 'instance-1',
@@ -43,10 +43,10 @@ describe('connectionsService mock connections', () => {
       type: 'Consumer',
     });
 
-    expect(fresh[0].clientId).toBe(originalClientId);
-    expect(fresh[0].address).toBe(originalAddress);
-    expect(fresh[0]).not.toBe(connections[0]);
-    expect(fresh.every((connection) => connection.clusterName === 'ns-prod')).toBe(true);
-    expect(fresh.every((connection) => connection.type === 'Consumer')).toBe(true);
+    expect(fresh.items[0].clientId).toBe(originalClientId);
+    expect(fresh.items[0].address).toBe(originalAddress);
+    expect(fresh.items[0]).not.toBe(connections.items[0]);
+    expect(fresh.items.every((connection) => connection.clusterName === 'ns-prod')).toBe(true);
+    expect(fresh.items.every((connection) => connection.type === 'Consumer')).toBe(true);
   });
 });

--- a/web/src/services/connectionsService.ts
+++ b/web/src/services/connectionsService.ts
@@ -1,19 +1,36 @@
 import { isMockMode } from './dataMode';
 import * as connApi from '../api/connections';
-import type { ClientConnection, ClientConnectionQuery } from '../api/connections';
+import type { ClientConnection, ClientConnectionPage, ClientConnectionQuery } from '../api/connections';
 import { mockClients } from '../mock/clients';
 
 function copyConnection(connection: ClientConnection): ClientConnection {
   return { ...connection };
 }
 
-export async function listConnections(params?: ClientConnectionQuery): Promise<ClientConnection[]> {
+export async function listConnections(
+  params: ClientConnectionQuery,
+): Promise<ClientConnectionPage> {
   if (isMockMode()) {
     let result = [...mockClients];
     if (params?.clusterId)
       result = result.filter((connection) => connection.clusterName === params.clusterId);
     if (params?.type) result = result.filter((c) => c.type === params.type);
-    return (result as unknown as ClientConnection[]).map(copyConnection);
+    const page = params.page ?? 1;
+    const pageSize = params.pageSize ?? 20;
+    const start = (page - 1) * pageSize;
+    return {
+      items: (result as unknown as ClientConnection[])
+        .sort((left, right) =>
+          `${left.clusterName}\0${left.type}\0${left.groupOrTopic}\0${left.clientId}\0${left.address}`.localeCompare(
+            `${right.clusterName}\0${right.type}\0${right.groupOrTopic}\0${right.clientId}\0${right.address}`,
+          ),
+        )
+        .slice(start, start + pageSize)
+        .map(copyConnection),
+      total: result.length,
+      page,
+      size: pageSize,
+    };
   }
   return connApi.listConnections(params);
 }


### PR DESCRIPTION
## Summary
- expose a bounded `PageResult` for client connection listings
- enforce page/pageSize limits and deterministic server-side ordering
- update the client connection API, mock service, and UI pagination

## Scope
This bounds API/UI results. Native filtering that avoids the underlying Remoting Broker/Group scan remains a future Proxy Admin capability.

## Verification
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home PATH="$JAVA_HOME/bin:$PATH" mvn -q -B -ntp -Dtest=ClientServiceTest,ClientControllerTest test`
- `npm run build`
- `npm test -- --run src/api/connections.test.ts src/services/connectionsService.test.ts src/pages/cluster/__tests__/ClientsPage.test.tsx`

Closes #2279
