### PR TITLE
fix(security): reject IPv6 unique-local addresses in SSRF guard

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/UrlHostGuard.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/UrlHostGuard.java
@@ -112,7 +112,7 @@ public final class UrlHostGuard {
         }
         for (InetAddress address : addresses) {
             if (address == null || address.isAnyLocalAddress() || address.isLinkLocalAddress()
-                    || address.isMulticastAddress()) {
+                    || address.isMulticastAddress() || isUniqueLocalAddress(address)) {
                 return false;
             }
             if (address.isLoopbackAddress() && !allowLoopback) {
@@ -120,5 +120,19 @@ public final class UrlHostGuard {
             }
         }
         return true;
+    }
+
+    /**
+     * Whether the address is an IPv6 unique-local address (fc00::/7). Java's
+     * {@link InetAddress} does not classify these as link-local or site-local, so they would
+     * otherwise pass the guard; notably {@code fd00:ec2::254} is the AWS EC2 IMDS IPv6
+     * metadata endpoint and must not be reachable.
+     */
+    private static boolean isUniqueLocalAddress(InetAddress address) {
+        if (!(address instanceof java.net.Inet6Address)) {
+            return false;
+        }
+        byte[] bytes = address.getAddress();
+        return bytes.length == 16 && (bytes[0] & 0xFE) == 0xFC;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardTest.java
@@ -40,4 +40,27 @@ class UrlHostGuardTest {
 
         assertThat(UrlHostGuard.areAllowed(new InetAddress[]{first, second}, false)).isTrue();
     }
+
+    @Test
+    void areAllowedShouldRejectIpv6UniqueLocalAddresses() throws Exception {
+        // fc00::/7 unique-local addresses are not classified as link/site-local by the JDK
+        // and would otherwise pass the guard; fd00:ec2::254 is the AWS EC2 IMDS IPv6 endpoint.
+        InetAddress ula = InetAddress.getByName("fd00:ec2::254");
+        InetAddress ulaFc = InetAddress.getByName("fc00::1");
+
+        assertThat(UrlHostGuard.areAllowed(new InetAddress[]{ula}, false)).isFalse();
+        assertThat(UrlHostGuard.areAllowed(new InetAddress[]{ulaFc}, false)).isFalse();
+    }
+
+    @Test
+    void areAllowedShouldStillAcceptGlobalIpv6Addresses() throws Exception {
+        InetAddress globalIpv6 = InetAddress.getByName("2606:4700:4700::1111");
+
+        assertThat(UrlHostGuard.areAllowed(new InetAddress[]{globalIpv6}, false)).isTrue();
+    }
+
+    @Test
+    void isAllowedHostShouldRejectIpv6UlaLiteralEvenWhenLoopbackIsAllowed() {
+        assertThat(UrlHostGuard.isAllowedHost("fd00:ec2::254", true)).isFalse();
+    }
 }


### PR DESCRIPTION
﻿## What is the purpose of the change

UrlHostGuard is the shared SSRF guard for server-side HTTP endpoints that accept caller-supplied URLs (metrics data sources, LLM gateways). `InetAddress.isLinkLocalAddress()` and `isSiteLocalAddress()` do not classify IPv6 unique-local addresses (fc00::/7) as local, so they currently pass the guard. This includes the AWS EC2 IMDS IPv6 metadata endpoint (`fd00:ec2::254`), which the guard's documented contract claims to block.

## Brief changelog

- `UrlHostGuard.areAllowed` now rejects IPv6 unique-local addresses (fc00::/7) in addition to loopback, link-local, any-local and multicast addresses, even when loopback is permitted.
- Added unit tests for ULA rejection (fd00:ec2::254, fc00::1), global IPv6 acceptance, and `isAllowedHost` with an IPv6 ULA literal.

## How was this patch verified

- `mvn -Dtest=UrlHostGuardTest test` -> 5/5 passed
- `git diff --check` clean
