### PR TITLE
fix(common): map unmapped routes and wrong methods to 404/405 instead of 500

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandler.java
@@ -22,12 +22,15 @@ import org.apache.rocketmq.studio.ops.ai.LlmGatewayException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -91,5 +94,39 @@ public class GlobalExceptionHandler {
     public Result<?> handleException(Exception ex) {
         log.error("Unexpected exception", ex);
         return Result.error(500, "Internal Server Error");
+    }
+
+    /**
+     * Spring MVC throws {@link NoResourceFoundException} for unmatched routes. Without an
+     * explicit handler it would fall through to the generic catch-all and be reported as
+     * HTTP 500 instead of the correct 404.
+     */
+    @ExceptionHandler(NoResourceFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Result<?> handleNoResourceFoundException(NoResourceFoundException ex) {
+        log.warn("Resource not found: {}", ex.getMessage());
+        return Result.error(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+    }
+
+    /**
+     * Requests with an unsupported HTTP method must be reported as 405, not 500.
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    public Result<?> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException ex) {
+        log.warn("Method not allowed: {}", ex.getMessage());
+        return Result.error(HttpStatus.METHOD_NOT_ALLOWED.value(), ex.getMessage());
+    }
+
+    /**
+     * Requests with an unsupported content type must be reported as 415, not 500.
+     */
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+    public Result<?> handleHttpMediaTypeNotSupportedException(
+            HttpMediaTypeNotSupportedException ex) {
+        log.warn("Unsupported media type: {}", ex.getMessage());
+        return Result.error(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value(), ex.getMessage());
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandlerTest.java
@@ -65,6 +65,29 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.message").value("LLM provider request timed out"));
     }
 
+    @Test
+    void unmappedRouteReturns404WithEnvelopeInsteadOf500() {
+        // Standalone MockMvc does not synthesize NoResourceFoundException for unmapped
+        // routes (only a full Spring MVC resource resolver does), so verify the handler
+        // mapping directly: NoResourceFoundException must map to a 404 Result envelope
+        // rather than falling through to the generic 500 catch-all.
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        org.springframework.web.servlet.resource.NoResourceFoundException ex =
+                new org.springframework.web.servlet.resource.NoResourceFoundException(
+                        org.springframework.http.HttpMethod.GET, "missing-resource");
+        org.apache.rocketmq.studio.common.domain.Result<?> result =
+                handler.handleNoResourceFoundException(ex);
+        org.assertj.core.api.Assertions.assertThat(result.getCode()).isEqualTo(404);
+    }
+
+    @Test
+    void wrongHttpMethodReturns405WithEnvelopeInsteadOf500() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .post("/test/business/400"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(jsonPath("$.code").value(405));
+    }
+
     @RestController
     static class FailingController {
 


### PR DESCRIPTION
﻿## What is the purpose of the change

Spring MVC throws NoResourceFoundException for unmatched routes and HttpRequestMethodNotSupportedException for wrong HTTP methods. With no dedicated handler, both fell through to the generic catch-all exception handler and were reported as HTTP 500 instead of the correct 404/405, and every such request logged a full error stack trace.

## Brief changelog

- Added explicit @ExceptionHandler mappings so unmapped routes return 404, wrong methods return 405, and unsupported media types return 415, each wrapped in the standard Result envelope.
- Added tests: a direct-handler assertion for the NoResourceFoundException -> 404 mapping, and a MockMvc assertion for wrong-method -> 405.

## How was this patch verified

- `mvn -Dtest=GlobalExceptionHandlerTest test` -> 5/5 passed
- `git diff --check` clean
