### PR TITLE
fix(audit): stabilize persisted audit queries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
@@ -29,6 +29,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /** MySQL-backed audit repository (rmq_operation_audit). */
@@ -36,7 +37,10 @@ import java.util.stream.Collectors;
 @Repository
 public class MybatisPlusAuditRepository implements AuditRepository {
 
+    private static final long FILTER_OPTIONS_CACHE_TTL_NANOS = TimeUnit.SECONDS.toNanos(30);
+
     private final RmqOperationAuditMapper auditMapper;
+    private volatile CachedFilterOptions cachedFilterOptions;
 
     @Override
     public PageResult<AuditRecordVO> findPage(String search, String operationType,
@@ -54,7 +58,7 @@ public class MybatisPlusAuditRepository implements AuditRepository {
                 .ge(startDate != null, "gmt_create", startDate)
                 .le(endDate != null, "gmt_create", endDate)
                 .eq(StringUtils.hasText(result), "result", result)
-                .orderByDesc("gmt_create");
+                .orderByDesc("gmt_create", "id");
         Page<RmqOperationAudit> resultPage = auditMapper.selectPage(
                 new Page<>(page, pageSize), query);
         List<AuditRecordVO> records = resultPage.getRecords().stream()
@@ -65,6 +69,23 @@ public class MybatisPlusAuditRepository implements AuditRepository {
 
     @Override
     public AuditFilterOptionsVO findFilterOptions() {
+        long now = System.nanoTime();
+        CachedFilterOptions cached = cachedFilterOptions;
+        if (isCacheValid(cached, now)) {
+            return cached.options();
+        }
+        synchronized (this) {
+            cached = cachedFilterOptions;
+            if (isCacheValid(cached, now)) {
+                return cached.options();
+            }
+            AuditFilterOptionsVO options = loadFilterOptions();
+            cachedFilterOptions = new CachedFilterOptions(options, now);
+            return options;
+        }
+    }
+
+    private AuditFilterOptionsVO loadFilterOptions() {
         List<Map<String, Object>> values = auditMapper.selectMaps(
                 new QueryWrapper<RmqOperationAudit>()
                         .select("operation", "resource_type", "cluster_id", "result")
@@ -92,6 +113,14 @@ public class MybatisPlusAuditRepository implements AuditRepository {
         entity.setGmtCreate(timestamp);
         entity.setGmtModified(timestamp);
         auditMapper.insert(entity);
+        cachedFilterOptions = null;
+    }
+
+    private static boolean isCacheValid(CachedFilterOptions cached, long now) {
+        return cached != null && now - cached.createdAtNanos() < FILTER_OPTIONS_CACHE_TTL_NANOS;
+    }
+
+    private record CachedFilterOptions(AuditFilterOptionsVO options, long createdAtNanos) {
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
@@ -80,11 +80,11 @@ class MybatisPlusAuditRepositoryTest {
         assertThat(record.getClusterId()).isEqualTo("prod-cn");
         assertThat(record.getErrorMessage()).isEqualTo("denied");
         assertThat(queryCaptor.getValue().getSqlSegment())
-                .contains("operation", "resource_type", "cluster_id", "result");
+                .contains("operation", "resource_type", "cluster_id", "result", "operated_at", "id");
     }
 
     @Test
-    void findFilterOptionsPreservesPersistedValuesFromOneQuery() {
+    void findFilterOptionsPreservesPersistedValuesAndCachesTheResult() {
         when(auditMapper.selectMaps(any(Wrapper.class))).thenReturn(List.of(
                 Map.of("operation", "DELETE_TOPIC", "resource_type", "TOPIC",
                         "cluster_id", "prod-cn", "result", "SUCCESS"),
@@ -94,17 +94,31 @@ class MybatisPlusAuditRepositoryTest {
                         "cluster_id", "", "result", "PARTIAL")));
 
         AuditFilterOptionsVO options = repository.findFilterOptions();
+        AuditFilterOptionsVO cachedOptions = repository.findFilterOptions();
 
         assertThat(options.getOperationTypes()).containsExactly(" CREATE_TOPIC ", "DELETE_TOPIC");
         assertThat(options.getResourceTypes()).containsExactly("GROUP", "TOPIC");
         assertThat(options.getClusterIds()).containsExactly("prod-cn", "prod-sh");
         assertThat(options.getResults()).containsExactly("FAILED", "PARTIAL", "SUCCESS");
+        assertThat(cachedOptions).isSameAs(options);
         ArgumentCaptor<Wrapper<RmqOperationAudit>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
         verify(auditMapper).selectMaps(queryCaptor.capture());
         assertThat(((QueryWrapper<RmqOperationAudit>) queryCaptor.getValue()).getSqlSelect())
                 .contains("operation", "resource_type", "cluster_id", "result");
         assertThat(queryCaptor.getValue().getSqlSegment())
                 .contains("GROUP BY operation,resource_type,cluster_id,result");
+    }
+
+    @Test
+    void saveInvalidatesCachedFilterOptions() {
+        when(auditMapper.selectMaps(any(Wrapper.class))).thenReturn(List.of());
+
+        repository.findFilterOptions();
+        repository.save(AuditRecordVO.builder().operationType("CREATE_TOPIC").build());
+        repository.findFilterOptions();
+
+        verify(auditMapper, org.mockito.Mockito.times(2)).selectMaps(any(Wrapper.class));
+        verify(auditMapper).insert(any(RmqOperationAudit.class));
     }
 
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
@@ -84,7 +84,7 @@ class MybatisPlusAuditRepositoryTest {
     }
 
     @Test
-    void findFilterOptionsPreservesPersistedValuesAndCachesTheResult() {
+    void findFilterOptionsPreservesPersistedValuesAndCachesTheResultTest() {
         when(auditMapper.selectMaps(any(Wrapper.class))).thenReturn(List.of(
                 Map.of("operation", "DELETE_TOPIC", "resource_type", "TOPIC",
                         "cluster_id", "prod-cn", "result", "SUCCESS"),
@@ -110,7 +110,7 @@ class MybatisPlusAuditRepositoryTest {
     }
 
     @Test
-    void saveInvalidatesCachedFilterOptions() {
+    void saveInvalidatesCachedFilterOptionsTest() {
         when(auditMapper.selectMaps(any(Wrapper.class))).thenReturn(List.of());
 
         repository.findFilterOptions();

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
@@ -80,7 +80,7 @@ class MybatisPlusAuditRepositoryTest {
         assertThat(record.getClusterId()).isEqualTo("prod-cn");
         assertThat(record.getErrorMessage()).isEqualTo("denied");
         assertThat(queryCaptor.getValue().getSqlSegment())
-                .contains("operation", "resource_type", "cluster_id", "result", "operated_at", "id");
+                .contains("operation", "resource_type", "cluster_id", "result", "gmt_create", "id");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- order persisted audit pages by `gmt_create DESC, id DESC` for deterministic pagination
- cache audit filter options for 30 seconds to avoid repeated grouped scans
- invalidate the filter-options cache after audit writes
- keep the frontend export/search sequencing from the current `rocketmq-studio` base; the overlapping frontend commit was dropped during rebase

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest='org.apache.rocketmq.studio.ops.audit.MybatisPlusAuditRepositoryTest,org.apache.rocketmq.studio.ops.audit.AuditServiceTest,org.apache.rocketmq.studio.ops.audit.AuditControllerTest' test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -DskipTests compile`
- `git diff --check origin/rocketmq-studio...HEAD`

## Review status

The earlier `gmt_create` assertion feedback is included in the current signed commits. The remaining `CHANGES_REQUESTED` state is waiting for reviewer re-approval.
