### PR TITLE
fix(ai): bound timestamp arguments in message query tool

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageQueryToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageQueryToolHandler.java
@@ -16,11 +16,13 @@
  */
 package org.apache.rocketmq.studio.ops.ai.tool;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
 import org.apache.rocketmq.studio.instance.message.MessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -76,9 +78,40 @@ public class MessageQueryToolHandler implements ToolHandler {
             return null;
         }
         if (value instanceof Number number) {
-            return number.longValue();
+            return toEpochMillis(number);
         }
-        return Long.parseLong(value.toString());
+        try {
+            return Long.parseLong(value.toString().trim());
+        } catch (NumberFormatException ex) {
+            throw new BusinessException(
+                    400, "startTime and endTime must be integer epoch-milliseconds");
+        }
+    }
+
+    /**
+     * Convert a caller-supplied numeric timestamp to epoch-milliseconds without silent
+     * overflow. Jackson may deliver out-of-range values as {@link BigInteger} (or as a
+     * floating-point number); {@code Number.longValue()} would silently wrap these into a
+     * nonsense, possibly negative, timestamp. Reject values that do not fit instead.
+     */
+    private static long toEpochMillis(Number number) {
+        if (number instanceof BigInteger bigInteger) {
+            try {
+                return bigInteger.longValueExact();
+            } catch (ArithmeticException ex) {
+                throw new BusinessException(
+                        400, "startTime and endTime must fit in a 64-bit epoch-milliseconds value");
+            }
+        }
+        if (number instanceof Double || number instanceof Float) {
+            double doubleValue = number.doubleValue();
+            if (!Double.isFinite(doubleValue) || doubleValue > Long.MAX_VALUE
+                    || doubleValue < Long.MIN_VALUE) {
+                throw new BusinessException(
+                        400, "startTime and endTime must fit in a 64-bit epoch-milliseconds value");
+            }
+        }
+        return number.longValue();
     }
 
     private static String require(String value, String field) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageQueryToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageQueryToolHandlerTest.java
@@ -85,4 +85,49 @@ class MessageQueryToolHandlerTest {
         verify(messageService)
                 .queryMessages(eq("instance-a"), any(), any(), any(), any(), eq(1000L), eq(2000L));
     }
+
+    @Test
+    void executeShouldRejectTimestampAboveLongRangeInsteadOfSilentlyWrapping() {
+        java.math.BigInteger overflow =
+                java.math.BigInteger.valueOf(Long.MAX_VALUE).add(java.math.BigInteger.ONE);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> handler.execute(Map.of(
+                                "cluster", "instance-a", "topic", "TopicA", "startTime", overflow)))
+                .isInstanceOf(org.apache.rocketmq.studio.common.exception.BusinessException.class)
+                .hasMessageContaining("epoch-milliseconds");
+    }
+
+    @Test
+    void executeShouldRejectNonFiniteTimestampInsteadOfWrapping() {
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> handler.execute(Map.of(
+                                "cluster", "instance-a", "topic", "TopicA",
+                                "startTime", Double.POSITIVE_INFINITY)))
+                .isInstanceOf(org.apache.rocketmq.studio.common.exception.BusinessException.class)
+                .hasMessageContaining("epoch-milliseconds");
+    }
+
+    @Test
+    void executeShouldRejectNonNumericTimestamp() {
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> handler.execute(Map.of(
+                                "cluster", "instance-a", "topic", "TopicA",
+                                "startTime", "not-a-number")))
+                .isInstanceOf(org.apache.rocketmq.studio.common.exception.BusinessException.class)
+                .hasMessageContaining("epoch-milliseconds");
+    }
+
+    @Test
+    void executeShouldConvertInBigIntegerTimestampExactly() {
+        when(messageService.queryMessages(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(List.of());
+
+        handler.execute(Map.of("cluster", "instance-a", "topic", "TopicA",
+                "startTime", java.math.BigInteger.valueOf(123456789L)));
+
+        verify(messageService)
+                .queryMessages(eq("instance-a"), any(), any(), any(), any(),
+                        eq(123456789L), any());
+    }
 }


### PR DESCRIPTION
﻿## What is the purpose of the change

`rmq.message.query` parsed caller-supplied `startTime`/`endTime` timestamps with `Number.longValue()`. Jackson delivers larger-than-Long values as `BigInteger`, and `longValue()` silently wraps them into a nonsense, possibly negative, epoch-millis timestamp instead of rejecting them. String arguments were routed through `Long.parseLong()`, whose `NumberFormatException` propagated as a generic HTTP 500.

## Brief changelog

- Convert numeric timestamps with `BigInteger.longValueExact()` and reject out-of-range / non-finite floating-point values with HTTP 400 instead of silently wrapping.
- Map unparseable string and unrepresentable numeric timestamps to HTTP 400 (BusinessException) rather than HTTP 500.
- Added `MessageQueryToolHandlerTest` cases: above-Long-range, non-finite, non-numeric rejection and in-range BigInt exact conversion.

## How was this patch verified

- `mvn -Dtest=MessageQueryToolHandlerTest test` -> 6/6 passed
- `git diff --check` clean
