### PR TITLE
refactor(server): standardize database schema with numeric auto-increment keys

### DIFF
--- a/.claude/skills/deploy-rocketmq/SKILL.md
+++ b/.claude/skills/deploy-rocketmq/SKILL.md
@@ -17,7 +17,7 @@ description: 部署 RocketMQ Studio 与开源 RocketMQ。当用户说 部署 stu
 | B. 单机部署开源 RocketMQ | 在目标机器部署纯净开源集群（nameserver + 双 broker + proxy），不带测试挂具 |
 | C. 单机部署 RocketMQ 测试客户端 | 在目标机器部署模式 B 集群 + producer/consumer 1 TPS 轨迹挂具，供 Studio 调试 |
 
-> ⚠️ `deploy/deploy.sh` 是旧的 podman 时代脚本，与当前 docker compose 流程不一致，**不要使用**。
+> ⚠️ 模式 A 可用 `deploy/deploy.sh` 一键执行；模式 B/C 无脚本，按手动步骤执行。
 
 ## 通用前置条件（目标机器）
 
@@ -37,6 +37,10 @@ description: 部署 RocketMQ Studio 与开源 RocketMQ。当用户说 部署 stu
 ---
 
 ## 模式 A：部署 Studio 到目标机器
+
+> 🚀 **一键脚本**：`deploy/deploy.sh [all|server|web]` 已实现本模式全流程
+> （打包 → 传输 → 目标机构建 → compose 启动 → actuator/health 验证），
+> `deploy/.env` 配置 `REMOTE_HOST` 等。后续部署优先用脚本；以下手动步骤用于首次初始化与排障。
 
 ### 核心原则
 
@@ -344,6 +348,15 @@ docker compose exec nameserver sh bin/mqadmin queryMsgByKey \
         export PATH=/opt/apache-maven-3.9.16/bin:$PATH
         mvn -B -ntp -s /maven-cache/settings.xml -Dmaven.repo.local=/maven-cache/repository package -DskipTests'
     ```
+  - 也可基于本地已有 dragonwell 镜像 + 宿主机 Maven 分发包自制包装镜像
+    （`FROM alibabadragonwell/dragonwell:21` + `COPY apache-maven-* /opt/maven` +
+    symlink `mvn`），再在 `deploy/.env` 配 `MAVEN_IMAGE=<包装镜像>` 供 deploy.sh 使用。
+- **Maven 容器产物属主为 root**：maven 容器默认 root 运行，写出的 `server/target/`
+  文件归 root，后续 deploy.sh 的 `rm -rf` 会 Permission denied。deploy.sh 已加
+  `--user $(id -u):$(id -g)` 规避；手动跑 maven 容器时也要带该参数。
+- **web 构建 `npm ci` 卡死 / `tsc: not found`**：国内机器连不上
+  `registry.npmjs.org`（实测 HTTP 000，npmmirror 可达）。web Dockerfile 已改为
+  `npm ci --registry=https://registry.npmmirror.com`；旧版 Dockerfile 手动补该参数。
 - **Maven 分发包下载慢**：`archive.apache.org` 国内常只有几 KB/s；改从
   `https://mirrors.aliyun.com/apache/maven/maven-3/<版本>/binaries/apache-maven-<版本>-bin.tar.gz`
   下载（阿里源实测 10MB/s+；如 3.9.16 即 `maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz`）。

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,28 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ─── RocketMQ Studio 一键部署脚本 ───
+# ─── RocketMQ Studio 一键部署脚本（模式 A：部署 Studio 到目标机器）───
+# 主线: 本地打包源码 → 复制到目标机 → 目标机构建镜像（复用 ~/.m2 与 docker 缓存）→ docker compose up
 # 用法:
 #   ./deploy/deploy.sh           # 部署 server + web
 #   ./deploy/deploy.sh server    # 仅部署 server
 #   ./deploy/deploy.sh web       # 仅部署 web
+# 配置: deploy/.env 中设置 REMOTE_HOST / REMOTE_USER / REMOTE_PATH / PUBLIC_PORT
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# ─── 颜色输出 ───
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
+log()  { echo -e "✅ $*"; }
+info() { echo -e "🚀 $*"; }
+warn() { echo -e "⚠️  $*"; }
+err()  { echo -e "❌ $*" >&2; exit 1; }
 
-log()  { echo -e "${GREEN}[✓]${NC} $*"; }
-info() { echo -e "${CYAN}[→]${NC} $*"; }
-warn() { echo -e "${YELLOW}[!]${NC} $*"; }
-err()  { echo -e "${RED}[✗]${NC} $*"; exit 1; }
-
-# 加载配置
 if [[ -f "$SCRIPT_DIR/.env" ]]; then
   set -a
   # shellcheck disable=SC1091
@@ -33,184 +27,122 @@ fi
 [[ -n "${REMOTE_HOST:-}" ]] || err "REMOTE_HOST 未配置，请在 deploy/.env 中设置"
 REMOTE="${REMOTE_USER:-root}@$REMOTE_HOST"
 REMOTE_PATH="${REMOTE_PATH:-/opt/rocketmq-studio}"
-NETWORK="${PODMAN_NETWORK:-rocketmq-studio}"
-TMP_DIR="/tmp/rocketmq-studio-deploy"
-MAVEN_IMAGE="${MAVEN_IMAGE:-maven:3.9.9-eclipse-temurin-21}"
-MAVEN_CACHE_DIR="${MAVEN_CACHE_DIR:-$HOME/.m2}"
+PUBLIC_PORT="${PUBLIC_PORT:-6789}"
+MAVEN_IMAGE="${MAVEN_IMAGE:-maven:3.9.16-eclipse-temurin-21}"
+SRC_TAR="/tmp/rocketmq-studio-src.tar.gz"
 
 TARGET="${1:-all}"  # all | server | web
+case "$TARGET" in
+  all|server|web) ;;
+  *) err "用法: $0 [all|server|web]" ;;
+esac
 
-# ─── 前置检查 ───
+run_remote() { ssh "$REMOTE" "$@"; }
+
 check_prereqs() {
-  info "检查前置条件..."
-  command -v docker >/dev/null 2>&1 || err "docker 未安装"
-  command -v ssh    >/dev/null 2>&1 || err "ssh 未安装"
-  command -v scp    >/dev/null 2>&1 || err "scp 未安装"
+  info "🔎 检查前置条件..."
+  for c in tar scp ssh; do command -v "$c" >/dev/null 2>&1 || err "本地缺少 $c"; done
   ssh -o ConnectTimeout=5 -o BatchMode=yes "$REMOTE" "echo ok" >/dev/null 2>&1 \
     || err "无法 SSH 连接到 $REMOTE（请确认免密登录已配置）"
+  run_remote 'command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1' \
+    || err "目标机缺少 docker 或 docker compose"
+  run_remote "test -f $REMOTE_PATH/.env" \
+    || err "目标机缺少 $REMOTE_PATH/.env（首次部署请按 SKILL.md 模式 A 步骤 1 初始化）"
   log "前置条件通过"
 }
 
-# ─── 构建镜像 ───
+package_source() {
+  info "📦 本地打包源码..."
+  tar czf "$SRC_TAR" -C "$PROJECT_DIR" \
+    --exclude='web/node_modules' --exclude='web/dist' --exclude='server/target' \
+    server web deploy
+  log "打包完成 ($(du -h "$SRC_TAR" | cut -f1))"
+}
+
+upload_source() {
+  info "📤 传输源码到 $REMOTE:$REMOTE_PATH ..."
+  run_remote "mkdir -p $REMOTE_PATH"
+  scp -q "$SRC_TAR" "$REMOTE:$REMOTE_PATH/"
+  run_remote "cd $REMOTE_PATH && rm -rf server web deploy && tar xzf $(basename "$SRC_TAR") && rm $(basename "$SRC_TAR")"
+  run_remote 'docker network inspect rocketmq_net >/dev/null 2>&1 || docker network create rocketmq_net'
+  log "源码就位，rocketmq_net 网络就绪"
+}
+
 build_server() {
-  info "在 Maven 容器中构建 server（复用宿主机缓存: $MAVEN_CACHE_DIR）..."
-  mkdir -p "$MAVEN_CACHE_DIR"
-
-  local maven_settings=()
-  if [[ -f "$MAVEN_CACHE_DIR/settings.xml" ]]; then
-    maven_settings=(-s /maven-cache/settings.xml)
+  info "🏗️  目标机编译后端 JAR（复用 ~/.m2 缓存）..."
+  local settings_flag=""
+  if run_remote 'test -f ~/.m2/settings.xml'; then
+    settings_flag="-s /maven-cache/settings.xml"
+  else
+    warn "目标机无 ~/.m2/settings.xml（国内机器请先配置 Maven 阿里源，见 SKILL.md 步骤 2）"
   fi
-
-  docker run --rm \
-    --user "$(id -u):$(id -g)" \
-    -e HOME=/tmp \
-    -v "$PROJECT_DIR/server:/app" \
-    -v "$MAVEN_CACHE_DIR:/maven-cache" \
-    -w /app \
-    "$MAVEN_IMAGE" \
-    mvn -B -ntp "${maven_settings[@]}" \
-      -Dmaven.repo.local=/maven-cache/repository \
-      package -DskipTests
-
-  info "构建 rocketmq-server 镜像..."
-  docker build \
-    --target runtime-prebuilt \
-    -t rocketmq-server:latest \
-    "$PROJECT_DIR/server"
+  run_remote "cd $REMOTE_PATH && docker run --rm -e HOME=/tmp \
+    --user \$(id -u):\$(id -g) \
+    -v \$PWD/server:/app -v \$HOME/.m2:/maven-cache -w /app \
+    $MAVEN_IMAGE \
+    mvn -B -ntp $settings_flag -Dmaven.repo.local=/maven-cache/repository package -DskipTests"
+  info "🏗️  构建 rocketmq-server 镜像（runtime-prebuilt）..."
+  run_remote "cd $REMOTE_PATH && docker build --target runtime-prebuilt -t rocketmq-server:latest server/"
   log "rocketmq-server 镜像构建完成"
 }
 
 build_web() {
-  info "构建 rocketmq-web 镜像..."
-  docker build -t rocketmq-web:latest "$PROJECT_DIR/web"
+  local commit
+  commit="$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo dev)"
+  info "🏗️  构建 rocketmq-web 镜像（VITE_GIT_COMMIT=$commit）..."
+  run_remote "cd $REMOTE_PATH && docker build --build-arg VITE_GIT_COMMIT=$commit -t rocketmq-web:latest web/"
   log "rocketmq-web 镜像构建完成"
 }
 
-# ─── 导出 & 传输 ───
-transfer_images() {
-  mkdir -p "$TMP_DIR"
-  local images=()
-
-  if [[ "$TARGET" == "all" || "$TARGET" == "server" ]]; then
-    images+=("rocketmq-server:latest")
-  fi
-  if [[ "$TARGET" == "all" || "$TARGET" == "web" ]]; then
-    images+=("rocketmq-web:latest")
-  fi
-
-  local tarball="$TMP_DIR/rocketmq-studio-images.tar.gz"
-  info "导出镜像: ${images[*]}"
-  docker save "${images[@]}" | gzip > "$tarball"
-  log "镜像导出完成 ($(du -h "$tarball" | cut -f1))"
-
-  info "传输到 $REMOTE:$REMOTE_PATH ..."
-  ssh "$REMOTE" "mkdir -p $REMOTE_PATH"
-  scp "$tarball" "$REMOTE:$REMOTE_PATH/"
-  log "传输完成"
-
-  # 同步部署配置文件
-  info "同步部署配置..."
-  scp "$SCRIPT_DIR/docker-compose.yml" "$REMOTE:$REMOTE_PATH/"
-  scp "$SCRIPT_DIR/nginx.conf"         "$REMOTE:$REMOTE_PATH/"
-  log "配置同步完成"
+start_services() {
+  local services=()
+  [[ "$TARGET" == "all" || "$TARGET" == "server" ]] && services+=("rocketmq-server")
+  [[ "$TARGET" == "all" || "$TARGET" == "web" ]] && services+=("rocketmq-web")
+  info "▶️  启动容器: ${services[*]} ..."
+  run_remote "cd $REMOTE_PATH && docker compose --env-file .env -f deploy/docker-compose.yml up -d ${services[*]}"
+  log "容器已启动"
 }
 
-# ─── 远程加载 & 启动 ───
-deploy_remote() {
-  local tarball="$REMOTE_PATH/rocketmq-studio-images.tar.gz"
-
-  info "远程加载镜像..."
-  ssh "$REMOTE" "gunzip -c $tarball | podman load"
-  log "镜像加载完成"
-
-  # 确保网络存在
-  ssh "$REMOTE" "podman network exists $NETWORK 2>/dev/null || podman network create $NETWORK"
-
-  if [[ "$TARGET" == "all" || "$TARGET" == "server" ]]; then
-    info "重启 rocketmq-server..."
-    # Backend port is only exposed inside the podman network; the edge nginx proxies /api/.
-    ssh "$REMOTE" "
-      podman rm -f rocketmq-server 2>/dev/null || true
-      podman run -d \
-        --name rocketmq-server \
-        --network $NETWORK \
-        --restart unless-stopped \
-        -e STUDIO_AUTH_LOGIN_REQUIRED=\"${STUDIO_AUTH_LOGIN_REQUIRED:-true}\" \
-        -e STUDIO_AUTH_ADMIN_USERNAME=\"${STUDIO_AUTH_ADMIN_USERNAME:-}\" \
-        -e STUDIO_AUTH_ADMIN_PASSWORD=\"${STUDIO_AUTH_ADMIN_PASSWORD:-}\" \
-        -e STUDIO_METRICS_PROMETHEUS_BASE_URL=\"${STUDIO_METRICS_PROMETHEUS_BASE_URL:-}\" \
-        -e STUDIO_METRICS_PROMETHEUS_USERNAME=\"${STUDIO_METRICS_PROMETHEUS_USERNAME:-}\" \
-        -e STUDIO_METRICS_PROMETHEUS_PASSWORD=\"${STUDIO_METRICS_PROMETHEUS_PASSWORD:-}\" \
-        -e STUDIO_METRICS_PROMETHEUS_BEARER_TOKEN=\"${STUDIO_METRICS_PROMETHEUS_BEARER_TOKEN:-}\" \
-        rocketmq-server:latest
-    "
-    log "rocketmq-server 已启动"
-  fi
-
-  if [[ "$TARGET" == "all" || "$TARGET" == "web" ]]; then
-    info "重启 rocketmq-web..."
-    ssh "$REMOTE" "
-      podman rm -f rocketmq-web 2>/dev/null || true
-      podman run -d \
-        --name rocketmq-web \
-        --network $NETWORK \
-        --restart unless-stopped \
-        -p ${PUBLIC_PORT:-6789}:80 \
-        rocketmq-web:latest
-    "
-    log "rocketmq-web 已启动"
-  fi
-}
-
-# ─── 验证 ───
 verify() {
-  info "验证部署..."
-  sleep 3
-
-  local status
-  status=$(ssh "$REMOTE" "podman ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'" 2>&1)
-  echo "$status"
-
-  echo ""
-  local http_code
-  http_code=$(ssh "$REMOTE" "curl -sf -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:${PUBLIC_PORT:-6789}" 2>/dev/null || echo "000")
-  if [[ "$http_code" == "200" ]]; then
-    log "前端响应正常 (HTTP $http_code)"
-  else
-    warn "前端返回 HTTP $http_code"
+  info "🔍 验证部署..."
+  if [[ "$TARGET" == "all" || "$TARGET" == "server" ]]; then
+    local i ok=""
+    for i in $(seq 1 30); do
+      if run_remote 'docker exec rocketmq-server curl -fsS http://localhost:8888/actuator/health' 2>/dev/null | grep -q '"UP"'; then
+        ok="yes"; break
+      fi
+      sleep 5
+    done
+    [[ -n "$ok" ]] || err "server 健康检查未通过（docker logs rocketmq-server 查看原因）"
+    log "后端 actuator/health = UP"
   fi
-
-  echo ""
-  log "部署完成 → http://${REMOTE_HOST}:${PUBLIC_PORT:-6789}"
+  if [[ "$TARGET" == "all" || "$TARGET" == "web" ]]; then
+    local i code=""
+    for i in $(seq 1 12); do
+      code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "http://$REMOTE_HOST:$PUBLIC_PORT/" 2>/dev/null || true)
+      [[ "$code" == "200" ]] && break
+      sleep 5
+    done
+    [[ "$code" == "200" ]] && log "前端响应正常 (HTTP $code)" || warn "前端返回 HTTP $code"
+  fi
+  log "🎉 部署完成 → http://$REMOTE_HOST:$PUBLIC_PORT/"
 }
 
-# ─── 清理临时文件 ───
-cleanup() {
-  rm -rf "$TMP_DIR"
-}
+cleanup() { rm -f "$SRC_TAR"; }
+trap cleanup EXIT
 
-# ─── 主流程 ───
 main() {
   echo "═══════════════════════════════════════════"
-  echo "  RocketMQ Studio 部署"
+  echo "  🚢 RocketMQ Studio 部署"
   echo "  目标: $TARGET | 远程: $REMOTE:$REMOTE_PATH"
   echo "═══════════════════════════════════════════"
-  echo ""
-
   check_prereqs
-
-  case "$TARGET" in
-    server) build_server ;;
-    web)    build_web ;;
-    all)    build_server && build_web ;;
-    *)      err "用法: $0 [all|server|web]" ;;
-  esac
-
-  transfer_images
-  deploy_remote
+  package_source
+  upload_source
+  [[ "$TARGET" == "all" || "$TARGET" == "server" ]] && build_server
+  [[ "$TARGET" == "all" || "$TARGET" == "web" ]] && build_web
+  start_services
   verify
-  cleanup
 }
 
-trap cleanup EXIT
 main

--- a/server/src/main/java/org/apache/rocketmq/studio/audit/OperationAuditService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/audit/OperationAuditService.java
@@ -45,7 +45,9 @@ public class OperationAuditService {
         audit.setResult(result);
         audit.setErrorMessage(errorMessage);
         audit.setOperator(AuthenticatedUserContext.currentUsernameOrSystem());
-        audit.setOperatedAt(LocalDateTime.now());
+        LocalDateTime now = LocalDateTime.now();
+        audit.setGmtCreate(now);
+        audit.setGmtModified(now);
         auditMapper.insert(audit);
         log.debug("Audit recorded: {} {} {}", operation, resourceType, resourceName);
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImpl.java
@@ -71,7 +71,7 @@ public class ClusterRepositoryImpl implements ClusterRepository {
         store.computeIfPresent(clusterId, (id, cluster) -> {
             ClusterVO updated = defensiveCopy(cluster);
             updated.setConfig(config);
-            updated.setUpdatedAt(LocalDateTime.now());
+            updated.setGmtModified(LocalDateTime.now());
             log.info("Config updated for cluster: {}", clusterId);
             return updated;
         });
@@ -100,8 +100,8 @@ public class ClusterRepositoryImpl implements ClusterRepository {
                 .tpsHistory(cluster.getTpsHistory() == null ? null : new ArrayList<>(cluster.getTpsHistory()))
                 .build();
         copy.setId(cluster.getId());
-        copy.setCreatedAt(cluster.getCreatedAt());
-        copy.setUpdatedAt(cluster.getUpdatedAt());
+        copy.setGmtCreate(cluster.getGmtCreate());
+        copy.setGmtModified(cluster.getGmtModified());
         return copy;
     }
 
@@ -189,8 +189,8 @@ public class ClusterRepositoryImpl implements ClusterRepository {
                 .tpsHistory(List.of(1200, 1350, 1100, 1450, 1280, 1500, 1380, 1420, 1300, 1550))
                 .build();
         cluster1.setId("cluster-001");
-        cluster1.setCreatedAt(LocalDateTime.now().minusDays(30));
-        cluster1.setUpdatedAt(LocalDateTime.now());
+        cluster1.setGmtCreate(LocalDateTime.now().minusDays(30));
+        cluster1.setGmtModified(LocalDateTime.now());
 
         ClusterVO cluster2 = ClusterVO.builder()
                 .name("rmq-cluster-staging")
@@ -242,8 +242,8 @@ public class ClusterRepositoryImpl implements ClusterRepository {
                 .tpsHistory(List.of(320, 280, 350, 310, 290, 340, 300, 330, 310, 350))
                 .build();
         cluster2.setId("cluster-002");
-        cluster2.setCreatedAt(LocalDateTime.now().minusDays(15));
-        cluster2.setUpdatedAt(LocalDateTime.now().minusHours(3));
+        cluster2.setGmtCreate(LocalDateTime.now().minusDays(15));
+        cluster2.setGmtModified(LocalDateTime.now().minusHours(3));
 
         store.put(cluster1.getId(), cluster1);
         store.put(cluster2.getId(), cluster2);

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterVO.java
@@ -20,23 +20,29 @@ import org.apache.rocketmq.studio.cluster.config.ClusterConfigVO;
 import org.apache.rocketmq.studio.cluster.nameserver.NameServerVO;
 import org.apache.rocketmq.studio.cluster.proxy.ProxyVO;
 
-import org.apache.rocketmq.studio.common.domain.BaseEntity;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * Clusters are discovered from live broker state and cached by cluster name; they are not
+ * backed by a database table, so the identifier stays a String instead of the numeric
+ * auto-increment primary key used by persisted entities.
+ */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-public class ClusterVO extends BaseEntity {
+public class ClusterVO {
+    private String id;
+    private LocalDateTime gmtCreate;
+    private LocalDateTime gmtModified;
     private String name;
     private String nsClusterName;
     private ClusterType type;

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/config/UpdateConfigDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/config/UpdateConfigDTO.java
@@ -29,6 +29,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateConfigDTO {
+    /** Runtime cluster identifier (cluster name); not a database primary key. */
     @NotBlank(message = "id is required")
     private String id;
 

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/CreateCertDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/CreateCertDTO.java
@@ -32,14 +32,13 @@ import java.util.List;
 public class CreateCertDTO {
     @NotBlank(message = "name is required")
     private String name;
-    @NotBlank(message = "namespace is required")
-    private String namespace;
     @NotBlank(message = "cluster is required")
     private String cluster;
     @NotBlank(message = "type is required")
     @Pattern(regexp = "TLS|mTLS|ServiceAccount", message = "type must be one of TLS, mTLS, ServiceAccount")
     private String type;
-    @NotBlank(message = "issuer is required")
     private String issuer;
     private List<String> san;
+    private String certPem;
+    private String keyPem;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/DeleteCertDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/DeleteCertDTO.java
@@ -16,7 +16,7 @@
  */
 package org.apache.rocketmq.studio.cluster.k8s;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,6 +27,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DeleteCertDTO {
-    @NotBlank(message = "id is required")
-    private String id;
+    @NotNull(message = "id is required")
+    private Long id;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertRepository.java
@@ -24,9 +24,9 @@ public interface K8sCertRepository {
 
     List<K8sCertVO> findAll();
 
-    Optional<K8sCertVO> findById(String id);
+    Optional<K8sCertVO> findById(Long id);
 
     K8sCertVO save(K8sCertVO cert);
 
-    boolean deleteById(String id);
+    boolean deleteById(Long id);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
@@ -24,12 +24,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.io.ByteArrayInputStream;
+import java.security.cert.CertificateFactory;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -66,25 +72,34 @@ public class K8sCertService {
         log.info("Creating K8s certificate: {}", command.getName());
 
         LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime notBefore = now;
         LocalDateTime notAfter = now.plusYears(1);
+        String issuer = command.getIssuer();
+        List<String> san = command.getSan();
+        if (command.getCertPem() != null && !command.getCertPem().isBlank()) {
+            X509Certificate parsed = parseCertificate(command.getCertPem());
+            notBefore = LocalDateTime.ofInstant(parsed.getNotBefore().toInstant(), ZoneId.systemDefault());
+            notAfter = LocalDateTime.ofInstant(parsed.getNotAfter().toInstant(), ZoneId.systemDefault());
+            issuer = parsed.getIssuerX500Principal().getName();
+            san = extractSubjectAlternativeNames(parsed);
+        }
 
         K8sCertVO cert = K8sCertVO.builder()
                 .name(command.getName())
-                .namespace(command.getNamespace())
                 .cluster(command.getCluster())
                 .type(CertType.valueOf(command.getType()))
-                .issuer(command.getIssuer())
-                .notBefore(now)
+                .issuer(issuer)
+                .notBefore(notBefore)
                 .notAfter(notAfter)
                 .status(CertStatus.valid)
-                .daysRemaining((int) ChronoUnit.DAYS.between(now, notAfter))
-                .san(command.getSan())
+                .san(san)
+                .certPem(command.getCertPem())
+                .keyPem(command.getKeyPem())
                 .build();
-        cert.setId(UUID.randomUUID().toString());
-        cert.setCreatedAt(now);
-        cert.setUpdatedAt(now);
+        cert.setGmtCreate(now);
+        cert.setGmtModified(now);
 
-        K8sCertVO saved = k8sCertRepository.save(cert);
+        K8sCertVO saved = k8sCertRepository.save(refreshExpirationState(cert, now));
         auditCertificate("CREATE_K8S_CERTIFICATE", saved);
         log.info("K8s certificate created: {} (id={})", saved.getName(), saved.getId());
         return saved;
@@ -98,14 +113,10 @@ public class K8sCertService {
 
         K8sCertVO updated = copyOf(existing);
         String name = normalizeOptionalIdentity(command.getName(), "name");
-        String namespace = normalizeOptionalIdentity(command.getNamespace(), "namespace");
         String cluster = normalizeOptionalIdentity(command.getCluster(), "cluster");
         String issuer = normalizeOptionalIdentity(command.getIssuer(), "issuer");
         if (name != null) {
             updated.setName(name);
-        }
-        if (namespace != null) {
-            updated.setNamespace(namespace);
         }
         if (cluster != null) {
             updated.setCluster(cluster);
@@ -120,7 +131,7 @@ public class K8sCertService {
             updated.setSan(command.getSan());
         }
         LocalDateTime now = LocalDateTime.now(clock);
-        updated.setUpdatedAt(now);
+        updated.setGmtModified(now);
 
         K8sCertVO saved = k8sCertRepository.save(refreshExpirationState(updated, now));
         auditCertificate("UPDATE_K8S_CERTIFICATE", saved);
@@ -142,7 +153,7 @@ public class K8sCertService {
         renewed.setNotAfter(notAfter);
         renewed.setStatus(CertStatus.valid);
         renewed.setDaysRemaining((int) ChronoUnit.DAYS.between(now, notAfter));
-        renewed.setUpdatedAt(now);
+        renewed.setGmtModified(now);
 
         K8sCertVO saved = k8sCertRepository.save(renewed);
         auditCertificate("RENEW_K8S_CERTIFICATE", saved);
@@ -158,7 +169,7 @@ public class K8sCertService {
         if (!k8sCertRepository.deleteById(command.getId())) {
             throw new BusinessException(404, "Certificate not found: " + command.getId());
         }
-        recordAudit("DELETE_K8S_CERTIFICATE", "K8S_CERTIFICATE", command.getId(), null,
+        recordAudit("DELETE_K8S_CERTIFICATE", "K8S_CERTIFICATE", String.valueOf(command.getId()), null,
                 null);
         log.info("K8s certificate deleted: {}", command.getId());
     }
@@ -202,7 +213,6 @@ public class K8sCertService {
     private K8sCertVO copyOf(K8sCertVO cert) {
         K8sCertVO copy = K8sCertVO.builder()
                 .name(cert.getName())
-                .namespace(cert.getNamespace())
                 .cluster(cert.getCluster())
                 .type(cert.getType())
                 .issuer(cert.getIssuer())
@@ -211,17 +221,49 @@ public class K8sCertService {
                 .status(cert.getStatus())
                 .daysRemaining(cert.getDaysRemaining())
                 .san(cert.getSan())
+                .certPem(cert.getCertPem())
+                .keyPem(cert.getKeyPem())
                 .build();
         copy.setId(cert.getId());
-        copy.setCreatedAt(cert.getCreatedAt());
-        copy.setUpdatedAt(cert.getUpdatedAt());
+        copy.setGmtCreate(cert.getGmtCreate());
+        copy.setGmtModified(cert.getGmtModified());
         return copy;
     }
 
     private void auditCertificate(String operation, K8sCertVO certificate) {
-        recordAudit(operation, "K8S_CERTIFICATE", certificate.getId(), null,
-                "name=" + certificate.getName() + ", namespace=" + certificate.getNamespace()
-                        + ", cluster=" + certificate.getCluster());
+        recordAudit(operation, "K8S_CERTIFICATE", String.valueOf(certificate.getId()), null,
+                "name=" + certificate.getName() + ", cluster=" + certificate.getCluster());
+    }
+
+    private X509Certificate parseCertificate(String certPem) {
+        String base64 = certPem
+                .replace("-----BEGIN CERTIFICATE-----", "")
+                .replace("-----END CERTIFICATE-----", "")
+                .replaceAll("\\s", "");
+        try {
+            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            return (X509Certificate) factory.generateCertificate(
+                    new ByteArrayInputStream(Base64.getDecoder().decode(base64)));
+        } catch (Exception exception) {
+            throw new BusinessException(400, "Invalid certificate content, expected a PEM encoded X.509 certificate");
+        }
+    }
+
+    private List<String> extractSubjectAlternativeNames(X509Certificate certificate) {
+        try {
+            Collection<List<?>> names = certificate.getSubjectAlternativeNames();
+            if (names == null) {
+                return List.of();
+            }
+            return names.stream()
+                    .filter(entry -> entry.size() >= 2 && entry.get(1) instanceof String)
+                    .map(entry -> (String) entry.get(1))
+                    .collect(Collectors.toList());
+        } catch (CertificateParsingException exception) {
+            log.warn("Failed to parse SANs of certificate {}: {}", certificate.getSubjectX500Principal(),
+                    exception.getMessage());
+            return List.of();
+        }
     }
 
     private void recordAudit(String operation, String resourceType, String resourceName,

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertVO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.cluster.k8s;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.rocketmq.studio.common.domain.BaseEntity;
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
@@ -35,7 +36,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 public class K8sCertVO extends BaseEntity {
     private String name;
-    private String namespace;
     private String cluster;
     private CertType type;
     private String issuer;
@@ -44,4 +44,8 @@ public class K8sCertVO extends BaseEntity {
     private CertStatus status;
     private int daysRemaining;
     private List<String> san;
+    private String certPem;
+    // The private key is persisted but never serialized into API responses.
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String keyPem;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -55,7 +55,10 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
     }
 
     @Override
-    public Optional<K8sCertVO> findById(String id) {
+    public Optional<K8sCertVO> findById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
         return Optional.ofNullable(certMapper.selectById(id)).map(this::toVO);
     }
 
@@ -76,15 +79,14 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
     }
 
     @Override
-    public boolean deleteById(String id) {
-        return certMapper.deleteById(id) > 0;
+    public boolean deleteById(Long id) {
+        return id != null && certMapper.deleteById(id) > 0;
     }
 
     private K8sCertVO toVO(RmqK8sCertificate entity) {
         K8sCertVO vo = new K8sCertVO();
         vo.setId(entity.getId());
         vo.setName(entity.getName());
-        vo.setNamespace(entity.getNamespace());
         vo.setCluster(entity.getCluster());
         vo.setType(parseCertType(entity.getId(), entity.getCertType()));
         vo.setIssuer(entity.getIssuer());
@@ -93,8 +95,10 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         vo.setStatus(parseCertStatus(entity.getId(), entity.getStatus()));
         vo.setDaysRemaining(entity.getDaysRemaining() == null ? 0 : entity.getDaysRemaining());
         vo.setSan(parseSan(entity.getId(), entity.getSan()));
-        vo.setCreatedAt(entity.getCreatedAt());
-        vo.setUpdatedAt(entity.getUpdatedAt());
+        vo.setCertPem(entity.getCertPem());
+        vo.setKeyPem(entity.getKeyPem());
+        vo.setGmtCreate(entity.getGmtCreate());
+        vo.setGmtModified(entity.getGmtModified());
         return vo;
     }
 
@@ -102,7 +106,6 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         RmqK8sCertificate entity = new RmqK8sCertificate();
         entity.setId(cert.getId());
         entity.setName(cert.getName());
-        entity.setNamespace(cert.getNamespace());
         entity.setCluster(cert.getCluster());
         entity.setCertType(cert.getType() == null ? null : cert.getType().name());
         entity.setIssuer(cert.getIssuer());
@@ -111,12 +114,14 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         entity.setStatus(cert.getStatus() == null ? null : cert.getStatus().name());
         entity.setDaysRemaining(cert.getDaysRemaining());
         entity.setSan(writeSan(cert.getSan()));
-        entity.setCreatedAt(cert.getCreatedAt());
-        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setCertPem(cert.getCertPem());
+        entity.setKeyPem(cert.getKeyPem());
+        entity.setGmtCreate(cert.getGmtCreate());
+        entity.setGmtModified(LocalDateTime.now());
         return entity;
     }
 
-    private CertType parseCertType(String certificateId, String value) {
+    private CertType parseCertType(Long certificateId, String value) {
         if (!StringUtils.hasText(value)) {
             return null;
         }
@@ -129,7 +134,7 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         throw invalidPersistedValue(certificateId, "type", value);
     }
 
-    private CertStatus parseCertStatus(String certificateId, String value) {
+    private CertStatus parseCertStatus(Long certificateId, String value) {
         if (!StringUtils.hasText(value)) {
             return null;
         }
@@ -140,7 +145,7 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         }
     }
 
-    private List<String> parseSan(String certificateId, String json) {
+    private List<String> parseSan(Long certificateId, String json) {
         if (!StringUtils.hasText(json)) {
             return List.of();
         }
@@ -156,7 +161,7 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         }
     }
 
-    private BusinessException invalidPersistedValue(String certificateId, String field, String value) {
+    private BusinessException invalidPersistedValue(Long certificateId, String field, String value) {
         return new BusinessException(500, "Invalid persisted certificate " + field
                 + " for certificate " + certificateId + ": " + value);
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/RenewCertDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/RenewCertDTO.java
@@ -16,7 +16,7 @@
  */
 package org.apache.rocketmq.studio.cluster.k8s;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,6 +27,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RenewCertDTO {
-    @NotBlank(message = "id is required")
-    private String id;
+    @NotNull(message = "id is required")
+    private Long id;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/UpdateCertDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/UpdateCertDTO.java
@@ -16,7 +16,7 @@
  */
 package org.apache.rocketmq.studio.cluster.k8s;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,10 +30,9 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateCertDTO {
-    @NotBlank(message = "id is required")
-    private String id;
+    @NotNull(message = "id is required")
+    private Long id;
     private String name;
-    private String namespace;
     private String cluster;
     @Pattern(regexp = "TLS|mTLS|ServiceAccount", message = "type must be one of TLS, mTLS, ServiceAccount")
     private String type;

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricProfileVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricProfileVO.java
@@ -28,6 +28,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MetricProfileVO {
+    /** Metric profile identifier; not a database primary key. */
     private String id;
     private String name;
     private String description;

--- a/server/src/main/java/org/apache/rocketmq/studio/common/domain/BaseEntity.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/domain/BaseEntity.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 
 @Data
 public abstract class BaseEntity {
-    private String id;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private Long id;
+    private LocalDateTime gmtCreate;
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/common/domain/DeleteRequestDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/domain/DeleteRequestDTO.java
@@ -20,7 +20,9 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 /**
- * Common delete-by-id request body shared by all delete endpoints.
+ * Common delete-by-id request body shared by all delete endpoints. The id stays a String
+ * because some backends (Tencent Cloud ACL) identify resources by name; consumers that
+ * operate on numeric database keys parse it to Long at the boundary.
  */
 @Data
 public class DeleteRequestDTO {

--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/EntityIds.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/EntityIds.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+
+/**
+ * Parses external string identifiers into the numeric auto-increment primary keys used by
+ * the persistence layer. All database entity ids are {@code bigint unsigned AUTO_INCREMENT};
+ * API inputs arriving as strings are converted here with a uniform 400 error on failure.
+ */
+public final class EntityIds {
+
+    private EntityIds() {
+    }
+
+    /**
+     * Parses a required external id into a database primary key.
+     *
+     * @throws BusinessException with HTTP 400 when the value is blank or not numeric
+     */
+    public static Long parseId(String value) {
+        if (value == null || value.isBlank()) {
+            throw new BusinessException(400, "id is required");
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException ex) {
+            throw new BusinessException(400, "id must be a numeric value: " + value);
+        }
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/InstanceIds.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/InstanceIds.java
@@ -14,29 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.rocketmq.studio.instance.acl;
+package org.apache.rocketmq.studio.common.util;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+/** Helpers for numeric instance identifiers crossing the String API boundary. */
+public final class InstanceIds {
 
-import java.time.LocalDateTime;
-import java.util.List;
+    private InstanceIds() {
+    }
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class AclRuleVO {
-    private Long id;
-    private String principal;
-    private String resource;
-    private String resourceType;
-    private String resourcePattern;
-    private List<String> actions;
-    private String decision;
-    private String scope;
-    private String aclVersion;
-    private LocalDateTime gmtCreate;
+    public static Long parseLongOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+
+    public static String asString(Long value) {
+        return value == null ? null : String.valueOf(value);
+    }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/CreateInstanceDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/CreateInstanceDTO.java
@@ -35,7 +35,7 @@ public class CreateInstanceDTO {
 
     private String cloudInstanceId;
 
-    private String credentialId;
+    private Long credentialId;
 
     private String adminCredentialRef;
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.studio.instance;
 import org.apache.rocketmq.studio.common.domain.DeleteRequestDTO;
 import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
+import org.apache.rocketmq.studio.common.util.EntityIds;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -57,7 +58,7 @@ public class InstanceController {
 
     @PostMapping("/delete")
     public Result<Void> deleteInstance(@Valid @RequestBody DeleteRequestDTO request) {
-        instanceService.deleteInstance(request.getId());
+        instanceService.deleteInstance(EntityIds.parseId(request.getId()));
         return Result.ok();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceRepository.java
@@ -31,28 +31,36 @@ public interface InstanceRepository {
 
     List<InstanceVO> findByTypeAndSearch(InstanceType type, String keyword);
 
-    Optional<InstanceVO> findById(String id);
+    Optional<InstanceVO> findById(Long id);
 
     Optional<InstanceVO> findByName(String name);
 
     /**
      * Resolves an instance by the external instance identifier: matches the unique name
-     * first, falling back to the internal primary key for legacy references.
+     * first, falling back to the numeric primary key for references that carry the id.
      */
     default Optional<InstanceVO> findByIdentifier(String identifier) {
         if (identifier == null || identifier.isBlank()) {
             return Optional.empty();
         }
-        return findByName(identifier).or(() -> findById(identifier));
+        Optional<InstanceVO> byName = findByName(identifier);
+        if (byName.isPresent()) {
+            return byName;
+        }
+        try {
+            return findById(Long.parseLong(identifier.trim()));
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
     }
 
     InstanceVO save(InstanceVO instance);
 
-    boolean deleteById(String id);
+    boolean deleteById(Long id);
 
-    boolean existsByCredentialId(String credentialId);
+    boolean existsByCredentialId(Long credentialId);
 
-    long countTopicsByInstance(String instanceId);
+    long countTopicsByInstance(Long instanceId);
 
-    long countGroupsByInstance(String instanceId);
+    long countGroupsByInstance(Long instanceId);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -75,8 +75,8 @@ public class InstanceService {
         InstanceVendor vendor = instance.getVendor() == null ? InstanceVendor.APACHE : instance.getVendor();
         try {
             InstanceProvider provider = providerRegistry.forVendor(vendor);
-            instance.setTopicCount(provider.countTopics(instance.getId()));
-            instance.setConsumerGroupCount(provider.countGroups(instance.getId()));
+            instance.setTopicCount(provider.countTopics(String.valueOf(instance.getId())));
+            instance.setConsumerGroupCount(provider.countGroups(String.valueOf(instance.getId())));
             instance.setResourceCountsAvailable(true);
         } catch (RuntimeException ex) {
             instance.setResourceCountsAvailable(false);
@@ -96,16 +96,15 @@ public class InstanceService {
         }
 
         requireUniqueInstanceName(instance.getName(), null);
-        instance.setId(instance.getName());
-        instance.setCreatedAt(LocalDateTime.now());
-        instance.setUpdatedAt(LocalDateTime.now());
+        instance.setGmtCreate(LocalDateTime.now());
+        instance.setGmtModified(LocalDateTime.now());
         InstanceVO saved = instanceRepository.save(instance);
-        recordAudit("CREATE_INSTANCE", "INSTANCE", saved.getId(), null,
+        recordAudit("CREATE_INSTANCE", "INSTANCE", String.valueOf(saved.getId()), null,
                 instanceAuditDetail(saved));
         return saved;
     }
 
-    private void requireUniqueInstanceName(String name, String excludeId) {
+    private void requireUniqueInstanceName(String name, Long excludeId) {
         if (!StringUtils.hasText(name)) {
             return;
         }
@@ -136,7 +135,7 @@ public class InstanceService {
         if (instance.getEndpoint() != null && !instance.getEndpoint().isBlank()) {
             throw new BusinessException(400, "Commercial instances must be selected from the cloud catalog, endpoint cannot be set manually");
         }
-        if (!StringUtils.hasText(instance.getCredentialId()) || !StringUtils.hasText(instance.getCloudInstanceId())
+        if (instance.getCredentialId() == null || !StringUtils.hasText(instance.getCloudInstanceId())
                 || !StringUtils.hasText(instance.getRegionId())) {
             throw new BusinessException(400,
                     "credentialId, cloudInstanceId and regionId are required for " + vendor + " instances");
@@ -218,7 +217,7 @@ public class InstanceService {
         requireInstance(instance);
         log.info("Updating instance: {}", instance.getId());
 
-        if (instance.getId() == null || instance.getId().isBlank()) {
+        if (instance.getId() == null) {
             throw new BusinessException(400, "InstanceVO ID is required");
         }
 
@@ -251,19 +250,19 @@ public class InstanceService {
         if (!cloudInstance && instance.getAdminCredentialRef() != null) {
             updated.setAdminCredentialRef(normalizeCredentialRef(instance.getAdminCredentialRef()));
         }
-        updated.setUpdatedAt(LocalDateTime.now());
+        updated.setGmtModified(LocalDateTime.now());
 
         InstanceVO saved = instanceRepository.save(updated);
         releaseApacheClientIfChanged(existing, saved);
-        recordAudit("UPDATE_INSTANCE", "INSTANCE", saved.getId(), null,
+        recordAudit("UPDATE_INSTANCE", "INSTANCE", String.valueOf(saved.getId()), null,
                 instanceAuditDetail(saved));
         return saved;
     }
 
-    public void deleteInstance(String id) {
+    public void deleteInstance(Long id) {
         log.info("Deleting instance: {}", id);
 
-        if (id == null || id.isBlank()) {
+        if (id == null) {
             throw new BusinessException(400, "InstanceVO ID is required");
         }
 
@@ -272,8 +271,8 @@ public class InstanceService {
 
         InstanceProvider provider = providerRegistry.forVendor(
                 existing.getVendor() == null ? InstanceVendor.APACHE : existing.getVendor());
-        int topicCount = provider.countTopics(id);
-        int consumerGroupCount = provider.countGroups(id);
+        int topicCount = provider.countTopics(String.valueOf(id));
+        int consumerGroupCount = provider.countGroups(String.valueOf(id));
         if (topicCount > 0 || consumerGroupCount > 0) {
             throw new BusinessException(409, String.format(
                     "Cannot delete instance with managed resources: topics=%d, consumerGroups=%d",
@@ -283,7 +282,7 @@ public class InstanceService {
             throw new BusinessException(404, "InstanceVO not found: " + id);
         }
         releaseApacheEndpointIfUnused(existing, null);
-        recordAudit("DELETE_INSTANCE", "INSTANCE", id, null,
+        recordAudit("DELETE_INSTANCE", "INSTANCE", String.valueOf(id), null,
                 instanceAuditDetail(existing));
     }
 
@@ -313,8 +312,8 @@ public class InstanceService {
                 .consumerGroupCount(instance.getConsumerGroupCount())
                 .build();
         copy.setId(instance.getId());
-        copy.setCreatedAt(instance.getCreatedAt());
-        copy.setUpdatedAt(instance.getUpdatedAt());
+        copy.setGmtCreate(instance.getGmtCreate());
+        copy.setGmtModified(instance.getGmtModified());
         return copy;
     }
 
@@ -340,7 +339,7 @@ public class InstanceService {
         releaseEndpointIfUnused(existing.getEndpoint(), saved.getEndpoint(), existing.getId());
     }
 
-    private void releaseEndpointIfUnused(String previousEndpoint, String currentEndpoint, String excludedInstanceId) {
+    private void releaseEndpointIfUnused(String previousEndpoint, String currentEndpoint, Long excludedInstanceId) {
         String oldEndpoint = normalizeEndpoint(previousEndpoint);
         if (oldEndpoint == null || oldEndpoint.equals(normalizeEndpoint(currentEndpoint))) {
             return;

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceVO.java
@@ -38,7 +38,7 @@ public class InstanceVO extends BaseEntity {
     private String endpoint;
     private InstanceVendor vendor;
     private String cloudInstanceId;
-    private String credentialId;
+    private Long credentialId;
     private String adminCredentialRef;
     private String regionId;
     private int topicCount;

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
@@ -86,7 +86,10 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
     }
 
     @Override
-    public Optional<InstanceVO> findById(String id) {
+    public Optional<InstanceVO> findById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
         RmqInstance entity = instanceMapper.selectById(id);
         if (entity == null) {
             return Optional.empty();
@@ -111,25 +114,26 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
     @Transactional
     public InstanceVO save(InstanceVO instance) {
         RmqInstance entity = toEntity(instance);
-        if (instanceMapper.selectById(entity.getId()) != null) {
+        if (entity.getId() != null && instanceMapper.selectById(entity.getId()) != null) {
             if (instanceMapper.updateById(entity) == 0) {
                 throw new BusinessException(409,
                         "Instance update was not applied: " + entity.getId());
             }
         } else {
             instanceMapper.insert(entity);
+            instance.setId(entity.getId());
         }
         return instance;
     }
 
     @Override
-    public boolean deleteById(String id) {
-        return instanceMapper.deleteById(id) > 0;
+    public boolean deleteById(Long id) {
+        return id != null && instanceMapper.deleteById(id) > 0;
     }
 
     @Override
-    public boolean existsByCredentialId(String credentialId) {
-        if (credentialId == null || credentialId.isBlank()) {
+    public boolean existsByCredentialId(Long credentialId) {
+        if (credentialId == null) {
             return false;
         }
         return instanceMapper.selectCount(
@@ -137,13 +141,13 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
     }
 
     @Override
-    public long countTopicsByInstance(String instanceId) {
+    public long countTopicsByInstance(Long instanceId) {
         return topicMapper.selectCount(
                 new QueryWrapper<RmqTopic>().eq("instance_id", instanceId));
     }
 
     @Override
-    public long countGroupsByInstance(String instanceId) {
+    public long countGroupsByInstance(Long instanceId) {
         return groupMapper.selectCount(
                 new QueryWrapper<RmqGroup>().eq("instance_id", instanceId));
     }
@@ -161,12 +165,12 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
                 .regionId(entity.getRegionId())
                 .build();
         vo.setId(entity.getId());
-        vo.setCreatedAt(entity.getCreatedAt());
-        vo.setUpdatedAt(entity.getUpdatedAt());
+        vo.setGmtCreate(entity.getGmtCreate());
+        vo.setGmtModified(entity.getGmtModified());
         return vo;
     }
 
-    private InstanceType parseType(String instanceId, String type) {
+    private InstanceType parseType(Long instanceId, String type) {
         try {
             return InstanceType.valueOf(type);
         } catch (IllegalArgumentException | NullPointerException ex) {
@@ -174,7 +178,7 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
         }
     }
 
-    private InstanceVendor parseVendor(String instanceId, String vendor) {
+    private InstanceVendor parseVendor(Long instanceId, String vendor) {
         try {
             return InstanceVendor.valueOf(vendor);
         } catch (IllegalArgumentException | NullPointerException ex) {
@@ -182,7 +186,7 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
         }
     }
 
-    private BusinessException invalidPersistedValue(String instanceId, String field, String value) {
+    private BusinessException invalidPersistedValue(Long instanceId, String field, String value) {
         return new BusinessException(500, "Invalid persisted instance " + field
                 + " for instance " + instanceId + ": " + value);
     }
@@ -199,8 +203,8 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
         entity.setCredentialId(vo.getCredentialId());
         entity.setAdminCredentialRef(vo.getAdminCredentialRef());
         entity.setRegionId(vo.getRegionId());
-        entity.setCreatedAt(vo.getCreatedAt());
-        entity.setUpdatedAt(vo.getUpdatedAt());
+        entity.setGmtCreate(vo.getGmtCreate());
+        entity.setGmtModified(vo.getGmtModified());
         return entity;
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/UpdateInstanceDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/UpdateInstanceDTO.java
@@ -16,15 +16,15 @@
  */
 package org.apache.rocketmq.studio.instance;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 
 @Data
 public class UpdateInstanceDTO {
 
-    @NotBlank(message = "instance id is required")
-    private String id;
+    @NotNull(message = "instance id is required")
+    private Long id;
 
     private String name;
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclCapabilitiesVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclCapabilitiesVO.java
@@ -24,7 +24,7 @@ import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
  * Describes whether ACL operations are backed by the selected instance.
  */
 public record AclCapabilitiesVO(
-        String instanceId,
+        Long instanceId,
         InstanceVendor vendor,
         InstanceType instanceType,
         String stateSource,

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclRepository.java
@@ -31,11 +31,11 @@ public interface AclRepository {
      */
     Optional<AclRuleVO> replaceRule(AclRuleVO rule);
 
-    boolean deleteRule(String id);
+    boolean deleteRule(Long id);
 
     List<AclUserVO> findUsers();
 
-    Optional<AclUserVO> findUserById(String id);
+    Optional<AclUserVO> findUserById(Long id);
 
     AclUserVO saveUser(AclUserVO user);
 
@@ -45,7 +45,7 @@ public interface AclRepository {
      */
     Optional<AclUserVO> replaceUser(AclUserVO user);
 
-    boolean deleteUser(String id);
+    boolean deleteUser(Long id);
 
     /**
      * Examines the effective ACL configuration of a broker cluster: the enabled

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -21,6 +21,7 @@ import org.springframework.util.StringUtils;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
+import org.apache.rocketmq.studio.common.util.EntityIds;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.model.Acl2PolicyContext;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
@@ -30,15 +31,17 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
-import java.util.UUID;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AclService {
+
+    private static final SecureRandom CREDENTIAL_RANDOM = new SecureRandom();
 
     private final AclRepository aclRepository;
     private final OperationAuditService operationAuditService;
@@ -81,8 +84,7 @@ public class AclService {
         if (!StringUtils.hasText(rule.getResource())) {
             throw new BusinessException(400, "ACL resource is required");
         }
-        rule.setId(UUID.randomUUID().toString());
-        rule.setCreatedAt(LocalDateTime.now());
+        rule.setGmtCreate(LocalDateTime.now());
         AclRuleVO saved = aclRepository.saveRule(rule);
         auditRule("CREATE_ACL_RULE", saved);
         return saved;
@@ -92,7 +94,7 @@ public class AclService {
         if (isTencentInstance(instanceId)) {
             return tencentAclService.updateRule(instanceId, rule);
         }
-        if (!StringUtils.hasText(rule.getId())) {
+        if (rule.getId() == null) {
             throw new BusinessException(400, "ACL rule id is required");
         }
         log.info("Updating ACL rule id={}, principal={}", rule.getId(), rule.getPrincipal());
@@ -108,7 +110,7 @@ public class AclService {
             return;
         }
         log.info("Deleting ACL rule id={}", id);
-        if (!aclRepository.deleteRule(id)) {
+        if (!aclRepository.deleteRule(EntityIds.parseId(id))) {
             throw new BusinessException(404, "ACL rule not found: " + id);
         }
         recordAudit("DELETE_ACL_RULE", "ACL_RULE", id, null, null);
@@ -136,10 +138,9 @@ public class AclService {
         if (!StringUtils.hasText(user.getUsername())) {
             throw new BusinessException(400, "ACL username is required");
         }
-        user.setId(UUID.randomUUID().toString());
-        user.setAccessKey(UUID.randomUUID().toString().replace("-", ""));
-        user.setSecretKey(UUID.randomUUID().toString().replace("-", ""));
-        user.setCreatedAt(LocalDateTime.now());
+        user.setAccessKey(randomCredentialToken());
+        user.setSecretKey(randomCredentialToken());
+        user.setGmtCreate(LocalDateTime.now());
         AclUserVO saved = aclRepository.saveUser(user);
         auditUser("CREATE_ACL_USER", saved);
         return saved;
@@ -149,7 +150,7 @@ public class AclService {
         if (isTencentInstance(instanceId)) {
             return tencentAclService.updateUser(instanceId, user.toAclUserVO());
         }
-        if (!StringUtils.hasText(user.getId())) {
+        if (user.getId() == null) {
             throw new BusinessException(400, "ACL user id is required");
         }
         log.info("Updating ACL user id={}, username={}", user.getId(), user.getUsername());
@@ -165,7 +166,7 @@ public class AclService {
                 .secretKey(existing.getSecretKey())
                 .admin(user.getAdmin() == null ? existing.isAdmin() : user.getAdmin())
                 .clusters(user.getClusters() == null ? existing.getClusters() : user.getClusters())
-                .createdAt(existing.getCreatedAt())
+                .gmtCreate(existing.getGmtCreate())
                 .build();
         AclUserVO saved = aclRepository.replaceUser(merged)
                 .orElseThrow(() -> new BusinessException(404, "ACL user not found: " + user.getId()));
@@ -180,7 +181,7 @@ public class AclService {
             return;
         }
         log.info("Deleting ACL user id={}", id);
-        if (!aclRepository.deleteUser(id)) {
+        if (!aclRepository.deleteUser(EntityIds.parseId(id))) {
             throw new BusinessException(404, "ACL user not found: " + id);
         }
         recordAudit("DELETE_ACL_USER", "ACL_USER", id, null, null);
@@ -232,7 +233,7 @@ public class AclService {
             throw new BusinessException(400, "ACL user id is required");
         }
         log.info("Revealing credentials for ACL user id={}", id);
-        return aclRepository.findUserById(id)
+        return aclRepository.findUserById(EntityIds.parseId(id))
                 .orElseThrow(() -> new BusinessException(404, "ACL user not found: " + id));
     }
 
@@ -300,18 +301,32 @@ public class AclService {
                 .permWrite(user.getPermWrite())
                 .clusters(user.getClusters() == null ? null : List.copyOf(user.getClusters()))
                 .whiteRemoteAddress(user.getWhiteRemoteAddress())
-                .createdAt(user.getCreatedAt())
+                .gmtCreate(user.getGmtCreate())
                 .build();
     }
 
     private void auditRule(String operation, AclRuleVO rule) {
-        recordAudit(operation, "ACL_RULE", rule.getId(), null,
+        recordAudit(operation, "ACL_RULE", String.valueOf(rule.getId()), null,
                 "principal=" + rule.getPrincipal());
     }
 
     private void auditUser(String operation, AclUserVO user) {
-        recordAudit(operation, "ACL_USER", user.getId(), null,
+        recordAudit(operation, "ACL_USER", String.valueOf(user.getId()), null,
                 "username=" + user.getUsername() + ", admin=" + user.isAdmin());
+    }
+
+    /**
+     * Generates a random 32-char hex token for locally provisioned ACL credentials.
+     */
+    private static String randomCredentialToken() {
+        byte[] bytes = new byte[16];
+        CREDENTIAL_RANDOM.nextBytes(bytes);
+        StringBuilder token = new StringBuilder(bytes.length * 2);
+        for (byte value : bytes) {
+            token.append(Character.forDigit((value >> 4) & 0xF, 16));
+            token.append(Character.forDigit(value & 0xF, 16));
+        }
+        return token.toString();
     }
 
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclUserVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclUserVO.java
@@ -30,7 +30,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AclUserVO {
-    private String id;
+    private Long id;
     private String username;
     @ToString.Exclude
     private String accessKey;
@@ -44,5 +44,5 @@ public class AclUserVO {
     private Boolean permWrite;
     /** IP whitelist pattern for plain access accounts; empty means no restriction. */
     private String whiteRemoteAddress;
-    private LocalDateTime createdAt;
+    private LocalDateTime gmtCreate;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -61,10 +61,11 @@ public class MybatisPlusAclRepository implements AclRepository {
     @Override
     public AclRuleVO saveRule(AclRuleVO rule) {
         RmqAclRule entity = toRuleEntity(rule);
-        if (ruleMapper.selectById(entity.getId()) != null) {
+        if (entity.getId() != null && ruleMapper.selectById(entity.getId()) != null) {
             ruleMapper.updateById(entity);
         } else {
             ruleMapper.insert(entity);
+            rule.setId(entity.getId());
         }
         return rule;
     }
@@ -76,17 +77,17 @@ public class MybatisPlusAclRepository implements AclRepository {
             return Optional.empty();
         }
         RmqAclRule entity = toRuleEntity(rule);
-        entity.setCreatedAt(existing.getCreatedAt());
+        entity.setGmtCreate(existing.getGmtCreate());
         if (ruleMapper.updateById(entity) == 0) {
             return Optional.empty();
         }
-        rule.setCreatedAt(existing.getCreatedAt());
+        rule.setGmtCreate(existing.getGmtCreate());
         return Optional.of(rule);
     }
 
     @Override
-    public boolean deleteRule(String id) {
-        return ruleMapper.deleteById(id) > 0;
+    public boolean deleteRule(Long id) {
+        return id != null && ruleMapper.deleteById(id) > 0;
     }
 
     @Override
@@ -97,7 +98,10 @@ public class MybatisPlusAclRepository implements AclRepository {
     }
 
     @Override
-    public Optional<AclUserVO> findUserById(String id) {
+    public Optional<AclUserVO> findUserById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
         RmqAclUser entity = userMapper.selectById(id);
         return Optional.ofNullable(entity).map(MybatisPlusAclRepository::toUserVO);
     }
@@ -105,10 +109,11 @@ public class MybatisPlusAclRepository implements AclRepository {
     @Override
     public AclUserVO saveUser(AclUserVO user) {
         RmqAclUser entity = toUserEntity(user);
-        if (userMapper.selectById(entity.getId()) != null) {
+        if (entity.getId() != null && userMapper.selectById(entity.getId()) != null) {
             userMapper.updateById(entity);
         } else {
             userMapper.insert(entity);
+            user.setId(entity.getId());
         }
         return user;
     }
@@ -120,15 +125,15 @@ public class MybatisPlusAclRepository implements AclRepository {
             return Optional.empty();
         }
         RmqAclUser entity = toUserEntity(user);
-        entity.setCreatedAt(existing.getCreatedAt());
+        entity.setGmtCreate(existing.getGmtCreate());
         userMapper.updateById(entity);
-        user.setCreatedAt(existing.getCreatedAt());
+        user.setGmtCreate(existing.getGmtCreate());
         return Optional.of(user);
     }
 
     @Override
-    public boolean deleteUser(String id) {
-        return userMapper.deleteById(id) > 0;
+    public boolean deleteUser(Long id) {
+        return id != null && userMapper.deleteById(id) > 0;
     }
 
     /**
@@ -173,10 +178,9 @@ public class MybatisPlusAclRepository implements AclRepository {
         RmqAclUser entity = new RmqAclUser();
         if (existing != null) {
             entity.setId(existing.getId());
-            entity.setCreatedAt(existing.getCreatedAt());
+            entity.setGmtCreate(existing.getGmtCreate());
         } else {
-            entity.setId("plain-" + config.getAccessKey());
-            entity.setCreatedAt(LocalDateTime.now());
+            entity.setGmtCreate(LocalDateTime.now());
         }
         entity.setUsername(config.getAccessKey());
         entity.setAccessKey(config.getAccessKey());
@@ -189,7 +193,7 @@ public class MybatisPlusAclRepository implements AclRepository {
         entity.setAdmin(config.isAdmin());
         entity.setClusters(null);
         entity.setWhiteRemoteAddress(normalizeWhiteRemoteAddress(config.getWhiteRemoteAddress()));
-        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setGmtModified(LocalDateTime.now());
         if (existing != null) {
             userMapper.updateById(entity);
             if (entity.getWhiteRemoteAddress() == null) {
@@ -216,7 +220,7 @@ public class MybatisPlusAclRepository implements AclRepository {
                 .defaultGroupPerm(config.getDefaultGroupPerm())
                 .topicPerms(config.getTopicPerms() == null ? null : new ArrayList<>(config.getTopicPerms()))
                 .groupPerms(config.getGroupPerms() == null ? null : new ArrayList<>(config.getGroupPerms()))
-                .createdAt(entity.getCreatedAt())
+                .gmtCreate(entity.getGmtCreate())
                 .build();
     }
 
@@ -231,32 +235,29 @@ public class MybatisPlusAclRepository implements AclRepository {
     private void upsertPlainAccessRules(PlainAccessConfigVO config) {
         ruleMapper.delete(new QueryWrapper<RmqAclRule>()
                 .eq("principal", config.getAccessKey())
-                .eq("acl_version", "2.0")
-                .likeRight("id", "plain-" + config.getAccessKey() + "-"));
+                .eq("acl_version", "2.0"));
         List<RmqAclRule> rules = new ArrayList<>();
         if (config.getDefaultTopicPerm() != null) {
-            rules.add(plainRule(config.getAccessKey(), "*", "Cluster", config.getDefaultTopicPerm(), "dt"));
+            rules.add(plainRule(config.getAccessKey(), "*", "Cluster", config.getDefaultTopicPerm(),
+                    "DEFAULT_TOPIC"));
         }
         if (config.getDefaultGroupPerm() != null) {
-            rules.add(plainRule(config.getAccessKey(), "*", "Cluster", config.getDefaultGroupPerm(), "dg"));
+            rules.add(plainRule(config.getAccessKey(), "*", "Cluster", config.getDefaultGroupPerm(),
+                    "DEFAULT_GROUP"));
         }
         if (config.getTopicPerms() != null) {
-            int index = 0;
             for (String entry : config.getTopicPerms()) {
                 String[] parts = splitPerm(entry);
                 if (parts != null) {
-                    rules.add(plainRule(config.getAccessKey(), parts[0], "Topic", parts[1], "t-" + index));
-                    index++;
+                    rules.add(plainRule(config.getAccessKey(), parts[0], "Topic", parts[1], "LITERAL"));
                 }
             }
         }
         if (config.getGroupPerms() != null) {
-            int index = 0;
             for (String entry : config.getGroupPerms()) {
                 String[] parts = splitPerm(entry);
                 if (parts != null) {
-                    rules.add(plainRule(config.getAccessKey(), parts[0], "Group", parts[1], "g-" + index));
-                    index++;
+                    rules.add(plainRule(config.getAccessKey(), parts[0], "Group", parts[1], "LITERAL"));
                 }
             }
         }
@@ -266,19 +267,18 @@ public class MybatisPlusAclRepository implements AclRepository {
     }
 
     private RmqAclRule plainRule(String principal, String resource, String resourceType,
-                                 String actions, String idSuffix) {
+                                 String actions, String resourcePattern) {
         RmqAclRule rule = new RmqAclRule();
-        rule.setId("plain-" + principal + "-" + idSuffix);
         rule.setPrincipal(principal);
         rule.setResource(resource);
         rule.setResourceType(resourceType);
-        rule.setResourcePattern("LITERAL");
+        rule.setResourcePattern(resourcePattern);
         rule.setActions(actions);
         rule.setDecision("ALLOW");
         rule.setScope("*");
         rule.setAclVersion("2.0");
-        rule.setCreatedAt(LocalDateTime.now());
-        rule.setUpdatedAt(LocalDateTime.now());
+        rule.setGmtCreate(LocalDateTime.now());
+        rule.setGmtModified(LocalDateTime.now());
         return rule;
     }
 
@@ -295,9 +295,9 @@ public class MybatisPlusAclRepository implements AclRepository {
             } else if ("Group".equals(rule.getResourceType())) {
                 groupPerms.add(rule.getResource() + "=" + actions);
             } else if ("Cluster".equals(rule.getResourceType()) && "*".equals(rule.getResource())) {
-                if (rule.getId() != null && rule.getId().endsWith("-dt")) {
+                if ("DEFAULT_TOPIC".equals(rule.getResourcePattern())) {
                     defaultTopicPerm = actions;
-                } else if (rule.getId() != null && rule.getId().endsWith("-dg")) {
+                } else if ("DEFAULT_GROUP".equals(rule.getResourcePattern())) {
                     defaultGroupPerm = actions;
                 }
             }
@@ -313,7 +313,7 @@ public class MybatisPlusAclRepository implements AclRepository {
                 .defaultGroupPerm(defaultGroupPerm)
                 .topicPerms(topicPerms)
                 .groupPerms(groupPerms)
-                .createdAt(user.getCreatedAt())
+                .gmtCreate(user.getGmtCreate())
                 .build();
     }
 
@@ -341,7 +341,7 @@ public class MybatisPlusAclRepository implements AclRepository {
                 .decision(entity.getDecision())
                 .scope(entity.getScope())
                 .aclVersion(entity.getAclVersion())
-                .createdAt(entity.getCreatedAt())
+                .gmtCreate(entity.getGmtCreate())
                 .build();
     }
 
@@ -356,8 +356,8 @@ public class MybatisPlusAclRepository implements AclRepository {
         entity.setDecision(rule.getDecision());
         entity.setScope(rule.getScope());
         entity.setAclVersion(rule.getAclVersion());
-        entity.setCreatedAt(rule.getCreatedAt());
-        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setGmtCreate(rule.getGmtCreate());
+        entity.setGmtModified(LocalDateTime.now());
         return entity;
     }
 
@@ -370,7 +370,7 @@ public class MybatisPlusAclRepository implements AclRepository {
                 .admin(Boolean.TRUE.equals(entity.getAdmin()))
                 .clusters(splitCsv(entity.getClusters()))
                 .whiteRemoteAddress(entity.getWhiteRemoteAddress())
-                .createdAt(entity.getCreatedAt())
+                .gmtCreate(entity.getGmtCreate())
                 .build();
     }
 
@@ -382,8 +382,8 @@ public class MybatisPlusAclRepository implements AclRepository {
         entity.setSecretKey(CredentialUtils.encodeBase64(user.getSecretKey()));
         entity.setAdmin(user.isAdmin());
         entity.setClusters(user.getClusters() == null ? null : String.join(",", user.getClusters()));
-        entity.setCreatedAt(user.getCreatedAt());
-        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setGmtCreate(user.getGmtCreate());
+        entity.setGmtModified(LocalDateTime.now());
         return entity;
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/PlainAccessConfigVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/PlainAccessConfigVO.java
@@ -66,5 +66,5 @@ public class PlainAccessConfigVO {
     /** Per-group permission entries, e.g. "cg-order-*=SUB". */
     private List<String> groupPerms;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime gmtCreate;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/UpdateAclRuleDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/UpdateAclRuleDTO.java
@@ -17,14 +17,15 @@
 package org.apache.rocketmq.studio.instance.acl;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
 public class UpdateAclRuleDTO {
-    @NotBlank(message = "id is required")
-    private String id;
+    @NotNull(message = "id is required")
+    private Long id;
     @NotBlank(message = "principal is required")
     private String principal;
     @NotBlank(message = "resource is required")

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/UpdateAclUserDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/UpdateAclUserDTO.java
@@ -16,15 +16,15 @@
  */
 package org.apache.rocketmq.studio.instance.acl;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
 public class UpdateAclUserDTO {
-    @NotBlank(message = "id is required")
-    private String id;
+    @NotNull(message = "id is required")
+    private Long id;
     private String username;
     /**
      * Null when the admin flag was not part of the partial update, in which case the existing

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupVO.java
@@ -30,7 +30,7 @@ public class ConsumerGroupVO extends BaseEntity {
     private String name;
     private String namespace;
     private String clusterId;
-    private String instanceId;
+    private Long instanceId;
     private SubscriptionMode subscriptionMode;
     private ConsumeType consumeType;
     private int onlineInstances;

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/CreateConsumerGroupDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/CreateConsumerGroupDTO.java
@@ -37,7 +37,7 @@ public class CreateConsumerGroupDTO {
     @PositiveOrZero(message = "delaySeconds must be zero or positive")
     private Integer delaySeconds;
 
-    private String instanceId;
+    private Long instanceId;
 
     public ConsumerGroupVO toConsumerGroupVO() {
         ConsumerGroupVO group = new ConsumerGroupVO();

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
@@ -75,7 +75,9 @@ public class QueryHistoryService {
         query.setResultCount(resultCount);
         query.setClusterId(clusterId);
         query.setQueriedBy(AuthenticatedUserContext.currentUsernameOrSystem());
-        query.setQueriedAt(LocalDateTime.now(clock));
+        LocalDateTime now = LocalDateTime.now(clock);
+        query.setGmtCreate(now);
+        query.setGmtModified(now);
         messageQueryMapper.insert(query);
         log.debug("Message query recorded: clusterId={} type={} topic={}", clusterId, queryType, topic);
     }
@@ -88,7 +90,9 @@ public class QueryHistoryService {
         query.setConsumerCount(consumerCount);
         query.setClusterId(clusterId);
         query.setQueriedBy(AuthenticatedUserContext.currentUsernameOrSystem());
-        query.setQueriedAt(LocalDateTime.now(clock));
+        LocalDateTime now = LocalDateTime.now(clock);
+        query.setGmtCreate(now);
+        query.setGmtModified(now);
         traceQueryMapper.insert(query);
         log.debug("Trace query recorded: clusterId={} msgId={} topic={}", clusterId, msgId, topic);
     }
@@ -104,7 +108,7 @@ public class QueryHistoryService {
                         .or().like("msg_id", pattern)
                         .or().like("message_key", pattern)
                         .or().like("queried_by", pattern))
-                .orderByDesc("queried_at", "id");
+                .orderByDesc("gmt_create", "id");
         Page<RmqMessageQuery> result = messageQueryMapper.selectPage(new Page<>(page, pageSize), query);
         List<MessageQueryHistoryVO> items = result.getRecords().stream()
                 .map(QueryHistoryService::toMessageHistory).toList();
@@ -120,7 +124,7 @@ public class QueryHistoryService {
                         .like("topic", pattern)
                         .or().like("msg_id", pattern)
                         .or().like("queried_by", pattern))
-                .orderByDesc("queried_at", "id");
+                .orderByDesc("gmt_create", "id");
         Page<RmqTraceQuery> result = traceQueryMapper.selectPage(new Page<>(page, pageSize), query);
         List<TraceQueryHistoryVO> items = result.getRecords().stream()
                 .map(QueryHistoryService::toTraceHistory).toList();
@@ -137,14 +141,14 @@ public class QueryHistoryService {
         RmqMessageQuery latestMessage = messageQueryMapper.selectOne(
                 new QueryWrapper<RmqMessageQuery>()
                         .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
-                        .orderByDesc("queried_at", "id").last("LIMIT 1"));
+                        .orderByDesc("gmt_create", "id").last("LIMIT 1"));
         RmqTraceQuery latestTrace = traceQueryMapper.selectOne(
                 new QueryWrapper<RmqTraceQuery>()
                         .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
-                        .orderByDesc("queried_at", "id").last("LIMIT 1"));
+                        .orderByDesc("gmt_create", "id").last("LIMIT 1"));
         LocalDateTime latest = latestOf(
-                latestMessage == null ? null : latestMessage.getQueriedAt(),
-                latestTrace == null ? null : latestTrace.getQueriedAt());
+                latestMessage == null ? null : latestMessage.getGmtCreate(),
+                latestTrace == null ? null : latestTrace.getGmtCreate());
         return QueryHistorySummaryVO.builder()
                 .messageQueries(messageCount)
                 .traceQueries(traceCount)
@@ -167,7 +171,7 @@ public class QueryHistoryService {
     private void deleteExpiredMessageQueries(LocalDateTime cutoff) {
         try {
             int deleted = messageQueryMapper.delete(Wrappers.<RmqMessageQuery>query()
-                    .lt("queried_at", cutoff));
+                    .lt("gmt_create", cutoff));
             log.debug("Purged {} expired message query records", deleted);
         } catch (RuntimeException e) {
             log.warn("Failed to purge expired message query records: {}", e.getMessage());
@@ -177,7 +181,7 @@ public class QueryHistoryService {
     private void deleteExpiredTraceQueries(LocalDateTime cutoff) {
         try {
             int deleted = traceQueryMapper.delete(Wrappers.<RmqTraceQuery>query()
-                    .lt("queried_at", cutoff));
+                    .lt("gmt_create", cutoff));
             log.debug("Purged {} expired trace query records", deleted);
         } catch (RuntimeException e) {
             log.warn("Failed to purge expired trace query records: {}", e.getMessage());
@@ -197,7 +201,7 @@ public class QueryHistoryService {
                 .startTime(query.getStartTime()).endTime(query.getEndTime())
                 .resultCount(query.getResultCount() == null ? 0 : query.getResultCount())
                 .clusterId(query.getClusterId()).queriedBy(query.getQueriedBy())
-                .queriedAt(query.getQueriedAt()).build();
+                .queriedAt(query.getGmtCreate()).build();
     }
 
     private static TraceQueryHistoryVO toTraceHistory(RmqTraceQuery query) {
@@ -206,7 +210,7 @@ public class QueryHistoryService {
                 .nodeCount(query.getNodeCount() == null ? 0 : query.getNodeCount())
                 .consumerCount(query.getConsumerCount() == null ? 0 : query.getConsumerCount())
                 .clusterId(query.getClusterId()).queriedBy(query.getQueriedBy())
-                .queriedAt(query.getQueriedAt()).build();
+                .queriedAt(query.getGmtCreate()).build();
     }
 
     /**

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/CreateTopicDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/CreateTopicDTO.java
@@ -36,7 +36,7 @@ public class CreateTopicDTO {
     private TopicPerm perm;
     private String remark;
 
-    private String instanceId;
+    private Long instanceId;
 
     public TopicVO toTopicVO() {
         TopicVO topic = new TopicVO();

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.studio.provider.apache.AdminClient;
 import org.apache.rocketmq.studio.provider.apache.MetadataProvider;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.util.InstanceIds;
 import org.springframework.util.StringUtils;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
@@ -61,13 +62,15 @@ public class MetadataService {
 
     public TopicVO createTopic(TopicVO topic) {
         requireTopic(topic);
-        return resolve(topic.getInstanceId()).createTopic(topic.getInstanceId(), topic);
+        String instanceId = InstanceIds.asString(topic.getInstanceId());
+        return resolve(instanceId).createTopic(instanceId, topic);
     }
 
 
     public TopicVO updateTopic(TopicVO topic) {
         requireTopic(topic);
-        return resolve(topic.getInstanceId()).updateTopic(topic.getInstanceId(), topic);
+        String instanceId = InstanceIds.asString(topic.getInstanceId());
+        return resolve(instanceId).updateTopic(instanceId, topic);
     }
 
 
@@ -172,7 +175,7 @@ public class MetadataService {
 
 
     public ConsumerGroupVO createConsumerGroup(ConsumerGroupVO group) {
-        String instanceId = group == null ? null : group.getInstanceId();
+        String instanceId = InstanceIds.asString(group == null ? null : group.getInstanceId());
         return resolve(instanceId).createConsumerGroup(instanceId, group);
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/TopicVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/TopicVO.java
@@ -28,7 +28,7 @@ public class TopicVO extends BaseEntity {
     private String name;
     private String namespace;
     private String clusterId;
-    private String instanceId;
+    private Long instanceId;
     private TopicType type;
     private int writeQueues;
     private int readQueues;

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/UpdateTopicDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/UpdateTopicDTO.java
@@ -28,7 +28,7 @@ public class UpdateTopicDTO {
     private String name;
     private String namespace;
     private String clusterId;
-    private String instanceId;
+    private Long instanceId;
     private TopicType type;
     @PositiveOrZero(message = "writeQueues must be zero or positive")
     private Integer writeQueues;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmModelItemVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmModelItemVO.java
@@ -25,6 +25,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LlmModelItemVO {
+    /** LLM model identifier such as "gpt-4o"; not a database primary key. */
     private String id;
     private String name;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/AlertRuleListToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/AlertRuleListToolHandler.java
@@ -70,7 +70,7 @@ public class AlertRuleListToolHandler implements ToolHandler {
 
     private static Map<String, Object> safeProjection(AlertRuleVO rule) {
         Map<String, Object> result = new LinkedHashMap<>();
-        result.put("id", blankIfNull(rule.getId()));
+        result.put("id", rule.getId());
         result.put("name", require(rule.getName(), "name"));
         result.put("metric", require(rule.getMetric(), "metric"));
         result.put("operator", blankIfNull(rule.getOperator()));

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AcknowledgeSystemAlertDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AcknowledgeSystemAlertDTO.java
@@ -16,7 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,6 +27,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AcknowledgeSystemAlertDTO {
-    @NotBlank(message = "id is required")
-    private String id;
+    @NotNull(message = "id is required")
+    private Long id;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
@@ -26,7 +26,7 @@ public interface AlertRepository {
 
     boolean replaceRule(AlertRuleVO rule);
 
-    boolean deleteRule(String id);
+    boolean deleteRule(Long id);
 
     List<SystemAlertVO> findAlerts(String level);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleBulkResultVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleBulkResultVO.java
@@ -25,7 +25,7 @@ import java.util.Map;
 @Data
 @Builder
 public class AlertRuleBulkResultVO {
-    private List<String> succeededIds;
-    private Map<String, String> failures;
+    private List<Long> succeededIds;
+    private Map<Long, String> failures;
     private List<AlertRuleVO> updatedRules;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleController.java
@@ -53,7 +53,7 @@ public class AlertRuleController {
     @PostMapping("/update")
     public Result<AlertRuleVO> updateRule(@Valid @RequestBody(required = false) AlertRuleRequestDTO rule) {
         AlertRuleRequestDTO request = requireAlertRule(rule);
-        if (request.getId() == null || request.getId().isBlank()) {
+        if (request.getId() == null) {
             throw new BusinessException(400, "id is required");
         }
         return Result.ok(alertService.updateRule(request.toAlertRuleVO()));

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTO.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 @Data
 public class AlertRuleRequestDTO {
-    private String id;
+    private Long id;
     @NotBlank(message = "name is required")
     private String name;
     private String metric;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleVO.java
@@ -28,7 +28,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AlertRuleVO {
-    private String id;
+    private Long id;
     private String name;
     private String metric;
     private String operator;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -30,7 +30,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.regex.Pattern;
 
 @Slf4j
@@ -97,7 +96,6 @@ public class AlertService {
             throw new BusinessException(400, "Alert rule request is required");
         }
         log.info("Creating alert rule: {}", rule.getName());
-        rule.setId(UUID.randomUUID().toString());
         AlertRuleVO saved = alertRepository.saveRule(rule);
         auditRule("CREATE_ALERT_RULE", saved, null);
         return saved;
@@ -108,7 +106,7 @@ public class AlertService {
         if (rule == null) {
             throw new BusinessException(400, "Alert rule request is required");
         }
-        String id = rule.getId();
+        Long id = rule.getId();
         log.info("Updating alert rule: {}", id);
         validateRuleId(id);
         if (!alertRepository.replaceRule(rule)) {
@@ -119,7 +117,7 @@ public class AlertService {
     }
 
 
-    public AlertRuleVO toggleRule(String id, boolean enabled) {
+    public AlertRuleVO toggleRule(Long id, boolean enabled) {
         log.info("Toggling alert rule id={}, enabled={}", id, enabled);
         validateRuleId(id);
         List<AlertRuleVO> rules = alertRepository.findAllRules();
@@ -134,25 +132,25 @@ public class AlertService {
     }
 
 
-    public void deleteRule(String id) {
+    public void deleteRule(Long id) {
         log.info("Deleting alert rule id={}", id);
         validateRuleId(id);
         if (!alertRepository.deleteRule(id)) {
             throw ruleNotFound(id);
         }
-        recordAudit("DELETE_ALERT_RULE", "ALERT_RULE", id, null, null);
+        recordAudit("DELETE_ALERT_RULE", "ALERT_RULE", String.valueOf(id), null, null);
     }
 
-    public AlertRuleBulkResultVO bulkToggleRules(List<String> ids, boolean enabled) {
-        List<String> normalizedIds = normalizeBulkIds(ids);
-        Map<String, AlertRuleVO> rulesById = new LinkedHashMap<>();
+    public AlertRuleBulkResultVO bulkToggleRules(List<Long> ids, boolean enabled) {
+        List<Long> normalizedIds = normalizeBulkIds(ids);
+        Map<Long, AlertRuleVO> rulesById = new LinkedHashMap<>();
         for (AlertRuleVO rule : alertRepository.findAllRules()) {
             rulesById.put(rule.getId(), rule);
         }
-        List<String> succeeded = new ArrayList<>();
-        Map<String, String> failures = new LinkedHashMap<>();
+        List<Long> succeeded = new ArrayList<>();
+        Map<Long, String> failures = new LinkedHashMap<>();
         List<AlertRuleVO> updated = new ArrayList<>();
-        for (String id : normalizedIds) {
+        for (Long id : normalizedIds) {
             AlertRuleVO rule = rulesById.get(id);
             if (rule == null) {
                 failures.put(id, "Alert rule not found");
@@ -177,17 +175,17 @@ public class AlertService {
                 .succeededIds(succeeded).failures(failures).updatedRules(updated).build();
     }
 
-    public AlertRuleBulkResultVO bulkDeleteRules(List<String> ids) {
-        List<String> normalizedIds = normalizeBulkIds(ids);
-        List<String> succeeded = new ArrayList<>();
-        Map<String, String> failures = new LinkedHashMap<>();
-        for (String id : normalizedIds) {
+    public AlertRuleBulkResultVO bulkDeleteRules(List<Long> ids) {
+        List<Long> normalizedIds = normalizeBulkIds(ids);
+        List<Long> succeeded = new ArrayList<>();
+        Map<Long, String> failures = new LinkedHashMap<>();
+        for (Long id : normalizedIds) {
             try {
                 if (!alertRepository.deleteRule(id)) {
                     failures.put(id, "Alert rule not found");
                     continue;
                 }
-                recordAudit("DELETE_ALERT_RULE", "ALERT_RULE", id, null, "bulk=true");
+                recordAudit("DELETE_ALERT_RULE", "ALERT_RULE", String.valueOf(id), null, "bulk=true");
                 succeeded.add(id);
             } catch (RuntimeException failure) {
                 failures.put(id, failure.getMessage() == null ? "Delete failed" : failure.getMessage());
@@ -197,17 +195,16 @@ public class AlertService {
                 .succeededIds(succeeded).failures(failures).updatedRules(List.of()).build();
     }
 
-    private List<String> normalizeBulkIds(List<String> ids) {
+    private List<Long> normalizeBulkIds(List<Long> ids) {
         if (ids == null || ids.isEmpty()) {
             throw new BusinessException(400, "ids are required");
         }
-        Set<String> seen = new HashSet<>();
-        List<String> normalized = new ArrayList<>();
-        for (String id : ids) {
+        Set<Long> seen = new HashSet<>();
+        List<Long> normalized = new ArrayList<>();
+        for (Long id : ids) {
             validateRuleId(id);
-            String trimmed = id.trim();
-            if (seen.add(trimmed)) {
-                normalized.add(trimmed);
+            if (seen.add(id)) {
+                normalized.add(id);
             }
         }
         return normalized;
@@ -220,9 +217,9 @@ public class AlertService {
     }
 
 
-    public SystemAlertVO acknowledgeAlert(String id) {
+    public SystemAlertVO acknowledgeAlert(Long id) {
         log.info("Acknowledging system alert id={}", id);
-        if (id == null || id.isBlank()) {
+        if (id == null) {
             throw new BusinessException(400, "System alert ID is required");
         }
         List<SystemAlertVO> alerts = alertRepository.findAlerts(null);
@@ -234,7 +231,7 @@ public class AlertService {
         if (!alertRepository.acknowledgeAlert(alert)) {
             throw new BusinessException(404, "System alert not found: " + id);
         }
-        recordAudit("ACKNOWLEDGE_SYSTEM_ALERT", "SYSTEM_ALERT", alert.getId(), null,
+        recordAudit("ACKNOWLEDGE_SYSTEM_ALERT", "SYSTEM_ALERT", String.valueOf(alert.getId()), null,
                 "acknowledged=true");
         return alert;
     }
@@ -334,7 +331,7 @@ public class AlertService {
 
     private void auditRule(String operation, AlertRuleVO rule, String detail) {
         String auditDetail = detail == null ? "name=" + rule.getName() : detail;
-        recordAudit(operation, "ALERT_RULE", rule.getId(), null,
+        recordAudit(operation, "ALERT_RULE", String.valueOf(rule.getId()), null,
                 auditDetail);
     }
 
@@ -433,13 +430,13 @@ public class AlertService {
         return value != null && !value.trim().isEmpty();
     }
 
-    private void validateRuleId(String id) {
-        if (id == null || id.isBlank()) {
+    private void validateRuleId(Long id) {
+        if (id == null) {
             throw new BusinessException(400, "Alert rule ID is required");
         }
     }
 
-    private BusinessException ruleNotFound(String id) {
+    private BusinessException ruleNotFound(Long id) {
         return new BusinessException(404, "Alert rule not found: " + id);
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/BulkDeleteAlertRulesDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/BulkDeleteAlertRulesDTO.java
@@ -16,7 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -27,5 +27,5 @@ import java.util.List;
 public class BulkDeleteAlertRulesDTO {
     @NotEmpty(message = "ids are required")
     @Size(max = 100, message = "at most 100 rule ids are allowed")
-    private List<@NotBlank(message = "rule id must not be blank") String> ids;
+    private List<@NotNull(message = "rule id is required") Long> ids;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/BulkToggleAlertRulesDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/BulkToggleAlertRulesDTO.java
@@ -16,9 +16,8 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
@@ -28,7 +27,7 @@ import java.util.List;
 public class BulkToggleAlertRulesDTO {
     @NotEmpty(message = "ids are required")
     @Size(max = 100, message = "at most 100 rule ids are allowed")
-    private List<@NotBlank(message = "rule id must not be blank") String> ids;
+    private List<@NotNull(message = "rule id is required") Long> ids;
     @NotNull(message = "enabled is required")
     private Boolean enabled;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/DeleteAlertRuleDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/DeleteAlertRuleDTO.java
@@ -16,7 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,6 +27,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DeleteAlertRuleDTO {
-    @NotBlank(message = "id is required")
-    private String id;
+    @NotNull(message = "id is required")
+    private Long id;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -58,21 +58,22 @@ public class MybatisPlusAlertRepository implements AlertRepository {
             ruleMapper.updateById(entity);
         } else {
             ruleMapper.insert(entity);
+            rule.setId(entity.getId());
         }
         return rule;
     }
 
     @Override
     public boolean replaceRule(AlertRuleVO rule) {
-        if (ruleMapper.selectById(rule.getId()) == null) {
+        if (rule.getId() == null || ruleMapper.selectById(rule.getId()) == null) {
             return false;
         }
         return ruleMapper.updateById(toRuleEntity(rule)) > 0;
     }
 
     @Override
-    public boolean deleteRule(String id) {
-        return ruleMapper.deleteById(id) > 0;
+    public boolean deleteRule(Long id) {
+        return id != null && ruleMapper.deleteById(id) > 0;
     }
 
     @Override
@@ -133,7 +134,7 @@ public class MybatisPlusAlertRepository implements AlertRepository {
         entity.setBrokerName(rule.getBrokerName());
         entity.setClusterName(rule.getClusterName());
         entity.setSeverity(rule.getSeverity());
-        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setGmtModified(LocalDateTime.now());
         return entity;
     }
 
@@ -156,7 +157,7 @@ public class MybatisPlusAlertRepository implements AlertRepository {
         entity.setDescription(alert.getDescription());
         entity.setTime(alert.getTime());
         entity.setAcknowledged(alert.isAcknowledged());
-        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setGmtModified(LocalDateTime.now());
         return entity;
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertVO.java
@@ -29,7 +29,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SystemAlertVO {
-    private String id;
+    private Long id;
     private AlertLevel level;
     private String title;
     private String description;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/ToggleAlertRuleDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/ToggleAlertRuleDTO.java
@@ -16,7 +16,6 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,8 +27,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ToggleAlertRuleDTO {
-    @NotBlank(message = "id is required")
-    private String id;
+    @NotNull(message = "id is required")
+    private Long id;
 
     @NotNull(message = "enabled is required")
     private Boolean enabled;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
@@ -51,10 +51,10 @@ public class MybatisPlusAuditRepository implements AuditRepository {
                 .eq(StringUtils.hasText(operationType), "operation", operationType)
                 .eq(StringUtils.hasText(resourceType), "resource_type", resourceType)
                 .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
-                .ge(startDate != null, "operated_at", startDate)
-                .le(endDate != null, "operated_at", endDate)
+                .ge(startDate != null, "gmt_create", startDate)
+                .le(endDate != null, "gmt_create", endDate)
                 .eq(StringUtils.hasText(result), "result", result)
-                .orderByDesc("operated_at");
+                .orderByDesc("gmt_create");
         Page<RmqOperationAudit> resultPage = auditMapper.selectPage(
                 new Page<>(page, pageSize), query);
         List<AuditRecordVO> records = resultPage.getRecords().stream()
@@ -88,14 +88,16 @@ public class MybatisPlusAuditRepository implements AuditRepository {
         entity.setResult(record.getResult());
         entity.setErrorMessage(record.getErrorMessage());
         entity.setOperator(record.getOperator());
-        entity.setOperatedAt(record.getTimestamp() == null ? LocalDateTime.now() : record.getTimestamp());
+        LocalDateTime timestamp = record.getTimestamp() == null ? LocalDateTime.now() : record.getTimestamp();
+        entity.setGmtCreate(timestamp);
+        entity.setGmtModified(timestamp);
         auditMapper.insert(entity);
     }
 
     @Override
     public int deleteBefore(LocalDateTime cutoff) {
         return Math.toIntExact(auditMapper.delete(
-                new QueryWrapper<RmqOperationAudit>().lt("operated_at", cutoff)));
+                new QueryWrapper<RmqOperationAudit>().lt("gmt_create", cutoff)));
     }
 
     private List<String> findDistinctValues(List<Map<String, Object>> rows, String column) {
@@ -111,8 +113,8 @@ public class MybatisPlusAuditRepository implements AuditRepository {
 
     private static AuditRecordVO toVO(RmqOperationAudit entity) {
         AuditRecordVO vo = new AuditRecordVO();
-        vo.setId(entity.getId() == null ? null : String.valueOf(entity.getId()));
-        vo.setTimestamp(entity.getOperatedAt());
+        vo.setId(entity.getId());
+        vo.setTimestamp(entity.getGmtCreate());
         vo.setOperator(entity.getOperator());
         vo.setOperationType(entity.getOperation());
         vo.setResourceType(entity.getResourceType());

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/ClusterOverviewVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/ClusterOverviewVO.java
@@ -31,6 +31,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ClusterOverviewVO {
+    /** Runtime cluster identifier (cluster name); not a database primary key. */
     private String id;
     private String name;
     private ClusterType type;

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.persistence;
 
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -39,8 +40,6 @@ import java.util.stream.Collectors;
 @Repository
 public class MybatisPlusSettingsRepository implements SettingsRepository {
 
-    private static final String SETTINGS_ID = "singleton";
-
     private final RmqSettingsMapper settingsMapper;
     private final RmqDataSourceMapper dataSourceMapper;
     private final ObjectMapper objectMapper;
@@ -53,9 +52,18 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
         this.objectMapper = objectMapper;
     }
 
+    /**
+     * The settings table holds a single row; load it regardless of its auto-increment id.
+     */
+    private RmqSettings findSingletonSettings() {
+        return settingsMapper.selectOne(new QueryWrapper<RmqSettings>()
+                .orderByAsc("id")
+                .last("LIMIT 1"));
+    }
+
     @Override
     public GeneralSettingsVO loadGeneralSettings() {
-        RmqSettings entity = settingsMapper.selectById(SETTINGS_ID);
+        RmqSettings entity = findSingletonSettings();
         if (entity == null || entity.getJson() == null) {
             return GeneralSettingsVO.builder()
                     .theme("system")
@@ -87,16 +95,16 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
     public void saveGeneralSettings(GeneralSettingsVO settings) {
         try {
             String json = objectMapper.writeValueAsString(settings);
-            RmqSettings entity = settingsMapper.selectById(SETTINGS_ID);
+            RmqSettings entity = findSingletonSettings();
             if (entity == null) {
                 entity = new RmqSettings();
-                entity.setId(SETTINGS_ID);
                 entity.setJson(json);
-                entity.setUpdatedAt(LocalDateTime.now());
+                entity.setGmtCreate(LocalDateTime.now());
+                entity.setGmtModified(LocalDateTime.now());
                 settingsMapper.insert(entity);
             } else {
                 entity.setJson(json);
-                entity.setUpdatedAt(LocalDateTime.now());
+                entity.setGmtModified(LocalDateTime.now());
                 settingsMapper.updateById(entity);
             }
         } catch (JsonProcessingException e) {
@@ -107,45 +115,63 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
 
     @Override
     public List<DataSourceVO> findAllDataSources() {
-        return dataSourceMapper.selectList(null).stream()
+        return dataSourceMapper.selectList(new QueryWrapper<RmqDataSource>().orderByAsc("id")).stream()
                 .map(this::toDataSourceVO)
                 .collect(Collectors.toList());
     }
 
     @Override
+    @Transactional
     public DataSourceVO saveDataSource(DataSourceVO dataSource) {
         RmqDataSource entity = new RmqDataSource();
-        entity.setDsKey(dataSource.getKey());
+        // The ds_key business key is derived from the auto-increment id: insert first with a
+        // temporary unique key, then publish "ds-<id>" once the id is known.
+        entity.setDsKey("ds-tmp-" + System.currentTimeMillis() + "-" + Math.floorMod(System.nanoTime(), 1_000_000));
         entity.setJson(toJson(dataSource));
-        entity.setCreatedAt(LocalDateTime.now());
-        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setGmtCreate(LocalDateTime.now());
+        entity.setGmtModified(LocalDateTime.now());
         dataSourceMapper.insert(entity);
+        String dsKey = "ds-" + entity.getId();
+        entity.setDsKey(dsKey);
+        dataSource.setKey(dsKey);
+        entity.setJson(toJson(dataSource));
+        dataSourceMapper.updateById(entity);
         return dataSource;
     }
 
     @Override
     public boolean replaceDataSource(DataSourceVO dataSource) {
-        RmqDataSource existing = dataSourceMapper.selectById(dataSource.getKey());
+        RmqDataSource existing = selectByDsKey(dataSource.getKey());
         if (existing == null) {
             return false;
         }
         existing.setJson(toJson(dataSource));
-        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setGmtModified(LocalDateTime.now());
         return dataSourceMapper.updateById(existing) > 0;
     }
 
     @Override
     public boolean deleteDataSource(String key) {
-        return dataSourceMapper.deleteById(key) > 0;
+        return dataSourceMapper.delete(
+                new QueryWrapper<RmqDataSource>().eq("ds_key", key)) > 0;
     }
 
     @Override
     public Optional<DataSourceVO> findDataSourceByKey(String key) {
-        RmqDataSource entity = dataSourceMapper.selectById(key);
+        RmqDataSource entity = selectByDsKey(key);
         if (entity == null) {
             return Optional.empty();
         }
         return Optional.of(toDataSourceVO(entity));
+    }
+
+    private RmqDataSource selectByDsKey(String key) {
+        if (key == null || key.isBlank()) {
+            return null;
+        }
+        return dataSourceMapper.selectOne(new QueryWrapper<RmqDataSource>()
+                .eq("ds_key", key)
+                .last("LIMIT 1"));
     }
 
     private DataSourceVO toDataSourceVO(RmqDataSource entity) {

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqAclRule.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqAclRule.java
@@ -27,8 +27,8 @@ import java.time.LocalDateTime;
 @TableName("rmq_acl_rule")
 public class RmqAclRule {
 
-    @TableId(type = IdType.INPUT)
-    private String id;
+    @TableId(type = IdType.AUTO)
+    private Long id;
 
     private String principal;
 
@@ -46,7 +46,7 @@ public class RmqAclRule {
 
     private String aclVersion;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime gmtCreate;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqAclUser.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqAclUser.java
@@ -27,8 +27,8 @@ import java.time.LocalDateTime;
 @TableName("rmq_acl_user")
 public class RmqAclUser {
 
-    @TableId(type = IdType.INPUT)
-    private String id;
+    @TableId(type = IdType.AUTO)
+    private Long id;
 
     private String username;
 
@@ -42,7 +42,7 @@ public class RmqAclUser {
 
     private String whiteRemoteAddress;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime gmtCreate;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqAlertRule.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqAlertRule.java
@@ -27,8 +27,8 @@ import java.time.LocalDateTime;
 @TableName("rmq_alert_rule")
 public class RmqAlertRule {
 
-    @TableId(type = IdType.INPUT)
-    private String id;
+    @TableId(type = IdType.AUTO)
+    private Long id;
 
     private String name;
 
@@ -56,7 +56,7 @@ public class RmqAlertRule {
 
     private String severity;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime gmtCreate;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqCloudCredential.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqCloudCredential.java
@@ -27,8 +27,8 @@ import java.time.LocalDateTime;
 @TableName("rmq_cloud_credential")
 public class RmqCloudCredential {
 
-    @TableId(type = IdType.INPUT)
-    private String id;
+    @TableId(type = IdType.AUTO)
+    private Long id;
 
     private String name;
 
@@ -40,7 +40,7 @@ public class RmqCloudCredential {
 
     private String remark;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime gmtCreate;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqDataSource.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqDataSource.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.persistence.entity;
 
+import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -26,12 +27,14 @@ import java.time.LocalDateTime;
 @TableName("rmq_data_source")
 public class RmqDataSource {
 
-    @TableId
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
     private String dsKey;
 
     private String json;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime gmtCreate;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqGroup.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqGroup.java
@@ -24,7 +24,7 @@ import lombok.Data;
 import java.time.LocalDateTime;
 
 @Data
-@TableName("rmq_group")
+@TableName("rmq_instance_group")
 public class RmqGroup {
 
     @TableId(type = IdType.AUTO)
@@ -32,7 +32,7 @@ public class RmqGroup {
 
     private String clusterId;
 
-    private String instanceId;
+    private Long instanceId;
 
     private String name;
 
@@ -46,7 +46,7 @@ public class RmqGroup {
 
     private String createdBy;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime gmtCreate;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqInstance.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqInstance.java
@@ -27,8 +27,8 @@ import java.time.LocalDateTime;
 @TableName("rmq_instance")
 public class RmqInstance {
 
-    @TableId(type = IdType.INPUT)
-    private String id;
+    @TableId(type = IdType.AUTO)
+    private Long id;
 
     private String name;
 
@@ -42,13 +42,13 @@ public class RmqInstance {
 
     private String cloudInstanceId;
 
-    private String credentialId;
+    private Long credentialId;
 
     private String adminCredentialRef;
 
     private String regionId;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime gmtCreate;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqK8sCertificate.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqK8sCertificate.java
@@ -27,12 +27,10 @@ import java.time.LocalDateTime;
 @TableName("rmq_k8s_certificate")
 public class RmqK8sCertificate {
 
-    @TableId(type = IdType.ASSIGN_UUID)
-    private String id;
+    @TableId(type = IdType.AUTO)
+    private Long id;
 
     private String name;
-
-    private String namespace;
 
     private String cluster;
 
@@ -50,7 +48,11 @@ public class RmqK8sCertificate {
 
     private String san;
 
-    private LocalDateTime createdAt;
+    private String certPem;
 
-    private LocalDateTime updatedAt;
+    private String keyPem;
+
+    private LocalDateTime gmtCreate;
+
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqMessageQuery.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqMessageQuery.java
@@ -24,7 +24,7 @@ import lombok.Data;
 import java.time.LocalDateTime;
 
 @Data
-@TableName("rmq_message_query")
+@TableName("rmq_instance_message")
 public class RmqMessageQuery {
 
     @TableId(type = IdType.AUTO)
@@ -50,5 +50,7 @@ public class RmqMessageQuery {
 
     private String queriedBy;
 
-    private LocalDateTime queriedAt;
+    private LocalDateTime gmtCreate;
+
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqNameserver.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqNameserver.java
@@ -27,8 +27,8 @@ import java.time.LocalDateTime;
 @TableName("rmq_nameserver")
 public class RmqNameserver {
 
-    @TableId(type = IdType.ASSIGN_UUID)
-    private String id;
+    @TableId(type = IdType.AUTO)
+    private Long id;
 
     private String name;
 
@@ -40,7 +40,7 @@ public class RmqNameserver {
 
     private String description;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime gmtCreate;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqOperationAudit.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqOperationAudit.java
@@ -46,5 +46,7 @@ public class RmqOperationAudit {
 
     private String operator;
 
-    private LocalDateTime operatedAt;
+    private LocalDateTime gmtCreate;
+
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqSettings.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqSettings.java
@@ -28,11 +28,13 @@ import java.time.LocalDateTime;
 @TableName("rmq_settings")
 public class RmqSettings {
 
-    @TableId(type = IdType.ASSIGN_UUID)
-    private String id;
+    @TableId(type = IdType.AUTO)
+    private Long id;
 
     @ToString.Exclude
     private String json;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime gmtCreate;
+
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqSystemAlert.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqSystemAlert.java
@@ -27,8 +27,8 @@ import java.time.LocalDateTime;
 @TableName("rmq_system_alert")
 public class RmqSystemAlert {
 
-    @TableId(type = IdType.INPUT)
-    private String id;
+    @TableId(type = IdType.AUTO)
+    private Long id;
 
     private String level;
 
@@ -40,7 +40,7 @@ public class RmqSystemAlert {
 
     private Boolean acknowledged;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime gmtCreate;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqTopic.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqTopic.java
@@ -24,7 +24,7 @@ import lombok.Data;
 import java.time.LocalDateTime;
 
 @Data
-@TableName("rmq_topic")
+@TableName("rmq_instance_topic")
 public class RmqTopic {
 
     @TableId(type = IdType.AUTO)
@@ -32,7 +32,7 @@ public class RmqTopic {
 
     private String clusterId;
 
-    private String instanceId;
+    private Long instanceId;
 
     private String name;
 
@@ -50,7 +50,7 @@ public class RmqTopic {
 
     private String createdBy;
 
-    private LocalDateTime createdAt;
+    private LocalDateTime gmtCreate;
 
-    private LocalDateTime updatedAt;
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqTraceQuery.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/entity/RmqTraceQuery.java
@@ -24,7 +24,7 @@ import lombok.Data;
 import java.time.LocalDateTime;
 
 @Data
-@TableName("rmq_trace_query")
+@TableName("rmq_instance_trace")
 public class RmqTraceQuery {
 
     @TableId(type = IdType.AUTO)
@@ -42,5 +42,7 @@ public class RmqTraceQuery {
 
     private String queriedBy;
 
-    private LocalDateTime queriedAt;
+    private LocalDateTime gmtCreate;
+
+    private LocalDateTime gmtModified;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/CloudCatalogProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/CloudCatalogProvider.java
@@ -28,9 +28,9 @@ public interface CloudCatalogProvider {
 
     InstanceVendor vendor();
 
-    List<CloudRegionVO> listRegions(String credentialId);
+    List<CloudRegionVO> listRegions(Long credentialId);
 
-    List<CloudInstanceOptionVO> listCloudInstances(String credentialId, String regionId, String search);
+    List<CloudInstanceOptionVO> listCloudInstances(Long credentialId, String regionId, String search);
 
-    CloudInstanceDetailVO getCloudInstance(String credentialId, String regionId, String cloudInstanceId);
+    CloudInstanceDetailVO getCloudInstance(Long credentialId, String regionId, String cloudInstanceId);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogController.java
@@ -38,12 +38,12 @@ public class AliyunCatalogController {
     private final AliyunCatalogService catalogService;
 
     @GetMapping("/regions")
-    public Result<List<CloudRegionVO>> listRegions(@RequestParam String credentialId) {
+    public Result<List<CloudRegionVO>> listRegions(@RequestParam Long credentialId) {
         return Result.ok(catalogService.listRegions(credentialId));
     }
 
     @GetMapping("/instances")
-    public Result<List<CloudInstanceOptionVO>> listInstances(@RequestParam String credentialId,
+    public Result<List<CloudInstanceOptionVO>> listInstances(@RequestParam Long credentialId,
                                                              @RequestParam String regionId,
                                                              @RequestParam(required = false) String search) {
         return Result.ok(catalogService.listCloudInstances(credentialId, regionId, search));

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogService.java
@@ -59,8 +59,8 @@ public class AliyunCatalogService implements CloudCatalogProvider {
     }
 
     @Override
-    public List<CloudRegionVO> listRegions(String credentialId) {
-        requireNonBlank(credentialId, "credentialId");
+    public List<CloudRegionVO> listRegions(Long credentialId) {
+        requireId(credentialId, "credentialId");
         ListRegionsResponse response = clientFactory.call(credentialId, DEFAULT_REGION,
                 client -> client.listRegions(ListRegionsRequest.builder().build()));
         ListRegionsResponseBody body = response == null ? null : response.getBody();
@@ -80,8 +80,8 @@ public class AliyunCatalogService implements CloudCatalogProvider {
     }
 
     @Override
-    public List<CloudInstanceOptionVO> listCloudInstances(String credentialId, String regionId, String search) {
-        requireNonBlank(credentialId, "credentialId");
+    public List<CloudInstanceOptionVO> listCloudInstances(Long credentialId, String regionId, String search) {
+        requireId(credentialId, "credentialId");
         requireNonBlank(regionId, "regionId");
         List<ListInstancesResponseBody.List> all = fetchAllInstances(credentialId, regionId);
         List<CloudInstanceOptionVO> options = new ArrayList<>();
@@ -98,8 +98,8 @@ public class AliyunCatalogService implements CloudCatalogProvider {
     }
 
     @Override
-    public CloudInstanceDetailVO getCloudInstance(String credentialId, String regionId, String cloudInstanceId) {
-        requireNonBlank(credentialId, "credentialId");
+    public CloudInstanceDetailVO getCloudInstance(Long credentialId, String regionId, String cloudInstanceId) {
+        requireId(credentialId, "credentialId");
         requireNonBlank(regionId, "regionId");
         requireNonBlank(cloudInstanceId, "cloudInstanceId");
         GetInstanceRequest request = GetInstanceRequest.builder().instanceId(cloudInstanceId).build();
@@ -113,7 +113,7 @@ public class AliyunCatalogService implements CloudCatalogProvider {
         return AliyunConverters.toInstanceDetailVO(data);
     }
 
-    private List<ListInstancesResponseBody.List> fetchAllInstances(String credentialId, String regionId) {
+    private List<ListInstancesResponseBody.List> fetchAllInstances(Long credentialId, String regionId) {
         List<ListInstancesResponseBody.List> all = new ArrayList<>();
         for (int page = 1; page <= AliyunConverters.MAX_PAGES; page++) {
             ListInstancesRequest request = ListInstancesRequest.builder()
@@ -150,6 +150,12 @@ public class AliyunCatalogService implements CloudCatalogProvider {
 
     private static void requireNonBlank(String value, String name) {
         if (value == null || value.isBlank()) {
+            throw new BusinessException(400, name + " is required");
+        }
+    }
+
+    private static void requireId(Long value, String name) {
+        if (value == null) {
             throw new BusinessException(400, name + " is required");
         }
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactory.java
@@ -59,7 +59,7 @@ public class AliyunClientFactory {
     private final Map<String, AsyncClient> clients = new ConcurrentHashMap<>();
     private long callTimeoutSeconds = DEFAULT_CALL_TIMEOUT_SECONDS;
 
-    public AsyncClient client(String credentialId, String region) {
+    public AsyncClient client(Long credentialId, String region) {
         String key = cacheKey(credentialId, region);
         return clients.computeIfAbsent(key, ignored -> createClient(credentialId, region));
     }
@@ -67,7 +67,7 @@ public class AliyunClientFactory {
     /**
      * Releases all clients created with a credential so the next call observes rotated secrets.
      */
-    public void invalidateCredential(String credentialId) {
+    public void invalidateCredential(Long credentialId) {
         String prefix = credentialId + "#";
         clients.entrySet().removeIf(entry -> {
             if (!entry.getKey().startsWith(prefix)) {
@@ -81,7 +81,7 @@ public class AliyunClientFactory {
     /**
      * Executes an SDK call with a bounded wait and unified exception mapping.
      */
-    public <T> T call(String credentialId, String region, Function<AsyncClient, CompletableFuture<T>> action) {
+    public <T> T call(Long credentialId, String region, Function<AsyncClient, CompletableFuture<T>> action) {
         AsyncClient client = client(credentialId, region);
         CompletableFuture<T> future;
         try {
@@ -114,7 +114,7 @@ public class AliyunClientFactory {
         this.callTimeoutSeconds = callTimeoutSeconds;
     }
 
-    static String cacheKey(String credentialId, String region) {
+    static String cacheKey(Long credentialId, String region) {
         return credentialId + "#" + region;
     }
 
@@ -122,7 +122,7 @@ public class AliyunClientFactory {
         return "rocketmq." + region + ".aliyuncs.com";
     }
 
-    protected AsyncClient createClient(String credentialId, String region) {
+    protected AsyncClient createClient(Long credentialId, String region) {
         CloudCredentialVO credential = credentialRepository.findById(credentialId)
                 .orElseThrow(() -> new BusinessException(404, "Cloud credential not found: " + credentialId));
         StaticCredentialProvider credentialProvider = StaticCredentialProvider.create(

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.provider.alibaba;
 
+import org.apache.rocketmq.studio.common.util.InstanceIds;
 import com.aliyun.sdk.service.rocketmq20220801.models.DataTopicLagMapValue;
 import com.aliyun.sdk.service.rocketmq20220801.models.GetConsumerGroupLagResponseBody;
 import com.aliyun.sdk.service.rocketmq20220801.models.GetInstanceResponseBody;
@@ -113,11 +114,11 @@ final class AliyunConverters {
     static TopicVO toTopicVO(ListTopicsResponseBody.List data, String studioInstanceId) {
         TopicVO vo = new TopicVO();
         vo.setName(data.getTopicName());
-        vo.setInstanceId(studioInstanceId);
+        vo.setInstanceId(InstanceIds.parseLongOrNull(studioInstanceId));
         vo.setType(toTopicType(data.getMessageType()));
         vo.setRemark(data.getRemark());
-        vo.setCreatedAt(parseDateTime(data.getCreateTime()));
-        vo.setUpdatedAt(parseDateTime(data.getUpdateTime()));
+        vo.setGmtCreate(parseDateTime(data.getCreateTime()));
+        vo.setGmtModified(parseDateTime(data.getUpdateTime()));
         vo.setWriteQueues(0);
         vo.setReadQueues(0);
         return vo;
@@ -152,10 +153,10 @@ final class AliyunConverters {
     static ConsumerGroupVO toConsumerGroupVO(ListConsumerGroupsResponseBody.List data, String studioInstanceId) {
         ConsumerGroupVO vo = new ConsumerGroupVO();
         vo.setName(data.getConsumerGroupId());
-        vo.setInstanceId(studioInstanceId);
+        vo.setInstanceId(InstanceIds.parseLongOrNull(studioInstanceId));
         vo.setConsumeType(toConsumeType(data.getMessageModel()));
-        vo.setCreatedAt(parseDateTime(data.getCreateTime()));
-        vo.setUpdatedAt(parseDateTime(data.getUpdateTime()));
+        vo.setGmtCreate(parseDateTime(data.getCreateTime()));
+        vo.setGmtModified(parseDateTime(data.getUpdateTime()));
         return vo;
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.provider.alibaba;
 
+import org.apache.rocketmq.studio.common.util.InstanceIds;
 import com.aliyun.sdk.service.rocketmq20220801.models.CreateConsumerGroupRequest;
 import com.aliyun.sdk.service.rocketmq20220801.models.CreateTopicRequest;
 import com.aliyun.sdk.service.rocketmq20220801.models.DeleteConsumerGroupRequest;
@@ -182,9 +183,9 @@ public class AliyunInstanceProvider implements InstanceProvider {
                 .remark(topic.getRemark())
                 .build();
         clientFactory.call(ctx.credentialId(), ctx.regionId(), client -> client.createTopic(request));
-        topic.setInstanceId(instanceId);
-        topic.setCreatedAt(java.time.LocalDateTime.now());
-        topic.setUpdatedAt(java.time.LocalDateTime.now());
+        topic.setInstanceId(InstanceIds.parseLongOrNull(instanceId));
+        topic.setGmtCreate(java.time.LocalDateTime.now());
+        topic.setGmtModified(java.time.LocalDateTime.now());
         return topic;
     }
 
@@ -200,7 +201,7 @@ public class AliyunInstanceProvider implements InstanceProvider {
                 .remark(topic.getRemark())
                 .build();
         clientFactory.call(ctx.credentialId(), ctx.regionId(), client -> client.updateTopic(request));
-        topic.setInstanceId(instanceId);
+        topic.setInstanceId(InstanceIds.parseLongOrNull(instanceId));
         return topic;
     }
 
@@ -293,12 +294,12 @@ public class AliyunInstanceProvider implements InstanceProvider {
                 .consumeRetryPolicy(retryPolicy.build())
                 .build();
         clientFactory.call(ctx.credentialId(), ctx.regionId(), client -> client.createConsumerGroup(request));
-        group.setInstanceId(instanceId);
+        group.setInstanceId(InstanceIds.parseLongOrNull(instanceId));
         group.setDeliveryOrderType(deliveryOrderType);
         group.setRetryMaxTimes(maxRetryTimes);
         group.setSubscribedTopics(java.util.List.of());
-        group.setCreatedAt(java.time.LocalDateTime.now());
-        group.setUpdatedAt(java.time.LocalDateTime.now());
+        group.setGmtCreate(java.time.LocalDateTime.now());
+        group.setGmtModified(java.time.LocalDateTime.now());
         return group;
     }
 
@@ -461,7 +462,7 @@ public class AliyunInstanceProvider implements InstanceProvider {
         InstanceVO instance = instanceRepository.findByIdentifier(instanceId)
                 .orElseThrow(() -> new BusinessException(404, "Instance not found: " + instanceId));
         if (!StringUtils.hasText(instance.getCloudInstanceId()) || !StringUtils.hasText(instance.getRegionId())
-                || !StringUtils.hasText(instance.getCredentialId())) {
+                || instance.getCredentialId() == null) {
             throw new BusinessException(400, "Instance " + instanceId + " is missing Aliyun cloud binding");
         }
         return new Context(instance.getCloudInstanceId(), instance.getRegionId(), instance.getCredentialId());
@@ -474,6 +475,6 @@ public class AliyunInstanceProvider implements InstanceProvider {
         return vo.getType() != null && vo.getType().name().equalsIgnoreCase(type.trim());
     }
 
-    private record Context(String cloudInstanceId, String regionId, String credentialId) {
+    private record Context(String cloudInstanceId, String regionId, Long credentialId) {
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.provider.apache;
 
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.util.InstanceIds;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
@@ -54,12 +55,17 @@ public class ApacheInstanceProvider implements InstanceProvider {
 
     @Override
     public int countTopics(String instanceId) {
-        return (int) instanceRepository.countTopicsByInstance(instanceId);
+        // The instance_id foreign key is numeric; resolve the external identifier first.
+        return instanceRepository.findByIdentifier(instanceId)
+                .map(instance -> (int) instanceRepository.countTopicsByInstance(instance.getId()))
+                .orElse(0);
     }
 
     @Override
     public int countGroups(String instanceId) {
-        return (int) instanceRepository.countGroupsByInstance(instanceId);
+        return instanceRepository.findByIdentifier(instanceId)
+                .map(instance -> (int) instanceRepository.countGroupsByInstance(instance.getId()))
+                .orElse(0);
     }
 
     @Override
@@ -135,10 +141,10 @@ public class ApacheInstanceProvider implements InstanceProvider {
         return messageProvider.getMessageTrace(instanceId, msgId, topic);
     }
 
-    private boolean matchesInstance(String topicInstanceId, String instanceId) {
+    private boolean matchesInstance(Long topicInstanceId, String instanceId) {
         if (instanceId == null || instanceId.isBlank()) {
             return true;
         }
-        return Objects.equals(topicInstanceId, instanceId);
+        return Objects.equals(InstanceIds.asString(topicInstanceId), instanceId);
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -30,6 +30,7 @@ import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfi
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.util.InstanceIds;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.topic.SendMessageDTO;
@@ -85,7 +86,6 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 }
                 var qd = routeData.getQueueDatas().get(0);
                 TopicVO vo = new TopicVO();
-                vo.setId(name);
                 vo.setName(name);
                 vo.setWriteQueues(qd.getWriteQueueNums());
                 vo.setReadQueues(qd.getReadQueueNums());
@@ -108,7 +108,6 @@ public class RocketMQAdminClientImpl implements AdminClient {
 
     private ConsumerGroupVO getConsumerGroup(MQAdminExt admin, String name) {
         ConsumerGroupVO vo = new ConsumerGroupVO();
-        vo.setId(name);
         vo.setName(name);
         try {
             var conn = admin.examineConsumerConnectionInfo(name);
@@ -138,7 +137,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
         int writeQueues = topic.getWriteQueues() > 0 ? topic.getWriteQueues() : 8;
         int readQueues = topic.getReadQueues() > 0 ? topic.getReadQueues() : 8;
 
-        return executeForInstance(topic.getInstanceId(), admin -> {
+        return executeForInstance(InstanceIds.asString(topic.getInstanceId()), admin -> {
             try {
                 String clusterName = getClusterName(admin);
                 // Match on the (cluster_id, name) key: the same topic name can exist in several
@@ -176,9 +175,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
                     entity = new RmqTopic();
                     entity.setName(topicName);
                     entity.setClusterId(clusterName);
-                    entity.setCreatedAt(LocalDateTime.now());
+                    entity.setGmtCreate(LocalDateTime.now());
                 }
-                if (StringUtils.hasText(topic.getInstanceId())) {
+                if (topic.getInstanceId() != null) {
                     entity.setInstanceId(topic.getInstanceId());
                 }
                 entity.setTopicType(topic.getType() != null ? topic.getType().name() : "NORMAL");
@@ -189,7 +188,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
                     entity.setRemark(topic.getRemark());
                 }
                 entity.setStatus("ACTIVE");
-                entity.setUpdatedAt(LocalDateTime.now());
+                entity.setGmtModified(LocalDateTime.now());
                 if (isNew) {
                     topicMapper.insert(entity);
                 } else {
@@ -199,7 +198,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 recordAudit("CREATE_TOPIC", topicName,
                         "queues=" + writeQueues + "/" + readQueues, "SUCCESS");
 
-                topic.setId(topicName);
+                topic.setId(entity.getId());
                 topic.setWriteQueues(writeQueues);
                 topic.setReadQueues(readQueues);
                 return topic;
@@ -217,7 +216,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
     public TopicVO updateTopic(TopicVO topic) {
         String topicName = topic.getName();
 
-        return executeForInstance(topic.getInstanceId(), admin -> {
+        return executeForInstance(InstanceIds.asString(topic.getInstanceId()), admin -> {
             try {
                 // Match on the (cluster_id, name) key to avoid ambiguity when several clusters share
                 // the same topic name (a name-only lookup would throw TooManyResultsException).
@@ -266,14 +265,14 @@ public class RocketMQAdminClientImpl implements AdminClient {
                     if (StringUtils.hasText(topic.getRemark())) {
                         existing.setRemark(topic.getRemark());
                     }
-                    existing.setUpdatedAt(LocalDateTime.now());
+                    existing.setGmtModified(LocalDateTime.now());
                     topicMapper.updateById(existing);
                 }
 
                 recordAudit("UPDATE_TOPIC", topicName,
                         "queues=" + writeQueues + "/" + readQueues, "SUCCESS");
 
-                topic.setId(topicName);
+                topic.setId(existing == null ? null : existing.getId());
                 topic.setWriteQueues(writeQueues);
                 topic.setReadQueues(readQueues);
                 return topic;
@@ -392,8 +391,8 @@ public class RocketMQAdminClientImpl implements AdminClient {
 
     @Override
     public ConsumerGroupVO createConsumerGroup(ConsumerGroupVO group) {
-        if (group != null && StringUtils.hasText(group.getInstanceId())) {
-            return runtimeAdminClientResolver.execute(group.getInstanceId(),
+        if (group != null && group.getInstanceId() != null) {
+            return runtimeAdminClientResolver.execute(InstanceIds.asString(group.getInstanceId()),
                     admin -> createConsumerGroup(admin, group));
         }
         return adminFactory.execute(namesrvAddr(), null, admin -> createConsumerGroup(admin, group));
@@ -430,16 +429,16 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 entity = new RmqGroup();
                 entity.setName(groupName);
                 entity.setClusterId(groupClusterName);
-                entity.setCreatedAt(LocalDateTime.now());
+                entity.setGmtCreate(LocalDateTime.now());
             }
-            if (StringUtils.hasText(group.getInstanceId())) {
+            if (group.getInstanceId() != null) {
                 entity.setInstanceId(group.getInstanceId());
             }
             entity.setConsumeType(group.getConsumeType() != null ? group.getConsumeType().name() : "CLUSTERING");
             entity.setMessageModel(group.getSubscriptionMode() != null ? group.getSubscriptionMode().name() : "Push");
             entity.setMaxRetry(config.getRetryMaxTimes());
             entity.setStatus("ACTIVE");
-            entity.setUpdatedAt(LocalDateTime.now());
+            entity.setGmtModified(LocalDateTime.now());
             if (isNewGroup) {
                 groupMapper.insert(entity);
             } else {
@@ -449,7 +448,7 @@ public class RocketMQAdminClientImpl implements AdminClient {
             recordAudit("CREATE_GROUP", groupName,
                     "retryMaxTimes=" + config.getRetryMaxTimes(), "SUCCESS");
 
-            group.setId(groupName);
+            group.setId(entity.getId());
             return group;
         } catch (BusinessException e) {
             recordAudit("CREATE_GROUP", groupName, e.getMessage(), "FAILED");

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -128,7 +128,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
 
     private TopicVO toTopicVO(RmqTopic entity) {
         TopicVO vo = new TopicVO();
-        vo.setId(entity.getName());
+        vo.setId(entity.getId());
         vo.setName(entity.getName());
         vo.setClusterId(entity.getClusterId());
         vo.setInstanceId(entity.getInstanceId());
@@ -137,8 +137,8 @@ public class RocketMQMetadataProvider implements MetadataProvider {
         vo.setWriteQueues(entity.getWriteQueueNums() == null ? 0 : entity.getWriteQueueNums());
         vo.setPerm(parseTopicPerm(entity.getPerm()));
         vo.setRemark(entity.getRemark());
-        vo.setCreatedAt(entity.getCreatedAt());
-        vo.setUpdatedAt(entity.getUpdatedAt());
+        vo.setGmtCreate(entity.getGmtCreate());
+        vo.setGmtModified(entity.getGmtModified());
         return vo;
     }
 
@@ -181,7 +181,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
         List<ConsumerGroupVO> result = new ArrayList<>();
         for (RmqGroup entity : groupMapper.selectList(query)) {
             ConsumerGroupVO vo = new ConsumerGroupVO();
-            vo.setId(entity.getName());
+            vo.setId(entity.getId());
             vo.setName(entity.getName());
             vo.setClusterId(entity.getClusterId());
             vo.setInstanceId(entity.getInstanceId());
@@ -192,8 +192,8 @@ public class RocketMQMetadataProvider implements MetadataProvider {
             // (web detail, AI rmq.group.list) never see a null subscriptionMode.
             vo.setSubscriptionMode(parseSubscriptionMode(entity.getMessageModel()));
             vo.setRetryMaxTimes(entity.getMaxRetry() == null ? 0 : entity.getMaxRetry());
-            vo.setCreatedAt(entity.getCreatedAt());
-            vo.setUpdatedAt(entity.getUpdatedAt());
+            vo.setGmtCreate(entity.getGmtCreate());
+            vo.setGmtModified(entity.getGmtModified());
 
             // Live connection info (online instances, lag) is intentionally NOT fetched
             // during list operations to avoid N+1 admin API calls. It is loaded on

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialController.java
@@ -20,6 +20,7 @@ import jakarta.validation.Valid;
 import org.apache.rocketmq.studio.common.domain.DeleteRequestDTO;
 import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.util.EntityIds;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -64,12 +65,12 @@ public class CloudCredentialController {
 
     @PostMapping("/delete")
     public Result<Void> deleteCredential(@Valid @RequestBody DeleteRequestDTO request) {
-        credentialService.delete(request.getId());
+        credentialService.delete(EntityIds.parseId(request.getId()));
         return Result.ok();
     }
 
     @GetMapping("/{id}/credentials")
-    public ResponseEntity<Result<CloudCredentialVO>> getCredentialSecrets(@PathVariable String id) {
+    public ResponseEntity<Result<CloudCredentialVO>> getCredentialSecrets(@PathVariable Long id) {
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noStore())
                 .body(Result.ok(credentialService.reveal(id)));

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialRepository.java
@@ -25,11 +25,11 @@ public interface CloudCredentialRepository {
 
     List<CloudCredentialVO> findAll();
 
-    Optional<CloudCredentialVO> findById(String id);
+    Optional<CloudCredentialVO> findById(Long id);
 
     Optional<CloudCredentialVO> findByVendorAndAccessKey(InstanceVendor vendor, String accessKey);
 
     CloudCredentialVO save(CloudCredentialVO credential);
 
-    boolean deleteById(String id);
+    boolean deleteById(Long id);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
@@ -30,7 +30,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -70,17 +69,16 @@ public class CloudCredentialService {
                                     + " and accessKey " + CredentialUtils.mask(credential.getAccessKey()));
                 });
         log.info("Creating cloud credential name={}, vendor={}", credential.getName(), credential.getVendor());
-        credential.setId(UUID.randomUUID().toString());
-        credential.setCreatedAt(LocalDateTime.now());
-        credential.setUpdatedAt(LocalDateTime.now());
+        credential.setGmtCreate(LocalDateTime.now());
+        credential.setGmtModified(LocalDateTime.now());
         CloudCredentialVO saved = credentialRepository.save(credential);
-        recordAudit("CREATE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", saved.getId(), null,
+        recordAudit("CREATE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", String.valueOf(saved.getId()), null,
                 credentialAuditDetail(saved));
         return maskAccessKey(saved);
     }
 
     public CloudCredentialVO update(UpdateCloudCredentialDTO request) {
-        if (request == null || !StringUtils.hasText(request.getId())) {
+        if (request == null || request.getId() == null) {
             throw new BusinessException(400, "Cloud credential id is required");
         }
         log.info("Updating cloud credential id={}", request.getId());
@@ -98,16 +96,16 @@ public class CloudCredentialService {
         if (request.getRemark() != null) {
             existing.setRemark(request.getRemark());
         }
-        existing.setUpdatedAt(LocalDateTime.now());
+        existing.setGmtModified(LocalDateTime.now());
         CloudCredentialVO saved = credentialRepository.save(existing);
         invalidateCloudClients(saved);
-        recordAudit("UPDATE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", saved.getId(), null,
+        recordAudit("UPDATE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", String.valueOf(saved.getId()), null,
                 credentialAuditDetail(saved));
         return maskAccessKey(saved);
     }
 
-    public void delete(String id) {
-        if (!StringUtils.hasText(id)) {
+    public void delete(Long id) {
+        if (id == null) {
             throw new BusinessException(400, "Cloud credential id is required");
         }
         log.info("Deleting cloud credential id={}", id);
@@ -120,12 +118,12 @@ public class CloudCredentialService {
             throw new BusinessException(404, "Cloud credential not found: " + id);
         }
         invalidateCloudClients(existing);
-        recordAudit("DELETE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", id, null,
+        recordAudit("DELETE_CLOUD_CREDENTIAL", "CLOUD_CREDENTIAL", String.valueOf(id), null,
                 credentialAuditDetail(existing));
     }
 
-    public CloudCredentialVO reveal(String id) {
-        if (!StringUtils.hasText(id)) {
+    public CloudCredentialVO reveal(Long id) {
+        if (id == null) {
             throw new BusinessException(400, "Cloud credential id is required");
         }
         return credentialRepository.findById(id)
@@ -140,8 +138,8 @@ public class CloudCredentialService {
         masked.setAccessKey(CredentialUtils.mask(credential.getAccessKey()));
         masked.setSecretKey(null);
         masked.setRemark(credential.getRemark());
-        masked.setCreatedAt(credential.getCreatedAt());
-        masked.setUpdatedAt(credential.getUpdatedAt());
+        masked.setGmtCreate(credential.getGmtCreate());
+        masked.setGmtModified(credential.getGmtModified());
         return masked;
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
@@ -49,7 +49,10 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
     }
 
     @Override
-    public Optional<CloudCredentialVO> findById(String id) {
+    public Optional<CloudCredentialVO> findById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
         return Optional.ofNullable(credentialMapper.selectById(id))
                 .map(MybatisPlusCloudCredentialRepository::toVO);
     }
@@ -67,20 +70,21 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
     @Override
     public CloudCredentialVO save(CloudCredentialVO credential) {
         RmqCloudCredential entity = toEntity(credential);
-        if (credentialMapper.selectById(entity.getId()) != null) {
+        if (entity.getId() != null && credentialMapper.selectById(entity.getId()) != null) {
             if (credentialMapper.updateById(entity) == 0) {
                 throw new BusinessException(409,
                         "Cloud credential update was not applied: " + entity.getId());
             }
         } else {
             credentialMapper.insert(entity);
+            credential.setId(entity.getId());
         }
         return credential;
     }
 
     @Override
-    public boolean deleteById(String id) {
-        return credentialMapper.deleteById(id) > 0;
+    public boolean deleteById(Long id) {
+        return id != null && credentialMapper.deleteById(id) > 0;
     }
 
     // ── Mapping ────────────────────────────────────────────────────
@@ -93,8 +97,8 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
         vo.setAccessKey(entity.getAccessKey());
         vo.setSecretKey(CredentialUtils.decodeBase64(entity.getSecretKey()));
         vo.setRemark(entity.getRemark());
-        vo.setCreatedAt(entity.getCreatedAt());
-        vo.setUpdatedAt(entity.getUpdatedAt());
+        vo.setGmtCreate(entity.getGmtCreate());
+        vo.setGmtModified(entity.getGmtModified());
         return vo;
     }
 
@@ -106,12 +110,12 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
         entity.setAccessKey(vo.getAccessKey());
         entity.setSecretKey(CredentialUtils.encodeBase64(vo.getSecretKey()));
         entity.setRemark(vo.getRemark());
-        entity.setCreatedAt(vo.getCreatedAt());
-        entity.setUpdatedAt(vo.getUpdatedAt() == null ? LocalDateTime.now() : vo.getUpdatedAt());
+        entity.setGmtCreate(vo.getGmtCreate());
+        entity.setGmtModified(vo.getGmtModified() == null ? LocalDateTime.now() : vo.getGmtModified());
         return entity;
     }
 
-    private static InstanceVendor parseVendor(String credentialId, String vendor) {
+    private static InstanceVendor parseVendor(Long credentialId, String vendor) {
         try {
             return InstanceVendor.valueOf(vendor);
         } catch (IllegalArgumentException | NullPointerException ex) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/UpdateCloudCredentialDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/UpdateCloudCredentialDTO.java
@@ -16,15 +16,15 @@
  */
 package org.apache.rocketmq.studio.provider.credential;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.ToString;
 
 @Data
 public class UpdateCloudCredentialDTO {
 
-    @NotBlank(message = "credential id is required")
-    private String id;
+    @NotNull(message = "credential id is required")
+    private Long id;
 
     private String name;
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentAclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentAclService.java
@@ -135,8 +135,8 @@ public class TencentAclService {
         clientFactory.call(context.credentialId(), context.regionId(),
                 client -> client.CreateRole(request));
         // The created role is not returned by the API; reconstruct from the known inputs.
+        // Tencent roles have no database row; the role name lives in username, id stays null.
         return AclUserVO.builder()
-                .id(user.getUsername())
                 .username(user.getUsername())
                 .accessKey(null)
                 .secretKey(null)
@@ -144,7 +144,7 @@ public class TencentAclService {
                 .permRead(user.getPermRead() == null || user.getPermRead())
                 .permWrite(user.getPermWrite() == null || user.getPermWrite())
                 .clusters(context.cloudInstanceId() == null ? List.of() : List.of(context.cloudInstanceId()))
-                .createdAt(LocalDateTime.now())
+                .gmtCreate(LocalDateTime.now())
                 .build();
     }
 
@@ -161,7 +161,6 @@ public class TencentAclService {
         clientFactory.call(context.credentialId(), context.regionId(),
                 client -> client.ModifyRole(request));
         return AclUserVO.builder()
-                .id(user.getUsername())
                 .username(user.getUsername())
                 .accessKey(null)
                 .secretKey(null)
@@ -169,7 +168,7 @@ public class TencentAclService {
                 .permRead(user.getPermRead() == null || user.getPermRead())
                 .permWrite(user.getPermWrite() == null || user.getPermWrite())
                 .clusters(context.cloudInstanceId() == null ? List.of() : List.of(context.cloudInstanceId()))
-                .createdAt(user.getCreatedAt())
+                .gmtCreate(user.getGmtCreate())
                 .build();
     }
 
@@ -241,7 +240,6 @@ public class TencentAclService {
             actions.add("SUB");
         }
         return AclRuleVO.builder()
-                .id(principal)
                 .principal(principal)
                 .resource(RESOURCE)
                 .resourceType(RESOURCE_TYPE)
@@ -268,10 +266,10 @@ public class TencentAclService {
         if (!StringUtils.hasText(instanceId)) {
             throw new BusinessException(400, "instanceId is required");
         }
-        InstanceVO instance = instanceRepository.findById(instanceId)
+        InstanceVO instance = instanceRepository.findByIdentifier(instanceId)
                 .orElseThrow(() -> new BusinessException(404, "Instance not found: " + instanceId));
         if (!StringUtils.hasText(instance.getCloudInstanceId()) || !StringUtils.hasText(instance.getRegionId())
-                || !StringUtils.hasText(instance.getCredentialId())) {
+                || instance.getCredentialId() == null) {
             throw new BusinessException(400, "Instance " + instanceId + " is missing Tencent Cloud binding");
         }
         return new Context(instance.getCloudInstanceId(), instance.getRegionId(), instance.getCredentialId());
@@ -279,7 +277,6 @@ public class TencentAclService {
 
     private static AclUserVO toUser(RoleItem role, String cloudInstanceId) {
         return AclUserVO.builder()
-                .id(role.getRoleName())
                 .username(role.getRoleName())
                 .accessKey(role.getAccessKey())
                 .secretKey(role.getSecretKey())
@@ -288,7 +285,7 @@ public class TencentAclService {
                 .permWrite(role.getPermWrite())
                 .clusters(cloudInstanceId == null ? List.of() : List.of(cloudInstanceId))
                 .whiteRemoteAddress(null)
-                .createdAt(toLocalDateTime(role.getCreatedTime()))
+                .gmtCreate(toLocalDateTime(role.getCreatedTime()))
                 .build();
     }
 
@@ -301,7 +298,6 @@ public class TencentAclService {
             actions.add("SUB");
         }
         return AclRuleVO.builder()
-                .id(role.getRoleName())
                 .principal(role.getRoleName())
                 .resource(RESOURCE)
                 .resourceType(RESOURCE_TYPE)
@@ -310,7 +306,7 @@ public class TencentAclService {
                 .decision(DECISION)
                 .scope(SCOPE)
                 .aclVersion(ACL_VERSION)
-                .createdAt(toLocalDateTime(role.getCreatedTime()))
+                .gmtCreate(toLocalDateTime(role.getCreatedTime()))
                 .build();
     }
 
@@ -322,6 +318,6 @@ public class TencentAclService {
         return Instant.ofEpochMilli(epochMillis).atZone(ZoneId.systemDefault()).toLocalDateTime();
     }
 
-    private record Context(String cloudInstanceId, String regionId, String credentialId) {
+    private record Context(String cloudInstanceId, String regionId, Long credentialId) {
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogController.java
@@ -38,12 +38,12 @@ public class TencentCatalogController {
     private final TencentCatalogService catalogService;
 
     @GetMapping("/regions")
-    public Result<List<CloudRegionVO>> listRegions(@RequestParam String credentialId) {
+    public Result<List<CloudRegionVO>> listRegions(@RequestParam Long credentialId) {
         return Result.ok(catalogService.listRegions(credentialId));
     }
 
     @GetMapping("/instances")
-    public Result<List<CloudInstanceOptionVO>> listInstances(@RequestParam String credentialId,
+    public Result<List<CloudInstanceOptionVO>> listInstances(@RequestParam Long credentialId,
                                                              @RequestParam String regionId,
                                                              @RequestParam(required = false) String search) {
         return Result.ok(catalogService.listCloudInstances(credentialId, regionId, search));

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
@@ -73,14 +73,14 @@ public class TencentCatalogService implements CloudCatalogProvider {
     }
 
     @Override
-    public List<CloudRegionVO> listRegions(String credentialId) {
-        requireNonBlank(credentialId, "credentialId");
+    public List<CloudRegionVO> listRegions(Long credentialId) {
+        requireId(credentialId, "credentialId");
         return SUPPORTED_REGIONS;
     }
 
     @Override
-    public List<CloudInstanceOptionVO> listCloudInstances(String credentialId, String regionId, String search) {
-        requireNonBlank(credentialId, "credentialId");
+    public List<CloudInstanceOptionVO> listCloudInstances(Long credentialId, String regionId, String search) {
+        requireId(credentialId, "credentialId");
         requireNonBlank(regionId, "regionId");
         List<CloudInstanceOptionVO> instances = new ArrayList<>();
         for (int page = 0; page < MAX_PAGES; page++) {
@@ -107,8 +107,8 @@ public class TencentCatalogService implements CloudCatalogProvider {
     }
 
     @Override
-    public CloudInstanceDetailVO getCloudInstance(String credentialId, String regionId, String cloudInstanceId) {
-        requireNonBlank(credentialId, "credentialId");
+    public CloudInstanceDetailVO getCloudInstance(Long credentialId, String regionId, String cloudInstanceId) {
+        requireId(credentialId, "credentialId");
         requireNonBlank(regionId, "regionId");
         requireNonBlank(cloudInstanceId, "cloudInstanceId");
         DescribeInstanceRequest request = new DescribeInstanceRequest();
@@ -186,6 +186,12 @@ public class TencentCatalogService implements CloudCatalogProvider {
         region.setRegionId(id);
         region.setRegionName(name);
         return region;
+    }
+
+    private static void requireId(Long value, String name) {
+        if (value == null) {
+            throw new BusinessException(400, name + " is required");
+        }
     }
 
     private static void requireNonBlank(String value, String name) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentClientFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentClientFactory.java
@@ -46,17 +46,17 @@ public class TencentClientFactory {
     private final CloudCredentialRepository credentialRepository;
     private final Map<String, TrocketClient> clients = new ConcurrentHashMap<>();
 
-    public TrocketClient client(String credentialId, String region) {
+    public TrocketClient client(Long credentialId, String region) {
         String key = cacheKey(credentialId, region);
         return clients.computeIfAbsent(key, ignored -> createClient(credentialId, region));
     }
 
-    public void invalidateCredential(String credentialId) {
+    public void invalidateCredential(Long credentialId) {
         String prefix = credentialId + "#";
         clients.keySet().removeIf(key -> key.startsWith(prefix));
     }
 
-    public <T> T call(String credentialId, String region, TencentCall<T> action) {
+    public <T> T call(Long credentialId, String region, TencentCall<T> action) {
         try {
             return action.execute(client(credentialId, region));
         } catch (TencentCloudSDKException ex) {
@@ -69,11 +69,11 @@ public class TencentClientFactory {
         }
     }
 
-    static String cacheKey(String credentialId, String region) {
+    static String cacheKey(Long credentialId, String region) {
         return credentialId + "#" + region;
     }
 
-    protected TrocketClient createClient(String credentialId, String region) {
+    protected TrocketClient createClient(Long credentialId, String region) {
         CloudCredentialVO credential = credentialRepository.findById(credentialId)
                 .orElseThrow(() -> new BusinessException(404, "Cloud credential not found: " + credentialId));
         Credential sdkCredential = new Credential(credential.getAccessKey(), credential.getSecretKey());

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.provider.tencent;
 
+import org.apache.rocketmq.studio.common.util.InstanceIds;
 import com.tencentcloudapi.trocket.v20230308.models.ConsumeGroupItem;
 import com.tencentcloudapi.trocket.v20230308.models.CreateConsumerGroupRequest;
 import com.tencentcloudapi.trocket.v20230308.models.CreateTopicRequest;
@@ -222,8 +223,8 @@ public class TencentInstanceProvider implements InstanceProvider {
             if (response == null) {
                 return;
             }
-            topic.setCreatedAt(toLocalDateTime(response.getCreatedTime()));
-            topic.setUpdatedAt(toLocalDateTime(response.getLastUpdateTime()));
+            topic.setGmtCreate(toLocalDateTime(response.getCreatedTime()));
+            topic.setGmtModified(toLocalDateTime(response.getLastUpdateTime()));
         } catch (BusinessException ignored) {
             // A single topic detail lookup failure should not fail the whole list.
         }
@@ -249,12 +250,12 @@ public class TencentInstanceProvider implements InstanceProvider {
         request.setQueueNum(queueNum(topic));
         request.setRemark(topic.getRemark());
         clientFactory.call(context.credentialId(), context.regionId(), client -> client.CreateTopic(request));
-        topic.setInstanceId(instanceId);
+        topic.setInstanceId(InstanceIds.parseLongOrNull(instanceId));
         topic.setPerm(defaultPerm(topic.getPerm()));
         topic.setWriteQueues(queueNum(topic).intValue());
         topic.setReadQueues(queueNum(topic).intValue());
-        topic.setCreatedAt(LocalDateTime.now());
-        topic.setUpdatedAt(LocalDateTime.now());
+        topic.setGmtCreate(LocalDateTime.now());
+        topic.setGmtModified(LocalDateTime.now());
         return topic;
     }
 
@@ -272,13 +273,13 @@ public class TencentInstanceProvider implements InstanceProvider {
             request.setQueueNum(requestedQueueNum);
         }
         clientFactory.call(context.credentialId(), context.regionId(), client -> client.ModifyTopic(request));
-        topic.setInstanceId(instanceId);
+        topic.setInstanceId(InstanceIds.parseLongOrNull(instanceId));
         topic.setPerm(defaultPerm(topic.getPerm()));
         if (requestedQueueNum != null) {
             topic.setWriteQueues(requestedQueueNum.intValue());
             topic.setReadQueues(requestedQueueNum.intValue());
         }
-        topic.setUpdatedAt(LocalDateTime.now());
+        topic.setGmtModified(LocalDateTime.now());
         return topic;
     }
 
@@ -378,7 +379,7 @@ public class TencentInstanceProvider implements InstanceProvider {
             if (response == null) {
                 return;
             }
-            group.setCreatedAt(toLocalDateTime(response.getCreatedTime()));
+            group.setGmtCreate(toLocalDateTime(response.getCreatedTime()));
             if (StringUtils.hasText(response.getConsumeModel())) {
                 group.setConsumeType(toConsumeType(response.getConsumeModel()));
             }
@@ -398,11 +399,11 @@ public class TencentInstanceProvider implements InstanceProvider {
         request.setConsumeEnable(true);
         request.setConsumeMessageOrderly(isOrderly(group));
         clientFactory.call(context.credentialId(), context.regionId(), client -> client.CreateConsumerGroup(request));
-        group.setInstanceId(instanceId);
+        group.setInstanceId(InstanceIds.parseLongOrNull(instanceId));
         group.setRetryMaxTimes(retryMaxTimes(group));
         group.setSubscribedTopics(java.util.List.of());
-        group.setCreatedAt(LocalDateTime.now());
-        group.setUpdatedAt(LocalDateTime.now());
+        group.setGmtCreate(LocalDateTime.now());
+        group.setGmtModified(LocalDateTime.now());
         return group;
     }
 
@@ -798,7 +799,7 @@ public class TencentInstanceProvider implements InstanceProvider {
         InstanceVO instance = instanceRepository.findByIdentifier(instanceId)
                 .orElseThrow(() -> new BusinessException(404, "Instance not found: " + instanceId));
         if (!StringUtils.hasText(instance.getCloudInstanceId()) || !StringUtils.hasText(instance.getRegionId())
-                || !StringUtils.hasText(instance.getCredentialId())) {
+                || instance.getCredentialId() == null) {
             throw new BusinessException(400, "Instance " + instanceId + " is missing Tencent Cloud binding");
         }
         return new Context(instance.getCloudInstanceId(), instance.getRegionId(), instance.getCredentialId());
@@ -807,7 +808,7 @@ public class TencentInstanceProvider implements InstanceProvider {
     private static TopicVO toTopic(TopicItem item, String instanceId) {
         TopicVO topic = new TopicVO();
         topic.setName(item.getTopic());
-        topic.setInstanceId(instanceId);
+        topic.setInstanceId(InstanceIds.parseLongOrNull(instanceId));
         topic.setType(toTopicType(item.getTopicType()));
         topic.setWriteQueues(toInteger(item.getQueueNum()));
         topic.setReadQueues(toInteger(item.getQueueNum()));
@@ -834,7 +835,7 @@ public class TencentInstanceProvider implements InstanceProvider {
     private static ConsumerGroupVO toConsumerGroup(ConsumeGroupItem item, String instanceId) {
         ConsumerGroupVO group = new ConsumerGroupVO();
         group.setName(item.getConsumerGroup());
-        group.setInstanceId(instanceId);
+        group.setInstanceId(InstanceIds.parseLongOrNull(instanceId));
         group.setClusterId(item.getClusterIdV4());
         group.setNamespace(item.getNamespaceV4());
         group.setConsumeType(toConsumeType(item.getConsumeMessageOrderly()));
@@ -1031,6 +1032,6 @@ public class TencentInstanceProvider implements InstanceProvider {
         }
     }
 
-    private record Context(String cloudInstanceId, String regionId, String credentialId) {
+    private record Context(String cloudInstanceId, String regionId, Long credentialId) {
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/GeneralSettingsUpdateDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/GeneralSettingsUpdateDTO.java
@@ -58,6 +58,9 @@ public class GeneralSettingsUpdateDTO {
     private String deploymentName;
     private String apiVersion;
     private String awsRegion;
+    private String dingtalkWebhook;
+    private String emailRecipients;
+    private String smsWebhook;
 
     public GeneralSettingsVO toSettings() {
         return GeneralSettingsVO.builder()
@@ -76,6 +79,9 @@ public class GeneralSettingsUpdateDTO {
                 .deploymentName(deploymentName)
                 .apiVersion(apiVersion)
                 .awsRegion(awsRegion)
+                .dingtalkWebhook(dingtalkWebhook)
+                .emailRecipients(emailRecipients)
+                .smsWebhook(smsWebhook)
                 .build();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/GeneralSettingsVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/GeneralSettingsVO.java
@@ -49,6 +49,9 @@ public class GeneralSettingsVO {
     private String awsRegion;
     private Integer maxTokens;
     private Double temperature;
+    private String dingtalkWebhook;
+    private String emailRecipients;
+    private String smsWebhook;
 
     @JsonProperty(value = "apiKeyConfigured", access = JsonProperty.Access.READ_ONLY)
     public boolean isApiKeyConfigured() {

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -47,7 +47,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.UUID;
 
 @Slf4j
 @Service
@@ -182,7 +181,6 @@ public class SettingsService {
             throw new BusinessException(400, "Data source request is required");
         }
         log.info("Creating data source: {}", dataSource.getName());
-        dataSource.setKey(UUID.randomUUID().toString());
         validateDataSourceUrl(dataSource.getUrl());
         DataSourceVO saved = settingsRepository.saveDataSource(dataSource);
         recordDataSourceAudit("CREATE_DATA_SOURCE", saved);

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -2,43 +2,54 @@
 -- RocketMQ Studio 数据库 Schema（MySQL 8.0）
 -- 此文件为唯一权威 DDL 来源，MyBatis-Plus Entity 与此保持同步
 -- 注意：MyBatis-Plus 不自动建表，需通过此 SQL 初始化（docker-compose 挂载执行）
+--
+-- 表结构规范（所有表强制）：
+--   id           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键'
+--   gmt_create   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间'
+--   gmt_modified datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间'
+-- 禁止 created_at/updated_at，禁止 VARCHAR UUID 主键。
 
 -- 固定连接编码，防止 mysql 客户端以 latin1 解释 UTF-8 字节导致中文双重编码
 SET NAMES utf8mb4;
 
 -- 1. NameServer / 集群地址注册表
 CREATE TABLE IF NOT EXISTS rmq_nameserver (
-  id VARCHAR(64) PRIMARY KEY,
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   name VARCHAR(128) NOT NULL,
   namesrv_addr VARCHAR(512) NOT NULL COMMENT 'NameServer 地址，逗号分隔',
   cluster_type VARCHAR(32) DEFAULT 'V5_PROXY_CLUSTER',
   status VARCHAR(32) DEFAULT 'healthy',
   description TEXT,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 -- 2. 实例注册表（实例管理页的数据源，topic/group 按 instance_id 归属统计）
 CREATE TABLE IF NOT EXISTS rmq_instance (
-  id VARCHAR(64) PRIMARY KEY,
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   name VARCHAR(128) NOT NULL,
   remark VARCHAR(255),
   type VARCHAR(32) NOT NULL COMMENT 'PROXY/DIRECT',
   endpoint VARCHAR(512) NOT NULL,
   vendor VARCHAR(32),
   cloud_instance_id VARCHAR(128),
-  credential_id VARCHAR(64),
+  credential_id bigint(20) unsigned COMMENT '引用 rmq_cloud_credential.id',
   admin_credential_ref VARCHAR(128) COMMENT 'External Apache admin credential reference; no secret material',
   region_id VARCHAR(128),
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
   UNIQUE KEY uk_instance_name (name)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 3. Topic 管理记录（通过 Studio 创建/管理的 Topic 元数据）
-CREATE TABLE IF NOT EXISTS rmq_topic (
-  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS rmq_instance_topic (
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   cluster_id VARCHAR(64) NOT NULL,
-  instance_id VARCHAR(64) COMMENT '归属实例，引用 rmq_instance.id',
+  instance_id bigint(20) unsigned COMMENT '归属实例，引用 rmq_instance.id',
   name VARCHAR(255) NOT NULL,
   topic_type VARCHAR(32) DEFAULT 'NORMAL',
   read_queue_nums INT DEFAULT 8,
@@ -47,34 +58,35 @@ CREATE TABLE IF NOT EXISTS rmq_topic (
   remark VARCHAR(255) COMMENT '业务用途备注',
   status VARCHAR(32) DEFAULT 'ACTIVE',
   created_by VARCHAR(64),
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
   UNIQUE KEY uk_cluster_topic (cluster_id, name),
   INDEX idx_topic_instance (instance_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 4. Consumer Group 管理记录
-CREATE TABLE IF NOT EXISTS rmq_group (
-  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS rmq_instance_group (
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   cluster_id VARCHAR(64) NOT NULL,
-  instance_id VARCHAR(64) COMMENT '归属实例，引用 rmq_instance.id',
+  instance_id bigint(20) unsigned COMMENT '归属实例，引用 rmq_instance.id',
   name VARCHAR(255) NOT NULL,
   consume_type VARCHAR(32) DEFAULT 'CONCURRENTLY',
   message_model VARCHAR(32) DEFAULT 'CLUSTERING',
   max_retry INT DEFAULT 16,
   status VARCHAR(32) DEFAULT 'ACTIVE',
   created_by VARCHAR(64),
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
   UNIQUE KEY uk_cluster_group (cluster_id, name),
   INDEX idx_group_instance (instance_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 5. K8s 证书管理
 CREATE TABLE IF NOT EXISTS rmq_k8s_certificate (
-  id VARCHAR(64) PRIMARY KEY,
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   name VARCHAR(128) NOT NULL,
-  namespace VARCHAR(128),
   cluster VARCHAR(128),
   cert_type VARCHAR(32) DEFAULT 'TLS',
   issuer VARCHAR(256),
@@ -83,13 +95,16 @@ CREATE TABLE IF NOT EXISTS rmq_k8s_certificate (
   status VARCHAR(32) DEFAULT 'valid',
   days_remaining INT,
   san TEXT COMMENT 'JSON array of SANs',
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+  cert_pem TEXT COMMENT 'PEM encoded certificate',
+  key_pem TEXT COMMENT 'PEM encoded private key',
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 6. 消息查询记录
-CREATE TABLE IF NOT EXISTS rmq_message_query (
-  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS rmq_instance_message (
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   query_type VARCHAR(32) NOT NULL COMMENT 'TOPIC/KEY/MSG_ID',
   topic VARCHAR(255),
   msg_id VARCHAR(128),
@@ -100,28 +115,32 @@ CREATE TABLE IF NOT EXISTS rmq_message_query (
   result_count INT DEFAULT 0,
   cluster_id VARCHAR(255),
   queried_by VARCHAR(64),
-  queried_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  INDEX idx_message_query_queried_at (queried_at),
+  PRIMARY KEY (`id`),
+  INDEX idx_message_query_gmt_create (gmt_create),
   INDEX idx_topic (topic)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 7. 消息轨迹查询记录
-CREATE TABLE IF NOT EXISTS rmq_trace_query (
-  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS rmq_instance_trace (
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   msg_id VARCHAR(128) NOT NULL,
   topic VARCHAR(255),
   node_count INT DEFAULT 0,
   consumer_count INT DEFAULT 0,
   cluster_id VARCHAR(255),
   queried_by VARCHAR(64),
-  queried_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
   INDEX idx_msg_id (msg_id),
-  INDEX idx_trace_query_queried_at (queried_at)
+  INDEX idx_trace_query_gmt_create (gmt_create)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 8. 操作审计日志（所有写操作）
 CREATE TABLE IF NOT EXISTS rmq_operation_audit (
-  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   operation VARCHAR(64) NOT NULL COMMENT 'CREATE_TOPIC/DELETE_TOPIC/CREATE_GROUP/RESET_OFFSET/SEND_MESSAGE/UPDATE_CONFIG/...',
   resource_type VARCHAR(64) NOT NULL COMMENT 'TOPIC/GROUP/CLUSTER/CERT/SETTINGS',
   resource_name VARCHAR(255),
@@ -130,30 +149,37 @@ CREATE TABLE IF NOT EXISTS rmq_operation_audit (
   result VARCHAR(16) DEFAULT 'SUCCESS' COMMENT 'SUCCESS/FAILED',
   error_message TEXT,
   operator VARCHAR(64),
-  operated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  INDEX idx_operated_at (operated_at),
+  PRIMARY KEY (`id`),
+  INDEX idx_gmt_create (gmt_create),
   INDEX idx_resource (resource_type, resource_name),
   INDEX idx_operation (operation)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 9. 通用设置（单行）
 CREATE TABLE IF NOT EXISTS rmq_settings (
-  id VARCHAR(16) DEFAULT 'singleton' PRIMARY KEY,
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   json TEXT NOT NULL COMMENT 'GeneralSettingsVO JSON',
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 10. 数据源配置
 CREATE TABLE IF NOT EXISTS rmq_data_source (
-  ds_key VARCHAR(64) PRIMARY KEY,
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  ds_key VARCHAR(64) NOT NULL COMMENT '对外业务键',
   json TEXT NOT NULL COMMENT 'DataSourceVO JSON',
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+  PRIMARY KEY (`id`),
+  UNIQUE KEY uk_ds_key (ds_key)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 11. ACL 规则
 CREATE TABLE IF NOT EXISTS rmq_acl_rule (
-  id VARCHAR(64) PRIMARY KEY,
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   principal VARCHAR(128) NOT NULL,
   resource VARCHAR(255) NOT NULL,
   resource_type VARCHAR(32) COMMENT 'Topic/Group/Cluster',
@@ -162,28 +188,30 @@ CREATE TABLE IF NOT EXISTS rmq_acl_rule (
   decision VARCHAR(16) COMMENT 'ALLOW/DENY',
   scope VARCHAR(64) COMMENT '生效范围（集群名/实例 id）',
   acl_version VARCHAR(16) COMMENT '1.0/2.0',
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
   INDEX idx_principal (principal)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 12. ACL 用户（secret_key 为 base64 编码后的密码，禁止明文存储）
 CREATE TABLE IF NOT EXISTS rmq_acl_user (
-  id VARCHAR(64) PRIMARY KEY,
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   username VARCHAR(128) NOT NULL,
   access_key VARCHAR(255) NOT NULL,
   secret_key VARCHAR(512) NOT NULL COMMENT 'base64 编码的密码',
   admin TINYINT(1) DEFAULT 0,
   clusters VARCHAR(1024) COMMENT '逗号分隔的集群/实例 id',
   white_remote_address VARCHAR(255) COMMENT 'plain access 账号 IP 白名单，空表示不限制',
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
   UNIQUE KEY uk_username (username)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 13. 告警规则
 CREATE TABLE IF NOT EXISTS rmq_alert_rule (
-  id VARCHAR(64) PRIMARY KEY,
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   name VARCHAR(128) NOT NULL,
   metric VARCHAR(128),
   operator VARCHAR(16),
@@ -197,33 +225,34 @@ CREATE TABLE IF NOT EXISTS rmq_alert_rule (
   broker_name VARCHAR(128),
   cluster_name VARCHAR(128),
   severity VARCHAR(32),
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 14. 系统告警事件
 CREATE TABLE IF NOT EXISTS rmq_system_alert (
-  id VARCHAR(64) PRIMARY KEY,
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   level VARCHAR(32),
   title VARCHAR(255),
   description TEXT,
   time DATETIME,
   acknowledged TINYINT(1) DEFAULT 0,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
   INDEX idx_level (level),
   INDEX idx_acknowledged (acknowledged)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 15. Cloud provider credentials (secret_key is base64-encoded and never seeded).
 CREATE TABLE IF NOT EXISTS rmq_cloud_credential (
-  id VARCHAR(64) PRIMARY KEY,
+  `id`           bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create`   datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   name VARCHAR(128) NOT NULL COMMENT 'Credential display name',
   vendor VARCHAR(32) NOT NULL COMMENT 'ALIYUN/TENCENT',
   access_key VARCHAR(255) NOT NULL,
   secret_key VARCHAR(512) NOT NULL COMMENT 'Base64-encoded secret key',
   remark VARCHAR(255),
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
   UNIQUE KEY uk_vendor_access_key (vendor, access_key)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/server/src/main/resources/tool-catalog/rmq-tools.yaml
+++ b/server/src/main/resources/tool-catalog/rmq-tools.yaml
@@ -471,7 +471,7 @@ tools:
         additionalProperties: false
         properties:
           id:
-            type: string
+            type: integer
           name:
             type: string
           metric:

--- a/server/src/test/java/org/apache/rocketmq/studio/StudioApplicationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/StudioApplicationTest.java
@@ -73,7 +73,6 @@ class StudioApplicationTest {
                 .endpoint("127.0.0.1:9876")
                 .adminCredentialRef("production-admin")
                 .build();
-        instance.setId("acl-admin-ref-roundtrip");
 
         instanceRepository.save(instance);
 

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCredentialAuthorizationIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCredentialAuthorizationIntegrationTest.java
@@ -85,7 +85,7 @@ class AuthCredentialAuthorizationIntegrationTest {
 
     @Test
     void shouldRejectCloudCredentialPathWithMatrixParameterForReader() throws Exception {
-        mockMvc.perform(get("/api/cloud-credentials;probe=1/credential-1/credentials")
+        mockMvc.perform(get("/api/cloud-credentials;probe=1/12/credentials")
                         .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION))
                 .andExpect(status().isForbidden());
 
@@ -99,11 +99,11 @@ class AuthCredentialAuthorizationIntegrationTest {
         mockMvc.perform(get("/api/acl/users/user-1/credentials;probe=1")
                         .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION))
                 .andExpect(status().isOk());
-        mockMvc.perform(get("/api/cloud-credentials;probe=1/credential-1/credentials")
+        mockMvc.perform(get("/api/cloud-credentials;probe=1/12/credentials")
                         .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION))
                 .andExpect(status().isOk());
 
         verify(aclService).getUserCredentials(eq("user-1"), isNull());
-        verify(cloudCredentialService).reveal("credential-1");
+        verify(cloudCredentialService).reveal(12L);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/SensitiveRequestToStringTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/SensitiveRequestToStringTest.java
@@ -39,7 +39,7 @@ class SensitiveRequestToStringTest {
         createCredential.setSecretKey("cloud-secret-key");
 
         UpdateCloudCredentialDTO updateCredential = new UpdateCloudCredentialDTO();
-        updateCredential.setId("credential-1");
+        updateCredential.setId(1L);
         updateCredential.setSecretKey("rotated-cloud-secret");
 
         UpsertPlainAccessConfigDTO plainAccess = new UpsertPlainAccessConfigDTO();
@@ -58,7 +58,7 @@ class SensitiveRequestToStringTest {
                 .contains("name=production")
                 .doesNotContain("cloud-access-key", "cloud-secret-key");
         assertThat(updateCredential.toString())
-                .contains("id=credential-1")
+                .contains("id=1")
                 .doesNotContain("rotated-cloud-secret");
         assertThat(plainAccess.toString())
                 .doesNotContain("rocketmq-access-key", "rocketmq-secret-key");

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolverTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolverTest.java
@@ -53,7 +53,7 @@ class RuntimeAdminClientResolverTest {
     @Test
     void resolvesTrimmedEndpointFromSelectedInstance() {
         InstanceVO instance = InstanceVO.builder().endpoint(" namesrv-a:9876 ").build();
-        instance.setId("instance-a");
+        instance.setId(1L);
         when(instanceRepository.findByIdentifier("instance-a")).thenReturn(Optional.of(instance));
 
         RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory,
@@ -97,17 +97,17 @@ class RuntimeAdminClientResolverTest {
                 .vendor(InstanceVendor.ALIYUN)
                 .endpoint("cloud-endpoint:9876")
                 .build();
-        instance.setId("cloud-instance");
+        instance.setId(2L);
         when(instanceRepository.findByIdentifier("cloud-instance")).thenReturn(Optional.of(instance));
         RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory,
                 new MqAdminProperties());
 
         assertThatThrownBy(() -> resolver.resolveEndpoint("cloud-instance"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("Runtime AdminClient only supports Apache instances: cloud-instance");
+                .hasMessage("Runtime AdminClient only supports Apache instances: 2");
         assertThatThrownBy(() -> resolver.execute(instance, admin -> "unused"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("Runtime AdminClient only supports Apache instances: cloud-instance");
+                .hasMessage("Runtime AdminClient only supports Apache instances: 2");
         verifyNoInteractions(adminFactory);
     }
 
@@ -117,7 +117,7 @@ class RuntimeAdminClientResolverTest {
                 .endpoint("namesrv-b:9876")
                 .adminCredentialRef(" production-admin ")
                 .build();
-        instance.setId("instance-b");
+        instance.setId(3L);
         MqAdminProperties properties = new MqAdminProperties();
         MqAdminProperties.Credential credential = new MqAdminProperties.Credential();
         credential.setAccessKey("admin-ak");
@@ -153,7 +153,7 @@ class RuntimeAdminClientResolverTest {
         properties.getCredentials().put("incomplete", incomplete);
         InstanceVO instance = InstanceVO.builder().endpoint("namesrv-b:9876")
                 .adminCredentialRef("missing").build();
-        instance.setId("instance-b");
+        instance.setId(3L);
         when(instanceRepository.findByIdentifier("instance-b")).thenReturn(Optional.of(instance));
         RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(instanceRepository, adminFactory,
                 properties);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
@@ -55,8 +55,8 @@ class K8sCertControllerTest {
 
     @Test
     void listCertsShouldReturnAllCerts() throws Exception {
-        K8sCertVO cert1 = buildCert("cert-1", "rocketmq-tls", CertType.TLS, CertStatus.valid);
-        K8sCertVO cert2 = buildCert("cert-2", "broker-mtls", CertType.mTLS, CertStatus.expiring);
+        K8sCertVO cert1 = buildCert(1L, "rocketmq-tls", CertType.TLS, CertStatus.valid);
+        K8sCertVO cert2 = buildCert(2L, "broker-mtls", CertType.mTLS, CertStatus.expiring);
         when(k8sCertService.listCerts()).thenReturn(Arrays.asList(cert1, cert2));
 
         mockMvc.perform(get("/api/k8s-certs"))
@@ -65,11 +65,11 @@ class K8sCertControllerTest {
                 .andExpect(jsonPath("$.message").value("success"))
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].id").value("cert-1"))
+                .andExpect(jsonPath("$.data[0].id").value(1))
                 .andExpect(jsonPath("$.data[0].name").value("rocketmq-tls"))
                 .andExpect(jsonPath("$.data[0].type").value("TLS"))
                 .andExpect(jsonPath("$.data[0].status").value("valid"))
-                .andExpect(jsonPath("$.data[1].id").value("cert-2"))
+                .andExpect(jsonPath("$.data[1].id").value(2))
                 .andExpect(jsonPath("$.data[1].name").value("broker-mtls"));
     }
 
@@ -86,8 +86,7 @@ class K8sCertControllerTest {
 
     @Test
     void createCertShouldReturnCreatedCert() throws Exception {
-        K8sCertVO createdCert = buildCert("cert-new", "new-cert", CertType.TLS, CertStatus.valid);
-        createdCert.setNamespace("default");
+        K8sCertVO createdCert = buildCert(3L, "new-cert", CertType.TLS, CertStatus.valid);
         createdCert.setCluster("test-cluster");
         createdCert.setIssuer("vault");
         createdCert.setSan(List.of("svc.example.com"));
@@ -95,7 +94,6 @@ class K8sCertControllerTest {
 
         CreateCertDTO command = CreateCertDTO.builder()
                 .name("new-cert")
-                .namespace("default")
                 .cluster("test-cluster")
                 .type("TLS")
                 .issuer("vault")
@@ -107,9 +105,8 @@ class K8sCertControllerTest {
                         .content(objectMapper.writeValueAsString(command)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.id").value("cert-new"))
+                .andExpect(jsonPath("$.data.id").value(3))
                 .andExpect(jsonPath("$.data.name").value("new-cert"))
-                .andExpect(jsonPath("$.data.namespace").value("default"))
                 .andExpect(jsonPath("$.data.cluster").value("test-cluster"))
                 .andExpect(jsonPath("$.data.type").value("TLS"))
                 .andExpect(jsonPath("$.data.status").value("valid"))
@@ -118,13 +115,12 @@ class K8sCertControllerTest {
 
     @Test
     void createCertShouldAcceptMinimalCommand() throws Exception {
-        K8sCertVO createdCert = buildCert("cert-min", "minimal-cert", CertType.TLS, CertStatus.valid);
+        K8sCertVO createdCert = buildCert(4L, "minimal-cert", CertType.TLS, CertStatus.valid);
         when(k8sCertService.createCert(any(CreateCertDTO.class))).thenReturn(createdCert);
 
         String json = """
                 {
                     "name": "minimal-cert",
-                    "namespace": "default",
                     "cluster": "test",
                     "type": "TLS",
                     "issuer": "test-issuer"
@@ -136,7 +132,7 @@ class K8sCertControllerTest {
                         .content(json))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.id").value("cert-min"));
+                .andExpect(jsonPath("$.data.id").value(4));
     }
 
     @Test
@@ -166,7 +162,6 @@ class K8sCertControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                    "namespace": "default",
                                     "cluster": "test-cluster",
                                     "type": "TLS",
                                     "issuer": "vault"
@@ -186,7 +181,6 @@ class K8sCertControllerTest {
                         .content("""
                                 {
                                     "name": "new-cert",
-                                    "namespace": "default",
                                     "cluster": "test-cluster",
                                     "type": "PEM",
                                     "issuer": "vault"
@@ -221,7 +215,7 @@ class K8sCertControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                    "id": " "
+                                    "id": null
                                 }
                                 """))
                 .andExpect(status().isBadRequest())
@@ -243,10 +237,9 @@ class K8sCertControllerTest {
         verifyNoInteractions(k8sCertService);
     }
 
-    private K8sCertVO buildCert(String id, String name, CertType type, CertStatus status) {
+    private K8sCertVO buildCert(Long id, String name, CertType type, CertStatus status) {
         K8sCertVO cert = K8sCertVO.builder()
                 .name(name)
-                .namespace("mq-system")
                 .cluster("prod-cluster")
                 .type(type)
                 .issuer("letsencrypt")

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
@@ -68,7 +68,6 @@ class K8sCertServiceTest {
         k8sCertService = new K8sCertService(k8sCertRepository, operationAuditService, CLOCK);
         sampleCert = K8sCertVO.builder()
                 .name("rocketmq-tls")
-                .namespace("mq-system")
                 .cluster("prod-cluster")
                 .type(CertType.TLS)
                 .issuer("letsencrypt")
@@ -78,9 +77,9 @@ class K8sCertServiceTest {
                 .daysRemaining(180)
                 .san(Arrays.asList("rocketmq.example.com", "*.rocketmq.example.com"))
                 .build();
-        sampleCert.setId("cert-1");
-        sampleCert.setCreatedAt(LocalDateTime.of(2024, 12, 1, 0, 0));
-        sampleCert.setUpdatedAt(LocalDateTime.of(2025, 1, 2, 0, 0));
+        sampleCert.setId(1L);
+        sampleCert.setGmtCreate(LocalDateTime.of(2024, 12, 1, 0, 0));
+        sampleCert.setGmtModified(LocalDateTime.of(2025, 1, 2, 0, 0));
     }
 
     @Test
@@ -90,7 +89,7 @@ class K8sCertServiceTest {
                 .type(CertType.mTLS)
                 .status(CertStatus.expiring)
                 .build();
-        secondCert.setId("cert-2");
+        secondCert.setId(2L);
 
         when(k8sCertRepository.findAll()).thenReturn(Arrays.asList(sampleCert, secondCert));
 
@@ -119,11 +118,11 @@ class K8sCertServiceTest {
         sampleCert.setNotAfter(now.minusDays(1));
         sampleCert.setStatus(CertStatus.valid);
         sampleCert.setDaysRemaining(180);
-        K8sCertVO expiresNowCert = copyWithExpiry("cert-expires-now", now,
+        K8sCertVO expiresNowCert = copyWithExpiry(3L, now,
                 CertStatus.valid, 180);
-        K8sCertVO expiringCert = copyWithExpiry("cert-expiring", now.plusDays(30),
+        K8sCertVO expiringCert = copyWithExpiry(4L, now.plusDays(30),
                 CertStatus.expired, -1);
-        K8sCertVO validCert = copyWithExpiry("cert-valid", now.plusDays(31),
+        K8sCertVO validCert = copyWithExpiry(5L, now.plusDays(31),
                 CertStatus.expired, -1);
         when(k8sCertRepository.findAll())
                 .thenReturn(List.of(sampleCert, expiresNowCert, expiringCert, validCert));
@@ -146,7 +145,6 @@ class K8sCertServiceTest {
     void createCertShouldCreateAndSaveCert() {
         CreateCertDTO command = CreateCertDTO.builder()
                 .name("new-tls-cert")
-                .namespace("default")
                 .cluster("test-cluster")
                 .type("TLS")
                 .issuer("vault")
@@ -156,7 +154,7 @@ class K8sCertServiceTest {
         when(k8sCertRepository.save(any(K8sCertVO.class))).thenAnswer(invocation -> {
             K8sCertVO cert = invocation.getArgument(0);
             if (cert.getId() == null) {
-                cert.setId("generated-id");
+                cert.setId(100L);
             }
             return cert;
         });
@@ -165,7 +163,6 @@ class K8sCertServiceTest {
         LocalDateTime now = LocalDateTime.now(CLOCK);
 
         assertThat(result.getName()).isEqualTo("new-tls-cert");
-        assertThat(result.getNamespace()).isEqualTo("default");
         assertThat(result.getCluster()).isEqualTo("test-cluster");
         assertThat(result.getType()).isEqualTo(CertType.TLS);
         assertThat(result.getIssuer()).isEqualTo("vault");
@@ -174,11 +171,11 @@ class K8sCertServiceTest {
         assertThat(result.getNotBefore()).isEqualTo(now);
         assertThat(result.getNotAfter()).isEqualTo(now.plusYears(1));
         assertThat(result.getDaysRemaining()).isEqualTo(365);
-        assertThat(result.getCreatedAt()).isEqualTo(now);
-        assertThat(result.getUpdatedAt()).isEqualTo(now);
+        assertThat(result.getGmtCreate()).isEqualTo(now);
+        assertThat(result.getGmtModified()).isEqualTo(now);
         verify(k8sCertRepository).save(any(K8sCertVO.class));
         verify(operationAuditService).record(eq("CREATE_K8S_CERTIFICATE"), eq("K8S_CERTIFICATE"),
-                eq(result.getId()), eq(null), eq("name=new-tls-cert, namespace=default, cluster=test-cluster"),
+                eq("100"), eq(null), eq("name=new-tls-cert, cluster=test-cluster"),
                 eq("SUCCESS"), eq(null));
     }
 
@@ -208,7 +205,6 @@ class K8sCertServiceTest {
     void createCertShouldSetCorrectValidityPeriod() {
         CreateCertDTO command = CreateCertDTO.builder()
                 .name("validity-test")
-                .namespace("default")
                 .cluster("test-cluster")
                 .type("TLS")
                 .issuer("test-issuer")
@@ -228,13 +224,12 @@ class K8sCertServiceTest {
 
     @Test
     void updateCertShouldUpdateFieldsWhenFound() {
-        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
         when(k8sCertRepository.save(any(K8sCertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         UpdateCertDTO command = UpdateCertDTO.builder()
-                .id("cert-1")
+                .id(1L)
                 .name("updated-name")
-                .namespace("new-namespace")
                 .cluster("new-cluster")
                 .type("mTLS")
                 .issuer("new-issuer")
@@ -244,21 +239,20 @@ class K8sCertServiceTest {
         K8sCertVO result = k8sCertService.updateCert(command);
 
         assertThat(result.getName()).isEqualTo("updated-name");
-        assertThat(result.getNamespace()).isEqualTo("new-namespace");
         assertThat(result.getCluster()).isEqualTo("new-cluster");
         assertThat(result.getType()).isEqualTo(CertType.mTLS);
         assertThat(result.getIssuer()).isEqualTo("new-issuer");
         assertThat(result.getSan()).containsExactly("new.example.com");
-        assertThat(result.getId()).isEqualTo("cert-1");
-        assertThat(result.getCreatedAt()).isEqualTo(LocalDateTime.of(2024, 12, 1, 0, 0));
-        assertThat(result.getUpdatedAt()).isEqualTo(LocalDateTime.now(CLOCK));
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getGmtCreate()).isEqualTo(LocalDateTime.of(2024, 12, 1, 0, 0));
+        assertThat(result.getGmtModified()).isEqualTo(LocalDateTime.now(CLOCK));
         assertThat(result).isNotSameAs(sampleCert);
         assertThat(sampleCert.getName()).isEqualTo("rocketmq-tls");
         assertThat(sampleCert.getType()).isEqualTo(CertType.TLS);
-        assertThat(sampleCert.getUpdatedAt()).isEqualTo(LocalDateTime.of(2025, 1, 2, 0, 0));
+        assertThat(sampleCert.getGmtModified()).isEqualTo(LocalDateTime.of(2025, 1, 2, 0, 0));
         verify(k8sCertRepository).save(any(K8sCertVO.class));
         verify(operationAuditService).record(eq("UPDATE_K8S_CERTIFICATE"), eq("K8S_CERTIFICATE"),
-                eq("cert-1"), eq(null), eq("name=updated-name, namespace=new-namespace, cluster=new-cluster"),
+                eq("1"), eq(null), eq("name=updated-name, cluster=new-cluster"),
                 eq("SUCCESS"), eq(null));
     }
 
@@ -268,10 +262,10 @@ class K8sCertServiceTest {
         sampleCert.setNotAfter(now.minusDays(1));
         sampleCert.setStatus(CertStatus.valid);
         sampleCert.setDaysRemaining(180);
-        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
         when(k8sCertRepository.save(any(K8sCertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
         UpdateCertDTO command = UpdateCertDTO.builder()
-                .id("cert-1")
+                .id(1L)
                 .name("updated-expired-cert")
                 .build();
 
@@ -286,18 +280,17 @@ class K8sCertServiceTest {
 
     @Test
     void updateCertShouldPreserveExistingFieldsWhenCommandFieldsAreNull() {
-        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
         when(k8sCertRepository.save(any(K8sCertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         UpdateCertDTO command = UpdateCertDTO.builder()
-                .id("cert-1")
+                .id(1L)
                 .name("only-name-changed")
                 .build();
 
         K8sCertVO result = k8sCertService.updateCert(command);
 
         assertThat(result.getName()).isEqualTo("only-name-changed");
-        assertThat(result.getNamespace()).isEqualTo("mq-system");
         assertThat(result.getCluster()).isEqualTo("prod-cluster");
         assertThat(result.getType()).isEqualTo(CertType.TLS);
         assertThat(result.getIssuer()).isEqualTo("letsencrypt");
@@ -305,15 +298,14 @@ class K8sCertServiceTest {
 
     @Test
     void updateCertShouldRejectBlankIdentityFields() {
-        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
         List<Map.Entry<String, Consumer<UpdateCertDTO>>> invalidUpdates = List.of(
                 Map.entry("name", command -> command.setName(" ")),
-                Map.entry("namespace", command -> command.setNamespace("\t")),
                 Map.entry("cluster", command -> command.setCluster("\n")),
                 Map.entry("issuer", command -> command.setIssuer("  ")));
 
         for (Map.Entry<String, Consumer<UpdateCertDTO>> invalidUpdate : invalidUpdates) {
-            UpdateCertDTO command = UpdateCertDTO.builder().id("cert-1").build();
+            UpdateCertDTO command = UpdateCertDTO.builder().id(1L).build();
             invalidUpdate.getValue().accept(command);
 
             assertThatThrownBy(() -> k8sCertService.updateCert(command))
@@ -327,25 +319,25 @@ class K8sCertServiceTest {
 
     @Test
     void updateCertShouldThrowWhenNotFound() {
-        when(k8sCertRepository.findById("nonexistent")).thenReturn(Optional.empty());
+        when(k8sCertRepository.findById(999L)).thenReturn(Optional.empty());
 
         UpdateCertDTO command = UpdateCertDTO.builder()
-                .id("nonexistent")
+                .id(999L)
                 .name("wont-work")
                 .build();
 
         assertThatThrownBy(() -> k8sCertService.updateCert(command))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("Certificate not found: nonexistent")
+                .hasMessageContaining("Certificate not found: 999")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
     }
 
     @Test
     void updateCertShouldNotMutateStoredCertWhenSaveFails() {
-        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
         when(k8sCertRepository.save(any(K8sCertVO.class))).thenThrow(new IllegalStateException("save failed"));
         UpdateCertDTO command = UpdateCertDTO.builder()
-                .id("cert-1")
+                .id(1L)
                 .name("should-not-persist")
                 .type("mTLS")
                 .build();
@@ -356,7 +348,7 @@ class K8sCertServiceTest {
 
         assertThat(sampleCert.getName()).isEqualTo("rocketmq-tls");
         assertThat(sampleCert.getType()).isEqualTo(CertType.TLS);
-        assertThat(sampleCert.getUpdatedAt()).isEqualTo(LocalDateTime.of(2025, 1, 2, 0, 0));
+        assertThat(sampleCert.getGmtModified()).isEqualTo(LocalDateTime.of(2025, 1, 2, 0, 0));
     }
 
     @Test
@@ -366,10 +358,10 @@ class K8sCertServiceTest {
         LocalDateTime originalNotBefore = sampleCert.getNotBefore();
         LocalDateTime originalNotAfter = sampleCert.getNotAfter();
 
-        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
         when(k8sCertRepository.save(any(K8sCertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        RenewCertDTO command = RenewCertDTO.builder().id("cert-1").build();
+        RenewCertDTO command = RenewCertDTO.builder().id(1L).build();
 
         K8sCertVO result = k8sCertService.renewCert(command);
         LocalDateTime now = LocalDateTime.now(CLOCK);
@@ -378,9 +370,9 @@ class K8sCertServiceTest {
         assertThat(result.getDaysRemaining()).isEqualTo(365);
         assertThat(result.getNotBefore()).isEqualTo(now);
         assertThat(result.getNotAfter()).isEqualTo(now.plusYears(1));
-        assertThat(result.getUpdatedAt()).isEqualTo(now);
-        assertThat(result.getId()).isEqualTo("cert-1");
-        assertThat(result.getCreatedAt()).isEqualTo(sampleCert.getCreatedAt());
+        assertThat(result.getGmtModified()).isEqualTo(now);
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getGmtCreate()).isEqualTo(sampleCert.getGmtCreate());
         assertThat(result).isNotSameAs(sampleCert);
         assertThat(sampleCert.getStatus()).isEqualTo(CertStatus.expired);
         assertThat(sampleCert.getDaysRemaining()).isZero();
@@ -388,7 +380,7 @@ class K8sCertServiceTest {
         assertThat(sampleCert.getNotAfter()).isEqualTo(originalNotAfter);
         verify(k8sCertRepository).save(any(K8sCertVO.class));
         verify(operationAuditService).record(eq("RENEW_K8S_CERTIFICATE"), eq("K8S_CERTIFICATE"),
-                eq("cert-1"), eq(null), eq("name=rocketmq-tls, namespace=mq-system, cluster=prod-cluster"),
+                eq("1"), eq(null), eq("name=rocketmq-tls, cluster=prod-cluster"),
                 eq("SUCCESS"), eq(null));
     }
 
@@ -399,10 +391,10 @@ class K8sCertServiceTest {
         LocalDateTime originalNotBefore = sampleCert.getNotBefore();
         LocalDateTime originalNotAfter = sampleCert.getNotAfter();
 
-        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
         when(k8sCertRepository.save(any(K8sCertVO.class))).thenThrow(new IllegalStateException("save failed"));
 
-        RenewCertDTO command = RenewCertDTO.builder().id("cert-1").build();
+        RenewCertDTO command = RenewCertDTO.builder().id(1L).build();
 
         assertThatThrownBy(() -> k8sCertService.renewCert(command))
                 .isInstanceOf(IllegalStateException.class)
@@ -412,64 +404,63 @@ class K8sCertServiceTest {
         assertThat(sampleCert.getDaysRemaining()).isZero();
         assertThat(sampleCert.getNotBefore()).isEqualTo(originalNotBefore);
         assertThat(sampleCert.getNotAfter()).isEqualTo(originalNotAfter);
-        assertThat(sampleCert.getUpdatedAt()).isEqualTo(LocalDateTime.of(2025, 1, 2, 0, 0));
+        assertThat(sampleCert.getGmtModified()).isEqualTo(LocalDateTime.of(2025, 1, 2, 0, 0));
     }
 
     @Test
     void renewCertShouldThrowWhenNotFound() {
-        when(k8sCertRepository.findById("nonexistent")).thenReturn(Optional.empty());
+        when(k8sCertRepository.findById(999L)).thenReturn(Optional.empty());
 
-        RenewCertDTO command = RenewCertDTO.builder().id("nonexistent").build();
+        RenewCertDTO command = RenewCertDTO.builder().id(999L).build();
 
         assertThatThrownBy(() -> k8sCertService.renewCert(command))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("Certificate not found: nonexistent");
+                .hasMessageContaining("Certificate not found: 999");
     }
 
     @Test
     void deleteCertShouldDeleteWhenFound() {
-        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
-        when(k8sCertRepository.deleteById("cert-1")).thenReturn(true);
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.deleteById(1L)).thenReturn(true);
 
-        DeleteCertDTO command = DeleteCertDTO.builder().id("cert-1").build();
+        DeleteCertDTO command = DeleteCertDTO.builder().id(1L).build();
 
         k8sCertService.deleteCert(command);
 
-        verify(k8sCertRepository).deleteById("cert-1");
+        verify(k8sCertRepository).deleteById(1L);
         verify(operationAuditService).record(eq("DELETE_K8S_CERTIFICATE"), eq("K8S_CERTIFICATE"),
-                eq("cert-1"), eq(null), eq(null), eq("SUCCESS"), eq(null));
+                eq("1"), eq(null), eq(null), eq("SUCCESS"), eq(null));
     }
 
     @Test
     void deleteCertShouldRejectConcurrentRemoval() {
-        when(k8sCertRepository.findById("cert-1")).thenReturn(Optional.of(sampleCert));
-        when(k8sCertRepository.deleteById("cert-1")).thenReturn(false);
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.deleteById(1L)).thenReturn(false);
 
-        DeleteCertDTO command = DeleteCertDTO.builder().id("cert-1").build();
+        DeleteCertDTO command = DeleteCertDTO.builder().id(1L).build();
 
         assertThatThrownBy(() -> k8sCertService.deleteCert(command))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("Certificate not found: cert-1")
+                .hasMessage("Certificate not found: 1")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
         verifyNoInteractions(operationAuditService);
     }
 
     @Test
     void deleteCertShouldThrowWhenNotFound() {
-        when(k8sCertRepository.findById("nonexistent")).thenReturn(Optional.empty());
+        when(k8sCertRepository.findById(999L)).thenReturn(Optional.empty());
 
-        DeleteCertDTO command = DeleteCertDTO.builder().id("nonexistent").build();
+        DeleteCertDTO command = DeleteCertDTO.builder().id(999L).build();
 
         assertThatThrownBy(() -> k8sCertService.deleteCert(command))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("Certificate not found: nonexistent");
+                .hasMessageContaining("Certificate not found: 999");
     }
 
-    private K8sCertVO copyWithExpiry(String id, LocalDateTime notAfter, CertStatus status,
+    private K8sCertVO copyWithExpiry(Long id, LocalDateTime notAfter, CertStatus status,
                                      int daysRemaining) {
         K8sCertVO cert = K8sCertVO.builder()
                 .name(sampleCert.getName())
-                .namespace(sampleCert.getNamespace())
                 .cluster(sampleCert.getCluster())
                 .type(sampleCert.getType())
                 .issuer(sampleCert.getIssuer())
@@ -480,8 +471,8 @@ class K8sCertServiceTest {
                 .san(sampleCert.getSan())
                 .build();
         cert.setId(id);
-        cert.setCreatedAt(sampleCert.getCreatedAt());
-        cert.setUpdatedAt(sampleCert.getUpdatedAt());
+        cert.setGmtCreate(sampleCert.getGmtCreate());
+        cert.setGmtModified(sampleCert.getGmtModified());
         return cert;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
@@ -36,9 +36,9 @@ class MybatisPlusK8sCertRepositoryTest {
         RmqK8sCertificate entity = certificate();
         entity.setCertType(" mtls ");
         entity.setStatus(" EXPIRING ");
-        when(mapper.selectById("cert-1")).thenReturn(entity);
+        when(mapper.selectById(1L)).thenReturn(entity);
 
-        assertThat(repository(mapper).findById("cert-1")).get()
+        assertThat(repository(mapper).findById(1L)).get()
                 .satisfies(cert -> {
                     assertThat(cert.getType()).isEqualTo(
                             org.apache.rocketmq.studio.common.domain.enums.CertType.mTLS);
@@ -50,14 +50,14 @@ class MybatisPlusK8sCertRepositoryTest {
     @Test
     void saveShouldReportALostConcurrentUpdate() {
         RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
-        when(mapper.selectById("cert-1")).thenReturn(certificate());
+        when(mapper.selectById(1L)).thenReturn(certificate());
         when(mapper.updateById(any(RmqK8sCertificate.class))).thenReturn(0);
         K8sCertVO cert = K8sCertVO.builder().name("broker").build();
-        cert.setId("cert-1");
+        cert.setId(1L);
 
         assertThatThrownBy(() -> repository(mapper).save(cert))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("Certificate update was not applied: cert-1")
+                .hasMessage("Certificate update was not applied: 1")
                 .satisfies(error -> org.assertj.core.api.Assertions.assertThat(
                         ((BusinessException) error).getCode()).isEqualTo(409));
     }
@@ -65,13 +65,13 @@ class MybatisPlusK8sCertRepositoryTest {
     @Test
     void deleteByIdShouldReportWhetherARowWasRemoved() {
         RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
-        when(mapper.deleteById("deleted")).thenReturn(1);
-        when(mapper.deleteById("missing")).thenReturn(0);
+        when(mapper.deleteById(1L)).thenReturn(1);
+        when(mapper.deleteById(2L)).thenReturn(0);
 
         MybatisPlusK8sCertRepository repository = repository(mapper);
 
-        assertThat(repository.deleteById("deleted")).isTrue();
-        assertThat(repository.deleteById("missing")).isFalse();
+        assertThat(repository.deleteById(1L)).isTrue();
+        assertThat(repository.deleteById(2L)).isFalse();
     }
 
     @Test
@@ -79,9 +79,9 @@ class MybatisPlusK8sCertRepositoryTest {
         RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
         RmqK8sCertificate entity = certificate();
         entity.setCertType("UNKNOWN_TYPE");
-        when(mapper.selectById("cert-1")).thenReturn(entity);
+        when(mapper.selectById(1L)).thenReturn(entity);
 
-        assertThatThrownBy(() -> repository(mapper).findById("cert-1"))
+        assertThatThrownBy(() -> repository(mapper).findById(1L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("certificate type");
     }
@@ -91,9 +91,9 @@ class MybatisPlusK8sCertRepositoryTest {
         RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
         RmqK8sCertificate entity = certificate();
         entity.setSan("not-json");
-        when(mapper.selectById("cert-1")).thenReturn(entity);
+        when(mapper.selectById(1L)).thenReturn(entity);
 
-        assertThatThrownBy(() -> repository(mapper).findById("cert-1"))
+        assertThatThrownBy(() -> repository(mapper).findById(1L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("SAN JSON");
     }
@@ -103,9 +103,9 @@ class MybatisPlusK8sCertRepositoryTest {
         RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
         RmqK8sCertificate entity = certificate();
         entity.setSan("null");
-        when(mapper.selectById("cert-1")).thenReturn(entity);
+        when(mapper.selectById(1L)).thenReturn(entity);
 
-        assertThatThrownBy(() -> repository(mapper).findById("cert-1"))
+        assertThatThrownBy(() -> repository(mapper).findById(1L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("SAN JSON");
     }
@@ -115,9 +115,9 @@ class MybatisPlusK8sCertRepositoryTest {
         RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
         RmqK8sCertificate entity = certificate();
         entity.setStatus("unknown");
-        when(mapper.selectById("cert-1")).thenReturn(entity);
+        when(mapper.selectById(1L)).thenReturn(entity);
 
-        assertThatThrownBy(() -> repository(mapper).findById("cert-1"))
+        assertThatThrownBy(() -> repository(mapper).findById(1L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("certificate status");
     }
@@ -128,7 +128,7 @@ class MybatisPlusK8sCertRepositoryTest {
 
     private RmqK8sCertificate certificate() {
         RmqK8sCertificate entity = new RmqK8sCertificate();
-        entity.setId("cert-1");
+        entity.setId(1L);
         entity.setCertType("TLS");
         entity.setStatus("valid");
         entity.setSan("[\"broker.example\"]");

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
@@ -60,7 +60,7 @@ class InstanceControllerTest {
 
     @Test
     void listInstancesShouldReturnAllInstances() throws Exception {
-        InstanceVO inst = buildInstance("inst-1", "production-proxy", InstanceType.PROXY, "10.0.1.1:8080");
+        InstanceVO inst = buildInstance(1L, "production-proxy", InstanceType.PROXY, "10.0.1.1:8080");
 
         when(instanceService.listInstances(isNull(), isNull())).thenReturn(List.of(inst));
 
@@ -68,7 +68,7 @@ class InstanceControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data[0].id").value("inst-1"))
+                .andExpect(jsonPath("$.data[0].id").value(1))
                 .andExpect(jsonPath("$.data[0].name").value("production-proxy"))
                 .andExpect(jsonPath("$.data[0].type").value("PROXY"))
                 .andExpect(jsonPath("$.data[0].endpoint").value("10.0.1.1:8080"));
@@ -76,7 +76,7 @@ class InstanceControllerTest {
 
     @Test
     void listInstancesShouldFilterByType() throws Exception {
-        InstanceVO inst = buildInstance("inst-1", "proxy-1", InstanceType.PROXY, "10.0.1.1:8080");
+        InstanceVO inst = buildInstance(1L, "proxy-1", InstanceType.PROXY, "10.0.1.1:8080");
 
         when(instanceService.listInstances(eq(InstanceType.PROXY), isNull())).thenReturn(List.of(inst));
 
@@ -91,7 +91,7 @@ class InstanceControllerTest {
 
     @Test
     void listInstancesShouldFilterBySearch() throws Exception {
-        InstanceVO inst = buildInstance("inst-1", "production", InstanceType.PROXY, "10.0.1.1:8080");
+        InstanceVO inst = buildInstance(1L, "production", InstanceType.PROXY, "10.0.1.1:8080");
 
         when(instanceService.listInstances(isNull(), eq("prod"))).thenReturn(List.of(inst));
 
@@ -118,9 +118,9 @@ class InstanceControllerTest {
                 .topicCount(0)
                 .consumerGroupCount(0)
                 .build();
-        created.setId("new-id");
-        created.setCreatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
-        created.setUpdatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+        created.setId(2L);
+        created.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
+        created.setGmtModified(LocalDateTime.of(2026, 1, 1, 0, 0));
 
         when(instanceService.createInstance(any(InstanceVO.class))).thenReturn(created);
 
@@ -129,7 +129,7 @@ class InstanceControllerTest {
                         .content(objectMapper.writeValueAsString(input)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.id").value("new-id"))
+                .andExpect(jsonPath("$.data.id").value(2))
                 .andExpect(jsonPath("$.data.name").value("new-instance"))
                 .andExpect(jsonPath("$.data.endpoint").value("10.0.2.1:8080"))
                 .andExpect(jsonPath("$.data.type").value("DIRECT"));
@@ -152,16 +152,16 @@ class InstanceControllerTest {
         InstanceVO update = InstanceVO.builder()
                 .name("updated-name")
                 .build();
-        update.setId("inst-1");
+        update.setId(1L);
 
         InstanceVO updated = InstanceVO.builder()
                 .name("updated-name")
                 .endpoint("10.0.1.1:8080")
                 .type(InstanceType.PROXY)
                 .build();
-        updated.setId("inst-1");
-        updated.setCreatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
-        updated.setUpdatedAt(LocalDateTime.of(2026, 7, 8, 12, 0));
+        updated.setId(1L);
+        updated.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
+        updated.setGmtModified(LocalDateTime.of(2026, 7, 8, 12, 0));
 
         when(instanceService.updateInstance(any(InstanceVO.class))).thenReturn(updated);
 
@@ -170,7 +170,7 @@ class InstanceControllerTest {
                         .content(objectMapper.writeValueAsString(update)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.id").value("inst-1"))
+                .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.name").value("updated-name"));
     }
 
@@ -188,9 +188,9 @@ class InstanceControllerTest {
 
     @Test
     void deleteInstanceShouldReturnSuccess() throws Exception {
-        doNothing().when(instanceService).deleteInstance("inst-1");
+        doNothing().when(instanceService).deleteInstance(1L);
 
-        Map<String, String> body = Map.of("id", "inst-1");
+        Map<String, String> body = Map.of("id", "1");
 
         mockMvc.perform(post("/api/instances/delete")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -199,24 +199,24 @@ class InstanceControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success"));
 
-        verify(instanceService).deleteInstance("inst-1");
+        verify(instanceService).deleteInstance(1L);
     }
 
     @Test
     void deleteInstanceShouldReturnConflictWhenManagedResourcesExist() throws Exception {
         doThrow(new BusinessException(409,
                 "Cannot delete instance with managed resources: topics=2, consumerGroups=1"))
-                .when(instanceService).deleteInstance("inst-1");
+                .when(instanceService).deleteInstance(1L);
 
         mockMvc.perform(post("/api/instances/delete")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("id", "inst-1"))))
+                        .content(objectMapper.writeValueAsString(Map.of("id", "1"))))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value(409))
                 .andExpect(jsonPath("$.message")
                         .value("Cannot delete instance with managed resources: topics=2, consumerGroups=1"));
 
-        verify(instanceService).deleteInstance("inst-1");
+        verify(instanceService).deleteInstance(1L);
     }
 
     @Test
@@ -243,7 +243,7 @@ class InstanceControllerTest {
         verifyNoInteractions(instanceService);
     }
 
-    private InstanceVO buildInstance(String id, String name, InstanceType type, String endpoint) {
+    private InstanceVO buildInstance(Long id, String name, InstanceType type, String endpoint) {
         InstanceVO instance = InstanceVO.builder()
                 .name(name)
                 .type(type)
@@ -252,8 +252,8 @@ class InstanceControllerTest {
                 .consumerGroupCount(5)
                 .build();
         instance.setId(id);
-        instance.setCreatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
-        instance.setUpdatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+        instance.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
+        instance.setGmtModified(LocalDateTime.of(2026, 1, 1, 0, 0));
         return instance;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -92,11 +92,11 @@ class InstanceServiceTest {
     @Test
     void listInstancesMarksCloudCountsUnavailableWhenProviderFails() {
         InstanceVO instance = InstanceVO.builder().vendor(InstanceVendor.ALIYUN).build();
-        instance.setId("cloud-1");
+        instance.setId(1L);
         InstanceProvider provider = org.mockito.Mockito.mock(InstanceProvider.class);
         when(instanceRepository.findAll()).thenReturn(List.of(instance));
         when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(provider);
-        when(provider.countTopics("cloud-1")).thenThrow(new IllegalStateException("access denied"));
+        when(provider.countTopics("1")).thenThrow(new IllegalStateException("access denied"));
 
         InstanceVO result = instanceService.listInstances(null, null).get(0);
 
@@ -106,12 +106,12 @@ class InstanceServiceTest {
     @Test
     void listInstancesKeepsCloudCountsAvailableWhenProviderReturnsEmptyLists() {
         InstanceVO instance = InstanceVO.builder().vendor(InstanceVendor.ALIYUN).build();
-        instance.setId("cloud-1");
+        instance.setId(2L);
         InstanceProvider provider = org.mockito.Mockito.mock(InstanceProvider.class);
         when(instanceRepository.findAll()).thenReturn(List.of(instance));
         when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(provider);
-        when(provider.countTopics("cloud-1")).thenReturn(0);
-        when(provider.countGroups("cloud-1")).thenReturn(0);
+        when(provider.countTopics("2")).thenReturn(0);
+        when(provider.countGroups("2")).thenReturn(0);
 
         InstanceVO result = instanceService.listInstances(null, null).get(0);
 
@@ -205,17 +205,17 @@ class InstanceServiceTest {
     @Test
     void listInstancesShouldFillCountsThroughVendorProviderTest() {
         InstanceVO apache = InstanceVO.builder().name("apache").build();
-        apache.setId("inst-apache");
+        apache.setId(3L);
         InstanceVO aliyun = InstanceVO.builder().name("aliyun").vendor(InstanceVendor.ALIYUN).build();
-        aliyun.setId("inst-aliyun");
+        aliyun.setId(4L);
         InstanceProvider aliyunProvider = org.mockito.Mockito.mock(InstanceProvider.class);
         when(instanceRepository.findAll()).thenReturn(List.of(apache, aliyun));
         when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
         when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(aliyunProvider);
-        when(instanceProvider.countTopics("inst-apache")).thenReturn(3);
-        when(instanceProvider.countGroups("inst-apache")).thenReturn(2);
-        when(aliyunProvider.countTopics("inst-aliyun")).thenReturn(5);
-        when(aliyunProvider.countGroups("inst-aliyun")).thenReturn(4);
+        when(instanceProvider.countTopics("3")).thenReturn(3);
+        when(instanceProvider.countGroups("3")).thenReturn(2);
+        when(aliyunProvider.countTopics("4")).thenReturn(5);
+        when(aliyunProvider.countGroups("4")).thenReturn(4);
 
         List<InstanceVO> result = instanceService.listInstances(null, null);
 
@@ -228,10 +228,10 @@ class InstanceServiceTest {
     @Test
     void listInstancesShouldKeepZeroCountsWhenProviderFailsTest() {
         InstanceVO instance = InstanceVO.builder().name("broken").build();
-        instance.setId("inst-broken");
+        instance.setId(5L);
         when(instanceRepository.findAll()).thenReturn(List.of(instance));
         when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
-        when(instanceProvider.countTopics("inst-broken"))
+        when(instanceProvider.countTopics("5"))
                 .thenThrow(new IllegalStateException("admin unavailable"));
 
         List<InstanceVO> result = instanceService.listInstances(null, null);
@@ -258,16 +258,22 @@ class InstanceServiceTest {
                 .type(InstanceType.PROXY)
                 .build();
 
-        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> {
+            InstanceVO saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(1L);
+            }
+            return saved;
+        });
 
         InstanceVO result = instanceService.createInstance(input);
 
-        assertThat(result.getId()).isEqualTo("new-instance");
-        assertThat(result.getCreatedAt()).isNotNull();
-        assertThat(result.getUpdatedAt()).isNotNull();
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getGmtCreate()).isNotNull();
+        assertThat(result.getGmtModified()).isNotNull();
         assertThat(result.getName()).isEqualTo("new-instance");
         verify(instanceRepository).save(any(InstanceVO.class));
-        verify(operationAuditService).record(eq("CREATE_INSTANCE"), eq("INSTANCE"), eq(result.getId()), eq(null),
+        verify(operationAuditService).record(eq("CREATE_INSTANCE"), eq("INSTANCE"), eq("1"), eq(null),
                 argThat(detail -> detail.equals("name=new-instance, vendor=APACHE, type=PROXY")
                         && !detail.contains("10.0.1.1:8080")),
                 eq("SUCCESS"), eq(null));
@@ -363,10 +369,10 @@ class InstanceServiceTest {
     void updateApacheInstanceShouldReleaseCachedClientWhenCredentialReferenceChanges() {
         InstanceVO existing = InstanceVO.builder().name("production").type(InstanceType.PROXY)
                 .endpoint("namesrv:9876").adminCredentialRef("credential-a").build();
-        existing.setId("inst-1");
+        existing.setId(1L);
         InstanceVO update = InstanceVO.builder().adminCredentialRef("credential-b").build();
-        update.setId("inst-1");
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        update.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         InstanceVO saved = instanceService.updateInstance(update);
@@ -387,17 +393,17 @@ class InstanceServiceTest {
                 .topicCount(7)
                 .consumerGroupCount(3)
                 .build();
-        existing.setId("inst-1");
-        existing.setCreatedAt(originalCreatedAt);
-        existing.setUpdatedAt(originalUpdatedAt);
+        existing.setId(1L);
+        existing.setGmtCreate(originalCreatedAt);
+        existing.setGmtModified(originalUpdatedAt);
 
         InstanceVO update = InstanceVO.builder()
                 .name("old-name")
                 .remark("new remark")
                 .build();
-        update.setId("inst-1");
+        update.setId(1L);
 
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(inv -> inv.getArgument(0));
 
         InstanceVO result = instanceService.updateInstance(update);
@@ -408,24 +414,24 @@ class InstanceServiceTest {
         assertThat(result.getRemark()).isEqualTo("new remark");
         assertThat(result.getTopicCount()).isEqualTo(7);
         assertThat(result.getConsumerGroupCount()).isEqualTo(3);
-        assertThat(result.getId()).isEqualTo("inst-1");
-        assertThat(result.getCreatedAt()).isEqualTo(originalCreatedAt);
-        assertThat(result.getUpdatedAt()).isAfter(originalUpdatedAt);
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getGmtCreate()).isEqualTo(originalCreatedAt);
+        assertThat(result.getGmtModified()).isAfter(originalUpdatedAt);
         assertThat(result).isNotSameAs(existing);
         assertThat(existing.getName()).isEqualTo("old-name");
         assertThat(existing.getRemark()).isEqualTo("old remark");
-        assertThat(existing.getUpdatedAt()).isEqualTo(originalUpdatedAt);
-        verify(operationAuditService).record(eq("UPDATE_INSTANCE"), eq("INSTANCE"), eq("inst-1"), eq(null),
+        assertThat(existing.getGmtModified()).isEqualTo(originalUpdatedAt);
+        verify(operationAuditService).record(eq("UPDATE_INSTANCE"), eq("INSTANCE"), eq("1"), eq(null),
                 eq("name=old-name, vendor=APACHE, type=PROXY"), eq("SUCCESS"), eq(null));
     }
 
     @Test
     void updateInstanceShouldRejectInstanceIdChangeTest() {
         InstanceVO existing = InstanceVO.builder().name("old-name").endpoint("namesrv:9876").build();
-        existing.setId("old-name");
+        existing.setId(1L);
         InstanceVO update = InstanceVO.builder().name("new-name").build();
-        update.setId("old-name");
-        when(instanceRepository.findById("old-name")).thenReturn(Optional.of(existing));
+        update.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
 
         assertThatThrownBy(() -> instanceService.updateInstance(update))
                 .isInstanceOf(BusinessException.class)
@@ -445,9 +451,9 @@ class InstanceServiceTest {
                 .topicCount(7)
                 .consumerGroupCount(3)
                 .build();
-        stored.setId("inst-1");
-        stored.setCreatedAt(originalCreatedAt);
-        stored.setUpdatedAt(originalUpdatedAt);
+        stored.setId(1L);
+        stored.setGmtCreate(originalCreatedAt);
+        stored.setGmtModified(originalUpdatedAt);
 
         InstanceVO update = InstanceVO.builder()
                 .name("old-name")
@@ -455,9 +461,9 @@ class InstanceServiceTest {
                 .type(InstanceType.DIRECT)
                 .endpoint("10.0.2.2:10911")
                 .build();
-        update.setId("inst-1");
+        update.setId(1L);
 
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(stored));
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(stored));
         when(instanceRepository.save(any(InstanceVO.class)))
                 .thenThrow(new IllegalStateException("storage unavailable"));
 
@@ -471,9 +477,9 @@ class InstanceServiceTest {
         assertThat(stored.getEndpoint()).isEqualTo("10.0.1.1:8080");
         assertThat(stored.getTopicCount()).isEqualTo(7);
         assertThat(stored.getConsumerGroupCount()).isEqualTo(3);
-        assertThat(stored.getId()).isEqualTo("inst-1");
-        assertThat(stored.getCreatedAt()).isEqualTo(originalCreatedAt);
-        assertThat(stored.getUpdatedAt()).isEqualTo(originalUpdatedAt);
+        assertThat(stored.getId()).isEqualTo(1L);
+        assertThat(stored.getGmtCreate()).isEqualTo(originalCreatedAt);
+        assertThat(stored.getGmtModified()).isEqualTo(originalUpdatedAt);
     }
 
     @Test
@@ -482,11 +488,11 @@ class InstanceServiceTest {
                 .name("instance")
                 .endpoint("old-namesrv:9876")
                 .build();
-        existing.setId("inst-1");
+        existing.setId(1L);
         InstanceVO update = InstanceVO.builder().endpoint("new-namesrv:9876").build();
-        update.setId("inst-1");
+        update.setId(1L);
 
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(instanceRepository.findAll()).thenReturn(List.of());
 
@@ -501,16 +507,16 @@ class InstanceServiceTest {
                 .name("instance")
                 .endpoint("shared-namesrv:9876")
                 .build();
-        existing.setId("inst-1");
+        existing.setId(1L);
         InstanceVO shared = InstanceVO.builder()
                 .name("shared-instance")
                 .endpoint(" shared-namesrv:9876 ")
                 .build();
-        shared.setId("inst-2");
+        shared.setId(2L);
         InstanceVO update = InstanceVO.builder().endpoint("new-namesrv:9876").build();
-        update.setId("inst-1");
+        update.setId(1L);
 
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(instanceRepository.findAll()).thenReturn(List.of(shared));
 
@@ -525,16 +531,16 @@ class InstanceServiceTest {
                 .name("instance")
                 .endpoint("namesrv-b:9876;namesrv-a:9876")
                 .build();
-        existing.setId("inst-1");
+        existing.setId(1L);
         InstanceVO shared = InstanceVO.builder()
                 .name("shared-instance")
                 .endpoint(" namesrv-a:9876, namesrv-b:9876 ")
                 .build();
-        shared.setId("inst-2");
+        shared.setId(2L);
         InstanceVO update = InstanceVO.builder().endpoint("new-namesrv:9876").build();
-        update.setId("inst-1");
+        update.setId(1L);
 
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(instanceRepository.findAll()).thenReturn(List.of(shared));
 
@@ -566,7 +572,7 @@ class InstanceServiceTest {
     @Test
     void updateInstanceShouldThrowWhenIdIsBlank() {
         InstanceVO input = InstanceVO.builder().name("test").build();
-        input.setId("  ");
+        input.setId(null);
 
         assertThatThrownBy(() -> instanceService.updateInstance(input))
                 .isInstanceOf(BusinessException.class)
@@ -576,13 +582,13 @@ class InstanceServiceTest {
     @Test
     void updateInstanceShouldThrowWhenInstanceNotFound() {
         InstanceVO input = InstanceVO.builder().name("test").build();
-        input.setId("nonexistent");
+        input.setId(999L);
 
-        when(instanceRepository.findById("nonexistent")).thenReturn(Optional.empty());
+        when(instanceRepository.findById(999L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> instanceService.updateInstance(input))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("InstanceVO not found: nonexistent");
+                .hasMessage("InstanceVO not found: 999");
     }
 
     @Test
@@ -591,11 +597,11 @@ class InstanceServiceTest {
                 .name("existing-name")
                 .endpoint("10.0.1.1:8080")
                 .build();
-        existing.setId("inst-1");
+        existing.setId(1L);
         InstanceVO update = InstanceVO.builder().name("   ").build();
-        update.setId("inst-1");
+        update.setId(1L);
 
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
 
         assertThatThrownBy(() -> instanceService.updateInstance(update))
                 .isInstanceOf(BusinessException.class)
@@ -611,14 +617,14 @@ class InstanceServiceTest {
                 .name("existing-name")
                 .endpoint("10.0.1.1:8080")
                 .build();
-        existing.setId("inst-1");
+        existing.setId(1L);
         InstanceVO update = InstanceVO.builder()
                 .name("existing-name")
                 .endpoint("   ")
                 .build();
-        update.setId("inst-1");
+        update.setId(1L);
 
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
 
         assertThatThrownBy(() -> instanceService.updateInstance(update))
                 .isInstanceOf(BusinessException.class)
@@ -632,10 +638,10 @@ class InstanceServiceTest {
     @Test
     void updateInstanceShouldRejectEndpointWithEmptyAddressSegment() {
         InstanceVO existing = InstanceVO.builder().name("instance").endpoint("namesrv:9876").build();
-        existing.setId("inst-1");
+        existing.setId(1L);
         InstanceVO update = InstanceVO.builder().endpoint("; ;").build();
-        update.setId("inst-1");
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        update.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
 
         assertThatThrownBy(() -> instanceService.updateInstance(update))
                 .isInstanceOf(BusinessException.class)
@@ -646,18 +652,18 @@ class InstanceServiceTest {
     @Test
     void deleteInstanceShouldRemoveExistingInstance() {
         InstanceVO existing = InstanceVO.builder().name("to-delete").build();
-        existing.setId("inst-1");
+        existing.setId(1L);
 
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
-        when(instanceProvider.countTopics("inst-1")).thenReturn(0);
-        when(instanceProvider.countGroups("inst-1")).thenReturn(0);
-        when(instanceRepository.deleteById("inst-1")).thenReturn(true);
+        when(instanceProvider.countTopics("1")).thenReturn(0);
+        when(instanceProvider.countGroups("1")).thenReturn(0);
+        when(instanceRepository.deleteById(1L)).thenReturn(true);
 
-        instanceService.deleteInstance("inst-1");
+        instanceService.deleteInstance(1L);
 
-        verify(instanceRepository).deleteById("inst-1");
-        verify(operationAuditService).record(eq("DELETE_INSTANCE"), eq("INSTANCE"), eq("inst-1"), eq(null),
+        verify(instanceRepository).deleteById(1L);
+        verify(operationAuditService).record(eq("DELETE_INSTANCE"), eq("INSTANCE"), eq("1"), eq(null),
                 eq("name=to-delete, vendor=APACHE, type=null"), eq("SUCCESS"), eq(null));
     }
 
@@ -667,18 +673,18 @@ class InstanceServiceTest {
                 .name("with-topics")
                 .topicCount(0)
                 .build();
-        existing.setId("inst-1");
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        existing.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
-        when(instanceProvider.countTopics("inst-1")).thenReturn(2);
-        when(instanceProvider.countGroups("inst-1")).thenReturn(0);
+        when(instanceProvider.countTopics("1")).thenReturn(2);
+        when(instanceProvider.countGroups("1")).thenReturn(0);
 
-        assertThatThrownBy(() -> instanceService.deleteInstance("inst-1"))
+        assertThatThrownBy(() -> instanceService.deleteInstance(1L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Cannot delete instance with managed resources: topics=2, consumerGroups=0")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(409));
 
-        verify(instanceRepository, never()).deleteById("inst-1");
+        verify(instanceRepository, never()).deleteById(1L);
     }
 
     @Test
@@ -687,18 +693,18 @@ class InstanceServiceTest {
                 .name("with-consumer-groups")
                 .consumerGroupCount(0)
                 .build();
-        existing.setId("inst-1");
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        existing.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
-        when(instanceProvider.countTopics("inst-1")).thenReturn(0);
-        when(instanceProvider.countGroups("inst-1")).thenReturn(3);
+        when(instanceProvider.countTopics("1")).thenReturn(0);
+        when(instanceProvider.countGroups("1")).thenReturn(3);
 
-        assertThatThrownBy(() -> instanceService.deleteInstance("inst-1"))
+        assertThatThrownBy(() -> instanceService.deleteInstance(1L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Cannot delete instance with managed resources: topics=0, consumerGroups=3")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(409));
 
-        verify(instanceRepository, never()).deleteById("inst-1");
+        verify(instanceRepository, never()).deleteById(1L);
     }
 
     @Test
@@ -707,15 +713,15 @@ class InstanceServiceTest {
                 .name("to-delete")
                 .endpoint("namesrv:9876")
                 .build();
-        existing.setId("inst-1");
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        existing.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(instanceRepository.findAll()).thenReturn(List.of());
         when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
-        when(instanceRepository.deleteById("inst-1")).thenReturn(true);
+        when(instanceRepository.deleteById(1L)).thenReturn(true);
 
-        instanceService.deleteInstance("inst-1");
+        instanceService.deleteInstance(1L);
 
-        verify(instanceRepository).deleteById("inst-1");
+        verify(instanceRepository).deleteById(1L);
         verify(adminFactory).release("namesrv:9876");
     }
 
@@ -725,14 +731,14 @@ class InstanceServiceTest {
                 .name("concurrently-removed")
                 .endpoint("namesrv:9876")
                 .build();
-        existing.setId("inst-1");
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        existing.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
-        when(instanceRepository.deleteById("inst-1")).thenReturn(false);
+        when(instanceRepository.deleteById(1L)).thenReturn(false);
 
-        assertThatThrownBy(() -> instanceService.deleteInstance("inst-1"))
+        assertThatThrownBy(() -> instanceService.deleteInstance(1L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("InstanceVO not found: inst-1")
+                .hasMessage("InstanceVO not found: 1")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
 
         verify(adminFactory, never()).release(any());
@@ -748,18 +754,18 @@ class InstanceServiceTest {
 
     @Test
     void deleteInstanceShouldThrowWhenIdIsBlank() {
-        assertThatThrownBy(() -> instanceService.deleteInstance("   "))
+        assertThatThrownBy(() -> instanceService.deleteInstance(null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("InstanceVO ID is required");
     }
 
     @Test
     void deleteInstanceShouldThrowWhenInstanceNotFound() {
-        when(instanceRepository.findById("missing")).thenReturn(Optional.empty());
+        when(instanceRepository.findById(999L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> instanceService.deleteInstance("missing"))
+        assertThatThrownBy(() -> instanceService.deleteInstance(999L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("InstanceVO not found: missing");
+                .hasMessage("InstanceVO not found: 999");
     }
 
     @Test
@@ -818,16 +824,16 @@ class InstanceServiceTest {
     void createInstanceShouldRejectMissingCloudCatalogDetails() {
         InstanceVO instance = InstanceVO.builder()
                 .vendor(InstanceVendor.ALIYUN)
-                .credentialId("cred-1")
+                .credentialId(1L)
                 .cloudInstanceId("rmq-missing")
                 .regionId("cn-hangzhou")
                 .build();
         CloudCredentialVO credential = new CloudCredentialVO();
         credential.setVendor(InstanceVendor.ALIYUN);
-        when(cloudCredentialRepository.findById("cred-1")).thenReturn(Optional.of(credential));
+        when(cloudCredentialRepository.findById(1L)).thenReturn(Optional.of(credential));
         CloudCatalogProvider catalog = org.mockito.Mockito.mock(CloudCatalogProvider.class);
         when(providerRegistry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
-        when(catalog.getCloudInstance("cred-1", "cn-hangzhou", "rmq-missing")).thenReturn(null);
+        when(catalog.getCloudInstance(1L, "cn-hangzhou", "rmq-missing")).thenReturn(null);
 
         assertThatThrownBy(() -> instanceService.createInstance(instance))
                 .isInstanceOf(BusinessException.class)
@@ -840,14 +846,14 @@ class InstanceServiceTest {
     void createInstanceShouldResolveAliyunEndpointFromCatalogTest() {
         InstanceVO instance = InstanceVO.builder()
                 .vendor(InstanceVendor.ALIYUN)
-                .credentialId("cred-1")
+                .credentialId(1L)
                 .cloudInstanceId("rmq-cn-xxx")
                 .regionId("cn-hangzhou")
                 .build();
         CloudCredentialVO credential = new CloudCredentialVO();
-        credential.setId("cred-1");
+        credential.setId(1L);
         credential.setVendor(InstanceVendor.ALIYUN);
-        when(cloudCredentialRepository.findById("cred-1")).thenReturn(Optional.of(credential));
+        when(cloudCredentialRepository.findById(1L)).thenReturn(Optional.of(credential));
         CloudCatalogProvider catalog = org.mockito.Mockito.mock(CloudCatalogProvider.class);
         CloudInstanceDetailVO detail = new CloudInstanceDetailVO();
         detail.setInstanceId("rmq-cn-xxx");
@@ -856,7 +862,7 @@ class InstanceServiceTest {
                 new CloudInstanceDetailVO.CloudEndpoint("TCP_INTERNET", "public:8080"),
                 new CloudInstanceDetailVO.CloudEndpoint("TCP_VPC", "vpc:8080")));
         when(providerRegistry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
-        when(catalog.getCloudInstance("cred-1", "cn-hangzhou", "rmq-cn-xxx")).thenReturn(detail);
+        when(catalog.getCloudInstance(1L, "cn-hangzhou", "rmq-cn-xxx")).thenReturn(detail);
         when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         InstanceVO created = instanceService.createInstance(instance);
@@ -870,13 +876,13 @@ class InstanceServiceTest {
     void createInstanceShouldSkipNullCloudEndpointEntries() {
         InstanceVO instance = InstanceVO.builder()
                 .vendor(InstanceVendor.ALIYUN)
-                .credentialId("cred-1")
+                .credentialId(1L)
                 .cloudInstanceId("rmq-cn-xxx")
                 .regionId("cn-hangzhou")
                 .build();
         CloudCredentialVO credential = new CloudCredentialVO();
         credential.setVendor(InstanceVendor.ALIYUN);
-        when(cloudCredentialRepository.findById("cred-1")).thenReturn(Optional.of(credential));
+        when(cloudCredentialRepository.findById(1L)).thenReturn(Optional.of(credential));
         CloudCatalogProvider catalog = org.mockito.Mockito.mock(CloudCatalogProvider.class);
         CloudInstanceDetailVO detail = new CloudInstanceDetailVO();
         detail.setInstanceId("rmq-cn-xxx");
@@ -884,7 +890,7 @@ class InstanceServiceTest {
         detail.setEndpoints(Arrays.asList(null,
                 new CloudInstanceDetailVO.CloudEndpoint("TCP_VPC", "vpc:8080")));
         when(providerRegistry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
-        when(catalog.getCloudInstance("cred-1", "cn-hangzhou", "rmq-cn-xxx")).thenReturn(detail);
+        when(catalog.getCloudInstance(1L, "cn-hangzhou", "rmq-cn-xxx")).thenReturn(detail);
         when(instanceRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         assertThat(instanceService.createInstance(instance).getEndpoint()).isEqualTo("vpc:8080");
@@ -894,14 +900,14 @@ class InstanceServiceTest {
     void createInstanceShouldPrioritizeEndpointsIndependentlyOfDefaultLocaleTest() {
         InstanceVO instance = InstanceVO.builder()
                 .vendor(InstanceVendor.ALIYUN)
-                .credentialId("cred-1")
+                .credentialId(1L)
                 .cloudInstanceId("rmq-cn-xxx")
                 .regionId("cn-hangzhou")
                 .build();
         CloudCredentialVO credential = new CloudCredentialVO();
-        credential.setId("cred-1");
+        credential.setId(1L);
         credential.setVendor(InstanceVendor.ALIYUN);
-        when(cloudCredentialRepository.findById("cred-1")).thenReturn(Optional.of(credential));
+        when(cloudCredentialRepository.findById(1L)).thenReturn(Optional.of(credential));
         CloudCatalogProvider catalog = org.mockito.Mockito.mock(CloudCatalogProvider.class);
         CloudInstanceDetailVO detail = new CloudInstanceDetailVO();
         detail.setInstanceId("rmq-cn-xxx");
@@ -910,7 +916,7 @@ class InstanceServiceTest {
                 new CloudInstanceDetailVO.CloudEndpoint("unknown", "fallback:8080"),
                 new CloudInstanceDetailVO.CloudEndpoint("tcp_internet", "public:8080")));
         when(providerRegistry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
-        when(catalog.getCloudInstance("cred-1", "cn-hangzhou", "rmq-cn-xxx")).thenReturn(detail);
+        when(catalog.getCloudInstance(1L, "cn-hangzhou", "rmq-cn-xxx")).thenReturn(detail);
         when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
         Locale originalLocale = Locale.getDefault();
 
@@ -929,14 +935,14 @@ class InstanceServiceTest {
     void createInstanceShouldResolveTencentEndpointFromCatalogTest() {
         InstanceVO instance = InstanceVO.builder()
                 .vendor(InstanceVendor.TENCENT)
-                .credentialId("cred-tencent")
+                .credentialId(2L)
                 .cloudInstanceId("rmq-abc")
                 .regionId("ap-chengdu")
                 .build();
         CloudCredentialVO credential = new CloudCredentialVO();
-        credential.setId("cred-tencent");
+        credential.setId(2L);
         credential.setVendor(InstanceVendor.TENCENT);
-        when(cloudCredentialRepository.findById("cred-tencent")).thenReturn(Optional.of(credential));
+        when(cloudCredentialRepository.findById(2L)).thenReturn(Optional.of(credential));
         CloudCatalogProvider catalog = org.mockito.Mockito.mock(CloudCatalogProvider.class);
         CloudInstanceDetailVO detail = new CloudInstanceDetailVO();
         detail.setInstanceId("rmq-abc");
@@ -945,7 +951,7 @@ class InstanceServiceTest {
                 new CloudInstanceDetailVO.CloudEndpoint("TCP_INTERNET", "public.tencent:8080"),
                 new CloudInstanceDetailVO.CloudEndpoint("TCP_VPC", "vpc.tencent:8080")));
         when(providerRegistry.catalogFor(InstanceVendor.TENCENT)).thenReturn(catalog);
-        when(catalog.getCloudInstance("cred-tencent", "ap-chengdu", "rmq-abc")).thenReturn(detail);
+        when(catalog.getCloudInstance(2L, "ap-chengdu", "rmq-abc")).thenReturn(detail);
         when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         InstanceVO created = instanceService.createInstance(instance);
@@ -962,17 +968,17 @@ class InstanceServiceTest {
                 .name("aliyun-inst")
                 .vendor(InstanceVendor.ALIYUN)
                 .cloudInstanceId("rmq-cn-xxx")
-                .credentialId("cred-1")
+                .credentialId(1L)
                 .regionId("cn-hangzhou")
                 .type(InstanceType.PROXY)
                 .endpoint("vpc:8080")
                 .build();
-        existing.setId("inst-1");
-        when(instanceRepository.findById("inst-1")).thenReturn(Optional.of(existing));
+        existing.setId(1L);
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(instanceRepository.save(any(InstanceVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         InstanceVO request = InstanceVO.builder().endpoint("hacked:8080").remark("updated").build();
-        request.setId("inst-1");
+        request.setId(1L);
         InstanceVO updated = instanceService.updateInstance(request);
 
         assertThat(updated.getEndpoint()).isEqualTo("vpc:8080");

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
@@ -62,16 +62,16 @@ class MybatisPlusInstanceRepositoryTest {
     @Test
     void findAllShouldMapEntitiesWithoutCountsTest() {
         when(instanceMapper.selectList(any(QueryWrapper.class)))
-                .thenReturn(List.of(entity("instance-direct-1", InstanceType.DIRECT),
-                        entity("instance-proxy-1", InstanceType.PROXY)));
+                .thenReturn(List.of(entity(1L, "instance-direct-1", InstanceType.DIRECT),
+                        entity(2L, "instance-proxy-1", InstanceType.PROXY)));
 
         List<InstanceVO> result = repository.findAll();
 
         assertThat(result).hasSize(2);
         InstanceVO direct = result.stream()
-                .filter(i -> "instance-direct-1".equals(i.getId())).findFirst().orElseThrow();
+                .filter(i -> Long.valueOf(1L).equals(i.getId())).findFirst().orElseThrow();
         InstanceVO proxy = result.stream()
-                .filter(i -> "instance-proxy-1".equals(i.getId())).findFirst().orElseThrow();
+                .filter(i -> Long.valueOf(2L).equals(i.getId())).findFirst().orElseThrow();
         assertThat(direct.getTopicCount()).isZero();
         assertThat(direct.getConsumerGroupCount()).isZero();
         assertThat(proxy.getTopicCount()).isZero();
@@ -98,16 +98,16 @@ class MybatisPlusInstanceRepositoryTest {
 
     @Test
     void findByIdShouldReturnEmptyWhenMissing() {
-        when(instanceMapper.selectById("missing")).thenReturn(null);
+        when(instanceMapper.selectById(999L)).thenReturn(null);
 
-        assertThat(repository.findById("missing")).isEmpty();
+        assertThat(repository.findById(999L)).isEmpty();
     }
 
     @Test
     void findByIdShouldNotComputeCountsTest() {
-        when(instanceMapper.selectById("instance-proxy-1")).thenReturn(entity("instance-proxy-1", InstanceType.PROXY));
+        when(instanceMapper.selectById(2L)).thenReturn(entity(2L, "instance-proxy-1", InstanceType.PROXY));
 
-        Optional<InstanceVO> result = repository.findById("instance-proxy-1");
+        Optional<InstanceVO> result = repository.findById(2L);
 
         assertThat(result).isPresent();
         assertThat(result.get().getTopicCount()).isZero();
@@ -117,33 +117,33 @@ class MybatisPlusInstanceRepositoryTest {
 
     @Test
     void findByIdShouldRejectInvalidPersistedInstanceType() {
-        RmqInstance entity = entity("instance-invalid-type", InstanceType.DIRECT);
+        RmqInstance entity = entity(3L, "instance-invalid-type", InstanceType.DIRECT);
         entity.setType("UNKNOWN_TYPE");
         when(instanceMapper.selectById(entity.getId())).thenReturn(entity);
 
         assertThatThrownBy(() -> repository.findById(entity.getId()))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Invalid persisted instance type")
-                .hasMessageContaining(entity.getId());
+                .hasMessageContaining(String.valueOf(entity.getId()));
     }
 
     @Test
     void findByIdShouldRejectInvalidPersistedInstanceVendor() {
-        RmqInstance entity = entity("instance-invalid-vendor", InstanceType.DIRECT);
+        RmqInstance entity = entity(4L, "instance-invalid-vendor", InstanceType.DIRECT);
         entity.setVendor("UNKNOWN_VENDOR");
         when(instanceMapper.selectById(entity.getId())).thenReturn(entity);
 
         assertThatThrownBy(() -> repository.findById(entity.getId()))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Invalid persisted instance vendor")
-                .hasMessageContaining(entity.getId());
+                .hasMessageContaining(String.valueOf(entity.getId()));
     }
 
     @Test
     void countTopicsByInstanceShouldDelegateToTopicMapperTest() {
         when(topicMapper.selectCount(any(QueryWrapper.class))).thenReturn(5L);
 
-        assertThat(repository.countTopicsByInstance("instance-proxy-1")).isEqualTo(5L);
+        assertThat(repository.countTopicsByInstance(2L)).isEqualTo(5L);
         verify(topicMapper).selectCount(any(QueryWrapper.class));
     }
 
@@ -151,14 +151,14 @@ class MybatisPlusInstanceRepositoryTest {
     void countGroupsByInstanceShouldDelegateToGroupMapperTest() {
         when(groupMapper.selectCount(any(QueryWrapper.class))).thenReturn(2L);
 
-        assertThat(repository.countGroupsByInstance("instance-proxy-1")).isEqualTo(2L);
+        assertThat(repository.countGroupsByInstance(2L)).isEqualTo(2L);
         verify(groupMapper).selectCount(any(QueryWrapper.class));
     }
 
     @Test
     void saveShouldInsertWhenInstanceAbsent() {
-        InstanceVO vo = vo("instance-proxy-2", InstanceType.PROXY);
-        when(instanceMapper.selectById("instance-proxy-2")).thenReturn(null);
+        InstanceVO vo = vo(5L, "instance-proxy-2", InstanceType.PROXY);
+        when(instanceMapper.selectById(5L)).thenReturn(null);
 
         repository.save(vo);
 
@@ -170,8 +170,8 @@ class MybatisPlusInstanceRepositoryTest {
 
     @Test
     void saveShouldUpdateWhenInstanceExists() {
-        InstanceVO vo = vo("instance-proxy-2", InstanceType.PROXY);
-        when(instanceMapper.selectById("instance-proxy-2")).thenReturn(entity("instance-proxy-2", InstanceType.PROXY));
+        InstanceVO vo = vo(5L, "instance-proxy-2", InstanceType.PROXY);
+        when(instanceMapper.selectById(5L)).thenReturn(entity(5L, "instance-proxy-2", InstanceType.PROXY));
         when(instanceMapper.updateById(any(RmqInstance.class))).thenReturn(1);
 
         repository.save(vo);
@@ -182,53 +182,53 @@ class MybatisPlusInstanceRepositoryTest {
 
     @Test
     void saveShouldReportALostConcurrentUpdate() {
-        InstanceVO vo = vo("instance-proxy-2", InstanceType.PROXY);
-        when(instanceMapper.selectById("instance-proxy-2"))
-                .thenReturn(entity("instance-proxy-2", InstanceType.PROXY));
+        InstanceVO vo = vo(5L, "instance-proxy-2", InstanceType.PROXY);
+        when(instanceMapper.selectById(5L))
+                .thenReturn(entity(5L, "instance-proxy-2", InstanceType.PROXY));
         when(instanceMapper.updateById(any(RmqInstance.class))).thenReturn(0);
 
         assertThatThrownBy(() -> repository.save(vo))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("Instance update was not applied: instance-proxy-2")
+                .hasMessage("Instance update was not applied: 5")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(409));
     }
 
     @Test
     void deleteByIdShouldDelegateToMapper() {
-        repository.deleteById("instance-direct-1");
-        verify(instanceMapper).deleteById("instance-direct-1");
+        repository.deleteById(1L);
+        verify(instanceMapper).deleteById(1L);
     }
 
     @Test
     void deleteByIdShouldReportWhetherARowWasRemoved() {
-        when(instanceMapper.deleteById("deleted")).thenReturn(1);
-        when(instanceMapper.deleteById("missing")).thenReturn(0);
+        when(instanceMapper.deleteById(1L)).thenReturn(1);
+        when(instanceMapper.deleteById(2L)).thenReturn(0);
 
-        assertThat(repository.deleteById("deleted")).isTrue();
-        assertThat(repository.deleteById("missing")).isFalse();
+        assertThat(repository.deleteById(1L)).isTrue();
+        assertThat(repository.deleteById(2L)).isFalse();
     }
 
-    private RmqInstance entity(String id, InstanceType type) {
+    private RmqInstance entity(Long id, String name, InstanceType type) {
         RmqInstance entity = new RmqInstance();
         entity.setId(id);
-        entity.setName(id);
+        entity.setName(name);
         entity.setType(type.name());
         entity.setEndpoint("10.0.0.1:9876");
         entity.setVendor(InstanceVendor.APACHE.name());
-        entity.setAdminCredentialRef("admin-" + id);
-        entity.setCreatedAt(LocalDateTime.of(2026, 8, 3, 0, 0));
-        entity.setUpdatedAt(LocalDateTime.of(2026, 8, 3, 0, 0));
+        entity.setAdminCredentialRef("admin-" + name);
+        entity.setGmtCreate(LocalDateTime.of(2026, 8, 3, 0, 0));
+        entity.setGmtModified(LocalDateTime.of(2026, 8, 3, 0, 0));
         return entity;
     }
 
-    private InstanceVO vo(String id, InstanceType type) {
+    private InstanceVO vo(Long id, String name, InstanceType type) {
         InstanceVO vo = InstanceVO.builder()
-                .name(id)
+                .name(name)
                 .type(type)
                 .endpoint("10.0.0.1:9876")
                 .build();
         vo.setId(id);
-        vo.setAdminCredentialRef("admin-" + id);
+        vo.setAdminCredentialRef("admin-" + name);
         return vo;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
@@ -65,14 +65,14 @@ class AclControllerTest {
     @Test
     void capabilitiesShouldReturnApacheRemoteReadState() throws Exception {
         when(aclService.capabilities("instance-1"))
-                .thenReturn(new AclCapabilitiesVO("instance-1",
+                .thenReturn(new AclCapabilitiesVO(1L,
                         org.apache.rocketmq.studio.common.domain.enums.InstanceVendor.APACHE,
                         org.apache.rocketmq.studio.common.domain.enums.InstanceType.DIRECT,
                         "APACHE_ACL2", true, false));
 
         mockMvc.perform(get("/api/acl/capabilities").param("instanceId", "instance-1"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.instanceId").value("instance-1"))
+                .andExpect(jsonPath("$.data.instanceId").value(1))
                 .andExpect(jsonPath("$.data.stateSource").value("APACHE_ACL2"))
                 .andExpect(jsonPath("$.data.remoteReadSupported").value(true))
                 .andExpect(jsonPath("$.data.remoteWriteSupported").value(false));
@@ -99,8 +99,8 @@ class AclControllerTest {
                 .resourceType("TOPIC")
                 .decision("ALLOW")
                 .build();
-        rule.setId("rule-1");
-        rule.setCreatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+        rule.setId(1L);
+        rule.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
 
         when(aclService.listRules(isNull(), isNull(), isNull())).thenReturn(List.of(rule));
 
@@ -108,7 +108,7 @@ class AclControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data[0].id").value("rule-1"))
+                .andExpect(jsonPath("$.data[0].id").value(1))
                 .andExpect(jsonPath("$.data[0].principal").value("user1"))
                 .andExpect(jsonPath("$.data[0].decision").value("ALLOW"));
     }
@@ -141,8 +141,8 @@ class AclControllerTest {
                 .resourceType("TOPIC")
                 .decision("ALLOW")
                 .build();
-        created.setId("new-rule-id");
-        created.setCreatedAt(LocalDateTime.of(2026, 7, 8, 12, 0));
+        created.setId(2L);
+        created.setGmtCreate(LocalDateTime.of(2026, 7, 8, 12, 0));
 
         when(aclService.createRule(any(AclRuleVO.class), isNull())).thenReturn(created);
 
@@ -151,7 +151,7 @@ class AclControllerTest {
                         .content(objectMapper.writeValueAsString(input)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.id").value("new-rule-id"))
+                .andExpect(jsonPath("$.data.id").value(2))
                 .andExpect(jsonPath("$.data.principal").value("user1"));
     }
 
@@ -170,7 +170,7 @@ class AclControllerTest {
     @Test
     void updateRuleShouldReturnUpdatedRule() throws Exception {
         AclRuleVO input = AclRuleVO.builder()
-                .id("rule-1")
+                .id(1L)
                 .principal("user1")
                 .resource("topic-1")
                 .resourceType("TOPIC")
@@ -184,27 +184,27 @@ class AclControllerTest {
                         .content(objectMapper.writeValueAsString(input)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.id").value("rule-1"))
+                .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.decision").value("DENY"));
     }
 
     @Test
     void updateRuleShouldReturnNotFoundForUnknownId() throws Exception {
         AclRuleVO input = AclRuleVO.builder()
-                .id("missing-rule")
+                .id(999L)
                 .principal("user1")
                 .resource("topic-1")
                 .decision("DENY")
                 .build();
         when(aclService.updateRule(any(AclRuleVO.class), isNull()))
-                .thenThrow(new BusinessException(404, "ACL rule not found: missing-rule"));
+                .thenThrow(new BusinessException(404, "ACL rule not found: 999"));
 
         mockMvc.perform(post("/api/acl/rules/update")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(input)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("ACL rule not found: missing-rule"));
+                .andExpect(jsonPath("$.message").value("ACL rule not found: 999"));
     }
 
     @Test
@@ -223,12 +223,12 @@ class AclControllerTest {
     void deleteRuleShouldPassValidatedRequest() throws Exception {
         mockMvc.perform(post("/api/acl/rules/delete")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("id", "rule-1"))))
+                        .content(objectMapper.writeValueAsString(Map.of("id", "1"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success"));
 
-        verify(aclService).deleteRule(eq("rule-1"), isNull());
+        verify(aclService).deleteRule(eq("1"), isNull());
     }
 
     @Test
@@ -251,8 +251,8 @@ class AclControllerTest {
                 .secretKey("secr****7654")
                 .admin(true)
                 .build();
-        user.setId("user-1");
-        user.setCreatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+        user.setId(1L);
+        user.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
 
         when(aclService.listUsers(isNull())).thenReturn(List.of(user));
 
@@ -260,7 +260,7 @@ class AclControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data[0].id").value("user-1"))
+                .andExpect(jsonPath("$.data[0].id").value(1))
                 .andExpect(jsonPath("$.data[0].username").value("admin"))
                 .andExpect(jsonPath("$.data[0].accessKey").value("acce****3456"))
                 .andExpect(jsonPath("$.data[0].secretKey").value("secr****7654"))
@@ -270,13 +270,13 @@ class AclControllerTest {
     @Test
     void getUserCredentialsShouldDisableResponseCaching() throws Exception {
         AclUserVO credentials = AclUserVO.builder()
-                .id("user-1")
+                .id(1L)
                 .accessKey("access-key")
                 .secretKey("secret-key")
                 .build();
-        when(aclService.getUserCredentials(eq("user-1"), isNull())).thenReturn(credentials);
+        when(aclService.getUserCredentials(eq("1"), isNull())).thenReturn(credentials);
 
-        mockMvc.perform(get("/api/acl/users/user-1/credentials"))
+        mockMvc.perform(get("/api/acl/users/1/credentials"))
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"));
     }
@@ -284,7 +284,7 @@ class AclControllerTest {
     @Test
     void createUserShouldReturnGeneratedCredentials() throws Exception {
         AclUserVO created = AclUserVO.builder()
-                .id("user-1")
+                .id(1L)
                 .username("new-user")
                 .accessKey("access-key-123456")
                 .secretKey("secret-key-987654")
@@ -333,11 +333,11 @@ class AclControllerTest {
     @Test
     void updateUserShouldReturnMaskedUpdatedUser() throws Exception {
         UpdateAclUserDTO input = new UpdateAclUserDTO();
-        input.setId("user-1");
+        input.setId(1L);
         input.setUsername("admin");
         input.setAdmin(false);
         AclUserVO updated = AclUserVO.builder()
-                .id("user-1")
+                .id(1L)
                 .username("admin")
                 .accessKey("acce****3456")
                 .secretKey("secr****7654")
@@ -351,7 +351,7 @@ class AclControllerTest {
                         .content(objectMapper.writeValueAsString(input)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.id").value("user-1"))
+                .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.accessKey").value("acce****3456"))
                 .andExpect(jsonPath("$.data.secretKey").value("secr****7654"))
                 .andExpect(jsonPath("$.data.admin").value(false));
@@ -373,12 +373,12 @@ class AclControllerTest {
     void deleteUserShouldPassValidatedRequest() throws Exception {
         mockMvc.perform(post("/api/acl/users/delete")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("id", "user-1"))))
+                        .content(objectMapper.writeValueAsString(Map.of("id", "1"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success"));
 
-        verify(aclService).deleteUser(eq("user-1"), isNull());
+        verify(aclService).deleteUser(eq("1"), isNull());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -72,7 +72,7 @@ class AclServiceTest {
     @BeforeEach
     void setUp() {
         existingUser = AclUserVO.builder()
-                .id("user-1")
+                .id(1L)
                 .username("orders")
                 .accessKey("access-key-123456")
                 .secretKey("secret-key-987654")
@@ -103,12 +103,12 @@ class AclServiceTest {
                 .vendor(InstanceVendor.APACHE)
                 .type(InstanceType.DIRECT)
                 .build();
-        instance.setId("instance-1");
+        instance.setId(1L);
         when(instanceRepository.findByIdentifier("instance-1")).thenReturn(Optional.of(instance));
 
         AclCapabilitiesVO capabilities = aclService.capabilities("instance-1");
 
-        assertThat(capabilities.instanceId()).isEqualTo("instance-1");
+        assertThat(capabilities.instanceId()).isEqualTo(1L);
         assertThat(capabilities.vendor()).isEqualTo(InstanceVendor.APACHE);
         assertThat(capabilities.instanceType()).isEqualTo(InstanceType.DIRECT);
         assertThat(capabilities.stateSource()).isEqualTo("APACHE_ACL2");
@@ -144,26 +144,32 @@ class AclServiceTest {
                 .decision("ALLOW")
                 .build();
 
-        when(aclRepository.saveRule(any(AclRuleVO.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(aclRepository.saveRule(any(AclRuleVO.class))).thenAnswer(invocation -> {
+            AclRuleVO rule = invocation.getArgument(0);
+            if (rule.getId() == null) {
+                rule.setId(1L);
+            }
+            return rule;
+        });
 
         AclRuleVO result = aclService.createRule(input, null);
 
-        assertThat(result.getId()).isNotBlank();
-        assertThat(result.getCreatedAt()).isNotNull();
+        assertThat(result.getId()).isNotNull();
+        assertThat(result.getGmtCreate()).isNotNull();
         assertThat(result.getPrincipal()).isEqualTo("user1");
         assertThat(result.getResource()).isEqualTo("topic-1");
         verify(aclRepository).saveRule(any(AclRuleVO.class));
-        verify(operationAuditService).record(eq("CREATE_ACL_RULE"), eq("ACL_RULE"), eq(result.getId()), eq(null),
+        verify(operationAuditService).record(eq("CREATE_ACL_RULE"), eq("ACL_RULE"), eq("1"), eq(null),
                 eq("principal=user1"), eq("SUCCESS"), eq(null));
     }
 
     @Test
     void deleteRuleShouldDelegateToRepository() {
-        when(aclRepository.deleteRule("rule-1")).thenReturn(true);
-        aclService.deleteRule("rule-1", null);
+        when(aclRepository.deleteRule(1L)).thenReturn(true);
+        aclService.deleteRule("1", null);
 
-        verify(aclRepository).deleteRule("rule-1");
-        verify(operationAuditService).record(eq("DELETE_ACL_RULE"), eq("ACL_RULE"), eq("rule-1"), eq(null),
+        verify(aclRepository).deleteRule(1L);
+        verify(operationAuditService).record(eq("DELETE_ACL_RULE"), eq("ACL_RULE"), eq("1"), eq(null),
                 eq(null), eq("SUCCESS"), eq(null));
     }
 
@@ -182,23 +188,23 @@ class AclServiceTest {
     void updateRuleShouldReplaceExistingRule() {
         LocalDateTime createdAt = LocalDateTime.of(2026, 1, 1, 0, 0);
         AclRuleVO input = AclRuleVO.builder()
-                .id("rule-1")
+                .id(1L)
                 .principal("user1")
                 .resource("topic-1")
                 .decision("DENY")
-                .createdAt(createdAt)
+                .gmtCreate(createdAt)
                 .build();
 
         when(aclRepository.replaceRule(input)).thenReturn(Optional.of(input));
 
         AclRuleVO result = aclService.updateRule(input, null);
 
-        assertThat(result.getId()).isEqualTo("rule-1");
-        assertThat(result.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getGmtCreate()).isEqualTo(createdAt);
         assertThat(result.getDecision()).isEqualTo("DENY");
         verify(aclRepository).replaceRule(input);
         verify(aclRepository, never()).saveRule(any(AclRuleVO.class));
-        verify(operationAuditService).record(eq("UPDATE_ACL_RULE"), eq("ACL_RULE"), eq("rule-1"), eq(null),
+        verify(operationAuditService).record(eq("UPDATE_ACL_RULE"), eq("ACL_RULE"), eq("1"), eq(null),
                 eq("principal=user1"), eq("SUCCESS"), eq(null));
     }
 
@@ -207,7 +213,7 @@ class AclServiceTest {
         when(aclRepository.replaceRule(any(AclRuleVO.class))).thenReturn(Optional.empty());
         when(aclRepository.findRules(null, null)).thenReturn(List.of());
         AclRuleVO update = AclRuleVO.builder()
-                .id("missing-rule")
+                .id(999L)
                 .principal("orders")
                 .resource("orders-topic")
                 .decision("DENY")
@@ -215,7 +221,7 @@ class AclServiceTest {
 
         assertThatThrownBy(() -> aclService.updateRule(update, null))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("ACL rule not found: missing-rule")
+                .hasMessage("ACL rule not found: 999")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
         assertThat(aclService.listRules(null, null, null)).isEmpty();
         verify(aclRepository, never()).saveRule(any(AclRuleVO.class));
@@ -225,8 +231,12 @@ class AclServiceTest {
     void updateRuleShouldPreserveStoredCreationTimestamp() {
         java.util.concurrent.atomic.AtomicReference<AclRuleVO> stored = new java.util.concurrent.atomic.AtomicReference<>();
         when(aclRepository.saveRule(any(AclRuleVO.class))).thenAnswer(invocation -> {
-            stored.set(invocation.getArgument(0));
-            return invocation.getArgument(0);
+            AclRuleVO rule = invocation.getArgument(0);
+            if (rule.getId() == null) {
+                rule.setId(1L);
+            }
+            stored.set(rule);
+            return rule;
         });
         when(aclRepository.replaceRule(any(AclRuleVO.class))).thenAnswer(invocation -> {
             AclRuleVO rule = invocation.getArgument(0);
@@ -241,7 +251,7 @@ class AclServiceTest {
                     .decision(rule.getDecision())
                     .scope(rule.getScope())
                     .aclVersion(rule.getAclVersion())
-                    .createdAt(stored.get().getCreatedAt())
+                    .gmtCreate(stored.get().getGmtCreate())
                     .build());
         });
         AclRuleVO created = aclService.createRule(AclRuleVO.builder()
@@ -249,7 +259,7 @@ class AclServiceTest {
                 .resource("orders-topic")
                 .decision("ALLOW")
                 .build(), null);
-        LocalDateTime originalCreatedAt = created.getCreatedAt();
+        LocalDateTime originalCreatedAt = created.getGmtCreate();
 
         LocalDateTime clientCreatedAt = originalCreatedAt.plusDays(1);
         AclRuleVO update = AclRuleVO.builder()
@@ -257,14 +267,14 @@ class AclServiceTest {
                 .principal("orders")
                 .resource("orders-topic")
                 .decision("DENY")
-                .createdAt(clientCreatedAt)
+                .gmtCreate(clientCreatedAt)
                 .build();
 
         AclRuleVO updated = aclService.updateRule(update, null);
 
-        assertThat(updated.getCreatedAt()).isEqualTo(originalCreatedAt);
+        assertThat(updated.getGmtCreate()).isEqualTo(originalCreatedAt);
         assertThat(updated.getDecision()).isEqualTo("DENY");
-        assertThat(update.getCreatedAt()).isEqualTo(clientCreatedAt);
+        assertThat(update.getGmtCreate()).isEqualTo(clientCreatedAt);
     }
 
     @Test
@@ -347,19 +357,25 @@ class AclServiceTest {
                 .admin(false)
                 .build();
 
-        when(aclRepository.saveUser(any(AclUserVO.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(aclRepository.saveUser(any(AclUserVO.class))).thenAnswer(invocation -> {
+            AclUserVO user = invocation.getArgument(0);
+            if (user.getId() == null) {
+                user.setId(1L);
+            }
+            return user;
+        });
 
         AclUserVO result = aclService.createUser(input, null);
 
-        assertThat(result.getId()).isNotBlank();
+        assertThat(result.getId()).isNotNull();
         assertThat(result.getAccessKey()).isNotBlank();
         assertThat(result.getSecretKey()).isNotBlank();
         assertThat(result.getAccessKey()).doesNotContain("-");
         assertThat(result.getSecretKey()).doesNotContain("-");
-        assertThat(result.getCreatedAt()).isNotNull();
+        assertThat(result.getGmtCreate()).isNotNull();
         assertThat(result.getUsername()).isEqualTo("newuser");
         verify(aclRepository).saveUser(any(AclUserVO.class));
-        verify(operationAuditService).record(eq("CREATE_ACL_USER"), eq("ACL_USER"), eq(result.getId()), eq(null),
+        verify(operationAuditService).record(eq("CREATE_ACL_USER"), eq("ACL_USER"), eq("1"), eq(null),
                 argThat(detail -> detail.equals("username=newuser, admin=false")
                         && !detail.contains(result.getAccessKey()) && !detail.contains(result.getSecretKey())),
                 eq("SUCCESS"), eq(null));
@@ -367,28 +383,28 @@ class AclServiceTest {
 
     @Test
     void deleteUserShouldDelegateToRepository() {
-        when(aclRepository.deleteUser("user-1")).thenReturn(true);
-        aclService.deleteUser("user-1", null);
+        when(aclRepository.deleteUser(1L)).thenReturn(true);
+        aclService.deleteUser("1", null);
 
-        verify(aclRepository).deleteUser("user-1");
-        verify(operationAuditService).record(eq("DELETE_ACL_USER"), eq("ACL_USER"), eq("user-1"), eq(null),
+        verify(aclRepository).deleteUser(1L);
+        verify(operationAuditService).record(eq("DELETE_ACL_USER"), eq("ACL_USER"), eq("1"), eq(null),
                 eq(null), eq("SUCCESS"), eq(null));
     }
 
     @Test
     void deleteRuleShouldRejectUnknownRule() {
-        when(aclRepository.deleteRule("missing")).thenReturn(false);
+        when(aclRepository.deleteRule(999L)).thenReturn(false);
 
-        assertThatThrownBy(() -> aclService.deleteRule("missing", null))
+        assertThatThrownBy(() -> aclService.deleteRule("999", null))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
     }
 
     @Test
     void deleteUserShouldRejectUnknownUser() {
-        when(aclRepository.deleteUser("missing")).thenReturn(false);
+        when(aclRepository.deleteUser(999L)).thenReturn(false);
 
-        assertThatThrownBy(() -> aclService.deleteUser("missing", null))
+        assertThatThrownBy(() -> aclService.deleteUser("999", null))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
     }
@@ -405,17 +421,17 @@ class AclServiceTest {
     @Test
     void updateUserShouldSaveExistingUser() {
         UpdateAclUserDTO input = new UpdateAclUserDTO();
-        input.setId("user-1");
+        input.setId(1L);
         input.setUsername("newuser");
         input.setAdmin(true);
 
         ArgumentCaptor<AclUserVO> captor = ArgumentCaptor.forClass(AclUserVO.class);
-        when(aclRepository.findUserById("user-1")).thenReturn(Optional.of(existingUser));
+        when(aclRepository.findUserById(1L)).thenReturn(Optional.of(existingUser));
         when(aclRepository.replaceUser(any(AclUserVO.class))).thenAnswer(inv -> Optional.of(inv.getArgument(0)));
 
         AclUserVO result = aclService.updateUser(input, null);
 
-        assertThat(result.getId()).isEqualTo("user-1");
+        assertThat(result.getId()).isEqualTo(1L);
         assertThat(result.getUsername()).isEqualTo("newuser");
         assertThat(result.getAccessKey()).isEqualTo("acce****3456");
         assertThat(result.getSecretKey()).isEqualTo("secr****7654");
@@ -423,14 +439,14 @@ class AclServiceTest {
         verify(aclRepository).replaceUser(captor.capture());
         assertThat(captor.getValue().getAccessKey()).isEqualTo("access-key-123456");
         assertThat(captor.getValue().getSecretKey()).isEqualTo("secret-key-987654");
-        verify(operationAuditService).record(eq("UPDATE_ACL_USER"), eq("ACL_USER"), eq("user-1"), eq(null),
+        verify(operationAuditService).record(eq("UPDATE_ACL_USER"), eq("ACL_USER"), eq("1"), eq(null),
                 eq("username=newuser, admin=true"), eq("SUCCESS"), eq(null));
     }
 
     @Test
     void updateUserShouldPreserveAdminWhenNotProvided() {
         AclUserVO adminUser = AclUserVO.builder()
-                .id("user-1")
+                .id(1L)
                 .username("orders")
                 .accessKey("access-key-123456")
                 .secretKey("secret-key-987654")
@@ -438,12 +454,12 @@ class AclServiceTest {
                 .clusters(List.of("cluster-a"))
                 .build();
         UpdateAclUserDTO input = new UpdateAclUserDTO();
-        input.setId("user-1");
+        input.setId(1L);
         input.setUsername("renamed");
         // admin intentionally left null: the existing admin flag must survive the partial update.
 
         ArgumentCaptor<AclUserVO> captor = ArgumentCaptor.forClass(AclUserVO.class);
-        when(aclRepository.findUserById("user-1")).thenReturn(Optional.of(adminUser));
+        when(aclRepository.findUserById(1L)).thenReturn(Optional.of(adminUser));
         when(aclRepository.replaceUser(any(AclUserVO.class))).thenAnswer(inv -> Optional.of(inv.getArgument(0)));
 
         AclUserVO result = aclService.updateUser(input, null);
@@ -457,10 +473,10 @@ class AclServiceTest {
     @Test
     void updateUserShouldRejectBlankUsernameWithoutSaving() {
         UpdateAclUserDTO input = new UpdateAclUserDTO();
-        input.setId("user-1");
+        input.setId(1L);
         input.setUsername("   ");
 
-        when(aclRepository.findUserById("user-1")).thenReturn(Optional.of(existingUser));
+        when(aclRepository.findUserById(1L)).thenReturn(Optional.of(existingUser));
 
         assertThatThrownBy(() -> aclService.updateUser(input, null))
                 .isInstanceOf(BusinessException.class)
@@ -472,14 +488,14 @@ class AclServiceTest {
     @Test
     void updateUserShouldThrowWhenUserDoesNotExist() {
         UpdateAclUserDTO input = new UpdateAclUserDTO();
-        input.setId("missing");
+        input.setId(999L);
         input.setUsername("ghost");
 
-        when(aclRepository.findUserById("missing")).thenReturn(Optional.empty());
+        when(aclRepository.findUserById(999L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> aclService.updateUser(input, null))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("ACL user not found: missing")
+                .hasMessage("ACL user not found: 999")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
         verify(aclRepository, never()).saveUser(any(AclUserVO.class));
     }
@@ -530,8 +546,12 @@ class AclServiceTest {
     void createListUpdateShouldPreserveStoredCredentials() {
         java.util.concurrent.atomic.AtomicReference<AclUserVO> stored = new java.util.concurrent.atomic.AtomicReference<>();
         when(aclRepository.saveUser(any(AclUserVO.class))).thenAnswer(invocation -> {
-            stored.set(invocation.getArgument(0));
-            return invocation.getArgument(0);
+            AclUserVO user = invocation.getArgument(0);
+            if (user.getId() == null) {
+                user.setId(1L);
+            }
+            stored.set(user);
+            return user;
         });
         when(aclRepository.findUserById(any())).thenAnswer(invocation -> Optional.ofNullable(stored.get()));
         when(aclRepository.replaceUser(any(AclUserVO.class))).thenAnswer(invocation -> {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclUserVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclUserVOTest.java
@@ -27,7 +27,7 @@ class AclUserVOTest {
     @Test
     void toStringShouldNotExposeCredentials() {
         AclUserVO user = AclUserVO.builder()
-            .id("user-1")
+            .id(1L)
             .username("ops-admin")
             .accessKey("plain-access-key")
             .secretKey("plain-secret-key")

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
@@ -60,13 +60,13 @@ class MybatisPlusAclRepositoryTest {
     @Test
     void replaceRuleShouldReturnEmptyWhenConcurrentDeleteWins() {
         RmqAclRule existing = new RmqAclRule();
-        existing.setId("rule-a");
-        existing.setCreatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
-        when(ruleMapper.selectById("rule-a")).thenReturn(existing);
+        existing.setId(1L);
+        existing.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
+        when(ruleMapper.selectById(1L)).thenReturn(existing);
         when(ruleMapper.updateById(any(RmqAclRule.class))).thenReturn(0);
 
         AclRuleVO replacement = AclRuleVO.builder()
-                .id("rule-a")
+                .id(1L)
                 .principal("svc-a")
                 .resource("orders")
                 .build();
@@ -79,7 +79,12 @@ class MybatisPlusAclRepositoryTest {
         when(userMapper.selectOne(any(QueryWrapper.class))).thenReturn(null);
         when(userMapper.insert(any(RmqAclUser.class))).thenReturn(1);
         when(ruleMapper.delete(any(QueryWrapper.class))).thenReturn(0);
-        when(ruleMapper.insert(any(RmqAclRule.class))).thenReturn(1);
+        java.util.concurrent.atomic.AtomicLong ruleSequence = new java.util.concurrent.atomic.AtomicLong();
+        when(ruleMapper.insert(any(RmqAclRule.class))).thenAnswer(invocation -> {
+            RmqAclRule inserted = invocation.getArgument(0);
+            inserted.setId(ruleSequence.incrementAndGet());
+            return 1;
+        });
 
         PlainAccessConfigVO config = PlainAccessConfigVO.builder()
                 .accessKey("svc-x")
@@ -96,12 +101,13 @@ class MybatisPlusAclRepositoryTest {
         verify(ruleMapper, times(6)).insert(captor.capture());
         List<RmqAclRule> rules = captor.getAllValues();
 
-        // Every permission gets a distinct primary key so no entry overwrites another.
+        // Every permission gets a distinct auto-increment primary key so no entry
+        // overwrites another.
         assertThat(rules).extracting(RmqAclRule::getId)
-                .containsExactly("plain-svc-x-dt", "plain-svc-x-dg",
-                        "plain-svc-x-t-0", "plain-svc-x-t-1",
-                        "plain-svc-x-g-0", "plain-svc-x-g-1")
+                .containsExactly(1L, 2L, 3L, 4L, 5L, 6L)
                 .doesNotHaveDuplicates();
+        assertThat(rules).extracting(RmqAclRule::getResourcePattern).containsExactly(
+                "DEFAULT_TOPIC", "DEFAULT_GROUP", "LITERAL", "LITERAL", "LITERAL", "LITERAL");
         assertThat(rules).extracting(RmqAclRule::getResource).containsExactly(
                 "*", "*", "order-*", "payment-*", "cg-order", "cg-payment");
     }
@@ -145,7 +151,7 @@ class MybatisPlusAclRepositoryTest {
 
     @Test
     void updateWithBlankSecretShouldKeepStoredSecret() {
-        RmqAclUser existing = userEntity("plain-svc-x", "svc-x",
+        RmqAclUser existing = userEntity(1L, "svc-x",
                 CredentialUtils.encodeBase64("kept-secret-value"));
         when(userMapper.selectOne(any(QueryWrapper.class))).thenReturn(existing);
         when(userMapper.updateById(any(RmqAclUser.class))).thenReturn(1);
@@ -208,7 +214,7 @@ class MybatisPlusAclRepositoryTest {
 
     @Test
     void updateShouldExplicitlyClearBlankWhiteRemoteAddress() {
-        RmqAclUser existing = userEntity("plain-svc-x", "svc-x",
+        RmqAclUser existing = userEntity(1L, "svc-x",
                 CredentialUtils.encodeBase64("kept-secret-value"));
         existing.setWhiteRemoteAddress("10.0.1.0/24");
         when(userMapper.selectOne(any(QueryWrapper.class))).thenReturn(existing);
@@ -234,7 +240,7 @@ class MybatisPlusAclRepositoryTest {
     @Test
     void examineShouldMaskAccountSecrets() {
         String plaintext = "supersecret-abcdef";
-        RmqAclUser user = userEntity("plain-svc-x", "svc-x",
+        RmqAclUser user = userEntity(1L, "svc-x",
                 CredentialUtils.encodeBase64(plaintext));
         when(userMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of(user));
         when(ruleMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of());
@@ -249,12 +255,12 @@ class MybatisPlusAclRepositoryTest {
 
     @Test
     void examineShouldScopeAccountsToRequestedCluster() {
-        RmqAclUser boundHere = userEntity("plain-a", "svc-a",
+        RmqAclUser boundHere = userEntity(2L, "svc-a",
                 CredentialUtils.encodeBase64("secret-a-value"));
         boundHere.setClusters("cluster-a,cluster-b");
-        RmqAclUser global = userEntity("plain-g", "svc-g",
+        RmqAclUser global = userEntity(3L, "svc-g",
                 CredentialUtils.encodeBase64("secret-g-value"));
-        RmqAclUser boundElsewhere = userEntity("plain-e", "svc-e",
+        RmqAclUser boundElsewhere = userEntity(4L, "svc-e",
                 CredentialUtils.encodeBase64("secret-e-value"));
         boundElsewhere.setClusters("cluster-c");
         when(userMapper.selectList(any(QueryWrapper.class)))
@@ -271,14 +277,14 @@ class MybatisPlusAclRepositoryTest {
         assertThat(config.isAclEnabled()).isTrue();
     }
 
-    private static RmqAclUser userEntity(String id, String accessKey, String encodedSecret) {
+    private static RmqAclUser userEntity(Long id, String accessKey, String encodedSecret) {
         RmqAclUser entity = new RmqAclUser();
         entity.setId(id);
         entity.setUsername(accessKey);
         entity.setAccessKey(accessKey);
         entity.setSecretKey(encodedSecret);
         entity.setAdmin(false);
-        entity.setCreatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+        entity.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
         return entity;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupControllerTest.java
@@ -63,7 +63,7 @@ class ConsumerGroupControllerTest {
     @Test
     void createConsumerGroupShouldPassValidatedRequest() throws Exception {
         Map<String, Object> body = Map.of(
-                "instanceId", "instance-a",
+                "instanceId", 7,
                 "name", "cg-orders",
                 "clusterId", "cluster-a",
                 "retryMaxTimes", 8,
@@ -88,7 +88,7 @@ class ConsumerGroupControllerTest {
         verify(metadataService).createConsumerGroup(captor.capture());
         assertThat(captor.getValue().getName()).isEqualTo("cg-orders");
         assertThat(captor.getValue().getClusterId()).isEqualTo("cluster-a");
-        assertThat(captor.getValue().getInstanceId()).isEqualTo("instance-a");
+        assertThat(captor.getValue().getInstanceId()).isEqualTo(7L);
         assertThat(captor.getValue().getRetryMaxTimes()).isEqualTo(8);
     }
 
@@ -112,7 +112,7 @@ class ConsumerGroupControllerTest {
     @Test
     void createConsumerGroupShouldRejectNegativeRetryMaxTimes() throws Exception {
         Map<String, Object> body = Map.of(
-                "instanceId", "instance-a",
+                "instanceId", 7,
                 "name", "cg-orders",
                 "retryMaxTimes", -1
         );

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
@@ -66,7 +66,7 @@ class QueryHistoryServiceTest {
         RmqMessageQuery query = captor.getValue();
         assertThat(query.getClusterId()).isEqualTo("cluster-a");
         assertThat(query.getQueriedBy()).isEqualTo("alice");
-        assertThat(query.getQueriedAt()).isEqualTo(LocalDateTime.of(2026, 8, 5, 12, 0));
+        assertThat(query.getGmtCreate()).isEqualTo(LocalDateTime.of(2026, 8, 5, 12, 0));
     }
 
     @Test
@@ -91,8 +91,8 @@ class QueryHistoryServiceTest {
         ArgumentCaptor<Wrapper<RmqTraceQuery>> traceCaptor = ArgumentCaptor.forClass(Wrapper.class);
         verify(messageQueryMapper).delete(messageCaptor.capture());
         verify(traceQueryMapper).delete(traceCaptor.capture());
-        assertThat(messageCaptor.getValue().getCustomSqlSegment()).contains("queried_at");
-        assertThat(traceCaptor.getValue().getCustomSqlSegment()).contains("queried_at");
+        assertThat(messageCaptor.getValue().getCustomSqlSegment()).contains("gmt_create");
+        assertThat(traceCaptor.getValue().getCustomSqlSegment()).contains("gmt_create");
     }
 
     @Test
@@ -115,7 +115,7 @@ class QueryHistoryServiceTest {
         entity.setResultCount(3);
         entity.setClusterId("cluster-a");
         entity.setQueriedBy("alice");
-        entity.setQueriedAt(LocalDateTime.of(2026, 8, 5, 12, 0));
+        entity.setGmtCreate(LocalDateTime.of(2026, 8, 5, 12, 0));
         when(messageQueryMapper.selectPage(any(Page.class), any(Wrapper.class)))
                 .thenAnswer(invocation -> {
                     Page<RmqMessageQuery> result = invocation.getArgument(0);
@@ -137,9 +137,9 @@ class QueryHistoryServiceTest {
     @Test
     void summarizesBothHistoryStreams() {
         RmqMessageQuery message = new RmqMessageQuery();
-        message.setQueriedAt(LocalDateTime.of(2026, 8, 5, 10, 0));
+        message.setGmtCreate(LocalDateTime.of(2026, 8, 5, 10, 0));
         RmqTraceQuery trace = new RmqTraceQuery();
-        trace.setQueriedAt(LocalDateTime.of(2026, 8, 5, 12, 0));
+        trace.setGmtCreate(LocalDateTime.of(2026, 8, 5, 12, 0));
         when(messageQueryMapper.selectCount(any())).thenReturn(7L);
         when(traceQueryMapper.selectCount(any())).thenReturn(4L);
         when(messageQueryMapper.selectOne(any())).thenReturn(message);

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/TopicControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/TopicControllerTest.java
@@ -123,7 +123,7 @@ class TopicControllerTest {
     void createTopicShouldReturnCreatedTopic() throws Exception {
         TopicVO input = new TopicVO();
         input.setName("new-topic");
-        input.setInstanceId("instance-a");
+        input.setInstanceId(1L);
         input.setWriteQueues(16);
         input.setReadQueues(16);
 
@@ -145,7 +145,7 @@ class TopicControllerTest {
         ArgumentCaptor<TopicVO> captor = ArgumentCaptor.forClass(TopicVO.class);
         verify(metadataService).createTopic(captor.capture());
         assertThat(captor.getValue().getName()).isEqualTo("new-topic");
-        assertThat(captor.getValue().getInstanceId()).isEqualTo("instance-a");
+        assertThat(captor.getValue().getInstanceId()).isEqualTo(1L);
         assertThat(captor.getValue().getWriteQueues()).isEqualTo(16);
         assertThat(captor.getValue().getReadQueues()).isEqualTo(16);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolGatewayServiceTest.java
@@ -405,8 +405,8 @@ class ToolGatewayServiceTest {
     @Test
     void executesAlertRuleListThroughADataMinimizingProjection() {
         when(alertService.listRules()).thenReturn(List.of(
-                alertRule("rule-1", "High Lag", "rocketmq_consumer_lag_messages", true),
-                alertRule("rule-2", "Broker Down", "up", false)));
+                alertRule(1L, "High Lag", "rocketmq_consumer_lag_messages", true),
+                alertRule(2L, "Broker Down", "up", false)));
 
         Object output = gateway.execute("rmq.alert.rule.list", Map.of(
                 "cluster", "cluster-v5",
@@ -414,7 +414,7 @@ class ToolGatewayServiceTest {
                 "enabled", true));
 
         assertThat(output).isEqualTo(List.of(Map.of(
-                "id", "rule-1",
+                "id", 1L,
                 "name", "High Lag",
                 "metric", "rocketmq_consumer_lag_messages",
                 "operator", ">",
@@ -676,7 +676,7 @@ class ToolGatewayServiceTest {
         return group;
     }
 
-    private static AlertRuleVO alertRule(String id, String name, String metric, boolean enabled) {
+    private static AlertRuleVO alertRule(Long id, String name, String metric, boolean enabled) {
         return AlertRuleVO.builder()
                 .id(id)
                 .name(name)

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleControllerTest.java
@@ -54,7 +54,7 @@ class AlertRuleControllerTest {
     @Test
     void listRulesShouldReturnRules() throws Exception {
         AlertRuleVO rule = AlertRuleVO.builder()
-                .id("rule-1")
+                .id(1L)
                 .name("High Lag")
                 .metric("rocketmq_consumer_lag_messages")
                 .enabled(true)
@@ -64,7 +64,7 @@ class AlertRuleControllerTest {
         mockMvc.perform(get("/api/alert-rules"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data[0].id").value("rule-1"))
+                .andExpect(jsonPath("$.data[0].id").value(1))
                 .andExpect(jsonPath("$.data[0].enabled").value(true));
     }
 
@@ -86,7 +86,7 @@ class AlertRuleControllerTest {
                 .enabled(true)
                 .build();
         AlertRuleVO created = AlertRuleVO.builder()
-                .id("rule-1")
+                .id(1L)
                 .name("High Lag")
                 .metric("rocketmq_consumer_lag_messages")
                 .enabled(true)
@@ -97,7 +97,7 @@ class AlertRuleControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value("rule-1"))
+                .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.name").value("High Lag"));
     }
 
@@ -176,21 +176,21 @@ class AlertRuleControllerTest {
     @Test
     void toggleRuleShouldPassValidatedRequest() throws Exception {
         AlertRuleVO toggled = AlertRuleVO.builder()
-                .id("rule-1")
+                .id(1L)
                 .name("High Lag")
                 .enabled(false)
                 .build();
-        when(alertService.toggleRule("rule-1", false)).thenReturn(toggled);
+        when(alertService.toggleRule(1L, false)).thenReturn(toggled);
 
         mockMvc.perform(post("/api/alert-rules/toggle")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("id", "rule-1", "enabled", false))))
+                        .content(objectMapper.writeValueAsString(Map.of("id", 1, "enabled", false))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.id").value("rule-1"))
+                .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.enabled").value(false));
 
-        verify(alertService).toggleRule(eq("rule-1"), eq(false));
+        verify(alertService).toggleRule(eq(1L), eq(false));
     }
 
     @Test
@@ -209,7 +209,7 @@ class AlertRuleControllerTest {
     void toggleRuleShouldRejectMissingEnabled() throws Exception {
         mockMvc.perform(post("/api/alert-rules/toggle")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("id", "rule-1"))))
+                        .content(objectMapper.writeValueAsString(Map.of("id", 1))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("enabled is required"));
@@ -221,7 +221,7 @@ class AlertRuleControllerTest {
     void toggleRuleShouldRejectInvalidEnabledType() throws Exception {
         mockMvc.perform(post("/api/alert-rules/toggle")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("id", "rule-1", "enabled", "invalid"))))
+                        .content(objectMapper.writeValueAsString(Map.of("id", 1, "enabled", "invalid"))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("Invalid request body"));
@@ -233,19 +233,19 @@ class AlertRuleControllerTest {
     void deleteRuleShouldPassValidatedRequest() throws Exception {
         mockMvc.perform(post("/api/alert-rules/delete")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("id", "rule-1"))))
+                        .content(objectMapper.writeValueAsString(Map.of("id", 1))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success"));
 
-        verify(alertService).deleteRule("rule-1");
+        verify(alertService).deleteRule(1L);
     }
 
     @Test
     void deleteRuleShouldRejectBlankId() throws Exception {
         mockMvc.perform(post("/api/alert-rules/delete")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("id", " "))))
+                        .content(objectMapper.writeValueAsString(java.util.Collections.singletonMap("id", null))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("id is required"));
@@ -255,19 +255,19 @@ class AlertRuleControllerTest {
 
     @Test
     void bulkToggleShouldReturnPartialResults() throws Exception {
-        AlertRuleVO updated = AlertRuleVO.builder().id("rule-1").enabled(false).build();
-        when(alertService.bulkToggleRules(List.of("rule-1", "missing"), false))
+        AlertRuleVO updated = AlertRuleVO.builder().id(1L).enabled(false).build();
+        when(alertService.bulkToggleRules(List.of(1L, 999L), false))
                 .thenReturn(AlertRuleBulkResultVO.builder()
-                        .succeededIds(List.of("rule-1"))
-                        .failures(Map.of("missing", "Alert rule not found"))
+                        .succeededIds(List.of(1L))
+                        .failures(Map.of(999L, "Alert rule not found"))
                         .updatedRules(List.of(updated)).build());
 
         mockMvc.perform(post("/api/alert-rules/bulk-toggle")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"ids\":[\"rule-1\",\"missing\"],\"enabled\":false}"))
+                        .content("{\"ids\":[1,999],\"enabled\":false}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.succeededIds[0]").value("rule-1"))
-                .andExpect(jsonPath("$.data.failures.missing").value("Alert rule not found"))
+                .andExpect(jsonPath("$.data.succeededIds[0]").value(1))
+                .andExpect(jsonPath("$.data.failures['999']").value("Alert rule not found"))
                 .andExpect(jsonPath("$.data.updatedRules[0].enabled").value(false));
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -58,9 +58,9 @@ class AlertServiceTest {
 
     @Test
     void listRulesShouldReturnAllRules() {
-        AlertRuleVO rule1 = AlertRuleVO.builder().id("1").name("High CPU").metric("cpu_usage")
+        AlertRuleVO rule1 = AlertRuleVO.builder().id(1L).name("High CPU").metric("cpu_usage")
                 .operator(">").threshold(90.0).enabled(true).build();
-        AlertRuleVO rule2 = AlertRuleVO.builder().id("2").name("Low Disk").metric("disk_free")
+        AlertRuleVO rule2 = AlertRuleVO.builder().id(2L).name("Low Disk").metric("disk_free")
                 .operator("<").threshold(10.0).enabled(false).build();
         when(alertRepository.findAllRules()).thenReturn(Arrays.asList(rule1, rule2));
 
@@ -451,16 +451,22 @@ class AlertServiceTest {
                 .clusterName("DefaultCluster")
                 .severity("critical")
                 .build();
-        when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> {
+            AlertRuleVO saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(1L);
+            }
+            return saved;
+        });
 
         AlertRuleVO result = alertService.createRule(input);
 
-        assertThat(result.getId()).isNotNull().isNotEmpty();
+        assertThat(result.getId()).isNotNull();
         assertThat(result.getBrokerName()).isEqualTo("broker-a");
         assertThat(result.getClusterName()).isEqualTo("DefaultCluster");
         assertThat(result.getSeverity()).isEqualTo("critical");
         verify(alertRepository).saveRule(result);
-        verify(operationAuditService).record(eq("CREATE_ALERT_RULE"), eq("ALERT_RULE"), eq(result.getId()),
+        verify(operationAuditService).record(eq("CREATE_ALERT_RULE"), eq("ALERT_RULE"), eq("1"),
                 eq(null), eq("name=Replication Lag High"), eq("SUCCESS"), eq(null));
     }
 
@@ -468,11 +474,17 @@ class AlertServiceTest {
     void createRuleShouldAssignId() {
         AlertRuleVO input = AlertRuleVO.builder().name("New Rule").metric("tps")
                 .operator(">").threshold(1000.0).build();
-        when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> {
+            AlertRuleVO saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(1L);
+            }
+            return saved;
+        });
 
         AlertRuleVO result = alertService.createRule(input);
 
-        assertThat(result.getId()).isNotNull().isNotEmpty();
+        assertThat(result.getId()).isNotNull();
         assertThat(result.getName()).isEqualTo("New Rule");
         assertThat(result.getMetric()).isEqualTo("tps");
         verify(alertRepository).saveRule(result);
@@ -482,7 +494,14 @@ class AlertServiceTest {
     void createRuleShouldGenerateUniqueIds() {
         AlertRuleVO input1 = AlertRuleVO.builder().name("Rule 1").build();
         AlertRuleVO input2 = AlertRuleVO.builder().name("Rule 2").build();
-        when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        java.util.concurrent.atomic.AtomicLong sequence = new java.util.concurrent.atomic.AtomicLong();
+        when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> {
+            AlertRuleVO saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(sequence.incrementAndGet());
+            }
+            return saved;
+        });
 
         AlertRuleVO result1 = alertService.createRule(input1);
         AlertRuleVO result2 = alertService.createRule(input2);
@@ -502,15 +521,15 @@ class AlertServiceTest {
 
     @Test
     void updateRuleShouldUpdateExistingRule() {
-        AlertRuleVO update = AlertRuleVO.builder().id("rule-1").name("CPU Alert").threshold(90.0).build();
+        AlertRuleVO update = AlertRuleVO.builder().id(1L).name("CPU Alert").threshold(90.0).build();
         when(alertRepository.replaceRule(update)).thenReturn(true);
 
         AlertRuleVO result = alertService.updateRule(update);
 
-        assertThat(result.getId()).isEqualTo("rule-1");
+        assertThat(result.getId()).isEqualTo(1L);
         assertThat(result.getThreshold()).isEqualTo(90.0);
         verify(alertRepository).replaceRule(update);
-        verify(operationAuditService).record(eq("UPDATE_ALERT_RULE"), eq("ALERT_RULE"), eq("rule-1"),
+        verify(operationAuditService).record(eq("UPDATE_ALERT_RULE"), eq("ALERT_RULE"), eq("1"),
                 eq(null), eq("name=CPU Alert"), eq("SUCCESS"), eq(null));
     }
 
@@ -537,7 +556,7 @@ class AlertServiceTest {
 
     @Test
     void updateRuleShouldRejectBlankId() {
-        AlertRuleVO update = AlertRuleVO.builder().id("  ").name("CPU Alert").build();
+        AlertRuleVO update = AlertRuleVO.builder().id(null).name("CPU Alert").build();
 
         assertThatThrownBy(() -> alertService.updateRule(update))
                 .isInstanceOf(BusinessException.class)
@@ -548,12 +567,12 @@ class AlertServiceTest {
 
     @Test
     void updateRuleShouldRejectUnknownId() {
-        AlertRuleVO update = AlertRuleVO.builder().id("missing").name("CPU Alert").build();
+        AlertRuleVO update = AlertRuleVO.builder().id(999L).name("CPU Alert").build();
         when(alertRepository.replaceRule(update)).thenReturn(false);
 
         assertThatThrownBy(() -> alertService.updateRule(update))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("Alert rule not found: missing")
+                .hasMessage("Alert rule not found: 999")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
         verify(alertRepository).replaceRule(update);
         verify(alertRepository, never()).saveRule(any());
@@ -561,32 +580,32 @@ class AlertServiceTest {
 
     @Test
     void toggleRuleShouldEnableRule() {
-        AlertRuleVO existing = AlertRuleVO.builder().id("rule-1").name("CPU Alert").enabled(false).build();
+        AlertRuleVO existing = AlertRuleVO.builder().id(1L).name("CPU Alert").enabled(false).build();
         when(alertRepository.findAllRules()).thenReturn(List.of(existing));
         when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        AlertRuleVO result = alertService.toggleRule("rule-1", true);
+        AlertRuleVO result = alertService.toggleRule(1L, true);
 
         assertThat(result.isEnabled()).isTrue();
         verify(alertRepository).saveRule(result);
-        verify(operationAuditService).record(eq("TOGGLE_ALERT_RULE"), eq("ALERT_RULE"), eq("rule-1"),
+        verify(operationAuditService).record(eq("TOGGLE_ALERT_RULE"), eq("ALERT_RULE"), eq("1"),
                 eq(null), eq("enabled=true"), eq("SUCCESS"), eq(null));
     }
 
     @Test
     void toggleRuleShouldDisableRule() {
-        AlertRuleVO existing = AlertRuleVO.builder().id("rule-1").name("CPU Alert").enabled(true).build();
+        AlertRuleVO existing = AlertRuleVO.builder().id(1L).name("CPU Alert").enabled(true).build();
         when(alertRepository.findAllRules()).thenReturn(List.of(existing));
         when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        AlertRuleVO result = alertService.toggleRule("rule-1", false);
+        AlertRuleVO result = alertService.toggleRule(1L, false);
 
         assertThat(result.isEnabled()).isFalse();
     }
 
     @Test
     void toggleRuleShouldRejectBlankIdBeforeLoadingRules() {
-        assertThatThrownBy(() -> alertService.toggleRule("  ", true))
+        assertThatThrownBy(() -> alertService.toggleRule(null, true))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Alert rule ID is required")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
@@ -598,23 +617,23 @@ class AlertServiceTest {
     void toggleRuleShouldIgnorePersistedRulesWithNullIds() {
         when(alertRepository.findAllRules()).thenReturn(List.of(AlertRuleVO.builder().name("corrupt").build()));
 
-        assertThatThrownBy(() -> alertService.toggleRule("missing", true))
+        assertThatThrownBy(() -> alertService.toggleRule(999L, true))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("Alert rule not found: missing");
+                .hasMessage("Alert rule not found: 999");
     }
 
     @Test
     void toggleRuleShouldThrowWhenRuleNotFound() {
         when(alertRepository.findAllRules()).thenReturn(Collections.emptyList());
 
-        assertThatThrownBy(() -> alertService.toggleRule("non-existent", true))
+        assertThatThrownBy(() -> alertService.toggleRule(999L, true))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("Alert rule not found: non-existent");
+                .hasMessageContaining("Alert rule not found: 999");
     }
 
     @Test
     void deleteRuleShouldRejectBlankIdBeforeDeleting() {
-        assertThatThrownBy(() -> alertService.deleteRule(" "))
+        assertThatThrownBy(() -> alertService.deleteRule(null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Alert rule ID is required")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
@@ -624,35 +643,35 @@ class AlertServiceTest {
 
     @Test
     void deleteRuleShouldCallRepository() {
-        when(alertRepository.deleteRule("rule-1")).thenReturn(true);
+        when(alertRepository.deleteRule(1L)).thenReturn(true);
 
-        alertService.deleteRule("rule-1");
+        alertService.deleteRule(1L);
 
-        verify(alertRepository).deleteRule("rule-1");
-        verify(operationAuditService).record(eq("DELETE_ALERT_RULE"), eq("ALERT_RULE"), eq("rule-1"),
+        verify(alertRepository).deleteRule(1L);
+        verify(operationAuditService).record(eq("DELETE_ALERT_RULE"), eq("ALERT_RULE"), eq("1"),
                 eq(null), eq(null), eq("SUCCESS"), eq(null));
     }
 
     @Test
     void deleteRuleShouldRejectUnknownRule() {
-        when(alertRepository.deleteRule("missing")).thenReturn(false);
+        when(alertRepository.deleteRule(999L)).thenReturn(false);
 
-        assertThatThrownBy(() -> alertService.deleteRule("missing"))
+        assertThatThrownBy(() -> alertService.deleteRule(999L))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
     }
 
     @Test
     void bulkToggleShouldDeduplicateIdsAndReportMissingRules() {
-        AlertRuleVO rule = AlertRuleVO.builder().id("rule-1").name("High CPU").enabled(false).build();
+        AlertRuleVO rule = AlertRuleVO.builder().id(1L).name("High CPU").enabled(false).build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
         when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(true);
 
         AlertRuleBulkResultVO result = alertService.bulkToggleRules(
-                List.of("rule-1", "missing", "rule-1"), true);
+                List.of(1L, 999L, 1L), true);
 
-        assertThat(result.getSucceededIds()).containsExactly("rule-1");
-        assertThat(result.getFailures()).containsEntry("missing", "Alert rule not found");
+        assertThat(result.getSucceededIds()).containsExactly(1L);
+        assertThat(result.getFailures()).containsEntry(999L, "Alert rule not found");
         assertThat(result.getUpdatedRules()).singleElement()
                 .extracting(AlertRuleVO::isEnabled).isEqualTo(true);
         verify(alertRepository).replaceRule(rule);
@@ -660,40 +679,40 @@ class AlertServiceTest {
 
     @Test
     void bulkToggleShouldReportRulesDeletedConcurrentlyInsteadOfRecreatingThem() {
-        AlertRuleVO rule = AlertRuleVO.builder().id("rule-1").name("High CPU").enabled(false).build();
+        AlertRuleVO rule = AlertRuleVO.builder().id(1L).name("High CPU").enabled(false).build();
         when(alertRepository.findAllRules()).thenReturn(List.of(rule));
         when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(false);
 
-        AlertRuleBulkResultVO result = alertService.bulkToggleRules(List.of("rule-1"), true);
+        AlertRuleBulkResultVO result = alertService.bulkToggleRules(List.of(1L), true);
 
         assertThat(result.getSucceededIds()).isEmpty();
-        assertThat(result.getFailures()).containsEntry("rule-1", "Alert rule not found");
+        assertThat(result.getFailures()).containsEntry(1L, "Alert rule not found");
         assertThat(result.getUpdatedRules()).isEmpty();
         verify(alertRepository, never()).saveRule(any(AlertRuleVO.class));
     }
 
     @Test
     void bulkDeleteShouldPreservePartialFailureDetails() {
-        when(alertRepository.deleteRule("rule-1")).thenReturn(true);
-        when(alertRepository.deleteRule("missing")).thenReturn(false);
-        when(alertRepository.deleteRule("rule-2"))
+        when(alertRepository.deleteRule(1L)).thenReturn(true);
+        when(alertRepository.deleteRule(999L)).thenReturn(false);
+        when(alertRepository.deleteRule(2L))
                 .thenThrow(new IllegalStateException("database unavailable"));
 
         AlertRuleBulkResultVO result = alertService.bulkDeleteRules(
-                List.of("rule-1", "missing", "rule-2"));
+                List.of(1L, 999L, 2L));
 
-        assertThat(result.getSucceededIds()).containsExactly("rule-1");
+        assertThat(result.getSucceededIds()).containsExactly(1L);
         assertThat(result.getFailures())
-                .containsEntry("missing", "Alert rule not found")
-                .containsEntry("rule-2", "database unavailable");
+                .containsEntry(999L, "Alert rule not found")
+                .containsEntry(2L, "database unavailable");
         assertThat(result.getUpdatedRules()).isEmpty();
     }
 
     @Test
     void listAlertsShouldReturnAlertsForLevel() {
-        SystemAlertVO alert1 = SystemAlertVO.builder().id("a1").level(AlertLevel.error)
+        SystemAlertVO alert1 = SystemAlertVO.builder().id(1L).level(AlertLevel.error)
                 .title("Broker Down").acknowledged(false).build();
-        SystemAlertVO alert2 = SystemAlertVO.builder().id("a2").level(AlertLevel.error)
+        SystemAlertVO alert2 = SystemAlertVO.builder().id(2L).level(AlertLevel.error)
                 .title("High Latency").acknowledged(false).build();
         when(alertRepository.findAlerts("error")).thenReturn(Arrays.asList(alert1, alert2));
 
@@ -707,7 +726,7 @@ class AlertServiceTest {
 
     @Test
     void listAlertsShouldReturnAllAlertsWhenLevelIsNull() {
-        SystemAlertVO alert = SystemAlertVO.builder().id("a1").level(AlertLevel.warning)
+        SystemAlertVO alert = SystemAlertVO.builder().id(1L).level(AlertLevel.warning)
                 .title("Slow Consumer").build();
         when(alertRepository.findAlerts(null)).thenReturn(List.of(alert));
 
@@ -720,22 +739,22 @@ class AlertServiceTest {
 
     @Test
     void acknowledgeAlertShouldSetAcknowledgedTrue() {
-        SystemAlertVO existing = SystemAlertVO.builder().id("a1").level(AlertLevel.error)
+        SystemAlertVO existing = SystemAlertVO.builder().id(1L).level(AlertLevel.error)
                 .title("Broker Down").acknowledged(false).build();
         when(alertRepository.findAlerts(null)).thenReturn(List.of(existing));
         when(alertRepository.acknowledgeAlert(any(SystemAlertVO.class))).thenReturn(true);
 
-        SystemAlertVO result = alertService.acknowledgeAlert("a1");
+        SystemAlertVO result = alertService.acknowledgeAlert(1L);
 
         assertThat(result.isAcknowledged()).isTrue();
         verify(alertRepository).acknowledgeAlert(result);
-        verify(operationAuditService).record(eq("ACKNOWLEDGE_SYSTEM_ALERT"), eq("SYSTEM_ALERT"), eq("a1"),
+        verify(operationAuditService).record(eq("ACKNOWLEDGE_SYSTEM_ALERT"), eq("SYSTEM_ALERT"), eq("1"),
                 eq(null), eq("acknowledged=true"), eq("SUCCESS"), eq(null));
     }
 
     @Test
     void acknowledgeAlertShouldRejectBlankIdBeforeLoadingAlerts() {
-        assertThatThrownBy(() -> alertService.acknowledgeAlert(" "))
+        assertThatThrownBy(() -> alertService.acknowledgeAlert(null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("System alert ID is required")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
@@ -747,30 +766,30 @@ class AlertServiceTest {
     void acknowledgeAlertShouldIgnorePersistedAlertsWithNullIds() {
         when(alertRepository.findAlerts(null)).thenReturn(List.of(SystemAlertVO.builder().title("corrupt").build()));
 
-        assertThatThrownBy(() -> alertService.acknowledgeAlert("missing"))
+        assertThatThrownBy(() -> alertService.acknowledgeAlert(999L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("System alert not found: missing");
+                .hasMessage("System alert not found: 999");
     }
 
     @Test
     void acknowledgeAlertShouldThrowWhenAlertNotFound() {
         when(alertRepository.findAlerts(null)).thenReturn(Collections.emptyList());
 
-        assertThatThrownBy(() -> alertService.acknowledgeAlert("non-existent"))
+        assertThatThrownBy(() -> alertService.acknowledgeAlert(999L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("System alert not found: non-existent");
+                .hasMessageContaining("System alert not found: 999");
     }
 
     @Test
     void acknowledgeAlertShouldRejectConcurrentRemoval() {
-        SystemAlertVO existing = SystemAlertVO.builder().id("a1").level(AlertLevel.error)
+        SystemAlertVO existing = SystemAlertVO.builder().id(1L).level(AlertLevel.error)
                 .title("Broker Down").acknowledged(false).build();
         when(alertRepository.findAlerts(null)).thenReturn(List.of(existing));
         when(alertRepository.acknowledgeAlert(any(SystemAlertVO.class))).thenReturn(false);
 
-        assertThatThrownBy(() -> alertService.acknowledgeAlert("a1"))
+        assertThatThrownBy(() -> alertService.acknowledgeAlert(1L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("System alert not found: a1")
+                .hasMessage("System alert not found: 1")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
 
         verify(operationAuditService, never()).record(any(), any(), any(), any(), any(), any(), any());

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -52,8 +52,8 @@ class MybatisPlusAlertRepositoryTest {
 
     @Test
     void replaceRuleShouldReportAConcurrentDelete() {
-        AlertRuleVO rule = AlertRuleVO.builder().id("rule-1").name("Lag").build();
-        when(ruleMapper.selectById("rule-1")).thenReturn(new RmqAlertRule());
+        AlertRuleVO rule = AlertRuleVO.builder().id(1L).name("Lag").build();
+        when(ruleMapper.selectById(1L)).thenReturn(new RmqAlertRule());
         when(ruleMapper.updateById(any(RmqAlertRule.class))).thenReturn(0);
 
         assertThat(repository.replaceRule(rule)).isFalse();
@@ -72,13 +72,13 @@ class MybatisPlusAlertRepositoryTest {
 
     @Test
     void acknowledgeAlertShouldReportUpdateOutcomeWithoutInserting() {
-        SystemAlertVO deleted = SystemAlertVO.builder().id("deleted").acknowledged(true).build();
-        SystemAlertVO existing = SystemAlertVO.builder().id("existing").acknowledged(true).build();
+        SystemAlertVO deleted = SystemAlertVO.builder().id(1L).acknowledged(true).build();
+        SystemAlertVO existing = SystemAlertVO.builder().id(2L).acknowledged(true).build();
         when(alertMapper.updateById(argThat((RmqSystemAlert entity) ->
-                entity != null && "deleted".equals(entity.getId()))))
+                entity != null && Long.valueOf(1L).equals(entity.getId()))))
                 .thenReturn(0);
         when(alertMapper.updateById(argThat((RmqSystemAlert entity) ->
-                entity != null && "existing".equals(entity.getId()))))
+                entity != null && Long.valueOf(2L).equals(entity.getId()))))
                 .thenReturn(1);
 
         assertThat(repository.acknowledgeAlert(deleted)).isFalse();

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
@@ -53,7 +53,7 @@ class SystemAlertControllerTest {
     @Test
     void listAlertsShouldReturnSystemAlerts() throws Exception {
         SystemAlertVO alert = SystemAlertVO.builder()
-                .id("alert-1")
+                .id(1L)
                 .level(AlertLevel.error)
                 .title("Broker Down")
                 .acknowledged(false)
@@ -63,7 +63,7 @@ class SystemAlertControllerTest {
         mockMvc.perform(get("/api/system-alerts").param("level", "error"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data[0].id").value("alert-1"))
+                .andExpect(jsonPath("$.data[0].id").value(1))
                 .andExpect(jsonPath("$.data[0].level").value("error"))
                 .andExpect(jsonPath("$.data[0].acknowledged").value(false));
 
@@ -73,22 +73,22 @@ class SystemAlertControllerTest {
     @Test
     void acknowledgeAlertShouldPassValidatedRequest() throws Exception {
         SystemAlertVO acknowledged = SystemAlertVO.builder()
-                .id("alert-1")
+                .id(1L)
                 .level(AlertLevel.warning)
                 .title("High Lag")
                 .acknowledged(true)
                 .build();
-        when(alertService.acknowledgeAlert("alert-1")).thenReturn(acknowledged);
+        when(alertService.acknowledgeAlert(1L)).thenReturn(acknowledged);
 
         mockMvc.perform(post("/api/system-alerts/acknowledge")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("id", "alert-1"))))
+                        .content(objectMapper.writeValueAsString(Map.of("id", 1))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.id").value("alert-1"))
+                .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.acknowledged").value(true));
 
-        verify(alertService).acknowledgeAlert("alert-1");
+        verify(alertService).acknowledgeAlert(1L);
     }
 
     @Test
@@ -107,7 +107,7 @@ class SystemAlertControllerTest {
     void acknowledgeAlertShouldRejectBlankId() throws Exception {
         mockMvc.perform(post("/api/system-alerts/acknowledge")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("id", " "))))
+                        .content(objectMapper.writeValueAsString(java.util.Collections.singletonMap("id", null))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("id is required"));

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
@@ -59,7 +59,7 @@ class MybatisPlusAuditRepositoryTest {
         entity.setDetail("delete requested");
         entity.setResult("FAILED");
         entity.setErrorMessage("denied");
-        entity.setOperatedAt(LocalDateTime.of(2026, 8, 4, 10, 15));
+        entity.setGmtCreate(LocalDateTime.of(2026, 8, 4, 10, 15));
         Page<RmqOperationAudit> mapperPage = new Page<RmqOperationAudit>(2, 25)
                 .setRecords(List.of(entity))
                 .setTotal(126);
@@ -75,7 +75,7 @@ class MybatisPlusAuditRepositoryTest {
         assertThat(pageCaptor.getValue().getSize()).isEqualTo(25);
         assertThat(result.getTotal()).isEqualTo(126);
         AuditRecordVO record = result.getItems().get(0);
-        assertThat(record.getId()).isEqualTo("42");
+        assertThat(record.getId()).isEqualTo(42L);
         assertThat(record.getResourceType()).isEqualTo("TOPIC");
         assertThat(record.getClusterId()).isEqualTo("prod-cn");
         assertThat(record.getErrorMessage()).isEqualTo("denied");

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,7 +39,7 @@ class MybatisPlusSettingsRepositoryTest {
 
     @Test
     void shouldReturnDefaultsWhenGeneralSettingsDoNotExist() {
-        when(settingsMapper.selectById("singleton")).thenReturn(null);
+        when(settingsMapper.selectOne(any())).thenReturn(null);
 
         GeneralSettingsVO settings = repository.loadGeneralSettings();
 
@@ -50,7 +51,7 @@ class MybatisPlusSettingsRepositoryTest {
     void shouldRejectCorruptPersistedGeneralSettings() {
         RmqSettings settings = new RmqSettings();
         settings.setJson("{not-json");
-        when(settingsMapper.selectById("singleton")).thenReturn(settings);
+        when(settingsMapper.selectOne(any())).thenReturn(settings);
 
         assertThatThrownBy(repository::loadGeneralSettings)
                 .isInstanceOf(BusinessException.class)
@@ -63,7 +64,7 @@ class MybatisPlusSettingsRepositoryTest {
     void shouldRejectNullPersistedGeneralSettings() {
         RmqSettings settings = new RmqSettings();
         settings.setJson("null");
-        when(settingsMapper.selectById("singleton")).thenReturn(settings);
+        when(settingsMapper.selectOne(any())).thenReturn(settings);
 
         assertThatThrownBy(repository::loadGeneralSettings)
                 .isInstanceOf(BusinessException.class)
@@ -76,7 +77,7 @@ class MybatisPlusSettingsRepositoryTest {
     void shouldReadValidPersistedGeneralSettings() {
         RmqSettings settings = new RmqSettings();
         settings.setJson("{\"theme\":\"dark\",\"requireLogin\":true}");
-        when(settingsMapper.selectById("singleton")).thenReturn(settings);
+        when(settingsMapper.selectOne(any())).thenReturn(settings);
 
         GeneralSettingsVO loaded = repository.loadGeneralSettings();
 
@@ -89,7 +90,7 @@ class MybatisPlusSettingsRepositoryTest {
         RmqDataSource dataSource = new RmqDataSource();
         dataSource.setDsKey("metrics-prod");
         dataSource.setJson("null");
-        when(dataSourceMapper.selectById("metrics-prod")).thenReturn(dataSource);
+        when(dataSourceMapper.selectOne(any())).thenReturn(dataSource);
 
         assertThatThrownBy(() -> repository.findDataSourceByKey("metrics-prod"))
                 .isInstanceOf(BusinessException.class)
@@ -103,7 +104,7 @@ class MybatisPlusSettingsRepositoryTest {
         RmqDataSource dataSource = new RmqDataSource();
         dataSource.setDsKey("metrics-prod");
         dataSource.setJson("{not-json");
-        when(dataSourceMapper.selectById("metrics-prod")).thenReturn(dataSource);
+        when(dataSourceMapper.selectOne(any())).thenReturn(dataSource);
 
         assertThatThrownBy(() -> repository.findDataSourceByKey("metrics-prod"))
                 .isInstanceOf(BusinessException.class)
@@ -116,7 +117,7 @@ class MybatisPlusSettingsRepositoryTest {
     void shouldReportWhenDataSourceDisappearsDuringReplacement() {
         RmqDataSource existing = new RmqDataSource();
         existing.setDsKey("metrics-prod");
-        when(dataSourceMapper.selectById("metrics-prod")).thenReturn(existing);
+        when(dataSourceMapper.selectOne(any())).thenReturn(existing);
         when(dataSourceMapper.updateById(existing)).thenReturn(0);
         DataSourceVO replacement = DataSourceVO.builder()
                 .key("metrics-prod")

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/entity/RmqSettingsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/entity/RmqSettingsTest.java
@@ -27,14 +27,14 @@ class RmqSettingsTest {
     @Test
     void toStringShouldNotExposePersistedSettingsJson() {
         RmqSettings settings = new RmqSettings();
-        settings.setId("settings");
+        settings.setId(1L);
         settings.setJson("{\"apiKey\":\"sk-secret\",\"model\":\"gpt-4o\"}");
-        settings.setUpdatedAt(LocalDateTime.of(2026, 8, 3, 12, 0));
+        settings.setGmtModified(LocalDateTime.of(2026, 8, 3, 12, 0));
 
         String text = settings.toString();
 
-        assertThat(text).contains("id=settings");
-        assertThat(text).contains("updatedAt=2026-08-03T12:00");
+        assertThat(text).contains("id=1");
+        assertThat(text).contains("gmtModified=2026-08-03T12:00");
         assertThat(text).doesNotContain("json");
         assertThat(text).doesNotContain("sk-secret");
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogServiceTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class AliyunCatalogServiceTest {
 
-    private static final String CREDENTIAL_ID = "cred-1";
+    private static final Long CREDENTIAL_ID = 1L;
     private static final String REGION = "cn-hangzhou";
 
     @Mock

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunClientFactoryTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class AliyunClientFactoryTest {
 
-    private static final String CREDENTIAL_ID = "cred-1";
+    private static final Long CREDENTIAL_ID = 1L;
     private static final String REGION = "cn-hangzhou";
 
     @Mock
@@ -89,9 +89,9 @@ class AliyunClientFactoryTest {
 
     @Test
     void clientShouldThrow404WhenCredentialMissingTest() {
-        when(credentialRepository.findById("missing")).thenReturn(Optional.empty());
+        when(credentialRepository.findById(999L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> factory.client("missing", REGION))
+        assertThatThrownBy(() -> factory.client(999L, REGION))
                 .isInstanceOf(BusinessException.class)
                 .extracting("code")
                 .isEqualTo(404);
@@ -104,7 +104,7 @@ class AliyunClientFactoryTest {
         AtomicInteger created = new AtomicInteger();
         factory = new AliyunClientFactory(credentialRepository) {
             @Override
-            protected AsyncClient createClient(String credentialId, String region) {
+            protected AsyncClient createClient(Long credentialId, String region) {
                 return created.getAndIncrement() == 0 ? first : second;
             }
         };
@@ -120,7 +120,7 @@ class AliyunClientFactoryTest {
     void callShouldThrow504OnTimeoutTest() {
         factory.setCallTimeoutSeconds(1L);
         AliyunClientFactory spy = Mockito.spy(factory);
-        doReturn(asyncClient).when(spy).client(anyString(), anyString());
+        doReturn(asyncClient).when(spy).client(any(Long.class), anyString());
         CompletableFuture<Object> future = new CompletableFuture<>();
 
         assertThatThrownBy(() -> spy.call(CREDENTIAL_ID, REGION,
@@ -134,7 +134,7 @@ class AliyunClientFactoryTest {
     @Test
     void callShouldCancelFutureAndPreserveInterruptTest() throws Exception {
         AliyunClientFactory spy = Mockito.spy(factory);
-        doReturn(asyncClient).when(spy).client(anyString(), anyString());
+        doReturn(asyncClient).when(spy).client(any(Long.class), anyString());
         CompletableFuture<Object> future = new CompletableFuture<>();
         CountDownLatch waiting = new CountDownLatch(1);
         AtomicReference<Throwable> failure = new AtomicReference<>();
@@ -167,7 +167,7 @@ class AliyunClientFactoryTest {
     @Test
     void callShouldMapServer404ToBusinessExceptionTest() {
         AliyunClientFactory spy = Mockito.spy(factory);
-        doReturn(asyncClient).when(spy).client(anyString(), anyString());
+        doReturn(asyncClient).when(spy).client(any(Long.class), anyString());
         PopServerException error = new PopServerException("instance not found");
         error.setStatusCode(404);
         error.setErrCode("Instance.NotFound");
@@ -187,7 +187,7 @@ class AliyunClientFactoryTest {
     @Test
     void callShouldMapInvalidAccessKeyTo422Test() {
         AliyunClientFactory spy = Mockito.spy(factory);
-        doReturn(asyncClient).when(spy).client(anyString(), anyString());
+        doReturn(asyncClient).when(spy).client(any(Long.class), anyString());
         PopServerException error = new PopServerException("bad key");
         error.setStatusCode(403);
         error.setErrCode("InvalidAccessKeyId");
@@ -204,7 +204,7 @@ class AliyunClientFactoryTest {
     @Test
     void callShouldMapGenericFailureTo502Test() {
         AliyunClientFactory spy = Mockito.spy(factory);
-        doReturn(asyncClient).when(spy).client(anyString(), anyString());
+        doReturn(asyncClient).when(spy).client(any(Long.class), anyString());
         when(asyncClient.listRegions(any(ListRegionsRequest.class)))
                 .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("boom")));
 
@@ -221,7 +221,7 @@ class AliyunClientFactoryTest {
     @Test
     void callShouldReturnSuccessfulBodyTest() {
         AliyunClientFactory spy = Mockito.spy(factory);
-        doReturn(asyncClient).when(spy).client(anyString(), anyString());
+        doReturn(asyncClient).when(spy).client(any(Long.class), anyString());
         ListRegionsResponse response = ListRegionsResponse.create().toBuilder()
                 .statusCode(200)
                 .body(ListRegionsResponseBody.builder().success(true).build())

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -74,10 +74,11 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class AliyunInstanceProviderTest {
 
-    private static final String STUDIO_INSTANCE_ID = "inst-1";
+    private static final String STUDIO_INSTANCE_ID = "7";
+    private static final Long STUDIO_INSTANCE_PK = 7L;
     private static final String CLOUD_INSTANCE_ID = "rmq-cn-001";
     private static final String REGION = "cn-hangzhou";
-    private static final String CREDENTIAL_ID = "cred-1";
+    private static final Long CREDENTIAL_ID = 1L;
 
     @Mock
     private AliyunClientFactory clientFactory;
@@ -111,7 +112,7 @@ class AliyunInstanceProviderTest {
         assertThat(all).hasSize(3);
         assertThat(all.get(0).getName()).isEqualTo("topic-normal");
         assertThat(all.get(0).getType()).isEqualTo(TopicType.NORMAL);
-        assertThat(all.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_ID);
+        assertThat(all.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_PK);
         assertThat(all.get(0).getWriteQueues()).isZero();
         assertThat(all.get(0).getReadQueues()).isZero();
         assertThat(all.get(0).getRemark()).isEqualTo("remark-topic-normal");
@@ -150,7 +151,7 @@ class AliyunInstanceProviderTest {
 
         assertThat(groups).hasSize(1);
         assertThat(groups.get(0).getName()).isEqualTo("GID_test");
-        assertThat(groups.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_ID);
+        assertThat(groups.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_PK);
         assertThat(groups.get(0).getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
     }
 
@@ -276,7 +277,7 @@ class AliyunInstanceProviderTest {
         assertThat(request.getDeliveryOrderType()).isEqualTo("Concurrently");
         assertThat(request.getConsumeRetryPolicy().getRetryPolicy()).isEqualTo("DefaultRetryPolicy");
         assertThat(request.getConsumeRetryPolicy().getMaxRetryTimes()).isEqualTo(16);
-        assertThat(created.getInstanceId()).isEqualTo(STUDIO_INSTANCE_ID);
+        assertThat(created.getInstanceId()).isEqualTo(STUDIO_INSTANCE_PK);
         assertThat(created.getDeliveryOrderType()).isEqualTo("Concurrently");
         assertThat(created.getRetryMaxTimes()).isEqualTo(16);
     }
@@ -407,7 +408,7 @@ class AliyunInstanceProviderTest {
     @Test
     void mappedBusinessExceptionShouldPropagateTest() {
         stubInstance();
-        when(clientFactory.call(anyString(), anyString(), any()))
+        when(clientFactory.call(any(Long.class), anyString(), any()))
                 .thenThrow(new BusinessException(404, "Aliyun resource not found"));
 
         assertThatThrownBy(() -> provider.listTopics(STUDIO_INSTANCE_ID, null, null))
@@ -444,7 +445,7 @@ class AliyunInstanceProviderTest {
     }
 
     private void stubCallThrough() {
-        when(clientFactory.call(anyString(), anyString(), any())).thenAnswer(invocation -> {
+        when(clientFactory.call(any(Long.class), anyString(), any())).thenAnswer(invocation -> {
             Function<AsyncClient, CompletableFuture<Object>> action = invocation.getArgument(2);
             return action.apply(asyncClient).join();
         });

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProviderTest.java
@@ -18,12 +18,15 @@ package org.apache.rocketmq.studio.provider.apache;
 
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.apache.rocketmq.studio.instance.message.MessageProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -54,14 +57,20 @@ class ApacheInstanceProviderTest {
 
     @Test
     void countTopicsShouldDelegateToRepositoryTest() {
-        when(instanceRepository.countTopicsByInstance("inst-1")).thenReturn(3L);
+        InstanceVO instance = InstanceVO.builder().name("inst-1").build();
+        instance.setId(1L);
+        when(instanceRepository.findByIdentifier("inst-1")).thenReturn(Optional.of(instance));
+        when(instanceRepository.countTopicsByInstance(1L)).thenReturn(3L);
 
         assertThat(provider.countTopics("inst-1")).isEqualTo(3);
     }
 
     @Test
     void countGroupsShouldDelegateToRepositoryTest() {
-        when(instanceRepository.countGroupsByInstance("inst-1")).thenReturn(2L);
+        InstanceVO instance = InstanceVO.builder().name("inst-1").build();
+        instance.setId(1L);
+        when(instanceRepository.findByIdentifier("inst-1")).thenReturn(Optional.of(instance));
+        when(instanceRepository.countGroupsByInstance(1L)).thenReturn(2L);
 
         assertThat(provider.countGroups("inst-1")).isEqualTo(2);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -106,7 +106,7 @@ class RocketMQAdminClientImplTest {
 
         ConsumerGroupVO group = adminClient.getConsumerGroup(null, "orders");
 
-        assertThat(group.getId()).isEqualTo("orders");
+        assertThat(group.getName()).isEqualTo("orders");
         assertThat(group.getOnlineInstances()).isZero();
     }
 
@@ -250,18 +250,18 @@ class RocketMQAdminClientImplTest {
         when(selectedAdmin.examineBrokerClusterInfo()).thenReturn(clusterInfoWithMaster());
         when(topicMapper.selectOne(any())).thenReturn(null);
         doNothing().when(selectedAdmin).createAndUpdateTopicConfig(anyString(), any(TopicConfig.class));
-        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("instance-a"), any()))
+        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("1"), any()))
                 .thenAnswer(invocation -> invocation.<MqAdminExtFactory.AdminAction<Object>>getArgument(1)
                         .apply(selectedAdmin));
 
         TopicVO topic = new TopicVO();
         topic.setName("topicA");
-        topic.setInstanceId("instance-a");
+        topic.setInstanceId(1L);
 
         adminClient.createTopic(topic);
         adminClient.updateTopic(topic);
 
-        verify(runtimeAdminClientResolver, times(2)).execute(org.mockito.ArgumentMatchers.eq("instance-a"), any());
+        verify(runtimeAdminClientResolver, times(2)).execute(org.mockito.ArgumentMatchers.eq("1"), any());
         verify(selectedAdmin, times(2)).createAndUpdateTopicConfig(
                 org.mockito.ArgumentMatchers.eq("10.0.0.1:10911"), any(TopicConfig.class));
         verify(adminExt, never()).createAndUpdateTopicConfig(anyString(), any(TopicConfig.class));
@@ -363,7 +363,7 @@ class RocketMQAdminClientImplTest {
         when(selectedAdmin.examineBrokerClusterInfo()).thenReturn(clusterInfo);
         when(groupMapper.selectOne(any())).thenReturn(null);
         doNothing().when(selectedAdmin).createAndUpdateSubscriptionGroupConfig(anyString(), any());
-        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("instance-a"), any()))
+        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("1"), any()))
                 .thenAnswer(invocation -> {
                     MqAdminExtFactory.AdminAction<?> action = invocation.getArgument(1);
                     return action.apply(selectedAdmin);
@@ -371,11 +371,11 @@ class RocketMQAdminClientImplTest {
 
         ConsumerGroupVO group = new ConsumerGroupVO();
         group.setName("cg-orders");
-        group.setInstanceId("instance-a");
+        group.setInstanceId(1L);
 
         adminClient.createConsumerGroup(group);
 
-        verify(runtimeAdminClientResolver).execute(org.mockito.ArgumentMatchers.eq("instance-a"), any());
+        verify(runtimeAdminClientResolver).execute(org.mockito.ArgumentMatchers.eq("1"), any());
         verify(selectedAdmin).createAndUpdateSubscriptionGroupConfig(
                 org.mockito.ArgumentMatchers.eq("10.0.0.1:10911"), any());
         verify(adminExt, never()).createAndUpdateSubscriptionGroupConfig(anyString(), any());
@@ -428,6 +428,11 @@ class RocketMQAdminClientImplTest {
         ClusterInfo clusterInfo = clusterInfoWithMaster();
         when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo);
         when(topicMapper.selectOne(any())).thenReturn(null);
+        when(topicMapper.insert(any(RmqTopic.class))).thenAnswer(invocation -> {
+            RmqTopic inserted = invocation.getArgument(0);
+            inserted.setId(1L);
+            return 1;
+        });
         doNothing().when(adminExt).createAndUpdateTopicConfig(anyString(), any(TopicConfig.class));
         doThrow(new RuntimeException("audit db down")).when(auditService)
                 .record(anyString(), anyString(), anyString(), anyString());
@@ -435,7 +440,7 @@ class RocketMQAdminClientImplTest {
         TopicVO topic = new TopicVO();
         topic.setName("topicA");
 
-        assertThat(adminClient.createTopic(topic).getId()).isEqualTo("topicA");
+        assertThat(adminClient.createTopic(topic).getId()).isEqualTo(1L);
         verify(auditService).record("CREATE_TOPIC", "topicA", "queues=8/8", "SUCCESS");
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -363,7 +363,7 @@ class RocketMQDashboardProviderTest {
                 .type(InstanceType.DIRECT)
                 .endpoint("namesrv-direct:9876")
                 .build();
-        instance.setId("instance-direct");
+        instance.setId(1L);
         when(resolver.resolveInstance("instance-direct")).thenReturn(instance);
         when(resolver.execute(eq(instance), any())).thenAnswer(invocation ->
                 invocation.<MqAdminExtFactory.AdminAction<DashboardDataVO>>getArgument(1).apply(adminExt));

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialControllerTest.java
@@ -42,12 +42,12 @@ class CloudCredentialControllerTest {
     @Test
     void getCredentialSecretsShouldDisableResponseCaching() throws Exception {
         CloudCredentialVO credentials = new CloudCredentialVO();
-        credentials.setId("credential-1");
+        credentials.setId(1L);
         credentials.setAccessKey("access-key");
         credentials.setSecretKey("secret-key");
-        when(credentialService.reveal("credential-1")).thenReturn(credentials);
+        when(credentialService.reveal(1L)).thenReturn(credentials);
 
-        mockMvc.perform(get("/api/cloud-credentials/credential-1/credentials"))
+        mockMvc.perform(get("/api/cloud-credentials/1/credentials"))
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"));
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
@@ -65,7 +65,7 @@ class CloudCredentialServiceTest {
     @Test
     void listShouldMaskAccessKeyAndHideSecretTest() {
         CloudCredentialVO stored = new CloudCredentialVO();
-        stored.setId("cred-1");
+        stored.setId(1L);
         stored.setName("aliyun-test");
         stored.setVendor(InstanceVendor.ALIYUN);
         stored.setAccessKey("LTAI5tUnitTestKey000000001");
@@ -127,15 +127,21 @@ class CloudCredentialServiceTest {
         request.setSecretKey("sk-value");
         when(credentialRepository.findByVendorAndAccessKey(any(), any())).thenReturn(Optional.empty());
         when(credentialRepository.save(any(CloudCredentialVO.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+                .thenAnswer(invocation -> {
+                    CloudCredentialVO saved = invocation.getArgument(0);
+                    if (saved.getId() == null) {
+                        saved.setId(1L);
+                    }
+                    return saved;
+                });
 
         CloudCredentialVO created = service.create(request);
 
-        assertThat(created.getId()).isNotBlank();
+        assertThat(created.getId()).isNotNull();
         assertThat(created.getAccessKey()).isEqualTo("LTAI****0001");
         assertThat(created.getSecretKey()).isNull();
         verify(operationAuditService).record(eq("CREATE_CLOUD_CREDENTIAL"), eq("CLOUD_CREDENTIAL"),
-                eq(created.getId()), eq(null), argThat(detail -> detail.equals("name=ok, vendor=ALIYUN")
+                eq("1"), eq(null), argThat(detail -> detail.equals("name=ok, vendor=ALIYUN")
                         && !detail.contains("LTAI5tGoodKey00000000001") && !detail.contains("sk-value")),
                 eq("SUCCESS"), eq(null));
     }
@@ -143,11 +149,11 @@ class CloudCredentialServiceTest {
     @Test
     void deleteShouldRejectWhenReferencedByInstanceTest() {
         CloudCredentialVO stored = new CloudCredentialVO();
-        stored.setId("cred-1");
-        when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
-        when(instanceRepository.existsByCredentialId("cred-1")).thenReturn(true);
+        stored.setId(1L);
+        when(credentialRepository.findById(1L)).thenReturn(Optional.of(stored));
+        when(instanceRepository.existsByCredentialId(1L)).thenReturn(true);
 
-        assertThatThrownBy(() -> service.delete("cred-1"))
+        assertThatThrownBy(() -> service.delete(1L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("referenced");
         verify(credentialRepository, never()).deleteById(any());
@@ -156,54 +162,54 @@ class CloudCredentialServiceTest {
     @Test
     void updateShouldInvalidateAliyunClientsAfterSavingCredentialTest() {
         CloudCredentialVO stored = new CloudCredentialVO();
-        stored.setId("cred-1");
+        stored.setId(1L);
         stored.setVendor(InstanceVendor.ALIYUN);
         stored.setAccessKey("LTAI5tUpdateKey000000001");
         stored.setSecretKey("old-secret");
-        when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
+        when(credentialRepository.findById(1L)).thenReturn(Optional.of(stored));
         when(credentialRepository.save(any(CloudCredentialVO.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
         UpdateCloudCredentialDTO request = new UpdateCloudCredentialDTO();
-        request.setId("cred-1");
+        request.setId(1L);
         request.setSecretKey("new-secret");
 
         service.update(request);
 
-        verify(aliyunClientFactory).invalidateCredential("cred-1");
+        verify(aliyunClientFactory).invalidateCredential(1L);
         verify(operationAuditService).record(eq("UPDATE_CLOUD_CREDENTIAL"), eq("CLOUD_CREDENTIAL"),
-                eq("cred-1"), eq(null), eq("name=null, vendor=ALIYUN"), eq("SUCCESS"), eq(null));
+                eq("1"), eq(null), eq("name=null, vendor=ALIYUN"), eq("SUCCESS"), eq(null));
     }
 
     @Test
     void deleteShouldInvalidateAliyunClientsAfterRemovingCredentialTest() {
         CloudCredentialVO stored = new CloudCredentialVO();
-        stored.setId("cred-1");
+        stored.setId(1L);
         stored.setVendor(InstanceVendor.ALIYUN);
-        when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
-        when(instanceRepository.existsByCredentialId("cred-1")).thenReturn(false);
-        when(credentialRepository.deleteById("cred-1")).thenReturn(true);
+        when(credentialRepository.findById(1L)).thenReturn(Optional.of(stored));
+        when(instanceRepository.existsByCredentialId(1L)).thenReturn(false);
+        when(credentialRepository.deleteById(1L)).thenReturn(true);
 
-        service.delete("cred-1");
+        service.delete(1L);
 
-        verify(credentialRepository).deleteById("cred-1");
-        verify(aliyunClientFactory).invalidateCredential("cred-1");
+        verify(credentialRepository).deleteById(1L);
+        verify(aliyunClientFactory).invalidateCredential(1L);
         verify(operationAuditService).record(eq("DELETE_CLOUD_CREDENTIAL"), eq("CLOUD_CREDENTIAL"),
-                eq("cred-1"), eq(null), eq("name=null, vendor=ALIYUN"), eq("SUCCESS"), eq(null));
+                eq("1"), eq(null), eq("name=null, vendor=ALIYUN"), eq("SUCCESS"), eq(null));
     }
 
     @Test
     void deleteShouldRejectConcurrentRemovalBeforeInvalidatingClientsTest() {
         CloudCredentialVO stored = new CloudCredentialVO();
-        stored.setId("cred-1");
+        stored.setId(1L);
         stored.setVendor(InstanceVendor.ALIYUN);
-        when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
-        when(instanceRepository.existsByCredentialId("cred-1")).thenReturn(false);
-        when(credentialRepository.deleteById("cred-1")).thenReturn(false);
+        when(credentialRepository.findById(1L)).thenReturn(Optional.of(stored));
+        when(instanceRepository.existsByCredentialId(1L)).thenReturn(false);
+        when(credentialRepository.deleteById(1L)).thenReturn(false);
 
-        assertThatThrownBy(() -> service.delete("cred-1"))
+        assertThatThrownBy(() -> service.delete(1L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("Cloud credential not found: cred-1");
+                .hasMessage("Cloud credential not found: 1");
 
         verify(aliyunClientFactory, never()).invalidateCredential(any());
     }
@@ -211,13 +217,13 @@ class CloudCredentialServiceTest {
     @Test
     void revealShouldReturnUnmaskedCredentialTest() {
         CloudCredentialVO stored = new CloudCredentialVO();
-        stored.setId("cred-1");
+        stored.setId(1L);
         stored.setVendor(InstanceVendor.ALIYUN);
         stored.setAccessKey("LTAI5tRevealKey000000001");
         stored.setSecretKey("plain-secret");
-        when(credentialRepository.findById("cred-1")).thenReturn(Optional.of(stored));
+        when(credentialRepository.findById(1L)).thenReturn(Optional.of(stored));
 
-        CloudCredentialVO revealed = service.reveal("cred-1");
+        CloudCredentialVO revealed = service.reveal(1L);
 
         assertThat(revealed.getAccessKey()).isEqualTo("LTAI5tRevealKey000000001");
         assertThat(revealed.getSecretKey()).isEqualTo("plain-secret");

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
@@ -46,22 +46,22 @@ class MybatisPlusCloudCredentialRepositoryTest {
     @Test
     void saveShouldReportALostConcurrentUpdate() {
         CloudCredentialVO credential = new CloudCredentialVO();
-        credential.setId("cred-1");
+        credential.setId(1L);
         credential.setVendor(InstanceVendor.ALIYUN);
-        when(credentialMapper.selectById("cred-1")).thenReturn(entity("cred-1", "ALIYUN"));
+        when(credentialMapper.selectById(1L)).thenReturn(entity(1L, "cred-1", "ALIYUN"));
         when(credentialMapper.updateById(any(RmqCloudCredential.class))).thenReturn(0);
 
         assertThatThrownBy(() -> repository.save(credential))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("Cloud credential update was not applied: cred-1")
+                .hasMessage("Cloud credential update was not applied: 1")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(409));
     }
 
     @Test
     void findByIdShouldMapValidPersistedVendor() {
-        when(credentialMapper.selectById("cred-valid")).thenReturn(entity("cred-valid", "ALIYUN"));
+        when(credentialMapper.selectById(2L)).thenReturn(entity(2L, "cred-valid", "ALIYUN"));
 
-        Optional<CloudCredentialVO> result = repository.findById("cred-valid");
+        Optional<CloudCredentialVO> result = repository.findById(2L);
 
         assertThat(result).isPresent();
         assertThat(result.orElseThrow().getVendor()).isEqualTo(InstanceVendor.ALIYUN);
@@ -69,18 +69,18 @@ class MybatisPlusCloudCredentialRepositoryTest {
 
     @Test
     void findByIdShouldRejectInvalidPersistedVendor() {
-        when(credentialMapper.selectById("cred-invalid")).thenReturn(entity("cred-invalid", "UNKNOWN"));
+        when(credentialMapper.selectById(3L)).thenReturn(entity(3L, "cred-invalid", "UNKNOWN"));
 
-        assertThatThrownBy(() -> repository.findById("cred-invalid"))
+        assertThatThrownBy(() -> repository.findById(3L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Invalid persisted cloud credential vendor")
-                .hasMessageContaining("cred-invalid");
+                .hasMessageContaining("3");
     }
 
-    private RmqCloudCredential entity(String id, String vendor) {
+    private RmqCloudCredential entity(Long id, String name, String vendor) {
         RmqCloudCredential entity = new RmqCloudCredential();
         entity.setId(id);
-        entity.setName(id);
+        entity.setName(name);
         entity.setVendor(vendor);
         entity.setAccessKey("access-key");
         entity.setSecretKey("c2VjcmV0");

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class TencentCatalogServiceTest {
 
-    private static final String CREDENTIAL_ID = "cred-1";
+    private static final Long CREDENTIAL_ID = 1L;
     private static final String REGION = "ap-chengdu";
 
     @Mock

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -80,10 +80,11 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class TencentInstanceProviderTest {
 
-    private static final String STUDIO_INSTANCE_ID = "inst-1";
+    private static final String STUDIO_INSTANCE_ID = "7";
+    private static final Long STUDIO_INSTANCE_PK = 7L;
     private static final String CLOUD_INSTANCE_ID = "rmq-abc";
     private static final String REGION = "ap-chengdu";
-    private static final String CREDENTIAL_ID = "cred-1";
+    private static final Long CREDENTIAL_ID = 1L;
 
     @Mock
     private TencentClientFactory clientFactory;
@@ -106,7 +107,7 @@ class TencentInstanceProviderTest {
                 .regionId(REGION)
                 .credentialId(CREDENTIAL_ID)
                 .build()));
-        lenient().when(clientFactory.call(anyString(), anyString(), any())).thenAnswer(invocation -> {
+        lenient().when(clientFactory.call(any(Long.class), anyString(), any())).thenAnswer(invocation -> {
             TencentClientFactory.TencentCall<Object> action = invocation.getArgument(2);
             return action.execute(client);
         });
@@ -170,11 +171,11 @@ class TencentInstanceProviderTest {
         assertThat(topics.get(0).getType()).isEqualTo(TopicType.FIFO);
         assertThat(topics.get(0).getWriteQueues()).isEqualTo(4);
         assertThat(topics.get(0).getReadQueues()).isEqualTo(4);
-        assertThat(topics.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_ID);
-        assertThat(topics.get(0).getCreatedAt())
+        assertThat(topics.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_PK);
+        assertThat(topics.get(0).getGmtCreate())
                 .isEqualTo(java.time.Instant.ofEpochMilli(1600000000000L)
                         .atZone(java.time.ZoneId.systemDefault()).toLocalDateTime());
-        assertThat(topics.get(0).getUpdatedAt())
+        assertThat(topics.get(0).getGmtModified())
                 .isEqualTo(java.time.Instant.ofEpochMilli(1600000100000L)
                         .atZone(java.time.ZoneId.systemDefault()).toLocalDateTime());
     }
@@ -247,7 +248,7 @@ class TencentInstanceProviderTest {
         assertThat(captor.getValue().getTopic()).isEqualTo("orders");
         assertThat(captor.getValue().getTopicType()).isEqualTo("NORMAL");
         assertThat(captor.getValue().getQueueNum()).isEqualTo(12L);
-        assertThat(created.getInstanceId()).isEqualTo(STUDIO_INSTANCE_ID);
+        assertThat(created.getInstanceId()).isEqualTo(STUDIO_INSTANCE_PK);
     }
 
     @Test
@@ -448,9 +449,9 @@ class TencentInstanceProviderTest {
 
         assertThat(groups).hasSize(1);
         assertThat(groups.get(0).getName()).isEqualTo("GID_orders");
-        assertThat(groups.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_ID);
+        assertThat(groups.get(0).getInstanceId()).isEqualTo(STUDIO_INSTANCE_PK);
         assertThat(groups.get(0).getRetryMaxTimes()).isEqualTo(16);
-        assertThat(groups.get(0).getCreatedAt()).isNotNull();
+        assertThat(groups.get(0).getGmtCreate()).isNotNull();
         assertThat(groups.get(0).getConsumeType()).isEqualTo(ConsumeType.CLUSTERING);
         assertThat(groups.get(0).getInstances()).isNotNull().isEmpty();
     }
@@ -469,7 +470,7 @@ class TencentInstanceProviderTest {
         assertThat(captor.getValue().getInstanceId()).isEqualTo(CLOUD_INSTANCE_ID);
         assertThat(captor.getValue().getConsumerGroup()).isEqualTo("GID_new");
         assertThat(captor.getValue().getMaxRetryTimes()).isEqualTo(20L);
-        assertThat(created.getInstanceId()).isEqualTo(STUDIO_INSTANCE_ID);
+        assertThat(created.getInstanceId()).isEqualTo(STUDIO_INSTANCE_PK);
         assertThat(created.getRetryMaxTimes()).isEqualTo(20);
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -274,7 +274,12 @@ class SettingsServiceTest {
         DataSourceVO input = DataSourceVO.builder().name("New DS").type("rocketmq")
                 .url("http://10.1.2.3").build();
         when(settingsRepository.saveDataSource(any(DataSourceVO.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+                .thenAnswer(invocation -> {
+                    DataSourceVO dataSource = invocation.getArgument(0);
+                    // Repository contract: the ds key is generated from the auto-increment id.
+                    dataSource.setKey("ds-1");
+                    return dataSource;
+                });
 
         DataSourceVO result = settingsService.createDataSource(input);
 
@@ -290,7 +295,12 @@ class SettingsServiceTest {
         DataSourceVO input = DataSourceVO.builder().key("existing-key").name("New DS")
                 .url("http://10.1.2.3").build();
         when(settingsRepository.saveDataSource(any(DataSourceVO.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+                .thenAnswer(invocation -> {
+                    DataSourceVO dataSource = invocation.getArgument(0);
+                    // Repository contract: a client-provided key is replaced by the generated one.
+                    dataSource.setKey("ds-1");
+                    return dataSource;
+                });
 
         DataSourceVO result = settingsService.createDataSource(input);
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -4,7 +4,7 @@ ARG VITE_GIT_COMMIT
 ENV VITE_GIT_COMMIT=${VITE_GIT_COMMIT}
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN npm ci --registry=https://registry.npmmirror.com
 COPY . .
 RUN npm run build
 

--- a/web/src/pages/settings/__tests__/AiAssistantTab.test.tsx
+++ b/web/src/pages/settings/__tests__/AiAssistantTab.test.tsx
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { App } from 'antd';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LangProvider } from '../../../i18n/LangContext';
+import { AiAssistantTab } from '../AiAssistantTab';
+
+const llmApiMocks = vi.hoisted(() => ({
+  getLlmConfig: vi.fn(),
+  saveLlmConfig: vi.fn(),
+  testLlmConnection: vi.fn(),
+  getLlmModels: vi.fn(),
+}));
+
+vi.mock('../../../api/llm', () => llmApiMocks);
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const renderPage = () =>
+  render(
+    <App>
+      <LangProvider>
+        <AiAssistantTab />
+      </LangProvider>
+    </App>,
+  );
+
+describe('AiAssistantTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    llmApiMocks.getLlmConfig.mockResolvedValue({
+      provider: 'tongyi',
+      apiBase: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      model: 'qwen3.8-max',
+      maxTokens: 4096,
+      temperature: 0.7,
+      enabled: true,
+      apiKeyConfigured: true,
+    });
+    llmApiMocks.getLlmModels.mockResolvedValue({
+      status: 0,
+      data: [{ id: 'qwen3.8-max' }, { id: 'qwen-max' }],
+    });
+    llmApiMocks.saveLlmConfig.mockResolvedValue({ status: 0 });
+    llmApiMocks.testLlmConnection.mockResolvedValue({ status: 0, msg: 'ok' });
+  });
+
+  it('loads the saved config and shows the configured-key badge', async () => {
+    renderPage();
+
+    expect(await screen.findByText('密钥已配置')).toBeInTheDocument();
+    expect(screen.getByText('qwen3.8-max')).toBeInTheDocument();
+  });
+
+  it('saves without sending an apiKey when the input stays empty', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('密钥已配置');
+    await user.click(screen.getByRole('button', { name: /保\s*存/ }));
+
+    await waitFor(() => expect(llmApiMocks.saveLlmConfig).toHaveBeenCalledTimes(1));
+    const payload = llmApiMocks.saveLlmConfig.mock.calls[0][0];
+    expect(payload).toMatchObject({ provider: 'tongyi', model: 'qwen3.8-max' });
+    expect(payload.apiKey).toBeUndefined();
+  });
+
+  it('submits the Azure deployment fields required by the backend', async () => {
+    const user = userEvent.setup();
+    const { container } = renderPage();
+
+    await waitFor(() => expect(llmApiMocks.getLlmConfig).toHaveBeenCalledTimes(1));
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(
+      await screen.findByText('Azure OpenAI', { selector: '.ant-select-item-option-content' }),
+    );
+
+    const apiBase = await screen.findByLabelText('API Base URL');
+    await user.type(apiBase, 'https://example.openai.azure.com/openai');
+    await user.type(screen.getByLabelText('Azure Deployment Name'), 'production-gpt');
+    expect(screen.getByLabelText('Azure API Version')).toHaveValue('2024-02-15-preview');
+    const saveButton = container.querySelector('.ant-btn-primary');
+    expect(saveButton).not.toBeNull();
+    await user.click(saveButton as HTMLButtonElement);
+
+    await waitFor(() => expect(llmApiMocks.saveLlmConfig).toHaveBeenCalledTimes(1));
+    expect(llmApiMocks.saveLlmConfig.mock.calls[0][0]).toMatchObject({
+      provider: 'azure',
+      apiBase: 'https://example.openai.azure.com/openai',
+      deploymentName: 'production-gpt',
+      apiVersion: '2024-02-15-preview',
+    });
+    expect(llmApiMocks.saveLlmConfig.mock.calls[0][0].awsRegion).toBeUndefined();
+  });
+
+  it('ignores a connection result after the tested configuration changes', async () => {
+    let resolveTest!: (result: { status: number; msg: string }) => void;
+    llmApiMocks.testLlmConnection.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveTest = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('密钥已配置');
+    await user.click(screen.getByRole('button', { name: /测试连接/ }));
+    await waitFor(() => expect(llmApiMocks.testLlmConnection).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(
+      await screen.findByText('OpenAI', { selector: '.ant-select-item-option-content' }),
+    );
+    await act(async () => resolveTest({ status: 0, msg: 'old provider succeeded' }));
+
+    expect(screen.queryByText('old provider succeeded')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /测试连接/ })).not.toHaveClass('ant-btn-loading');
+  });
+});


### PR DESCRIPTION
## Summary
- Standardize every table to start with `id bigint(20) unsigned NOT NULL AUTO_INCREMENT` as the primary key, with `gmt_create` / `gmt_modified` as the fixed 2nd/3rd columns; drop varchar UUID primary keys and `created_at` / `updated_at`
- Rename tables for clarity: `rmq_topic` → `rmq_instance_topic`, `rmq_group` → `rmq_instance_group`, `rmq_message_query` → `rmq_instance_message`, `rmq_trace_query` → `rmq_instance_trace`
- Switch entities, repositories, services, VOs and DTOs from String to Long ids and remove all UUID generation
- Preserve special semantics: the ACL default-permission marker moves from id suffixes to `resource_pattern` (`DEFAULT_TOPIC`/`DEFAULT_GROUP`), the settings singleton resolves by first row, data sources keep `ds_key` as a business key (`ds-<id>`), and new `InstanceIds`/`EntityIds` helpers bridge String API parameters to numeric ids

## Test plan
- [x] `mvn test` green: 1197 tests pass
- [x] Remote MySQL rebuilt from the new schema and verified column order; server redeployed and API smoke-tested