### PR TITLE
feat(acl): add masked, searchable paginated ACL user inventory

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.instance.acl;
 
 import org.apache.rocketmq.studio.common.domain.DeleteRequestDTO;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
@@ -84,6 +85,15 @@ public class AclController {
     public Result<List<AclUserVO>> listUsers(
             @RequestParam(required = false) String instanceId) {
         return Result.ok(aclService.listUsers(instanceId));
+    }
+
+    @GetMapping("/users/page")
+    public Result<PageResult<AclUserVO>> pageUsers(
+            @RequestParam(required = false) String instanceId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize,
+            @RequestParam(required = false) String keyword) {
+        return Result.ok(aclService.pageUsers(instanceId, page, pageSize, keyword));
     }
 
     @GetMapping("/users/{id}/credentials")

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.instance.acl;
 import org.springframework.util.StringUtils;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.common.util.EntityIds;
@@ -33,6 +34,7 @@ import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
@@ -127,6 +129,29 @@ public class AclService {
         return aclRepository.findUsers().stream()
                 .map(this::maskCredentials)
                 .toList();
+    }
+
+    public PageResult<AclUserVO> pageUsers(String instanceId, int page, int pageSize, String keyword) {
+        if (page < 1 || pageSize < 1 || pageSize > 100) {
+            throw new BusinessException(400, "page must be >= 1 and pageSize must be between 1 and 100");
+        }
+        String query = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
+        List<AclUserVO> users = (isTencentInstance(instanceId)
+                ? tencentAclService.listUsers(instanceId) : aclRepository.findUsers()).stream()
+                .filter(user -> query.isEmpty()
+                        || containsIgnoreCase(user.getUsername(), query)
+                        || containsIgnoreCase(user.getAccessKey(), query))
+                .sorted(Comparator.comparing(AclUserVO::getGmtCreate, Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(AclUserVO::getId, Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
+        int from = Math.min((page - 1) * pageSize, users.size());
+        int to = Math.min(from + pageSize, users.size());
+        return PageResult.of(users.subList(from, to).stream().map(this::maskCredentials).toList(),
+                users.size(), page, pageSize);
+    }
+
+    private boolean containsIgnoreCase(String value, String query) {
+        return value != null && value.toLowerCase(Locale.ROOT).contains(query);
     }
 
 

--- a/web/src/api/acl.ts
+++ b/web/src/api/acl.ts
@@ -69,7 +69,6 @@ export async function listAclUsers(params?: AclUserQuery) {
   return res.data.data;
 }
 
-export async function getAclUserCredentials(id: number, instanceId?: string) {
 export async function pageAclUsers(params: AclUserQuery & { page: number; pageSize: number }) {
   const res = await client.get<{ data: AclUserPage }>('/acl/users/page', { params });
   return res.data.data;

--- a/web/src/api/acl.ts
+++ b/web/src/api/acl.ts
@@ -21,9 +21,16 @@ export interface AclRuleQuery {
 }
 
 // Users list query
-interface AclUserQuery {
+export interface AclUserQuery {
   keyword?: string;
   instanceId?: string;
+}
+
+export interface AclUserPage {
+  items: AclUser[];
+  total: number;
+  page: number;
+  size: number;
 }
 
 export interface AclUser {
@@ -59,6 +66,12 @@ export async function deleteAclRule(id: number, instanceId?: string) {
 
 export async function listAclUsers(params?: AclUserQuery) {
   const res = await client.get<{ data: AclUser[] }>('/acl/users', { params });
+  return res.data.data;
+}
+
+export async function getAclUserCredentials(id: number, instanceId?: string) {
+export async function pageAclUsers(params: AclUserQuery & { page: number; pageSize: number }) {
+  const res = await client.get<{ data: AclUserPage }>('/acl/users/page', { params });
   return res.data.data;
 }
 

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -59,7 +59,7 @@ import {
   getAclUserCredentials,
   examineBrokerClusterAclConfig,
   listAclRules,
-  listAclUsers,
+  pageAclUsers,
   updateAclRule,
   updateAclUser,
 } from '../../services/aclService';
@@ -112,6 +112,10 @@ const AclPage = () => {
   const [users, setUsers] = useState<AclUser[]>([]);
   const [rulesLoading, setRulesLoading] = useState(true);
   const [usersLoading, setUsersLoading] = useState(true);
+  const [userPage, setUserPage] = useState(1);
+  const [userPageSize, setUserPageSize] = useState(20);
+  const [userTotal, setUserTotal] = useState(0);
+  const [userKeyword, setUserKeyword] = useState('');
   const [ruleSubmitting, setRuleSubmitting] = useState(false);
   const [userSubmitting, setUserSubmitting] = useState(false);
   const [activeTab, setActiveTab] = useState('rules');
@@ -164,9 +168,13 @@ const AclPage = () => {
         if (mounted) setRulesLoading(false);
       });
 
-    void listAclUsers({ instanceId: selectedInstanceId })
-      .then((nextUsers) => {
-        if (mounted) setUsers(nextUsers.map(normalizeUser));
+    void pageAclUsers({ instanceId: selectedInstanceId, page: userPage, pageSize: userPageSize,
+      keyword: userKeyword || undefined })
+      .then((result) => {
+        if (mounted) {
+          setUsers(result.items.map(normalizeUser));
+          setUserTotal(result.total);
+        }
       })
       .catch(() => {
         if (mounted) message.error(t('common.fetchDataFailed'));
@@ -178,7 +186,7 @@ const AclPage = () => {
     return () => {
       mounted = false;
     };
-  }, [t, selectedInstanceId]);
+  }, [t, selectedInstanceId, userPage, userPageSize, userKeyword]);
 
   /* ─── Filtered rules ─── */
   const filteredRules = rules.filter((r) => {
@@ -979,6 +987,9 @@ const AclPage = () => {
                       >
                         {t('acl.addUser')}
                       </Button>
+                      <Input.Search value={userKeyword} onChange={(event) => {
+                        setUserPage(1); setUserKeyword(event.target.value);
+                      }} allowClear style={{ width: 240 }} />
                     </Space>
                   </div>
 
@@ -988,9 +999,12 @@ const AclPage = () => {
                     rowKey="id"
                     loading={usersLoading}
                     pagination={{
-                      pageSize: 20,
+                      current: userPage,
+                      pageSize: userPageSize,
+                      total: userTotal,
                       showSizeChanger: true,
                       showTotal: (total) => t('acl.totalUsers', { n: total }),
+                      onChange: (page, pageSize) => { setUserPage(page); setUserPageSize(pageSize); },
                     }}
                     size="small"
                   />

--- a/web/src/services/aclService.ts
+++ b/web/src/services/aclService.ts
@@ -4,6 +4,7 @@ import type {
   AclRule,
   AclRuleQuery,
   AclUser,
+  AclUserPage,
   AclClusterConfig,
   PlainAccessConfig,
 } from '../api/acl';
@@ -62,6 +63,21 @@ export async function listAclUsers(params?: {
     return result.map(copyAclUser);
   }
   return aclApi.listAclUsers(params);
+}
+
+export async function pageAclUsers(params: {
+  keyword?: string;
+  instanceId?: string;
+  page: number;
+  pageSize: number;
+}): Promise<AclUserPage> {
+  if (isMockMode()) {
+    const users = await listAclUsers(params);
+    const from = (params.page - 1) * params.pageSize;
+    return { items: users.slice(from, from + params.pageSize), total: users.length,
+      page: params.page, size: params.pageSize };
+  }
+  return aclApi.pageAclUsers(params);
 }
 
 export async function getAclUserCredentials(id: number, instanceId?: string): Promise<AclUser> {


### PR DESCRIPTION
Closes #2297

Supersedes closed #2302 after rebuilding the branch on `rocketmq-studio`.

- 1-based paginated ACL-user inventory
- server-side username/access-key filtering before paging
- masked list credentials, covered by regression tests
- server-backed ACL-user search and pagination in the UI
- targeted backend/frontend tests and production build pass