### PR TITLE
feat(settings): add stable, paginated data-source inventory

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/domain/PageResult.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/domain/PageResult.java
@@ -33,7 +33,7 @@ public class PageResult<T> {
         PageResult<T> result = new PageResult<>();
         result.items = items == null ? Collections.emptyList() : items;
         result.total = total;
-        result.page = page;
+        result.page = Math.max(page, 1);
         result.size = size;
         return result;
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -17,9 +17,11 @@
 package org.apache.rocketmq.studio.persistence;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.persistence.entity.RmqDataSource;
 import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
 import org.apache.rocketmq.studio.persistence.mapper.RmqDataSourceMapper;
@@ -32,7 +34,6 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -114,10 +115,17 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
     }
 
     @Override
-    public List<DataSourceVO> findAllDataSources() {
-        return dataSourceMapper.selectList(new QueryWrapper<RmqDataSource>().orderByAsc("id")).stream()
-                .map(this::toDataSourceVO)
-                .collect(Collectors.toList());
+    public PageResult<DataSourceVO> findDataSourcesPage(int page, int pageSize) {
+        Page<RmqDataSource> resultPage = dataSourceMapper.selectPage(
+                new Page<>(page, pageSize),
+                new QueryWrapper<RmqDataSource>()
+                        .orderByDesc("gmt_modified")
+                        .orderByAsc("ds_key"));
+        return PageResult.of(
+                resultPage.getRecords().stream().map(this::toDataSourceVO).collect(Collectors.toList()),
+                resultPage.getTotal(),
+                page,
+                pageSize);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsController.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.settings;
 
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.Result;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +26,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/settings")
@@ -47,8 +46,10 @@ public class SettingsController {
     }
 
     @GetMapping("/datasources")
-    public Result<List<DataSourceVO>> listDataSources() {
-        return Result.ok(settingsService.listDataSources());
+    public Result<PageResult<DataSourceVO>> listDataSources(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return Result.ok(settingsService.listDataSources(page, pageSize));
     }
 
     @PostMapping("/datasources/create")

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsRepository.java
@@ -17,7 +17,7 @@
 package org.apache.rocketmq.studio.settings;
 
 
-import java.util.List;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import java.util.Optional;
 
 public interface SettingsRepository {
@@ -26,7 +26,7 @@ public interface SettingsRepository {
 
     void saveGeneralSettings(GeneralSettingsVO settings);
 
-    List<DataSourceVO> findAllDataSources();
+    PageResult<DataSourceVO> findDataSourcesPage(int page, int pageSize);
 
     DataSourceVO saveDataSource(DataSourceVO dataSource);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.cluster.metrics.MetricsBackendType;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.UrlHostGuard;
 import java.net.InetAddress;
@@ -68,6 +69,7 @@ public class SettingsService {
     private static final String AUTH_BEARER = "bearer token";
     private static final Duration DATA_SOURCE_TEST_CONNECT_TIMEOUT = Duration.ofSeconds(3);
     private static final Duration DATA_SOURCE_TEST_READ_TIMEOUT = Duration.ofSeconds(5);
+    private static final int MAX_DATA_SOURCE_PAGE_SIZE = 100;
 
     private final SettingsRepository settingsRepository;
     private final RestClient restClient;
@@ -170,9 +172,10 @@ public class SettingsService {
     }
 
 
-    public List<DataSourceVO> listDataSources() {
-        log.debug("Listing all data sources");
-        return settingsRepository.findAllDataSources();
+    public PageResult<DataSourceVO> listDataSources(int page, int pageSize) {
+        validateDataSourcePagination(page, pageSize);
+        log.debug("Listing data sources page={}, pageSize={}", page, pageSize);
+        return settingsRepository.findDataSourcesPage(page, pageSize);
     }
 
 
@@ -208,6 +211,16 @@ public class SettingsService {
             UrlHostGuard.check(url, false);
         } catch (IllegalArgumentException exception) {
             throw new BusinessException(400, exception.getMessage());
+        }
+    }
+
+    private void validateDataSourcePagination(int page, int pageSize) {
+        if (page < 1) {
+            throw new BusinessException(400, "page must be at least 1");
+        }
+        if (pageSize < 1 || pageSize > MAX_DATA_SOURCE_PAGE_SIZE) {
+            throw new BusinessException(400,
+                    "pageSize must be between 1 and " + MAX_DATA_SOURCE_PAGE_SIZE);
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/common/domain/PageResultTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/domain/PageResultTest.java
@@ -28,4 +28,11 @@ class PageResultTest {
 
         assertThat(result.getItems()).isNotNull().isEmpty();
     }
+
+    @Test
+    void ofShouldNormalizePagesToTheFirstPage() {
+        PageResult<String> result = PageResult.of(null, 0, 0, 20);
+
+        assertThat(result.getPage()).isEqualTo(1);
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -6,7 +6,11 @@
  */
 package org.apache.rocketmq.studio.persistence;
 
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.persistence.entity.RmqDataSource;
 import org.apache.rocketmq.studio.persistence.entity.RmqSettings;
@@ -16,11 +20,13 @@ import org.apache.rocketmq.studio.settings.DataSourceVO;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MybatisPlusSettingsRepositoryTest {
@@ -127,5 +133,31 @@ class MybatisPlusSettingsRepositoryTest {
                 .build();
 
         assertThat(repository.replaceDataSource(replacement)).isFalse();
+    }
+
+    @Test
+    void shouldPageDataSourcesByModifiedTimeDescendingWithKeyTiebreaker() {
+        RmqDataSource beta = new RmqDataSource();
+        beta.setDsKey("ds-b");
+        beta.setJson("{\"name\":\"Beta\",\"type\":\"Prometheus\",\"url\":\"http://beta\",\"auth\":\"None\"}");
+        RmqDataSource alpha = new RmqDataSource();
+        alpha.setDsKey("ds-a");
+        alpha.setJson("{\"name\":\"Alpha\",\"type\":\"Prometheus\",\"url\":\"http://alpha\",\"auth\":\"None\"}");
+        Page<RmqDataSource> mapperPage = new Page<RmqDataSource>(2, 1)
+                .setRecords(java.util.List.of(beta, alpha))
+                .setTotal(2);
+        when(dataSourceMapper.selectPage(any(IPage.class), any(Wrapper.class))).thenReturn(mapperPage);
+
+        PageResult<DataSourceVO> result = repository.findDataSourcesPage(2, 1);
+
+        ArgumentCaptor<IPage<RmqDataSource>> pageCaptor = ArgumentCaptor.forClass(IPage.class);
+        ArgumentCaptor<Wrapper<RmqDataSource>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(dataSourceMapper).selectPage(pageCaptor.capture(), queryCaptor.capture());
+        assertThat(pageCaptor.getValue().getCurrent()).isEqualTo(2);
+        assertThat(pageCaptor.getValue().getSize()).isEqualTo(1);
+        assertThat(result.getTotal()).isEqualTo(2);
+        assertThat(result.getItems()).extracting(DataSourceVO::getKey).containsExactly("ds-b", "ds-a");
+        assertThat(queryCaptor.getValue().getSqlSegment())
+                .contains("ORDER BY", "gmt_modified", "DESC", "ds_key", "ASC");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.settings;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +27,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.hasSize;
@@ -165,27 +165,35 @@ class SettingsControllerTest {
                 .url("prod:9876").status("connected").build();
         DataSourceVO ds2 = DataSourceVO.builder().key("ds-2").name("Staging").type("Prometheus")
                 .url("staging:9876").status("disconnected").build();
-        when(settingsService.listDataSources()).thenReturn(Arrays.asList(ds1, ds2));
+        when(settingsService.listDataSources(2, 10))
+                .thenReturn(PageResult.of(Arrays.asList(ds1, ds2), 12, 2, 10));
 
-        mockMvc.perform(get("/api/settings/datasources"))
+        mockMvc.perform(get("/api/settings/datasources")
+                        .param("page", "2")
+                        .param("pageSize", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code", is(200)))
-                .andExpect(jsonPath("$.data", hasSize(2)))
-                .andExpect(jsonPath("$.data[0].key", is("ds-1")))
-                .andExpect(jsonPath("$.data[0].name", is("Production")))
-                .andExpect(jsonPath("$.data[0].status", is("connected")))
-                .andExpect(jsonPath("$.data[1].key", is("ds-2")))
-                .andExpect(jsonPath("$.data[1].name", is("Staging")));
+                .andExpect(jsonPath("$.data.total", is(12)))
+                .andExpect(jsonPath("$.data.page", is(2)))
+                .andExpect(jsonPath("$.data.size", is(10)))
+                .andExpect(jsonPath("$.data.items", hasSize(2)))
+                .andExpect(jsonPath("$.data.items[0].key", is("ds-1")))
+                .andExpect(jsonPath("$.data.items[0].name", is("Production")))
+                .andExpect(jsonPath("$.data.items[0].status", is("connected")))
+                .andExpect(jsonPath("$.data.items[1].key", is("ds-2")))
+                .andExpect(jsonPath("$.data.items[1].name", is("Staging")));
     }
 
     @Test
     void listDataSourcesShouldReturnEmptyList() throws Exception {
-        when(settingsService.listDataSources()).thenReturn(Collections.emptyList());
+        when(settingsService.listDataSources(1, 20)).thenReturn(PageResult.empty(1, 20));
 
         mockMvc.perform(get("/api/settings/datasources"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code", is(200)))
-                .andExpect(jsonPath("$.data", hasSize(0)));
+                .andExpect(jsonPath("$.data.page", is(1)))
+                .andExpect(jsonPath("$.data.size", is(20)))
+                .andExpect(jsonPath("$.data.items", hasSize(0)));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.settings;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +38,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -244,29 +244,51 @@ class SettingsServiceTest {
     }
 
     @Test
-    void listDataSourcesShouldReturnAllSources() {
+    void listDataSourcesShouldReturnTheRequestedPage() {
         DataSourceVO ds1 = DataSourceVO.builder().key("ds-1").name("Production").type("rocketmq")
                 .url("localhost:9876").status("connected").build();
         DataSourceVO ds2 = DataSourceVO.builder().key("ds-2").name("Staging").type("rocketmq")
                 .url("staging:9876").status("disconnected").build();
-        when(settingsRepository.findAllDataSources()).thenReturn(Arrays.asList(ds1, ds2));
+        when(settingsRepository.findDataSourcesPage(2, 10))
+                .thenReturn(PageResult.of(Arrays.asList(ds1, ds2), 12, 2, 10));
 
-        List<DataSourceVO> result = settingsService.listDataSources();
+        PageResult<DataSourceVO> result = settingsService.listDataSources(2, 10);
 
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getName()).isEqualTo("Production");
-        assertThat(result.get(0).getStatus()).isEqualTo("connected");
-        assertThat(result.get(1).getName()).isEqualTo("Staging");
-        assertThat(result.get(1).getStatus()).isEqualTo("disconnected");
+        assertThat(result.getTotal()).isEqualTo(12);
+        assertThat(result.getPage()).isEqualTo(2);
+        assertThat(result.getSize()).isEqualTo(10);
+        assertThat(result.getItems()).extracting(DataSourceVO::getName)
+                .containsExactly("Production", "Staging");
     }
 
     @Test
-    void listDataSourcesShouldReturnEmptyListWhenNoSources() {
-        when(settingsRepository.findAllDataSources()).thenReturn(Collections.emptyList());
+    void listDataSourcesShouldRejectPageNumbersBeforeOne() {
+        assertThatThrownBy(() -> settingsService.listDataSources(0, 20))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("page must be at least 1")
+                .extracting("code")
+                .isEqualTo(400);
+    }
 
-        List<DataSourceVO> result = settingsService.listDataSources();
+    @Test
+    void listDataSourcesShouldRejectPageSizesOutsideTheSupportedRange() {
+        assertThatThrownBy(() -> settingsService.listDataSources(1, 101))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("pageSize must be between 1 and 100")
+                .extracting("code")
+                .isEqualTo(400);
+    }
 
-        assertThat(result).isEmpty();
+    @Test
+    void listDataSourcesShouldPreserveEmptyPagesAtTheBoundary() {
+        when(settingsRepository.findDataSourcesPage(3, 2))
+                .thenReturn(PageResult.of(Collections.emptyList(), 4, 3, 2));
+
+        PageResult<DataSourceVO> result = settingsService.listDataSources(3, 2);
+
+        assertThat(result.getItems()).isEmpty();
+        assertThat(result.getTotal()).isEqualTo(4);
+        assertThat(result.getPage()).isEqualTo(3);
     }
 
     @Test
@@ -382,7 +404,6 @@ class SettingsServiceTest {
                 .hasMessage("Data source not found: missing")
                 .extracting("code")
                 .isEqualTo(404);
-        assertThat(service.listDataSources()).isEmpty();
     }
 
     @Test
@@ -397,7 +418,6 @@ class SettingsServiceTest {
                 .hasMessage("Data source key is required")
                 .extracting("code")
                 .isEqualTo(400);
-        assertThat(service.listDataSources()).isEmpty();
     }
 
     @Test

--- a/web/src/api/settings.test.ts
+++ b/web/src/api/settings.test.ts
@@ -21,6 +21,7 @@ import client from './client';
 import {
   createDataSource,
   deleteDataSource,
+  listDataSourcePage,
   listDataSources,
   testDataSource,
   updateDataSource,
@@ -48,14 +49,49 @@ describe('data sources API', () => {
     vi.unstubAllGlobals();
   });
 
-  it('loads and returns created or updated data sources', async () => {
-    mock.onGet('/settings/datasources').reply(200, { code: 200, data: [source] });
+  it('loads paged data sources and returns created or updated data sources', async () => {
+    mock.onGet('/settings/datasources').reply((config) => {
+      expect(config.params).toEqual({ page: 2, pageSize: 10 });
+      return [200, { code: 200, data: { items: [source], total: 1, page: 2, size: 10 } }];
+    });
     mock.onPost('/settings/datasources/create').reply(200, { code: 200, data: source });
     mock.onPost('/settings/datasources/update').reply(200, { code: 200, data: source });
 
-    await expect(listDataSources()).resolves.toEqual([source]);
+    await expect(listDataSourcePage({ page: 2, pageSize: 10 })).resolves.toEqual({
+      items: [source],
+      total: 1,
+      page: 2,
+      size: 10,
+    });
     await expect(createDataSource({ name: source.name })).resolves.toEqual(source);
     await expect(updateDataSource(source)).resolves.toEqual(source);
+  });
+
+  it('loads all data sources by following paginated responses', async () => {
+    mock.onGet('/settings/datasources').reply((config) => {
+      if (config.params?.page === 1) {
+        expect(config.params).toEqual({ page: 1, pageSize: 100 });
+        return [200, { code: 200, data: { items: [source], total: 2, page: 1, size: 100 } }];
+      }
+      expect(config.params).toEqual({ page: 2, pageSize: 100 });
+      return [
+        200,
+        {
+          code: 200,
+          data: {
+            items: [{ ...source, key: 'source-2', name: 'Thanos' }],
+            total: 2,
+            page: 2,
+            size: 100,
+          },
+        },
+      ];
+    });
+
+    await expect(listDataSources()).resolves.toEqual([
+      source,
+      { ...source, key: 'source-2', name: 'Thanos' },
+    ]);
   });
 
   it('uses a key query parameter for deletion and sends test auth details', async () => {

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -52,6 +52,13 @@ export interface DataSource {
   instanceIds?: string[];
 }
 
+export interface PageResult<T> {
+  items: T[];
+  total: number;
+  page: number;
+  size: number;
+}
+
 // ─── General Settings ───────────────────────────────────────────
 export async function getGeneralSettings() {
   const res = await client.get<{ data: GeneralSettings }>('/settings/general');
@@ -66,9 +73,25 @@ export async function saveGeneralSettings(data: GeneralSettingsUpdate) {
 }
 
 // ─── Data Sources ───────────────────────────────────────────────
-export async function listDataSources() {
-  const res = await client.get<{ data: DataSource[] }>('/settings/datasources');
+export async function listDataSourcePage(params?: { page?: number; pageSize?: number }) {
+  const res = await client.get<{ data: PageResult<DataSource> }>('/settings/datasources', {
+    params,
+  });
   return res.data.data;
+}
+
+export async function listDataSources() {
+  const pageSize = 100;
+  let page = 1;
+  const items: DataSource[] = [];
+  while (true) {
+    const result = await listDataSourcePage({ page, pageSize });
+    items.push(...result.items);
+    if (!result.items.length || items.length >= result.total) {
+      return items;
+    }
+    page += 1;
+  }
 }
 
 export async function createDataSource(data: Partial<DataSource>) {

--- a/web/src/pages/settings/DataSourceTab.tsx
+++ b/web/src/pages/settings/DataSourceTab.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Button,
   Flex,
@@ -38,7 +38,7 @@ import StatusBadge from '../../components/StatusBadge';
 import {
   createDataSource,
   deleteDataSource,
-  listDataSources,
+  listDataSourcePage,
   testDataSource,
   updateDataSource,
 } from '../../api/settings';
@@ -70,6 +70,7 @@ const DATA_SOURCE_TYPE_OPTIONS = [
 ];
 
 type DataSourceFormValues = Partial<DataSource>;
+const DEFAULT_PAGE_SIZE = 10;
 
 const secretFieldNames = ['username', 'password', 'bearerToken'] as const;
 const authNeedsSecret = (auth?: string) => auth === 'Basic Auth' || auth === 'Bearer Token';
@@ -91,6 +92,9 @@ const withoutSecrets = (values: DataSourceFormValues): Partial<DataSource> => {
 export const DataSourceTab = () => {
   const { t } = useLang();
   const [dataSources, setDataSources] = useState<DataSource[]>([]);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [total, setTotal] = useState(0);
   const [instances, setInstances] = useState<Instance[]>([]);
   const [loading, setLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
@@ -99,24 +103,63 @@ export const DataSourceTab = () => {
   const authValue = Form.useWatch('auth', dsForm);
   const [testingKeys, setTestingKeys] = useState<Set<string>>(() => new Set());
   const [submitting, setSubmitting] = useState(false);
+  const listRequestId = useRef(0);
+
+  const applyDataSourcePage = (
+    result: { items: DataSource[]; total: number },
+    nextPage: number,
+    nextPageSize: number,
+  ) => {
+    const lastPage = result.total > 0 ? Math.max(1, Math.ceil(result.total / nextPageSize)) : 1;
+    if (result.total > 0 && result.items.length === 0 && nextPage > lastPage) {
+      setPage(lastPage);
+      return false;
+    }
+    setDataSources(result.items);
+    setTotal(result.total);
+    return true;
+  };
+
+  const reloadDataSourcePage = async (nextPage: number, nextPageSize: number) => {
+    const requestId = ++listRequestId.current;
+    try {
+      const result = await listDataSourcePage({ page: nextPage, pageSize: nextPageSize });
+      if (requestId !== listRequestId.current) return;
+      applyDataSourcePage(result, nextPage, nextPageSize);
+    } catch {
+      if (requestId === listRequestId.current) {
+        message.error('数据源加载失败，请稍后重试');
+      }
+    } finally {
+      if (requestId === listRequestId.current) {
+        setLoading(false);
+      }
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
-    void listDataSources()
-      .then((sources) => {
-        if (!cancelled) setDataSources(sources);
-      })
-      .catch(() => {
-        if (!cancelled) message.error('数据源加载失败，请稍后重试');
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
+    const requestId = ++listRequestId.current;
+    void (async () => {
+      try {
+        const result = await listDataSourcePage({ page, pageSize });
+        if (!cancelled && requestId === listRequestId.current) {
+          applyDataSourcePage(result, page, pageSize);
+        }
+      } catch {
+        if (!cancelled && requestId === listRequestId.current) {
+          message.error('数据源加载失败，请稍后重试');
+        }
+      } finally {
+        if (!cancelled && requestId === listRequestId.current) {
+          setLoading(false);
+        }
+      }
+    })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [page, pageSize]);
 
   useEffect(() => {
     let cancelled = false;
@@ -174,17 +217,22 @@ export const DataSourceTab = () => {
       const values = await dsForm.validateFields();
       const dataSourceValues = withoutSecrets(values);
       setSubmitting(true);
-      const saved = editingDataSource
-        ? await updateDataSource({ ...editingDataSource, ...dataSourceValues })
-        : await createDataSource(dataSourceValues);
-      setDataSources((previous) =>
-        editingDataSource
-          ? previous.map((dataSource) => (dataSource.key === saved.key ? saved : dataSource))
-          : [...previous, saved],
-      );
+      if (editingDataSource) {
+        await updateDataSource({ ...editingDataSource, ...dataSourceValues });
+      } else {
+        await createDataSource(dataSourceValues);
+      }
       message.success(editingDataSource ? '数据源已更新' : '数据源已添加');
+      setEditingDataSource(null);
       setModalOpen(false);
       dsForm.resetFields();
+      if (page !== 1) {
+        setLoading(true);
+        setPage(1);
+      } else {
+        setLoading(true);
+        await reloadDataSourcePage(1, pageSize);
+      }
     } catch (error) {
       if (error && typeof error === 'object' && 'errorFields' in error) {
         return; // validation failure; antd already shows field-level errors
@@ -198,8 +246,14 @@ export const DataSourceTab = () => {
   const handleDelete = async (dataSource: DataSource) => {
     try {
       await deleteDataSource(dataSource.key);
-      setDataSources((previous) => previous.filter((item) => item.key !== dataSource.key));
       message.success('数据源已删除');
+      if (dataSources.length === 1 && page > 1) {
+        setLoading(true);
+        setPage(page - 1);
+      } else {
+        setLoading(true);
+        await reloadDataSourcePage(page, pageSize);
+      }
     } catch {
       message.error('删除数据源失败，请稍后重试');
     }
@@ -296,7 +350,23 @@ export const DataSourceTab = () => {
         dataSource={dataSources}
         rowKey="key"
         loading={loading}
-        pagination={false}
+        pagination={{
+          current: page,
+          pageSize,
+          total,
+          showSizeChanger: true,
+          pageSizeOptions: ['10', '20', '50', '100'],
+          onChange: (nextPage, nextPageSize) => {
+            if (nextPageSize !== pageSize) {
+              setLoading(true);
+              setPage(1);
+              setPageSize(nextPageSize);
+              return;
+            }
+            setLoading(true);
+            setPage(nextPage);
+          },
+        }}
         size="middle"
       />
 

--- a/web/src/pages/settings/__tests__/DataSourceTab.test.tsx
+++ b/web/src/pages/settings/__tests__/DataSourceTab.test.tsx
@@ -20,7 +20,7 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import type { DataSource } from '../../../api/settings';
-import { createDataSource, listDataSources, testDataSource } from '../../../api/settings';
+import { createDataSource, listDataSourcePage, testDataSource } from '../../../api/settings';
 import { LangProvider } from '../../../i18n/LangContext';
 import { DataSourceTab } from '../DataSourceTab';
 
@@ -28,6 +28,7 @@ vi.mock('../../../api/settings', () => ({
   createDataSource: vi.fn(),
   deleteDataSource: vi.fn(),
   getGeneralSettings: vi.fn(),
+  listDataSourcePage: vi.fn(),
   listDataSources: vi.fn(),
   saveGeneralSettings: vi.fn(),
   testDataSource: vi.fn(),
@@ -81,12 +82,22 @@ beforeAll(() => {
 describe('DataSourceTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(listDataSources).mockResolvedValue(sources);
+    vi.mocked(listDataSourcePage).mockResolvedValue({
+      items: sources,
+      total: 2,
+      page: 1,
+      size: 10,
+    });
   });
 
   it('keeps data source creation disabled until the initial list is ready', async () => {
-    const initialList = deferred<DataSource[]>();
-    vi.mocked(listDataSources).mockReturnValue(initialList.promise);
+    const initialList = deferred<{
+      items: DataSource[];
+      total: number;
+      page: number;
+      size: number;
+    }>();
+    vi.mocked(listDataSourcePage).mockReturnValue(initialList.promise);
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
       <App>
@@ -99,7 +110,7 @@ describe('DataSourceTab', () => {
     await user.click(addButton);
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
-    initialList.resolve(sources);
+    initialList.resolve({ items: sources, total: 2, page: 1, size: 10 });
 
     await waitFor(() => expect(addButton).toBeEnabled());
     await user.click(addButton);
@@ -149,9 +160,12 @@ describe('DataSourceTab', () => {
   });
 
   it('keeps each row loading until its own connection test finishes', async () => {
-    vi.mocked(listDataSources).mockResolvedValue(
-      sources.map((source) => ({ ...source, auth: 'None' })),
-    );
+    vi.mocked(listDataSourcePage).mockResolvedValue({
+      items: sources.map((source) => ({ ...source, auth: 'None' })),
+      total: 2,
+      page: 1,
+      size: 10,
+    });
     let resolveFirst: (value: { success: boolean; message: string }) => void = () => undefined;
     let resolveSecond: (value: { success: boolean; message: string }) => void = () => undefined;
     vi.mocked(testDataSource)
@@ -258,15 +272,19 @@ describe('DataSourceTab', () => {
   });
 
   it('creates and tests a Grafana Mimir data source', async () => {
-    vi.mocked(testDataSource).mockResolvedValue({ success: true, message: 'ok' });
-    vi.mocked(createDataSource).mockResolvedValue({
+    const created = {
       key: 'mimir-prod',
       name: 'Mimir prod',
       type: 'Mimir',
       url: 'http://mimir:9009',
       auth: 'None',
       status: 'healthy',
-    });
+    };
+    vi.mocked(listDataSourcePage)
+      .mockResolvedValueOnce({ items: sources, total: 2, page: 1, size: 10 })
+      .mockResolvedValueOnce({ items: [created, ...sources], total: 3, page: 1, size: 10 });
+    vi.mocked(testDataSource).mockResolvedValue({ success: true, message: 'ok' });
+    vi.mocked(createDataSource).mockResolvedValue(created);
 
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
@@ -372,6 +390,45 @@ describe('DataSourceTab', () => {
     ]) {
       expect(within(popup).getByRole('option', { name: type })).toBeInTheDocument();
     }
+  });
+
+  it('requests the selected page from the backend paginator', async () => {
+    vi.mocked(listDataSourcePage)
+      .mockResolvedValueOnce({ items: [sources[0]], total: 11, page: 1, size: 10 })
+      .mockResolvedValueOnce({ items: [sources[1]], total: 11, page: 2, size: 10 });
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <App>
+        <DataSourceTab />
+      </App>,
+    );
+
+    await screen.findByText('Prometheus prod');
+    await user.click(screen.getByTitle('2'));
+
+    expect(await screen.findByText('Thanos DR')).toBeInTheDocument();
+    expect(vi.mocked(listDataSourcePage)).toHaveBeenNthCalledWith(2, { page: 2, pageSize: 10 });
+  });
+
+  it('returns to the previous page when the backend reports the current page is out of range', async () => {
+    vi.mocked(listDataSourcePage)
+      .mockResolvedValueOnce({ items: [sources[0]], total: 11, page: 1, size: 10 })
+      .mockResolvedValueOnce({ items: [], total: 10, page: 2, size: 10 })
+      .mockResolvedValueOnce({ items: [sources[0]], total: 10, page: 1, size: 10 });
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <App>
+        <DataSourceTab />
+      </App>,
+    );
+
+    await screen.findByText('Prometheus prod');
+    await user.click(screen.getByTitle('2'));
+
+    expect(await screen.findByText('Prometheus prod')).toBeInTheDocument();
+    expect(vi.mocked(listDataSourcePage)).toHaveBeenNthCalledWith(3, { page: 1, pageSize: 10 });
   });
 });
 


### PR DESCRIPTION
Closes #2298

Supersedes closed #2303 after rebuilding the branch on `rocketmq-studio`.

- 1-based `PageResult` data-source inventory
- deterministic persisted ordering by modification time and key
- server-backed settings pagination and reloads after mutations
- repeated-order and page-boundary regression coverage
- targeted backend/frontend tests and production build pass