### PR TITLE
fix(security): restrict proxy reloads to discovered cluster endpoints

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -28,6 +28,7 @@ import org.apache.rocketmq.studio.cluster.nameserver.NameserverRegistryVO;
 import org.apache.rocketmq.studio.cluster.nameserver.RestartNameServerDTO;
 import org.apache.rocketmq.studio.cluster.nameserver.UpdateNameServerDTO;
 import org.apache.rocketmq.studio.cluster.nameserver.UpgradeNameServerDTO;
+import org.apache.rocketmq.studio.cluster.proxy.ProxyVO;
 import org.apache.rocketmq.studio.cluster.proxy.RestartProxyDTO;
 
 import org.apache.rocketmq.studio.common.domain.enums.FlushDiskType;
@@ -146,6 +147,19 @@ public class ClusterService {
             return live;
         }
         throw new BusinessException(503, "Cluster details are unavailable: " + id);
+    }
+
+    public List<ProxyVO> listProxies(String clusterId) {
+        ClusterVO cluster = resolveCluster(clusterId);
+        if (cluster.getProxies() == null || cluster.getProxies().isEmpty()) {
+            return List.of();
+        }
+        return List.copyOf(cluster.getProxies());
+    }
+
+    public void requireProxy(String clusterId, String addr) {
+        ClusterVO cluster = resolveCluster(clusterId);
+        requireProxy(cluster, addr);
     }
 
     /**

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
@@ -17,11 +17,9 @@
 
 package org.apache.rocketmq.studio.cluster.proxy;
 
-import org.apache.rocketmq.studio.common.util.NoRedirectClientHttpRequestFactory;
-
-
-
+import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.util.NoRedirectClientHttpRequestFactory;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +31,6 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.Duration;
-
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -76,6 +73,7 @@ public class ProxyAddressService {
     /** Bounded pool for the I/O-bound TCP probes; probes queue beyond this share the budget. */
     private static final int PROBE_EXECUTOR_THREADS = 8;
 
+    private final ClusterService clusterService;
     private final Set<String> proxyAddrs = new LinkedHashSet<>(List.of("127.0.0.1:8081"));
     private String currentProxyAddr = "127.0.0.1:8081";
     private final RestTemplate restTemplate;
@@ -84,19 +82,33 @@ public class ProxyAddressService {
     private final long topologyTotalTimeoutMillis;
 
     @Autowired
-    public ProxyAddressService(ProxyHealthProbe healthProbe) {
-        this(healthProbe, defaultProbeExecutor(), TOPOLOGY_TOTAL_TIMEOUT_MILLIS);
+    public ProxyAddressService(ClusterService clusterService, ProxyHealthProbe healthProbe) {
+        this(clusterService, healthProbe, newRestTemplate(), defaultProbeExecutor(), TOPOLOGY_TOTAL_TIMEOUT_MILLIS);
     }
 
-    ProxyAddressService(ProxyHealthProbe healthProbe, ExecutorService probeExecutor,
-                        long topologyTotalTimeoutMillis) {
+    ProxyAddressService(ClusterService clusterService, ProxyHealthProbe healthProbe, RestTemplate restTemplate) {
+        this(clusterService, healthProbe, restTemplate, defaultProbeExecutor(), TOPOLOGY_TOTAL_TIMEOUT_MILLIS);
+    }
+
+    ProxyAddressService(ClusterService clusterService, ProxyHealthProbe healthProbe,
+                        ExecutorService probeExecutor, long topologyTotalTimeoutMillis) {
+        this(clusterService, healthProbe, newRestTemplate(), probeExecutor, topologyTotalTimeoutMillis);
+    }
+
+    ProxyAddressService(ClusterService clusterService, ProxyHealthProbe healthProbe, RestTemplate restTemplate,
+                        ExecutorService probeExecutor, long topologyTotalTimeoutMillis) {
+        this.clusterService = clusterService;
         this.healthProbe = healthProbe;
+        this.restTemplate = restTemplate;
         this.probeExecutor = probeExecutor;
         this.topologyTotalTimeoutMillis = topologyTotalTimeoutMillis;
+    }
+
+    private static RestTemplate newRestTemplate() {
         NoRedirectClientHttpRequestFactory factory = new NoRedirectClientHttpRequestFactory();
         factory.setConnectTimeout(Duration.ofSeconds(3));
         factory.setReadTimeout(Duration.ofSeconds(3));
-        this.restTemplate = new RestTemplate(factory);
+        return new RestTemplate(factory);
     }
 
     private static ExecutorService defaultProbeExecutor() {
@@ -258,13 +270,10 @@ public class ProxyAddressService {
      * POSTs to {@code http://<addr>/admin/reloadConfig}. Throws {@link BusinessException}
      * on transport or protocol failure so the caller receives a structured error response.
      */
-    public void reloadConfig(String addr) {
+    public void reloadConfig(String clusterId, String addr) {
+        String normalizedClusterId = normalizeClusterId(clusterId);
         String normalized = normalizeProxyAddr(addr, "addr");
-        synchronized (this) {
-            if (!proxyAddrs.contains(normalized)) {
-                throw new BusinessException(400, "addr is not a registered proxy address");
-            }
-        }
+        clusterService.requireProxy(normalizedClusterId, normalized);
         String url = "http://" + normalized + RELOAD_PATH;
         try {
             ResponseEntity<String> response = restTemplate.postForEntity(url, null, String.class);
@@ -284,6 +293,13 @@ public class ProxyAddressService {
             log.warn("Proxy config reload via {} failed: {}", url, ex.getMessage());
             throw new BusinessException(500, "Config reload failed: " + ex.getMessage());
         }
+    }
+
+    private String normalizeClusterId(String clusterId) {
+        if (clusterId == null || clusterId.trim().isEmpty()) {
+            throw new BusinessException(400, "clusterId is required");
+        }
+        return clusterId.trim();
     }
 
     private String normalizeProxyAddr(String proxyAddr, String fieldName) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyController.java
@@ -42,10 +42,7 @@ public class ProxyController {
     @GetMapping
     public Result<List<ProxyVO>> listProxies(@RequestParam(required = false) String clusterId) {
         requireClusterId(clusterId);
-        List<ProxyVO> proxies = proxyAddressService.getHomePage().getProxyAddrList().stream()
-                .map(addr -> ProxyVO.builder().addr(addr).build())
-                .toList();
-        return Result.ok(proxies);
+        return Result.ok(clusterService.listProxies(clusterId));
     }
 
     @GetMapping("/topology")
@@ -55,7 +52,7 @@ public class ProxyController {
 
     @PostMapping("/config/reload")
     public Result<Map<String, Boolean>> reloadProxyConfig(@Valid @RequestBody RestartProxyDTO command) {
-        proxyAddressService.reloadConfig(command.getAddr());
+        proxyAddressService.reloadConfig(command.getClusterId(), command.getAddr());
         return Result.ok(Map.of("success", true));
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -203,6 +203,25 @@ class ClusterServiceTest {
     }
 
     @Test
+    void listProxiesShouldUseResolvedCluster() {
+        when(clusterProvider.refreshClusterDetail("cluster-1")).thenReturn(sampleCluster);
+
+        List<ProxyVO> proxies = clusterService.listProxies("cluster-1");
+
+        assertThat(proxies).extracting(ProxyVO::getAddr).containsExactly("10.0.0.10:8081");
+    }
+
+    @Test
+    void requireProxyShouldRejectUnknownAddress() {
+        when(clusterProvider.refreshClusterDetail("cluster-1")).thenReturn(sampleCluster);
+
+        assertThatThrownBy(() -> clusterService.requireProxy("cluster-1", "127.0.0.1:8081"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Proxy not found: 127.0.0.1:8081")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
+    }
+
+    @Test
     void updateConfigShouldUpdateFlushDiskType() {
         when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
@@ -17,9 +17,15 @@
 
 package org.apache.rocketmq.studio.cluster.proxy;
 
+import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 
@@ -28,16 +34,29 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class ProxyAddressServiceTest {
 
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
     private final ProxyHealthProbe healthProbe = mock(ProxyHealthProbe.class);
-    private final ProxyAddressService proxyAddressService = new ProxyAddressService(healthProbe);
+    private ProxyAddressService proxyAddressService;
 
     @BeforeEach
     void setUp() {
+        proxyAddressService = new ProxyAddressService(clusterService, healthProbe, restTemplate);
         // Default probe outcome: everything reachable with 1 ms latency.
         when(healthProbe.probe(anyString(), anyInt(), anyInt()))
                 .thenReturn(ProxyHealthProbe.ProbeResult.reachable(1L));
@@ -141,11 +160,41 @@ class ProxyAddressServiceTest {
     }
 
     @Test
-    void reloadConfigShouldRejectUnregisteredAddressTest() {
-        assertThatThrownBy(() -> proxyAddressService.reloadConfig("10.0.0.1:8081"))
+    void reloadConfigShouldRejectLoopbackOutsideTrustedCluster() {
+        doThrow(new BusinessException(404, "Proxy not found: 127.0.0.2:8081"))
+                .when(clusterService).requireProxy("cluster-1", "127.0.0.2:8081");
+
+        assertThatThrownBy(() -> proxyAddressService.reloadConfig("cluster-1", "127.0.0.2:8081"))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("addr is not a registered proxy address")
-                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+                .hasMessage("Proxy not found: 127.0.0.2:8081")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
+
+        verifyNoInteractions(restTemplate);
+    }
+
+    @Test
+    void reloadConfigShouldRejectNonTrustedEndpoint() {
+        doThrow(new BusinessException(404, "Proxy not found: 198.51.100.10:8081"))
+                .when(clusterService).requireProxy("cluster-1", "198.51.100.10:8081");
+
+        assertThatThrownBy(() -> proxyAddressService.reloadConfig("cluster-1", "198.51.100.10:8081"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Proxy not found: 198.51.100.10:8081")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
+
+        verifyNoInteractions(restTemplate);
+    }
+
+    @Test
+    void reloadConfigShouldPostToTrustedDiscoveredProxy() {
+        doNothing().when(clusterService).requireProxy("cluster-1", "10.0.0.10:8081");
+        when(restTemplate.postForEntity(eq("http://10.0.0.10:8081/admin/reloadConfig"), isNull(), eq(String.class)))
+                .thenReturn(ResponseEntity.ok("ok"));
+
+        proxyAddressService.reloadConfig("cluster-1", "10.0.0.10:8081");
+
+        verify(clusterService).requireProxy("cluster-1", "10.0.0.10:8081");
+        verify(restTemplate).postForEntity(eq("http://10.0.0.10:8081/admin/reloadConfig"), isNull(), eq(String.class));
     }
 
     @Test
@@ -216,7 +265,7 @@ class ProxyAddressServiceTest {
             }
             return ProxyHealthProbe.ProbeResult.reachable(300L);
         };
-        ProxyAddressService service = new ProxyAddressService(slowProbe);
+        ProxyAddressService service = new ProxyAddressService(clusterService, slowProbe);
         service.addProxyAddr("10.0.0.11:8081");
         service.addProxyAddr("10.0.0.12:8081");
         service.addProxyAddr("10.0.0.13:8081");
@@ -246,7 +295,7 @@ class ProxyAddressServiceTest {
         };
         java.util.concurrent.ExecutorService executor =
                 java.util.concurrent.Executors.newFixedThreadPool(4);
-        ProxyAddressService service = new ProxyAddressService(selectiveProbe, executor, 500L);
+        ProxyAddressService service = new ProxyAddressService(clusterService, selectiveProbe, executor, 500L);
         service.addProxyAddr("10.0.0.21:8081");
         service.addProxyAddr("10.0.0.22:8081");
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -105,18 +106,15 @@ class ProxyControllerTest {
 
     @Test
     void listProxiesShouldReturnProxiesForCluster() throws Exception {
-        when(proxyAddressService.getHomePage())
-                .thenReturn(ProxyHomeVO.builder()
-                        .proxyAddrList(List.of("127.0.0.1:8081"))
-                        .currentProxyAddr("127.0.0.1:8081")
-                        .build());
+        when(clusterService.listProxies("cluster-1"))
+                .thenReturn(List.of(ProxyVO.builder().addr("10.0.0.10:8081").build()));
 
         mockMvc.perform(get("/api/proxies").param("clusterId", "cluster-1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data[0].addr").value("127.0.0.1:8081"));
+                .andExpect(jsonPath("$.data[0].addr").value("10.0.0.10:8081"));
 
-        verify(proxyAddressService).getHomePage();
+        verify(clusterService).listProxies("cluster-1");
     }
 
     @Test
@@ -176,7 +174,7 @@ class ProxyControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.success").value(true));
 
-        verify(proxyAddressService).reloadConfig("127.0.0.1:8081");
+        verify(proxyAddressService).reloadConfig(eq("cluster-1"), eq("127.0.0.1:8081"));
     }
 
     @Test


### PR DESCRIPTION
Closes #2338

## Summary

- resolve Proxy reload targets from the selected cluster instead of the mutable compatibility address registry
- verify every reload target is a discovered proxy for that cluster
- keep legacy address registration compatible while removing its ability to authorize outbound reload requests

## Verification

- `mvn -f server/pom.xml -Dtest=ClusterServiceTest,ProxyAddressServiceTest,ProxyControllerTest test`