### PR TITLE
fix(security): redact notification webhook secrets from reader settings

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
@@ -59,9 +59,15 @@ public class AuthInterceptor implements HandlerInterceptor {
             writeError(response, HttpStatus.UNAUTHORIZED, "Unauthorized");
             return false;
         }
-        authService.getAuthenticatedUser(authorization)
-                .ifPresent(user -> AuthenticatedUserContext.setUser(user.getUserId(), user.getUsername()));
-        if (requiresAdmin(request, requestPath(request)) && !authService.isAdmin(authorization)) {
+        var authenticatedUser = authService.getAuthenticatedUser(authorization).orElse(null);
+        if (authenticatedUser != null) {
+            AuthenticatedUserContext.setUser(
+                    authenticatedUser.getUserId(),
+                    authenticatedUser.getUsername(),
+                    authenticatedUser.isAdmin());
+        }
+        if (requiresAdmin(request, requestPath(request))
+                && (authenticatedUser == null || !authenticatedUser.isAdmin())) {
             writeError(response, HttpStatus.FORBIDDEN, "Admin permission required");
             return false;
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthenticatedUserContext.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthenticatedUserContext.java
@@ -26,20 +26,30 @@ public final class AuthenticatedUserContext {
 
     private static final ThreadLocal<String> CURRENT_USERNAME = new ThreadLocal<>();
     private static final ThreadLocal<String> CURRENT_USER_ID = new ThreadLocal<>();
+    private static final ThreadLocal<Boolean> CURRENT_ADMIN = new ThreadLocal<>();
 
     private AuthenticatedUserContext() {
     }
 
-    public static void setUsername(String username) {
+    public static void setUser(String username, boolean admin) {
         if (username == null || username.isBlank()) {
             clear();
             return;
         }
         CURRENT_USERNAME.set(username);
+        CURRENT_ADMIN.set(admin);
+    }
+
+    public static void setUsername(String username) {
+        setUser(username, false);
     }
 
     public static void setUser(Long userId, String username) {
-        setUsername(username);
+        setUser(userId, username, false);
+    }
+
+    public static void setUser(Long userId, String username, boolean admin) {
+        setUser(username, admin);
         if (userId == null) {
             CURRENT_USER_ID.remove();
         } else {
@@ -56,8 +66,14 @@ public final class AuthenticatedUserContext {
         return username == null ? SYSTEM_ACTOR : username;
     }
 
+    public static boolean currentUserIsAdminOrSystem() {
+        Boolean admin = CURRENT_ADMIN.get();
+        return admin == null || admin;
+    }
+
     public static void clear() {
         CURRENT_USERNAME.remove();
         CURRENT_USER_ID.remove();
+        CURRENT_ADMIN.remove();
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthenticatedUserContext.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthenticatedUserContext.java
@@ -66,6 +66,11 @@ public final class AuthenticatedUserContext {
         return username == null ? SYSTEM_ACTOR : username;
     }
 
+    /**
+     * Returns whether the current request is an administrator or a system-initiated operation.
+     * A missing context represents background/system work, which must retain access to persisted
+     * configuration rather than being treated as a reader request.
+     */
     public static boolean currentUserIsAdminOrSystem() {
         Boolean admin = CURRENT_ADMIN.get();
         return admin == null || admin;

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/GeneralSettingsVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/GeneralSettingsVO.java
@@ -25,7 +25,7 @@ import lombok.ToString;
 import org.springframework.util.StringUtils;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class GeneralSettingsVO {
@@ -56,5 +56,15 @@ public class GeneralSettingsVO {
     @JsonProperty(value = "apiKeyConfigured", access = JsonProperty.Access.READ_ONLY)
     public boolean isApiKeyConfigured() {
         return StringUtils.hasText(apiKey);
+    }
+
+    @JsonProperty(value = "dingtalkWebhookConfigured", access = JsonProperty.Access.READ_ONLY)
+    public boolean isDingtalkWebhookConfigured() {
+        return StringUtils.hasText(dingtalkWebhook);
+    }
+
+    @JsonProperty(value = "smsWebhookConfigured", access = JsonProperty.Access.READ_ONLY)
+    public boolean isSmsWebhookConfigured() {
+        return StringUtils.hasText(smsWebhook);
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.settings;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.auth.AuthenticatedUserContext;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.cluster.metrics.MetricsBackendType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -52,6 +53,7 @@ import java.util.Set;
 @Service
 public class SettingsService {
 
+    private static final String REDACTED_NOTIFICATION_WEBHOOK = "******";
     private static final List<byte[]> CLOUD_METADATA_ADDRESSES = List.of(
             new byte[] {
                 (byte) 0xfd, 0x00, 0x0e, (byte) 0xc2,
@@ -98,7 +100,25 @@ public class SettingsService {
 
     public GeneralSettingsVO getGeneralSettings() {
         log.debug("Loading general settings");
-        return settingsRepository.loadGeneralSettings();
+        GeneralSettingsVO settings = settingsRepository.loadGeneralSettings();
+        if (AuthenticatedUserContext.currentUserIsAdminOrSystem()) {
+            return settings;
+        }
+        return redactNotificationWebhooks(settings);
+    }
+
+    private GeneralSettingsVO redactNotificationWebhooks(GeneralSettingsVO settings) {
+        if (settings == null) {
+            return null;
+        }
+        return settings.toBuilder()
+                .dingtalkWebhook(StringUtils.hasText(settings.getDingtalkWebhook())
+                        ? REDACTED_NOTIFICATION_WEBHOOK
+                        : settings.getDingtalkWebhook())
+                .smsWebhook(StringUtils.hasText(settings.getSmsWebhook())
+                        ? REDACTED_NOTIFICATION_WEBHOOK
+                        : settings.getSmsWebhook())
+                .build();
     }
 
 

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCredentialAuthorizationIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCredentialAuthorizationIntegrationTest.java
@@ -31,6 +31,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Optional;
+
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
@@ -72,6 +74,7 @@ class AuthCredentialAuthorizationIntegrationTest {
         when(authProperties.isLoginRequired()).thenReturn(true);
         when(authService.isAuthenticated(AUTHORIZATION)).thenReturn(true);
         when(authService.isAdmin(AUTHORIZATION)).thenReturn(false);
+        when(authService.getAuthenticatedUser(AUTHORIZATION)).thenReturn(Optional.of(user(false)));
     }
 
     @Test
@@ -95,6 +98,7 @@ class AuthCredentialAuthorizationIntegrationTest {
     @Test
     void shouldAllowCredentialPathsWithMatrixParametersForAdministrator() throws Exception {
         when(authService.isAdmin(AUTHORIZATION)).thenReturn(true);
+        when(authService.getAuthenticatedUser(AUTHORIZATION)).thenReturn(Optional.of(user(true)));
 
         mockMvc.perform(get("/api/acl/users/user-1/credentials;probe=1")
                         .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION))
@@ -105,5 +109,13 @@ class AuthCredentialAuthorizationIntegrationTest {
 
         verify(aclService).getUserCredentials(eq("user-1"), isNull());
         verify(cloudCredentialService).reveal(12L);
+    }
+
+    private LoginVO.UserInfo user(boolean admin) {
+        return LoginVO.UserInfo.builder()
+                .userId(1L)
+                .username(admin ? "admin" : "reader")
+                .admin(admin)
+                .build();
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -100,6 +100,26 @@ class AuthInterceptorTest {
     }
 
     @Test
+    void shouldTrackAuthenticatedAdminStateInUserContext() throws Exception {
+        TestSession session = login(true);
+        MockHttpServletRequest request = authenticatedRequest("GET", "/api/clusters", session.token());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        Object handler = new Object();
+
+        boolean allowed = session.interceptor().preHandle(request, response, handler);
+
+        assertThat(allowed).isTrue();
+        assertThat(AuthenticatedUserContext.currentUsernameOrSystem()).isEqualTo("test-user");
+        assertThat(AuthenticatedUserContext.currentUserIsAdminOrSystem()).isTrue();
+
+        session.interceptor().afterCompletion(request, response, handler, null);
+
+        assertThat(AuthenticatedUserContext.currentUsernameOrSystem())
+                .isEqualTo(AuthenticatedUserContext.SYSTEM_ACTOR);
+        assertThat(AuthenticatedUserContext.currentUserIsAdminOrSystem()).isTrue();
+    }
+
+    @Test
     void shouldEnforceLoginWhenDatabaseRequiresItEvenIfPropertyIsDisabled() throws Exception {
         AuthProperties properties = new AuthProperties();
         AuthInterceptor interceptor = new AuthInterceptor(properties, authService(properties),

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.settings;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.auth.AuthenticatedUserContext;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -86,6 +87,41 @@ class SettingsControllerTest {
                 .andExpect(jsonPath("$.data.apiKeyConfigured", is(true)))
                 .andExpect(jsonPath("$.data.clearApiKey").doesNotExist())
                 .andExpect(jsonPath("$.data.model", is("gpt-4")));
+    }
+
+    @Test
+    void getGeneralSettingsShouldRedactNotificationWebhooksForReaders() throws Exception {
+        AuthenticatedUserContext.setUser("reader", false);
+        try {
+            GeneralSettingsVO settings = GeneralSettingsVO.builder()
+                    .theme("dark")
+                    .compact(true)
+                    .desktopNotify(true)
+                    .notifySound(false)
+                    .sessionTimeout(30)
+                    .requireLogin(true)
+                    .llmProvider("openai")
+                    .dingtalkWebhook("https://oapi.dingtalk.com/robot/send?access_token=secret")
+                    .emailRecipients("ops@example.com")
+                    .smsWebhook("https://sms.example.test/notify")
+                    .model("gpt-4")
+                    .baseUrl("https://api.openai.com")
+                    .build();
+            when(settingsService.getGeneralSettings()).thenReturn(settings.toBuilder()
+                    .dingtalkWebhook("******")
+                    .smsWebhook("******")
+                    .build());
+
+            mockMvc.perform(get("/api/settings/general"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.dingtalkWebhook", is("******")))
+                    .andExpect(jsonPath("$.data.dingtalkWebhookConfigured", is(true)))
+                    .andExpect(jsonPath("$.data.emailRecipients", is("ops@example.com")))
+                    .andExpect(jsonPath("$.data.smsWebhook", is("******")))
+                    .andExpect(jsonPath("$.data.smsWebhookConfigured", is(true)));
+        } finally {
+            AuthenticatedUserContext.clear();
+        }
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.settings;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.auth.AuthenticatedUserContext;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.AfterEach;
@@ -115,6 +116,28 @@ class SettingsServiceTest {
         assertThat(result.isRequireLogin()).isTrue();
         assertThat(result.getLlmProvider()).isEqualTo("openai");
         assertThat(result.getModel()).isEqualTo("gpt-4");
+    }
+
+    @Test
+    void getGeneralSettingsShouldRedactNotificationWebhooksForReaderSessions() {
+        GeneralSettingsVO settings = GeneralSettingsVO.builder()
+                .theme("dark")
+                .dingtalkWebhook("https://oapi.dingtalk.com/robot/send?access_token=secret")
+                .smsWebhook("https://sms.example.test/notify")
+                .build();
+        when(settingsRepository.loadGeneralSettings()).thenReturn(settings);
+        AuthenticatedUserContext.setUser("reader", false);
+
+        try {
+            GeneralSettingsVO result = settingsService.getGeneralSettings();
+
+            assertThat(result.getDingtalkWebhook()).isEqualTo("******");
+            assertThat(result.isDingtalkWebhookConfigured()).isTrue();
+            assertThat(result.getSmsWebhook()).isEqualTo("******");
+            assertThat(result.isSmsWebhookConfigured()).isTrue();
+        } finally {
+            AuthenticatedUserContext.clear();
+        }
     }
 
     @Test

--- a/web/src/api/generalSettings.test.ts
+++ b/web/src/api/generalSettings.test.ts
@@ -33,6 +33,11 @@ const settings: GeneralSettings = {
   apiKeyConfigured: true,
   model: 'gpt-5',
   baseUrl: 'https://api.example.com/v1',
+  dingtalkWebhook: '******',
+  dingtalkWebhookConfigured: true,
+  emailRecipients: 'ops@example.com',
+  smsWebhook: '******',
+  smsWebhookConfigured: true,
 };
 const editableSettings: GeneralSettingsUpdate = {
   theme: settings.theme,
@@ -82,6 +87,8 @@ describe('general settings API', () => {
       const body = JSON.parse(config.data);
       expect(body).not.toHaveProperty('apiKey');
       expect(body).not.toHaveProperty('apiKeyConfigured');
+      expect(body).not.toHaveProperty('dingtalkWebhookConfigured');
+      expect(body).not.toHaveProperty('smsWebhookConfigured');
       return [200, { code: 200, data: null }];
     });
 

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -30,11 +30,16 @@ export interface GeneralSettings {
   model: string;
   baseUrl: string;
   dingtalkWebhook?: string;
+  dingtalkWebhookConfigured?: boolean;
   emailRecipients?: string;
   smsWebhook?: string;
+  smsWebhookConfigured?: boolean;
 }
 
-export type GeneralSettingsUpdate = Omit<GeneralSettings, 'apiKeyConfigured'> & {
+export type GeneralSettingsUpdate = Omit<
+  GeneralSettings,
+  'apiKeyConfigured' | 'dingtalkWebhookConfigured' | 'smsWebhookConfigured'
+> & {
   apiKey?: string;
   clearApiKey?: boolean;
 };
@@ -59,8 +64,16 @@ export async function getGeneralSettings() {
 }
 
 export async function saveGeneralSettings(data: GeneralSettingsUpdate) {
-  const payload = { ...data } as GeneralSettingsUpdate & { apiKeyConfigured?: boolean };
+  const payload = {
+    ...data,
+  } as GeneralSettingsUpdate & {
+    apiKeyConfigured?: boolean;
+    dingtalkWebhookConfigured?: boolean;
+    smsWebhookConfigured?: boolean;
+  };
   delete payload.apiKeyConfigured;
+  delete payload.dingtalkWebhookConfigured;
+  delete payload.smsWebhookConfigured;
   if (!payload.apiKey?.trim()) delete payload.apiKey;
   await client.post('/settings/general/save', payload);
 }


### PR DESCRIPTION
Closes #2336

## Summary

- redact DingTalk and SMS webhook values for authenticated reader sessions
- expose configured-state flags without exposing the secret values
- preserve existing settings API behavior for administrators

## Verification

- `mvn -q -Dtest=SettingsServiceTest,SettingsControllerTest,AuthInterceptorTest test`
- `mvn -q -DskipTests package`
- `npm test -- src/api/generalSettings.test.ts src/pages/settings/__tests__/GeneralSettingsTab.test.tsx`
- `npm run build`