### PR TITLE
fix(topic): honor explicit queue counts on update

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -317,14 +317,14 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 // Preserve the existing queue counts when the update request does not change them,
                 // matching the perm semantics below; defaulting to 8 would silently resize the
                 // topic on partial updates (e.g. perm or remark only).
-                int writeQueues = existing != null && existing.getWriteQueueNums() != null
-                                && existing.getWriteQueueNums() > 0
-                        ? existing.getWriteQueueNums()
-                        : topic.getWriteQueues() > 0 ? topic.getWriteQueues() : 8;
-                int readQueues = existing != null && existing.getReadQueueNums() != null
-                                && existing.getReadQueueNums() > 0
-                        ? existing.getReadQueueNums()
-                        : topic.getReadQueues() > 0 ? topic.getReadQueues() : 8;
+                int writeQueues = topic.getWriteQueues() > 0
+                        ? topic.getWriteQueues()
+                        : existing != null && existing.getWriteQueueNums() != null
+                                && existing.getWriteQueueNums() > 0 ? existing.getWriteQueueNums() : 8;
+                int readQueues = topic.getReadQueues() > 0
+                        ? topic.getReadQueues()
+                        : existing != null && existing.getReadQueueNums() != null
+                                && existing.getReadQueueNums() > 0 ? existing.getReadQueueNums() : 8;
                 TopicPerm effectivePerm = topic.getPerm() != null
                         ? topic.getPerm()
                         : existing == null ? TopicPerm.RW : fromRocketMQPerm(existing.getPerm());

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -480,6 +480,34 @@ class RocketMQAdminClientImplTest {
     }
 
     @Test
+    void updateTopicAppliesExplicitQueueCounts() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqTopic.class);
+        RmqTopic existing = new RmqTopic();
+        existing.setWriteQueueNums(8);
+        existing.setReadQueueNums(8);
+        existing.setPerm(6);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithMaster());
+        when(topicMapper.selectOne(any())).thenReturn(existing);
+        doNothing().when(adminExt).createAndUpdateTopicConfig(anyString(), any(TopicConfig.class));
+
+        TopicVO topic = new TopicVO();
+        topic.setName("orders");
+        topic.setWriteQueues(16);
+        topic.setReadQueues(12);
+
+        TopicVO updated = adminClient.updateTopic(topic);
+
+        ArgumentCaptor<TopicConfig> topicConfigCaptor = ArgumentCaptor.forClass(TopicConfig.class);
+        verify(adminExt).createAndUpdateTopicConfig(anyString(), topicConfigCaptor.capture());
+        assertThat(topicConfigCaptor.getValue().getWriteQueueNums()).isEqualTo(16);
+        assertThat(topicConfigCaptor.getValue().getReadQueueNums()).isEqualTo(12);
+        assertThat(existing.getWriteQueueNums()).isEqualTo(16);
+        assertThat(existing.getReadQueueNums()).isEqualTo(12);
+        assertThat(updated.getWriteQueues()).isEqualTo(16);
+        assertThat(updated.getReadQueues()).isEqualTo(12);
+    }
+
+    @Test
     void topicDeleteUsesSelectedInstanceAndScopesMetadataToClusterAndInstance() throws Exception {
         TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqTopic.class);
         DefaultMQAdminExt selectedAdmin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);


### PR DESCRIPTION
## Summary

- prefer explicitly supplied positive read/write queue counts when updating an Apache topic
- preserve persisted queue counts when a partial update omits them
- keep the existing fallback of 8 only when neither source provides a usable value
- add a regression test covering broker configuration, metadata persistence, and the returned topic

## Root cause

The update path checked persisted queue counts before request values. Once a topic had positive counts in metadata, every later resize request was silently replaced with those old values before the broker update.

Closes #2345

## Validation

- `mvn -B -ntp -Dtest=RocketMQAdminClientImplTest test` (29 tests passed)
- `mvn -B -ntp checkstyle:check` (0 violations)
- `git diff --check`