### PR TITLE
fix(instance): recover from malformed route encoding

### DIFF
--- a/web/src/hooks/useInstanceFilter.test.tsx
+++ b/web/src/hooks/useInstanceFilter.test.tsx
@@ -60,4 +60,32 @@ describe('useInstanceFilter', () => {
       expect(screen.getByText('/instance/instance-a/topic|instance-a')).toBeInTheDocument();
     });
   });
+
+  it('recovers from a malformed encoded instance id', async () => {
+    instanceServiceMocks.listInstances.mockResolvedValue([
+      {
+        id: 7,
+        name: 'instance-a',
+        remark: '',
+        type: 'PROXY',
+        endpoint: '127.0.0.1:8080',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        gmtCreate: '2026-01-01T00:00:00Z',
+        gmtModified: '2026-01-01T00:00:00Z',
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={['/instance/%E0%A4%A/topic']}>
+        <Routes>
+          <Route path="/instance/:instanceId/topic" element={<InstanceRouteProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('/instance/instance-a/topic|instance-a')).toBeInTheDocument();
+    });
+  });
 });

--- a/web/src/hooks/useInstanceFilter.ts
+++ b/web/src/hooks/useInstanceFilter.ts
@@ -23,6 +23,15 @@ import type { Instance } from '../api/instance';
 const INSTANCE_SCOPED_PATH = /^\/instance\/([^/]+)\/(topic|consumer|message|acl|dlq)$/;
 const STATIC_SECTION_PATH = /^\/instance\/(topic|consumer|message|acl|dlq)$/;
 
+function decodeRouteSegment(segment: string | undefined) {
+  if (segment === undefined) return undefined;
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * 实例维度页面的公共筛选逻辑：从 /instance/:instanceId/<section> 路由解析当前实例，
  * 无实例参数时重定向到第一个实例；实例列表加载失败时降级为不过滤。
@@ -33,7 +42,7 @@ export function useInstanceFilter() {
 
   const scopedMatch = pathname.match(INSTANCE_SCOPED_PATH);
   const staticMatch = pathname.match(STATIC_SECTION_PATH);
-  const routeInstanceId = scopedMatch ? decodeURIComponent(scopedMatch[1]) : undefined;
+  const routeInstanceId = decodeRouteSegment(scopedMatch?.[1]);
   const section = scopedMatch?.[2] ?? staticMatch?.[1] ?? 'topic';
 
   const [instances, setInstances] = useState<Instance[]>([]);


### PR DESCRIPTION
## Summary

- decode instance route segments without throwing on malformed percent encoding
- treat an undecodable instance id as unknown so the existing instance-list fallback can recover the route
- add a router-level regression test for a truncated encoded segment

## Root cause

`useInstanceFilter` decoded the raw path segment during render with an unguarded `decodeURIComponent` call. Invalid input therefore raised a synchronous `URIError` before the hook could load instances and redirect to a valid selection.

Closes #2346

## Validation

- `npm test -- --run src/hooks/useInstanceFilter.test.tsx` (2 tests passed)
- `npx eslint src/hooks/useInstanceFilter.ts src/hooks/useInstanceFilter.test.tsx`
- `npm run build`
- `git diff --check`