### PR TITLE
fix(clients): export only visible filtered rows

### DIFF
--- a/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
@@ -264,6 +264,42 @@ describe('Clients page', () => {
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:client-connections');
   });
 
+  it('applies table column filters to the exported CSV', async () => {
+    const createObjectURL = vi.fn((blob: Blob | MediaSource) => {
+      expect(blob).toBeInstanceOf(Blob);
+      return 'blob:filtered-client-connections';
+    });
+    Object.defineProperty(URL, 'createObjectURL', {
+      writable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      writable: true,
+      value: vi.fn(),
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    vi.mocked(connectionsService.listConnections).mockResolvedValue(connections);
+    const user = userEvent.setup();
+    renderWithProviders(<ClientsPage />);
+
+    await screen.findByText('order-svc-0@10.0.1.12:49152');
+    const filterTriggers = document.querySelectorAll<HTMLElement>('.ant-table-filter-trigger');
+    await user.click(filterTriggers[1]);
+    const filterDropdown = document.querySelector<HTMLElement>('.ant-table-filter-dropdown');
+    expect(filterDropdown).not.toBeNull();
+    await user.click(within(filterDropdown!).getByText('Consumer'));
+    await user.click(within(filterDropdown!).getByRole('button', { name: 'OK' }));
+
+    expect(screen.queryByText('order-svc-0@10.0.1.12:49152')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: '导出' }));
+
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    const csv = await blob.text();
+    expect(csv).not.toContain('order-svc-0@10.0.1.12:49152');
+    expect(csv).toContain('payment-svc-0@10.0.1.13:49153');
+    expect(csv).toContain('audit-svc-0@10.0.2.10:49154');
+  });
+
   it('renders empty distributions when no connections are available', async () => {
     vi.mocked(connectionsService.listConnections).mockResolvedValue([]);
     renderWithProviders(<ClientsPage />);

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -34,6 +34,7 @@ import {
 } from 'antd';
 import { DownloadSimple, Eye, MagnifyingGlass } from '@phosphor-icons/react';
 import type { ColumnsType } from 'antd/es/table';
+import type { TableProps } from 'antd';
 
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
@@ -83,6 +84,8 @@ const CLIENT_CONNECTION_EXPORT_COLUMNS: CsvColumn<ClientConnection>[] = [
   { header: 'Partial', value: (connection) => (connection.partial ? 'true' : 'false') },
 ];
 
+type ClientTableFilters = Parameters<NonNullable<TableProps<ClientConnection>['onChange']>>[1];
+
 const countBy = (values: string[]) =>
   [
     ...values.reduce(
@@ -130,6 +133,7 @@ const ClientsPage = () => {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [registryLoadKey, setRegistryLoadKey] = useState(0);
   const [connectionLoadKey, setConnectionLoadKey] = useState(0);
+  const [columnFilters, setColumnFilters] = useState<ClientTableFilters>({});
 
   const selectedCluster = registryClusters.find((cluster) => cluster.endpoint === selectedEndpoint);
 
@@ -263,9 +267,23 @@ const ClientsPage = () => {
     );
   }, [clusterConnections, search]);
 
+  const exportConnections = useMemo(() => {
+    const matches = (key: string, value: string) => {
+      const selected = columnFilters[key];
+      return !selected?.length || selected.some((filterValue) => String(filterValue) === value);
+    };
+    return filtered.filter(
+      (connection) =>
+        matches('clusterName', connection.clusterName) &&
+        matches('type', connection.type) &&
+        matches('protocol', connection.protocol) &&
+        matches('language', connection.language),
+    );
+  }, [columnFilters, filtered]);
+
   const handleExport = () => {
     const filename = `rocketmq-client-connections-${new Date().toISOString().slice(0, 10)}.csv`;
-    const csv = buildCsv(CLIENT_CONNECTION_EXPORT_COLUMNS, filtered);
+    const csv = buildCsv(CLIENT_CONNECTION_EXPORT_COLUMNS, exportConnections);
     downloadCsv(filename, csv);
   };
 
@@ -476,7 +494,7 @@ const ClientsPage = () => {
         </Space>
         <Button
           icon={<DownloadSimple size={16} />}
-          disabled={filtered.length === 0}
+          disabled={exportConnections.length === 0}
           onClick={handleExport}
         >
           {t('common.export')}
@@ -553,6 +571,7 @@ const ClientsPage = () => {
             `${connection.type}:${connection.clientId}:${connection.groupOrTopic}`
           }
           loading={loading}
+          onChange={(_, filters) => setColumnFilters(filters)}
           scroll={{ x: 1320 }}
           pagination={{
             pageSize: 20,


### PR DESCRIPTION
## Summary

- keep the Clients table's active column-filter state for export
- apply Cluster, Type, Protocol, and Language filters to the CSV row set
- disable export when the active filters leave no visible records
- add a UI regression test that filters out a Producer before downloading the CSV

## Root cause

The table applied its column filters internally, while `handleExport` used only the separately computed cluster-and-search result. The displayed rows and exported rows therefore diverged whenever a column filter was active.

Closes #2348

## Validation

- `npm test -- --run src/pages/cluster/__tests__/ClientsPage.test.tsx` (12 tests passed)
- `npx eslint src/pages/cluster/clients.tsx src/pages/cluster/__tests__/ClientsPage.test.tsx`
- `npm run build`
- `git diff --check`