### PR TITLE
fix(dashboard): calculate today message delta

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -218,13 +218,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                         tpsIn += parseTps(table.get("putTps"));
                         tpsOut += parseTps(table.get("getTransferredTps"));
 
-                        String msgPutToday = table.get("msgPutTotalTodayMorning");
-                        if (msgPutToday != null) {
-                            try {
-                                messagesToday += Long.parseLong(msgPutToday.trim());
-                            } catch (NumberFormatException ignored) {
-                            }
-                        }
+                        messagesToday += parseMessagesToday(table);
                     }
                 } catch (Exception e) {
                     log.warn("Failed to get runtime info from broker {}: {}", brokerAddr, e.getMessage());
@@ -365,6 +359,26 @@ public class RocketMQDashboardProvider implements DashboardProvider {
             log.debug("Failed to parse TPS value: {}", tpsStr);
         }
         return 0;
+    }
+
+    private long parseMessagesToday(Map<String, String> runtimeStats) {
+        String morningValue = runtimeStats.get("msgPutTotalTodayMorning");
+        String currentValue = runtimeStats.get("msgPutTotalTodayNow");
+        if (morningValue == null || currentValue == null) {
+            return 0;
+        }
+        try {
+            long morning = Long.parseLong(morningValue.trim());
+            long current = Long.parseLong(currentValue.trim());
+            if (morning < 0 || current < 0) {
+                return 0;
+            }
+            return Math.max(0, current - morning);
+        } catch (NumberFormatException exception) {
+            log.debug("Failed to parse today's message counters: morning={}, current={}",
+                    morningValue, currentValue);
+            return 0;
+        }
     }
 
     private boolean isSystemTopic(String topic) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -435,6 +435,46 @@ class RocketMQDashboardProviderTest {
     }
 
     @Test
+    void dashboardShouldReportMessagesProducedSinceTodayMorning() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithTwoMasters());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911"))
+                .thenReturn(runtimeStats("2.0", "5.0", "1000", "1250"));
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.12:10911"))
+                .thenReturn(runtimeStats("2.0", "5.0", "400", "475"));
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getStats().getTotalMessagesToday()).isEqualTo(325L);
+    }
+
+    @Test
+    void dashboardShouldNotReportNegativeCountWhenBrokerCounterMovesBackwards() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911"))
+                .thenReturn(runtimeStats("2.0", "5.0", "1000", "50"));
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getStats().getTotalMessagesToday()).isZero();
+    }
+
+    @Test
+    void dashboardShouldIgnoreMalformedTodayMessageCounters() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithTwoMasters());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911"))
+                .thenReturn(runtimeStats("2.0", "5.0", "invalid", "1250"));
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.12:10911"))
+                .thenReturn(runtimeStats("2.0", "5.0", "400", "invalid"));
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getStats().getTotalMessagesToday()).isZero();
+    }
+
+    @Test
     void dashboardShouldTolerateMissingTopicListAndClusterMembership() throws Exception {
         DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
         ClusterInfo info = new ClusterInfo();
@@ -531,11 +571,17 @@ class RocketMQDashboardProviderTest {
     }
 
     private KVTable runtimeStats(String putTps, String getTransferredTps) {
+        return runtimeStats(putTps, getTransferredTps, "42", "84");
+    }
+
+    private KVTable runtimeStats(String putTps, String getTransferredTps,
+                                 String todayMorning, String todayNow) {
         HashMap<String, String> table = new HashMap<>();
         table.put("brokerVersionDesc", "  V5_3_3  ");
         table.put("putTps", "1.0 " + putTps + " 3.0");
         table.put("getTransferredTps", "4.0 " + getTransferredTps + " 6.0");
-        table.put("msgPutTotalTodayMorning", "42");
+        table.put("msgPutTotalTodayMorning", todayMorning);
+        table.put("msgPutTotalTodayNow", todayNow);
 
         KVTable kvTable = new KVTable();
         kvTable.setTable(table);


### PR DESCRIPTION
## Summary

- calculate today's Apache broker message count from the current and midnight cumulative counters
- clamp backwards counter pairs and ignore missing, negative, or malformed values
- add regression coverage for multiple masters and invalid counter data

## Root cause

`totalMessagesToday` added `msgPutTotalTodayMorning` directly. That field is the cumulative counter snapshot at midnight; the produced-message count for the current day is the difference between `msgPutTotalTodayNow` and that snapshot.

Closes #2347

## Validation

- `mvn -B -ntp -Dtest=RocketMQDashboardProviderTest test` (24 tests passed)
- `mvn -B -ntp checkstyle:check` (0 violations)
- `git diff --check`