### PR TITLE
fix: return conflict for concurrent Studio user creation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
@@ -176,7 +176,11 @@ public class AuthService {
         user.setAdmin(admin);
         user.setEnabled(true);
         user.setPasswordChangedAt(now());
-        userMapper.insert(user);
+        try {
+            userMapper.insert(user);
+        } catch (DuplicateKeyException exception) {
+            throw new BusinessException(409, "Username is already in use");
+        }
         return user;
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceDatabaseTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceDatabaseTest.java
@@ -160,6 +160,19 @@ class AuthServiceDatabaseTest {
     }
 
     @Test
+    void createUserShouldReturnConflictWhenConcurrentInsertWins() {
+        when(userMapper.selectOne(any(Wrapper.class))).thenReturn(null);
+        when(userMapper.insert(any(RmqStudioUser.class)))
+                .thenThrow(new org.springframework.dao.DuplicateKeyException("duplicate username"));
+
+        assertThatThrownBy(() -> authService.createUser("operator", "password-1", false))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Username is already in use")
+                .satisfies(exception ->
+                        assertThat(((BusinessException) exception).getCode()).isEqualTo(409));
+    }
+
+    @Test
     void repeatedFailedLoginsAreRejectedWithTooManyRequestsTest() {
         when(userMapper.selectCount(isNull())).thenReturn(1L);
         when(userMapper.selectOne(any(Wrapper.class))).thenReturn(null);


### PR DESCRIPTION
Fixes #2349

Translate the duplicate-key race after the username pre-check into the existing 409 conflict response and cover it with a service regression test.