### PR TITLE
fix: align paged Topic filtering with canonical system topics

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/SystemTopicFilter.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/SystemTopicFilter.java
@@ -16,6 +16,8 @@
  */
 package org.apache.rocketmq.studio.common.util;
 
+import org.apache.rocketmq.common.topic.TopicValidator;
+
 import java.util.Set;
 
 /**
@@ -27,16 +29,7 @@ import java.util.Set;
  */
 public final class SystemTopicFilter {
 
-    private static final Set<String> SYSTEM_TOPIC_PREFIXES = Set.of(
-            "RMQ_SYS_", "rmq_sys_", "SCHEDULE_TOPIC_", "%RETRY%", "%DLQ%",
-            "CID_", "broker_", "BenchmarkTest"
-    );
-
-    private static final Set<String> SYSTEM_TOPICS = Set.of(
-            "TBW102", "SELF_TEST_TOPIC", "DefaultCluster", "OFFSET_MOVED_EVENT",
-            "broker", "SCHEDULE_TOPIC_XXXX", "RMQ_SYS_TRANS_HALF_TOPIC",
-            "RMQ_SYS_TRACE_TOPIC", "RMQ_SYS_TRANS_OP_HALF_TOPIC"
-    );
+    private static final Set<String> RETRY_AND_DLQ_PREFIXES = Set.of("%RETRY%", "%DLQ%");
 
     private SystemTopicFilter() {
     }
@@ -54,10 +47,10 @@ public final class SystemTopicFilter {
         if (topicName == null || topicName.isEmpty()) {
             return true;
         }
-        if (SYSTEM_TOPICS.contains(topicName)) {
+        if (TopicValidator.isSystemTopic(topicName)) {
             return true;
         }
-        for (String prefix : SYSTEM_TOPIC_PREFIXES) {
+        for (String prefix : RETRY_AND_DLQ_PREFIXES) {
             if (topicName.startsWith(prefix)) {
                 return true;
             }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -42,6 +42,7 @@ import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.util.Pagination;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
 import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
+import org.apache.rocketmq.common.topic.TopicValidator;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
@@ -140,8 +141,10 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                 .eq(StringUtils.hasText(clusterId), RmqTopic::getClusterId, clusterId)
                 .eq(StringUtils.hasText(type), RmqTopic::getTopicType, type)
                 .like(StringUtils.hasText(search), RmqTopic::getName, search)
-                .notLikeRight(RmqTopic::getName, "RMQ_SYS_")
+                .notIn(RmqTopic::getName, TopicValidator.getSystemTopicSet())
                 .notLikeRight(RmqTopic::getName, "rmq_sys_")
+                .notLikeRight(RmqTopic::getName, "%RETRY%")
+                .notLikeRight(RmqTopic::getName, "%DLQ%")
                 .orderByAsc(RmqTopic::getName, RmqTopic::getId);
         Page<RmqTopic> result = topicMapper.selectPage(new Page<>(page, pageSize), query);
         return PageResult.of(result.getRecords().stream().map(this::toTopicVO).toList(),

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemTopicFilterTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemTopicFilterTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SystemTopicFilterTest {
 
     @Test
-    void shouldRecognizeSharedSystemTopicPrefixesAndBrokerNamesTest() {
+    void shouldRecognizeCanonicalSystemTopicsAndBrokerNamesTest() {
         Set<String> brokerNames = Set.of("broker-prod-a", "broker-prod-b");
 
         assertThat(SystemTopicFilter.isSystem(null, brokerNames)).isTrue();
@@ -35,14 +35,15 @@ class SystemTopicFilterTest {
         assertThat(SystemTopicFilter.isSystem("SCHEDULE_TOPIC_XXXX", brokerNames)).isTrue();
         assertThat(SystemTopicFilter.isSystem("%RETRY%consumer-a", brokerNames)).isTrue();
         assertThat(SystemTopicFilter.isSystem("%DLQ%consumer-a", brokerNames)).isTrue();
-        assertThat(SystemTopicFilter.isSystem("CID_RMQ_SYS_TRANS", brokerNames)).isTrue();
-        assertThat(SystemTopicFilter.isSystem("broker_config", brokerNames)).isTrue();
-        assertThat(SystemTopicFilter.isSystem("BenchmarkTestTopic", brokerNames)).isTrue();
         assertThat(SystemTopicFilter.isSystem("TBW102", brokerNames)).isTrue();
         assertThat(SystemTopicFilter.isSystem("SELF_TEST_TOPIC", brokerNames)).isTrue();
         assertThat(SystemTopicFilter.isSystem("OFFSET_MOVED_EVENT", brokerNames)).isTrue();
         assertThat(SystemTopicFilter.isSystem("broker-prod-a", brokerNames)).isTrue();
 
         assertThat(SystemTopicFilter.isSystem("orders", brokerNames)).isFalse();
+        assertThat(SystemTopicFilter.isSystem("CID_orders", brokerNames)).isFalse();
+        assertThat(SystemTopicFilter.isSystem("broker_events", brokerNames)).isFalse();
+        assertThat(SystemTopicFilter.isSystem("BenchmarkTestOrders", brokerNames)).isFalse();
+        assertThat(SystemTopicFilter.isSystem("SCHEDULE_TOPIC_orders", brokerNames)).isFalse();
     }
 }


### PR DESCRIPTION
Fixes #2285

Fixes #2244

Align Apache paged Topic inventory with the canonical RocketMQ system Topic definitions while retaining only the dynamic broker-name check locally. This prevents internal retry, DLQ and schedule topics from appearing in the paged inventory without hiding user-created Topics that merely share historical prefixes.