### PR TITLE
fix(deploy): add auth table upgrade for reused MySQL volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ user-management page; browsers authenticate with an `HttpOnly` session cookie, a
 request a bearer token explicitly. Disabling login protection only skips API interception for local
 development.
 
+If you are upgrading an existing MySQL volume from a pre-auth deployment, import
+`deploy/mysql/upgrade-auth-tables.sql` once before the first login on the new build. Fresh volumes
+already receive `rmq_studio_user` and `rmq_studio_session` from `schema.sql`.
+
 ## Features
 
 | Module | Capabilities |

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ user-management page; browsers authenticate with an `HttpOnly` session cookie, a
 request a bearer token explicitly. Disabling login protection only skips API interception for local
 development.
 
-If you are upgrading an existing MySQL volume from a pre-auth deployment, import
-`deploy/mysql/upgrade-auth-tables.sql` once before the first login on the new build. Fresh volumes
-already receive `rmq_studio_user` and `rmq_studio_session` from `schema.sql`.
+If you are upgrading an existing MySQL volume from a pre-auth deployment, first run
+`deploy/mysql/upgrade-settings-singleton-key.sql` when `rmq_settings` still lacks `settings_key`,
+then import `deploy/mysql/upgrade-auth-tables.sql` once before the first login on the new build.
+Fresh volumes already receive `rmq_studio_user` and `rmq_studio_session` from `schema.sql`.
 
 ## Features
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -28,6 +28,10 @@ cd .. && docker compose up -d --build
 `STUDIO_AUTH_ADMIN_PASSWORD` 开启登录保护。登录接口仅接受已配置用户；
 关闭登录保护只会跳过本地开发场景下的 API 拦截。
 
+如果是从未包含认证表的旧版部署升级，并且继续复用现有 MySQL volume，请在新版本首次登录前先执行
+`deploy/mysql/upgrade-auth-tables.sql`。全新 volume 会直接从 `schema.sql` 获得
+`rmq_studio_user` 和 `rmq_studio_session`，无需额外导入。
+
 ## 功能概览
 
 | 模块 | 能力 |

--- a/README_zh.md
+++ b/README_zh.md
@@ -28,9 +28,10 @@ cd .. && docker compose up -d --build
 `STUDIO_AUTH_ADMIN_PASSWORD` 开启登录保护。登录接口仅接受已配置用户；
 关闭登录保护只会跳过本地开发场景下的 API 拦截。
 
-如果是从未包含认证表的旧版部署升级，并且继续复用现有 MySQL volume，请在新版本首次登录前先执行
-`deploy/mysql/upgrade-auth-tables.sql`。全新 volume 会直接从 `schema.sql` 获得
-`rmq_studio_user` 和 `rmq_studio_session`，无需额外导入。
+如果是从未包含认证表的旧版部署升级，并且继续复用现有 MySQL volume，请先检查 `rmq_settings`
+是否缺少 `settings_key`；若缺少，先执行 `deploy/mysql/upgrade-settings-singleton-key.sql`，再在
+新版本首次登录前执行 `deploy/mysql/upgrade-auth-tables.sql`。全新 volume 会直接从 `schema.sql`
+获得 `rmq_studio_user` 和 `rmq_studio_session`，无需额外导入。
 
 ## 功能概览
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -73,8 +73,9 @@ STUDIO_AUTH_ADMIN_PASSWORD=change-me
 且用户表为空，后端会拒绝登录以避免误签发会话。
 `studio.auth.login-required=false` 仅用于本地开发场景跳过 `/api/**` 拦截。
 
-如果是从 2026-08 之前、尚未包含认证表的旧部署升级，并且继续复用现有 MySQL volume，请在新版本
-首次登录前先执行一次：
+如果是从 2026-08 之前、尚未包含认证表的旧部署升级，并且继续复用现有 MySQL volume，请先确认
+`rmq_settings` 是否已经包含 `settings_key`；若没有，先执行
+`deploy/mysql/upgrade-settings-singleton-key.sql`，再在新版本首次登录前执行一次：
 
 ```bash
 docker exec -i rocketmq-studio-mysql mysql -uroot -p"${MYSQL_ROOT_PASSWORD:-studio123}" rocketmq \

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -73,6 +73,17 @@ STUDIO_AUTH_ADMIN_PASSWORD=change-me
 且用户表为空，后端会拒绝登录以避免误签发会话。
 `studio.auth.login-required=false` 仅用于本地开发场景跳过 `/api/**` 拦截。
 
+如果是从 2026-08 之前、尚未包含认证表的旧部署升级，并且继续复用现有 MySQL volume，请在新版本
+首次登录前先执行一次：
+
+```bash
+docker exec -i rocketmq-studio-mysql mysql -uroot -p"${MYSQL_ROOT_PASSWORD:-studio123}" rocketmq \
+  < deploy/mysql/upgrade-auth-tables.sql
+```
+
+全新 volume 会直接从 `server/src/main/resources/db/schema.sql` 创建 `rmq_studio_user` /
+`rmq_studio_session`，无需额外导入。
+
 ## 前置条件
 
 - 本地安装 Docker

--- a/deploy/mysql/upgrade-auth-tables.sql
+++ b/deploy/mysql/upgrade-auth-tables.sql
@@ -1,0 +1,42 @@
+-- deploy/mysql/upgrade-auth-tables.sql
+-- Existing MySQL volumes: create the Studio auth tables introduced in 2026-08.
+-- Fresh volumes already receive these tables from server/src/main/resources/db/schema.sql.
+-- Applicable when the MySQL data volume was initialized before Studio auth shipped, so
+-- docker-entrypoint-initdb.d will not run schema.sql again.
+-- Idempotent: safe to run multiple times.
+--
+-- Run once on an upgraded deployment before the first login:
+--   docker exec -i rocketmq-studio-mysql mysql -uroot -pstudio123 rocketmq < upgrade-auth-tables.sql
+
+-- Keep the client encoding fixed so comments and bootstrap usernames are not double-encoded.
+SET NAMES utf8mb4;
+
+-- 1. Studio console users (distinct from RocketMQ ACL users).
+CREATE TABLE IF NOT EXISTS rmq_studio_user (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  `username` VARCHAR(128) NOT NULL COMMENT '用户名',
+  `password_hash` VARCHAR(512) NOT NULL COMMENT 'PBKDF2 密码哈希，禁止存储明文',
+  `admin` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否管理员',
+  `enabled` TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否启用',
+  `password_changed_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '最近修改密码时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_studio_user_username` (`username`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 2. Studio bearer-token sessions. token_hash stores SHA-256(token), never the raw token.
+CREATE TABLE IF NOT EXISTS rmq_studio_session (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  `user_id` bigint(20) unsigned NOT NULL COMMENT '会话所属用户，引用 rmq_studio_user.id',
+  `token_hash` CHAR(64) NOT NULL COMMENT 'SHA-256(session token)',
+  `expires_at` DATETIME NOT NULL COMMENT '会话过期时间',
+  `revoked_at` DATETIME NULL COMMENT '会话注销时间',
+  `last_seen_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '最近活跃时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_studio_session_token_hash` (`token_hash`),
+  KEY `idx_studio_session_user` (`user_id`),
+  KEY `idx_studio_session_expiry` (`expires_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthVolumeUpgradeIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthVolumeUpgradeIntegrationTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.rocketmq.studio.auth;
+
+import org.apache.rocketmq.studio.persistence.entity.RmqStudioUser;
+import org.apache.rocketmq.studio.persistence.mapper.RmqStudioSessionMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqStudioUserMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+
+import javax.sql.DataSource;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+    "studio.auth.login-required=true",
+    "studio.auth.users[0].username=bootstrap-admin",
+    "studio.auth.users[0].password=password-123",
+    "studio.auth.users[0].admin=true",
+    "spring.datasource.url=jdbc:h2:mem:auth_upgrade;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE",
+    "spring.sql.init.mode=never"
+})
+class AuthVolumeUpgradeIntegrationTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private RmqStudioUserMapper userMapper;
+
+    @Autowired
+    private RmqStudioSessionMapper sessionMapper;
+
+    @BeforeEach
+    void resetLegacySchema() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS rmq_studio_session");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS rmq_studio_user");
+        jdbcTemplate.execute("""
+                CREATE TABLE IF NOT EXISTS rmq_settings (
+                  id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+                  gmt_create datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  gmt_modified datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  json text NOT NULL,
+                  PRIMARY KEY (id)
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE IF NOT EXISTS rmq_instance_message (
+                  id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+                  gmt_create datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  PRIMARY KEY (id)
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE IF NOT EXISTS rmq_instance_trace (
+                  id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+                  gmt_create datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  PRIMARY KEY (id)
+                )
+                """);
+        jdbcTemplate.update("DELETE FROM rmq_settings");
+        jdbcTemplate.update("DELETE FROM rmq_instance_message");
+        jdbcTemplate.update("DELETE FROM rmq_instance_trace");
+    }
+
+    @Test
+    void upgradeScriptCreatesAuthTablesIdempotentlyTest() {
+        applyUpgradeScript();
+        jdbcTemplate.update("""
+                INSERT INTO rmq_studio_user
+                    (username, password_hash, admin, enabled, password_changed_at)
+                VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+                """, "existing-admin", "pbkdf2$test", 1, 1);
+        applyUpgradeScript();
+
+        assertThat(tableExists("rmq_studio_user")).isTrue();
+        assertThat(tableExists("rmq_studio_session")).isTrue();
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM rmq_studio_user WHERE username = ?",
+                Integer.class,
+                "existing-admin")).isEqualTo(1);
+    }
+
+    @Test
+    void upgradedLegacySchemaSupportsBootstrapLoginTest() {
+        applyUpgradeScript();
+
+        LoginDTO request = new LoginDTO();
+        request.setUsername("bootstrap-admin");
+        request.setPassword("password-123");
+
+        LoginVO login = authService.login(request);
+
+        assertThat(login.getUser().getUserId()).isNotNull();
+        assertThat(login.getUser().getUsername()).isEqualTo("bootstrap-admin");
+        assertThat(login.getUser().isAdmin()).isTrue();
+
+        RmqStudioUser persisted = userMapper.selectById(login.getUser().getUserId());
+        assertThat(persisted).isNotNull();
+        assertThat(persisted.getUsername()).isEqualTo("bootstrap-admin");
+        assertThat(sessionMapper.selectCount(null)).isEqualTo(1);
+        assertThat(authService.isAuthenticated("Bearer " + login.getToken())).isTrue();
+    }
+
+    private void applyUpgradeScript() {
+        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+        populator.addScript(new FileSystemResource(upgradeScriptPath()));
+        populator.execute(dataSource);
+    }
+
+    private boolean tableExists(String tableName) {
+        Integer count = jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                FROM information_schema.tables
+                WHERE lower(table_name) = ?
+                """, Integer.class, tableName);
+        return count != null && count > 0;
+    }
+
+    private String upgradeScriptPath() {
+        return Path.of("..", "deploy", "mysql", "upgrade-auth-tables.sql").toAbsolutePath().toString();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthVolumeUpgradeIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthVolumeUpgradeIntegrationTest.java
@@ -60,8 +60,10 @@ class AuthVolumeUpgradeIntegrationTest {
                   id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
                   gmt_create datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
                   gmt_modified datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  settings_key varchar(128) NOT NULL DEFAULT 'general',
                   json text NOT NULL,
-                  PRIMARY KEY (id)
+                  PRIMARY KEY (id),
+                  UNIQUE KEY uk_rmq_settings_settings_key (settings_key)
                 )
                 """);
         jdbcTemplate.execute("""


### PR DESCRIPTION
Fixes #2350

## Summary
- add an idempotent MySQL upgrade script for `rmq_studio_user` and `rmq_studio_session`
- document when existing Docker MySQL volumes must import the auth upgrade script
- add an integration test that applies the deploy migration script to a legacy schema and verifies bootstrap login still works

## Testing
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=AuthVolumeUpgradeIntegrationTest,AuthServiceBootstrapIntegrationTest test
- git diff --check