### PR TITLE
style: refresh Studio login experience

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -815,7 +815,22 @@ const translations: Record<string, Record<Lang, string>> = {
   'login.passwordRequired': { zh: '密码为必填项', en: 'Password is required' },
   'login.success': { zh: '登录成功', en: 'Login successful' },
   'login.failed': { zh: '登录失败', en: 'Login failed' },
-  'login.welcome': { zh: '欢迎使用 RocketMQ 仪表盘', en: 'Welcome to RocketMQ Dashboard' },
+  'login.welcome': { zh: '登录到控制台', en: 'Sign in to the console' },
+  'login.brandTitle': {
+    zh: '统一管理每一条消息链路',
+    en: 'Operate every message path from one place',
+  },
+  'login.brandDescription': {
+    zh: '跨集群、跨架构、跨云环境查看运行状态并执行可靠的消息运维操作。',
+    en: 'Observe runtime health and operate RocketMQ reliably across clusters, architectures, and clouds.',
+  },
+  'login.formDescription': {
+    zh: '使用已配置的控制台账号继续。',
+    en: 'Use a configured console account to continue.',
+  },
+  'login.statusLabel': { zh: '控制台服务可用', en: 'Control plane available' },
+  'login.switchToLight': { zh: '切换到浅色模式', en: 'Switch to light mode' },
+  'login.switchToDark': { zh: '切换到深色模式', en: 'Switch to dark mode' },
   'login.statusCheckFailed': {
     zh: '无法验证登录状态',
     en: 'Unable to verify login status',

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -816,6 +816,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'login.success': { zh: '登录成功', en: 'Login successful' },
   'login.failed': { zh: '登录失败', en: 'Login failed' },
   'login.welcome': { zh: '登录到控制台', en: 'Sign in to the console' },
+  'login.brandEyebrow': { zh: '控制台', en: 'Control plane' },
   'login.brandTitle': {
     zh: '统一管理每一条消息链路',
     en: 'Operate every message path from one place',

--- a/web/src/pages/login/index.css
+++ b/web/src/pages/login/index.css
@@ -9,7 +9,8 @@
   color: var(--login-text);
   display: grid;
   grid-template-columns: minmax(420px, 1.1fr) minmax(420px, 0.9fr);
-  min-height: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
   overflow: auto;
 }
 

--- a/web/src/pages/login/index.css
+++ b/web/src/pages/login/index.css
@@ -77,7 +77,7 @@
 .login-brand-eyebrow {
   color: #7dd3fc;
   display: block;
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 700;
   letter-spacing: 1.4px;
   margin-bottom: 18px;
@@ -100,7 +100,7 @@
 
 .login-brand-status {
   color: #c5d3e7;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
 }
 
@@ -200,7 +200,7 @@
 
 .login-form-footer {
   color: var(--login-muted);
-  font-size: 12px;
+  font-size: 14px;
   margin: 34px 0 0;
 }
 

--- a/web/src/pages/login/index.css
+++ b/web/src/pages/login/index.css
@@ -1,0 +1,234 @@
+.login-page {
+  --login-border: #d9e1ec;
+  --login-muted: #667085;
+  --login-page-bg: #f7f9fc;
+  --login-surface: #ffffff;
+  --login-text: #14213d;
+  align-items: stretch;
+  background: var(--login-page-bg);
+  color: var(--login-text);
+  display: grid;
+  grid-template-columns: minmax(420px, 1.1fr) minmax(420px, 0.9fr);
+  min-height: 100%;
+  overflow: auto;
+}
+
+.login-page[data-theme='dark'] {
+  --login-border: #343d4d;
+  --login-muted: #aeb8c8;
+  --login-page-bg: #171b24;
+  --login-surface: #202632;
+  --login-text: #f0f4fa;
+}
+
+.login-brand-panel {
+  background: #13203a;
+  color: #f8fbff;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 100%;
+  padding: clamp(32px, 7vw, 96px);
+  position: relative;
+}
+
+.login-brand-panel::after {
+  border: 1px solid rgba(125, 211, 252, 0.24);
+  content: '';
+  height: min(54vw, 760px);
+  position: absolute;
+  right: min(-19vw, -210px);
+  top: 50%;
+  transform: translateY(-50%) rotate(28deg);
+  width: min(54vw, 760px);
+}
+
+.login-brand-lockup,
+.login-brand-status {
+  align-items: center;
+  display: flex;
+  font-size: 16px;
+  font-weight: 600;
+  gap: 10px;
+  position: relative;
+  z-index: 1;
+}
+
+.login-brand-mark,
+.login-form-mark {
+  align-items: center;
+  background: #2676d9;
+  border-radius: 8px;
+  color: #ffffff;
+  display: inline-flex;
+  font-size: 19px;
+  height: 36px;
+  justify-content: center;
+  width: 36px;
+}
+
+.login-brand-copy {
+  max-width: 590px;
+  position: relative;
+  z-index: 1;
+}
+
+.login-brand-eyebrow {
+  color: #7dd3fc;
+  display: block;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 1.4px;
+  margin-bottom: 18px;
+}
+
+.login-brand-title.ant-typography {
+  color: inherit;
+  font-size: clamp(36px, 4vw, 58px);
+  line-height: 1.15;
+  margin: 0 0 20px;
+}
+
+.login-brand-description.ant-typography {
+  color: #c5d3e7;
+  font-size: 17px;
+  line-height: 1.7;
+  margin: 0;
+  max-width: 510px;
+}
+
+.login-brand-status {
+  color: #c5d3e7;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.login-status-dot {
+  background: #43c878;
+  border-radius: 50%;
+  box-shadow: 0 0 0 4px rgba(67, 200, 120, 0.16);
+  height: 8px;
+  width: 8px;
+}
+
+.login-form-panel {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  min-height: 100%;
+  padding: 48px;
+  position: relative;
+}
+
+.login-theme-action {
+  position: absolute;
+  right: 28px;
+  top: 24px;
+}
+
+.login-theme-action .ant-btn {
+  color: var(--login-muted);
+}
+
+.login-form-shell {
+  max-width: 400px;
+  width: 100%;
+}
+
+.login-form-heading {
+  margin-bottom: 36px;
+}
+
+.login-form-mark {
+  font-size: 17px;
+  height: 32px;
+  margin-bottom: 22px;
+  width: 32px;
+}
+
+.login-form-heading .ant-typography {
+  color: var(--login-text);
+}
+
+.login-form-heading h2.ant-typography {
+  font-size: 28px;
+  margin-bottom: 8px;
+}
+
+.login-form-heading .ant-typography-paragraph {
+  color: var(--login-muted);
+  margin-bottom: 0;
+}
+
+.login-form-shell .ant-form-item-label > label {
+  color: var(--login-text);
+  font-weight: 600;
+}
+
+.login-form-shell .ant-input-affix-wrapper,
+.login-form-shell .ant-input {
+  background: var(--login-surface);
+  border-color: var(--login-border);
+}
+
+.login-form-shell .ant-input-affix-wrapper {
+  min-height: 42px;
+}
+
+.login-form-shell .ant-input {
+  color: var(--login-text);
+}
+
+.login-form-shell .ant-input::placeholder {
+  color: var(--login-muted);
+}
+
+.login-form-shell .ant-input-prefix,
+.login-form-shell .ant-input-password-icon {
+  color: var(--login-muted);
+}
+
+.login-submit-item {
+  margin-top: 28px;
+}
+
+.login-submit-item .ant-btn {
+  font-weight: 600;
+  height: 44px;
+}
+
+.login-form-footer {
+  color: var(--login-muted);
+  font-size: 12px;
+  margin: 34px 0 0;
+}
+
+@media (max-width: 820px) {
+  .login-page {
+    display: block;
+  }
+
+  .login-brand-panel {
+    min-height: 236px;
+    padding: 28px 28px 32px;
+  }
+
+  .login-brand-copy {
+    margin-top: 34px;
+  }
+
+  .login-brand-title.ant-typography {
+    font-size: 30px;
+    margin-bottom: 10px;
+  }
+
+  .login-brand-description.ant-typography,
+  .login-brand-status {
+    display: none;
+  }
+
+  .login-form-panel {
+    min-height: calc(100vh - 236px);
+    padding: 64px 28px 40px;
+  }
+}

--- a/web/src/pages/login/index.test.tsx
+++ b/web/src/pages/login/index.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntdApp } from 'antd';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// antd's responsive observer calls window.matchMedia; jsdom does not implement it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+const navigateMock = vi.hoisted(() => vi.fn());
+const loginApiMock = vi.hoisted(() => vi.fn());
+const loginStoreMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+vi.mock('../../api/auth', () => ({ login: loginApiMock }));
+
+vi.mock('../../stores/authStore', () => ({
+  default: (selector: (state: { login: typeof loginStoreMock }) => unknown) =>
+    selector({ login: loginStoreMock }),
+}));
+
+vi.mock('../../i18n/LangContext', () => ({
+  useLang: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../theme/useTheme', () => ({
+  useTheme: () => ({ darkMode: false, toggleTheme: vi.fn() }),
+}));
+
+import LoginPage from './index';
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+    loginApiMock.mockClear();
+    loginStoreMock.mockClear();
+  });
+
+  const renderPage = () =>
+    render(
+      <MemoryRouter>
+        <AntdApp>
+          <LoginPage />
+        </AntdApp>
+      </MemoryRouter>,
+    );
+
+  it('renders the brand and an accessible theme toggle', () => {
+    renderPage();
+    expect(screen.getByText('RocketMQ Studio')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'login.switchToDark' })).toBeTruthy();
+  });
+
+  it('submits login with username, numeric userId and admin, then navigates to /', async () => {
+    loginApiMock.mockResolvedValue({
+      user: { username: 'alice', userId: 42, admin: true },
+    });
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('login.usernamePlaceholder'), {
+      target: { value: 'alice' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('login.passwordPlaceholder'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'login.title' }));
+
+    await waitFor(() => expect(loginStoreMock).toHaveBeenCalledWith('alice', 42, true));
+    expect(loginApiMock).toHaveBeenCalledWith('alice', 'secret');
+    expect(navigateMock).toHaveBeenCalledWith('/', { replace: true });
+  });
+
+  it('keeps required-field validation and does not call the API on empty submit', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'login.title' }));
+
+    await waitFor(() => expect(screen.getByText('login.usernameRequired')).toBeTruthy());
+    expect(screen.getByText('login.passwordRequired')).toBeTruthy();
+    expect(loginApiMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -16,11 +16,20 @@
  */
 
 import { useState } from 'react';
-import { Button, Form, Input, Typography, App } from 'antd';
+import {
+  LockOutlined,
+  MoonOutlined,
+  RocketOutlined,
+  SunOutlined,
+  UserOutlined,
+} from '@ant-design/icons';
+import { App, Button, Form, Input, Typography } from 'antd';
 import { useNavigate } from 'react-router-dom';
 import { useLang } from '../../i18n/LangContext';
 import useAuthStore from '../../stores/authStore';
 import { login as loginApi } from '../../api/auth';
+import { useTheme } from '../../theme/useTheme';
+import './index.css';
 
 const { Title } = Typography;
 
@@ -36,6 +45,7 @@ const LoginPage = () => {
   const { message } = App.useApp();
   const navigate = useNavigate();
   const authLogin = useAuthStore((s) => s.login);
+  const { darkMode, toggleTheme } = useTheme();
 
   const onFinish = async (values: LoginFormValues) => {
     setLoading(true);
@@ -53,48 +63,90 @@ const LoginPage = () => {
   };
 
   return (
-    <div
-      style={{
-        maxWidth: 400,
-        margin: '100px auto',
-        padding: 24,
-        boxShadow: '0 2px 8px #f0f1f2',
-        borderRadius: 8,
-      }}
-    >
-      <Title level={3} style={{ textAlign: 'center', marginBottom: 24 }}>
-        {t('login.welcome')}
-      </Title>
-      <Form
-        form={form}
-        name="login_form"
-        layout="vertical"
-        onFinish={onFinish}
-        initialValues={{ username: '', password: '' }}
-      >
-        <Form.Item
-          label={t('login.username')}
-          name="username"
-          rules={[{ required: true, message: t('login.usernameRequired') }]}
-        >
-          <Input placeholder={t('login.usernamePlaceholder')} />
-        </Form.Item>
+    <main className="login-page" data-theme={darkMode ? 'dark' : 'light'}>
+      <section className="login-brand-panel" aria-labelledby="login-brand-title">
+        <div className="login-brand-lockup">
+          <span className="login-brand-mark" aria-hidden="true">
+            <RocketOutlined />
+          </span>
+          <span>RocketMQ Studio</span>
+        </div>
+        <div className="login-brand-copy">
+          <span className="login-brand-eyebrow">CONTROL PLANE</span>
+          <Title id="login-brand-title" level={1} className="login-brand-title">
+            {t('login.brandTitle')}
+          </Title>
+          <Typography.Paragraph className="login-brand-description">
+            {t('login.brandDescription')}
+          </Typography.Paragraph>
+        </div>
+        <div className="login-brand-status" aria-label={t('login.statusLabel')}>
+          <span className="login-status-dot" aria-hidden="true" />
+          {t('login.statusLabel')}
+        </div>
+      </section>
 
-        <Form.Item
-          label={t('login.password')}
-          name="password"
-          rules={[{ required: true, message: t('login.passwordRequired') }]}
-        >
-          <Input.Password placeholder={t('login.passwordPlaceholder')} />
-        </Form.Item>
+      <section className="login-form-panel" aria-labelledby="login-form-title">
+        <div className="login-theme-action">
+          <Button
+            type="text"
+            shape="circle"
+            aria-label={darkMode ? t('login.switchToLight') : t('login.switchToDark')}
+            icon={darkMode ? <SunOutlined /> : <MoonOutlined />}
+            onClick={toggleTheme}
+          />
+        </div>
+        <div className="login-form-shell">
+          <div className="login-form-heading">
+            <span className="login-form-mark" aria-hidden="true">
+              <RocketOutlined />
+            </span>
+            <Title id="login-form-title" level={2}>
+              {t('login.welcome')}
+            </Title>
+            <Typography.Paragraph>{t('login.formDescription')}</Typography.Paragraph>
+          </div>
+          <Form
+            form={form}
+            name="login_form"
+            layout="vertical"
+            onFinish={onFinish}
+            initialValues={{ username: '', password: '' }}
+          >
+            <Form.Item
+              label={t('login.username')}
+              name="username"
+              rules={[{ required: true, message: t('login.usernameRequired') }]}
+            >
+              <Input
+                prefix={<UserOutlined />}
+                placeholder={t('login.usernamePlaceholder')}
+                autoComplete="username"
+              />
+            </Form.Item>
 
-        <Form.Item>
-          <Button type="primary" htmlType="submit" block loading={loading}>
-            {t('login.title')}
-          </Button>
-        </Form.Item>
-      </Form>
-    </div>
+            <Form.Item
+              label={t('login.password')}
+              name="password"
+              rules={[{ required: true, message: t('login.passwordRequired') }]}
+            >
+              <Input.Password
+                prefix={<LockOutlined />}
+                placeholder={t('login.passwordPlaceholder')}
+                autoComplete="current-password"
+              />
+            </Form.Item>
+
+            <Form.Item className="login-submit-item">
+              <Button type="primary" htmlType="submit" block loading={loading}>
+                {t('login.title')}
+              </Button>
+            </Form.Item>
+          </Form>
+          <p className="login-form-footer">Apache RocketMQ Studio</p>
+        </div>
+      </section>
+    </main>
   );
 };
 

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -72,7 +72,7 @@ const LoginPage = () => {
           <span>RocketMQ Studio</span>
         </div>
         <div className="login-brand-copy">
-          <span className="login-brand-eyebrow">CONTROL PLANE</span>
+          <span className="login-brand-eyebrow">{t('login.brandEyebrow')}</span>
           <Title id="login-brand-title" level={1} className="login-brand-title">
             {t('login.brandTitle')}
           </Title>


### PR DESCRIPTION
Closes #2384

## Changes

- Replace the minimal login form with a responsive Studio-branded login layout.
- Add a light/dark theme toggle, translated login copy, input icons, and autocomplete metadata.
- Fill the viewport with `100vh` and `100dvh` to prevent empty space below the page.
- Keep the existing session contract: `login(username, userId, admin)`, without handling a token.
- Add focused login-page coverage for successful login, required validation, and theme control.

## Validation

- `npm test -- --run src/pages/login/index.test.tsx`
- `npm run build`