### PR TITLE
feat(ai): refresh models after connection test

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
@@ -141,11 +141,11 @@ public class LlmConfigService {
                     "Use one of: openai, deepseek, tongyi, ollama.");
         }
         try {
-            llmClient.listModels(normalized);
+            List<LlmModelItemVO> models = llmClient.listModels(normalized);
+            return LlmOperationResultVO.successWithModels("Connection successful", models);
         } catch (LlmGatewayException exception) {
             return LlmOperationResultVO.failure(exception.getCode(), exception.getMessage(), exception.getHint());
         }
-        return LlmOperationResultVO.success("Connection successful");
     }
 
     private LlmOperationResultVO testCliEngine(String engine) {
@@ -209,7 +209,10 @@ public class LlmConfigService {
     }
 
     public LlmModelsResultVO listModels() {
-        LlmConfigVO config = getConfig();
+        return listModels(getConfig());
+    }
+
+    private LlmModelsResultVO listModels(LlmConfigVO config) {
         String provider = config.getProvider();
         // The token-plan gateway model set is curated locally; do not query the gateway.
         if (DEFAULT_PROVIDER.equals(provider)) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmOperationResultVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmOperationResultVO.java
@@ -21,6 +21,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -30,9 +32,14 @@ public class LlmOperationResultVO {
     private String errMsg;
     private String code;
     private String hint;
+    private List<LlmModelItemVO> models;
 
     public static LlmOperationResultVO success(String message) {
-        return new LlmOperationResultVO(0, message, null, null, null);
+        return new LlmOperationResultVO(0, message, null, null, null, null);
+    }
+
+    public static LlmOperationResultVO successWithModels(String message, List<LlmModelItemVO> models) {
+        return new LlmOperationResultVO(0, message, null, null, null, models);
     }
 
     public static LlmOperationResultVO failure(String message) {
@@ -40,6 +47,6 @@ public class LlmOperationResultVO {
     }
 
     public static LlmOperationResultVO failure(String code, String message, String hint) {
-        return new LlmOperationResultVO(1, null, message, code, hint);
+        return new LlmOperationResultVO(1, null, message, code, hint, null);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
@@ -338,6 +338,7 @@ class LlmConfigServiceTest {
 
         assertThat(result.getStatus()).isZero();
         assertThat(result.getMsg()).isEqualTo("Connection successful");
+        assertThat(result.getModels()).isNull();
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
@@ -338,7 +338,7 @@ class LlmConfigServiceTest {
 
         assertThat(result.getStatus()).isZero();
         assertThat(result.getMsg()).isEqualTo("Connection successful");
-        assertThat(result.getModels()).isNull();
+        assertThat(result.getModels()).isEmpty();
     }
 
     @Test

--- a/web/src/api/llm.ts
+++ b/web/src/api/llm.ts
@@ -39,6 +39,7 @@ export interface LlmTestResult {
   errMsg?: string;
   code?: string;
   hint?: string;
+  models?: LlmModelItem[];
 }
 
 export interface LlmModelItem {

--- a/web/src/pages/settings/AiAssistantTab.tsx
+++ b/web/src/pages/settings/AiAssistantTab.tsx
@@ -234,6 +234,10 @@ export const AiAssistantTab = () => {
       const result = await testLlmConnection(payload);
       if (testRequestIdRef.current === requestId) {
         applyTestResult(result);
+        if (result.status === 0) {
+          const remoteModels = result.models?.map((model) => model.id || '').filter(Boolean) ?? [];
+          setModelOptions(buildModelOptions(payload.provider, remoteModels, payload.model));
+        }
       }
     } catch {
       if (testRequestIdRef.current === requestId) {

--- a/web/src/pages/settings/__tests__/AiAssistantTab.test.tsx
+++ b/web/src/pages/settings/__tests__/AiAssistantTab.test.tsx
@@ -145,6 +145,29 @@ describe('AiAssistantTab', () => {
     ).toBeInTheDocument();
   });
 
+  it('refreshes the model list from a successful connection test', async () => {
+    const user = userEvent.setup();
+    llmApiMocks.testLlmConnection.mockResolvedValue({
+      status: 0,
+      msg: 'ok',
+      models: [{ id: 'qwen3.8-max' }, { id: 'qwen-plus-latest' }],
+    });
+    renderPage();
+
+    await screen.findByText('密钥已配置');
+    await user.type(screen.getByLabelText('API Key'), 'sk-preview');
+    await user.click(screen.getByRole('button', { name: /测试连接/ }));
+
+    await waitFor(() => expect(llmApiMocks.testLlmConnection).toHaveBeenCalledTimes(1));
+    expect(llmApiMocks.testLlmConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'sk-preview', provider: 'tongyi' }),
+    );
+    await user.click(screen.getAllByRole('combobox')[2]);
+    expect(
+      await screen.findByText('qwen-plus-latest', { selector: '.ant-select-item-option-content' }),
+    ).toBeInTheDocument();
+  });
+
   it('ignores a connection result after the tested configuration changes', async () => {
     let resolveTest!: (result: { status: number; msg: string }) => void;
     llmApiMocks.testLlmConnection.mockImplementationOnce(


### PR DESCRIPTION
Closes #2386

## Changes

- Return provider-discovered models directly from `POST /api/llm/config/test` after the temporary configuration passes validation.
- Keep connection testing non-persistent: the API key and runtime overrides are neither saved nor changed.
- Refresh the model selector from the successful test response and discard stale form responses.
- Remove the separate preview endpoint, so a test runs only one upstream model-list request.

## Validation

- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=LlmConfigServiceTest,LlmControllerTest test`
- `npm test -- --run src/pages/settings/__tests__/AiAssistantTab.test.tsx`
- `npm run build`