### PR TITLE
fix(alerts): export rule assets as attachments

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -65,7 +66,9 @@ public class AlertRuleAssetController {
         String yaml = alertRuleAssetService.getAssetYaml(name);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.parseMediaType("application/x-yaml"));
-        headers.setContentDispositionFormData("attachment", name + ".yaml");
+        headers.setContentDisposition(ContentDisposition.attachment()
+                .filename(name + ".yaml", StandardCharsets.UTF_8)
+                .build());
         return new ResponseEntity<>(yaml.getBytes(StandardCharsets.UTF_8), headers, HttpStatus.OK);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetControllerTest.java
@@ -25,6 +25,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -75,7 +77,7 @@ class AlertRuleAssetControllerTest {
         mockMvc.perform(get("/api/alert-rules/assets/rocketmq-broker-down/export"))
                 .andExpect(status().isOk())
                 .andExpect(header().string("Content-Type", "application/x-yaml"))
-                .andExpect(header().string("Content-Disposition",
-                        "form-data; name=\"attachment\"; filename=\"rocketmq-broker-down.yaml\""));
+                .andExpect(header().string("Content-Disposition", startsWith("attachment;")))
+                .andExpect(header().string("Content-Disposition", containsString("rocketmq-broker-down.yaml")));
     }
 }


### PR DESCRIPTION
## Summary
- emit a standards-compliant attachment content disposition for alert rule YAML exports
- encode the download filename with UTF-8
- cover the response header contract in the controller test

## Test
- `mvn -q -Dtest=AlertRuleAssetControllerTest test`

Fixes #2192