### PR TITLE
fix(metrics): use availability for RocketMQ 5 broker health

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricProfileService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricProfileService.java
@@ -100,9 +100,9 @@ public class MetricProfileService {
                 mapping(SemanticMetric.CONSUMER_LAG_LATENCY, "rocketmq_consumer_lag_latency",
                         "max(rocketmq_consumer_lag_latency) by (cluster, topic, consumer_group)",
                         "cluster", "topic", "consumer_group"),
-                mapping(SemanticMetric.BROKER_HEALTH, "rocketmq_processor_watermark",
-                        "max(rocketmq_processor_watermark) by (cluster, node_id, processor)",
-                        "cluster", "node_id", "processor")
+                mapping(SemanticMetric.BROKER_HEALTH, "up",
+                        "max(up) by (cluster, node_id)",
+                        "cluster", "node_id")
         );
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricProfileServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricProfileServiceTest.java
@@ -54,7 +54,11 @@ class MetricProfileServiceTest {
         assertThat(mapping(profile, SemanticMetric.CONSUMER_LAG_MESSAGES).getPrometheusMetric())
                 .isEqualTo("rocketmq_consumer_lag_messages");
         assertThat(mapping(profile, SemanticMetric.BROKER_HEALTH).getPrometheusMetric())
-                .isEqualTo("rocketmq_processor_watermark");
+                .isEqualTo("up");
+        assertThat(mapping(profile, SemanticMetric.BROKER_HEALTH).getPromql())
+                .isEqualTo("max(up) by (cluster, node_id)");
+        assertThat(mapping(profile, SemanticMetric.BROKER_HEALTH).getLabels())
+                .containsExactly("cluster", "node_id");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- map RocketMQ 5 broker health to Prometheus target availability instead of processor queue load
- aggregate `up` by broker identity
- verify the metric, query, and labels in the profile test

## Test
- `mvn -q -Dtest=MetricProfileServiceTest test`

Fixes #2188