### PR TITLE
fix(clients): parse long consumer diagnostic thread names

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProvider.java
@@ -49,7 +49,7 @@ import java.util.regex.Pattern;
 public class RocketMQConsumerDiagnosticsProvider implements ConsumerDiagnosticsProvider {
 
     private static final Pattern THREAD_HEADER =
-            Pattern.compile("^(?<name>.+?)\\s+TID:\\s+(?<id>\\d+)\\s+STATE:\\s+(?<state>\\S+)\\s*$");
+            Pattern.compile("^(?<name>.+?)\\s*TID:\\s+(?<id>\\d+)\\s+STATE:\\s+(?<state>\\S+)\\s*$");
 
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
     private final MqAdminExtFactory adminFactory;

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProviderTest.java
@@ -99,6 +99,23 @@ class RocketMQConsumerDiagnosticsProviderTest {
     }
 
     @Test
+    void getConsumerStackShouldParseLongThreadNameWithoutPadding() throws Exception {
+        String threadName = "ConsumeMessageThread_With_A_Name_Longer_Than_Forty_Characters";
+        ConsumerRunningInfo runningInfo = new ConsumerRunningInfo();
+        runningInfo.setJstack(threadName + "TID: 42 STATE: RUNNABLE\n"
+                + threadName + "com.example.Listener.consume(Listener.java:10)");
+        when(adminExt.getConsumerRunningInfo("cg-orders", "client-1", true)).thenReturn(runningInfo);
+
+        ConsumerStackTraceVO result = provider.getConsumerStack("instance-a", "cg-orders", "client-1");
+
+        assertThat(result.getThreads()).singleElement().satisfies(thread -> {
+            assertThat(thread.getThreadName()).isEqualTo(threadName);
+            assertThat(thread.getThreadId()).isEqualTo(42);
+            assertThat(thread.getStackTrace()).containsExactly("com.example.Listener.consume(Listener.java:10)");
+        });
+    }
+
+    @Test
     void getConsumerStackShouldUseDefaultNameServerWhenInstanceIsBlank() throws Exception {
         ConsumerRunningInfo runningInfo = new ConsumerRunningInfo();
         runningInfo.setJstack("");


### PR DESCRIPTION
## Summary
- recognize RocketMQ jstack headers when a long thread name consumes all padding before `TID:`
- preserve the complete thread name, id, state, and frames
- add a regression test for names longer than the formatter width

## Test
- `mvn -q -Dtest=RocketMQConsumerDiagnosticsProviderTest test`

Fixes #2190