### PR TITLE
fix(tencent): skip null catalog instance rows

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
@@ -94,6 +94,9 @@ public class TencentCatalogService implements CloudCatalogProvider {
                 break;
             }
             for (InstanceItem item : data) {
+                if (item == null) {
+                    continue;
+                }
                 CloudInstanceOptionVO option = toInstanceOption(item, regionId);
                 if (matchesSearch(search, option)) {
                     instances.add(option);

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
@@ -86,6 +86,21 @@ class TencentCatalogServiceTest {
     }
 
     @Test
+    void listCloudInstancesShouldSkipNullItemsTest() {
+        InstanceItem item = new InstanceItem();
+        item.setInstanceId("rmq-valid");
+        item.setInstanceName("valid-instance");
+        DescribeInstanceListResponse response = new DescribeInstanceListResponse();
+        response.setData(new InstanceItem[]{null, item});
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any())).thenReturn(response);
+
+        List<CloudInstanceOptionVO> instances = service.listCloudInstances(CREDENTIAL_ID, REGION, null);
+
+        assertThat(instances).extracting(CloudInstanceOptionVO::getInstanceId)
+                .containsExactly("rmq-valid");
+    }
+
+    @Test
     void getCloudInstanceShouldMapOnlyOpenEndpointsTest() {
         Endpoint vpc = endpoint("VPC", "OPEN", "vpc.tencent:8080");
         Endpoint publicEndpoint = endpoint("PUBLIC", "OPEN", "public.tencent:8080");


### PR DESCRIPTION
## Summary
- ignore malformed null rows returned by Tencent instance-list pages
- continue mapping valid instances from the same response
- add a regression test with a mixed null/valid SDK page

## Test
- `mvn -q -Dtest=TencentCatalogServiceTest test`

Fixes #2176