### PR TITLE
fix(messages): validate query timestamps without overflow

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -72,9 +72,13 @@ public class MessageService {
         }
         long end = endTime == null ? System.currentTimeMillis() : endTime;
         long start = startTime == null ? end - 60 * 60 * 1000L : startTime;
-        if (start > end) {
-            throw new BusinessException(400, "startTime must not be after endTime");
+        if (start < 0 || end < 0) {
+            throw new BusinessException(400, "startTime and endTime must not be negative");
         }
+        if (start >= end) {
+            throw new BusinessException(400, "startTime must be before endTime");
+        }
+        // Subtraction is safe after both timestamps are proven non-negative and strictly ordered.
         if (end - start > MAX_TOPIC_QUERY_WINDOW_MILLIS) {
             throw new BusinessException(400, "topic query time range must not exceed 7 days");
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -67,9 +67,36 @@ class MessageServiceTest {
 
         assertThatThrownBy(() -> service.queryMessages("instance-a", "TopicA", null, null, null, 200L, 100L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage("startTime must not be after endTime");
+                .hasMessage("startTime must be before endTime");
 
         verifyNoInteractions(provider);
+    }
+
+    @Test
+    void rejectsEqualTopicQueryTimestampsBeforeCallingProvider() {
+        MessageProvider provider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(provider, registry);
+
+        assertThatThrownBy(() -> service.queryMessages("instance-a", "TopicA", null, null, null, 100L, 100L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("startTime must be before endTime");
+
+        verifyNoInteractions(provider, registry);
+    }
+
+    @Test
+    void rejectsNegativeAndOverflowingTopicQueryTimestampsBeforeCallingProvider() {
+        MessageProvider provider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(provider, registry);
+
+        assertThatThrownBy(() -> service.queryMessages("instance-a", "TopicA", null, null, null,
+                Long.MIN_VALUE, Long.MAX_VALUE))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("startTime and endTime must not be negative");
+
+        verifyNoInteractions(provider, registry);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- reject negative and equal topic-query timestamps at the provider-neutral service boundary
- establish a non-negative ordered range before calculating its duration, preventing long overflow bypasses
- cover equal and extreme-long timestamp inputs

## Test
- `mvn -q -Dtest=MessageServiceTest test`

Fixes #2117