### PR TITLE
fix(metrics): validate Prometheus duration grammar

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
@@ -40,7 +40,9 @@ public class MetricsService {
     private static final long MAX_RANGE_SECONDS = 31L * 24 * 60 * 60;
     private static final long MAX_SAMPLE_POINTS = 11_000L;
     private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+(?:\\.\\d+)?");
-    private static final Pattern DURATION_PART_PATTERN = Pattern.compile("(\\d+(?:\\.\\d+)?)(ms|s|m|h|d|w|y)");
+    private static final Pattern DURATION_PATTERN = Pattern.compile(
+            "(?=\\d)(?:\\d+y)?(?:\\d+w)?(?:\\d+d)?(?:\\d+h)?(?:\\d+m)?(?:\\d+s)?(?:\\d+ms)?");
+    private static final Pattern DURATION_PART_PATTERN = Pattern.compile("(\\d+)(ms|s|m|h|d|w|y)");
     private static final Map<String, BigDecimal> UNIT_TO_MILLIS = Map.of(
             "ms", BigDecimal.ONE,
             "s", BigDecimal.valueOf(1_000L),
@@ -184,6 +186,9 @@ public class MetricsService {
             return new BigDecimal(value).multiply(BigDecimal.valueOf(1_000L));
         }
 
+        if (!DURATION_PATTERN.matcher(value).matches()) {
+            throw badRequest("Metric query step is invalid");
+        }
         Matcher matcher = DURATION_PART_PATTERN.matcher(value);
         BigDecimal millis = BigDecimal.ZERO;
         int position = 0;

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
@@ -271,6 +271,21 @@ class MetricsServiceTest {
     }
 
     @Test
+    void queryShouldRejectPrometheusInvalidDurationGrammar() {
+        for (String step : List.of("1s1h", "1m1m", "1.5h")) {
+            MetricQueryDTO query = MetricQueryDTO.builder()
+                    .metric("rocketmq_messages_in_total")
+                    .start(1700000000L)
+                    .end(1700003600L)
+                    .step(step)
+                    .build();
+
+            assertBadRequest(query, "Metric query step is invalid");
+        }
+        verifyNoInteractions(metricsSource);
+    }
+
+    @Test
     void queryShouldRejectTooManySamples() {
         MetricQueryDTO query = MetricQueryDTO.builder()
                 .metric("rocketmq_messages_in_total")


### PR DESCRIPTION
## Summary
- require integer duration components in Prometheus range-query steps
- enforce longest-to-shortest unit ordering and reject repeated units
- retain support for decimal bare-second steps and valid combined durations

## Test
- `mvn -q -Dtest=MetricsServiceTest test`

Fixes #2174