### PR TITLE
fix(messages): validate pasted custom properties

### DIFF
--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -54,6 +54,7 @@ import {
 } from '@ant-design/icons';
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
+import { parseMessagePropertiesText } from '../../utils/messageProperties';
 import { TOPIC_TYPE_MAP, CLUSTER_TYPE_MAP } from '../../constants/theme';
 import type { Topic, BrokerRoute, ConsumerGroupInfo, TopicConsumerPage } from '../../api/metadata';
 import {
@@ -245,19 +246,6 @@ const RANDOM_BODY_GENERATORS = [
 // ─── Format helpers ───────────────────────────────────────────────
 const formatNumber = (n: number) => n.toLocaleString('zh-CN');
 
-// 解析批量粘贴的用户属性串：key=value 按换行或逗号分隔，等号只取第一个
-const parsePropsText = (text: string): Record<string, string> => {
-  const props: Record<string, string> = {};
-  for (const line of text.split(/[\n,]+/)) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    const eqIndex = trimmed.indexOf('=');
-    if (eqIndex <= 0) continue;
-    const key = trimmed.slice(0, eqIndex).trim();
-    if (key) props[key] = trimmed.slice(eqIndex + 1).trim();
-  }
-  return props;
-};
 const formatDateTime = (iso?: string): string => {
   if (!iso) return '-';
   const d = new Date(iso);
@@ -832,17 +820,29 @@ const TopicPage = () => {
       // validation error, keep the modal open
       return;
     }
+    // Validate pasted properties before entering the request state so invalid or duplicate
+    // entries cannot be silently dropped and sent.
+    let props: Record<string, string> = {};
+    if (propsMode === 'text') {
+      try {
+        props = parseMessagePropertiesText(values.propsText || '');
+      } catch (error) {
+        sendForm.setFields([
+          {
+            name: 'propsText',
+            errors: [error instanceof Error ? error.message : '用户属性格式无效'],
+          },
+        ]);
+        return;
+      }
+    } else if (values.properties && Array.isArray(values.properties)) {
+      values.properties.forEach((property: { key?: string; value?: string }) => {
+        if (property.key) props[property.key] = property.value || '';
+      });
+    }
+
     setSending(true);
     try {
-      // Build properties: batch-paste text mode or key-value form rows
-      let props: Record<string, string> = {};
-      if (propsMode === 'text') {
-        props = parsePropsText(values.propsText || '');
-      } else if (values.properties && Array.isArray(values.properties)) {
-        values.properties.forEach((p: { key?: string; value?: string }) => {
-          if (p.key) props[p.key] = p.value || '';
-        });
-      }
       const result = await sendTopicMessage({
         topic: values.topic,
         instanceId: selectedInstanceId || undefined,

--- a/web/src/utils/messageProperties.test.ts
+++ b/web/src/utils/messageProperties.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseMessagePropertiesText } from './messageProperties';
+
+describe('parseMessagePropertiesText', () => {
+  it('preserves content after the first equals sign', () => {
+    expect(parseMessagePropertiesText('traceId=abc=def, tenant=rocketmq')).toEqual({
+      traceId: 'abc=def',
+      tenant: 'rocketmq',
+    });
+  });
+
+  it.each([
+    ['tenant', '属性格式无效'],
+    ['=rocketmq', '属性名不能为空'],
+    ['traceId=first\ntraceId=second', '属性名重复'],
+  ])('rejects malformed input %s', (input, message) => {
+    expect(() => parseMessagePropertiesText(input)).toThrow(message);
+  });
+});

--- a/web/src/utils/messageProperties.ts
+++ b/web/src/utils/messageProperties.ts
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const parseMessagePropertiesText = (text: string): Record<string, string> => {
+  const properties: Record<string, string> = {};
+  for (const token of text.split(/[\n,]+/)) {
+    const entry = token.trim();
+    if (!entry) continue;
+
+    const equalsIndex = entry.indexOf('=');
+    if (equalsIndex < 0) {
+      throw new Error(`属性格式无效：“${entry}”，请使用 key=value`);
+    }
+    const key = entry.slice(0, equalsIndex).trim();
+    if (!key) {
+      throw new Error('属性名不能为空');
+    }
+    if (Object.prototype.hasOwnProperty.call(properties, key)) {
+      throw new Error(`属性名重复：“${key}”`);
+    }
+    properties[key] = entry.slice(equalsIndex + 1).trim();
+  }
+  return properties;
+};


### PR DESCRIPTION
## Summary
- reject malformed and duplicate entries in batch-pasted message properties
- show the parser error on the form and stop before issuing a send request
- preserve all value content after the first equals sign

## Test
- `npx vitest run src/utils/messageProperties.test.ts`
- `npx eslint src/utils/messageProperties.ts src/utils/messageProperties.test.ts src/pages/instance/topic.tsx`

Fixes #2154