### PR TITLE
fix(metrics): sort provider samples by timestamp

### DIFF
--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -60,7 +60,8 @@ interface NumericSample {
 const toNumericSamples = (series: MetricSeries): NumericSample[] =>
   series.values
     .map((sample) => ({ timestamp: sample.timestamp, value: Number(sample.value) }))
-    .filter((sample) => Number.isFinite(sample.timestamp) && Number.isFinite(sample.value));
+    .filter((sample) => Number.isFinite(sample.timestamp) && Number.isFinite(sample.value))
+    .sort((left, right) => left.timestamp - right.timestamp);
 
 const seriesLabel = (series: MetricSeries, fallback: string) => {
   const labels = Object.entries(series.labels)

--- a/web/src/components/__tests__/MetricsExplorer.test.tsx
+++ b/web/src/components/__tests__/MetricsExplorer.test.tsx
@@ -147,6 +147,27 @@ describe('MetricsExplorer', () => {
     expect(screen.getByText('42 messages/s')).toBeInTheDocument();
   });
 
+  it('sorts provider samples before drawing and selecting the latest value', async () => {
+    vi.mocked(queryMetrics).mockResolvedValue({
+      ...metricData,
+      series: [
+        {
+          ...metricData.series[0],
+          values: [
+            { timestamp: 1_800_000_000, value: '42' },
+            { timestamp: 1_799_996_400, value: '40' },
+          ],
+        },
+      ],
+    });
+
+    const { container } = renderWithProviders(<MetricsExplorer />);
+
+    expect(await screen.findByText('42 messages/s')).toBeInTheDocument();
+    const points = container.querySelector('polyline')?.getAttribute('points')?.split(' ') ?? [];
+    expect(Number(points[0].split(',')[0])).toBeLessThan(Number(points[1].split(',')[0]));
+  });
+
   it('updates the query window when the range changes', async () => {
     const user = userEvent.setup();
     renderWithProviders(<MetricsExplorer />);


### PR DESCRIPTION
## Summary
- stably order finite metric samples by timestamp before chart rendering
- ensure chart geometry always moves forward in time
- derive the legend latest value from the newest timestamp rather than provider response order

## Test
- `npx vitest run src/components/__tests__/MetricsExplorer.test.tsx`
- `npx eslint src/components/MetricsExplorer.tsx src/components/__tests__/MetricsExplorer.test.tsx`

Fixes #2152