### PR TITLE
fix(message): normalize null provider query results

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -43,8 +44,9 @@ public class MessageService {
         List<MessageRecordVO> result = providerRegistry.byInstanceId(instanceId)
                 .map(provider -> provider.queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime))
                 .orElseGet(() -> messageProvider.queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime));
-        recordMessageQuery(instanceId, topic, msgId, tag, key, startTime, endTime, result.size());
-        return result;
+        List<MessageRecordVO> safeResult = result == null ? Collections.emptyList() : result;
+        recordMessageQuery(instanceId, topic, msgId, tag, key, startTime, endTime, safeResult.size());
+        return safeResult;
     }
 
     public TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -108,6 +109,24 @@ class MessageServiceTest {
         verify(history).recordMessageQuery("cloud-instance", "KEY", "orders", null, null,
                 "ORDER-1", null, null, 1);
         verifyNoInteractions(fallback);
+    }
+
+    @Test
+    void normalizesNullProviderMessageResults() {
+        MessageProvider fallback = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        QueryHistoryService history = mock(QueryHistoryService.class);
+        MessageService service = new MessageService(fallback, registry, history);
+        when(registry.byInstanceId("instance-a")).thenReturn(Optional.empty());
+        when(fallback.queryMessages("instance-a", "orders", null, null, null, 100L, 200L))
+                .thenReturn(null);
+
+        List<MessageRecordVO> result = service.queryMessages(
+                "instance-a", "orders", null, null, null, 100L, 200L);
+
+        assertThat(result).isEmpty();
+        verify(history).recordMessageQuery("instance-a", "TOPIC", "orders", null, null,
+                null, 100L, 200L, 0);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- normalize a null provider message-query result to an empty list
- record query history with a zero result count instead of dereferencing null
- cover the fallback-provider boundary with a regression test

## Why

A provider adapter can represent an empty query with `null`. The service currently calls `size()` immediately, turning an otherwise empty result into a 500 and skipping query history.

## Tests

- `mvn -q -f server/pom.xml -Dtest=MessageServiceTest test`
