### PR TITLE
fix(auth): bound stored password hash fields

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/PasswordHasher.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/PasswordHasher.java
@@ -27,6 +27,9 @@ public class PasswordHasher {
     private static final int SALT_LENGTH = 16;
     private static final int MIN_ITERATIONS = 100_000;
     private static final int MAX_ITERATIONS = 1_000_000;
+    private static final int DIGEST_LENGTH = KEY_LENGTH / Byte.SIZE;
+    private static final int ENCODED_SALT_LENGTH = 24;
+    private static final int ENCODED_DIGEST_LENGTH = 44;
 
     private final SecureRandom secureRandom = new SecureRandom();
 
@@ -51,8 +54,15 @@ public class PasswordHasher {
             if (iterations < MIN_ITERATIONS || iterations > MAX_ITERATIONS) {
                 return false;
             }
+            if (parts[2].length() != ENCODED_SALT_LENGTH
+                    || parts[3].length() != ENCODED_DIGEST_LENGTH) {
+                return false;
+            }
             byte[] salt = Base64.getDecoder().decode(parts[2]);
             byte[] expected = Base64.getDecoder().decode(parts[3]);
+            if (salt.length != SALT_LENGTH || expected.length != DIGEST_LENGTH) {
+                return false;
+            }
             return MessageDigest.isEqual(expected, derive(password.toCharArray(), salt, iterations));
         } catch (IllegalArgumentException exception) {
             return false;

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/PasswordHasherTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/PasswordHasherTest.java
@@ -34,4 +34,16 @@ class PasswordHasherTest {
         assertThat(hasher.matches("a-long-enough-password", firstHash)).isTrue();
         assertThat(hasher.matches("different-password", firstHash)).isFalse();
     }
+    @Test
+    void rejectsUnexpectedSaltAndDigestSizesBeforeDerivingAKey() {
+        PasswordHasher hasher = new PasswordHasher();
+        String validHash = hasher.hash("a-long-enough-password");
+        String[] parts = validHash.split("\\$", -1);
+
+        assertThat(hasher.matches("a-long-enough-password",
+                "pbkdf2$210000$" + "A".repeat(1_000_000) + "$" + parts[3])).isFalse();
+        assertThat(hasher.matches("a-long-enough-password",
+                "pbkdf2$210000$" + parts[2] + "$AA==")).isFalse();
+    }
+
 }


### PR DESCRIPTION
## Summary

- validate encoded PBKDF2 salt and digest lengths before Base64 decoding
- require the decoded salt and digest to match the format generated by the hasher
- reject oversized or truncated stored hash fields without deriving a key

## Why

Iteration counts are bounded, but corrupted database values can still contain arbitrarily large Base64 fields. Decoding those fields allocates memory before the password check can reject them.

## Tests

- `mvn -q -f server/pom.xml -Dtest=PasswordHasherTest test`
