### PR TITLE
fix(instance): normalize provider capabilities

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceCapabilityService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceCapabilityService.java
@@ -26,6 +26,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Resolves the capability contract for an instance by delegating to the vendor provider.
@@ -42,7 +45,10 @@ public class InstanceCapabilityService {
                 .orElseThrow(() -> new BusinessException(404, "Instance not found: " + instanceId));
         InstanceVendor vendor = instance.getVendor() == null ? InstanceVendor.APACHE : instance.getVendor();
         InstanceProvider provider = providerRegistry.forVendor(vendor);
-        List<InstanceCapability> capabilities = provider.capabilities().stream()
+        List<InstanceCapability> capabilities = Optional.ofNullable(provider.capabilities())
+                .orElseGet(Set::of)
+                .stream()
+                .filter(Objects::nonNull)
                 .sorted(Comparator.comparingInt(InstanceCapability::ordinal))
                 .toList();
         return new InstanceCapabilitiesVO(instance.getName(), vendor, instance.getType(), capabilities);

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceCapabilityServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceCapabilityServiceTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -91,6 +93,41 @@ class InstanceCapabilityServiceTest {
 
         assertThat(result.instanceId()).isEqualTo("direct-1");
         assertThat(result.vendor()).isEqualTo(InstanceVendor.APACHE);
+    }
+
+    @Test
+    void getCapabilitiesShouldNormalizeMalformedProviderResultsTest() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("cloud-1")
+                .vendor(InstanceVendor.ALIYUN)
+                .type(InstanceType.PROXY)
+                .build();
+        instance.setId(3L);
+        when(instanceRepository.findById(3L)).thenReturn(Optional.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(instanceProvider);
+        when(instanceProvider.capabilities()).thenReturn(null);
+
+        InstanceCapabilitiesVO result = service.getCapabilities(3L);
+
+        assertThat(result.capabilities()).isEmpty();
+    }
+
+    @Test
+    void getCapabilitiesShouldIgnoreNullProviderEntriesTest() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("cloud-2")
+                .vendor(InstanceVendor.ALIYUN)
+                .type(InstanceType.PROXY)
+                .build();
+        instance.setId(4L);
+        when(instanceRepository.findById(4L)).thenReturn(Optional.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(instanceProvider);
+        when(instanceProvider.capabilities()).thenReturn(new HashSet<>(Arrays.asList(
+                null, InstanceCapability.DLQ_MANAGEMENT)));
+
+        InstanceCapabilitiesVO result = service.getCapabilities(4L);
+
+        assertThat(result.capabilities()).containsExactly(InstanceCapability.DLQ_MANAGEMENT);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- treat a null provider capability set as empty
- ignore null capability entries before stable ordinal sorting
- add coverage for malformed provider results

## Why

Capability discovery is an SPI boundary. A sparse or null provider result currently raises an NPE and prevents the instance page from loading.

## Tests

- `mvn -q -f server/pom.xml -Dtest=InstanceCapabilityServiceTest test`
