### PR TITLE
fix(tencent): normalize malformed catalog metadata

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
@@ -118,7 +118,7 @@ public class TencentCatalogService implements CloudCatalogProvider {
         request.setInstanceId(cloudInstanceId);
         DescribeInstanceResponse response = clientFactory.call(credentialId, regionId,
                 client -> client.DescribeInstance(request));
-        if (response == null || response.getInstanceId() == null) {
+        if (response == null || response.getInstanceId() == null || response.getInstanceId().isBlank()) {
             throw new BusinessException(404, "Tencent Cloud RocketMQ 5.x instance not found: " + cloudInstanceId);
         }
         CloudInstanceDetailVO detail = new CloudInstanceDetailVO();
@@ -149,9 +149,10 @@ public class TencentCatalogService implements CloudCatalogProvider {
             return result;
         }
         for (Endpoint endpoint : endpoints) {
-            if (endpoint != null && "OPEN".equalsIgnoreCase(endpoint.getStatus())) {
+            if (endpoint != null && "OPEN".equalsIgnoreCase(endpoint.getStatus())
+                    && endpoint.getEndpointUrl() != null && !endpoint.getEndpointUrl().isBlank()) {
                 result.add(new CloudInstanceDetailVO.CloudEndpoint(
-                        endpointType(endpoint.getType()), endpoint.getEndpointUrl()));
+                        endpointType(endpoint.getType()), endpoint.getEndpointUrl().trim()));
             }
         }
         return result;
@@ -168,14 +169,23 @@ public class TencentCatalogService implements CloudCatalogProvider {
     }
 
     private static Integer toInteger(Long value) {
-        return value == null ? null : Math.toIntExact(value);
+        if (value == null) {
+            return null;
+        }
+        if (value > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        if (value < 0) {
+            return 0;
+        }
+        return value.intValue();
     }
 
     private static boolean matchesSearch(String search, CloudInstanceOptionVO option) {
         if (search == null || search.isBlank()) {
             return true;
         }
-        String needle = search.toLowerCase(Locale.ROOT);
+        String needle = search.trim().toLowerCase(Locale.ROOT);
         return containsIgnoreCase(option.getInstanceId(), needle)
                 || containsIgnoreCase(option.getInstanceName(), needle);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
@@ -86,6 +86,26 @@ class TencentCatalogServiceTest {
     }
 
     @Test
+    void listCloudInstancesShouldNormalizeOutOfRangeCountsAndTrimSearchTest() {
+        InstanceItem item = new InstanceItem();
+        item.setInstanceId("rmq-abc");
+        item.setInstanceName("chengdu-prod");
+        item.setTopicNum(Long.MAX_VALUE);
+        item.setGroupNum(-1L);
+        DescribeInstanceListResponse response = new DescribeInstanceListResponse();
+        response.setData(new InstanceItem[]{item});
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any())).thenReturn(response);
+
+        List<CloudInstanceOptionVO> instances = service.listCloudInstances(
+                CREDENTIAL_ID, REGION, "  PROD  ");
+
+        assertThat(instances).singleElement().satisfies(instance -> {
+            assertThat(instance.getTopicCount()).isEqualTo(Integer.MAX_VALUE);
+            assertThat(instance.getGroupCount()).isZero();
+        });
+    }
+
+    @Test
     void listCloudInstancesShouldSkipNullItemsTest() {
         InstanceItem item = new InstanceItem();
         item.setInstanceId("rmq-valid");
@@ -118,6 +138,24 @@ class TencentCatalogServiceTest {
         assertThat(detail.getEndpoints()).hasSize(2);
         assertThat(detail.getEndpoints().get(0).getEndpointType()).isEqualTo("TCP_VPC");
         assertThat(detail.getEndpoints().get(1).getEndpointType()).isEqualTo("TCP_INTERNET");
+    }
+
+    @Test
+    void getCloudInstanceShouldSkipBlankOpenEndpointsTest() {
+        Endpoint blank = endpoint("PUBLIC", "OPEN", "  ");
+        Endpoint missing = endpoint("VPC", "OPEN", null);
+        Endpoint valid = endpoint("VPC", "OPEN", "  vpc.tencent:8080  ");
+        DescribeInstanceResponse response = new DescribeInstanceResponse();
+        response.setInstanceId("rmq-abc");
+        response.setEndpointList(new Endpoint[]{blank, missing, valid});
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any())).thenReturn(response);
+
+        CloudInstanceDetailVO detail = service.getCloudInstance(CREDENTIAL_ID, REGION, "rmq-abc");
+
+        assertThat(detail.getEndpoints()).singleElement().satisfies(endpoint -> {
+            assertThat(endpoint.getEndpointType()).isEqualTo("TCP_VPC");
+            assertThat(endpoint.getEndpointUrl()).isEqualTo("vpc.tencent:8080");
+        });
     }
 
     private static Endpoint endpoint(String type, String status, String url) {


### PR DESCRIPTION
## Summary

- clamp out-of-range topic/group counts instead of throwing integer overflow
- skip blank open endpoints and trim usable endpoint URLs
- trim catalog search input and reject blank instance identifiers from detail responses

## Why

Tencent catalog fields are remote data. Oversized counts currently fail the entire catalog call, while blank endpoints are exposed as selectable connection targets.

## Tests

- `mvn -q -f server/pom.xml -Dtest=TencentCatalogServiceTest test`
