### PR TITLE
fix(provider): make default pagination null safe

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
@@ -53,11 +53,13 @@ public interface InstanceProvider {
     default PageResult<TopicVO> listTopicsPage(String instanceId, String type, String search,
             int page, int pageSize) {
         List<TopicVO> topics = listTopics(instanceId, type, search);
-        int total = topics.size();
-        long offset = Pagination.pageOffset(page, pageSize);
+        List<TopicVO> safeTopics = topics == null ? List.of() : topics;
+        int safePageSize = Math.max(pageSize, 0);
+        int total = safeTopics.size();
+        long offset = Pagination.pageOffset(page, safePageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
-        return PageResult.of(topics.subList(from, to), total, page, pageSize);
+        int to = from + Math.min(safePageSize, total - from);
+        return PageResult.of(safeTopics.subList(from, to), total, page, safePageSize);
     }
 
     TopicVO createTopic(String instanceId, TopicVO topic);
@@ -70,15 +72,17 @@ public interface InstanceProvider {
 
     default TopicConsumerPageVO getTopicConsumersPage(String instanceId, String topicName, int page, int pageSize) {
         List<TopicConsumerVO> consumers = getTopicConsumers(instanceId, topicName);
-        int total = consumers.size();
-        long offset = Pagination.pageOffset(page, pageSize);
+        List<TopicConsumerVO> safeConsumers = consumers == null ? List.of() : consumers;
+        int safePageSize = Math.max(pageSize, 0);
+        int total = safeConsumers.size();
+        long offset = Pagination.pageOffset(page, safePageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
+        int to = from + Math.min(safePageSize, total - from);
         return TopicConsumerPageVO.builder()
-                .items(consumers.subList(from, to))
+                .items(safeConsumers.subList(from, to))
                 .total(total)
                 .page(page)
-                .pageSize(pageSize)
+                .pageSize(safePageSize)
                 .build();
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/InstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/InstanceProviderTest.java
@@ -17,6 +17,8 @@
 package org.apache.rocketmq.studio.provider;
 
 import java.util.Arrays;
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerPageVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.junit.jupiter.api.Test;
@@ -44,4 +46,37 @@ public class InstanceProviderTest {
         assertThat(result.getPage()).isEqualTo(Integer.MAX_VALUE);
         assertThat(result.getPageSize()).isEqualTo(100);
     }
+
+    @Test
+    public void defaultPagesShouldNormalizeNullProviderCollectionsTest() {
+        InstanceProvider provider = mock(InstanceProvider.class);
+        when(provider.listTopics("instance-a", null, null)).thenReturn(null);
+        when(provider.listTopicsPage("instance-a", null, null, 1, 20)).thenCallRealMethod();
+        when(provider.getTopicConsumers("instance-a", "orders")).thenReturn(null);
+        when(provider.getTopicConsumersPage("instance-a", "orders", 1, 20)).thenCallRealMethod();
+
+        PageResult<TopicVO> topics = provider.listTopicsPage("instance-a", null, null, 1, 20);
+        TopicConsumerPageVO consumers = provider.getTopicConsumersPage("instance-a", "orders", 1, 20);
+
+        assertThat(topics.getItems()).isEmpty();
+        assertThat(topics.getTotal()).isZero();
+        assertThat(consumers.getItems()).isEmpty();
+        assertThat(consumers.getTotal()).isZero();
+    }
+
+    @Test
+    public void defaultPagesShouldTreatNegativePageSizeAsEmptyTest() {
+        InstanceProvider provider = mock(InstanceProvider.class);
+        TopicVO topic = new TopicVO();
+        topic.setName("orders");
+        when(provider.listTopics("instance-a", null, null)).thenReturn(Arrays.asList(topic));
+        when(provider.listTopicsPage("instance-a", null, null, 1, -1)).thenCallRealMethod();
+
+        PageResult<TopicVO> result = provider.listTopicsPage("instance-a", null, null, 1, -1);
+
+        assertThat(result.getItems()).isEmpty();
+        assertThat(result.getTotal()).isEqualTo(1);
+        assertThat(result.getSize()).isZero();
+    }
+
 }


### PR DESCRIPTION
## Summary

- normalize null topic and consumer collections in the default SPI pagination methods
- treat negative page sizes as empty pages rather than invalid sub-list indexes
- preserve totals and return the normalized page size in page metadata

## Why

The default provider methods dereference collection results and use a negative page size directly in index arithmetic. Custom providers can therefore turn empty results or defensive direct calls into NPE/index failures.

## Tests

- `mvn -q -f server/pom.xml -Dtest=InstanceProviderTest test`
