### PR TITLE
fix(cluster): harden connection probe boundaries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionService.java
@@ -18,9 +18,13 @@ package org.apache.rocketmq.studio.cluster.broker;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Verifies live connectivity to a RocketMQ NameServer and summarises the topology it reports.
@@ -43,14 +47,25 @@ public class ClusterConnectionService {
      * @return a populated {@link ClusterProbeResult} on success
      */
     public ClusterProbeResult testConnection(TestConnectionDTO command) {
+        if (command == null || !StringUtils.hasText(command.getNamesrvAddr())) {
+            throw new BusinessException(400, "NameServer address is required");
+        }
         String namesrvAddr = command.getNamesrvAddr().trim();
         log.info("Testing connection to NameServer {}", namesrvAddr);
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         ClusterVO cluster = clusterProvider.describeCluster(namesrvAddr);
-        long elapsed = System.currentTimeMillis() - start;
+        long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+        if (cluster == null) {
+            throw new BusinessException(502, "NameServer returned no cluster topology");
+        }
 
         List<String> brokerNames = cluster.getBrokers() == null ? List.of()
-                : cluster.getBrokers().stream().map(BrokerVO::getName).toList();
+                : cluster.getBrokers().stream()
+                        .filter(Objects::nonNull)
+                        .map(BrokerVO::getName)
+                        .filter(StringUtils::hasText)
+                        .map(String::trim)
+                        .toList();
 
         return ClusterProbeResult.builder()
                 .connected(true)

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionServiceTest.java
@@ -67,6 +67,42 @@ class ClusterConnectionServiceTest {
     }
 
     @Test
+    void testConnectionShouldRejectMissingCommand() {
+        assertThatThrownBy(() -> service.testConnection(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("NameServer address is required");
+    }
+
+    @Test
+    void testConnectionShouldRejectMissingTopology() {
+        when(clusterProvider.describeCluster(eq("10.0.0.1:9876"))).thenReturn(null);
+
+        assertThatThrownBy(() -> service.testConnection(
+                TestConnectionDTO.builder().namesrvAddr("10.0.0.1:9876").build()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502))
+                .hasMessage("NameServer returned no cluster topology");
+    }
+
+    @Test
+    void testConnectionShouldIgnoreMalformedBrokerRows() {
+        ClusterVO cluster = ClusterVO.builder()
+                .name("DefaultCluster")
+                .brokers(java.util.Arrays.asList(
+                        null,
+                        BrokerVO.builder().name("  ").build(),
+                        BrokerVO.builder().name(" broker-a ").build()))
+                .build();
+        when(clusterProvider.describeCluster(eq("10.0.0.1:9876"))).thenReturn(cluster);
+
+        ClusterProbeResult result = service.testConnection(
+                TestConnectionDTO.builder().namesrvAddr("10.0.0.1:9876").build());
+
+        assertThat(result.getBrokerNames()).containsExactly("broker-a");
+        assertThat(result.getBrokerCount()).isEqualTo(1);
+    }
+
+    @Test
     void testConnectionShouldPropagateProviderFailure() {
         when(clusterProvider.describeCluster(eq("10.0.0.9:9876")))
                 .thenThrow(new BusinessException(502, "Failed to connect NameServer"));


### PR DESCRIPTION
## Summary

- validate a missing connection command before reading its address
- map a null NameServer topology to an explicit 502 response
- filter sparse broker rows and use monotonic time for probe latency

## Why

The connection probe assumes both the command and returned topology are complete. Malformed boundary data currently produces generic NPE responses, and wall-clock adjustments can report negative latency.

## Tests

- `mvn -q -f server/pom.xml -Dtest=ClusterConnectionServiceTest test`
