### PR TITLE
fix(ai): sanitize malformed read tool results

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/AlertRuleListToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/AlertRuleListToolHandler.java
@@ -43,7 +43,7 @@ public class AlertRuleListToolHandler implements ToolHandler {
     public Object execute(Map<String, Object> input) {
         String search = (String) input.get("search");
         Boolean enabled = (Boolean) input.get("enabled");
-        return alertService.listRules().stream()
+        return ToolResultUtils.stream(alertService.listRules())
                 .filter(rule -> matchesEnabled(rule, enabled))
                 .filter(rule -> matchesSearch(rule, search))
                 .map(AlertRuleListToolHandler::safeProjection)
@@ -91,7 +91,7 @@ public class AlertRuleListToolHandler implements ToolHandler {
     }
 
     private static List<String> copyList(List<String> value) {
-        return value == null ? List.of() : List.copyOf(value);
+        return ToolResultUtils.copyStrings(value);
     }
 
     private static String blankIfNull(String value) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ConsumerGroupListToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ConsumerGroupListToolHandler.java
@@ -42,7 +42,7 @@ public class ConsumerGroupListToolHandler implements ToolHandler {
     public Object execute(Map<String, Object> input) {
         String clusterId = (String) input.get("cluster");
         String search = (String) input.get("search");
-        return metadataService.listConsumerGroups(clusterId, search).stream()
+        return ToolResultUtils.stream(metadataService.listConsumerGroups(clusterId, search))
                 .map(ConsumerGroupListToolHandler::safeProjection)
                 .toList();
     }
@@ -79,7 +79,7 @@ public class ConsumerGroupListToolHandler implements ToolHandler {
     }
 
     private static List<String> copyList(List<String> value) {
-        return value == null ? List.of() : List.copyOf(value);
+        return ToolResultUtils.copyStrings(value);
     }
 
     private static String blankIfNull(String value) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/DashboardSummaryToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/DashboardSummaryToolHandler.java
@@ -45,8 +45,8 @@ public class DashboardSummaryToolHandler implements ToolHandler {
     public Object execute(Map<String, Object> input) {
         String clusterId = (String) input.get("cluster");
         DashboardDataVO dashboard = dashboardService.getDashboard();
-        ClusterOverviewVO cluster = clusters(dashboard).stream()
-                .filter(item -> clusterId.equals(item.getId()))
+        ClusterOverviewVO cluster = ToolResultUtils.stream(clusters(dashboard))
+                .filter(item -> java.util.Objects.equals(clusterId, item.getId()))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(
                         404, "Dashboard cluster not found: " + clusterId));

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandler.java
@@ -54,10 +54,11 @@ public class MessageTraceToolHandler implements ToolHandler {
     private static Map<String, Object> project(String msgId, TraceRecordVO trace) {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("msgId", msgId);
-        result.put("nodes", trace.getNodes().stream()
+        result.put("nodes", ToolResultUtils.stream(trace == null ? null : trace.getNodes())
                 .map(MessageTraceToolHandler::projectNode)
                 .toList());
-        result.put("consumerStatus", trace.getConsumerStatus().stream()
+        result.put("consumerStatus", ToolResultUtils.stream(
+                        trace == null ? null : trace.getConsumerStatus())
                 .map(MessageTraceToolHandler::projectConsumerStatus)
                 .toList());
         return result;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ToolResultUtils.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ToolResultUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+final class ToolResultUtils {
+
+    private ToolResultUtils() {
+    }
+
+    static <T> Stream<T> stream(Collection<T> values) {
+        return values == null ? Stream.empty() : values.stream().filter(Objects::nonNull);
+    }
+
+    static List<String> copyStrings(Collection<String> values) {
+        return stream(values).toList();
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/TopicListToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/TopicListToolHandler.java
@@ -42,7 +42,7 @@ public class TopicListToolHandler implements ToolHandler {
         String clusterId = (String) input.get("cluster");
         String type = (String) input.get("type");
         String search = (String) input.get("search");
-        return metadataService.listTopics(clusterId, type, search).stream()
+        return ToolResultUtils.stream(metadataService.listTopics(clusterId, type, search))
                 .map(TopicListToolHandler::safeProjection)
                 .toList();
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandlerTest.java
@@ -83,4 +83,16 @@ class MessageTraceToolHandlerTest {
 
         verify(messageService).getMessageTrace("instance-a", "msg-1", "TopicA");
     }
+    @Test
+    void executeShouldNormalizeMissingTraceCollections() {
+        when(messageService.getMessageTrace(eq("instance-a"), eq("msg-1"), eq("TopicA")))
+                .thenReturn(null);
+
+        Map<?, ?> result = (Map<?, ?>) handler.execute(Map.of(
+                "cluster", "instance-a", "msgId", "msg-1", "topic", "TopicA"));
+
+        assertThat((List<?>) result.get("nodes")).isEmpty();
+        assertThat((List<?>) result.get("consumerStatus")).isEmpty();
+    }
+
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ReadToolResultSanitizationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ReadToolResultSanitizationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.instance.topic.MetadataService;
+import org.apache.rocketmq.studio.ops.alert.AlertRuleVO;
+import org.apache.rocketmq.studio.ops.alert.AlertService;
+import org.apache.rocketmq.studio.ops.dashboard.ClusterOverviewVO;
+import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
+import org.apache.rocketmq.studio.ops.dashboard.DashboardService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ReadToolResultSanitizationTest {
+
+    @Test
+    void listHandlersShouldNormalizeNullServiceCollections() {
+        MetadataService metadataService = mock(MetadataService.class);
+        AlertService alertService = mock(AlertService.class);
+        when(metadataService.listTopics("instance-a", null, null)).thenReturn(null);
+        when(metadataService.listConsumerGroups("instance-a", null)).thenReturn(null);
+        when(alertService.listRules()).thenReturn(null);
+
+        Object topics = new TopicListToolHandler(metadataService).execute(Map.of("cluster", "instance-a"));
+        Object groups = new ConsumerGroupListToolHandler(metadataService).execute(Map.of("cluster", "instance-a"));
+        Object rules = new AlertRuleListToolHandler(alertService).execute(Map.of());
+
+        assertThat((List<?>) topics).isEmpty();
+        assertThat((List<?>) groups).isEmpty();
+        assertThat((List<?>) rules).isEmpty();
+    }
+
+    @Test
+    void alertHandlerShouldIgnoreNullRowsAndNestedListEntries() {
+        AlertService alertService = mock(AlertService.class);
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .name("broker unavailable")
+                .metric("broker_up")
+                .channels(Arrays.asList(null, "email"))
+                .build();
+        when(alertService.listRules()).thenReturn(Arrays.asList(null, rule));
+
+        List<?> rows = (List<?>) new AlertRuleListToolHandler(alertService).execute(Map.of());
+
+        assertThat(rows).singleElement().satisfies(row ->
+                assertThat((List<?>) ((Map<?, ?>) row).get("channels")).isEqualTo(List.of("email")));
+    }
+
+    @Test
+    void dashboardHandlerShouldIgnoreNullClusterRows() {
+        DashboardService dashboardService = mock(DashboardService.class);
+        when(dashboardService.getDashboard()).thenReturn(DashboardDataVO.builder()
+                .clusters(Arrays.asList((ClusterOverviewVO) null))
+                .build());
+
+        assertThatThrownBy(() -> new DashboardSummaryToolHandler(dashboardService)
+                .execute(Map.of("cluster", "instance-a")))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Dashboard cluster not found: instance-a");
+    }
+}


### PR DESCRIPTION
## Summary

- share null-safe collection projection across read-only AI tool handlers
- ignore null rows and nested string-list entries without weakening required-field checks
- return empty trace collections when a message trace is unavailable

## Why

The read tools project data from multiple provider and service boundaries. A null collection or sparse row currently fails the whole tool call, even when the remaining result is safe to return.

## Tests

- `mvn -q -f server/pom.xml -Dtest=ReadToolResultSanitizationTest,MessageTraceToolHandlerTest test`
