### PR TITLE
fix(auth): normalize configured user entries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthProperties.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthProperties.java
@@ -25,6 +25,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Setter
@@ -38,10 +39,23 @@ public class AuthProperties {
     private List<User> users = new ArrayList<>();
 
     public List<User> configuredUsers() {
+        if (users == null) {
+            return List.of();
+        }
         return users.stream()
+                .filter(Objects::nonNull)
                 .filter(user -> StringUtils.hasText(user.getUsername()))
                 .filter(user -> StringUtils.hasText(user.getPassword()))
+                .map(AuthProperties::normalizedUser)
                 .toList();
+    }
+
+    private static User normalizedUser(User configured) {
+        User normalized = new User();
+        normalized.setUsername(configured.getUsername().trim());
+        normalized.setPassword(configured.getPassword());
+        normalized.setAdmin(configured.isAdmin());
+        return normalized;
     }
 
     @Getter

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthPropertiesTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthPropertiesTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.auth;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthPropertiesTest {
+
+    @Test
+    void configuredUsersShouldTolerateNullConfiguration() {
+        AuthProperties properties = new AuthProperties();
+        properties.setUsers(null);
+
+        assertThat(properties.configuredUsers()).isEmpty();
+    }
+
+    @Test
+    void configuredUsersShouldSkipMalformedRowsAndNormalizeUsername() {
+        AuthProperties.User blank = new AuthProperties.User();
+        blank.setUsername("  ");
+        blank.setPassword("password-1");
+        AuthProperties.User valid = new AuthProperties.User();
+        valid.setUsername("  operator  ");
+        valid.setPassword(" password-2 ");
+        valid.setAdmin(true);
+        AuthProperties properties = new AuthProperties();
+        properties.setUsers(Arrays.asList(null, blank, valid));
+
+        assertThat(properties.configuredUsers()).singleElement().satisfies(user -> {
+            assertThat(user.getUsername()).isEqualTo("operator");
+            assertThat(user.getPassword()).isEqualTo(" password-2 ");
+            assertThat(user.isAdmin()).isTrue();
+        });
+        assertThat(valid.getUsername()).isEqualTo("  operator  ");
+    }
+}


### PR DESCRIPTION
## Summary

- tolerate a null configured-user list and null rows
- filter incomplete configured users before bootstrap/authentication
- trim usernames in copied results without mutating bound configuration or passwords

## Why

Sparse externalized configuration currently crashes startup/authentication. Leading or trailing username whitespace also seeds an account that normal database login cannot resolve consistently.

## Tests

- `mvn -q -f server/pom.xml -Dtest=AuthPropertiesTest test`
