### PR TITLE
fix(cors): reject invalid credentialed origins

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/config/CorsConfig.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/config/CorsConfig.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.common.config;
 
+import java.net.URI;
 import java.util.Arrays;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -33,7 +34,32 @@ public class CorsConfig implements WebMvcConfigurer {
         this.allowedOrigins = Arrays.stream(allowedOrigins.split(","))
                 .map(String::trim)
                 .filter(origin -> !origin.isEmpty())
+                .peek(CorsConfig::validateOrigin)
                 .toArray(String[]::new);
+    }
+
+    private static void validateOrigin(String origin) {
+        if ("*".equals(origin)) {
+            throw new IllegalArgumentException(
+                    "studio.cors.allowed-origins cannot contain '*' when credentials are enabled");
+        }
+        final URI uri;
+        try {
+            uri = URI.create(origin);
+        } catch (IllegalArgumentException invalid) {
+            throw new IllegalArgumentException("Invalid CORS origin: " + origin, invalid);
+        }
+        boolean http = "http".equalsIgnoreCase(uri.getScheme())
+                || "https".equalsIgnoreCase(uri.getScheme());
+        boolean originOnly = uri.getHost() != null
+                && uri.getUserInfo() == null
+                && (uri.getPath() == null || uri.getPath().isEmpty())
+                && uri.getQuery() == null
+                && uri.getFragment() == null;
+        if (!http || !originOnly) {
+            throw new IllegalArgumentException(
+                    "CORS origin must be an HTTP(S) origin without a path: " + origin);
+        }
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/common/config/CorsConfigTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/config/CorsConfigTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CorsConfigTest {
+
+    @Test
+    void acceptsCommaSeparatedHttpOrigins() {
+        assertThatCode(() -> new CorsConfig("https://dashboard.example.com, http://localhost:5173"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsCredentialedWildcardOrigin() {
+        assertThatThrownBy(() -> new CorsConfig("https://dashboard.example.com,*"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cannot contain '*'");
+    }
+
+    @Test
+    void rejectsOriginsWithPathsOrUnsupportedSchemes() {
+        assertThatThrownBy(() -> new CorsConfig("https://dashboard.example.com/app"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("without a path");
+        assertThatThrownBy(() -> new CorsConfig("file://dashboard/index.html"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("HTTP(S)");
+    }
+}


### PR DESCRIPTION
## Summary

- fail fast when `*` is combined with credentialed CORS
- validate configured entries as pathless HTTP(S) origins
- cover valid multi-origin and invalid wildcard/path/scheme configurations

## Why

Spring cannot use an allowed origin of `*` together with credentials and otherwise fails at request time. Path-bearing or unsupported origin strings silently never match browser Origin headers.

## Tests

- `mvn -q -f server/pom.xml -Dtest=CorsConfigTest test`
