### PR TITLE
fix(cluster): normalize admin credential configuration

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminProperties.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminProperties.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -47,6 +48,18 @@ public class MqAdminProperties {
      * Kubernetes Secret, and must never be persisted in the Studio database.
      */
     private Map<String, Credential> credentials = new LinkedHashMap<>();
+
+    public void setCredentials(Map<String, Credential> credentials) {
+        this.credentials = new LinkedHashMap<>();
+        if (credentials == null) {
+            return;
+        }
+        credentials.forEach((reference, credential) -> {
+            if (StringUtils.hasText(reference) && credential != null) {
+                this.credentials.put(reference.trim(), credential);
+            }
+        });
+    }
 
     @Getter
     @Setter

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolver.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolver.java
@@ -73,7 +73,8 @@ public class RuntimeAdminClientResolver {
         if (!StringUtils.hasText(credentialRef)) {
             return null;
         }
-        MqAdminProperties.Credential credential = adminProperties.getCredentials().get(credentialRef);
+        MqAdminProperties.Credential credential = adminProperties == null
+                ? null : adminProperties.getCredentials().get(credentialRef);
         if (credential == null || !StringUtils.hasText(credential.getAccessKey())
                 || !StringUtils.hasText(credential.getSecretKey())) {
             throw new BusinessException(422,

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolverTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RuntimeAdminClientResolverTest.java
@@ -29,6 +29,7 @@ import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -202,6 +203,36 @@ class RuntimeAdminClientResolverTest {
         assertThatThrownBy(() -> resolver.execute("instance-b", ignored -> "unused"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Admin credential reference is not configured: incomplete");
+        verifyNoInteractions(adminFactory);
+    }
+
+    @Test
+    void normalizesCredentialMapsAndRejectsMissingReferencesCleanly() {
+        MqAdminProperties.Credential credential = new MqAdminProperties.Credential();
+        credential.setAccessKey("admin-ak");
+        credential.setSecretKey("admin-sk");
+        Map<String, MqAdminProperties.Credential> configured = new HashMap<>();
+        configured.put(" production-admin ", credential);
+        configured.put("empty-entry", null);
+        configured.put("  ", credential);
+        MqAdminProperties properties = new MqAdminProperties();
+        properties.setCredentials(configured);
+
+        assertThat(properties.getCredentials()).containsOnlyKeys("production-admin");
+        properties.setCredentials(null);
+        assertThat(properties.getCredentials()).isEmpty();
+
+        InstanceVO instance = InstanceVO.builder()
+                .endpoint("namesrv-b:9876")
+                .adminCredentialRef("production-admin")
+                .build();
+        when(instanceRepository.findByIdentifier("instance-b")).thenReturn(Optional.of(instance));
+        RuntimeAdminClientResolver resolver = new RuntimeAdminClientResolver(
+                instanceRepository, adminFactory, properties);
+
+        assertThatThrownBy(() -> resolver.execute("instance-b", ignored -> "unused"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Admin credential reference is not configured: production-admin");
         verifyNoInteractions(adminFactory);
     }
 


### PR DESCRIPTION
## Summary

- keep the external credential map non-null
- trim credential references and discard blank/null map entries
- return the existing 422 configuration error instead of an NPE for missing maps

## Why

External property binding or programmatic configuration can replace the credential map with null or sparse entries. Resolving an instance credential then crashes before the intended configuration error is returned.

## Tests

- `mvn -q -f server/pom.xml -Dtest=RuntimeAdminClientResolverTest test`
