### PR TITLE
fix(api): reject non-positive entity identifiers

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/EntityIds.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/EntityIds.java
@@ -38,7 +38,11 @@ public final class EntityIds {
             throw new BusinessException(400, "id is required");
         }
         try {
-            return Long.parseLong(value.trim());
+            long id = Long.parseLong(value.trim());
+            if (id <= 0) {
+                throw new BusinessException(400, "id must be a positive numeric value: " + value);
+            }
+            return id;
         } catch (NumberFormatException ex) {
             throw new BusinessException(400, "id must be a numeric value: " + value);
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/EntityIdsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/EntityIdsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EntityIdsTest {
+
+    @Test
+    void parsesTrimmedPositiveIdentifiers() {
+        assertThat(EntityIds.parseId(" 42 ")).isEqualTo(42L);
+    }
+
+    @Test
+    void rejectsZeroAndNegativeIdentifiers() {
+        assertThatThrownBy(() -> EntityIds.parseId("0"))
+                .isInstanceOfSatisfying(BusinessException.class,
+                        error -> assertThat(error.getCode()).isEqualTo(400))
+                .hasMessageContaining("positive numeric value");
+        assertThatThrownBy(() -> EntityIds.parseId("-1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("positive numeric value");
+    }
+}


### PR DESCRIPTION
## Summary

- require externally supplied database entity IDs to be greater than zero
- return a uniform HTTP 400 error for zero and negative identifiers
- retain trimmed positive-ID parsing and overflow handling

## Why

These IDs target unsigned auto-increment primary keys. Accepting zero or negative values sends impossible identifiers into credential and ACL repository operations instead of rejecting the request boundary.

## Tests

- `mvn -q -f server/pom.xml -Dtest=EntityIdsTest test`
