### PR TITLE
fix(diagnostics): bound and isolate jstack parsing

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProvider.java
@@ -50,6 +50,7 @@ public class RocketMQConsumerDiagnosticsProvider implements ConsumerDiagnosticsP
 
     private static final Pattern THREAD_HEADER =
             Pattern.compile("^(?<name>.+?)TID:\\s+(?<id>\\d+)\\s+STATE:\\s+(?<state>\\S+)\\s*$");
+    static final int MAX_JSTACK_CHARS = 2 * 1024 * 1024;
 
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
     private final MqAdminExtFactory adminFactory;
@@ -139,6 +140,10 @@ public class RocketMQConsumerDiagnosticsProvider implements ConsumerDiagnosticsP
         if (!StringUtils.hasText(jstack)) {
             return List.of();
         }
+        if (jstack.length() > MAX_JSTACK_CHARS) {
+            throw new BusinessException(502,
+                    "Consumer stack exceeds the supported size of " + MAX_JSTACK_CHARS + " characters");
+        }
 
         List<ConsumerThreadStackVO> threads = new ArrayList<>();
         ThreadBuilder current = null;
@@ -150,11 +155,16 @@ public class RocketMQConsumerDiagnosticsProvider implements ConsumerDiagnosticsP
             if (header.matches()) {
                 if (current != null) {
                     threads.add(current.build());
+                    current = null;
                 }
-                current = new ThreadBuilder(
-                        header.group("name").trim(),
-                        Long.parseLong(header.group("id")),
-                        header.group("state").trim());
+                try {
+                    current = new ThreadBuilder(
+                            header.group("name").trim(),
+                            Long.parseLong(header.group("id")),
+                            header.group("state").trim());
+                } catch (NumberFormatException malformedThreadId) {
+                    log.debug("Ignoring consumer stack row with an invalid thread id");
+                }
                 continue;
             }
             if (current != null) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProviderTest.java
@@ -118,6 +118,37 @@ class RocketMQConsumerDiagnosticsProviderTest {
     }
 
     @Test
+    void getConsumerStackShouldIgnoreOverflowingThreadIdsTest() throws Exception {
+        ConsumerRunningInfo runningInfo = new ConsumerRunningInfo();
+        runningInfo.setJstack("""
+                first TID: 12 STATE: RUNNABLE
+                first com.example.First.run(First.java:1)
+                malformed TID: 999999999999999999999999999999 STATE: WAITING
+                malformed ignored.frame(Line.java:2)
+                second TID: 13 STATE: WAITING
+                second com.example.Second.run(Second.java:3)
+                """);
+        when(adminExt.getConsumerRunningInfo("cg-orders", "client-1", true)).thenReturn(runningInfo);
+
+        ConsumerStackTraceVO result = provider.getConsumerStack("instance-a", "cg-orders", "client-1");
+
+        assertThat(result.getThreads()).extracting(thread -> thread.getThreadName())
+                .containsExactly("first", "second");
+    }
+
+    @Test
+    void getConsumerStackShouldRejectOversizedJstackTest() throws Exception {
+        ConsumerRunningInfo runningInfo = new ConsumerRunningInfo();
+        runningInfo.setJstack("x".repeat(RocketMQConsumerDiagnosticsProvider.MAX_JSTACK_CHARS + 1));
+        when(adminExt.getConsumerRunningInfo("cg-orders", "client-1", true)).thenReturn(runningInfo);
+
+        assertThatThrownBy(() -> provider.getConsumerStack("instance-a", "cg-orders", "client-1"))
+                .isInstanceOfSatisfying(BusinessException.class,
+                        error -> assertThat(error.getCode()).isEqualTo(502))
+                .hasMessageContaining("exceeds the supported size");
+    }
+
+    @Test
     void getConsumerStackShouldUseDefaultNameServerWhenInstanceIsBlank() throws Exception {
         ConsumerRunningInfo runningInfo = new ConsumerRunningInfo();
         runningInfo.setJstack("");


### PR DESCRIPTION
## Summary

- reject consumer jstack payloads above a 2 MiB character bound
- isolate overflowing thread IDs instead of failing all valid stack rows
- retain valid threads before and after a malformed header

## Why

Consumer diagnostics parse broker-supplied text using a full-string split. An oversized dump can consume excessive heap, while one out-of-range thread ID currently makes the entire diagnostic request fail.

## Tests

- `mvn -q -f server/pom.xml -Dtest=RocketMQConsumerDiagnosticsProviderTest test`
