### PR TITLE
fix(config): sanitize malformed broker settings

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigService.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.Locale;
 import java.util.Properties;
 
 @Slf4j
@@ -100,37 +101,66 @@ public class RocketMQBrokerConfigService {
     }
 
     private ClusterConfigVO mapToClusterConfigVO(Properties props) {
+        Properties safeProps = props == null ? new Properties() : props;
         ClusterConfigVO vo = new ClusterConfigVO();
-        vo.setFlushDiskType(parseFlushDiskType(props.getProperty("flushDiskType", "ASYNC_FLUSH")));
-        vo.setAutoCreateTopicEnable(Boolean.parseBoolean(props.getProperty("autoCreateTopicEnable", "true")));
-        vo.setAutoCreateSubscriptionGroup(Boolean.parseBoolean(props.getProperty("autoCreateSubscriptionGroup", "true")));
-        vo.setMaxMessageSize(parseIntSafe(props.getProperty("maxMessageSize"), 4194304));
-        vo.setWriteQueueNums(parseIntSafe(props.getProperty("defaultTopicQueueNums"), 8));
-        vo.setReadQueueNums(parseIntSafe(props.getProperty("defaultTopicQueueNums"), 8));
-        vo.setFileReservedTime(parseIntSafe(props.getProperty("fileReservedTime"), 72));
-        vo.setBrokerPermission(parseIntSafe(props.getProperty("brokerPermission"), 6));
-        vo.setDeleteWhen(props.getProperty("deleteWhen", "04"));
-        vo.setMsgTraceTopicName(props.getProperty("msgTraceTopicName", "RMQ_SYS_TRACE_TOPIC"));
+        vo.setFlushDiskType(parseFlushDiskType(safeProps.getProperty("flushDiskType")));
+        vo.setAutoCreateTopicEnable(parseBoolean(safeProps.getProperty("autoCreateTopicEnable"), true));
+        vo.setAutoCreateSubscriptionGroup(
+                parseBoolean(safeProps.getProperty("autoCreateSubscriptionGroup"), true));
+        vo.setMaxMessageSize(parseIntInRange(safeProps.getProperty("maxMessageSize"), 4194304, 1,
+                Integer.MAX_VALUE));
+        int queueCount = parseIntInRange(safeProps.getProperty("defaultTopicQueueNums"), 8, 1,
+                Integer.MAX_VALUE);
+        vo.setWriteQueueNums(queueCount);
+        vo.setReadQueueNums(queueCount);
+        vo.setFileReservedTime(parseIntInRange(safeProps.getProperty("fileReservedTime"), 72, 1,
+                Integer.MAX_VALUE));
+        vo.setBrokerPermission(parseIntInRange(safeProps.getProperty("brokerPermission"), 6, 0, 7));
+        vo.setDeleteWhen(textOrDefault(safeProps.getProperty("deleteWhen"), "04"));
+        vo.setMsgTraceTopicName(textOrDefault(
+                safeProps.getProperty("msgTraceTopicName"), "RMQ_SYS_TRACE_TOPIC"));
         return vo;
     }
 
     private FlushDiskType parseFlushDiskType(String value) {
+        if (!StringUtils.hasText(value)) {
+            return FlushDiskType.ASYNC_FLUSH;
+        }
         try {
-            return FlushDiskType.valueOf(value);
+            return FlushDiskType.valueOf(value.trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
             return FlushDiskType.ASYNC_FLUSH;
         }
     }
 
-    private int parseIntSafe(String value, int defaultValue) {
-        if (value == null || value.isEmpty()) {
+    private boolean parseBoolean(String value, boolean defaultValue) {
+        if (!StringUtils.hasText(value)) {
+            return defaultValue;
+        }
+        String normalized = value.trim();
+        if ("true".equalsIgnoreCase(normalized)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(normalized)) {
+            return false;
+        }
+        return defaultValue;
+    }
+
+    private int parseIntInRange(String value, int defaultValue, int minimum, int maximum) {
+        if (!StringUtils.hasText(value)) {
             return defaultValue;
         }
         try {
-            return Integer.parseInt(value.trim());
+            int parsed = Integer.parseInt(value.trim());
+            return parsed >= minimum && parsed <= maximum ? parsed : defaultValue;
         } catch (NumberFormatException e) {
             return defaultValue;
         }
+    }
+
+    private String textOrDefault(String value, String defaultValue) {
+        return StringUtils.hasText(value) ? value.trim() : defaultValue;
     }
 
     private String namesrvAddr() {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigServiceTest.java
@@ -8,6 +8,7 @@ package org.apache.rocketmq.studio.provider.apache;
 
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.common.domain.enums.FlushDiskType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.ops.audit.AuditService;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
@@ -19,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Properties;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -26,6 +28,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RocketMQBrokerConfigServiceTest {
@@ -50,6 +53,44 @@ class RocketMQBrokerConfigServiceTest {
                 invocation.<MqAdminExtFactory.AdminAction<Object>>getArgument(2).apply(adminExt));
         brokerConfigService = new RocketMQBrokerConfigService(
                 adminFactory, properties, runtimeAdminClientResolver, auditService);
+    }
+
+    @Test
+    void getBrokerConfigShouldUseDefaultsForMissingResponse() throws Exception {
+        when(adminExt.getBrokerConfig("broker-a:10911")).thenReturn(null);
+
+        var config = brokerConfigService.getBrokerConfig("broker-a:10911");
+
+        assertThat(config.getFlushDiskType()).isEqualTo(FlushDiskType.ASYNC_FLUSH);
+        assertThat(config.getMaxMessageSize()).isEqualTo(4_194_304);
+        assertThat(config.getWriteQueueNums()).isEqualTo(8);
+        assertThat(config.getFileReservedTime()).isEqualTo(72);
+    }
+
+    @Test
+    void getBrokerConfigShouldNormalizeMalformedValues() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("flushDiskType", " sync_flush ");
+        properties.setProperty("autoCreateTopicEnable", " FALSE ");
+        properties.setProperty("autoCreateSubscriptionGroup", "invalid");
+        properties.setProperty("maxMessageSize", "-1");
+        properties.setProperty("defaultTopicQueueNums", "0");
+        properties.setProperty("fileReservedTime", "not-a-number");
+        properties.setProperty("brokerPermission", "8");
+        properties.setProperty("deleteWhen", "  ");
+        when(adminExt.getBrokerConfig("broker-a:10911")).thenReturn(properties);
+
+        var config = brokerConfigService.getBrokerConfig("broker-a:10911");
+
+        assertThat(config.getFlushDiskType()).isEqualTo(FlushDiskType.SYNC_FLUSH);
+        assertThat(config.isAutoCreateTopicEnable()).isFalse();
+        assertThat(config.isAutoCreateSubscriptionGroup()).isTrue();
+        assertThat(config.getMaxMessageSize()).isEqualTo(4_194_304);
+        assertThat(config.getWriteQueueNums()).isEqualTo(8);
+        assertThat(config.getReadQueueNums()).isEqualTo(8);
+        assertThat(config.getFileReservedTime()).isEqualTo(72);
+        assertThat(config.getBrokerPermission()).isEqualTo(6);
+        assertThat(config.getDeleteWhen()).isEqualTo("04");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- apply safe defaults when a broker returns no configuration
- trim and normalize flush/boolean/text values
- enforce valid ranges for message size, queues, retention, and permission bits

## Why

Broker configuration is remote runtime data. Null responses currently raise an NPE, while negative or out-of-range numeric values pass parsing and produce invalid editable settings in Studio.

## Tests

- `mvn -q -f server/pom.xml -Dtest=RocketMQBrokerConfigServiceTest test`
