### PR TITLE
fix(web): preserve special message property keys

### DIFF
--- a/web/src/utils/messageProperties.test.ts
+++ b/web/src/utils/messageProperties.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseMessageProperties } from './messageProperties';
+
+describe('parseMessageProperties', () => {
+  it('preserves JavaScript object prototype property names', () => {
+    const result = parseMessageProperties(
+      '__proto__=trace-prototype\nconstructor=trace-constructor\ntoString=trace-string',
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(Object.keys(result.properties)).toEqual(['__proto__', 'constructor', 'toString']);
+    expect(result.properties['__proto__']).toBe('trace-prototype');
+    expect(result.properties['constructor']).toBe('trace-constructor');
+    expect(result.properties['toString']).toBe('trace-string');
+    const serialized = JSON.parse(JSON.stringify(result.properties)) as Record<string, string>;
+    expect(serialized['__proto__']).toBe('trace-prototype');
+    expect(serialized['constructor']).toBe('trace-constructor');
+    expect(serialized['toString']).toBe('trace-string');
+  });
+
+  it('still reports duplicate special property names', () => {
+    const result = parseMessageProperties('__proto__=first\n__proto__=second');
+
+    expect(result.properties['__proto__']).toBe('first');
+    expect(result.errors).toEqual(['属性名“__proto__”重复']);
+  });
+});

--- a/web/src/utils/messageProperties.ts
+++ b/web/src/utils/messageProperties.ts
@@ -22,7 +22,7 @@ interface ParsedProperties {
 
 // 解析批量粘贴的用户属性串：key=value 按换行或逗号分隔，等号只取第一个
 export const parseMessageProperties = (text: string): ParsedProperties => {
-  const properties: Record<string, string> = {};
+  const entries = new Map<string, string>();
   const errors: string[] = [];
   for (const line of text.split(/[\n,]+/)) {
     const trimmed = line.trim();
@@ -35,11 +35,11 @@ export const parseMessageProperties = (text: string): ParsedProperties => {
     const key = trimmed.slice(0, eqIndex).trim();
     if (!key) {
       errors.push(`“${trimmed}”的属性名不能为空`);
-    } else if (Object.prototype.hasOwnProperty.call(properties, key)) {
+    } else if (entries.has(key)) {
       errors.push(`属性名“${key}”重复`);
     } else {
-      properties[key] = trimmed.slice(eqIndex + 1).trim();
+      entries.set(key, trimmed.slice(eqIndex + 1).trim());
     }
   }
-  return { properties, errors };
+  return { properties: Object.fromEntries(entries), errors };
 };


### PR DESCRIPTION
## Summary

- collect pasted message properties in a `Map` before creating the result object
- preserve own properties named `__proto__`, `constructor`, and `toString`
- keep duplicate detection working for those special keys

## Why

Assigning parsed keys directly to `{}` invokes or shadows Object prototype members. In particular, a valid `__proto__` message property is silently lost before the send request is serialized.

## Tests

- `npm test -- --run src/utils/messageProperties.test.ts`
- `npx eslint src/utils/messageProperties.ts src/utils/messageProperties.test.ts`
