### PR TITLE
fix(settings): keep Studio LLM configuration consistent

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/LlmConfigService.java
@@ -90,12 +90,9 @@ public class LlmConfigService {
     private final OpenAiCompatibleLlmClient llmClient;
     private final AgentProviderRegistry agentProviders;
     private final LlmProperties llmProperties;
-    private LlmConfigVO overrides;
 
     public synchronized LlmConfigVO getConfig() {
-        LlmConfigVO config = overrides != null
-                ? copy(overrides)
-                : fromGeneralSettings(settingsService.getGeneralSettings());
+        LlmConfigVO config = fromGeneralSettings(settingsService.getGeneralSettings());
         String token = envToken();
         if (StringUtils.hasText(token)) {
             config.setApiKey(token.trim());
@@ -133,9 +130,7 @@ public class LlmConfigService {
                 .maxTokens(normalized.getMaxTokens())
                 .temperature(normalized.getTemperature())
                 .build();
-        LlmConfigVO nextOverrides = copy(normalized);
         settingsService.saveGeneralSettings(updated);
-        overrides = nextOverrides;
     }
 
     public LlmOperationResultVO testConfig(LlmConfigVO config) {
@@ -295,10 +290,6 @@ public class LlmConfigService {
                 .apiVersion(defaultString(config == null ? null : config.getApiVersion(), "2024-02-15-preview"))
                 .awsRegion(defaultString(config == null ? null : config.getAwsRegion(), "us-east-1"))
                 .build();
-    }
-
-    private LlmConfigVO copy(LlmConfigVO config) {
-        return normalize(config);
     }
 
     private LlmConfigVO normalizeWithStoredApiKey(LlmConfigVO config) {

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -98,11 +98,9 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
         try {
             com.fasterxml.jackson.databind.node.ObjectNode node =
                     (com.fasterxml.jackson.databind.node.ObjectNode) objectMapper.valueToTree(settings);
-            if (org.springframework.util.StringUtils.hasText(settings.getApiKey())) {
-                // apiKey is WRITE_ONLY (hidden from API responses), so plain serialization
-                // drops it; re-add it here or the configured LLM token is lost on restart.
-                node.put("apiKey", settings.getApiKey());
-            }
+            // apiKey is WRITE_ONLY (hidden from API responses), but it must be serialized even
+            // when blank so the LLM configuration endpoint can explicitly clear a stored key.
+            node.put("apiKey", settings.getApiKey() == null ? "" : settings.getApiKey());
             if (org.springframework.util.StringUtils.hasText(settings.getDingtalkSigningSecret())) {
                 // The signing secret is also WRITE_ONLY and must be retained in persisted settings.
                 node.put("dingtalkSigningSecret", settings.getDingtalkSigningSecret());

--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -138,6 +138,9 @@ public class SettingsService {
             settings.setDingtalkSigningSecret(currentSettings.getDingtalkSigningSecret());
         }
         if (currentSettings != null) {
+            if (!StringUtils.hasText(settings.getLlmEngine())) {
+                settings.setLlmEngine(currentSettings.getLlmEngine());
+            }
             if (!StringUtils.hasText(settings.getDeploymentName())) {
                 settings.setDeploymentName(currentSettings.getDeploymentName());
             }
@@ -146,6 +149,12 @@ public class SettingsService {
             }
             if (!StringUtils.hasText(settings.getAwsRegion())) {
                 settings.setAwsRegion(currentSettings.getAwsRegion());
+            }
+            if (settings.getMaxTokens() == null) {
+                settings.setMaxTokens(currentSettings.getMaxTokens());
+            }
+            if (settings.getTemperature() == null) {
+                settings.setTemperature(currentSettings.getTemperature());
             }
         }
         settings.setClearApiKey(false);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigServiceTest.java
@@ -29,11 +29,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -187,6 +189,7 @@ class LlmConfigServiceTest {
         assertThat(saved.getBaseUrl()).isEqualTo("https://api.deepseek.com/v1");
         assertThat(saved.getMaxTokens()).isEqualTo(8192);
         assertThat(saved.getTemperature()).isEqualTo(0.2);
+        when(settingsService.getGeneralSettings()).thenReturn(saved);
         assertThat(llmConfigService.getConfig().getProvider()).isEqualTo("deepseek");
         assertThat(llmConfigService.getConfig().getMaxTokens()).isEqualTo(8192);
         assertThat(llmConfigService.getConfig().getTemperature()).isEqualTo(0.2);
@@ -243,6 +246,36 @@ class LlmConfigServiceTest {
     }
 
     @Test
+    void getConfigShouldReflectGeneralSettingsSavedAfterLlmConfigurationTest() {
+        llmConfigService.saveConfig(LlmConfigVO.builder()
+                .provider("deepseek")
+                .apiKey("sk-deepseek")
+                .apiBase("https://api.deepseek.com/v1")
+                .model("deepseek-chat")
+                .maxTokens(8192)
+                .temperature(0.2)
+                .enabled(true)
+                .build());
+        when(settingsService.getGeneralSettings()).thenReturn(GeneralSettingsVO.builder()
+                .llmProvider("ollama")
+                .llmEngine("http")
+                .apiKey("")
+                .model("llama3")
+                .baseUrl("http://localhost:11434/v1")
+                .maxTokens(4096)
+                .temperature(0.7)
+                .build());
+
+        LlmConfigVO config = llmConfigService.getConfig();
+
+        assertThat(config.getProvider()).isEqualTo("ollama");
+        assertThat(config.getEngine()).isEqualTo("http");
+        assertThat(config.getModel()).isEqualTo("llama3");
+        assertThat(config.getMaxTokens()).isEqualTo(4096);
+        assertThat(config.getTemperature()).isEqualTo(0.7);
+    }
+
+    @Test
     void saveConfigShouldPreserveStoredApiKeyWhenApiKeyIsOmitted() {
         LlmConfigVO config = LlmConfigVO.builder()
                 .provider("deepseek")
@@ -275,6 +308,7 @@ class LlmConfigServiceTest {
         ArgumentCaptor<GeneralSettingsVO> captor = ArgumentCaptor.forClass(GeneralSettingsVO.class);
         verify(settingsService).saveGeneralSettings(captor.capture());
         assertThat(captor.getValue().getApiKey()).isBlank();
+        when(settingsService.getGeneralSettings()).thenReturn(captor.getValue());
         assertThat(llmConfigService.getConfig().getApiKey()).isBlank();
         assertThat(llmConfigService.getConfig().isApiKeyConfigured()).isFalse();
     }
@@ -550,6 +584,13 @@ class LlmConfigServiceTest {
 
     @Test
     void listModelsShouldUseSavedProvider() {
+        AtomicReference<GeneralSettingsVO> persisted = new AtomicReference<>(settingsService.getGeneralSettings());
+        when(settingsService.getGeneralSettings()).thenAnswer(invocation -> persisted.get());
+        doAnswer(invocation -> {
+            persisted.set(invocation.getArgument(0));
+            return null;
+        }).when(settingsService).saveGeneralSettings(any(GeneralSettingsVO.class));
+
         llmConfigService.saveConfig(LlmConfigVO.builder()
                 .provider("tongyi")
                 .apiKey("dashscope-key")
@@ -599,6 +640,13 @@ class LlmConfigServiceTest {
 
     @Test
     void listModelsShouldNotBlockConcurrentConfigReadsOrWrites() throws Exception {
+        AtomicReference<GeneralSettingsVO> persisted = new AtomicReference<>(settingsService.getGeneralSettings());
+        when(settingsService.getGeneralSettings()).thenAnswer(invocation -> persisted.get());
+        doAnswer(invocation -> {
+            persisted.set(invocation.getArgument(0));
+            return null;
+        }).when(settingsService).saveGeneralSettings(any(GeneralSettingsVO.class));
+
         CountDownLatch listingStarted = new CountDownLatch(1);
         CountDownLatch releaseListing = new CountDownLatch(1);
         when(llmClient.supports(any())).thenReturn(true);

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -16,11 +16,13 @@ import org.apache.rocketmq.studio.settings.DataSourceVO;
 import org.apache.rocketmq.studio.settings.GeneralSettingsVO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MybatisPlusSettingsRepositoryTest {
@@ -83,6 +85,21 @@ class MybatisPlusSettingsRepositoryTest {
 
         assertThat(loaded.getTheme()).isEqualTo("dark");
         assertThat(loaded.isRequireLogin()).isTrue();
+    }
+
+    @Test
+    void shouldPersistBlankApiKeyForExplicitLlmClearTest() throws Exception {
+        when(settingsMapper.selectOne(any())).thenReturn(null);
+
+        repository.saveGeneralSettings(GeneralSettingsVO.builder()
+                .theme("dark")
+                .apiKey("")
+                .build());
+
+        ArgumentCaptor<RmqSettings> captor = ArgumentCaptor.forClass(RmqSettings.class);
+        verify(settingsMapper).insert(captor.capture());
+        GeneralSettingsVO persisted = new ObjectMapper().readValue(captor.getValue().getJson(), GeneralSettingsVO.class);
+        assertThat(persisted.getApiKey()).isEmpty();
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -165,6 +165,9 @@ class SettingsServiceTest {
                 .deploymentName("production-gpt")
                 .apiVersion("2024-06-01")
                 .awsRegion("eu-west-1")
+                .llmEngine("http")
+                .maxTokens(8192)
+                .temperature(0.2)
                 .build();
         GeneralSettingsVO update = GeneralSettingsVO.builder()
                 .theme("light")
@@ -176,6 +179,9 @@ class SettingsServiceTest {
         assertThat(update.getDeploymentName()).isEqualTo("production-gpt");
         assertThat(update.getApiVersion()).isEqualTo("2024-06-01");
         assertThat(update.getAwsRegion()).isEqualTo("eu-west-1");
+        assertThat(update.getLlmEngine()).isEqualTo("http");
+        assertThat(update.getMaxTokens()).isEqualTo(8192);
+        assertThat(update.getTemperature()).isEqualTo(0.2);
     }
 
     @Test


### PR DESCRIPTION
Closes #813

## Summary

- Preserve omitted `llmEngine`, `maxTokens`, and `temperature` when General Settings receives a partial/reduced payload.
- Remove the in-memory LLM configuration override so runtime reads always reflect successfully persisted settings.
- Keep explicit blank API-key persistence for the clear-key path, while leaving the normal API-key persistence behavior from #2482 intact.

## Current scope after rebase

#2482 already covered the regular LLM API key persistence path. This refreshed PR intentionally keeps only the parts that are still independently needed on the current `rocketmq-studio` branch: partial General Settings preservation, no runtime/persistent-state divergence, and explicit key clearing semantics.

## Validation

- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=MybatisPlusSettingsRepositoryTest,LlmConfigServiceTest,SettingsServiceTest,SettingsControllerTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -DskipTests package`
- `git diff --cached --check`
- `git diff --check origin/rocketmq-studio..HEAD`