### PR TITLE
fix: preserve unavailable dashboard topology counts

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/ClusterOverviewVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/ClusterOverviewVO.java
@@ -37,7 +37,8 @@ public class ClusterOverviewVO {
     private ClusterType type;
     private ClusterStatus status;
     private int brokers;
-    private int proxies;
+    /** Null means Studio cannot discover the Proxy count through the selected access path. */
+    private Integer proxies;
     private int topics;
     private int groups;
     private long tpsIn;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardStatsVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/dashboard/DashboardStatsVO.java
@@ -30,8 +30,10 @@ public class DashboardStatsVO {
     private int totalClusters;
     private int healthyClusters;
     private int totalBrokers;
-    private int totalProxies;
-    private int totalNameServers;
+    /** Null means Studio cannot discover the count through the selected access path. */
+    private Integer totalProxies;
+    /** Null means Studio cannot discover the count through the selected access path. */
+    private Integer totalNameServers;
     private int totalTopics;
     private int totalConsumerGroups;
     private long totalMessagesToday;

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.provider.apache;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -34,6 +35,7 @@ import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.apache.rocketmq.studio.ops.dashboard.ClusterOverviewVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
@@ -69,20 +71,23 @@ public class RocketMQDashboardProvider implements DashboardProvider {
         String namesrvAddr = properties.getNamesrvAddr();
         if (!StringUtils.hasText(namesrvAddr)) {
             log.warn("NameServer address not configured, returning empty dashboard");
-            return emptyDashboard();
+            return unavailableTopologyDashboard();
         }
         return adminFactory.execute(namesrvAddr, null,
-                admin -> collectDashboardData(admin, ClusterType.V5_PROXY_CLUSTER));
+                admin -> collectDashboardData(admin, ClusterType.V5_PROXY_CLUSTER, countEndpoints(namesrvAddr)));
     }
 
     @Override
     public DashboardDataVO getDashboardData(String instanceId) {
         InstanceVO instance = runtimeAdminClientResolver.resolveInstance(instanceId);
+        Integer configuredNameServers = instance.getType() == InstanceType.DIRECT
+                ? countEndpoints(instance.getEndpoint()) : null;
         return runtimeAdminClientResolver.execute(instance,
-                admin -> collectDashboardData(admin, clusterTypeFor(instance)));
+                admin -> collectDashboardData(admin, clusterTypeFor(instance), configuredNameServers));
     }
 
-    private DashboardDataVO collectDashboardData(MQAdminExt admin, ClusterType clusterType) {
+    private DashboardDataVO collectDashboardData(
+            MQAdminExt admin, ClusterType clusterType, Integer configuredNameServers) {
         int totalClusters = 0;
         int totalBrokers = 0;
         int totalTopics = 0;
@@ -286,7 +291,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                         .type(clusterType)
                         .status(runtimeMetricsUnavailable ? ClusterStatus.warning : ClusterStatus.healthy)
                         .brokers(clusterBrokers)
-                        .proxies(0)
+                        .proxies(clusterType == ClusterType.V4_DIRECT ? 0 : null)
                         .topics(topicsByCluster.getOrDefault(clusterName, Set.of()).size())
                         .groups(groupsByCluster.getOrDefault(clusterName, Set.of()).size())
                         .tpsIn(clusterTpsIn)
@@ -314,8 +319,8 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 .totalClusters(totalClusters)
                 .healthyClusters(healthyClusters)
                 .totalBrokers(totalBrokers)
-                .totalProxies(0)
-                .totalNameServers(0)
+                .totalProxies(clusterType == ClusterType.V4_DIRECT ? 0 : null)
+                .totalNameServers(configuredNameServers)
                 .totalTopics(totalTopics)
                 .totalConsumerGroups(totalGroups)
                 .totalMessagesToday(messagesToday)
@@ -338,13 +343,13 @@ public class RocketMQDashboardProvider implements DashboardProvider {
         };
     }
 
-    private DashboardDataVO emptyDashboard() {
+    private DashboardDataVO unavailableTopologyDashboard() {
         DashboardStatsVO stats = DashboardStatsVO.builder()
                 .totalClusters(0)
                 .healthyClusters(0)
                 .totalBrokers(0)
-                .totalProxies(0)
-                .totalNameServers(0)
+                .totalProxies(null)
+                .totalNameServers(null)
                 .totalTopics(0)
                 .totalConsumerGroups(0)
                 .totalMessagesToday(0)
@@ -356,6 +361,17 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                 .stats(stats)
                 .clusters(List.of())
                 .build();
+    }
+
+    private int countEndpoints(String endpoint) {
+        if (!StringUtils.hasText(endpoint)) {
+            return 0;
+        }
+        return (int) Arrays.stream(endpoint.split("[;,]"))
+                .map(String::trim)
+                .filter(address -> !address.isEmpty())
+                .distinct()
+                .count();
     }
 
     /**

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardControllerTest.java
@@ -90,6 +90,8 @@ class DashboardControllerTest {
                 .andExpect(jsonPath("$.data.stats.totalClusters").value(2))
                 .andExpect(jsonPath("$.data.stats.healthyClusters").value(2))
                 .andExpect(jsonPath("$.data.stats.totalBrokers").value(6))
+                .andExpect(jsonPath("$.data.stats.totalProxies").value(2))
+                .andExpect(jsonPath("$.data.stats.totalNameServers").value(4))
                 .andExpect(jsonPath("$.data.stats.totalTopics").value(80))
                 .andExpect(jsonPath("$.data.stats.messagesPerSecond").value(250))
                 .andExpect(jsonPath("$.data.clusters").isArray())
@@ -99,6 +101,36 @@ class DashboardControllerTest {
                 .andExpect(jsonPath("$.data.clusters[0].version").value("5.1.0"));
 
         verify(dashboardService).getDashboard(isNull());
+    }
+
+    @Test
+    void getDashboardShouldPreserveUnavailableTopologyCounts() throws Exception {
+        DashboardStatsVO stats = DashboardStatsVO.builder()
+                .totalClusters(1)
+                .healthyClusters(1)
+                .totalBrokers(2)
+                .totalProxies(null)
+                .totalNameServers(null)
+                .build();
+        ClusterOverviewVO cluster = ClusterOverviewVO.builder()
+                .id("proxy-cluster")
+                .name("proxy-cluster")
+                .type(ClusterType.V5_PROXY_CLUSTER)
+                .status(ClusterStatus.healthy)
+                .brokers(2)
+                .proxies(null)
+                .build();
+        DashboardDataVO data = DashboardDataVO.builder()
+                .stats(stats)
+                .clusters(List.of(cluster))
+                .build();
+        when(dashboardService.getDashboard(isNull())).thenReturn(data);
+
+        mockMvc.perform(get("/api/dashboard"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.stats.totalProxies").doesNotExist())
+                .andExpect(jsonPath("$.data.stats.totalNameServers").doesNotExist())
+                .andExpect(jsonPath("$.data.clusters[0].proxies").doesNotExist());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -377,6 +377,9 @@ class RocketMQDashboardProviderTest {
 
         assertThat(dashboard.getClusters()).hasSize(1);
         assertThat(dashboard.getClusters().get(0).getType()).isEqualTo(ClusterType.V4_DIRECT);
+        assertThat(dashboard.getClusters().get(0).getProxies()).isZero();
+        assertThat(dashboard.getStats().getTotalProxies()).isZero();
+        assertThat(dashboard.getStats().getTotalNameServers()).isEqualTo(1);
         verify(resolver).execute(eq(instance), any());
     }
 
@@ -401,6 +404,45 @@ class RocketMQDashboardProviderTest {
         assertThat(dashboard.getClusters()).singleElement()
                 .extracting(cluster -> cluster.getType())
                 .isEqualTo(ClusterType.V5_PROXY_LOCAL);
+        assertThat(dashboard.getClusters().get(0).getProxies()).isNull();
+        assertThat(dashboard.getStats().getTotalProxies()).isNull();
+        assertThat(dashboard.getStats().getTotalNameServers()).isNull();
+    }
+
+    @Test
+    void dashboardShouldCountConfiguredDirectNameServerEndpoints() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        InstanceVO instance = InstanceVO.builder()
+                .type(InstanceType.DIRECT)
+                .endpoint(" ns-a:9876 ; ns-b:9876,ns-a:9876 ;; ")
+                .build();
+        instance.setId(1L);
+        when(resolver.resolveInstance("instance-direct")).thenReturn(instance);
+        when(resolver.execute(eq(instance), any())).thenAnswer(invocation ->
+                invocation.<MqAdminExtFactory.AdminAction<DashboardDataVO>>getArgument(1).apply(adminExt));
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = newProvider(adminExt, resolver).getDashboardData("instance-direct");
+
+        assertThat(dashboard.getStats().getTotalNameServers()).isEqualTo(2);
+    }
+
+    @Test
+    void dashboardShouldReportUnconfiguredLegacyTopologyAsUnavailable() {
+        RocketMQProperties properties = new RocketMQProperties();
+        properties.setNamesrvAddr(" ");
+        RocketMQDashboardProvider provider = new RocketMQDashboardProvider(
+                mock(MqAdminExtFactory.class), properties, mock(RuntimeAdminClientResolver.class));
+
+        DashboardDataVO dashboard = provider.getDashboardData();
+
+        assertThat(dashboard.getStats().getTotalClusters()).isZero();
+        assertThat(dashboard.getStats().getTotalProxies()).isNull();
+        assertThat(dashboard.getStats().getTotalNameServers()).isNull();
+        assertThat(dashboard.getClusters()).isEmpty();
     }
 
     @Test

--- a/web/src/api/metrics.ts
+++ b/web/src/api/metrics.ts
@@ -10,8 +10,8 @@ export interface DashboardStats {
   totalClusters: number;
   healthyClusters: number;
   totalBrokers: number;
-  totalProxies: number;
-  totalNameServers: number;
+  totalProxies: number | null;
+  totalNameServers: number | null;
   totalTopics: number;
   totalConsumerGroups: number;
   totalMessagesToday: number;
@@ -26,7 +26,7 @@ export interface ClusterOverview {
   type: string;
   status: string;
   brokers: number;
-  proxies: number;
+  proxies: number | null;
   topics: number;
   groups: number;
   tpsIn: number;

--- a/web/src/pages/home/__tests__/DashboardPage.test.tsx
+++ b/web/src/pages/home/__tests__/DashboardPage.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { App } from 'antd';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
@@ -50,6 +50,19 @@ const dashboard = (name: string): DashboardData => ({
       throughput: [1],
     },
   ],
+});
+
+const unavailableTopologyDashboard = (): DashboardData => ({
+  ...dashboard('proxy-cluster'),
+  stats: {
+    ...dashboard('proxy-cluster').stats,
+    totalProxies: null,
+    totalNameServers: null,
+  },
+  clusters: dashboard('proxy-cluster').clusters.map((cluster) => ({
+    ...cluster,
+    proxies: null,
+  })),
 });
 
 const deferred = <T,>() => {
@@ -119,6 +132,18 @@ beforeEach(() => {
 });
 
 describe('DashboardPage', () => {
+  it('renders unavailable Proxy topology counts as N/A instead of zero', async () => {
+    vi.mocked(dashboardService.getDashboard).mockResolvedValue(unavailableTopologyDashboard());
+    renderWithProviders(<DashboardPage />);
+
+    await screen.findByText('proxy-cluster');
+    expect(await screen.findByText(/1 Brokers · N\/A Proxy/u)).toBeInTheDocument();
+    expect(screen.queryByText('0 Proxy')).not.toBeInTheDocument();
+    const row = screen.getByText('proxy-cluster').closest('tr');
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getAllByText('N/A').length).toBeGreaterThanOrEqual(1);
+  });
+
   it('does not show dashboard data from the previous instance while loading a new selection', async () => {
     const instanceA = deferred<DashboardData>();
     vi.mocked(dashboardService.getDashboard)

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -29,6 +29,9 @@ import { useLang } from '../../i18n/LangContext';
 
 const { Text } = Typography;
 
+const renderTopologyCount = (value: number | null) =>
+  value === null ? 'N/A' : value.toLocaleString();
+
 const DashboardPage = () => {
   const navigate = useNavigate();
   const { t } = useLang();
@@ -144,7 +147,7 @@ const DashboardPage = () => {
       icon: <ClusterOutlined style={{ fontSize: 22, color: '#52c41a' }} />,
       color: '#52c41a',
       suffix: '',
-      detail: `${stats.totalBrokers} Brokers · ${stats.totalProxies} Proxy`,
+      detail: `${stats.totalBrokers} Brokers · ${renderTopologyCount(stats.totalProxies)} Proxy`,
     },
     {
       title: t('dashboard.topics'),
@@ -209,7 +212,7 @@ const DashboardPage = () => {
       key: 'brokers',
       width: 80,
       align: 'center' as const,
-      render: (v: number) => Math.max(0, v),
+      render: renderTopologyCount,
     },
     {
       title: t('dashboard.proxy'),
@@ -217,7 +220,7 @@ const DashboardPage = () => {
       key: 'proxies',
       width: 80,
       align: 'center' as const,
-      render: (v: number) => Math.max(0, v),
+      render: renderTopologyCount,
     },
     {
       title: t('dashboard.topic'),


### PR DESCRIPTION
## Why

The Apache dashboard provider still hardcodes Proxy and NameServer topology counts to `0`. Because both the backend response contract and the frontend types model those values as non-null numbers, the home page renders "0 Proxy" and a Proxy count of `0` even when Studio cannot discover the topology through the selected access path.

This is different from "there are no Proxy nodes". A Proxy access endpoint may be a load balancer and does not reveal the number of Proxy or NameServer nodes behind it. The legacy no-instance path has the same problem when no NameServer is configured.

This is based on the still-current issue #1947. The earlier #1948 was closed as superseded by #1953, and #1953 was later superseded by #2307, but #2307 did not carry the nullable topology-count contract.

## Backend contract

`DashboardStatsVO.totalProxies`, `DashboardStatsVO.totalNameServers`, and `ClusterOverviewVO.proxies` now use nullable `Integer`:

- `null` means unavailable through the selected access path;
- `0` is retained only when the architecture makes absence known.

Counting rules:

- selected `DIRECT` instances:
  - NameServer count is derived from the configured endpoint list (`;`/`,` separated, trimmed, deduplicated);
  - Proxy count is a known `0`.
- selected Proxy instances:
  - Proxy and NameServer topology remain `null`;
  - no claim is made about nodes hidden behind a Proxy/load-balancer endpoint.
- legacy no-instance path:
  - NameServer count is derived from the configured `rocketmq.namesrvAddr`;
  - Proxy topology remains `null`.
- when no endpoint is configured at all, topology counts remain `null` rather than being converted into false zeroes.

The AI dashboard tool forwards the nullable values unchanged; clients can distinguish unknown topology from a real zero.

## Frontend

`DashboardStats` and `ClusterOverview` now model the topology counts as `number | null`. The home dashboard renders unavailable values as `N/A`, including the summary detail and the per-cluster Proxy column.

## Size

Production/API/UI change, excluding tests:

- 40 additions
- 18 deletions

Complete PR, including tests:

- 136 additions
- 18 deletions

The small production footprint is intentional: this is a contract-correctness fix, not filler. It is not part of the "100+ line" batch; it is submitted because #1947 is an existing confirmed issue that remains open.

## Testing

Backend focused:

```text
mvn -Dtest=RocketMQDashboardProviderTest,DashboardControllerTest test
30 tests
0 failures
0 errors
BUILD SUCCESS
Checkstyle: 0 violations
```

Backend full suite:

```text
mvn -DskipTests=false test
1,471 tests
0 failures
0 errors
BUILD SUCCESS
```

Frontend focused:

```text
npm test -- src/pages/home/__tests__/DashboardPage.test.tsx src/api/metrics.test.ts
2 files
14 tests
all passed
```

Frontend full verification:

```text
npm test
all passed

npm run build
success

npm run lint
0 errors
1 pre-existing react-hooks warning in src/pages/instance/topic.tsx
```

Targeted ESLint and Prettier checks pass. `git diff --check` passes.

Tests are deterministic unit/controller/UI tests. No live Broker or Proxy cluster is claimed.

Closes #1947.
