### PR TITLE
fix: normalize batch instance deletion ids

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -476,14 +476,20 @@ public class InstanceService {
         if (instanceIds == null || instanceIds.isEmpty()) {
             throw new BusinessException(400, "Instance IDs are required");
         }
+        List<String> normalizedIds = instanceIds.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(instanceId -> !instanceId.isEmpty())
+                .distinct()
+                .toList();
+        if (normalizedIds.isEmpty()) {
+            throw new BusinessException(400, "Instance IDs are required");
+        }
         int deleted = 0;
         List<String> failed = new ArrayList<>();
-        for (String instanceId : instanceIds) {
-            if (instanceId == null || instanceId.isBlank()) {
-                continue;
-            }
+        for (String instanceId : normalizedIds) {
             try {
-                deleteInstance(resolveInstanceId(instanceId.trim()));
+                deleteInstance(resolveInstanceId(instanceId));
                 deleted++;
             } catch (BusinessException ex) {
                 failed.add(instanceId + ": " + ex.getMessage());

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -758,6 +758,32 @@ class InstanceServiceTest {
     }
 
     @Test
+    void deleteInstancesShouldDeduplicateTrimmedIdentifiersTest() {
+        InstanceVO existing = InstanceVO.builder().name("inst-a").build();
+        existing.setId(1L);
+        when(instanceRepository.findByIdentifier("inst-a")).thenReturn(Optional.of(existing));
+        when(instanceRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("1")).thenReturn(0);
+        when(instanceProvider.countGroups("1")).thenReturn(0);
+        when(instanceRepository.deleteById(1L)).thenReturn(true);
+
+        BatchDeleteResultVO result = instanceService.deleteInstances(List.of("inst-a", " inst-a ", "inst-a"));
+
+        assertThat(result.getDeleted()).isEqualTo(1);
+        assertThat(result.getFailed()).isEmpty();
+        verify(instanceRepository).deleteById(1L);
+    }
+
+    @Test
+    void deleteInstancesShouldRejectAllBlankIdentifiersTest() {
+        assertThatThrownBy(() -> instanceService.deleteInstances(Arrays.asList(" ", null, "")))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Instance IDs are required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+    }
+
+    @Test
     void deleteInstanceShouldRejectInstanceWithTopics() {
         InstanceVO existing = InstanceVO.builder()
                 .name("with-topics")


### PR DESCRIPTION
## Why

`POST /api/instances/delete-batch` iterates over the raw request list and only skips null/blank entries. Repeated IDs are not normalized or de-duplicated:

```java
for (String instanceId : instanceIds) {
    if (instanceId == null || instanceId.isBlank()) {
        continue;
    }
    deleteInstance(resolveInstanceId(instanceId.trim()));
    deleted++;
}
```

A request such as `["inst-a", "inst-a"]` processes the same row twice. A request such as `["", " "]` is accepted as a non-empty batch and returns `deleted=0, failed=[]` instead of a validation error.

Closes #2420.

## Change

`InstanceService.deleteInstances` now normalizes the request once before deletion:

- null entries are ignored;
- IDs are trimmed;
- empty IDs are discarded;
- repeated IDs are de-duplicated;
- if no usable ID remains, the request returns HTTP 400 with the existing `Instance IDs are required` error.

Deletion behavior for distinct IDs is unchanged. Existing managed-resource checks, data-source binding cleanup, endpoint cleanup, audits, and per-instance failure reporting remain exactly as before.

## Verification

Focused tests:

```text
mvn "-Dtest=InstanceServiceTest#deleteInstances*" test
4 tests
0 failures
0 errors
BUILD SUCCESS
Checkstyle: 0 violations
```

Full backend suite:

```text
mvn -DskipTests=false test
1,483 tests
0 failures
0 errors
BUILD SUCCESS
```

`git diff --check` passes.

The new tests cover:

- repeated and whitespace-padded IDs resolve to one deletion with no duplicate failure;
- an all-null/blank/empty request returns HTTP 400;
- the existing valid/missing mixed batch behavior remains covered.

No frontend change is needed because the normal UI sends AntD table row keys and does not intentionally create duplicates. This PR fixes the directly callable API contract.
