### PR TITLE
feat: consume paginated cloud credential inventory

### DIFF
--- a/web/src/pages/settings/CloudCredentialTab.tsx
+++ b/web/src/pages/settings/CloudCredentialTab.tsx
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Button,
+  Input,
   Descriptions,
   Flex,
   Form,
-  Input,
   Modal,
   Popconfirm,
   Select,
@@ -32,6 +32,7 @@ import {
 } from 'antd';
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
+import { MagnifyingGlass } from '@phosphor-icons/react';
 
 import {
   createCloudCredential,
@@ -57,6 +58,8 @@ const VENDOR_OPTIONS = [
   { value: 'TENCENT', label: '腾讯云' },
 ];
 
+const PAGE_SIZE_OPTIONS = [20, 50, 100];
+
 interface CredentialFormValues {
   name: string;
   vendor: InstanceVendor;
@@ -67,28 +70,76 @@ interface CredentialFormValues {
 
 export const CloudCredentialTab = () => {
   const [credentials, setCredentials] = useState<CloudCredential[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [vendorFilter, setVendorFilter] = useState<InstanceVendor | undefined>();
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const [loading, setLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
   const [editingCredential, setEditingCredential] = useState<CloudCredential | null>(null);
   const [form] = Form.useForm<CredentialFormValues>();
   const [submitting, setSubmitting] = useState(false);
+  const requestSeqRef = useRef(0);
 
   useEffect(() => {
-    let cancelled = false;
-    void listCloudCredentials()
-      .then((result) => {
-        if (!cancelled) setCredentials(result.items);
-      })
-      .catch(() => {
-        if (!cancelled) message.error('云凭据加载失败，请稍后重试');
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    const timer = window.setTimeout(() => setDebouncedSearch(search.trim()), 300);
+    return () => window.clearTimeout(timer);
+  }, [search]);
+
+  const loadCredentials = useCallback(() => {
+    const requestId = ++requestSeqRef.current;
+    Promise.resolve().then(() => {
+      if (requestId === requestSeqRef.current) {
+        setLoading(true);
+      }
+    });
+    return (async () => {
+      try {
+        const result = await listCloudCredentials(vendorFilter, debouncedSearch, page, pageSize);
+        if (requestId !== requestSeqRef.current) return;
+        if (result.items.length === 0 && result.total > 0 && page > 1) {
+          const lastPage = Math.max(1, Math.ceil(result.total / result.size));
+          if (page > lastPage) {
+            setPage(lastPage);
+            return;
+          }
+        }
+        setCredentials(result.items);
+        setTotal(result.total);
+      } catch {
+        if (requestId === requestSeqRef.current) {
+          message.error('云凭据加载失败，请稍后重试');
+        }
+      } finally {
+        if (requestId === requestSeqRef.current) {
+          setLoading(false);
+        }
+      }
+    })();
+  }, [debouncedSearch, page, pageSize, vendorFilter]);
+
+  useEffect(() => {
+    void loadCredentials();
+  }, [loadCredentials]);
+
+  useEffect(
+    () => () => {
+      requestSeqRef.current += 1;
+    },
+    [],
+  );
+
+  const changeVendorFilter = (value?: InstanceVendor) => {
+    setVendorFilter(value);
+    setPage(1);
+  };
+
+  const changeSearch = (value: string) => {
+    setSearch(value);
+    setPage(1);
+  };
 
   const closeModal = () => {
     setModalOpen(false);
@@ -126,16 +177,17 @@ export const CloudCredentialTab = () => {
         setCredentials((previous) => previous.map((item) => (item.id === saved.id ? saved : item)));
         message.success('云凭据已更新');
       } else {
-        const saved = await createCloudCredential({
+        await createCloudCredential({
           name: values.name,
           vendor: values.vendor,
           accessKey: values.accessKey ?? '',
           secretKey: values.secretKey ?? '',
           remark: values.remark,
         });
-        setCredentials((previous) => [...previous, saved]);
+        setPage(1);
         message.success('云凭据已添加');
       }
+      await loadCredentials();
       closeModal();
     } catch (error) {
       if (error && typeof error === 'object' && 'errorFields' in error) {
@@ -150,7 +202,12 @@ export const CloudCredentialTab = () => {
   const handleDelete = async (credential: CloudCredential) => {
     try {
       await deleteCloudCredential(credential.id);
-      setCredentials((previous) => previous.filter((item) => item.id !== credential.id));
+      const remainingOnPage = credentials.length - 1;
+      if (remainingOnPage === 0 && page > 1) {
+        setPage(page - 1);
+      } else {
+        await loadCredentials();
+      }
       message.success('云凭据已删除');
     } catch {
       message.error('删除云凭据失败（可能仍被实例引用），请稍后重试');
@@ -200,7 +257,25 @@ export const CloudCredentialTab = () => {
 
   return (
     <>
-      <Flex justify="flex-end" style={{ marginBottom: 16 }}>
+      <Flex justify="space-between" align="center" gap={12} wrap style={{ marginBottom: 16 }}>
+        <Flex gap={12} align="center" wrap>
+          <Input
+            allowClear
+            prefix={<MagnifyingGlass size={14} color="#9CA3AF" />}
+            placeholder="搜索凭据名称"
+            style={{ width: 240 }}
+            value={search}
+            onChange={(event) => changeSearch(event.target.value)}
+          />
+          <Select<InstanceVendor>
+            allowClear
+            placeholder="全部云厂商"
+            style={{ width: 160 }}
+            value={vendorFilter}
+            onChange={changeVendorFilter}
+            options={VENDOR_OPTIONS}
+          />
+        </Flex>
         <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal} disabled={loading}>
           添加云凭据
         </Button>
@@ -211,7 +286,22 @@ export const CloudCredentialTab = () => {
         dataSource={credentials}
         rowKey="id"
         loading={loading}
-        pagination={false}
+        pagination={{
+          current: page,
+          pageSize,
+          total,
+          showSizeChanger: true,
+          pageSizeOptions: PAGE_SIZE_OPTIONS.map(String),
+          showTotal: (count) => `共 ${count} 条`,
+          onChange: (nextPage, nextPageSize) => {
+            if (nextPageSize !== pageSize) {
+              setPage(1);
+              setPageSize(nextPageSize);
+            } else {
+              setPage(nextPage);
+            }
+          },
+        }}
         size="middle"
       />
 

--- a/web/src/pages/settings/__tests__/CloudCredentialTab.test.tsx
+++ b/web/src/pages/settings/__tests__/CloudCredentialTab.test.tsx
@@ -52,6 +52,14 @@ const credentials: CloudCredentialPage = {
   size: 20,
 };
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+};
+
 const renderTab = () =>
   render(
     <App>
@@ -91,6 +99,62 @@ describe('CloudCredentialTab', () => {
     expect(screen.getByText('阿里云')).toBeInTheDocument();
   });
 
+  it('loads the first page and sends the selected filters', async () => {
+    renderTab();
+
+    await waitFor(() => expect(listCloudCredentials).toHaveBeenCalledWith(undefined, '', 1, 20));
+  });
+
+  it('resets to the first page and queries filters after they change', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderTab();
+    await waitFor(() => expect(listCloudCredentials).toHaveBeenCalled());
+
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(
+      await screen.findByText('阿里云', { selector: '.ant-select-item-option-content' }),
+    );
+    await user.type(screen.getByPlaceholderText('搜索凭据名称'), 'prod');
+
+    await waitFor(() => expect(listCloudCredentials).toHaveBeenCalledWith('ALIYUN', 'prod', 1, 20));
+  });
+
+  it('does not let a stale credential response overwrite the latest filters', async () => {
+    const initial = deferred<CloudCredentialPage>();
+    const latest = deferred<CloudCredentialPage>();
+    vi.mocked(listCloudCredentials)
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(latest.promise);
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderTab();
+
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(await screen.findByText('腾讯云'));
+    await waitFor(() =>
+      expect(listCloudCredentials).toHaveBeenLastCalledWith('TENCENT', '', 1, 20),
+    );
+
+    latest.resolve({
+      items: [
+        {
+          id: 9,
+          name: 'latest-credential',
+          vendor: 'TENCENT',
+          accessKey: 'AKID****9999',
+          gmtCreate: '2026-08-18T12:00:00',
+        },
+      ],
+      total: 1,
+      page: 1,
+      size: 20,
+    });
+    await screen.findByText('latest-credential');
+
+    initial.resolve(credentials);
+    await waitFor(() => expect(screen.getByText('latest-credential')).toBeInTheDocument());
+    expect(screen.queryByText('aliyun-test')).not.toBeInTheDocument();
+  });
+
   it('creates a credential from the modal form', async () => {
     vi.mocked(createCloudCredential).mockResolvedValue({
       id: 2,
@@ -106,9 +170,8 @@ describe('CloudCredentialTab', () => {
     await user.click(screen.getByRole('button', { name: /添加云凭据/ }));
 
     const dialog = await screen.findByRole('dialog');
-    await user.type(within(dialog).getByPlaceholderText(/请输入凭据名称|例如/), 'tencent-prod');
-    // fill name field explicitly (placeholder shared with example text)
-    await user.click(within(dialog).getByLabelText('云厂商'));
+    await user.type(within(dialog).getByPlaceholderText(/例如/), 'tencent-prod');
+    await user.click(within(dialog).getAllByRole('combobox')[0]);
     await user.click(await screen.findByText('腾讯云'));
     await user.type(screen.getByPlaceholderText('LTAI...'), 'AKID000000009999');
     await user.type(screen.getByPlaceholderText('请输入 SecretKey'), 'secret-9999');
@@ -123,7 +186,9 @@ describe('CloudCredentialTab', () => {
         remark: undefined,
       }),
     );
-    await waitFor(() => expect(screen.getByText('tencent-prod')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(listCloudCredentials).toHaveBeenLastCalledWith(undefined, '', 1, 20),
+    );
   });
 
   it('updates name and remark while keeping the secret unchanged when blank', async () => {
@@ -155,7 +220,9 @@ describe('CloudCredentialTab', () => {
         remark: '新备注',
       }),
     );
-    await waitFor(() => expect(screen.getByText('aliyun-renamed')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(listCloudCredentials).toHaveBeenLastCalledWith(undefined, '', 1, 20),
+    );
   });
 
   it('deletes a credential after confirmation', async () => {
@@ -168,6 +235,8 @@ describe('CloudCredentialTab', () => {
     await user.click(await screen.findByRole('button', { name: /确\s*定/ }));
 
     await waitFor(() => expect(deleteCloudCredential).toHaveBeenCalledWith(1));
-    await waitFor(() => expect(screen.queryByText('aliyun-test')).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(listCloudCredentials).toHaveBeenLastCalledWith(undefined, '', 1, 20),
+    );
   });
 });


### PR DESCRIPTION
## Why

#2306 gave the backend a bounded cloud-credential inventory:

```text
GET /api/cloud-credentials?vendor=&search=&page=&pageSize=
```

The repository applies vendor/name filtering and page bounds at the SQL layer and returns `PageResult<CloudCredentialVO>`.

The Settings page did not consume that contract. It requested only the default first page, unwrapped `result.items`, and rendered the table with `pagination={false}`. Credentials beyond the first 20 rows could not be reached, and the API's vendor/name filters were not exposed to the user. Create and delete also only patched the local first-page array.

Closes #2424.

## What changes

The Cloud Credential tab is now a real inventory view:

- vendor filter (`ALIYUN` / `TENCENT`);
- debounced name search;
- server-side pagination with 20/50/100 page-size options;
- server-provided total row count;
- filters reset the page to 1;
- request sequencing prevents a stale response from overwriting a newer filter result;
- if the current page becomes empty while later rows still exist, the page moves to the latest valid page;
- creating a credential refreshes the server page instead of appending to an unbounded local list;
- updating a credential still replaces the row with the masked server response;
- deleting the last row on a later page moves to the previous page;
- the existing masked AccessKey and write-only SecretKey behavior is unchanged.

## Size

Production/UI code, excluding tests:

- 112 additions
- 22 deletions

Complete PR, including tests:

- 187 additions
- 28 deletions

The production change exceeds 100 lines naturally from the full filter/pagination/race/mutation flow, not from test padding.

## Verification

Focused tests:

```text
npm test -- src/pages/settings/__tests__/CloudCredentialTab.test.tsx src/api/cloudCredential.test.ts
2 files
10 tests
all passed
```

Full frontend suite:

```text
npm test
94 test files
636 tests
all passed
```

Build:

```text
npm run build
success
```

Lint:

```text
npm run lint
0 errors
1 pre-existing react-hooks warning in src/pages/instance/topic.tsx
```

Targeted ESLint and Prettier checks pass. `git diff --check` passes.

Tests cover:

- initial page/pageSize request;
- vendor and debounced search filters resetting to page 1;
- stale-response suppression after a filter change;
- create/update/delete refreshing the canonical server page;
- existing masked-key and modal behavior.
