### PR TITLE
feat: add paginated K8s certificate inventory

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertController.java
@@ -17,6 +17,9 @@
 package org.apache.rocketmq.studio.cluster.k8s;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
+import org.apache.rocketmq.studio.common.domain.enums.CertType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +27,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -38,6 +42,17 @@ public class K8sCertController {
     @GetMapping
     public Result<List<K8sCertVO>> listCerts() {
         return Result.ok(k8sCertService.listCerts());
+    }
+
+    @GetMapping("/page")
+    public Result<PageResult<K8sCertVO>> listCertsPage(
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String cluster,
+            @RequestParam(required = false) CertType type,
+            @RequestParam(required = false) CertStatus status,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return Result.ok(k8sCertService.listCerts(search, cluster, type, status, page, pageSize));
     }
 
     @PostMapping("/create")

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertRepository.java
@@ -20,9 +20,16 @@ package org.apache.rocketmq.studio.cluster.k8s;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
+import org.apache.rocketmq.studio.common.domain.enums.CertType;
+
 public interface K8sCertRepository {
 
     List<K8sCertVO> findAll();
+
+    PageResult<K8sCertVO> findPage(String search, String cluster, CertType type,
+            CertStatus status, int page, int pageSize);
 
     Optional<K8sCertVO> findById(Long id);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.k8s;
 
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import lombok.extern.slf4j.Slf4j;
@@ -65,6 +66,22 @@ public class K8sCertService {
         return k8sCertRepository.findAll().stream()
                 .map(cert -> refreshExpirationState(cert, now))
                 .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    public PageResult<K8sCertVO> listCerts(String search, String cluster, CertType type,
+            CertStatus status, int page, int pageSize) {
+        if (page < 1 || pageSize < 1 || pageSize > 100) {
+            throw new BusinessException(400, "Invalid page or pageSize");
+        }
+        log.info("Listing K8s certificates page={}, pageSize={}, cluster={}, type={}, status={}",
+                page, pageSize, cluster, type, status);
+        PageResult<K8sCertVO> result = k8sCertRepository.findPage(
+                normalizeFilter(search), normalizeFilter(cluster), type, status, page, pageSize);
+        LocalDateTime now = LocalDateTime.now(clock);
+        List<K8sCertVO> refreshed = result.getItems().stream()
+                .map(cert -> refreshExpirationState(cert, now))
+                .collect(Collectors.toCollection(ArrayList::new));
+        return PageResult.of(refreshed, result.getTotal(), page, pageSize);
     }
 
     public K8sCertVO createCert(CreateCertDTO command) {
@@ -203,6 +220,13 @@ public class K8sCertService {
             throw new BusinessException(400, "Certificate " + field + " cannot be blank");
         }
         return normalized;
+    }
+
+    private String normalizeFilter(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
     }
 
     private K8sCertVO refreshExpirationState(K8sCertVO cert, LocalDateTime now) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -17,9 +17,11 @@
 package org.apache.rocketmq.studio.cluster.k8s;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -52,6 +54,24 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         return certMapper.selectList(new QueryWrapper<RmqK8sCertificate>().orderByAsc("k8s_id")).stream()
                 .map(this::toVO)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public PageResult<K8sCertVO> findPage(String search, String cluster, CertType type,
+            CertStatus status, int page, int pageSize) {
+        String normalizedSearch = normalizeFilter(search);
+        String normalizedCluster = normalizeFilter(cluster);
+        QueryWrapper<RmqK8sCertificate> query = new QueryWrapper<RmqK8sCertificate>()
+                .like(normalizedSearch != null, "k8s_id", normalizedSearch)
+                .like(normalizedSearch != null, "cluster", normalizedSearch)
+                .eq(normalizedCluster != null, "cluster", normalizedCluster)
+                .eq(type != null, "cert_type", type == null ? null : type.name())
+                .eq(status != null, "status", status == null ? null : status.name())
+                .orderByDesc("gmt_modified", "id");
+
+        Page<RmqK8sCertificate> result = certMapper.selectPage(new Page<>(page, pageSize), query);
+        return PageResult.of(result.getRecords().stream().map(this::toVO).toList(),
+                result.getTotal(), page, pageSize);
     }
 
     @Override
@@ -175,5 +195,12 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException("Failed to serialize certificate SAN values", exception);
         }
+    }
+
+    private String normalizeFilter(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.cluster.k8s;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -82,6 +84,33 @@ class K8sCertControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    void listCertsPageShouldReturnPageContract() throws Exception {
+        K8sCertVO cert = buildCert(1L, "rocketmq-tls", CertType.TLS, CertStatus.valid);
+        cert.setCluster("prod-cluster");
+        when(k8sCertService.listCerts("rocketmq", "prod-cluster", CertType.TLS,
+                CertStatus.valid, 2, 20))
+                .thenReturn(PageResult.of(List.of(cert), 21, 2, 20));
+
+        mockMvc.perform(get("/api/k8s-certs/page")
+                        .param("search", "rocketmq")
+                        .param("cluster", "prod-cluster")
+                        .param("type", "TLS")
+                        .param("status", "valid")
+                        .param("page", "2")
+                        .param("pageSize", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.items[0].id").value(1))
+                .andExpect(jsonPath("$.data.items[0].k8sId").value("rocketmq-tls"))
+                .andExpect(jsonPath("$.data.total").value(21))
+                .andExpect(jsonPath("$.data.page").value(2))
+                .andExpect(jsonPath("$.data.size").value(20));
+
+        verify(k8sCertService).listCerts("rocketmq", "prod-cluster", CertType.TLS,
+                CertStatus.valid, 2, 20);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.cluster.k8s;
 
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,6 +111,39 @@ class K8sCertServiceTest {
         List<K8sCertVO> result = k8sCertService.listCerts();
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void listCertsPageShouldReturnBoundedPageWithRefreshedExpiry() {
+        PageResult<K8sCertVO> repositoryPage = PageResult.of(List.of(sampleCert), 21, 2, 20);
+        sampleCert.setNotAfter(LocalDateTime.now(CLOCK).minusDays(1));
+        sampleCert.setStatus(CertStatus.valid);
+        sampleCert.setDaysRemaining(180);
+        when(k8sCertRepository.findPage("rocketmq", "prod-cluster", CertType.TLS,
+                CertStatus.expired, 2, 20)).thenReturn(repositoryPage);
+
+        PageResult<K8sCertVO> result = k8sCertService.listCerts(
+                " rocketmq ", " prod-cluster ", CertType.TLS, CertStatus.expired, 2, 20);
+
+        assertThat(result.getTotal()).isEqualTo(21);
+        assertThat(result.getPage()).isEqualTo(2);
+        assertThat(result.getSize()).isEqualTo(20);
+        assertThat(result.getItems()).hasSize(1);
+        assertThat(result.getItems().get(0).getStatus()).isEqualTo(CertStatus.expired);
+        assertThat(result.getItems().get(0).getDaysRemaining()).isEqualTo(-1);
+        verify(k8sCertRepository).findPage("rocketmq", "prod-cluster", CertType.TLS,
+                CertStatus.expired, 2, 20);
+    }
+
+    @Test
+    void listCertsPageShouldRejectInvalidPaginationBeforeRepositoryAccess() {
+        assertThatThrownBy(() -> k8sCertService.listCerts(null, null, null, null, 0, 20))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Invalid page or pageSize");
+        assertThatThrownBy(() -> k8sCertService.listCerts(null, null, null, null, 1, 101))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Invalid page or pageSize");
+        verifyNoInteractions(k8sCertRepository);
     }
 
     @Test

--- a/web/src/api/cluster.test.ts
+++ b/web/src/api/cluster.test.ts
@@ -26,6 +26,7 @@ import {
   getNameServerConfigDiff,
   getCluster,
   listK8sCerts,
+  listK8sCertsPage,
   renewK8sCert,
   restartBroker,
   restartNameServer,
@@ -66,6 +67,31 @@ describe('K8s certificate API', () => {
     mock.onGet('/k8s-certs').reply(200, { code: 200, message: 'success', data: [cert] });
 
     await expect(listK8sCerts()).resolves.toEqual([cert]);
+  });
+
+  it('loads a filtered certificate page', async () => {
+    mock.onGet('/k8s-certs/page').reply((config) => {
+      expect(config.params).toEqual({
+        search: 'rocketmq',
+        cluster: 'prod',
+        type: 'TLS',
+        status: 'valid',
+        page: 2,
+        pageSize: 50,
+      });
+      return [200, { code: 200, message: 'success', data: { items: [cert], total: 21, page: 2, size: 50 } }];
+    });
+
+    await expect(
+      listK8sCertsPage({
+        search: 'rocketmq',
+        cluster: 'prod',
+        type: 'TLS',
+        status: 'valid',
+        page: 2,
+        pageSize: 50,
+      }),
+    ).resolves.toEqual({ items: [cert], total: 21, page: 2, size: 50 });
   });
 
   it('returns the certificate created by the backend', async () => {

--- a/web/src/api/cluster.ts
+++ b/web/src/api/cluster.ts
@@ -125,6 +125,13 @@ export interface K8sCertInfo {
   keyPem?: string;
 }
 
+export interface PageResult<T> {
+  items: T[];
+  total: number;
+  page: number;
+  size: number;
+}
+
 export interface NameServerConfigValue {
   address: string;
   configured: boolean;
@@ -273,6 +280,18 @@ export async function restartProxy(data: { clusterId: string; addr: string }) {
 // ─── K8s Certs ──────────────────────────────────────────────────
 export async function listK8sCerts() {
   const res = await client.get<{ data: K8sCertInfo[] }>('/k8s-certs');
+  return res.data.data;
+}
+
+export async function listK8sCertsPage(params: {
+  search?: string;
+  cluster?: string;
+  type?: string;
+  status?: string;
+  page: number;
+  pageSize: number;
+}) {
+  const res = await client.get<{ data: PageResult<K8sCertInfo> }>('/k8s-certs/page', { params });
   return res.data.data;
 }
 

--- a/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
@@ -20,11 +20,15 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import type { K8sCertInfo } from '../../../api/cluster';
-import { listK8sCerts, createK8sCert, deleteK8sCert } from '../../../services/clusterService';
+import {
+  listK8sCertsPage,
+  createK8sCert,
+  deleteK8sCert,
+} from '../../../services/clusterService';
 import K8sCertsPage from '../certs';
 
 vi.mock('../../../services/clusterService', () => ({
-  listK8sCerts: vi.fn(),
+  listK8sCertsPage: vi.fn(),
   createK8sCert: vi.fn(),
   deleteK8sCert: vi.fn(),
 }));
@@ -76,7 +80,12 @@ beforeAll(() => {
 describe('K8sCertsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(listK8sCerts).mockResolvedValue(certs);
+    vi.mocked(listK8sCertsPage).mockResolvedValue({
+      items: certs,
+      total: certs.length,
+      page: 1,
+      size: 20,
+    });
   });
 
   const renderPage = () =>
@@ -109,10 +118,23 @@ describe('K8sCertsPage', () => {
     ['staging-cluster', 'rocketmq-staging-tls', 'rocketmq-prod-tls'],
     ['prod-tls', 'rocketmq-prod-tls', 'rocketmq-staging-tls'],
   ])('searches certificate metadata by %s', async (query, expected, hidden) => {
+    vi.mocked(listK8sCertsPage).mockResolvedValue({
+      items: certs,
+      total: certs.length,
+      page: 1,
+      size: 20,
+    });
     const user = userEvent.setup();
     renderPage();
 
-    await screen.findByText('rocketmq-prod-tls');
+    vi.mocked(listK8sCertsPage).mockResolvedValue({
+      items: certs.filter((cert) =>
+        [cert.k8sId, cert.cluster].some((value) => value.toLowerCase().includes(query)),
+      ),
+      total: 1,
+      page: 1,
+      size: 20,
+    });
     await user.type(screen.getByPlaceholderText('搜索 k8s ID 或集群'), `${query}{enter}`);
 
     expect(screen.getByText(expected)).toBeInTheDocument();
@@ -151,11 +173,24 @@ describe('K8sCertsPage', () => {
         }),
       ),
     );
-    expect(await screen.findByText('kubernetes-admin-client')).toBeInTheDocument();
+    await waitFor(() => expect(listK8sCertsPage).toHaveBeenCalledTimes(2));
   });
 
   it('deletes a certificate after confirmation', async () => {
     vi.mocked(deleteK8sCert).mockResolvedValue();
+    vi.mocked(listK8sCertsPage)
+      .mockResolvedValueOnce({
+        items: certs,
+        total: certs.length,
+        page: 1,
+        size: 20,
+      })
+      .mockResolvedValueOnce({
+        items: certs.filter((cert) => cert.id !== 1),
+        total: 1,
+        page: 1,
+        size: 20,
+      });
     const user = userEvent.setup();
     renderPage();
 
@@ -167,5 +202,6 @@ describe('K8sCertsPage', () => {
 
     await waitFor(() => expect(deleteK8sCert).toHaveBeenCalledWith(1));
     await waitFor(() => expect(screen.queryByText('rocketmq-prod-tls')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('rocketmq-staging-tls')).toBeInTheDocument());
   });
 });

--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Table,
   Tag,
@@ -36,7 +36,11 @@ import type { ColumnsType } from 'antd/es/table';
 import PageHeader from '../../components/PageHeader';
 import InfoBanner from '../../components/InfoBanner';
 import type { K8sCertInfo } from '../../api/cluster';
-import { listK8sCerts, createK8sCert, deleteK8sCert } from '../../services/clusterService';
+import {
+  listK8sCertsPage,
+  createK8sCert,
+  deleteK8sCert,
+} from '../../services/clusterService';
 import { formatDateTime } from '../../utils/format';
 
 const { Text } = Typography;
@@ -56,39 +60,83 @@ const K8sCertsPage = () => {
   const [certs, setCerts] = useState<K8sCertInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [certSearch, setCertSearch] = useState('');
+  const [clusterSearch, setClusterSearch] = useState('');
   const [certTypeFilter, setCertTypeFilter] = useState<string>('');
+  const [certStatusFilter, setCertStatusFilter] = useState<string>('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [total, setTotal] = useState(0);
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [createForm] = Form.useForm<CreateCertFormValues>();
+  const requestId = useRef(0);
+
+  const queryKey = `${certSearch}:${clusterSearch}:${certTypeFilter}:${certStatusFilter}:${page}:${pageSize}`;
+  const [prevQueryKey, setPrevQueryKey] = useState(queryKey);
+  if (prevQueryKey !== queryKey) {
+    setPrevQueryKey(queryKey);
+    setLoading(true);
+  }
 
   useEffect(() => {
     let active = true;
-    listK8sCerts()
+    const currentRequest = ++requestId.current;
+    listK8sCertsPage({
+      search: certSearch.trim() || undefined,
+      cluster: clusterSearch.trim() || undefined,
+      type: certTypeFilter || undefined,
+      status: certStatusFilter || undefined,
+      page,
+      pageSize,
+    })
       .then((data) => {
-        if (active) setCerts(data);
+        if (!active || currentRequest !== requestId.current) return;
+        setCerts(data.items);
+        setTotal(data.total);
+        if (data.items.length === 0 && data.total > 0 && data.page > 1) {
+          setPage(Math.max(1, Math.ceil(data.total / data.size)));
+        }
+        setLoading(false);
       })
       .catch((error: unknown) => {
-        if (active) message.error(getErrorMessage(error));
-      })
-      .finally(() => {
-        if (active) setLoading(false);
+        if (active && currentRequest === requestId.current) {
+          message.error(getErrorMessage(error));
+          setLoading(false);
+        }
       });
     return () => {
       active = false;
     };
-  }, []);
+  }, [certSearch, clusterSearch, certTypeFilter, certStatusFilter, page, pageSize]);
 
-  const normalizedCertSearch = certSearch.trim().toLowerCase();
-  const filteredCerts = certs.filter((cert) => {
-    const matchSearch =
-      !normalizedCertSearch ||
-      [cert.k8sId, cert.cluster].some((value) =>
-        value.toLowerCase().includes(normalizedCertSearch),
-      );
-    const matchType = !certTypeFilter || cert.type === certTypeFilter;
-    return matchSearch && matchType;
-  });
+  const applyFilterChange = (setter: (value: string) => void, value: string) => {
+    setPage(1);
+    setter(value);
+  };
+
+  const reloadPage = async () => {
+    const currentRequest = ++requestId.current;
+    setLoading(true);
+    try {
+      const data = await listK8sCertsPage({
+        search: certSearch.trim() || undefined,
+        cluster: clusterSearch.trim() || undefined,
+        type: certTypeFilter || undefined,
+        status: certStatusFilter || undefined,
+        page,
+        pageSize,
+      });
+      if (currentRequest !== requestId.current) return;
+      setCerts(data.items);
+      setTotal(data.total);
+      if (data.items.length === 0 && data.total > 0 && data.page > 1) {
+        setPage(Math.max(1, Math.ceil(data.total / data.size)));
+      }
+    } finally {
+      if (currentRequest === requestId.current) setLoading(false);
+    }
+  };
 
   const handleCreate = async () => {
     let values: CreateCertFormValues;
@@ -106,7 +154,7 @@ const K8sCertsPage = () => {
         certPem: values.certPem?.trim() || undefined,
         keyPem: values.keyPem?.trim() || undefined,
       });
-      setCerts((previous) => [...previous, created]);
+      await reloadPage();
       message.success(`证书「${created.k8sId}」已添加`);
       setCreateModalOpen(false);
       createForm.resetFields();
@@ -121,7 +169,7 @@ const K8sCertsPage = () => {
     setDeletingId(cert.id);
     try {
       await deleteK8sCert(cert.id);
-      setCerts((previous) => previous.filter((item) => item.id !== cert.id));
+      await reloadPage();
       message.success(`证书「${cert.k8sId}」已删除`);
     } catch (error: unknown) {
       message.error(getErrorMessage(error));
@@ -247,7 +295,7 @@ const K8sCertsPage = () => {
 
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader title="K8s 证书管理" subtitle={`共 ${filteredCerts.length} 个证书`} />
+      <PageHeader title="K8s 证书管理" subtitle={`共 ${total} 个证书`} />
       <InfoBanner
         data-testid="k8s-cert-local-metadata-notice"
         title="当前证书记录仅保存为 Studio 本地元数据"
@@ -258,19 +306,37 @@ const K8sCertsPage = () => {
           <Input.Search
             placeholder="搜索 k8s ID 或集群"
             allowClear
-            onSearch={setCertSearch}
-            onChange={(e) => !e.target.value && setCertSearch('')}
+            onSearch={(value) => applyFilterChange(setCertSearch, value)}
+            onChange={(e) => !e.target.value && applyFilterChange(setCertSearch, '')}
             style={{ width: 320 }}
+          />
+          <Input.Search
+            placeholder="搜索集群"
+            allowClear
+            onSearch={(value) => applyFilterChange(setClusterSearch, value)}
+            onChange={(e) => !e.target.value && applyFilterChange(setClusterSearch, '')}
+            style={{ width: 200 }}
           />
           <Select
             value={certTypeFilter}
-            onChange={setCertTypeFilter}
+            onChange={(value) => applyFilterChange(setCertTypeFilter, value)}
             style={{ width: 160 }}
             options={[
               { value: '', label: '全部' },
               { value: 'TLS', label: 'TLS' },
               { value: 'mTLS', label: 'mTLS' },
               { value: 'ServiceAccount', label: 'ServiceAccount' },
+            ]}
+          />
+          <Select
+            value={certStatusFilter}
+            onChange={(value) => applyFilterChange(setCertStatusFilter, value)}
+            style={{ width: 140 }}
+            options={[
+              { value: '', label: '全部状态' },
+              { value: 'valid', label: '有效' },
+              { value: 'expiring', label: '即将过期' },
+              { value: 'expired', label: '已过期' },
             ]}
           />
         </Space>
@@ -281,10 +347,20 @@ const K8sCertsPage = () => {
       <Card styles={{ body: { padding: 0 } }}>
         <Table
           columns={certColumns}
-          dataSource={filteredCerts}
+          dataSource={certs}
           rowKey="id"
           loading={loading}
-          pagination={{ pageSize: 20 }}
+          pagination={{
+            current: page,
+            pageSize,
+            total,
+            showSizeChanger: true,
+            pageSizeOptions: [20, 50, 100],
+            onChange: (nextPage, nextPageSize) => {
+              setPage(nextPage);
+              setPageSize(nextPageSize);
+            },
+          }}
           size="small"
           scroll={{ x: 1400 }}
         />

--- a/web/src/services/clusterService.ts
+++ b/web/src/services/clusterService.ts
@@ -145,6 +145,38 @@ export async function listK8sCerts(): Promise<K8sCertInfo[]> {
   return clusterApi.listK8sCerts();
 }
 
+export async function listK8sCertsPage(params: {
+  search?: string;
+  cluster?: string;
+  type?: string;
+  status?: string;
+  page: number;
+  pageSize: number;
+}): Promise<clusterApi.PageResult<K8sCertInfo>> {
+  if (isMockMode()) {
+    const search = params.search?.trim().toLowerCase() ?? '';
+    const cluster = params.cluster?.trim().toLowerCase() ?? '';
+    const filtered = mockCertStore.filter((cert) => {
+      const matchesSearch =
+        !search ||
+        cert.k8sId.toLowerCase().includes(search) ||
+        cert.cluster.toLowerCase().includes(search);
+      const matchesCluster = !cluster || cert.cluster.toLowerCase().includes(cluster);
+      const matchesType = !params.type || cert.type === params.type;
+      const matchesStatus = !params.status || cert.status === params.status;
+      return matchesSearch && matchesCluster && matchesType && matchesStatus;
+    });
+    const start = (params.page - 1) * params.pageSize;
+    return {
+      items: filtered.slice(start, start + params.pageSize).map((cert) => ({ ...cert })),
+      total: filtered.length,
+      page: params.page,
+      size: params.pageSize,
+    };
+  }
+  return clusterApi.listK8sCertsPage(params);
+}
+
 export async function createK8sCert(data: Partial<K8sCertInfo>): Promise<K8sCertInfo> {
   if (isMockMode()) {
     const now = new Date();


### PR DESCRIPTION
### What changes are included?

`GET /api/k8s-certs` still loads every local certificate, refreshes expiry state for all of them, and leaves filtering to the browser. This adds a bounded server-side inventory contract while keeping the existing endpoint unchanged:

- `GET /api/k8s-certs/page?search=&cluster=&type=&status=&page=&pageSize=`
- repository-level filtering and pagination, ordered by `gmt_modified DESC, id DESC`
- expiry state is recalculated only for the returned page
- service validates `page >= 1` and `1 <= pageSize <= 100` before repository access
- the UI consumes the page contract, adds cluster and status filters, server totals, page-size switching, and request sequencing that ignores stale responses
- creating or deleting a certificate now reloads the canonical server page; filters reset to page 1

### Verification

- Backend focused: `K8sCertServiceTest`, `K8sCertControllerTest`, `MybatisPlusK8sCertRepositoryTest`
- Backend full suite: 1,484 tests passed, Checkstyle 0 violations
- Frontend focused: `cluster.test.ts`, `K8sCertsPage.test.tsx`
- Frontend full suite: 94 files / 634 tests passed
- `npm run build` passed
- `npm run lint` passed with only the existing `topic.tsx` hooks warning
- `git diff --check` passed

Fixes #2275