### PR TITLE
fix: bound ACL rule page sizes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -46,6 +46,7 @@ public class AclService {
 
     private static final SecureRandom CREDENTIAL_RANDOM = new SecureRandom();
     private static final int DEFAULT_RULE_PAGE_SIZE = 20;
+    private static final int MAX_PAGE_SIZE = 100;
 
     private final AclRepository aclRepository;
     private final OperationAuditService operationAuditService;
@@ -70,8 +71,8 @@ public class AclService {
 
     public PageResult<AclRuleVO> listRules(String principal, String resource, String scope, String decision,
             String aclVersion, String instanceId, Integer page, Integer pageSize) {
-        int normalizedPage = normalizePage(page);
-        int normalizedPageSize = normalizePageSize(pageSize);
+        int normalizedPage = requireValidPage(page);
+        int normalizedPageSize = requireValidPageSize(pageSize);
         if (isTencentInstance(instanceId)) {
             List<AclRuleVO> filtered = tencentAclService.listRules(instanceId, principal).stream()
                     .filter(rule -> containsIgnoreCase(rule.getResource(), resource))
@@ -356,6 +357,25 @@ public class AclService {
 
     private static int normalizePageSize(Integer pageSize) {
         return pageSize == null || pageSize < 1 ? DEFAULT_RULE_PAGE_SIZE : pageSize;
+    }
+
+    private static int requireValidPage(Integer page) {
+        if (page != null && page < 1) {
+            throw invalidPagination();
+        }
+        return normalizePage(page);
+    }
+
+    private static int requireValidPageSize(Integer pageSize) {
+        if (pageSize != null && (pageSize < 1 || pageSize > MAX_PAGE_SIZE)) {
+            throw invalidPagination();
+        }
+        return normalizePageSize(pageSize);
+    }
+
+    private static BusinessException invalidPagination() {
+        return new BusinessException(400,
+                "page must be >= 1 and pageSize must be between 1 and " + MAX_PAGE_SIZE);
     }
 
     private static boolean containsIgnoreCase(String value, String expectedFragment) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
@@ -141,6 +141,24 @@ class AclControllerTest {
     }
 
     @Test
+    void listRulesShouldRejectPageSizeAboveTheInventoryLimit() throws Exception {
+        when(aclService.listRules(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
+                eq(1), eq(101))).thenThrow(new BusinessException(400,
+                "page must be >= 1 and pageSize must be between 1 and 100"));
+
+        mockMvc.perform(get("/api/acl/rules")
+                        .param("page", "1")
+                        .param("pageSize", "101"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message")
+                        .value("page must be >= 1 and pageSize must be between 1 and 100"));
+
+        verify(aclService).listRules(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
+                eq(1), eq(101));
+    }
+
+    @Test
     void createRuleShouldReturnCreatedRule() throws Exception {
         AclRuleVO input = AclRuleVO.builder()
                 .principal("user1")

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.provider.tencent.TencentAclService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,6 +52,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -65,6 +67,9 @@ class AclServiceTest {
 
     @Mock
     private InstanceRepository instanceRepository;
+
+    @Mock
+    private TencentAclService tencentAclService;
 
     @InjectMocks
     private AclService aclService;
@@ -143,13 +148,43 @@ class AclServiceTest {
     }
 
     @Test
-    void listRulesShouldNormalizeInvalidPaginationBounds() {
-        when(aclRepository.findRulePage(null, null, null, null, null, 1, 20))
-                .thenReturn(PageResult.empty(1, 20));
+    void listRulesShouldRejectInvalidPaginationBeforeQueryingRules() {
+        assertThatThrownBy(() -> aclService.listRules(null, null, null, null, null,
+                null, 0, 20))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("page must be >= 1 and pageSize must be between 1 and 100")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+        assertThatThrownBy(() -> aclService.listRules(null, null, null, null, null,
+                null, 1, 0))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("page must be >= 1 and pageSize must be between 1 and 100");
+        assertThatThrownBy(() -> aclService.listRules(null, null, null, null, null,
+                null, 1, 101))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("page must be >= 1 and pageSize must be between 1 and 100");
 
-        aclService.listRules(null, null, null, null, null, null, 0, 0);
+        verifyNoInteractions(aclRepository);
+    }
 
-        verify(aclRepository).findRulePage(null, null, null, null, null, 1, 20);
+    @Test
+    void listRulesShouldAcceptTheMaximumPageSizeForApacheRules() {
+        when(aclRepository.findRulePage(null, null, null, null, null, 1, 100))
+                .thenReturn(PageResult.empty(1, 100));
+
+        aclService.listRules(null, null, null, null, null, null, 1, 100);
+
+        verify(aclRepository).findRulePage(null, null, null, null, null, 1, 100);
+    }
+
+    @Test
+    void listRulesShouldRejectInvalidPaginationBeforeTencentRuleDiscovery() {
+        assertThatThrownBy(() -> aclService.listRules(null, null, null, null, null,
+                "tencent-instance", 1, 101))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("page must be >= 1 and pageSize must be between 1 and 100");
+
+        verifyNoInteractions(instanceRepository);
+        verifyNoInteractions(tencentAclService);
     }
 
     @Test


### PR DESCRIPTION
`GET /api/acl/rules` silently normalized invalid pagination values and accepted an arbitrarily large page size, while `GET /api/acl/users/page` rejects values outside `1..100`. This aligns the rule inventory with the user inventory contract:

- reject `page < 1`, `pageSize < 1`, and `pageSize > 100` with 400 before repository or Tencent rule discovery
- keep omitted values on the existing defaults (`page=1`, `pageSize=20`)
- accept the full valid range up to 100
- cover the Apache repository path, the pre-Tencent-discovery path, and the HTTP error envelope

Verification:

- focused: `mvn -Dtest=AclServiceTest,AclControllerTest test`
- backend full suite: 1,484 tests passed, Checkstyle 0 violations
- `git diff --check` passed

Fixes #2438