### PR TITLE
fix(ai): stabilize Studio chat interaction and HTTP streaming

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -63,7 +63,7 @@ public class OpenAiCompatibleLlmClient {
     private static final String CHAT_COMPLETIONS_PATH = "/chat/completions";
     private static final String MODELS_PATH = "/models";
     private static final int MAX_RESPONSE_BODY_BYTES = 5 * 1024 * 1024;
-    private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMinutes(5);
+    private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMinutes(2);
     private static final Set<String> SUPPORTED_PROVIDERS = Set.of("openai", "deepseek", "tongyi", "ollama");
 
     private final ObjectMapper objectMapper;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -63,6 +63,7 @@ public class OpenAiCompatibleLlmClient {
     private static final String CHAT_COMPLETIONS_PATH = "/chat/completions";
     private static final String MODELS_PATH = "/models";
     private static final int MAX_RESPONSE_BODY_BYTES = 5 * 1024 * 1024;
+    private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMinutes(5);
     private static final Set<String> SUPPORTED_PROVIDERS = Set.of("openai", "deepseek", "tongyi", "ollama");
 
     private final ObjectMapper objectMapper;
@@ -74,7 +75,7 @@ public class OpenAiCompatibleLlmClient {
         this(objectMapper, HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .followRedirects(HttpClient.Redirect.NEVER)
-                .build(), Duration.ofSeconds(60));
+                .build(), DEFAULT_REQUEST_TIMEOUT);
     }
 
     OpenAiCompatibleLlmClient(ObjectMapper objectMapper, HttpClient httpClient, Duration requestTimeout) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -56,6 +56,10 @@ import java.util.function.Consumer;
 @Component
 public class OpenAiCompatibleLlmClient {
 
+    private static final String MARKDOWN_SYSTEM_PROMPT = """
+            Format responses as valid CommonMark Markdown. Put a space after heading and list markers,
+            put code fence languages on their own line, and keep code contents inside fenced code blocks.
+            """;
     private static final String CHAT_COMPLETIONS_PATH = "/chat/completions";
     private static final String MODELS_PATH = "/models";
     private static final int MAX_RESPONSE_BODY_BYTES = 5 * 1024 * 1024;
@@ -300,9 +304,9 @@ public class OpenAiCompatibleLlmClient {
                                             boolean stream) {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("model", StringUtils.hasText(modelOverride) ? modelOverride.trim() : config.getModel().trim());
-        body.put("messages", List.of(Map.of(
-                "role", "user",
-                "content", StringUtils.hasText(prompt) ? prompt.trim() : "")));
+        body.put("messages", List.of(
+                Map.of("role", "system", "content", MARKDOWN_SYSTEM_PROMPT),
+                Map.of("role", "user", "content", StringUtils.hasText(prompt) ? prompt.trim() : "")));
         body.put("temperature", config.getTemperature());
         body.put("max_tokens", config.getMaxTokens());
         body.put("stream", stream);

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
@@ -47,7 +47,8 @@ import java.util.function.LongFunction;
 @Component
 public class OpenAiCompatibleLlmGateway implements LlmGateway {
 
-    private static final long HTTP_STREAM_TIMEOUT_MILLIS = 60_000L;
+    // HTTP providers can spend more than a minute before emitting the first token.
+    private static final long HTTP_STREAM_TIMEOUT_MILLIS = 300_000L;
     private static final long CLI_STREAM_TIMEOUT_MILLIS = 300_000L;
     private static final int MAX_CONCURRENT_CHATS = 16;
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGateway.java
@@ -47,8 +47,8 @@ import java.util.function.LongFunction;
 @Component
 public class OpenAiCompatibleLlmGateway implements LlmGateway {
 
-    // HTTP providers can spend more than a minute before emitting the first token.
-    private static final long HTTP_STREAM_TIMEOUT_MILLIS = 300_000L;
+    // Keep this above the client timeout so provider timeouts can be sent as SSE errors.
+    private static final long HTTP_STREAM_TIMEOUT_MILLIS = 125_000L;
     private static final long CLI_STREAM_TIMEOUT_MILLIS = 300_000L;
     private static final int MAX_CONCURRENT_CHATS = 16;
 
@@ -96,6 +96,8 @@ public class OpenAiCompatibleLlmGateway implements LlmGateway {
             return errorEmitter(incompleteConfigException());
         }
         String engine = resolveEngine(request == null ? null : request.getEngine(), config);
+        log.info("Starting AI chat: engine={}, model={}", engine,
+                request == null ? null : request.getModel());
         if (isCliEngine(engine)) {
             return submitChat(CLI_STREAM_TIMEOUT_MILLIS,
                     session -> runCliChat(request, config, engine, session));

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
@@ -75,8 +75,11 @@ class OpenAiCompatibleLlmClientTest {
         assertThat(authorization.get()).isEqualTo("Bearer sk-test");
         assertThat(requestBody.get().path("model").asText()).isEqualTo("gpt-4o-mini");
         assertThat(requestBody.get().path("stream").asBoolean()).isFalse();
-        assertThat(requestBody.get().path("messages").path(0).path("role").asText()).isEqualTo("user");
-        assertThat(requestBody.get().path("messages").path(0).path("content").asText()).isEqualTo("hello");
+        assertThat(requestBody.get().path("messages").path(0).path("role").asText()).isEqualTo("system");
+        assertThat(requestBody.get().path("messages").path(0).path("content").asText())
+                .contains("valid CommonMark Markdown");
+        assertThat(requestBody.get().path("messages").path(1).path("role").asText()).isEqualTo("user");
+        assertThat(requestBody.get().path("messages").path(1).path("content").asText()).isEqualTo("hello");
         assertThat(requestBody.get().path("max_tokens").asInt()).isEqualTo(256);
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGatewayTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGatewayTest.java
@@ -76,7 +76,7 @@ class OpenAiCompatibleLlmGatewayTest {
             testedGateway.chat(ChatDTO.builder().message("hello").build());
 
             assertThat(emitters).hasSize(1);
-            assertThat(emitters.get(0).timeoutMillis).isEqualTo(TimeUnit.MINUTES.toMillis(5));
+            assertThat(emitters.get(0).timeoutMillis).isEqualTo(TimeUnit.SECONDS.toMillis(125));
         } finally {
             testedGateway.destroy();
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGatewayTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGatewayTest.java
@@ -65,7 +65,7 @@ class OpenAiCompatibleLlmGatewayTest {
     }
 
     @Test
-    void httpChatAllowsSlowProvidersToStartStreaming() throws Exception {
+    void httpChatAllowsSlowProvidersToStartStreamingTest() throws Exception {
         ExecutorService executor = singleChatExecutor();
         List<RecordingSseEmitter> emitters = new CopyOnWriteArrayList<>();
         OpenAiCompatibleLlmGateway testedGateway = gateway(executor, emitters);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGatewayTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmGatewayTest.java
@@ -65,6 +65,24 @@ class OpenAiCompatibleLlmGatewayTest {
     }
 
     @Test
+    void httpChatAllowsSlowProvidersToStartStreaming() throws Exception {
+        ExecutorService executor = singleChatExecutor();
+        List<RecordingSseEmitter> emitters = new CopyOnWriteArrayList<>();
+        OpenAiCompatibleLlmGateway testedGateway = gateway(executor, emitters);
+        LlmConfigVO config = config("openai", "sk-test");
+        when(configService.getConfig()).thenReturn(config);
+        when(llmClient.supports(config)).thenReturn(true);
+        try {
+            testedGateway.chat(ChatDTO.builder().message("hello").build());
+
+            assertThat(emitters).hasSize(1);
+            assertThat(emitters.get(0).timeoutMillis).isEqualTo(TimeUnit.MINUTES.toMillis(5));
+        } finally {
+            testedGateway.destroy();
+        }
+    }
+
+    @Test
     void executeShouldRejectIncompleteConfig() {
         when(configService.getConfig()).thenReturn(config("openai", ""));
 
@@ -279,6 +297,7 @@ class OpenAiCompatibleLlmGatewayTest {
     }
 
     private static final class RecordingSseEmitter extends SseEmitter {
+        private final long timeoutMillis;
         private final List<Set<ResponseBodyEmitter.DataWithMediaType>> sentEvents = new CopyOnWriteArrayList<>();
         private final CountDownLatch completedLatch = new CountDownLatch(1);
         private Runnable completionCallback;
@@ -288,6 +307,7 @@ class OpenAiCompatibleLlmGatewayTest {
 
         RecordingSseEmitter(long timeout) {
             super(timeout);
+            timeoutMillis = timeout;
         }
 
         @Override

--- a/web/src/pages/ai/__tests__/AiMessage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiMessage.test.tsx
@@ -49,4 +49,20 @@ describe('AiMessage', () => {
     expect(screen.getByText('mqadmin clusterList')).toBeInTheDocument();
     expect(screen.getByText('mqadmin clusterList').closest('pre')).toBeInTheDocument();
   });
+
+  it('normalizes common malformed Markdown markers from model responses', () => {
+    render(
+      <AiMessage
+        msg={{
+          id: 'ai-2',
+          role: 'ai',
+          summary: ['##结论', '-第一项', '', '```bashmqadmin clusterList', '```'].join('\n'),
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: '结论', level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole('listitem')).toHaveTextContent('第一项');
+    expect(screen.getByText('mqadmin clusterList').closest('pre')).toBeInTheDocument();
+  });
 });

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -26,6 +26,7 @@ import { listClusters, type ClusterInfo } from '../../../api/cluster';
 import { getLlmConfig, getLlmModels } from '../../../api/llm';
 import { useAiChatHistoryStore } from '../../../stores/aiChatHistoryStore';
 import useAuthStore from '../../../stores/authStore';
+import { useEngineStore } from '../../../stores/engineStore';
 import AiPage from '../index';
 
 const dataModeMocks = vi.hoisted(() => ({ useMock: false }));

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -166,6 +166,22 @@ describe('AiPage tool runner', () => {
     });
   });
 
+  it('keeps the engine selected on the home page and exposes it in the AI toolbar', async () => {
+    vi.mocked(chatStream).mockResolvedValue(undefined);
+    renderPage({ prompt: '检查集群状态', engine: 'qoder' });
+
+    await waitFor(() => {
+      expect(chatStream).toHaveBeenCalledWith(
+        expect.objectContaining({ message: '检查集群状态', engine: 'qoder' }),
+        expect.any(Function),
+        expect.any(AbortSignal),
+        expect.any(Function),
+      );
+    });
+    expect(screen.getAllByTitle('执行引擎')[0]).toHaveTextContent('Qoder');
+    expect(useEngineStore.getState().engine).toBe('qoder');
+  });
+
   it('keeps prompt enhancement enabled after a home-page draft is opened', async () => {
     vi.mocked(chatStream).mockResolvedValue(undefined);
     renderPage({ prompt: '检查集群状态', enhance: true });

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -332,6 +332,7 @@ describe('AiPage tool runner', () => {
     renderPage({ prompt: 'Start streaming', newConversation: true });
 
     await waitFor(() => expect(requestSignal).toBeDefined());
+    expect(screen.getByRole('button', { name: '停止生成' })).toBeVisible();
     await user.click(screen.getByRole('button', { name: 'AI 对话历史' }));
     const historyDrawer = await screen.findByRole('dialog', { name: 'AI 对话历史' });
     await user.click(within(historyDrawer).getByRole('button', { name: /^Previous conversation/ }));
@@ -339,7 +340,7 @@ describe('AiPage tool runner', () => {
     expect(requestSignal?.aborted).toBe(true);
     expect(useAiChatHistoryStore.getState().histories.real.activeConversationId).toBe('previous');
     await waitFor(() =>
-      expect(screen.queryByRole('button', { name: '停止' })).not.toBeInTheDocument(),
+      expect(screen.queryByRole('button', { name: '停止生成' })).not.toBeInTheDocument(),
     );
   });
 

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -166,6 +166,21 @@ describe('AiPage tool runner', () => {
     });
   });
 
+  it('keeps prompt enhancement enabled after a home-page draft is opened', async () => {
+    vi.mocked(chatStream).mockResolvedValue(undefined);
+    renderPage({ prompt: '检查集群状态', enhance: true });
+
+    await waitFor(() => {
+      expect(chatStream).toHaveBeenCalledWith(
+        expect.objectContaining({ message: '检查集群状态', enhance: true }),
+        expect.any(Function),
+        expect.any(AbortSignal),
+        expect.any(Function),
+      );
+    });
+    expect(screen.getByTitle('发送前增强 Prompt')).toHaveStyle({ borderColor: '#1677ff' });
+  });
+
   it('starts a new conversation when the home-page draft requests it', async () => {
     useAiChatHistoryStore.setState({
       histories: {

--- a/web/src/pages/ai/chatDraft.ts
+++ b/web/src/pages/ai/chatDraft.ts
@@ -15,13 +15,17 @@
  * limitations under the License.
  */
 
+import type { AgentEngine } from '../../stores/engineStore';
+
 export type ChatMode = 'chat' | 'diagnose' | 'manage' | 'query';
 
 const CHAT_MODES = new Set<ChatMode>(['chat', 'diagnose', 'manage', 'query']);
+const AGENT_ENGINES = new Set<AgentEngine>(['claude-code', 'qoder', 'http']);
 
 export interface ChatDraft {
   prompt: string;
   model?: string;
+  engine?: AgentEngine;
   mode?: ChatMode;
   enhance?: boolean;
   newConversation?: boolean;
@@ -42,10 +46,15 @@ export function getChatDraft(state: unknown): ChatDraft | null {
     typeof candidate.mode === 'string' && CHAT_MODES.has(candidate.mode as ChatMode)
       ? (candidate.mode as ChatMode)
       : undefined;
+  const engine =
+    typeof candidate.engine === 'string' && AGENT_ENGINES.has(candidate.engine as AgentEngine)
+      ? (candidate.engine as AgentEngine)
+      : undefined;
 
   return {
     prompt,
     ...(model ? { model } : {}),
+    ...(engine ? { engine } : {}),
     ...(mode ? { mode } : {}),
     ...(candidate.enhance === true ? { enhance: true } : {}),
     ...(candidate.newConversation === true ? { newConversation: true } : {}),

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -55,8 +55,12 @@ import { listClusters } from '../../api/cluster';
 import { getLlmConfig, getLlmModels, type LlmConfig } from '../../api/llm';
 import { formatRelativeTime, formatTimeOfDay } from '../../utils/format';
 import { useDataModeStore } from '../../stores/dataModeStore';
-import { useEngineStore } from '../../stores/engineStore';
+<<<<<<< HEAD
+import { useEngineStore, type AgentEngine } from '../../stores/engineStore';
 import InfoBanner from '../../components/InfoBanner';
+=======
+import { useEngineStore, type AgentEngine } from '../../stores/engineStore';
+>>>>>>> fb5e3566 (fix: retain engine selection when opening AI chat)
 import useAuthStore from '../../stores/authStore';
 import {
   getRecentAiChatConversations,
@@ -124,6 +128,11 @@ const quickActions = [
 ];
 
 const GLOBAL_TOOL_SCOPE = '__global__';
+const ENGINE_OPTIONS = [
+  { value: 'claude-code', label: 'Claude Code' },
+  { value: 'qoder', label: 'Qoder' },
+  { value: 'http', label: 'HTTP' },
+];
 
 export const normalizeAiMarkdown = (content: string): string =>
   content
@@ -442,6 +451,8 @@ const AiPage = () => {
   const useMock = useDataModeStore((state) => state.useMock);
   const userId = useAuthStore((state) => state.userId);
   const admin = useAuthStore((state) => state.admin);
+  const engine = useEngineStore((state) => state.engine);
+  const setEngine = useEngineStore((state) => state.setEngine);
   const chatMode: AiChatDataMode = useMock ? 'mock' : 'real';
   const { token } = theme.useToken();
   const history = useAiChatHistoryStore((state) => state.histories[chatMode]);
@@ -482,6 +493,7 @@ const AiPage = () => {
   const chatInFlightRef = useRef(false);
   const toolLoadRequestRef = useRef(0);
   const consumedDraftRef = useRef(false);
+  const draftEngineRef = useRef<AgentEngine | null>(null);
   const pendingAutoSendRef = useRef<{
     prompt: string;
     model?: string;
@@ -522,6 +534,12 @@ const AiPage = () => {
     try {
       const config = await getLlmConfig();
       setLlmConfig(config);
+      if (
+        draftEngineRef.current === null &&
+        (config.engine === 'http' || config.engine === 'claude-code' || config.engine === 'qoder')
+      ) {
+        setEngine(config.engine);
+      }
       if (config?.model) {
         setSelectedModel((current) => current || config.model);
       }
@@ -542,7 +560,7 @@ const AiPage = () => {
     } finally {
       setModelsLoading(false);
     }
-  }, [canInspectLlmRuntime, t, useMock]);
+  }, [canInspectLlmRuntime, setEngine, t, useMock]);
 
   useEffect(() => {
     void Promise.resolve().then(loadLlmRuntime);
@@ -564,6 +582,10 @@ const AiPage = () => {
       }
       if (draft.prompt) setInputValue(draft.prompt);
       if (draft.enhance !== undefined) setEnhance(draft.enhance);
+      if (draft.engine) {
+        draftEngineRef.current = draft.engine;
+        setEngine(draft.engine);
+      }
       const draftModel = draft.model;
       if (draftModel) {
         setSelectedModel(draftModel);
@@ -583,7 +605,7 @@ const AiPage = () => {
       }
       navigate('/ai', { replace: true, state: null });
     });
-  }, [chatMode, location.state, navigate, selectConversation, startConversation]);
+  }, [chatMode, location.state, navigate, selectConversation, setEngine, startConversation]);
 
   /* ─── Auto-resize textarea ─── */
   useEffect(() => {
@@ -654,7 +676,7 @@ const AiPage = () => {
             message: text,
             mode: modeOverride,
             model,
-            engine: useEngineStore.getState().engine,
+            engine,
             enhance,
             conversationId,
           },
@@ -708,7 +730,17 @@ const AiPage = () => {
         if (streamRequestIdRef.current === requestId) setLoading(false);
       }
     },
-    [chatMode, inputValue, llmReady, loading, selectedModel, startConversation, t, updateMessages],
+    [
+      chatMode,
+      engine,
+      inputValue,
+      llmReady,
+      loading,
+      selectedModel,
+      startConversation,
+      t,
+      updateMessages,
+    ],
   );
 
   /* ─── Auto-send the draft from the home page as soon as runtime is ready ─── */
@@ -1005,6 +1037,17 @@ const AiPage = () => {
                 suffixIcon={<CaretDown size={10} color="#9CA3AF" />}
                 className="model-selector"
                 style={{ fontSize: '0.893rem' }}
+              />
+              <Select
+                size="small"
+                value={engine}
+                onChange={(value) => setEngine(value as AgentEngine)}
+                options={ENGINE_OPTIONS}
+                variant="borderless"
+                popupMatchSelectWidth={false}
+                suffixIcon={<CaretDown size={10} color="#9CA3AF" />}
+                title="执行引擎"
+                style={{ fontSize: '0.893rem', minWidth: 110 }}
               />
               {llmConfig && (
                 <Tag color={llmReady ? 'green' : 'default'} style={{ borderRadius: 6 }}>

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -56,12 +56,8 @@ import { listClusters } from '../../api/cluster';
 import { getLlmConfig, getLlmModels, type LlmConfig } from '../../api/llm';
 import { formatRelativeTime, formatTimeOfDay } from '../../utils/format';
 import { useDataModeStore } from '../../stores/dataModeStore';
-<<<<<<< HEAD
 import { useEngineStore, type AgentEngine } from '../../stores/engineStore';
 import InfoBanner from '../../components/InfoBanner';
-=======
-import { useEngineStore, type AgentEngine } from '../../stores/engineStore';
->>>>>>> fb5e3566 (fix: retain engine selection when opening AI chat)
 import useAuthStore from '../../stores/authStore';
 import {
   getRecentAiChatConversations,

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -563,6 +563,7 @@ const AiPage = () => {
         conversationIdRef.current = draft.conversationId;
       }
       if (draft.prompt) setInputValue(draft.prompt);
+      if (draft.enhance !== undefined) setEnhance(draft.enhance);
       const draftModel = draft.model;
       if (draftModel) {
         setSelectedModel(draftModel);

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -125,6 +125,12 @@ const quickActions = [
 
 const GLOBAL_TOOL_SCOPE = '__global__';
 
+export const normalizeAiMarkdown = (content: string): string =>
+  content
+    .replace(/^(#{1,6})(?=\S)/gm, '$1 ')
+    .replace(/^([-+*])(?=\S)/gm, '$1 ')
+    .replace(/^```(bash|sh|shell|json|ya?ml|sql|text)(?=\S)/gim, '```$1\n');
+
 const newConversationId = (): string =>
   `conversation-${typeof crypto?.randomUUID === 'function' ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`}`;
 
@@ -395,7 +401,9 @@ export const AiMessage = ({ msg }: { msg: Message }) => {
         {/* Summary text */}
         {msg.summary && (
           <div className="ai-markdown">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.summary}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {normalizeAiMarkdown(msg.summary)}
+            </ReactMarkdown>
           </div>
         )}
 

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -131,7 +131,7 @@ const ENGINE_OPTIONS = [
   { value: 'http', label: 'HTTP' },
 ];
 
-export const normalizeAiMarkdown = (content: string): string =>
+const normalizeAiMarkdown = (content: string): string =>
   content
     .replace(/^(#{1,6})(?=\S)/gm, '$1 ')
     .replace(/^([-+*])(?=\S)/gm, '$1 ')

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -47,6 +47,7 @@ import {
   ClockCounterClockwise,
   SlidersHorizontal,
   Sparkle,
+  Stop,
 } from '@phosphor-icons/react';
 import type { ColumnsType } from 'antd/es/table';
 import { useLang } from '../../i18n/LangContext';
@@ -1126,8 +1127,21 @@ const AiPage = () => {
                     <ArrowUp size={19} weight="bold" />
                   </button>
                   {loading && (
-                    <Button size="small" onClick={handleStop}>
-                      停止
+                    <Button
+                      danger
+                      type="primary"
+                      size="middle"
+                      icon={<Stop size={16} weight="fill" />}
+                      onClick={handleStop}
+                      title="停止生成"
+                      style={{
+                        height: 36,
+                        borderRadius: 8,
+                        fontWeight: 600,
+                        boxShadow: '0 2px 8px rgba(255, 77, 79, 0.24)',
+                      }}
+                    >
+                      停止生成
                     </Button>
                   )}
                 </div>

--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -78,6 +78,32 @@ describe('HomePage LLM models', () => {
     expect(await screen.findByText('qwen3.8-max')).toBeInTheDocument();
   });
 
+  it('selects the model saved in the LLM configuration', async () => {
+    llmApiMocks.getLlmConfig.mockResolvedValue({
+      provider: 'deepseek',
+      apiBase: 'https://api.deepseek.com/v1',
+      model: 'deepseek-v4-flash',
+      maxTokens: 4096,
+      temperature: 0.7,
+      enabled: true,
+      ready: true,
+    });
+    const user = userEvent.setup();
+    renderHome();
+    await screen.findByText('deepseek-v4-flash');
+
+    await user.type(
+      screen.getByPlaceholderText('向 RocketMQ Bot 提问，全程加密、安全、可信'),
+      '查看集群状态{enter}',
+    );
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/ai', {
+        state: expect.objectContaining({ model: 'deepseek-v4-flash' }),
+      });
+    });
+  });
+
   it('does not fetch LLM config in Mock mode', async () => {
     const { useDataModeStore } = await import('../../../stores/dataModeStore');
     useDataModeStore.getState().toggle();

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -135,7 +135,7 @@ const HomePage = () => {
         })),
       );
       setSelectedModel((current) =>
-        current && values.includes(current) ? current : values[0] || '',
+        current && values.includes(current) ? current : configuredModel || values[0] || '',
       );
     };
 


### PR DESCRIPTION
Closes #2440

## What this fixes

This PR stabilizes the Studio AI path from the home-page shortcut through an HTTP streamed conversation. It addresses state handoff, persisted defaults, incremental Markdown rendering, stream timeout reporting, and the cancellation affordance.

### Home page to AI chat state handoff

The home-page draft is now the explicit source of truth when opening /ai:

- Preserve the selected Prompt Enhancement mode.
- Preserve the selected execution engine: http, claude-code, or qoder, without allowing asynchronous LLM configuration loading to overwrite it.
- Initialize the home-page model from the persisted LLM configuration rather than a hard-coded provider default.

### Stream rendering and failure behavior

- Normalize fragmented provider Markdown before rendering so streamed fenced blocks and line boundaries render consistently.
- Allow a slow but valid HTTP provider stream enough time to emit its first event.
- Keep the outer SSE response alive slightly longer than the upstream HTTP request deadline so a timeout is returned to the client as a terminal SSE error instead of appearing as a silent cancellation.

### In-flight cancellation

- Replace the small text-only stop action with a visible red stop-generating control and icon while a response is streaming.
- The control is absent once the request finishes, is cancelled, or the conversation changes.

## Deliberate boundaries

- This PR does not modify LLM settings persistence, API-key storage, authentication, or provider selection rules.
- It does not change the underlying model/provider protocol; it only makes Studio state and timeout behavior observable and consistent.
- Model catalog refresh and API-key persistence changes that are already covered by newer Studio baseline changes are intentionally not duplicated here.

## Test coverage

- AI page: draft mode handoff, engine handoff, selected-model behavior, stop-control lifecycle.
- AI message: streamed Markdown normalization.
- Home page: saved model initialization.
- Server: OpenAI-compatible client startup timeout and gateway terminal-error handling.

## Validation performed

Rebased onto origin/rocketmq-studio@d3469e2c3.

- npm test -- --run src/pages/ai/__tests__/AiMessage.test.tsx src/pages/ai/__tests__/AiPage.test.tsx src/pages/home/__tests__/HomePage.test.tsx (23 tests passed)
- npm run lint (0 errors; existing baseline warnings remain outside this PR scope)
- npm run build
- JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=OpenAiCompatibleLlmClientTest,OpenAiCompatibleLlmGatewayTest test
- git diff --check origin/rocketmq-studio...HEAD
