### PR TITLE
[ISSUE #2446] fix(credentials): normalize boundary values

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
@@ -53,7 +53,8 @@ public class CloudCredentialService {
     }
     public PageResult<CloudCredentialVO> listMasked(InstanceVendor vendor, String search, int page, int pageSize) {
         if (page < 1 || pageSize < 1 || pageSize > 100) throw new BusinessException(400, "Invalid page or pageSize");
-        PageResult<CloudCredentialVO> result = credentialRepository.findPage(vendor, search, page, pageSize);
+        String normalizedSearch = StringUtils.hasText(search) ? search.strip() : null;
+        PageResult<CloudCredentialVO> result = credentialRepository.findPage(vendor, normalizedSearch, page, pageSize);
         return PageResult.of(result.getItems().stream().map(this::maskAccessKey).toList(), result.getTotal(), page, pageSize);
     }
 
@@ -70,6 +71,9 @@ public class CloudCredentialService {
         if (!StringUtils.hasText(credential.getAccessKey()) || !StringUtils.hasText(credential.getSecretKey())) {
             throw new BusinessException(400, "Cloud credential accessKey and secretKey are required");
         }
+        credential.setName(credential.getName().strip());
+        credential.setAccessKey(credential.getAccessKey().strip());
+        credential.setSecretKey(credential.getSecretKey().strip());
         credentialRepository.findByVendorAndAccessKey(credential.getVendor(), credential.getAccessKey())
                 .ifPresent(existing -> {
                     throw new BusinessException(400,
@@ -102,10 +106,10 @@ public class CloudCredentialService {
             throw new BusinessException(400, "Cloud credential name cannot be blank");
         }
         if (request.getName() != null) {
-            existing.setName(request.getName());
+            existing.setName(request.getName().strip());
         }
         if (request.getSecretKey() != null && !request.getSecretKey().isBlank()) {
-            existing.setSecretKey(request.getSecretKey());
+            existing.setSecretKey(request.getSecretKey().strip());
         }
         if (request.getRemark() != null) {
             existing.setRemark(request.getRemark());

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
@@ -16,9 +16,10 @@
  */
 package org.apache.rocketmq.studio.provider.credential;
 
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
-import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.provider.alibaba.AliyunClientFactory;
@@ -88,6 +89,18 @@ class CloudCredentialServiceTest {
         when(credentialRepository.findAll()).thenReturn(List.of(stored));
 
         assertThat(service.listMasked().get(0).getAccessKey()).isEqualTo("****");
+    }
+
+    @Test
+    void pagedListShouldNormalizeSearchTextTest() {
+        when(credentialRepository.findPage(InstanceVendor.ALIYUN, "production", 2, 20))
+                .thenReturn(PageResult.empty(2, 20));
+
+        PageResult<CloudCredentialVO> result = service.listMasked(
+                InstanceVendor.ALIYUN, "  production  ", 2, 20);
+
+        assertThat(result.getItems()).isEmpty();
+        verify(credentialRepository).findPage(InstanceVendor.ALIYUN, "production", 2, 20);
     }
 
     @Test
@@ -163,6 +176,25 @@ class CloudCredentialServiceTest {
     }
 
     @Test
+    void createShouldNormalizeCredentialIdentityTest() {
+        CloudCredentialVO request = new CloudCredentialVO();
+        request.setName("  production  ");
+        request.setVendor(InstanceVendor.ALIYUN);
+        request.setAccessKey("  LTAI5tNormalizedKey000001  ");
+        request.setSecretKey("  secret-value  ");
+        when(credentialRepository.findByVendorAndAccessKey(
+                InstanceVendor.ALIYUN, "LTAI5tNormalizedKey000001")).thenReturn(Optional.empty());
+        when(credentialRepository.save(any(CloudCredentialVO.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.create(request);
+
+        verify(credentialRepository).save(argThat(saved -> saved.getName().equals("production")
+                && saved.getAccessKey().equals("LTAI5tNormalizedKey000001")
+                && saved.getSecretKey().equals("secret-value")));
+    }
+
+    @Test
     void deleteShouldRejectWhenReferencedByInstanceTest() {
         CloudCredentialVO stored = new CloudCredentialVO();
         stored.setId(1L);
@@ -194,6 +226,26 @@ class CloudCredentialServiceTest {
         verify(aliyunClientFactory).invalidateCredential(1L);
         verify(operationAuditService).record(eq("UPDATE_CLOUD_CREDENTIAL"), eq("CLOUD_CREDENTIAL"),
                 eq("1"), eq(null), eq("name=null, vendor=ALIYUN"), eq("SUCCESS"), eq(null));
+    }
+
+    @Test
+    void updateShouldNormalizeEditableCredentialFieldsTest() {
+        CloudCredentialVO stored = new CloudCredentialVO();
+        stored.setId(1L);
+        stored.setVendor(InstanceVendor.TENCENT);
+        stored.setAccessKey("AKIDexample");
+        stored.setSecretKey("old-secret");
+        when(credentialRepository.findById(1L)).thenReturn(Optional.of(stored));
+        when(credentialRepository.replace(any(CloudCredentialVO.class))).thenReturn(true);
+        UpdateCloudCredentialDTO request = new UpdateCloudCredentialDTO();
+        request.setId(1L);
+        request.setName("  renamed  ");
+        request.setSecretKey("  new-secret  ");
+
+        service.update(request);
+
+        verify(credentialRepository).replace(argThat(saved -> saved.getName().equals("renamed")
+                && saved.getSecretKey().equals("new-secret")));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- normalize paged search text before repository lookup
- strip credential names, access keys, and secrets before create
- strip editable credential identity fields before update

## Verification

- CloudCredentialServiceTest: 17 tests passed
- Maven Checkstyle: 0 violations
- scope check: 64 changed lines

Fixes #2446