### PR TITLE
[ISSUE #2443] fix(users): guard concurrent management requests

### DIFF
--- a/web/src/pages/studio/UserManagement.tsx
+++ b/web/src/pages/studio/UserManagement.tsx
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Card, Form, Input, Modal, Space, Switch, Table, Tag, message } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { Key, Plus } from '@phosphor-icons/react';
@@ -51,33 +51,57 @@ const UserManagementPage = () => {
   const clearAuth = useAuthStore((state) => state.logout);
   const [users, setUsers] = useState<StudioUser[]>([]);
   const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [savingPassword, setSavingPassword] = useState(false);
+  const [updatingUsers, setUpdatingUsers] = useState<Set<number>>(new Set());
   const [createOpen, setCreateOpen] = useState(false);
   const [passwordTarget, setPasswordTarget] = useState<StudioUser | null>(null);
   const [createForm] = Form.useForm<CreateFormValues>();
   const [passwordForm] = Form.useForm<PasswordFormValues>();
+  const mountedRef = useRef(true);
+  const loadRequestRef = useRef(0);
+  const createInFlightRef = useRef(false);
+  const passwordInFlightRef = useRef(false);
+  const updatingUsersRef = useRef<Set<number>>(new Set());
 
   const loadUsers = useCallback(async () => {
     if (!admin) return;
+    const requestId = ++loadRequestRef.current;
     setLoading(true);
     try {
-      setUsers(await listStudioUsers());
+      const loadedUsers = await listStudioUsers();
+      if (mountedRef.current && requestId === loadRequestRef.current) {
+        setUsers(loadedUsers);
+      }
     } catch {
-      message.error('加载用户列表失败');
+      if (mountedRef.current && requestId === loadRequestRef.current) {
+        message.error('加载用户列表失败');
+      }
     } finally {
-      setLoading(false);
+      if (mountedRef.current && requestId === loadRequestRef.current) {
+        setLoading(false);
+      }
     }
   }, [admin]);
 
   useEffect(() => {
+    mountedRef.current = true;
     const timer = window.setTimeout(() => {
       void loadUsers();
     }, 0);
-    return () => window.clearTimeout(timer);
+    return () => {
+      mountedRef.current = false;
+      loadRequestRef.current += 1;
+      window.clearTimeout(timer);
+    };
   }, [loadUsers]);
 
   const createUser = async () => {
-    const values = await createForm.validateFields();
+    if (createInFlightRef.current) return;
+    createInFlightRef.current = true;
+    setCreating(true);
     try {
+      const values = await createForm.validateFields();
       await createStudioUser(values);
       message.success('用户已创建');
       setCreateOpen(false);
@@ -85,23 +109,34 @@ const UserManagementPage = () => {
       await loadUsers();
     } catch {
       message.error('创建用户失败');
+    } finally {
+      createInFlightRef.current = false;
+      if (mountedRef.current) setCreating(false);
     }
   };
 
   const setEnabled = async (record: StudioUser, enabled: boolean) => {
+    if (updatingUsersRef.current.has(record.id)) return;
+    updatingUsersRef.current.add(record.id);
+    setUpdatingUsers(new Set(updatingUsersRef.current));
     try {
       await setStudioUserEnabled(record.id, enabled);
       message.success(enabled ? '用户已启用' : '用户已禁用，全部会话已注销');
       await loadUsers();
     } catch {
       message.error('更新用户状态失败');
+    } finally {
+      updatingUsersRef.current.delete(record.id);
+      if (mountedRef.current) setUpdatingUsers(new Set(updatingUsersRef.current));
     }
   };
 
   const updatePassword = async () => {
-    if (!passwordTarget) return;
-    const values = await passwordForm.validateFields();
+    if (!passwordTarget || passwordInFlightRef.current) return;
+    passwordInFlightRef.current = true;
+    setSavingPassword(true);
     try {
+      const values = await passwordForm.validateFields();
       if (passwordTarget.id === userId) {
         await changePassword(values.currentPassword ?? '', values.newPassword);
         clearAuth();
@@ -115,6 +150,9 @@ const UserManagementPage = () => {
       passwordForm.resetFields();
     } catch {
       message.error('修改密码失败');
+    } finally {
+      passwordInFlightRef.current = false;
+      if (mountedRef.current) setSavingPassword(false);
     }
   };
 
@@ -143,6 +181,7 @@ const UserManagementPage = () => {
           </Button>
           <Switch
             checked={record.enabled}
+            loading={updatingUsers.has(record.id)}
             checkedChildren="启用"
             unCheckedChildren="禁用"
             onChange={(enabled) => void setEnabled(record, enabled)}
@@ -195,6 +234,7 @@ const UserManagementPage = () => {
       <Modal
         title="新建 Studio 用户"
         open={createOpen}
+        confirmLoading={creating}
         onOk={() => void createUser()}
         onCancel={() => setCreateOpen(false)}
       >
@@ -222,6 +262,7 @@ const UserManagementPage = () => {
             : `重置 ${passwordTarget?.username ?? ''} 的密码`
         }
         open={passwordTarget !== null}
+        confirmLoading={savingPassword}
         onOk={() => void updatePassword()}
         onCancel={() => {
           setPasswordTarget(null);

--- a/web/src/pages/studio/__tests__/UserManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/UserManagement.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { App } from 'antd';
+import {
+  createStudioUser,
+  listStudioUsers,
+  setStudioUserEnabled,
+  type StudioUser,
+} from '../../../api/studioUsers';
+import useAuthStore from '../../../stores/authStore';
+import UserManagementPage from '../UserManagement';
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
+vi.mock('../../../api/studioUsers', () => ({
+  createStudioUser: vi.fn(),
+  listStudioUsers: vi.fn(),
+  resetStudioUserPassword: vi.fn(),
+  setStudioUserEnabled: vi.fn(),
+}));
+vi.mock('../../../api/auth', () => ({ changePassword: vi.fn() }));
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const studioUser: StudioUser = {
+  id: 2,
+  username: 'operator',
+  admin: false,
+  enabled: true,
+  passwordChangedAt: '',
+  gmtCreate: '',
+  gmtModified: '',
+};
+
+const renderPage = () =>
+  render(
+    <App>
+      <UserManagementPage />
+    </App>,
+  );
+
+describe('UserManagementPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.setState({ admin: true, userId: 1, user: 'admin' });
+    vi.mocked(listStudioUsers).mockResolvedValue([studioUser]);
+  });
+
+  it('deduplicates create submissions before loading state is rendered', async () => {
+    vi.mocked(createStudioUser).mockImplementation(() => new Promise(() => {}));
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('operator');
+    await user.click(screen.getByRole('button', { name: '新建用户' }));
+    await user.type(screen.getByLabelText('用户名'), 'new-user');
+    await user.type(screen.getByLabelText('初始密码'), 'password1');
+    const confirm = screen.getByRole('button', { name: /OK|确\s*定/ });
+
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+
+    await waitFor(() => expect(createStudioUser).toHaveBeenCalledTimes(1));
+  });
+
+  it('deduplicates repeated status changes for the same user', async () => {
+    vi.mocked(setStudioUserEnabled).mockImplementation(() => new Promise(() => {}));
+    renderPage();
+
+    await screen.findByText('operator');
+    const enabledSwitch = screen.getByRole('switch');
+    fireEvent.click(enabledSwitch);
+    fireEvent.click(enabledSwitch);
+
+    await waitFor(() => expect(setStudioUserEnabled).toHaveBeenCalledTimes(1));
+    expect(setStudioUserEnabled).toHaveBeenCalledWith(2, false);
+  });
+});


### PR DESCRIPTION
## Summary

- ignore stale user list responses
- synchronously guard create, password, and per-user status mutations
- expose modal and row loading states while requests are active

## Verification

- UserManagement.test.tsx: 2 tests passed
- targeted ESLint and Prettier checks passed
- scope check: 166 changed lines

Fixes #2443