### PR TITLE
[ISSUE #2444] fix(settings): serialize general settings saves

### DIFF
--- a/web/src/pages/settings/GeneralSettingsTab.tsx
+++ b/web/src/pages/settings/GeneralSettingsTab.tsx
@@ -69,6 +69,8 @@ export const GeneralSettingsTab = () => {
   const [savingPreference, setSavingPreference] = useState(false);
   const [savingSecurity, setSavingSecurity] = useState(false);
   const [savingNotification, setSavingNotification] = useState(false);
+  const settingsRef = useRef<GeneralSettings | null>(null);
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
   const securityInFlightRef = useRef(false);
   const notifyInFlightRef = useRef(false);
   const [securityForm] = Form.useForm();
@@ -79,6 +81,7 @@ export const GeneralSettingsTab = () => {
     void getGeneralSettings()
       .then((loaded) => {
         if (cancelled) return;
+        settingsRef.current = loaded;
         setSettings(loaded);
         securityForm.setFieldsValue({ sessionTimeout: loaded.sessionTimeout });
         notifyForm.setFieldsValue({
@@ -100,31 +103,46 @@ export const GeneralSettingsTab = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const persistPreference = async (patch: Partial<GeneralSettings>) => {
-    if (!settings) return;
-    const next = { ...settings, ...patch };
-    setSettings(next);
-    setSavingPreference(true);
-    try {
-      await saveGeneralSettings(buildPayload(next));
-      message.success('设置已保存');
-    } catch {
-      message.error('设置保存失败，请稍后重试');
-    } finally {
-      setSavingPreference(false);
-    }
+  const mergeAndSave = (patch: Partial<GeneralSettings>) => {
+    const operation = saveQueueRef.current.then(async () => {
+      const previous = settingsRef.current;
+      if (!previous) return { saved: false, previous: null };
+
+      const next = { ...previous, ...patch };
+      try {
+        await saveGeneralSettings(buildPayload(next));
+        settingsRef.current = next;
+        setSettings((current) => (current ? { ...current, ...patch } : next));
+        return { saved: true, previous };
+      } catch {
+        message.error('设置保存失败，请稍后重试');
+        return { saved: false, previous };
+      }
+    });
+    saveQueueRef.current = operation.then(() => undefined);
+    return operation;
   };
 
-  const mergeAndSave = async (patch: Partial<GeneralSettings>) => {
-    if (!settings) return false;
-    try {
-      await saveGeneralSettings(buildPayload({ ...settings, ...patch }));
-      setSettings({ ...settings, ...patch });
-      return true;
-    } catch {
-      message.error('设置保存失败，请稍后重试');
-      return false;
+  const persistPreference = async (patch: Partial<GeneralSettings>) => {
+    if (!settingsRef.current) return;
+    setSettings((current) => (current ? { ...current, ...patch } : current));
+    setSavingPreference(true);
+    const result = await mergeAndSave(patch);
+    if (result.saved) {
+      message.success('设置已保存');
+    } else if (result.previous) {
+      const rollback: Partial<GeneralSettings> = {};
+      if (patch.theme !== undefined) {
+        rollback.theme = result.previous.theme;
+        setThemeMode(toThemeMode(result.previous.theme));
+      }
+      if (patch.compact !== undefined) {
+        rollback.compact = result.previous.compact;
+        setCompact(result.previous.compact);
+      }
+      setSettings((current) => (current ? { ...current, ...rollback } : current));
     }
+    setSavingPreference(false);
   };
 
   const handleSecurityFinish = async (values: { sessionTimeout: number }) => {
@@ -132,7 +150,7 @@ export const GeneralSettingsTab = () => {
     securityInFlightRef.current = true;
     setSavingSecurity(true);
     try {
-      if (await mergeAndSave({ sessionTimeout: values.sessionTimeout })) {
+      if ((await mergeAndSave({ sessionTimeout: values.sessionTimeout })).saved) {
         message.success('设置已保存');
       }
     } finally {
@@ -150,7 +168,7 @@ export const GeneralSettingsTab = () => {
     notifyInFlightRef.current = true;
     setSavingNotification(true);
     try {
-      if (await mergeAndSave(values)) {
+      if ((await mergeAndSave(values)).saved) {
         message.success('设置已保存');
       }
     } finally {

--- a/web/src/pages/settings/__tests__/GeneralSettingsTab.test.tsx
+++ b/web/src/pages/settings/__tests__/GeneralSettingsTab.test.tsx
@@ -21,6 +21,7 @@ import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { getGeneralSettings, saveGeneralSettings } from '../../../api/settings';
 import { ThemeProvider } from '../../../theme/ThemeProvider';
+import { useTheme } from '../../../theme/useTheme';
 import { GeneralSettingsTab } from '../GeneralSettingsTab';
 
 beforeAll(() => {
@@ -49,11 +50,22 @@ vi.mock('../../../api/settings', () => ({
   updateDataSource: vi.fn(),
 }));
 
+const ThemeProbe = () => {
+  const { themeMode, compact } = useTheme();
+  return (
+    <>
+      <span data-testid="theme-mode">{themeMode}</span>
+      <span data-testid="compact-mode">{String(compact)}</span>
+    </>
+  );
+};
+
 const renderTab = () =>
   render(
     <App>
       <ThemeProvider>
         <GeneralSettingsTab />
+        <ThemeProbe />
       </ThemeProvider>
     </App>,
   );
@@ -137,5 +149,69 @@ describe('GeneralSettingsTab', () => {
       ),
     );
     expect(localStorage.getItem('rocketmq-studio-theme')).toBe('dark');
+  });
+
+  it('rolls back the appearance preference when saving fails', async () => {
+    vi.mocked(saveGeneralSettings).mockRejectedValue(new Error('save failed'));
+    const user = userEvent.setup();
+    renderTab();
+
+    await screen.findByText('主题模式');
+    await user.click(screen.getByText('深色'));
+
+    await waitFor(() => expect(saveGeneralSettings).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByTestId('theme-mode')).toHaveTextContent('system'));
+    expect(screen.getByRole('radio', { name: '跟随系统' })).toBeChecked();
+    expect(localStorage.getItem('rocketmq-studio-theme')).toBe('system');
+  });
+
+  it('rolls back compact mode when saving fails', async () => {
+    vi.mocked(saveGeneralSettings).mockRejectedValue(new Error('save failed'));
+    const user = userEvent.setup();
+    renderTab();
+
+    await screen.findByText('紧凑模式');
+    const compactSwitch = screen.getByRole('switch');
+    await user.click(compactSwitch);
+
+    await waitFor(() => expect(saveGeneralSettings).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByTestId('compact-mode')).toHaveTextContent('false'));
+    expect(compactSwitch).not.toBeChecked();
+    expect(localStorage.getItem('rocketmq-studio-compact')).toBe('false');
+  });
+
+  it('serializes form saves and merges each patch into the latest settings', async () => {
+    let resolveFirstSave!: () => void;
+    vi.mocked(saveGeneralSettings)
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirstSave = resolve;
+          }),
+      )
+      .mockResolvedValueOnce();
+    const user = userEvent.setup();
+    renderTab();
+
+    const timeout = await screen.findByDisplayValue('30');
+    const saveButtons = screen.getAllByRole('button', { name: '保存设置' });
+    await user.clear(timeout);
+    await user.type(timeout, '45');
+    fireEvent.submit(saveButtons[0].closest('form')!);
+    await waitFor(() => expect(saveGeneralSettings).toHaveBeenCalledTimes(1));
+
+    await user.type(screen.getByLabelText('钉钉机器人 Webhook'), 'https://example.test/notify');
+    fireEvent.submit(saveButtons[1].closest('form')!);
+    await waitFor(() => expect(saveButtons[1]).toHaveClass('ant-btn-loading'));
+    expect(saveGeneralSettings).toHaveBeenCalledTimes(1);
+
+    resolveFirstSave();
+    await waitFor(() => expect(saveGeneralSettings).toHaveBeenCalledTimes(2));
+    expect(saveGeneralSettings).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sessionTimeout: 45,
+        dingtalkWebhook: 'https://example.test/notify',
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- serialize full settings payload writes across forms
- merge each patch into the latest successful state
- roll back theme and compact preferences when persistence fails

## Verification

- GeneralSettingsTab.test.tsx: 7 tests passed
- targeted ESLint and Prettier checks passed
- scope check: 140 changed lines

Fixes #2444