### PR TITLE
[ISSUE #2454] fix(producers): ignore placeholder client ids

### DIFF
--- a/web/src/api/producer.test.ts
+++ b/web/src/api/producer.test.ts
@@ -202,4 +202,26 @@ describe('Producer API', () => {
     expect(result.duplicateClientIds).toEqual(['producer-a']);
     expect(result.warnings).toContain('DUPLICATE_CLIENT_ID');
   });
+
+  it('excludes null client identifier placeholders from unique and duplicate counts', () => {
+    const result = buildProducerConnectionSummary([
+      {
+        clientId: 'null',
+        clientAddr: '10.0.0.1',
+        language: 'Java',
+        versionDesc: '5.1.0',
+      },
+      {
+        clientId: ' NULL ',
+        clientAddr: '10.0.0.2',
+        language: 'Java',
+        versionDesc: '5.1.0',
+      },
+    ]);
+
+    expect(result.uniqueClientCount).toBe(0);
+    expect(result.duplicateClientIds).toEqual([]);
+    expect(result.warnings).toEqual(['INCOMPLETE_CLIENT_METADATA']);
+    expect(result.readiness).toBe('WARNING');
+  });
 });

--- a/web/src/api/producer.ts
+++ b/web/src/api/producer.ts
@@ -69,7 +69,12 @@ interface ProducerConnectionResponse {
 
 // ─── API ────────────────────────────────────────────────────────
 
-const hasText = (value?: string | null) => Boolean(value?.trim() && value.trim() !== 'null');
+const normalizeIdentity = (value?: string | null) => {
+  const normalized = value?.trim();
+  return normalized && normalized.toLowerCase() !== 'null' ? normalized : undefined;
+};
+
+const hasText = (value?: string | null) => Boolean(normalizeIdentity(value));
 
 const normalizeDimension = (value?: string | null) => (hasText(value) ? value!.trim() : 'UNKNOWN');
 
@@ -80,8 +85,8 @@ const countDistinct = (
   new Set(
     connections
       .map(extractor)
-      .filter(hasText)
-      .map((value) => value.trim()),
+      .map(normalizeIdentity)
+      .filter((value): value is string => Boolean(value)),
   ).size;
 
 const distribution = (
@@ -103,7 +108,7 @@ export function buildProducerConnectionSummary(
 ): ProducerConnectionSummary {
   const duplicateClientIds = [
     ...connections.reduce((counts, connection) => {
-      const clientId = connection.clientId?.trim();
+      const clientId = normalizeIdentity(connection.clientId);
       if (clientId) counts.set(clientId, (counts.get(clientId) ?? 0) + 1);
       return counts;
     }, new Map<string, number>()),


### PR DESCRIPTION
## Summary

- normalize producer client identities in one helper
- exclude case-insensitive null placeholders from unique and duplicate counts
- retain incomplete metadata diagnostics for placeholder rows

## Verification

- producer.test.ts: 10 tests passed
- targeted ESLint and Prettier checks passed
- scope check: 35 changed lines

Fixes #2454