### PR TITLE
[ISSUE #2456] fix(instances): normalize named identifiers

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceRepository.java
@@ -43,12 +43,13 @@ public interface InstanceRepository {
         if (identifier == null || identifier.isBlank()) {
             return Optional.empty();
         }
-        Optional<InstanceVO> byName = findByName(identifier);
+        String normalizedIdentifier = identifier.trim();
+        Optional<InstanceVO> byName = findByName(normalizedIdentifier);
         if (byName.isPresent()) {
             return byName;
         }
         try {
-            return findById(Long.parseLong(identifier.trim()));
+            return findById(Long.parseLong(normalizedIdentifier));
         } catch (NumberFormatException ex) {
             return Optional.empty();
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
@@ -169,6 +169,21 @@ class MybatisPlusInstanceRepositoryTest {
     }
 
     @Test
+    void findByIdentifierShouldNormalizeNamedInstanceTest() {
+        when(instanceMapper.selectOne(any(QueryWrapper.class)))
+                .thenReturn(entity(5L, "instance-proxy-2", InstanceType.PROXY_CLUSTER));
+
+        Optional<InstanceVO> result = repository.findByIdentifier("  instance-proxy-2  ");
+
+        assertThat(result).isPresent();
+        ArgumentCaptor<QueryWrapper<RmqInstance>> query = ArgumentCaptor.forClass(QueryWrapper.class);
+        verify(instanceMapper).selectOne(query.capture());
+        assertThat(query.getValue().getSqlSegment()).contains("name =");
+        assertThat(query.getValue().getParamNameValuePairs().values())
+                .containsExactly("instance-proxy-2");
+    }
+
+    @Test
     void countTopicsByInstanceShouldDelegateToTopicMapperTest() {
         when(topicMapper.selectCount(any(QueryWrapper.class))).thenReturn(5L);
 


### PR DESCRIPTION
## Summary

- normalize instance identifiers once at the repository boundary
- use the canonical value for both name and numeric lookups
- cover a padded named identifier query

## Verification

- MybatisPlusInstanceRepositoryTest: 17 tests passed
- Maven Checkstyle: 0 violations
- scope check: 20 changed lines

Fixes #2456