### PR TITLE
[ISSUE #2455] fix(status): preserve unknown backend values

### DIFF
--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -22,19 +22,20 @@ import { useLang } from '../i18n/LangContext';
 const { Text } = Typography;
 
 interface StatusBadgeProps {
-  status: keyof typeof STATUS_MAP;
+  status: string;
   text?: string;
   showDot?: boolean;
 }
 
 const StatusBadge = ({ status, text, showDot = true }: StatusBadgeProps) => {
   const { t } = useLang();
-  const config = STATUS_MAP[status] || STATUS_MAP.offline;
-  const label = text || t(config.labelKey);
+  const config = STATUS_MAP[status];
+  const label = text || (config ? t(config.labelKey) : status);
+  const color = config?.color ?? '#8c8c8c';
   return (
     <Space size={4} role="status" aria-label={label}>
-      {showDot && <Badge color={config.dot} aria-hidden="true" />}
-      <Text style={{ color: config.color, fontSize: 14 }}>{label}</Text>
+      {showDot && <Badge color={config?.dot ?? color} aria-hidden="true" />}
+      <Text style={{ color, fontSize: 14 }}>{label}</Text>
     </Space>
   );
 };

--- a/web/src/components/__tests__/StatusBadge.test.tsx
+++ b/web/src/components/__tests__/StatusBadge.test.tsx
@@ -56,10 +56,12 @@ describe('StatusBadge', () => {
     expect(screen.getByText('连接中')).toBeInTheDocument();
   });
 
-  it('falls back to offline config for unknown status', () => {
-    renderWithLang(<StatusBadge status="unknown_status" />);
-    // Should render offline label
-    expect(screen.getByText('离线')).toBeInTheDocument();
+  it('preserves an unknown backend status instead of reporting it as offline', () => {
+    renderWithLang(<StatusBadge status="degraded" />);
+
+    expect(screen.getByRole('status')).toHaveAccessibleName('degraded');
+    expect(screen.getByText('degraded')).toBeInTheDocument();
+    expect(screen.queryByText('离线')).not.toBeInTheDocument();
   });
 
   it('uses custom text when provided', () => {


### PR DESCRIPTION
## Summary

- stop mapping unknown statuses to offline
- render unknown backend values with a neutral style
- preserve the original accessible status name

## Verification

- StatusBadge.test.tsx: 10 tests passed
- targeted ESLint and Prettier checks passed
- scope check: 21 changed lines

Fixes #2455