### PR TITLE
[ISSUE #2452] fix(ops): distinguish configuration load states

### DIFF
--- a/web/src/pages/studio/Ops.tsx
+++ b/web/src/pages/studio/Ops.tsx
@@ -59,6 +59,8 @@ const OpsPage: React.FC = () => {
   const namesrvMutationInFlight = useRef(false);
   const vipUpdateInFlight = useRef(false);
   const tlsUpdateInFlight = useRef(false);
+  const [loadState, setLoadState] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [reloadKey, setReloadKey] = useState(0);
   const [configurationAvailable, setConfigurationAvailable] = useState(false);
   const [unavailableReason, setUnavailableReason] = useState('');
   const writeOperationEnabled = configurationAvailable && (!userId || admin === true);
@@ -69,6 +71,7 @@ const OpsPage: React.FC = () => {
     let cancelled = false;
 
     const loadOpsData = async () => {
+      setLoadState('loading');
       try {
         const data = await queryOpsHomePage();
         if (!cancelled) {
@@ -79,10 +82,11 @@ const OpsPage: React.FC = () => {
           setCurrentNamesrv(data.currentNamesrv);
           setConfigurationAvailable(data.configurationAvailable);
           setUnavailableReason(data.unavailableReason || '');
+          setLoadState('ready');
         }
       } catch {
         if (!cancelled) {
-          message.error(fetchFailedMessage);
+          setLoadState('error');
         }
       }
     };
@@ -92,7 +96,7 @@ const OpsPage: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [fetchFailedMessage, message]);
+  }, [reloadKey]);
 
   const handleUpdateNameSvrAddr = async () => {
     if (namesrvMutationInFlight.current) return;
@@ -191,7 +195,20 @@ const OpsPage: React.FC = () => {
 
   return (
     <div style={{ padding: 24 }}>
-      {!configurationAvailable && (
+      {loadState === 'error' && (
+        <Alert
+          type="error"
+          showIcon
+          message={fetchFailedMessage}
+          action={
+            <Button size="small" onClick={() => setReloadKey((key) => key + 1)}>
+              {t('common.retry')}
+            </Button>
+          }
+          style={{ marginBottom: 24 }}
+        />
+      )}
+      {loadState === 'ready' && !configurationAvailable && (
         <Alert
           type="info"
           showIcon

--- a/web/src/pages/studio/__tests__/Ops.test.tsx
+++ b/web/src/pages/studio/__tests__/Ops.test.tsx
@@ -22,7 +22,12 @@ import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
 import OpsPage from '../Ops';
-import { addNameSvrAddr, deleteNameSvrAddr, queryOpsHomePage, updateIsVIPChannel } from '../../../api/ops';
+import {
+  addNameSvrAddr,
+  deleteNameSvrAddr,
+  queryOpsHomePage,
+  updateIsVIPChannel,
+} from '../../../api/ops';
 import useAuthStore from '../../../stores/authStore';
 
 vi.mock('../../../api/ops', () => ({
@@ -83,6 +88,49 @@ describe('OpsPage', () => {
     expect(await screen.findByText('127.0.0.1:9876')).toBeInTheDocument();
     expect(screen.getAllByRole('switch')[0]).toBeChecked();
     expect(screen.getAllByRole('switch')[1]).not.toBeChecked();
+  });
+
+  it('does not report unsupported configuration while loading', async () => {
+    vi.mocked(queryOpsHomePage).mockImplementation(() => new Promise(() => {}));
+
+    renderWithProviders(<OpsPage />);
+
+    await waitFor(() => expect(queryOpsHomePage).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText('运行时配置不可用')).not.toBeInTheDocument();
+  });
+
+  it('shows a retryable load error instead of an unsupported warning', async () => {
+    vi.mocked(queryOpsHomePage).mockRejectedValueOnce(new Error('network error'));
+    const user = userEvent.setup();
+
+    renderWithProviders(<OpsPage />);
+
+    expect(
+      await screen.findByText(/获取运维数据失败|Failed to fetch ops data/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('运行时配置不可用')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /重\s*试|Retry/ }));
+
+    await waitFor(() => expect(queryOpsHomePage).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('127.0.0.1:9876')).toBeInTheDocument();
+    expect(screen.queryByText(/获取运维数据失败|Failed to fetch ops data/)).not.toBeInTheDocument();
+  });
+
+  it('reports unsupported configuration only after a successful response', async () => {
+    vi.mocked(queryOpsHomePage).mockResolvedValue({
+      namesvrAddrList: [],
+      configurationAvailable: false,
+      useVIPChannel: false,
+      useTLS: false,
+      currentNamesrv: '',
+      unavailableReason: 'Provider does not expose runtime settings',
+    });
+
+    renderWithProviders(<OpsPage />);
+
+    expect(await screen.findByText('运行时配置不可用')).toBeInTheDocument();
+    expect(screen.getByText('Provider does not expose runtime settings')).toBeInTheDocument();
   });
 
   it('prevents overlapping NameServer mutations', async () => {


### PR DESCRIPTION
## Summary

- separate loading, ready, and error states for Ops configuration
- show unsupported only after an explicit successful response
- provide a retry action for request failures

## Verification

- Ops.test.tsx: 9 tests passed
- targeted ESLint and Prettier checks passed
- scope check: 73 changed lines

Fixes #2452