### PR TITLE
[ISSUE #2462] fix(a11y): label information banners

### DIFF
--- a/web/src/components/InfoBanner.tsx
+++ b/web/src/components/InfoBanner.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import type { CSSProperties, ReactNode } from 'react';
+import { useId, type CSSProperties, type ReactNode } from 'react';
 import { theme } from 'antd';
 
 interface InfoBannerProps {
@@ -30,9 +30,13 @@ interface InfoBannerProps {
 // 颜色取 antd 主题 token，深色模式下自动适配（浅色模式观感等同 #fafafa/#f0f0f0）
 const InfoBanner = ({ title, description, children, style, ...rest }: InfoBannerProps) => {
   const { token } = theme.useToken();
+  const titleId = useId();
+
   return (
     <div
       {...rest}
+      role="note"
+      aria-labelledby={title ? titleId : undefined}
       style={{
         marginBottom: 16,
         padding: '12px 16px',
@@ -42,7 +46,11 @@ const InfoBanner = ({ title, description, children, style, ...rest }: InfoBanner
         ...style,
       }}
     >
-      {title && <div style={{ fontSize: 14, fontWeight: 500 }}>{title}</div>}
+      {title && (
+        <div id={titleId} style={{ fontSize: 14, fontWeight: 500 }}>
+          {title}
+        </div>
+      )}
       {description && (
         <div
           style={{

--- a/web/src/components/__tests__/InfoBanner.test.tsx
+++ b/web/src/components/__tests__/InfoBanner.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import InfoBanner from '../InfoBanner';
+
+describe('InfoBanner', () => {
+  it('exposes the title as the accessible name of the note', () => {
+    render(<InfoBanner title="Local metadata">Changes are stored by Studio.</InfoBanner>);
+
+    expect(screen.getByRole('note', { name: 'Local metadata' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- expose persistent information banners as accessible notes
- associate visible banner titles with the note container
- avoid dangling or language-specific labels when no title is supplied

## Verification

- InfoBanner.test.tsx: 1 test passed
- targeted ESLint and Prettier checks passed
- scope check: 40 changed lines

Fixes #2462