### PR TITLE
[ISSUE #2463] fix(auth): make status updates idempotent

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
@@ -187,6 +187,9 @@ public class AuthService {
     public RmqStudioUser setUserEnabled(Long userId, boolean enabled) {
         requireDatabaseBacked();
         RmqStudioUser user = getUser(userId);
+        if (Boolean.valueOf(enabled).equals(user.getEnabled())) {
+            return user;
+        }
         if (!enabled && Boolean.TRUE.equals(user.getAdmin()) && enabledAdminCount() <= 1) {
             throw new BusinessException(409, "The last enabled administrator cannot be disabled");
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceDatabaseTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceDatabaseTest.java
@@ -108,6 +108,19 @@ class AuthServiceDatabaseTest {
     }
 
     @Test
+    void disablingAnAlreadyDisabledAdministratorIsIdempotent() {
+        RmqStudioUser user = user(1L, "retired-admin", true, false, "password-1");
+        when(userMapper.selectById(1L)).thenReturn(user);
+
+        RmqStudioUser result = authService.setUserEnabled(1L, false);
+
+        assertThat(result).isSameAs(user);
+        verify(userMapper, never()).selectCount(any(Wrapper.class));
+        verify(userMapper, never()).updateById(any(RmqStudioUser.class));
+        verify(sessionMapper, never()).update(isNull(), any(Wrapper.class));
+    }
+
+    @Test
     void databaseAuthenticationThrottlesLastSeenWrites() {
         RmqStudioUser user = user(1L, "operator", false, true, "password-1");
         RmqStudioSession session = activeSession(10L, 1L,


### PR DESCRIPTION
## Summary

- return early when a requested enabled state already matches storage
- avoid last-admin validation for disabled-admin no-op updates
- skip database writes and session revocation for no-op requests

## Verification

- AuthServiceDatabaseTest: 9 tests passed
- Checkstyle passed with 0 violations
- scope check: 16 changed lines

Fixes #2463