### PR TITLE
[ISSUE #2470] fix(dlq): normalize action identifiers

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQService.java
@@ -55,17 +55,22 @@ public class DLQService {
     public DLQResendResultVO resendMessages(String instanceId, String groupName, Long startTime, Long endTime,
                                              String targetTopic) {
         requireApacheInstance(instanceId);
-        validateResendRequest(groupName, startTime, endTime);
-        log.info("Resending DLQ messages: group={}, targetTopic={}", groupName, targetTopic);
-        return dlqProvider.resendMessages(instanceId, groupName, startTime, endTime, targetTopic);
+        String normalizedGroupName = requireGroupName(groupName);
+        validateTimeRange(startTime, endTime);
+        String normalizedTargetTopic = normalizeOptional(targetTopic);
+        log.info("Resending DLQ messages: group={}, targetTopic={}",
+                normalizedGroupName, normalizedTargetTopic);
+        return dlqProvider.resendMessages(
+                instanceId, normalizedGroupName, startTime, endTime, normalizedTargetTopic);
     }
 
     public List<DLQMessageVO> exportMessages(String instanceId, String groupName, Long startTime, Long endTime,
                                              Integer maxCount) {
         requireApacheInstance(instanceId);
-        validateResendRequest(groupName, startTime, endTime);
-        log.info("Exporting DLQ messages: group={}, maxCount={}", groupName, maxCount);
-        return dlqProvider.exportMessages(instanceId, groupName, startTime, endTime, maxCount);
+        String normalizedGroupName = requireGroupName(groupName);
+        validateTimeRange(startTime, endTime);
+        log.info("Exporting DLQ messages: group={}, maxCount={}", normalizedGroupName, maxCount);
+        return dlqProvider.exportMessages(instanceId, normalizedGroupName, startTime, endTime, maxCount);
     }
 
     private void requireApacheInstance(String instanceId) {
@@ -76,10 +81,18 @@ public class DLQService {
         });
     }
 
-    private void validateResendRequest(String groupName, Long startTime, Long endTime) {
+    private String requireGroupName(String groupName) {
         if (!StringUtils.hasText(groupName)) {
             throw new BusinessException(400, "groupName is required");
         }
+        return groupName.trim();
+    }
+
+    private String normalizeOptional(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    private void validateTimeRange(Long startTime, Long endTime) {
         if ((startTime == null) != (endTime == null)) {
             throw new BusinessException(400, "startTime and endTime must be provided together");
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQServiceTest.java
@@ -90,6 +90,20 @@ class DLQServiceTest {
     }
 
     @Test
+    void resendMessagesShouldNormalizeIdentifiersBeforeDelegatingTest() {
+        dlqService.resendMessages("instance-1", " group-1 ", 1000L, 2000L, " target-topic ");
+
+        verify(dlqProvider).resendMessages("instance-1", "group-1", 1000L, 2000L, "target-topic");
+    }
+
+    @Test
+    void resendMessagesShouldTreatBlankTargetTopicAsAbsentTest() {
+        dlqService.resendMessages("instance-1", "group-1", 1000L, 2000L, "   ");
+
+        verify(dlqProvider).resendMessages("instance-1", "group-1", 1000L, 2000L, null);
+    }
+
+    @Test
     void resendMessagesShouldAcceptNullTimeRange() {
         dlqService.resendMessages("instance-1", "group-1", null, null, "target-topic");
 
@@ -131,6 +145,13 @@ class DLQServiceTest {
     @Test
     void exportMessagesShouldDelegateToProviderTest() {
         dlqService.exportMessages("instance-1", "group-1", 1000L, 2000L, 100);
+
+        verify(dlqProvider).exportMessages("instance-1", "group-1", 1000L, 2000L, 100);
+    }
+
+    @Test
+    void exportMessagesShouldNormalizeGroupNameBeforeDelegatingTest() {
+        dlqService.exportMessages("instance-1", " group-1 ", 1000L, 2000L, 100);
 
         verify(dlqProvider).exportMessages("instance-1", "group-1", 1000L, 2000L, 100);
     }


### PR DESCRIPTION
## Summary

- normalize DLQ group names at the service boundary
- strip explicit resend targets and treat blank targets as absent
- pass normalized values consistently to resend and export providers

## Verification

- DLQServiceTest: 17 tests passed
- Checkstyle passed with 0 violations
- scope check: 48 changed lines

Fixes #2470