### PR TITLE
[ISSUE #2472] fix(clusters): bound registry probes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -35,36 +35,89 @@ import org.apache.rocketmq.studio.common.domain.enums.FlushDiskType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.ops.audit.AuditService;
 import org.apache.rocketmq.studio.provider.apache.RocketMQBrokerConfigService;
-import lombok.RequiredArgsConstructor;
+import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class ClusterService {
 
-    private static final long REGISTRY_PROBE_TIMEOUT_SECONDS = 15;
-
-    private static final ExecutorService REGISTRY_PROBE_EXECUTOR = Executors.newCachedThreadPool(runnable -> {
-        Thread thread = new Thread(runnable, "nameserver-registry-probe");
-        thread.setDaemon(true);
-        return thread;
-    });
+    private static final long REGISTRY_PROBE_TIMEOUT_MILLIS = 15_000L;
+    private static final int REGISTRY_PROBE_THREADS = 8;
+    private static final int REGISTRY_PROBE_QUEUE_CAPACITY = 64;
 
     private final ClusterRepository clusterRepository;
     private final ClusterProvider clusterProvider;
     private final RocketMQBrokerConfigService brokerConfigService;
     private final AuditService auditService;
     private final NameserverRegistryService registryService;
+    private final ExecutorService registryProbeExecutor;
+    private final long registryProbeTimeoutMillis;
+
+    @Autowired
+    public ClusterService(
+            ClusterRepository clusterRepository,
+            ClusterProvider clusterProvider,
+            RocketMQBrokerConfigService brokerConfigService,
+            AuditService auditService,
+            NameserverRegistryService registryService) {
+        this(clusterRepository, clusterProvider, brokerConfigService, auditService, registryService,
+                defaultRegistryProbeExecutor(), REGISTRY_PROBE_TIMEOUT_MILLIS);
+    }
+
+    ClusterService(
+            ClusterRepository clusterRepository,
+            ClusterProvider clusterProvider,
+            RocketMQBrokerConfigService brokerConfigService,
+            AuditService auditService,
+            NameserverRegistryService registryService,
+            ExecutorService registryProbeExecutor,
+            long registryProbeTimeoutMillis) {
+        this.clusterRepository = clusterRepository;
+        this.clusterProvider = clusterProvider;
+        this.brokerConfigService = brokerConfigService;
+        this.auditService = auditService;
+        this.registryService = registryService;
+        this.registryProbeExecutor = registryProbeExecutor;
+        this.registryProbeTimeoutMillis = registryProbeTimeoutMillis;
+    }
+
+    private static ExecutorService defaultRegistryProbeExecutor() {
+        AtomicInteger threadIndex = new AtomicInteger();
+        return new ThreadPoolExecutor(
+                REGISTRY_PROBE_THREADS,
+                REGISTRY_PROBE_THREADS,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<>(REGISTRY_PROBE_QUEUE_CAPACITY),
+                runnable -> {
+                    Thread thread = new Thread(runnable,
+                            "nameserver-registry-probe-" + threadIndex.incrementAndGet());
+                    thread.setDaemon(true);
+                    return thread;
+                },
+                new ThreadPoolExecutor.AbortPolicy());
+    }
+
+    @PreDestroy
+    public void shutdownRegistryProbeExecutor() {
+        registryProbeExecutor.shutdownNow();
+    }
 
     public List<ClusterVO> listClusters() {
         log.info("Listing all clusters");
@@ -86,21 +139,52 @@ public class ClusterService {
         if (entries.isEmpty()) {
             return List.of();
         }
-        List<CompletableFuture<List<ClusterVO>>> futures = entries.stream()
-                .filter(entry -> entry.getNamesrvAddr() != null && !entry.getNamesrvAddr().isBlank())
-                .map(entry -> CompletableFuture
-                        .supplyAsync(() -> probeRegistryEntry(entry), REGISTRY_PROBE_EXECUTOR)
-                        .orTimeout(REGISTRY_PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                        .exceptionally(ex -> {
-                            log.warn("NameServer registry probe timed out or failed for {} ({}): {}",
-                                    entry.getName(), entry.getNamesrvAddr(), ex.getMessage());
-                            return List.of();
-                        }))
-                .toList();
-        return futures.stream()
-                .map(CompletableFuture::join)
-                .flatMap(List::stream)
-                .toList();
+        List<RegistryProbe> probes = new ArrayList<>();
+        for (NameserverRegistryVO entry : entries) {
+            if (entry.getNamesrvAddr() == null || entry.getNamesrvAddr().isBlank()) {
+                continue;
+            }
+            try {
+                probes.add(new RegistryProbe(entry,
+                        registryProbeExecutor.submit(() -> probeRegistryEntry(entry))));
+            } catch (RejectedExecutionException ex) {
+                log.warn("NameServer registry probe was rejected for {} ({}): {}",
+                        entry.getName(), entry.getNamesrvAddr(), ex.getMessage());
+            }
+        }
+
+        long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(registryProbeTimeoutMillis);
+        List<ClusterVO> clusters = new ArrayList<>();
+        for (RegistryProbe probe : probes) {
+            long remainingNanos = deadline - System.nanoTime();
+            if (remainingNanos <= 0) {
+                cancelTimedOutProbe(probe);
+                continue;
+            }
+            try {
+                clusters.addAll(probe.future().get(remainingNanos, TimeUnit.NANOSECONDS));
+            } catch (TimeoutException ex) {
+                cancelTimedOutProbe(probe);
+            } catch (ExecutionException ex) {
+                log.warn("NameServer registry probe failed for {} ({}): {}",
+                        probe.entry().getName(), probe.entry().getNamesrvAddr(), ex.getMessage());
+            } catch (InterruptedException ex) {
+                probes.forEach(item -> item.future().cancel(true));
+                Thread.currentThread().interrupt();
+                log.warn("NameServer registry probing was interrupted");
+                break;
+            }
+        }
+        return List.copyOf(clusters);
+    }
+
+    private void cancelTimedOutProbe(RegistryProbe probe) {
+        probe.future().cancel(true);
+        log.warn("NameServer registry probe timed out for {} ({}) after {} ms",
+                probe.entry().getName(), probe.entry().getNamesrvAddr(), registryProbeTimeoutMillis);
+    }
+
+    private record RegistryProbe(NameserverRegistryVO entry, Future<List<ClusterVO>> future) {
     }
 
     private List<ClusterVO> probeRegistryEntry(NameserverRegistryVO entry) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -22,6 +22,8 @@ import org.apache.rocketmq.studio.cluster.config.UpdateConfigDTO;
 import org.apache.rocketmq.studio.cluster.nameserver.CreateNameServerDTO;
 import org.apache.rocketmq.studio.cluster.nameserver.DeleteNameServerDTO;
 import org.apache.rocketmq.studio.cluster.nameserver.NameServerVO;
+import org.apache.rocketmq.studio.cluster.nameserver.NameserverRegistryService;
+import org.apache.rocketmq.studio.cluster.nameserver.NameserverRegistryVO;
 import org.apache.rocketmq.studio.cluster.nameserver.RestartNameServerDTO;
 import org.apache.rocketmq.studio.cluster.nameserver.UpdateNameServerDTO;
 import org.apache.rocketmq.studio.cluster.nameserver.UpgradeNameServerDTO;
@@ -34,10 +36,10 @@ import org.apache.rocketmq.studio.common.domain.enums.FlushDiskType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.ops.audit.AuditService;
 import org.apache.rocketmq.studio.provider.apache.RocketMQBrokerConfigService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -45,6 +47,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.assertj.core.api.ThrowableAssert;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,13 +81,19 @@ class ClusterServiceTest {
     @Mock
     private AuditService auditService;
 
-    @InjectMocks
+    @Mock
+    private NameserverRegistryService registryService;
+
     private ClusterService clusterService;
+    private ExecutorService registryProbeExecutor;
 
     private ClusterVO sampleCluster;
 
     @BeforeEach
     void setUp() {
+        registryProbeExecutor = Executors.newFixedThreadPool(2);
+        clusterService = new ClusterService(clusterRepository, clusterProvider, brokerConfigService,
+                auditService, registryService, registryProbeExecutor, 1_000L);
         sampleCluster = ClusterVO.builder()
                 .name("test-cluster")
                 .nsClusterName("ns-test-cluster")
@@ -113,6 +127,69 @@ class ClusterServiceTest {
                 .groupCount(5)
                 .build();
         sampleCluster.setId("cluster-1");
+    }
+
+    @AfterEach
+    void tearDown() {
+        clusterService.shutdownRegistryProbeExecutor();
+    }
+
+    @Test
+    void listRegistryClustersShouldLimitConcurrentProbesTest() throws Exception {
+        when(registryService.list()).thenReturn(List.of(
+                registry("ns-1"), registry("ns-2"), registry("ns-3"), registry("ns-4")));
+        AtomicInteger active = new AtomicInteger();
+        AtomicInteger maxActive = new AtomicInteger();
+        CountDownLatch firstPairStarted = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        when(clusterProvider.discoverClustersAt(org.mockito.ArgumentMatchers.anyString()))
+                .thenAnswer(invocation -> {
+                    int current = active.incrementAndGet();
+                    maxActive.accumulateAndGet(current, Math::max);
+                    firstPairStarted.countDown();
+                    try {
+                        release.await(2, TimeUnit.SECONDS);
+                    } finally {
+                        active.decrementAndGet();
+                    }
+                    return List.of(ClusterVO.builder().name("remote-cluster").build());
+                });
+
+        CompletableFuture<List<ClusterVO>> result =
+                CompletableFuture.supplyAsync(clusterService::listRegistryClusters);
+
+        assertThat(firstPairStarted.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(maxActive).hasValue(2);
+        release.countDown();
+        assertThat(result.get(2, TimeUnit.SECONDS)).hasSize(4);
+        assertThat(maxActive).hasValue(2);
+    }
+
+    @Test
+    void listRegistryClustersShouldCancelTimedOutProbeTest() throws Exception {
+        when(registryService.list()).thenReturn(List.of(registry("blocked")));
+        CountDownLatch interrupted = new CountDownLatch(1);
+        when(clusterProvider.discoverClustersAt("blocked:9876")).thenAnswer(invocation -> {
+            try {
+                new CountDownLatch(1).await();
+            } catch (InterruptedException ex) {
+                interrupted.countDown();
+                Thread.currentThread().interrupt();
+            }
+            return List.of();
+        });
+        clusterService = new ClusterService(clusterRepository, clusterProvider, brokerConfigService,
+                auditService, registryService, registryProbeExecutor, 25L);
+
+        assertThat(clusterService.listRegistryClusters()).isEmpty();
+        assertThat(interrupted.await(1, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void shutdownShouldStopRegistryProbeExecutorTest() {
+        clusterService.shutdownRegistryProbeExecutor();
+
+        assertThat(registryProbeExecutor.isShutdown()).isTrue();
     }
 
     @Test
@@ -716,5 +793,12 @@ class ClusterServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(message)
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
+    }
+
+    private NameserverRegistryVO registry(String name) {
+        return NameserverRegistryVO.builder()
+                .name(name)
+                .namesrvAddr(name + ":9876")
+                .build();
     }
 }


### PR DESCRIPTION
## Summary

- replace the unbounded static probe pool with a lifecycle-managed bounded executor
- enforce one shared registry request budget and cancel timed-out futures
- degrade rejected, failed, and timed-out entries without failing healthy results

## Verification

- ClusterServiceTest: 39 tests passed
- Checkstyle passed with 0 violations
- scope check: 224 changed lines

Fixes #2472