### PR TITLE
[ISSUE #2474] fix(history): preserve applied drawer search

### DIFF
--- a/web/src/components/MessageQueryHistoryDrawer.tsx
+++ b/web/src/components/MessageQueryHistoryDrawer.tsx
@@ -32,6 +32,7 @@ const formatTime = (value?: string) => {
 const MessageQueryHistoryDrawer = ({ open, clusterId, onClose }: Props) => {
   const [tab, setTab] = useState<'messages' | 'traces'>('messages');
   const [search, setSearch] = useState('');
+  const [searchInput, setSearchInput] = useState('');
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -117,9 +118,13 @@ const MessageQueryHistoryDrawer = ({ open, clusterId, onClose }: Props) => {
       <Input.Search
         allowClear
         placeholder="搜索 Topic、Message ID、Key 或操作者"
+        value={searchInput}
+        onChange={(event) => setSearchInput(event.target.value)}
         onSearch={(value) => {
+          const normalized = value.trim();
           setPage(1);
-          setSearch(value.trim());
+          setSearchInput(normalized);
+          setSearch(normalized);
         }}
         style={{ marginBottom: 12, width: 420 }}
       />

--- a/web/src/components/__tests__/MessageQueryHistoryDrawer.test.tsx
+++ b/web/src/components/__tests__/MessageQueryHistoryDrawer.test.tsx
@@ -108,4 +108,48 @@ describe('MessageQueryHistoryDrawer', () => {
     expect(screen.queryByText('order-1')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /重\s*试/ })).toBeEnabled();
   });
+
+  it('keeps the applied search visible after the drawer is reopened', async () => {
+    const user = userEvent.setup();
+    const view = render(
+      <App>
+        <MessageQueryHistoryDrawer open clusterId="instance-a" onClose={vi.fn()} />
+      </App>,
+    );
+    const searchInput = await screen.findByPlaceholderText('搜索 Topic、Message ID、Key 或操作者');
+
+    await user.type(searchInput, ' orders ');
+    await user.keyboard('{Enter}');
+    await waitFor(() =>
+      expect(listMessageQueryHistory).toHaveBeenLastCalledWith(
+        expect.objectContaining({ search: 'orders' }),
+      ),
+    );
+    vi.mocked(listMessageQueryHistory).mockClear();
+
+    view.rerender(
+      <App>
+        <MessageQueryHistoryDrawer open={false} clusterId="instance-a" onClose={vi.fn()} />
+      </App>,
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByPlaceholderText('搜索 Topic、Message ID、Key 或操作者'),
+      ).not.toBeInTheDocument(),
+    );
+    view.rerender(
+      <App>
+        <MessageQueryHistoryDrawer open clusterId="instance-a" onClose={vi.fn()} />
+      </App>,
+    );
+
+    expect(await screen.findByPlaceholderText('搜索 Topic、Message ID、Key 或操作者')).toHaveValue(
+      'orders',
+    );
+    await waitFor(() =>
+      expect(listMessageQueryHistory).toHaveBeenCalledWith(
+        expect.objectContaining({ search: 'orders' }),
+      ),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- keep query-history search text in a controlled draft state
- apply normalized search only on explicit submission
- restore the visible applied filter after drawer content recreation

## Verification

- MessageQueryHistoryDrawer.test.tsx: 3 tests passed
- targeted ESLint and Prettier checks passed
- scope check: 51 changed lines

Fixes #2474