### PR TITLE
[ISSUE #2480] fix(config): normalize API base URL

### DIFF
--- a/web/src/config.test.ts
+++ b/web/src/config.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { API_BASE_URL } from './config';
+import { API_BASE_URL, normalizeApiBaseUrl } from './config';
 
 describe('config API base url', () => {
   it('defaults to a relative /api path when no env override is set', () => {
@@ -29,7 +29,20 @@ describe('config API base url', () => {
     expect(API_BASE_URL.startsWith('//localhost')).toBe(false);
   });
 
-  it('strips a single trailing slash', () => {
-    expect(API_BASE_URL.endsWith('/')).toBe(false);
+  it.each([
+    [undefined, '/api'],
+    ['', '/api'],
+    ['   ', '/api'],
+    ['/api', '/api'],
+    [' /api/ ', '/api'],
+    ['/api///', '/api'],
+    [' https://gateway.example.com/studio/api/// ', 'https://gateway.example.com/studio/api'],
+  ])('normalizes API base override %j to %j', (input, expected) => {
+    expect(normalizeApiBaseUrl(input)).toBe(expected);
+  });
+
+  it('represents a same-origin root override without a trailing slash', () => {
+    expect(normalizeApiBaseUrl('/')).toBe('');
+    expect(normalizeApiBaseUrl(' /// ')).toBe('');
   });
 });

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -9,5 +9,17 @@
  */
 export const USE_MOCK = false;
 
+/**
+ * Normalizes the optional API endpoint supplied at build time.
+ *
+ * An empty result intentionally represents the same-origin root: API callers use
+ * absolute paths such as `/auth/status`, so configuring `/` must not introduce a
+ * double slash. Blank overrides fall back to the reverse-proxy-friendly `/api`.
+ */
+export function normalizeApiBaseUrl(value?: string): string {
+  const configured = value?.trim() || '/api';
+  return configured.replace(/\/+$/, '');
+}
+
 /** API prefix for browser requests. Defaults to the reverse-proxy friendly `/api`. */
-export const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '/api').replace(/\/$/, '');
+export const API_BASE_URL = normalizeApiBaseUrl(import.meta.env.VITE_API_BASE_URL);


### PR DESCRIPTION
## Summary

- trim the optional build-time API base URL
- fall back to /api when the override is blank
- remove repeated trailing slashes while preserving same-origin root semantics

## Verification

- config.test.ts: 10 tests passed
- targeted ESLint and Prettier checks passed
- scope check: 33 changed lines

Fixes #2480