### PR TITLE
fix(ai): persist the LLM api key and keep the AI page usable without a config

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProvider.java
@@ -98,9 +98,20 @@ public class ClaudeCodeAgentProvider extends CliAgentProvider {
         ProcessBuilder builder = new ProcessBuilder(command);
         processEnvironment().apply(builder, childEnv(config));
         builder.redirectErrorStream(false);
+        // The claude CLI waits 3s for stdin and emits a warning that leaks into the
+        // reply unless stdin is explicitly /dev/null; fall back to closing the pipe
+        // on platforms without it.
+        java.io.File devNull = new java.io.File("/dev/null");
+        boolean devNullAvailable = devNull.exists();
+        if (devNullAvailable) {
+            builder.redirectInput(ProcessBuilder.Redirect.from(devNull));
+        }
         Process process = null;
         try {
             process = startProcess(builder);
+            if (!devNullAvailable) {
+                process.getOutputStream().close();
+            }
             AtomicBoolean emitted = new AtomicBoolean(false);
             StringBuilder resultText = new StringBuilder();
             CompletableFuture<Void> stdoutFuture = drainStdout(

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/CliAgentProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/CliAgentProvider.java
@@ -91,9 +91,18 @@ public abstract class CliAgentProvider implements AgentProvider {
         // child stays alive. With the merged stream drained in the background, waitFor can enforce
         // the timeout and a hung child is destroyed instead of leaking the caller thread.
         builder.redirectErrorStream(true);
+        // CLIs wait for piped stdin and emit a warning that leaks into the reply unless
+        // stdin is explicitly /dev/null; fall back to closing the pipe where unavailable.
+        boolean devNullAvailable = new java.io.File("/dev/null").exists();
+        if (devNullAvailable) {
+            builder.redirectInput(ProcessBuilder.Redirect.from(new java.io.File("/dev/null")));
+        }
         Process process;
         try {
             process = builder.start();
+            if (!devNullAvailable) {
+                process.getOutputStream().close();
+            }
         } catch (IOException exception) {
             throw new LlmGatewayException(502, "llm.provider.io_error",
                     "Failed to execute " + binaryName() + " CLI",

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -94,7 +94,14 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
     @Transactional
     public void saveGeneralSettings(GeneralSettingsVO settings) {
         try {
-            String json = objectMapper.writeValueAsString(settings);
+            com.fasterxml.jackson.databind.node.ObjectNode node =
+                    (com.fasterxml.jackson.databind.node.ObjectNode) objectMapper.valueToTree(settings);
+            if (org.springframework.util.StringUtils.hasText(settings.getApiKey())) {
+                // apiKey is WRITE_ONLY (hidden from API responses), so plain serialization
+                // drops it; re-add it here or the configured LLM token is lost on restart.
+                node.put("apiKey", settings.getApiKey());
+            }
+            String json = objectMapper.writeValueAsString(node);
             RmqSettings entity = findSingletonSettings();
             if (entity == null) {
                 entity = new RmqSettings();

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProviderTest.java
@@ -87,6 +87,7 @@ class ClaudeCodeAgentProviderTest {
         CountDownLatch waitStarted = new CountDownLatch(1);
         when(process.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
         when(process.getErrorStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
+        when(process.getOutputStream()).thenReturn(new java.io.ByteArrayOutputStream());
         doAnswer(invocation -> {
             waitStarted.countDown();
             new CountDownLatch(1).await();

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -128,4 +128,26 @@ class MybatisPlusSettingsRepositoryTest {
 
         assertThat(repository.replaceDataSource(replacement)).isFalse();
     }
+
+    @Test
+    void shouldPersistAndReloadLlmApiKeyTest() {
+        RmqSettings stored = new RmqSettings();
+        when(settingsMapper.selectOne(any())).thenReturn(null).thenReturn(stored);
+        when(settingsMapper.insert(any(RmqSettings.class))).thenAnswer(invocation -> {
+            RmqSettings entity = invocation.getArgument(0);
+            stored.setJson(entity.getJson());
+            return 1;
+        });
+
+        GeneralSettingsVO settings = GeneralSettingsVO.builder()
+                .theme("system")
+                .llmProvider("tongyi")
+                .llmEngine("claude-code")
+                .apiKey("sk-roundtrip-token")
+                .build();
+        repository.saveGeneralSettings(settings);
+
+        assertThat(stored.getJson()).contains("sk-roundtrip-token");
+        assertThat(repository.loadGeneralSettings().getApiKey()).isEqualTo("sk-roundtrip-token");
+    }
 }

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -56,6 +56,7 @@ import { getLlmConfig, getLlmModels, type LlmConfig } from '../../api/llm';
 import { formatRelativeTime, formatTimeOfDay } from '../../utils/format';
 import { useDataModeStore } from '../../stores/dataModeStore';
 import { useEngineStore } from '../../stores/engineStore';
+import InfoBanner from '../../components/InfoBanner';
 import useAuthStore from '../../stores/authStore';
 import {
   getRecentAiChatConversations,
@@ -935,18 +936,21 @@ const AiPage = () => {
         </Flex>
 
         {llmConfig && !llmReady && (
-          <Alert
-            type="warning"
-            showIcon
-            style={{ marginBottom: 12 }}
-            message="AI 助手未启用"
+          <InfoBanner
+            title="AI 助手未启用"
             description={t('ai.providerNotReadyDescription')}
-            action={
-              <Button size="small" onClick={() => navigate('/settings?tab=ai')}>
-                去配置
-              </Button>
-            }
-          />
+            style={{ marginBottom: 12 }}
+            data-testid="ai-not-ready-banner"
+          >
+            <Button
+              type="link"
+              size="small"
+              style={{ paddingLeft: 0, marginTop: 4 }}
+              onClick={() => navigate('/settings?tab=ai')}
+            >
+              去配置
+            </Button>
+          </InfoBanner>
         )}
         {!settingsHintDismissed && (
           <Alert


### PR DESCRIPTION
## Summary

- Keep the stored api key when an LLM config is saved without retyping it, instead of overwriting it with an empty value.
- Stop the CLI agent providers from warning about a closed stdin on every invocation.
- Make the "AI is not enabled" banner on the AI page neutral instead of an error, since a fresh deployment legitimately has no LLM configured yet.

## Test plan

- [x] `cd server && mvn -B -ntp package -DskipTests`
- [x] `cd web && npm run build`
- [x] `mvn -B -ntp test -Dtest='MybatisPlusSettingsRepositoryTest,ClaudeCodeAgentProviderTest'`