### PR TITLE
feat(studio): manage individual DLQ messages

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQController.java
@@ -51,11 +51,30 @@ public class DLQController {
         return Result.ok(dlqService.listDLQGroups(instanceId, search, page, pageSize));
     }
 
+    @GetMapping("/messages")
+    public Result<DLQMessagePageVO> listMessages(@RequestParam String instanceId, @RequestParam String groupName,
+                                                   @RequestParam(required = false) Long startTime,
+                                                   @RequestParam(required = false) Long endTime,
+                                                   @RequestParam(defaultValue = "1") int page,
+                                                   @RequestParam(defaultValue = "20") int pageSize) {
+        return Result.ok(dlqService.listMessages(instanceId, groupName, startTime, endTime, page, pageSize));
+    }
+
     @PostMapping("/resend")
     public Result<DLQResendResultVO> resendMessages(@Valid @RequestBody(required = false) DLQResendRequestDTO request) {
         requireRequest(request);
         return Result.ok(dlqService.resendMessages(request.getInstanceId(), request.getGroupName(),
                 request.getStartTime(), request.getEndTime(), request.getTargetTopic()));
+    }
+
+    @PostMapping("/messages/resend")
+    public Result<DLQResendResultVO> resendSelectedMessages(
+            @Valid @RequestBody(required = false) DLQSelectedResendRequestDTO request) {
+        if (request == null) {
+            throw new BusinessException(400, "DLQ selected resend request is required");
+        }
+        return Result.ok(dlqService.resendSelectedMessages(request.getInstanceId(), request.getGroupName(),
+                request.getStartTime(), request.getEndTime(), request.getTargetTopic(), request.getMessages()));
     }
 
     @GetMapping("/export")

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQMessagePageVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQMessagePageVO.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.dlq;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class DLQMessagePageVO {
+    List<DLQMessageVO> items;
+    long total;
+    int page;
+    int size;
+    boolean scanIncomplete;
+    int failedQueueCount;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQMessageRefDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQMessageRefDTO.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.dlq;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Data;
+
+@Data
+public class DLQMessageRefDTO {
+    @NotBlank(message = "msgId is required")
+    private String msgId;
+    private int queueId;
+    @PositiveOrZero(message = "offset must not be negative")
+    private long offset;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQProvider.java
@@ -29,4 +29,10 @@ public interface DLQProvider {
                                      String targetTopic);
     List<DLQMessageVO> exportMessages(String instanceId, String groupName, Long startTime, Long endTime,
                                       Integer maxCount);
+
+    DLQMessagePageVO listMessages(String instanceId, String groupName, Long startTime, Long endTime,
+                                  int page, int pageSize);
+
+    DLQResendResultVO resendSelectedMessages(String instanceId, String groupName, Long startTime, Long endTime,
+                                              String targetTopic, List<DLQMessageRefDTO> messages);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQProviderStub.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQProviderStub.java
@@ -58,6 +58,19 @@ public class DLQProviderStub implements DLQProvider {
         throw unsupported();
     }
 
+    @Override
+    public DLQMessagePageVO listMessages(String instanceId, String groupName, Long startTime, Long endTime,
+                                          int page, int pageSize) {
+        throw unsupported();
+    }
+
+    @Override
+    public DLQResendResultVO resendSelectedMessages(String instanceId, String groupName, Long startTime,
+                                                     Long endTime, String targetTopic,
+                                                     List<DLQMessageRefDTO> messages) {
+        throw unsupported();
+    }
+
     private BusinessException unsupported() {
         return new BusinessException(501, "DLQ provider is not configured");
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQSelectedResendRequestDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQSelectedResendRequestDTO.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file except in compliance with the License.
+ */
+package org.apache.rocketmq.studio.instance.dlq;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class DLQSelectedResendRequestDTO {
+    @NotBlank(message = "instanceId is required")
+    private String instanceId;
+    @NotBlank(message = "groupName is required")
+    private String groupName;
+    private Long startTime;
+    private Long endTime;
+    private String targetTopic;
+    @Valid
+    @NotEmpty(message = "messages is required")
+    private List<DLQMessageRefDTO> messages;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQService.java
@@ -33,6 +33,7 @@ import java.util.List;
 public class DLQService {
 
     private static final int MAX_PAGE_SIZE = 100;
+    private static final int MAX_SELECTED_MESSAGES = 100;
 
     private final DLQProvider dlqProvider;
     private final InstanceProviderRegistry providerRegistry;
@@ -66,6 +67,28 @@ public class DLQService {
         validateResendRequest(groupName, startTime, endTime);
         log.info("Exporting DLQ messages: group={}, maxCount={}", groupName, maxCount);
         return dlqProvider.exportMessages(instanceId, groupName, startTime, endTime, maxCount);
+    }
+
+    public DLQMessagePageVO listMessages(String instanceId, String groupName, Long startTime, Long endTime,
+                                          int page, int pageSize) {
+        requireApacheInstance(instanceId);
+        validateResendRequest(groupName, startTime, endTime);
+        if (page < 1 || pageSize < 1 || pageSize > MAX_PAGE_SIZE) {
+            throw new BusinessException(400, "Invalid page or pageSize");
+        }
+        return dlqProvider.listMessages(instanceId, groupName.trim(), startTime, endTime, page, pageSize);
+    }
+
+    public DLQResendResultVO resendSelectedMessages(String instanceId, String groupName, Long startTime,
+                                                      Long endTime, String targetTopic,
+                                                      List<DLQMessageRefDTO> messages) {
+        requireApacheInstance(instanceId);
+        validateResendRequest(groupName, startTime, endTime);
+        if (messages == null || messages.isEmpty() || messages.size() > MAX_SELECTED_MESSAGES) {
+            throw new BusinessException(400, "messages must contain between 1 and 100 entries");
+        }
+        return dlqProvider.resendSelectedMessages(instanceId, groupName.trim(), startTime, endTime, targetTopic,
+                messages);
     }
 
     private void requireApacheInstance(String instanceId) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -37,6 +37,8 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.Pagination;
 import org.apache.rocketmq.studio.instance.dlq.DLQGroupVO;
 import org.apache.rocketmq.studio.instance.dlq.DLQMessageVO;
+import org.apache.rocketmq.studio.instance.dlq.DLQMessagePageVO;
+import org.apache.rocketmq.studio.instance.dlq.DLQMessageRefDTO;
 import org.apache.rocketmq.studio.instance.dlq.DLQProvider;
 import org.apache.rocketmq.studio.instance.dlq.DLQResendResultVO;
 import org.apache.rocketmq.studio.ops.audit.AuditService;
@@ -240,6 +242,75 @@ public class RocketMQDLQProvider implements DLQProvider {
         int cap = maxCount == null || maxCount <= 0 ? RESEND_HARD_CAP : Math.min(maxCount, RESEND_HARD_CAP);
         DeadLetterScanResult scanResult = collectDeadLetters(endpoint, credentialHook, dlqTopic, begin, end, cap);
         return scanResult.messages().stream().map(this::toExportVO).toList();
+    }
+
+    @Override
+    public DLQMessagePageVO listMessages(String instanceId, String groupName, Long startTime, Long endTime,
+                                          int page, int pageSize) {
+        String endpoint = runtimeAdminClientResolver.resolveEndpoint(instanceId);
+        RPCHook credentialHook = runtimeAdminClientResolver.resolveCredentialHook(instanceId);
+        long end = endTime != null ? endTime : System.currentTimeMillis();
+        long begin = startTime != null ? startTime : end - ONE_HOUR_MILLIS;
+        DeadLetterScanResult scanResult = collectDeadLetters(endpoint, credentialHook,
+                MixAll.DLQ_GROUP_TOPIC_PREFIX + groupName, begin, end, RESEND_HARD_CAP);
+        List<DLQMessageVO> messages = scanResult.messages().stream().map(this::toExportVO)
+                .sorted(Comparator.comparingLong(DLQMessageVO::getStoreTime).reversed()).toList();
+        long offset = Pagination.pageOffset(page, pageSize);
+        int from = (int) Math.min(offset, messages.size());
+        int to = (int) Math.min(offset + pageSize, messages.size());
+        return DLQMessagePageVO.builder().items(messages.subList(from, to)).total(messages.size()).page(page)
+                .size(pageSize).scanIncomplete(scanResult.scanIncomplete())
+                .failedQueueCount(scanResult.failedQueueCount()).build();
+    }
+
+    @Override
+    public DLQResendResultVO resendSelectedMessages(String instanceId, String groupName, Long startTime,
+                                                     Long endTime, String targetTopic,
+                                                     List<DLQMessageRefDTO> messages) {
+        String endpoint = runtimeAdminClientResolver.resolveEndpoint(instanceId);
+        RPCHook credentialHook = runtimeAdminClientResolver.resolveCredentialHook(instanceId);
+        long end = endTime != null ? endTime : System.currentTimeMillis();
+        long begin = startTime != null ? startTime : end - ONE_HOUR_MILLIS;
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + groupName;
+        DeadLetterScanResult scanResult = collectDeadLetters(endpoint, credentialHook, dlqTopic, begin, end,
+                RESEND_HARD_CAP);
+        Set<String> selected = messages.stream().map(this::selectionKey).collect(java.util.stream.Collectors.toSet());
+        List<MessageExt> matches = scanResult.messages().stream()
+                .filter(message -> selected.contains(selectionKey(message))).toList();
+        int resent = 0;
+        int failed = 0;
+        if (!matches.isEmpty()) {
+            DefaultMQProducer producer = newProducer(endpoint, credentialHook);
+            try {
+                producer.start();
+                for (MessageExt deadLetter : matches) {
+                    if (resendOne(producer, deadLetter, targetTopic)) {
+                        resent++;
+                    } else {
+                        failed++;
+                    }
+                }
+            } catch (Exception exception) {
+                failed += matches.size() - resent;
+            } finally {
+                producer.shutdown();
+            }
+        }
+        String outcome = classifyOutcome(matches.size(), resent, failed, scanResult.scanIncomplete());
+        String detail = String.format("instanceId=%s, group=%s, selected=%d, matched=%d, resent=%d, failed=%d, "
+                        + "scanIncomplete=%s, scanFailedQueues=%d", instanceId, groupName, messages.size(),
+                matches.size(), resent, failed, scanResult.scanIncomplete(), scanResult.failedQueueCount());
+        recordAudit(groupName, detail, outcome);
+        return DLQResendResultVO.builder().matched(matches.size()).resent(resent).failed(failed).outcome(outcome)
+                .scanIncomplete(scanResult.scanIncomplete()).failedQueueCount(scanResult.failedQueueCount()).build();
+    }
+
+    private String selectionKey(DLQMessageRefDTO reference) {
+        return reference.getMsgId() + ':' + reference.getQueueId() + ':' + reference.getOffset();
+    }
+
+    private String selectionKey(MessageExt message) {
+        return message.getMsgId() + ":" + message.getQueueId() + ":" + message.getQueueOffset();
     }
 
     private DLQMessageVO toExportVO(MessageExt message) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQControllerTest.java
@@ -113,7 +113,7 @@ class DLQControllerTest {
     }
 
     @Test
-    void listMessagesShouldPassQueryParameters() throws Exception {
+    void listMessagesShouldPassQueryParametersTest() throws Exception {
         when(dlqService.listMessages("instance-1", "test-group", 1000L, 2000L, 2, 20))
                 .thenReturn(DLQMessagePageVO.builder().items(List.of()).total(0).page(2).size(20).build());
 
@@ -130,7 +130,7 @@ class DLQControllerTest {
     }
 
     @Test
-    void selectedResendShouldPassStableMessageReferences() throws Exception {
+    void selectedResendShouldPassStableMessageReferencesTest() throws Exception {
         Map<String, Object> body = Map.of(
                 "instanceId", "instance-1", "groupName", "test-group", "messages",
                 List.of(Map.of("msgId", "msg-1", "queueId", 0, "offset", 5)));

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQControllerTest.java
@@ -37,6 +37,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -109,6 +110,43 @@ class DLQControllerTest {
                 .andExpect(jsonPath("$.data.size").value(50));
 
         verify(dlqService).listDLQGroups(eq("instance-1"), eq("order"), eq(2), eq(50));
+    }
+
+    @Test
+    void listMessagesShouldPassQueryParameters() throws Exception {
+        when(dlqService.listMessages("instance-1", "test-group", 1000L, 2000L, 2, 20))
+                .thenReturn(DLQMessagePageVO.builder().items(List.of()).total(0).page(2).size(20).build());
+
+        mockMvc.perform(get("/api/dlq/messages")
+                        .param("instanceId", "instance-1")
+                        .param("groupName", "test-group")
+                        .param("startTime", "1000")
+                        .param("endTime", "2000")
+                        .param("page", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.page").value(2));
+
+        verify(dlqService).listMessages("instance-1", "test-group", 1000L, 2000L, 2, 20);
+    }
+
+    @Test
+    void selectedResendShouldPassStableMessageReferences() throws Exception {
+        Map<String, Object> body = Map.of(
+                "instanceId", "instance-1", "groupName", "test-group", "messages",
+                List.of(Map.of("msgId", "msg-1", "queueId", 0, "offset", 5)));
+
+        mockMvc.perform(post("/api/dlq/messages/resend").contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isOk());
+
+        org.mockito.ArgumentCaptor<List<DLQMessageRefDTO>> messages = org.mockito.ArgumentCaptor.forClass(List.class);
+        verify(dlqService).resendSelectedMessages(eq("instance-1"), eq("test-group"), isNull(), isNull(),
+                isNull(), messages.capture());
+        assertThat(messages.getValue()).singleElement().satisfies(reference -> {
+            assertThat(reference.getMsgId()).isEqualTo("msg-1");
+            assertThat(reference.getQueueId()).isZero();
+            assertThat(reference.getOffset()).isEqualTo(5L);
+        });
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQServiceTest.java
@@ -163,6 +163,32 @@ class DLQServiceTest {
     }
 
     @Test
+    void listMessagesShouldDelegatePagedQuery() {
+        DLQMessagePageVO result = DLQMessagePageVO.builder().items(List.of()).total(0).page(2).size(20).build();
+        when(dlqProvider.listMessages("instance-1", "group-1", 1000L, 2000L, 2, 20)).thenReturn(result);
+
+        assertThat(dlqService.listMessages("instance-1", "group-1", 1000L, 2000L, 2, 20)).isSameAs(result);
+
+        verify(dlqProvider).listMessages("instance-1", "group-1", 1000L, 2000L, 2, 20);
+    }
+
+    @Test
+    void selectedResendShouldRejectMoreThanOneHundredMessages() {
+        List<DLQMessageRefDTO> messages = java.util.stream.IntStream.range(0, 101)
+                .mapToObj(index -> {
+                    DLQMessageRefDTO reference = new DLQMessageRefDTO();
+                    reference.setMsgId("msg-" + index);
+                    return reference;
+                }).toList();
+
+        assertThatThrownBy(() -> dlqService.resendSelectedMessages("instance-1", "group-1", 1000L,
+                2000L, null, messages)).isInstanceOf(BusinessException.class)
+                .hasMessage("messages must contain between 1 and 100 entries");
+
+        verifyNoInteractions(dlqProvider);
+    }
+
+    @Test
     void listDLQGroupsShouldDelegatePagedQueryWithTrimmedSearch() {
         PageResult<DLQGroupVO> page = PageResult.of(List.of(), 0, 2, 50);
         when(dlqProvider.listDLQGroups("instance-1", "order", 2, 50)).thenReturn(page);

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQServiceTest.java
@@ -163,7 +163,7 @@ class DLQServiceTest {
     }
 
     @Test
-    void listMessagesShouldDelegatePagedQuery() {
+    void listMessagesShouldDelegatePagedQueryTest() {
         DLQMessagePageVO result = DLQMessagePageVO.builder().items(List.of()).total(0).page(2).size(20).build();
         when(dlqProvider.listMessages("instance-1", "group-1", 1000L, 2000L, 2, 20)).thenReturn(result);
 
@@ -173,7 +173,7 @@ class DLQServiceTest {
     }
 
     @Test
-    void selectedResendShouldRejectMoreThanOneHundredMessages() {
+    void selectedResendShouldRejectMoreThanOneHundredMessagesTest() {
         List<DLQMessageRefDTO> messages = java.util.stream.IntStream.range(0, 101)
                 .mapToObj(index -> {
                     DLQMessageRefDTO reference = new DLQMessageRefDTO();

--- a/web/src/api/dlq.test.ts
+++ b/web/src/api/dlq.test.ts
@@ -18,7 +18,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { listDLQGroups, resendDLQ } from './message';
+import { listDLQGroups, listDLQMessages, resendDLQ, resendSelectedDLQMessages } from './message';
 import type { DLQGroup } from './message';
 
 const mock = new MockAdapter(client);
@@ -88,5 +88,27 @@ describe('DLQ API', () => {
     });
 
     await expect(resendDLQ(payload)).resolves.toEqual(result);
+  });
+
+  it('uses the detail and selected-resend contracts', async () => {
+    const params = { instanceId: 'instance-1', groupName: group.groupName, page: 1, pageSize: 20 };
+    const page = {
+      items: [],
+      total: 0,
+      page: 1,
+      size: 20,
+      scanIncomplete: false,
+      failedQueueCount: 0,
+    };
+    mock.onGet('/dlq/messages', { params }).reply(200, { code: 200, data: page });
+    await expect(listDLQMessages(params)).resolves.toEqual(page);
+
+    const payload = { ...params, messages: [{ msgId: 'msg-1', queueId: 0, offset: 5 }] };
+    const result = { matched: 1, resent: 1, failed: 0, outcome: 'SUCCESS' };
+    mock.onPost('/dlq/messages/resend').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual(payload);
+      return [200, { code: 200, data: result }];
+    });
+    await expect(resendSelectedDLQMessages(payload)).resolves.toEqual(result);
   });
 });

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -81,6 +81,26 @@ export interface DLQResendResult {
   failedQueueCount?: number;
 }
 
+export interface DLQMessage {
+  msgId: string;
+  topic: string;
+  queueId: number;
+  offset: number;
+  storeTime: number;
+  keys?: string | null;
+  body?: string | null;
+  bodyBase64?: string | null;
+}
+
+export interface DLQMessagePage {
+  items: DLQMessage[];
+  total: number;
+  page: number;
+  size: number;
+  scanIncomplete: boolean;
+  failedQueueCount: number;
+}
+
 // ─── Messages ───────────────────────────────────────────────────
 export async function queryMessages(params: MessageQuery) {
   const res = await client.get<{ data: MessageRecord[] }>('/messages', { params });
@@ -114,6 +134,30 @@ export async function resendDLQ(data: {
   targetTopic?: string;
 }): Promise<DLQResendResult> {
   const res = await client.post<{ data: DLQResendResult }>('/dlq/resend', data);
+  return res.data.data;
+}
+
+export async function listDLQMessages(params: {
+  instanceId: string;
+  groupName: string;
+  startTime?: number;
+  endTime?: number;
+  page?: number;
+  pageSize?: number;
+}): Promise<DLQMessagePage> {
+  const res = await client.get<{ data: DLQMessagePage }>('/dlq/messages', { params });
+  return res.data.data;
+}
+
+export async function resendSelectedDLQMessages(data: {
+  instanceId: string;
+  groupName: string;
+  startTime?: number;
+  endTime?: number;
+  targetTopic?: string;
+  messages: Array<Pick<DLQMessage, 'msgId' | 'queueId' | 'offset'>>;
+}): Promise<DLQResendResult> {
+  const res = await client.post<{ data: DLQResendResult }>('/dlq/messages/resend', data);
   return res.data.data;
 }
 

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type Key } from 'react';
 import {
   Alert,
   Card,
@@ -36,8 +36,14 @@ import type { Dayjs } from 'dayjs';
 import PageHeader from '../../components/PageHeader';
 import { InstanceSelect } from '../../components/InstanceSelect';
 import { useLang } from '../../i18n/LangContext';
-import type { DLQGroup } from '../../api/message';
-import { exportDLQMessages, listDLQGroups, resendDLQ } from '../../services/messageService';
+import type { DLQGroup, DLQMessage } from '../../api/message';
+import {
+  exportDLQMessages,
+  listDLQGroups,
+  listDLQMessages,
+  resendDLQ,
+  resendSelectedDLQMessages,
+} from '../../services/messageService';
 import { useInstanceFilter } from '../../hooks/useInstanceFilter';
 import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 import { tableScrollX } from '../../utils/table';
@@ -91,6 +97,19 @@ const exportDLQGroups = (groups: DLQGroup[], filename: string) => {
   downloadCsv(filename, buildCsv(DLQ_EXPORT_COLUMNS, groups));
 };
 
+const messageKey = (message: DLQMessage) => `${message.msgId}:${message.queueId}:${message.offset}`;
+
+const DLQ_MESSAGE_EXPORT_COLUMNS: CsvColumn<DLQMessage>[] = [
+  { header: 'Message ID', value: (message) => message.msgId },
+  { header: 'Topic', value: (message) => message.topic },
+  { header: 'Queue ID', value: (message) => message.queueId },
+  { header: 'Offset', value: (message) => message.offset },
+  { header: 'Store Time', value: (message) => new Date(message.storeTime).toISOString() },
+  { header: 'Keys', value: (message) => message.keys },
+  { header: 'Body', value: (message) => message.body },
+  { header: 'Body Base64', value: (message) => message.bodyBase64 },
+];
+
 /* ═══════════════════════════════════════════
    DLQPage
    ═══════════════════════════════════════════ */
@@ -120,6 +139,14 @@ const DLQPage = () => {
   const [retryTargetTopic, setRetryTargetTopic] = useState('');
   const [retrySubmitting, setRetrySubmitting] = useState(false);
   const [detailGroup, setDetailGroup] = useState<DLQGroup | null>(null);
+  const [detailMessages, setDetailMessages] = useState<DLQMessage[]>([]);
+  const [detailTotal, setDetailTotal] = useState(0);
+  const [detailPage, setDetailPage] = useState(1);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailIncomplete, setDetailIncomplete] = useState(false);
+  const [detailFailedQueues, setDetailFailedQueues] = useState(0);
+  const [selectedMessageKeys, setSelectedMessageKeys] = useState<Key[]>([]);
+  const [selectedResendSubmitting, setSelectedResendSubmitting] = useState(false);
   const [selectedGroupNames, setSelectedGroupNames] = useState<string[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [retryError, setRetryError] = useState<string | null>(null);
@@ -216,6 +243,65 @@ const DLQPage = () => {
     setRetryTargetTopic('');
     setRetryError(null);
     setRetryModalOpen(true);
+  };
+
+  const loadDetailMessages = async (group: DLQGroup, nextPage = 1) => {
+    if (!selectedInstanceId) return;
+    setDetailLoading(true);
+    try {
+      const result = await listDLQMessages({
+        instanceId: selectedInstanceId,
+        groupName: group.groupName,
+        startTime: exportRange[0].valueOf(),
+        endTime: exportRange[1].valueOf(),
+        page: nextPage,
+        pageSize: 20,
+      });
+      setDetailMessages(result.items);
+      setDetailTotal(result.total);
+      setDetailPage(result.page);
+      setDetailIncomplete(result.scanIncomplete);
+      setDetailFailedQueues(result.failedQueueCount);
+    } catch (error) {
+      message.error(getErrorMessage(error, '加载死信消息失败，请稍后重试'));
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  const openDetailModal = (group: DLQGroup) => {
+    setDetailGroup(group);
+    setDetailMessages([]);
+    setDetailTotal(0);
+    setDetailPage(1);
+    setSelectedMessageKeys([]);
+    void loadDetailMessages(group);
+  };
+
+  const handleSelectedResend = async () => {
+    if (!detailGroup || !selectedInstanceId) return;
+    const selected = detailMessages.filter((item) =>
+      selectedMessageKeys.includes(messageKey(item)),
+    );
+    if (selected.length === 0) return;
+    setSelectedResendSubmitting(true);
+    try {
+      const result = await resendSelectedDLQMessages({
+        instanceId: selectedInstanceId,
+        groupName: detailGroup.groupName,
+        startTime: exportRange[0].valueOf(),
+        endTime: exportRange[1].valueOf(),
+        messages: selected.map(({ msgId, queueId, offset }) => ({ msgId, queueId, offset })),
+      });
+      message.success(`已直接重投 ${result.resent} 条死信消息`);
+      setSelectedMessageKeys([]);
+      void loadDetailMessages(detailGroup, detailPage);
+      setRefreshKey((key) => key + 1);
+    } catch (error) {
+      message.error(getErrorMessage(error, '重投选中的死信消息失败，请稍后重试'));
+    } finally {
+      setSelectedResendSubmitting(false);
+    }
   };
 
   const handleRetry = async () => {
@@ -360,7 +446,7 @@ const DLQPage = () => {
             size="small"
             icon={<Eye size={14} />}
             style={{ borderColor: '#1677ff', color: '#1677ff' }}
-            onClick={() => setDetailGroup(record)}
+            onClick={() => openDetailModal(record)}
           >
             查看详情
           </Button>
@@ -578,65 +664,103 @@ const DLQPage = () => {
         title="死信队列详情"
         open={Boolean(detailGroup)}
         onCancel={() => setDetailGroup(null)}
-        footer={<Button onClick={() => setDetailGroup(null)}>关闭</Button>}
-        width={560}
+        footer={null}
+        width={1080}
         destroyOnHidden
       >
         {detailGroup && (
           <div style={{ marginTop: 8 }}>
-            <div style={{ marginBottom: 16 }}>
-              <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
-                Group 名称
-              </Text>
-              <Text strong copyable style={{ fontSize: 14, fontFamily: 'monospace' }}>
-                {detailGroup.groupName}
-              </Text>
-            </div>
-            <div style={{ marginBottom: 16 }}>
-              <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
-                DLQ Topic
-              </Text>
-              <Text copyable style={{ fontSize: 14, fontFamily: 'monospace' }}>
-                {detailGroup.dlqTopic}
-              </Text>
-            </div>
-            <Flex gap={24} wrap="wrap">
-              <div>
-                <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
-                  死信数量
+            <Flex justify="space-between" align="center" style={{ marginBottom: 12 }}>
+              <Space direction="vertical" size={0}>
+                <Text strong copyable style={{ fontFamily: 'monospace' }}>
+                  {detailGroup.groupName}
                 </Text>
-                <Text
-                  strong
-                  style={{ color: detailGroup.messageCount > 0 ? '#fa8c16' : undefined }}
+                <Text type="secondary" copyable style={{ fontFamily: 'monospace' }}>
+                  {detailGroup.dlqTopic}
+                </Text>
+                <Space size={4}>
+                  <Text type="secondary">状态：</Text>
+                  <Text>
+                    {detailGroup.statsAvailable === false ? '统计不可用' : detailGroup.status}
+                  </Text>
+                </Space>
+              </Space>
+              <Space>
+                <Button
+                  icon={<Download size={14} />}
+                  disabled={detailMessages.length === 0}
+                  onClick={() =>
+                    downloadCsv(
+                      `${detailGroup.groupName}-dlq-messages.csv`,
+                      buildCsv(DLQ_MESSAGE_EXPORT_COLUMNS, detailMessages),
+                    )
+                  }
                 >
-                  {detailGroup.statsAvailable === false
-                    ? '不可用'
-                    : detailGroup.messageCount.toLocaleString()}
-                </Text>
-              </div>
-              <div>
-                <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
-                  重试次数
-                </Text>
-                <Text>{detailGroup.retryCount.toLocaleString()}</Text>
-              </div>
-              <div>
-                <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
-                  状态
-                </Text>
-                <Text>
-                  {detailGroup.statsAvailable === false ? '统计不可用' : detailGroup.status}
-                </Text>
-              </div>
+                  导出当前页
+                </Button>
+                <Button
+                  type="primary"
+                  icon={<ArrowsCounterClockwise size={14} />}
+                  loading={selectedResendSubmitting}
+                  disabled={selectedMessageKeys.length === 0}
+                  onClick={() => void handleSelectedResend()}
+                >
+                  重投选中消息{selectedMessageKeys.length ? ` (${selectedMessageKeys.length})` : ''}
+                </Button>
+              </Space>
             </Flex>
-            <div style={{ marginTop: 16 }}>
-              <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
-                最近入队时间
-              </Text>
-              <Text style={{ fontFamily: 'monospace' }}>
-                {formatDateTime(detailGroup.lastEnqueueTime)}
-              </Text>
-            </div>
+            {detailIncomplete && (
+              <Alert
+                showIcon
+                type="warning"
+                message={`扫描不完整，${detailFailedQueues} 个队列无法读取或结果达到上限。`}
+                style={{ marginBottom: 12 }}
+              />
+            )}
+            <Table<DLQMessage>
+              rowKey={messageKey}
+              size="small"
+              loading={detailLoading}
+              dataSource={detailMessages}
+              rowSelection={{
+                selectedRowKeys: selectedMessageKeys,
+                onChange: setSelectedMessageKeys,
+              }}
+              columns={[
+                {
+                  title: '消息 ID',
+                  dataIndex: 'msgId',
+                  width: 220,
+                  render: (value: string) => (
+                    <Text copyable style={{ fontFamily: 'monospace' }}>
+                      {value}
+                    </Text>
+                  ),
+                },
+                { title: '队列', dataIndex: 'queueId', width: 70 },
+                { title: 'Offset', dataIndex: 'offset', width: 100 },
+                {
+                  title: '存储时间',
+                  dataIndex: 'storeTime',
+                  width: 170,
+                  render: (value: number) => formatDateTime(new Date(value).toISOString()),
+                },
+                { title: 'Keys', dataIndex: 'keys', width: 160, ellipsis: true },
+                {
+                  title: '消息体',
+                  dataIndex: 'body',
+                  ellipsis: true,
+                  render: (value?: string) => value || '-',
+                },
+              ]}
+              pagination={{
+                current: detailPage,
+                pageSize: 20,
+                total: detailTotal,
+                onChange: (nextPage) => void loadDetailMessages(detailGroup, nextPage),
+              }}
+              scroll={{ x: 1000 }}
+            />
           </div>
         )}
       </Modal>

--- a/web/src/services/messageService.ts
+++ b/web/src/services/messageService.ts
@@ -69,8 +69,7 @@ export async function listDLQGroups(
 ): Promise<DLQGroupPage> {
   if (isMockMode()) {
     const groups = (mockDLQGroups as unknown as DLQGroup[]).filter(
-      (group) =>
-        !search || group.groupName.includes(search) || group.dlqTopic.includes(search),
+      (group) => !search || group.groupName.includes(search) || group.dlqTopic.includes(search),
     );
     const from = Math.min((page - 1) * pageSize, groups.length);
     return {
@@ -92,6 +91,45 @@ export async function resendDLQ(data: {
 }): Promise<DLQResendResult> {
   if (isMockMode()) return { matched: 0, resent: 0, failed: 0, outcome: 'SUCCESS' };
   return messageApi.resendDLQ(data);
+}
+
+export async function listDLQMessages(params: {
+  instanceId: string;
+  groupName: string;
+  startTime?: number;
+  endTime?: number;
+  page?: number;
+  pageSize?: number;
+}) {
+  if (isMockMode()) {
+    return {
+      items: [],
+      total: 0,
+      page: params.page ?? 1,
+      size: params.pageSize ?? 20,
+      scanIncomplete: false,
+      failedQueueCount: 0,
+    };
+  }
+  return messageApi.listDLQMessages(params);
+}
+
+export async function resendSelectedDLQMessages(data: {
+  instanceId: string;
+  groupName: string;
+  startTime?: number;
+  endTime?: number;
+  targetTopic?: string;
+  messages: Array<{ msgId: string; queueId: number; offset: number }>;
+}) {
+  if (isMockMode())
+    return {
+      matched: data.messages.length,
+      resent: data.messages.length,
+      failed: 0,
+      outcome: 'SUCCESS' as const,
+    };
+  return messageApi.resendSelectedDLQMessages(data);
 }
 
 export async function exportDLQMessages(params: {


### PR DESCRIPTION
Closes #2509

## Summary
- add a paged DLQ message inspection API and message detail table
- allow an operator to resend up to 100 explicitly selected DLQ messages, identified by message ID, queue ID, and offset
- preserve batch resend and add spreadsheet-friendly CSV export for the displayed message records
- expose incomplete-scan and failed-queue signals so partial results are not presented as complete
- audit selected-message resend operations

## Validation
- `mvn -q -Dtest=DLQServiceTest,DLQControllerTest,RocketMQDLQProviderTest test`
- `npm test -- --run src/api/dlq.test.ts src/services/messageService.test.ts src/pages/instance/__tests__/DLQPage.test.tsx`
- `npm run build`