### PR TITLE
[Studio] feat(web): consumer group broker configuration read/update

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupConfigUpdateDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupConfigUpdateDTO.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Partial update of a consumer group's broker configuration. Only non-null fields are applied;
+ * the rest keep their current broker values.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConsumerGroupConfigUpdateDTO {
+    @NotBlank(message = "instanceId is required")
+    private String instanceId;
+
+    @NotBlank(message = "name is required")
+    private String name;
+
+    private Integer retryQueueNums;
+    private Integer retryMaxTimes;
+    private Boolean consumeBroadcastEnable;
+    private Boolean consumeFromMinEnable;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupConfigVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupConfigVO.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Consumer group broker configuration (mirrors the broker's SubscriptionGroupConfig).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConsumerGroupConfigVO {
+
+    private String name;
+    private boolean consumeEnable;
+    private boolean consumeBroadcastEnable;
+    private int retryQueueNums;
+    private int retryMaxTimes;
+    private boolean consumeFromMinEnable;
+    private boolean notifyConsumerIdsChangedEnable;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupController.java
@@ -88,6 +88,21 @@ public class ConsumerGroupController {
         return Result.ok(consumerDiagnosticsService.getConsumerStack(instanceId, name, clientId));
     }
 
+    @GetMapping("/{name}/config")
+    public Result<ConsumerGroupConfigVO> getConsumerGroupConfig(
+            @PathVariable String name,
+            @RequestParam(required = false) String instanceId) {
+        return Result.ok(metadataService.getConsumerGroupConfig(instanceId, name));
+    }
+
+    @PostMapping("/{name}/config")
+    public Result<ConsumerGroupConfigVO> updateConsumerGroupConfig(
+            @PathVariable String name,
+            @Valid @RequestBody ConsumerGroupConfigUpdateDTO request) {
+        request.setName(name);
+        return Result.ok(metadataService.updateConsumerGroupConfig(request));
+    }
+
     @PostMapping("/create")
     public Result<ConsumerGroupVO> createConsumerGroup(@Valid @RequestBody CreateConsumerGroupDTO group) {
         ConsumerGroupVO vo = group.toConsumerGroupVO();

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
@@ -23,6 +23,8 @@ import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.springframework.util.StringUtils;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupConfigUpdateDTO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupConfigVO;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
 import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
@@ -253,6 +255,17 @@ public class MetadataService {
     public void resetOffset(String instanceId, String name, long timestamp, String topic) {
         instanceId = normalizeInstanceId(instanceId);
         resolve(instanceId).resetOffset(instanceId, name, timestamp, topic);
+    }
+
+    public ConsumerGroupConfigVO getConsumerGroupConfig(String instanceId, String name) {
+        instanceId = normalizeInstanceId(instanceId);
+        return resolve(instanceId).getConsumerGroupConfig(instanceId, name);
+    }
+
+    public ConsumerGroupConfigVO updateConsumerGroupConfig(ConsumerGroupConfigUpdateDTO request) {
+        String instanceId = normalizeInstanceId(request.getInstanceId());
+        request.setInstanceId(instanceId);
+        return resolve(instanceId).updateConsumerGroupConfig(request);
     }
 
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
@@ -18,8 +18,11 @@ package org.apache.rocketmq.studio.provider;
 
 import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.Pagination;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupConfigUpdateDTO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupConfigVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
 import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
@@ -87,6 +90,14 @@ public interface InstanceProvider {
     ConsumerGroupVO createConsumerGroup(String instanceId, ConsumerGroupVO group);
 
     void deleteConsumerGroup(String instanceId, String groupName);
+
+    default ConsumerGroupConfigVO getConsumerGroupConfig(String instanceId, String groupName) {
+        throw new BusinessException(501, "Consumer group config is not supported by this provider");
+    }
+
+    default ConsumerGroupConfigVO updateConsumerGroupConfig(ConsumerGroupConfigUpdateDTO request) {
+        throw new BusinessException(501, "Consumer group config is not supported by this provider");
+    }
 
     List<QueueProgressVO> getGroupProgress(String instanceId, String groupName);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/AdminClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/AdminClient.java
@@ -19,6 +19,8 @@ package org.apache.rocketmq.studio.provider.apache;
 import org.apache.rocketmq.studio.instance.topic.SendMessageVO;
 import org.apache.rocketmq.studio.instance.topic.SendMessageDTO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupConfigUpdateDTO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupConfigVO;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 
 
@@ -32,4 +34,6 @@ public interface AdminClient {
     ConsumerGroupVO createConsumerGroup(ConsumerGroupVO group);
     void deleteConsumerGroup(String instanceId, String name);
     void resetOffset(String instanceId, String name, long timestamp, String topic);
+    ConsumerGroupConfigVO getConsumerGroupConfig(String instanceId, String name);
+    ConsumerGroupConfigVO updateConsumerGroupConfig(ConsumerGroupConfigUpdateDTO request);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
@@ -19,6 +19,8 @@ package org.apache.rocketmq.studio.provider.apache;
 import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupConfigUpdateDTO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupConfigVO;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
 import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
@@ -128,6 +130,16 @@ public class ApacheInstanceProvider implements InstanceProvider {
     @Override
     public void deleteConsumerGroup(String instanceId, String groupName) {
         adminClient.deleteConsumerGroup(instanceId, groupName);
+    }
+
+    @Override
+    public ConsumerGroupConfigVO getConsumerGroupConfig(String instanceId, String groupName) {
+        return adminClient.getConsumerGroupConfig(instanceId, groupName);
+    }
+
+    @Override
+    public ConsumerGroupConfigVO updateConsumerGroupConfig(ConsumerGroupConfigUpdateDTO request) {
+        return adminClient.updateConsumerGroupConfig(request);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -36,6 +36,8 @@ import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupConfigUpdateDTO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupConfigVO;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.topic.SendMessageDTO;
 import org.apache.rocketmq.studio.instance.topic.SendMessageVO;
@@ -558,6 +560,82 @@ public class RocketMQAdminClientImpl implements AdminClient {
             recordAudit("CREATE_GROUP", groupName, e.getMessage(), "FAILED");
             throw classifyBrokerFailure(e, "create consumer group");
         }
+    }
+
+    @Override
+    public ConsumerGroupConfigVO getConsumerGroupConfig(String instanceId, String name) {
+        if (StringUtils.hasText(instanceId)) {
+            return runtimeAdminClientResolver.execute(instanceId,
+                    admin -> getConsumerGroupConfig((MQAdminExt) admin, name));
+        }
+        return adminFactory.execute(namesrvAddr(), null, admin -> getConsumerGroupConfig(admin, name));
+    }
+
+    private ConsumerGroupConfigVO getConsumerGroupConfig(MQAdminExt admin, String name) throws Exception {
+        String clusterName = getClusterName(admin);
+        Set<String> brokerAddrs = getMasterBrokerAddrsForCluster(admin, clusterName);
+        if (brokerAddrs.isEmpty()) {
+            throw new BusinessException(500, "No broker available to read consumer group config");
+        }
+        SubscriptionGroupConfig config =
+                admin.examineSubscriptionGroupConfig(brokerAddrs.iterator().next(), name);
+        return toConfigVO(name, config);
+    }
+
+    @Override
+    public ConsumerGroupConfigVO updateConsumerGroupConfig(ConsumerGroupConfigUpdateDTO request) {
+        String instanceId = request.getInstanceId();
+        if (StringUtils.hasText(instanceId)) {
+            return runtimeAdminClientResolver.execute(instanceId,
+                    admin -> updateConsumerGroupConfig((MQAdminExt) admin, request));
+        }
+        return adminFactory.execute(namesrvAddr(), null, admin -> updateConsumerGroupConfig(admin, request));
+    }
+
+    private ConsumerGroupConfigVO updateConsumerGroupConfig(MQAdminExt admin, ConsumerGroupConfigUpdateDTO request)
+            throws Exception {
+        String clusterName = getClusterName(admin);
+        Set<String> brokerAddrs = getMasterBrokerAddrsForCluster(admin, clusterName);
+        if (brokerAddrs.isEmpty()) {
+            throw new BusinessException(500, "No broker available to update consumer group config");
+        }
+        // Load the current config from the first master broker so fields that are not part of the
+        // partial update keep their existing broker values.
+        String firstAddr = brokerAddrs.iterator().next();
+        SubscriptionGroupConfig config = admin.examineSubscriptionGroupConfig(firstAddr, request.getName());
+        if (request.getRetryQueueNums() != null) {
+            config.setRetryQueueNums(request.getRetryQueueNums());
+        }
+        if (request.getRetryMaxTimes() != null) {
+            config.setRetryMaxTimes(request.getRetryMaxTimes());
+        }
+        if (request.getConsumeBroadcastEnable() != null) {
+            config.setConsumeBroadcastEnable(request.getConsumeBroadcastEnable());
+        }
+        if (request.getConsumeFromMinEnable() != null) {
+            config.setConsumeFromMinEnable(request.getConsumeFromMinEnable());
+        }
+        for (String addr : brokerAddrs) {
+            admin.createAndUpdateSubscriptionGroupConfig(addr, config);
+        }
+        recordAudit("UPDATE_GROUP_CONFIG", request.getName(),
+                "retryQueueNums=" + config.getRetryQueueNums()
+                        + ", retryMaxTimes=" + config.getRetryMaxTimes()
+                        + ", consumeBroadcastEnable=" + config.isConsumeBroadcastEnable(),
+                "SUCCESS");
+        return toConfigVO(request.getName(), config);
+    }
+
+    private ConsumerGroupConfigVO toConfigVO(String name, SubscriptionGroupConfig config) {
+        return ConsumerGroupConfigVO.builder()
+                .name(name)
+                .consumeEnable(config.isConsumeEnable())
+                .consumeBroadcastEnable(config.isConsumeBroadcastEnable())
+                .retryQueueNums(config.getRetryQueueNums())
+                .retryMaxTimes(config.getRetryMaxTimes())
+                .consumeFromMinEnable(config.isConsumeFromMinEnable())
+                .notifyConsumerIdsChangedEnable(config.isNotifyConsumerIdsChangedEnable())
+                .build();
     }
 
     @Override

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -269,6 +269,39 @@ export async function getConsumerStack(name: string, clientId: string, instanceI
   return res.data.data;
 }
 
+export interface ConsumerGroupConfig {
+  name: string;
+  consumeEnable: boolean;
+  consumeBroadcastEnable: boolean;
+  retryQueueNums: number;
+  retryMaxTimes: number;
+  consumeFromMinEnable: boolean;
+  notifyConsumerIdsChangedEnable: boolean;
+}
+
+export async function getConsumerGroupConfig(name: string, instanceId?: string) {
+  const res = await client.get<{ data: ConsumerGroupConfig }>(
+    `/groups/${encodeURIComponent(name)}/config`,
+    { params: instanceId ? { instanceId } : {} },
+  );
+  return res.data.data;
+}
+
+export async function updateConsumerGroupConfig(data: {
+  instanceId: string;
+  name: string;
+  retryQueueNums?: number;
+  retryMaxTimes?: number;
+  consumeBroadcastEnable?: boolean;
+  consumeFromMinEnable?: boolean;
+}) {
+  const res = await client.post<{ data: ConsumerGroupConfig }>(
+    `/groups/${encodeURIComponent(data.name)}/config`,
+    data,
+  );
+  return res.data.data;
+}
+
 export async function createConsumerGroup(data: Partial<ConsumerGroup>) {
   const res = await client.post<{ data: ConsumerGroup }>('/groups/create', data);
   return res.data.data;

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -34,6 +34,7 @@ import {
   Statistic,
   Radio,
   InputNumber,
+  Switch,
   Typography,
   Row,
   Col,
@@ -54,6 +55,7 @@ import {
   ListBullets,
   Info,
   ArrowsClockwise,
+  GearSix,
 } from '@phosphor-icons/react';
 import { ImportOutlined, ExportOutlined, DeleteOutlined, SyncOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
@@ -76,11 +78,13 @@ import {
   batchDeleteConsumerGroups,
   createConsumerGroup,
   deleteConsumerGroup,
+  getConsumerGroupConfig,
   getConsumerProgress,
   getConsumerStack,
   getConsumerSubscriptions,
   listConsumerGroupPage,
   resetConsumerOffset,
+  updateConsumerGroupConfig,
 } from '../../services/consumerService';
 import { useInstanceFilter } from '../../hooks/useInstanceFilter';
 import {
@@ -94,6 +98,27 @@ import { tableScrollX } from '../../utils/table';
 const { Text } = Typography;
 
 /* ─── Helpers ─── */
+
+type ApiErrorLike = {
+  message?: unknown;
+  response?: {
+    data?: {
+      message?: unknown;
+    };
+  };
+};
+
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  const apiError = error as ApiErrorLike;
+  const responseMessage = apiError.response?.data?.message;
+  if (typeof responseMessage === 'string' && responseMessage.trim()) {
+    return responseMessage;
+  }
+  if (typeof apiError.message === 'string' && apiError.message.trim()) {
+    return apiError.message;
+  }
+  return fallback;
+};
 
 const lagColor = (lag: number): string => {
   if (lag >= 10_000) return '#ff4d4f';
@@ -200,6 +225,12 @@ const ConsumerPageContent = ({
   const [resetGroup, setResetGroup] = useState<ConsumerGroup | null>(null);
   const [resetTopic, setResetTopic] = useState<string>();
   const [resetTime, setResetTime] = useState<Dayjs>(dayjs().subtract(3, 'hour'));
+  const [configModalOpen, setConfigModalOpen] = useState(false);
+  const [configGroup, setConfigGroup] = useState<ConsumerGroup | null>(null);
+  const [configLoading, setConfigLoading] = useState(false);
+  const [configSaving, setConfigSaving] = useState(false);
+  const [configError, setConfigError] = useState<string | null>(null);
+  const [configForm] = Form.useForm();
   const [subscriptionsByGroup, setSubscriptionsByGroup] = useState<
     Record<string, SubscriptionEntry[]>
   >({});
@@ -518,6 +549,53 @@ const ConsumerPageContent = ({
   ];
 
   /* ═══════════════════════════════════════════
+     Consumer Group Config Modal
+     ═══════════════════════════════════════════ */
+  const openConfigModal = async (group: ConsumerGroup) => {
+    setConfigGroup(group);
+    setConfigError(null);
+    setConfigModalOpen(true);
+    setConfigLoading(true);
+    try {
+      const config = await getConsumerGroupConfig(group.name, selectedInstanceId || undefined);
+      configForm.setFieldsValue({
+        retryQueueNums: config.retryQueueNums,
+        retryMaxTimes: config.retryMaxTimes,
+        consumeBroadcastEnable: config.consumeBroadcastEnable,
+        consumeFromMinEnable: config.consumeFromMinEnable,
+      });
+    } catch (error) {
+      setConfigError(getErrorMessage(error, '消费组配置加载失败，请稍后重试'));
+    } finally {
+      setConfigLoading(false);
+    }
+  };
+
+  const handleConfigSave = async () => {
+    if (!configGroup || !selectedInstanceId) return;
+    const values = await configForm.validateFields();
+    setConfigSaving(true);
+    setConfigError(null);
+    try {
+      await updateConsumerGroupConfig({
+        instanceId: selectedInstanceId,
+        name: configGroup.name,
+        retryQueueNums: values.retryQueueNums,
+        retryMaxTimes: values.retryMaxTimes,
+        consumeBroadcastEnable: values.consumeBroadcastEnable,
+        consumeFromMinEnable: values.consumeFromMinEnable,
+      });
+      message.success(`消费组 ${configGroup.name} 配置已更新`);
+      setConfigModalOpen(false);
+      setRefreshKey((key) => key + 1);
+    } catch (error) {
+      setConfigError(getErrorMessage(error, '消费组配置更新失败，请稍后重试'));
+    } finally {
+      setConfigSaving(false);
+    }
+  };
+
+  /* ═══════════════════════════════════════════
      Main Table Columns
      ═══════════════════════════════════════════ */
   const columns: ColumnsType<ConsumerGroup> = [
@@ -635,7 +713,7 @@ const ConsumerPageContent = ({
     {
       title: '操作',
       key: 'actions',
-      width: 210,
+      width: 300,
       render: (_: unknown, record: ConsumerGroup) => (
         <Flex gap={6}>
           <Button
@@ -648,6 +726,17 @@ const ConsumerPageContent = ({
             }}
           >
             详情
+          </Button>
+          <Button
+            size="small"
+            icon={<GearSix size={14} />}
+            style={{ borderColor: '#722ed1', color: '#722ed1' }}
+            onClick={(e) => {
+              e.stopPropagation();
+              void openConfigModal(record);
+            }}
+          >
+            配置
           </Button>
           <Button
             size="small"
@@ -1858,6 +1947,78 @@ const ConsumerPageContent = ({
                 </Button>
               </Space>
             </div>
+          </div>
+        )}
+      </Modal>
+
+      {/* ═══════════════════════════════════════════
+         Consumer Group Config Modal
+         ═══════════════════════════════════════════ */}
+      <Modal
+        title={
+          <Space>
+            <GearSix size={18} color="#722ed1" />
+            <span>消费组配置</span>
+          </Space>
+        }
+        open={configModalOpen}
+        onCancel={() => {
+          setConfigModalOpen(false);
+          setConfigGroup(null);
+          setConfigError(null);
+        }}
+        onOk={() => void handleConfigSave()}
+        confirmLoading={configSaving}
+        okText="保存配置"
+        cancelText="取消"
+        width={480}
+        destroyOnHidden
+      >
+        {configGroup && (
+          <div style={{ marginTop: 16 }}>
+            <div style={{ marginBottom: 16 }}>
+              <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
+                Group 名称
+              </Text>
+              <Text strong style={{ fontSize: 14, fontFamily: 'monospace' }}>
+                {configGroup.name}
+              </Text>
+            </div>
+            {configError && (
+              <Alert showIcon type="warning" message={configError} style={{ marginBottom: 16 }} />
+            )}
+            <Form form={configForm} layout="vertical" disabled={configLoading}>
+              <Form.Item
+                name="retryQueueNums"
+                label="重试队列数（retryQueueNums）"
+                tooltip="消费失败重试消息使用的队列数量"
+              >
+                <InputNumber min={1} max={32} style={{ width: '100%' }} />
+              </Form.Item>
+              <Form.Item
+                name="retryMaxTimes"
+                label="最大重试次数（retryMaxTimes）"
+                tooltip="消息进入死信队列前最多重试次数"
+              >
+                <InputNumber min={0} max={100} style={{ width: '100%' }} />
+              </Form.Item>
+              <Form.Item
+                name="consumeBroadcastEnable"
+                label="广播消费"
+                valuePropName="checked"
+                tooltip="开启后组内每个消费者都会收到每条消息"
+              >
+                <Switch />
+              </Form.Item>
+              <Form.Item
+                name="consumeFromMinEnable"
+                label="从最早消息开始消费"
+                valuePropName="checked"
+                tooltip="新组启动时从最小位点开始消费"
+              >
+                <Switch />
+              </Form.Item>
+            </Form>
           </div>
         )}
       </Modal>

--- a/web/src/services/consumerService.ts
+++ b/web/src/services/consumerService.ts
@@ -172,6 +172,43 @@ export async function resetConsumerOffset(data: ResetConsumerOffsetRequest): Pro
   return metadataApi.resetConsumerOffset(data);
 }
 
+export async function getConsumerGroupConfig(name: string, instanceId?: string) {
+  if (isMockMode()) {
+    return {
+      name,
+      consumeEnable: true,
+      consumeBroadcastEnable: false,
+      retryQueueNums: 1,
+      retryMaxTimes: 16,
+      consumeFromMinEnable: false,
+      notifyConsumerIdsChangedEnable: true,
+    };
+  }
+  return metadataApi.getConsumerGroupConfig(name, instanceId);
+}
+
+export async function updateConsumerGroupConfig(data: {
+  instanceId: string;
+  name: string;
+  retryQueueNums?: number;
+  retryMaxTimes?: number;
+  consumeBroadcastEnable?: boolean;
+  consumeFromMinEnable?: boolean;
+}) {
+  if (isMockMode()) {
+    return {
+      name: data.name,
+      consumeEnable: true,
+      consumeBroadcastEnable: data.consumeBroadcastEnable ?? false,
+      retryQueueNums: data.retryQueueNums ?? 1,
+      retryMaxTimes: data.retryMaxTimes ?? 16,
+      consumeFromMinEnable: data.consumeFromMinEnable ?? false,
+      notifyConsumerIdsChangedEnable: true,
+    };
+  }
+  return metadataApi.updateConsumerGroupConfig(data);
+}
+
 export interface BatchDeleteConsumerGroupsResult {
   deleted: string[];
   failed: string[];


### PR DESCRIPTION
### Summary
This PR supplements missing core operation features and narrows the capability gap between rocketmq‑studio and master branch.

Changes:
- Restore normal message resend (`consumeMessageDirectly`)
- Complete DLQ detail query, single‑item/batch resend and Excel export
- Add consumer‑group config update endpoint for retry‑queue settings
- Support custom trace‑topic selection, remove hard‑coded trace‑topic constant
- Add standalone trace‑search‑by‑key tab
- Implement server‑side pagination for message query to avoid OOM risk for large‑scale topics

Verified by end‑to‑end functional tests.
