### PR TITLE
[Studio] feat(server,web): server-side paging for message query

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageController.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.instance.message;
 
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.Result;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,6 +44,21 @@ public class MessageController {
             @RequestParam(required = false) Long startTime,
             @RequestParam(required = false) Long endTime) {
         return Result.ok(messageService.queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime));
+    }
+
+    @GetMapping("/page")
+    public Result<PageResult<MessageRecordVO>> queryMessagesPage(
+            @RequestParam String instanceId,
+            @RequestParam(required = false) String topic,
+            @RequestParam(required = false) String msgId,
+            @RequestParam(required = false) String tag,
+            @RequestParam(required = false) String key,
+            @RequestParam(required = false) Long startTime,
+            @RequestParam(required = false) Long endTime,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return Result.ok(messageService.queryMessagesPage(instanceId, topic, msgId, tag, key,
+                startTime, endTime, page, pageSize));
     }
 
     @GetMapping("/{msgId}/trace")

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProvider.java
@@ -18,10 +18,22 @@ package org.apache.rocketmq.studio.instance.message;
 
 
 import java.util.List;
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 
 public interface MessageProvider {
     List<MessageRecordVO> queryMessages(String instanceId, String topic, String msgId, String tag, String key, Long startTime,
                                         Long endTime);
 
     TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic);
+
+    /**
+     * Server-side paged message query. Implementations may cap the underlying scan; the page is
+     * computed over whatever the provider was able to resolve within the query window.
+     */
+    default PageResult<MessageRecordVO> queryMessagesPage(String instanceId, String topic, String msgId,
+                                                          String tag, String key, Long startTime, Long endTime,
+                                                          int page, int pageSize) {
+        throw new BusinessException(501, "Paged message query is not supported by this provider");
+    }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.instance.message;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.InstanceProviderRegistry;
 import org.springframework.stereotype.Service;
@@ -44,6 +45,22 @@ public class MessageService {
                 .map(provider -> provider.queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime))
                 .orElseGet(() -> messageProvider.queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime));
         recordMessageQuery(instanceId, topic, msgId, tag, key, startTime, endTime, result.size());
+        return result;
+    }
+
+    public PageResult<MessageRecordVO> queryMessagesPage(
+            String instanceId, String topic, String msgId, String tag, String key, Long startTime, Long endTime,
+            int page, int pageSize) {
+        validateTopicQueryWindow(topic, msgId, key, startTime, endTime);
+        log.info("Querying messages (page): topic={}, msgId={}, tag={}, key={}, page={}, pageSize={}",
+                topic, msgId, tag, key, page, pageSize);
+        PageResult<MessageRecordVO> result = providerRegistry.byInstanceId(instanceId)
+                .map(provider -> provider.queryMessagesPage(instanceId, topic, msgId, tag, key,
+                        startTime, endTime, page, pageSize))
+                .orElseGet(() -> messageProvider.queryMessagesPage(instanceId, topic, msgId, tag, key,
+                        startTime, endTime, page, pageSize));
+        recordMessageQuery(instanceId, topic, msgId, tag, key, startTime, endTime,
+                Math.toIntExact(result.getTotal()));
         return result;
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.provider;
 
 import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.Pagination;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
@@ -96,6 +97,12 @@ public interface InstanceProvider {
 
     List<MessageRecordVO> queryMessages(String instanceId, String topic, String msgId,
                                         String tag, String key, Long startTime, Long endTime);
+
+    default PageResult<MessageRecordVO> queryMessagesPage(String instanceId, String topic, String msgId,
+                                                          String tag, String key, Long startTime, Long endTime,
+                                                          int page, int pageSize) {
+        throw new BusinessException(501, "Paged message query is not supported by this provider");
+    }
 
     TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ApacheInstanceProvider.java
@@ -152,6 +152,14 @@ public class ApacheInstanceProvider implements InstanceProvider {
     }
 
     @Override
+    public PageResult<MessageRecordVO> queryMessagesPage(String instanceId, String topic, String msgId,
+                                                         String tag, String key, Long startTime, Long endTime,
+                                                         int page, int pageSize) {
+        return messageProvider.queryMessagesPage(instanceId, topic, msgId, tag, key, startTime, endTime,
+                page, pageSize);
+    }
+
+    @Override
     public TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic) {
         return messageProvider.getMessageTrace(instanceId, msgId, topic);
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -29,8 +29,10 @@ import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
-import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.util.Pagination;
 import org.apache.rocketmq.studio.instance.message.ConsumerStatusVO;
 import org.apache.rocketmq.studio.instance.message.MessageProvider;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
@@ -105,6 +107,18 @@ public class RocketMQMessageProvider implements MessageProvider {
         return runtimeAdminClientResolver.execute(instanceId,
                 adminExt -> queryMessages(instanceId, (DefaultMQAdminExt) adminExt, endpoint,
                         credentialHook, topic, msgId, tag, key, startTime, endTime));
+    }
+
+    @Override
+    public PageResult<MessageRecordVO> queryMessagesPage(String instanceId, String topic, String msgId,
+                                                         String tag, String key, Long startTime, Long endTime,
+                                                         int page, int pageSize) {
+        List<MessageRecordVO> all =
+                queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime);
+        long offset = Pagination.pageOffset(page, pageSize);
+        int from = (int) Math.min(offset, all.size());
+        int to = (int) Math.min(offset + pageSize, all.size());
+        return PageResult.of(all.subList(from, to), all.size(), page, pageSize);
     }
 
     private List<MessageRecordVO> queryMessages(String instanceId, DefaultMQAdminExt adminExt, String endpoint,

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -44,6 +44,13 @@ export interface MessageQuery {
   endTime?: number;
 }
 
+export interface MessagePageResult {
+  items: MessageRecord[];
+  total: number;
+  page: number;
+  size: number;
+}
+
 const toStoreTimestamp = (storeTime: MessageRecord['storeTime']): number => {
   if (typeof storeTime === 'number') return storeTime;
 
@@ -85,6 +92,13 @@ export interface DLQResendResult {
 export async function queryMessages(params: MessageQuery) {
   const res = await client.get<{ data: MessageRecord[] }>('/messages', { params });
   return sortMessagesByStoreTimeDesc(res.data.data);
+}
+
+export async function queryMessagesPage(
+  params: MessageQuery & { page?: number; pageSize?: number },
+): Promise<MessagePageResult> {
+  const res = await client.get<{ data: MessagePageResult }>('/messages/page', { params });
+  return res.data.data;
 }
 
 export async function getMessageTrace(msgId: string, instanceId?: string, topic?: string) {

--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -27,6 +27,7 @@ import { LangProvider } from '../../../i18n/LangContext';
 const messageServiceMocks = vi.hoisted(() => ({
   getMessageTrace: vi.fn(),
   queryMessages: vi.fn(),
+  queryMessagesPage: vi.fn(),
 }));
 const topicServiceMocks = vi.hoisted(() => ({
   listTopics: vi.fn(),
@@ -91,7 +92,9 @@ describe('Message page query history', () => {
   beforeEach(() => {
     localStorage.clear();
     messageServiceMocks.getMessageTrace.mockReset().mockResolvedValue(null);
-    messageServiceMocks.queryMessages.mockReset().mockResolvedValue([]);
+    messageServiceMocks.queryMessagesPage
+      .mockReset()
+      .mockResolvedValue({ items: [], total: 0, page: 1, size: 20 });
     topicServiceMocks.listTopics
       .mockReset()
       .mockResolvedValue([
@@ -132,17 +135,19 @@ describe('Message page query history', () => {
     const keyInput = screen.getByPlaceholderText('输入 Message Key');
     await user.type(keyInput, '   ');
     expect(queryButton).toBeDisabled();
-    expect(messageServiceMocks.queryMessages).not.toHaveBeenCalled();
+    expect(messageServiceMocks.queryMessagesPage).not.toHaveBeenCalled();
 
     await user.clear(keyInput);
     await user.type(keyInput, '  ORDER-001  ');
     expect(queryButton).toBeEnabled();
     await user.click(queryButton);
     await waitFor(() => {
-      expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith({
+      expect(messageServiceMocks.queryMessagesPage).toHaveBeenLastCalledWith({
         topic: 'order-create',
         key: 'ORDER-001',
         instanceId: 1,
+        page: 1,
+        pageSize: 20,
       });
     });
 
@@ -159,10 +164,12 @@ describe('Message page query history', () => {
     expect(queryButton).toBeEnabled();
     await user.click(queryButton);
     await waitFor(() => {
-      expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith({
+      expect(messageServiceMocks.queryMessagesPage).toHaveBeenLastCalledWith({
         topic: 'order-create',
         msgId: 'MID-001',
         instanceId: 1,
+        page: 1,
+        pageSize: 20,
       });
     });
   });
@@ -198,7 +205,7 @@ describe('Message page query history', () => {
     await user.type(screen.getByPlaceholderText('输入 Message ID'), 'MID-001');
     expect(queryButton).toBeDisabled();
     expect(queryButton).toHaveAttribute('title', '请选择 Topic');
-    expect(messageServiceMocks.queryMessages).not.toHaveBeenCalled();
+    expect(messageServiceMocks.queryMessagesPage).not.toHaveBeenCalled();
   });
 
   it('ignores stored queries that are missing fields required by their mode', () => {
@@ -214,7 +221,7 @@ describe('Message page query history', () => {
     renderWithProviders(<MessagePage />);
 
     expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
-    expect(messageServiceMocks.queryMessages).not.toHaveBeenCalled();
+    expect(messageServiceMocks.queryMessagesPage).not.toHaveBeenCalled();
   });
 
   it('persists successful queries for replay and allows clearing the history', async () => {
@@ -229,16 +236,18 @@ describe('Message page query history', () => {
     await user.click(screen.getByRole('button', { name: /^search查询$/ }));
 
     await waitFor(() => {
-      expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
+      expect(messageServiceMocks.queryMessagesPage).toHaveBeenCalledWith({
         topic: 'order-create',
         msgId: 'MID-001',
         instanceId: 1,
+        page: 1,
+        pageSize: 20,
       });
       expect(screen.getByRole('button', { name: /最近查询/ })).toBeEnabled();
     });
 
     firstView.unmount();
-    messageServiceMocks.queryMessages.mockClear();
+    messageServiceMocks.queryMessagesPage.mockClear();
     renderWithProviders(<MessagePage />);
 
     await user.click(screen.getByRole('button', { name: /最近查询/ }));
@@ -246,24 +255,22 @@ describe('Message page query history', () => {
 
     expect(screen.getByPlaceholderText('输入 Message ID')).toHaveValue('MID-001');
     await waitFor(() => {
-      expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
+      expect(messageServiceMocks.queryMessagesPage).toHaveBeenCalledWith({
         topic: 'order-create',
         msgId: 'MID-001',
         instanceId: 1,
+        page: 1,
+        pageSize: 20,
       });
     });
 
     await user.click(screen.getByRole('button', { name: /最近查询/ }));
     // Clearing requires confirmation: the dialog is commanded imperatively, so spy on it
     // and drive the confirm callback instead of depending on portal rendering in jsdom.
-    const confirmSpy = vi
-      .spyOn(Modal, 'confirm')
-      .mockImplementation((config) => {
-        config.onOk?.();
-        return { destroy: vi.fn(), update: vi.fn() } as unknown as ReturnType<
-          typeof Modal.confirm
-        >;
-      });
+    const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
+      config.onOk?.();
+      return { destroy: vi.fn(), update: vi.fn() } as unknown as ReturnType<typeof Modal.confirm>;
+    });
     await user.click(await screen.findByText('清空历史'));
     expect(confirmSpy).toHaveBeenCalled();
     confirmSpy.mockRestore();
@@ -273,7 +280,7 @@ describe('Message page query history', () => {
 
   it('does not save failed queries', async () => {
     const user = userEvent.setup();
-    messageServiceMocks.queryMessages.mockRejectedValue(new Error('network error'));
+    messageServiceMocks.queryMessagesPage.mockRejectedValue(new Error('network error'));
     renderWithProviders(<MessagePage />);
 
     await user.click(screen.getByText('按 Message ID'));
@@ -283,10 +290,12 @@ describe('Message page query history', () => {
     await user.click(screen.getByRole('button', { name: /^search查询$/ }));
 
     await waitFor(() => {
-      expect(messageServiceMocks.queryMessages).toHaveBeenCalledWith({
+      expect(messageServiceMocks.queryMessagesPage).toHaveBeenCalledWith({
         topic: 'order-create',
         msgId: 'MID-FAILED',
         instanceId: 1,
+        page: 1,
+        pageSize: 20,
       });
     });
     expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
@@ -307,7 +316,7 @@ describe('Message page query history', () => {
       await user.type(messageIdInput, `MID-${index}`);
       await user.click(queryButton);
       await waitFor(() => {
-        expect(messageServiceMocks.queryMessages).toHaveBeenCalledTimes(index);
+        expect(messageServiceMocks.queryMessagesPage).toHaveBeenCalledTimes(index);
       });
     }
 
@@ -328,7 +337,7 @@ describe('Message page query history', () => {
     await user.type(messageIdInput, 'MID-3');
     await user.click(queryButton);
     await waitFor(() => {
-      expect(messageServiceMocks.queryMessages).toHaveBeenCalledTimes(7);
+      expect(messageServiceMocks.queryMessagesPage).toHaveBeenCalledTimes(7);
     });
 
     const updatedHistory = JSON.parse(localStorage.getItem(storageKey!) || '[]') as Array<{
@@ -369,22 +378,26 @@ describe('Message page query history', () => {
     await user.click(screen.getByRole('button', { name: /最近查询/ }));
     await user.click(await screen.findByText('Topic: order-create'));
     await waitFor(() => {
-      expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith({
+      expect(messageServiceMocks.queryMessagesPage).toHaveBeenLastCalledWith({
         topic: 'order-create',
         tag: 'vip',
         startTime: 1_700_000_000_000,
         endTime: 1_700_003_600_000,
         instanceId: 1,
+        page: 1,
+        pageSize: 20,
       });
     });
 
     await user.click(screen.getByRole('button', { name: /最近查询/ }));
     await user.click(await screen.findByText('Key: ORDER-001 · Topic: payment-callback'));
     await waitFor(() => {
-      expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith({
+      expect(messageServiceMocks.queryMessagesPage).toHaveBeenLastCalledWith({
         topic: 'payment-callback',
         key: 'ORDER-001',
         instanceId: 1,
+        page: 1,
+        pageSize: 20,
       });
       expect(screen.getByPlaceholderText('输入 Message Key')).toHaveValue('ORDER-001');
     });
@@ -411,7 +424,12 @@ describe('Message page query history', () => {
 
   it('does not report consume verification success without a backend API', async () => {
     const user = userEvent.setup();
-    messageServiceMocks.queryMessages.mockResolvedValue([createMessage('MID-CONSUME-VERIFY-001')]);
+    messageServiceMocks.queryMessagesPage.mockResolvedValue({
+      items: [createMessage('MID-CONSUME-VERIFY-001')],
+      total: 1,
+      page: 1,
+      size: 20,
+    });
     renderWithProviders(<MessagePage />);
 
     await user.click(screen.getByText('按 Message ID'));
@@ -431,10 +449,15 @@ describe('Message page query history', () => {
 
   it('sorts and renders messages without tags or keys', async () => {
     const user = userEvent.setup();
-    messageServiceMocks.queryMessages.mockResolvedValue([
-      { ...createMessage('MID-NULL-FIELDS'), tag: null, key: null },
-      { ...createMessage('MID-FULL-FIELDS'), tag: 'vip', key: 'order-001' },
-    ]);
+    messageServiceMocks.queryMessagesPage.mockResolvedValue({
+      items: [
+        { ...createMessage('MID-NULL-FIELDS'), tag: null, key: null },
+        { ...createMessage('MID-FULL-FIELDS'), tag: 'vip', key: 'order-001' },
+      ],
+      total: 2,
+      page: 1,
+      size: 20,
+    });
     renderWithProviders(<MessagePage />);
 
     await user.click(screen.getByText('按 Message ID'));
@@ -467,7 +490,7 @@ describe('Message page query history', () => {
 
     expect(screen.getByRole('button', { name: /^search查询$/ })).toBeDisabled();
     expect(screen.getByRole('button', { name: /最近查询/ })).toBeDisabled();
-    expect(messageServiceMocks.queryMessages).not.toHaveBeenCalled();
+    expect(messageServiceMocks.queryMessagesPage).not.toHaveBeenCalled();
   });
 
   it('loads topic options only for the selected instance', async () => {

--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -20,13 +20,14 @@ import { MemoryRouter } from 'react-router-dom';
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { MessageRecord, TraceRecord } from '../../../api/message';
+import type { MessagePageResult, MessageRecord, TraceRecord } from '../../../api/message';
 import { LangProvider } from '../../../i18n/LangContext';
 import MessagePage from '../message';
 
 const serviceMocks = vi.hoisted(() => ({
   getMessageTrace: vi.fn(),
   queryMessages: vi.fn(),
+  queryMessagesPage: vi.fn(),
 }));
 const instanceFilterMocks = vi.hoisted(() => ({
   useInstanceFilter: vi.fn(),
@@ -132,25 +133,30 @@ describe('MessagePage async request ownership', () => {
   });
 
   it('does not restore query results after the user resets an in-flight query', async () => {
-    const query = createDeferred<MessageRecord[]>();
-    serviceMocks.queryMessages.mockReturnValue(query.promise);
+    const query = createDeferred<MessagePageResult>();
+    serviceMocks.queryMessagesPage.mockReturnValue(query.promise);
     const user = userEvent.setup();
     renderPage();
     await selectTopic(user);
 
     await user.click(screen.getByRole('button', { name: /^search查询$/ }));
-    await waitFor(() => expect(serviceMocks.queryMessages).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(serviceMocks.queryMessagesPage).toHaveBeenCalledTimes(1));
     await user.click(screen.getByRole('button', { name: /重置/ }));
 
     await act(async () => {
-      query.resolve([createMessage('late-after-reset')]);
+      query.resolve({ items: [createMessage('late-after-reset')], total: 1, page: 1, size: 20 });
     });
 
     expect(screen.queryByText('late-after-reset')).not.toBeInTheDocument();
   });
 
   it('clears query results and message details when the selected instance changes', async () => {
-    serviceMocks.queryMessages.mockResolvedValue([createMessage('message-from-instance-a')]);
+    serviceMocks.queryMessagesPage.mockResolvedValue({
+      items: [createMessage('message-from-instance-a')],
+      total: 1,
+      page: 1,
+      size: 20,
+    });
     let currentInstanceId = 1;
     const selectInstance = vi.fn((id: number) => {
       currentInstanceId = id;
@@ -184,7 +190,7 @@ describe('MessagePage async request ownership', () => {
     expect(selectInstance).toHaveBeenCalledWith(2, expect.anything());
   });
   it('surfaces unavailable message provider errors from query requests', async () => {
-    serviceMocks.queryMessages.mockRejectedValue(
+    serviceMocks.queryMessagesPage.mockRejectedValue(
       new Error('Message query provider is not configured'),
     );
     const user = userEvent.setup();
@@ -198,7 +204,12 @@ describe('MessagePage async request ownership', () => {
   });
 
   it('surfaces unavailable message provider errors from trace requests', async () => {
-    serviceMocks.queryMessages.mockResolvedValue([createMessage('message-a')]);
+    serviceMocks.queryMessagesPage.mockResolvedValue({
+      items: [createMessage('message-a')],
+      total: 1,
+      page: 1,
+      size: 20,
+    });
     serviceMocks.getMessageTrace.mockRejectedValue(
       new Error('Message query provider is not configured'),
     );
@@ -217,7 +228,12 @@ describe('MessagePage async request ownership', () => {
   });
 
   it('keeps normal message resend disabled until a real API is wired', async () => {
-    serviceMocks.queryMessages.mockResolvedValue([createMessage('message-a')]);
+    serviceMocks.queryMessagesPage.mockResolvedValue({
+      items: [createMessage('message-a')],
+      total: 1,
+      page: 1,
+      size: 20,
+    });
     const user = userEvent.setup();
     renderPage();
     await selectTopic(user);
@@ -233,9 +249,9 @@ describe('MessagePage async request ownership', () => {
   });
 
   it('keeps the latest query loading and ignores an earlier query result', async () => {
-    const firstQuery = createDeferred<MessageRecord[]>();
-    const secondQuery = createDeferred<MessageRecord[]>();
-    serviceMocks.queryMessages
+    const firstQuery = createDeferred<MessagePageResult>();
+    const secondQuery = createDeferred<MessagePageResult>();
+    serviceMocks.queryMessagesPage
       .mockReturnValueOnce(firstQuery.promise)
       .mockReturnValueOnce(secondQuery.promise);
     const user = userEvent.setup();
@@ -245,17 +261,27 @@ describe('MessagePage async request ownership', () => {
     const queryButton = screen.getByRole('button', { name: /^search查询$/ });
     await user.click(queryButton);
     await user.click(queryButton);
-    await waitFor(() => expect(serviceMocks.queryMessages).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(serviceMocks.queryMessagesPage).toHaveBeenCalledTimes(2));
 
     await act(async () => {
-      firstQuery.resolve([createMessage('stale-first-query')]);
+      firstQuery.resolve({
+        items: [createMessage('stale-first-query')],
+        total: 1,
+        page: 1,
+        size: 20,
+      });
     });
 
     expect(screen.queryByText('stale-first-query')).not.toBeInTheDocument();
     expect(document.querySelector('.ant-table-wrapper .ant-spin-spinning')).toBeInTheDocument();
 
     await act(async () => {
-      secondQuery.resolve([createMessage('latest-second-query')]);
+      secondQuery.resolve({
+        items: [createMessage('latest-second-query')],
+        total: 1,
+        page: 1,
+        size: 20,
+      });
     });
 
     expect(await screen.findByText('latest-second-query')).toBeInTheDocument();
@@ -270,7 +296,12 @@ describe('MessagePage async request ownership', () => {
     'invalidates a trace request when the detail closes before a late %s',
     async (settlement) => {
       const trace = createDeferred<TraceRecord | null>();
-      serviceMocks.queryMessages.mockResolvedValue([createMessage('message-a')]);
+      serviceMocks.queryMessagesPage.mockResolvedValue({
+        items: [createMessage('message-a')],
+        total: 1,
+        page: 1,
+        size: 20,
+      });
       serviceMocks.getMessageTrace.mockReturnValue(trace.promise);
       const errorSpy = vi.spyOn(message, 'error').mockImplementation(vi.fn());
       const user = userEvent.setup();
@@ -304,10 +335,12 @@ describe('MessagePage async request ownership', () => {
   it('keeps the current trace loading when an earlier trace finishes first', async () => {
     const firstTrace = createDeferred<TraceRecord | null>();
     const secondTrace = createDeferred<TraceRecord | null>();
-    serviceMocks.queryMessages.mockResolvedValue([
-      createMessage('message-a'),
-      createMessage('message-b'),
-    ]);
+    serviceMocks.queryMessagesPage.mockResolvedValue({
+      items: [createMessage('message-a'), createMessage('message-b')],
+      total: 2,
+      page: 1,
+      size: 20,
+    });
     serviceMocks.getMessageTrace.mockImplementation((msgId: string) =>
       msgId === 'message-a' ? firstTrace.promise : secondTrace.promise,
     );
@@ -344,10 +377,12 @@ describe('MessagePage async request ownership', () => {
   it('does not display a late trace from a previously closed message detail', async () => {
     const firstTrace = createDeferred<TraceRecord | null>();
     const secondTrace = createDeferred<TraceRecord | null>();
-    serviceMocks.queryMessages.mockResolvedValue([
-      createMessage('message-a'),
-      createMessage('message-b'),
-    ]);
+    serviceMocks.queryMessagesPage.mockResolvedValue({
+      items: [createMessage('message-a'), createMessage('message-b')],
+      total: 2,
+      page: 1,
+      size: 20,
+    });
     serviceMocks.getMessageTrace.mockImplementation((msgId: string) =>
       msgId === 'message-a' ? firstTrace.promise : secondTrace.promise,
     );

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -48,7 +48,7 @@ import {
   HistoryOutlined,
   DeleteOutlined,
 } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
+import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
 import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
 import PageHeader from '../../components/PageHeader';
@@ -56,7 +56,7 @@ import { InstanceSelect } from '../../components/InstanceSelect';
 import MessageQueryHistoryDrawer from '../../components/MessageQueryHistoryDrawer';
 import { useLang } from '../../i18n/LangContext';
 import type { MessageQuery, MessageRecord, TraceRecord } from '../../api/message';
-import { getMessageTrace, queryMessages } from '../../services/messageService';
+import { getMessageTrace, queryMessagesPage } from '../../services/messageService';
 import { listTopics } from '../../services/topicService';
 import { useInstanceFilter } from '../../hooks/useInstanceFilter';
 import { downloadBlob } from '../../utils/download';
@@ -313,6 +313,9 @@ const MessagePageContent = ({
   const [msgIdInput, setMsgIdInput] = useState('');
   const [messages, setMessages] = useState<MessageRecord[]>([]);
   const [queryLoading, setQueryLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [total, setTotal] = useState(0);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalTab, setModalTab] = useState('content');
   const [selectedMsg, setSelectedMsg] = useState<MessageRecord | null>(null);
@@ -358,6 +361,8 @@ const MessagePageContent = ({
     setMessages([]);
     setQueryError(null);
     setQueryLoading(false);
+    setPage(1);
+    setTotal(0);
   };
 
   const saveRecentQuery = (mode: QueryMode, params: MessageQuery) => {
@@ -377,7 +382,13 @@ const MessagePageContent = ({
     });
   };
 
-  const executeQuery = async (mode: QueryMode, params: MessageQuery) => {
+  const runQuery = async (
+    mode: QueryMode,
+    params: MessageQuery,
+    nextPage = 1,
+    nextPageSize = pageSize,
+    saveHistory = true,
+  ) => {
     const requestGeneration = queryGenerationRef.current + 1;
     queryGenerationRef.current = requestGeneration;
     if (!selectedInstanceId) {
@@ -395,12 +406,22 @@ const MessagePageContent = ({
     setQueryLoading(true);
     setQueryError(null);
     try {
-      const result = await queryMessages({ ...normalizedParams, instanceId: selectedInstanceId });
+      const result = await queryMessagesPage({
+        ...normalizedParams,
+        instanceId: selectedInstanceId,
+        page: nextPage,
+        pageSize: nextPageSize,
+      });
       if (queryGenerationRef.current !== requestGeneration) return;
-      setMessages(result);
+      setMessages(result.items);
+      setTotal(result.total);
+      setPage(result.page);
+      setPageSize(result.size);
       setQueryError(null);
-      saveRecentQuery(mode, normalizedParams);
-      message.success(`查询完成，共 ${result.length} 条`);
+      if (saveHistory) {
+        saveRecentQuery(mode, normalizedParams);
+        message.success(`查询完成，共 ${result.total} 条`);
+      }
     } catch (error) {
       if (queryGenerationRef.current === requestGeneration) {
         setQueryError(getErrorMessage(error, DEFAULT_QUERY_ERROR));
@@ -413,7 +434,17 @@ const MessagePageContent = ({
   };
 
   const handleQuery = async () => {
-    await executeQuery(queryMode, currentQueryParams);
+    await runQuery(queryMode, currentQueryParams, 1, pageSize, true);
+  };
+
+  const handleTableChange = (pagination: TablePaginationConfig) => {
+    void runQuery(
+      queryMode,
+      currentQueryParams,
+      pagination.current ?? 1,
+      pagination.pageSize ?? pageSize,
+      false,
+    );
   };
 
   const replayRecentQuery = (recentQuery: RecentQuery) => {
@@ -425,7 +456,7 @@ const MessagePageContent = ({
     if (mode === 'topic' && params.startTime !== undefined && params.endTime !== undefined) {
       setDateRange([dayjs(params.startTime), dayjs(params.endTime)]);
     }
-    void executeQuery(mode, params);
+    void runQuery(mode, params, 1, pageSize, true);
   };
 
   const clearRecentQueries = () => {
@@ -942,10 +973,13 @@ const MessagePageContent = ({
           loading={queryLoading}
           rowKey="msgId"
           pagination={{
-            pageSize: 50,
+            current: page,
+            pageSize,
+            total,
             showSizeChanger: true,
-            showTotal: (total) => `共 ${total} 条消息`,
+            showTotal: (totalCount) => `共 ${totalCount} 条消息`,
           }}
+          onChange={handleTableChange}
           size="small"
           scroll={{ x: tableScrollX(columns) }}
         />

--- a/web/src/services/messageService.ts
+++ b/web/src/services/messageService.ts
@@ -2,6 +2,7 @@ import { isMockMode } from './dataMode';
 import * as messageApi from '../api/message';
 import { sortMessagesByStoreTimeDesc } from '../api/message';
 import type {
+  MessagePageResult,
   MessageQuery,
   MessageRecord,
   TraceRecord,
@@ -49,6 +50,23 @@ export async function queryMessages(params: MessageQuery): Promise<MessageRecord
   return messageApi.queryMessages(params);
 }
 
+export async function queryMessagesPage(
+  params: MessageQuery & { page?: number; pageSize?: number },
+): Promise<MessagePageResult> {
+  if (isMockMode()) {
+    const filtered = await queryMessages(params);
+    const page = params.page ?? 1;
+    const pageSize = params.pageSize ?? 20;
+    return {
+      items: filtered.slice((page - 1) * pageSize, page * pageSize),
+      total: filtered.length,
+      page,
+      size: pageSize,
+    };
+  }
+  return messageApi.queryMessagesPage(params);
+}
+
 export async function getMessageTrace(
   msgId: string,
   instanceId?: string,
@@ -69,8 +87,7 @@ export async function listDLQGroups(
 ): Promise<DLQGroupPage> {
   if (isMockMode()) {
     const groups = (mockDLQGroups as unknown as DLQGroup[]).filter(
-      (group) =>
-        !search || group.groupName.includes(search) || group.dlqTopic.includes(search),
+      (group) => !search || group.groupName.includes(search) || group.dlqTopic.includes(search),
     );
     const from = Math.min((page - 1) * pageSize, groups.length);
     return {


### PR DESCRIPTION
# PR: Server-side paging for message query

**Branch:** `feature/studio-message-paging`

## Summary

Introduces server-side pagination for the message query endpoint and moves the
message query page from client-side pagination of a full result set to paged
requests, so large result sets no longer overload the browser or the API
response.

## Backend

- `MessageProvider` / `InstanceProvider`
  - New default `queryMessagesPage(...)` that throws `501 Paged message query
    is not supported by this provider`, keeping non-Apache providers safe.
- `RocketMQMessageProvider`
  - Overrides `queryMessagesPage(...)`; slices the provider-resolved query
    window using `Pagination.pageOffset` and returns a `PageResult`.
- `ApacheInstanceProvider`
  - Delegates the new method to `MessageProvider`.
- `MessageService`
  - New `queryMessagesPage(...)` validates the query window, dispatches through
    the instance registry, and records query history with the paged total.
- `MessageController`
  - New `GET /api/messages/page` endpoint with `page` (default 1) and
    `pageSize` (default 20) request params.

## Frontend

- `api/message.ts`
  - New `MessagePageResult` type and `queryMessagesPage` API call.
- `services/messageService.ts`
  - `queryMessagesPage` wrapper with mock-mode fallback (slices in memory).
- `pages/instance/message.tsx`
  - Tracks `page` / `pageSize` / `total` state; the query form issues paged
    requests and the table re-queries on page or page-size change. The
    "查询完成" toast now reports the server-side total instead of the local
    array length.
- Tests updated: `MessagePage.test.tsx` and `MessagePageAsyncState.test.tsx`
  now mock `queryMessagesPage` with `PageResult` shapes and assert the extra
  `page` / `pageSize` parameters.

## Verification

- `mvn -o test` — all server tests pass
- `tsc -b` — no type errors
- `vitest run` on both message page suites — 25 tests pass
