### PR TITLE
fix(history): align query-history owner columns with username limits

### DIFF
--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -145,7 +145,7 @@ CREATE TABLE IF NOT EXISTS rmq_instance_message (
   end_time BIGINT,
   result_count INT DEFAULT 0,
   cluster_id VARCHAR(255),
-  queried_by VARCHAR(64),
+  queried_by VARCHAR(128),
   PRIMARY KEY (`id`),
   INDEX idx_message_query_gmt_create (gmt_create),
   INDEX idx_topic (topic)
@@ -161,7 +161,7 @@ CREATE TABLE IF NOT EXISTS rmq_instance_trace (
   node_count INT DEFAULT 0,
   consumer_count INT DEFAULT 0,
   cluster_id VARCHAR(255),
-  queried_by VARCHAR(64),
+  queried_by VARCHAR(128),
   PRIMARY KEY (`id`),
   INDEX idx_msg_id (msg_id),
   INDEX idx_trace_query_gmt_create (gmt_create)
@@ -288,3 +288,10 @@ CREATE TABLE IF NOT EXISTS rmq_cloud_credential (
   PRIMARY KEY (`id`),
   UNIQUE KEY uk_vendor_access_key (vendor, access_key)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Idempotent upgrades for databases created before the corresponding CREATE statements
+-- were widened. Safe to re-run: on fresh databases the columns already match, and on
+-- existing databases the MODIFY below only grows the column width. Usernames may be up
+-- to 128 characters (see AuthService), so query-history owner columns must match.
+ALTER TABLE rmq_instance_message MODIFY queried_by VARCHAR(128);
+ALTER TABLE rmq_instance_trace MODIFY queried_by VARCHAR(128);

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceIntegrationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import org.apache.rocketmq.studio.auth.AuthenticatedUserContext;
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.persistence.entity.RmqMessageQuery;
+import org.apache.rocketmq.studio.persistence.entity.RmqTraceQuery;
+import org.apache.rocketmq.studio.persistence.mapper.RmqMessageQueryMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqTraceQueryMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = "studio.auth.login-required=true")
+class QueryHistoryServiceIntegrationTest {
+
+    @Autowired
+    private QueryHistoryService queryHistoryService;
+
+    @Autowired
+    private RmqMessageQueryMapper messageQueryMapper;
+
+    @Autowired
+    private RmqTraceQueryMapper traceQueryMapper;
+
+    @Test
+    void queryHistoryKeepsFullLengthUsernames() {
+        // Usernames may be up to 128 characters; the query-history owner columns must
+        // store the full value instead of rejecting or truncating it.
+        String longUsername = "long".repeat(32);
+        assertThat(longUsername).hasSize(128);
+        try {
+            AuthenticatedUserContext.setUser(longUsername, true);
+            queryHistoryService.recordMessageQuery("qh-cluster", "TOPIC", "qh-topic",
+                    null, null, null, null, null, 3);
+            queryHistoryService.recordTraceQuery("qh-cluster", "qh-msg-id", "qh-topic", 2, 1);
+
+            PageResult<MessageQueryHistoryVO> messageHistory =
+                    queryHistoryService.listMessageQueries("qh-cluster", null, null, 1, 20);
+            assertThat(messageHistory.getItems()).anySatisfy(item ->
+                    assertThat(item.getQueriedBy()).isEqualTo(longUsername));
+
+            PageResult<TraceQueryHistoryVO> traceHistory =
+                    queryHistoryService.listTraceQueries("qh-cluster", null, 1, 20);
+            assertThat(traceHistory.getItems()).anySatisfy(item ->
+                    assertThat(item.getQueriedBy()).isEqualTo(longUsername));
+        } finally {
+            AuthenticatedUserContext.clear();
+            messageQueryMapper.delete(new QueryWrapper<RmqMessageQuery>()
+                    .eq("queried_by", longUsername));
+            traceQueryMapper.delete(new QueryWrapper<RmqTraceQuery>()
+                    .eq("queried_by", longUsername));
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Usernames may be up to 128 characters, but the `queried_by` columns of `rmq_instance_message` and `rmq_instance_trace` were `VARCHAR(64)`. When a user with a 65-128 character name ran a message or trace query, the history insert failed and `MessageService` swallowed the exception - the business query succeeded while the history row was silently lost.

## Brief changelog

- widened `queried_by` to `VARCHAR(128)` in both query-history tables
- appended idempotent `ALTER TABLE ... MODIFY` upgrades so pre-existing databases pick up the wider columns when the DDL is re-applied (fresh databases already get them from the CREATE statements)
- added an integration test that records a message query and a trace query under a 128-character username and asserts both rows come back from the history listings with the full, untruncated owner

## How was this patch verified

- server: `QueryHistoryServiceIntegrationTest` green; the same test fails when the columns are reverted to `VARCHAR(64)`, proving it catches the original bug; full `mvn test` green apart from the 7 pre-existing environment failures in the CLI agent tests (missing `sh` binary on a Windows machine, identical on the clean base)

Fixes #2491
