### PR TITLE
fix(metrics): render native histogram samples in Metrics Explorer

### DIFF
--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -57,12 +57,48 @@ interface NumericSample {
   value: number;
 }
 
-const toNumericSamples = (series: MetricSeries): NumericSample[] =>
-  series.values
-    .map((sample, index) => ({ timestamp: sample.timestamp, value: Number(sample.value), index }))
+const sortAndStrip = (
+  samples: { timestamp: number; value: number; index: number }[],
+): NumericSample[] =>
+  samples
     .filter((sample) => Number.isFinite(sample.timestamp) && Number.isFinite(sample.value))
     .sort((left, right) => left.timestamp - right.timestamp || left.index - right.index)
     .map(({ timestamp, value }) => ({ timestamp, value }));
+
+const toScalarSamples = (series: MetricSeries): NumericSample[] =>
+  sortAndStrip(
+    series.values.map((sample, index) => ({
+      timestamp: sample.timestamp,
+      value: Number(sample.value),
+      index,
+    })),
+  );
+
+// Native histograms carry no scalar samples. To avoid plotting them as "no data", derive a
+// trend value per histogram: the observed sum (in the metric's unit), falling back to the
+// observation count when the sum is absent or non-finite.
+const toHistogramSamples = (series: MetricSeries): NumericSample[] =>
+  sortAndStrip(
+    series.histograms.map((sample, index) => {
+      // An empty string parses to 0, so treat a blank field as missing rather than zero.
+      const sumText = sample.histogram.sum?.trim();
+      const countText = sample.histogram.count?.trim();
+      const sum = sumText ? Number(sumText) : Number.NaN;
+      const count = countText ? Number(countText) : Number.NaN;
+      const value = Number.isFinite(sum) ? sum : count;
+      return { timestamp: sample.timestamp, value, index };
+    }),
+  );
+
+const toNumericSamples = (
+  series: MetricSeries,
+): { samples: NumericSample[]; fromHistogram: boolean } => {
+  const scalar = toScalarSamples(series);
+  if (scalar.length > 0) {
+    return { samples: scalar, fromHistogram: false };
+  }
+  return { samples: toHistogramSamples(series), fromHistogram: true };
+};
 
 const seriesLabel = (series: MetricSeries, fallback: string) => {
   const labels = Object.entries(series.labels)
@@ -80,15 +116,20 @@ interface MetricChartProps {
   metric: MetricMapping;
   locale: string;
   noSamples: string;
+  histogramLabel: string;
 }
 
-const MetricChart = ({ data, metric, locale, noSamples }: MetricChartProps) => {
+const MetricChart = ({ data, metric, locale, noSamples, histogramLabel }: MetricChartProps) => {
   const chartSeries = data.series
-    .map((series, index) => ({
-      color: SERIES_COLORS[index % SERIES_COLORS.length],
-      label: seriesLabel(series, metric.name),
-      samples: toNumericSamples(series),
-    }))
+    .map((series, index) => {
+      const { samples, fromHistogram } = toNumericSamples(series);
+      return {
+        color: SERIES_COLORS[index % SERIES_COLORS.length],
+        label: seriesLabel(series, metric.name),
+        samples,
+        fromHistogram,
+      };
+    })
     .filter((series) => series.samples.length > 0);
 
   if (chartSeries.length === 0) {
@@ -205,6 +246,13 @@ const MetricChart = ({ data, metric, locale, noSamples }: MetricChartProps) => {
               <Text ellipsis={{ tooltip: series.label }} style={{ maxWidth: 220 }}>
                 {series.label}
               </Text>
+              {series.fromHistogram ? (
+                <Tooltip title="No scalar samples; trend derived from histogram observations">
+                  <Tag color="purple" style={{ marginInlineEnd: 0 }}>
+                    {histogramLabel}
+                  </Tag>
+                </Tooltip>
+              ) : null}
               <Text strong>
                 {formatMetricValue(latest.value)} {metric.unit}
               </Text>
@@ -272,7 +320,8 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
           profileError: '指标模板加载失败',
           queryError: queryErrorFallback,
           noProfiles: '暂无指标模板',
-          noSamples: '暂无标量数据',
+          noSamples: '暂无数据',
+          histogram: '直方图',
           defaultDataSource: '默认数据源',
           authTitle: '数据源认证',
           authDescription: '凭据仅用于当前数据源，离开该数据源后会被清除。',
@@ -292,7 +341,8 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
           profileError: 'Failed to load metric profiles',
           queryError: queryErrorFallback,
           noProfiles: 'No metric profiles',
-          noSamples: 'No scalar samples',
+          noSamples: 'No samples',
+          histogram: 'Histogram',
           defaultDataSource: 'Default source',
           authTitle: 'Data source authentication',
           authDescription:
@@ -607,6 +657,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
             metric={selectedMetric}
             locale={lang === 'zh' ? 'zh-CN' : 'en-US'}
             noSamples={copy.noSamples}
+            histogramLabel={copy.histogram}
           />
         </>
       ) : null}

--- a/web/src/components/__tests__/MetricsExplorer.test.tsx
+++ b/web/src/components/__tests__/MetricsExplorer.test.tsx
@@ -84,6 +84,27 @@ const metricData = {
   warnings: [],
 };
 
+const histogramOnlyData = {
+  resultType: 'matrix',
+  series: [
+    {
+      labels: { cluster: 'prod', node_id: 'broker-a' },
+      values: [],
+      histograms: [
+        {
+          timestamp: 1_799_996_400,
+          histogram: { count: '10', sum: '250', buckets: [] },
+        },
+        {
+          timestamp: 1_800_000_000,
+          histogram: { count: '20', sum: '600', buckets: [] },
+        },
+      ],
+    },
+  ],
+  warnings: [],
+};
+
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -257,12 +278,63 @@ describe('MetricsExplorer', () => {
     expect(await screen.findByText('Prometheus base URL is not configured')).toBeInTheDocument();
   });
 
-  it('shows an empty state when Prometheus returns no scalar samples', async () => {
+  it('shows an empty state when Prometheus returns no samples at all', async () => {
     vi.mocked(queryMetrics).mockResolvedValue({ ...metricData, series: [] });
 
     renderWithProviders(<MetricsExplorer />);
 
-    expect(await screen.findByText('暂无标量数据')).toBeInTheDocument();
+    expect(await screen.findByText('暂无数据')).toBeInTheDocument();
+  });
+
+  it('renders histogram-only series from observed sums instead of an empty state', async () => {
+    vi.mocked(queryMetrics).mockResolvedValue(histogramOnlyData);
+
+    renderWithProviders(<MetricsExplorer />);
+
+    expect(
+      await screen.findByRole('img', { name: 'Message In TPS time series' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('600 messages/s')).toBeInTheDocument();
+    expect(screen.getByText('直方图')).toBeInTheDocument();
+    expect(screen.queryByText('暂无数据')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the observation count when the histogram sum is missing', async () => {
+    vi.mocked(queryMetrics).mockResolvedValue({
+      ...histogramOnlyData,
+      series: [
+        {
+          ...histogramOnlyData.series[0],
+          histograms: [
+            { timestamp: 1_800_000_000, histogram: { count: '20', sum: '', buckets: [] } },
+          ],
+        },
+      ],
+    });
+
+    renderWithProviders(<MetricsExplorer />);
+
+    expect(await screen.findByText('20 messages/s')).toBeInTheDocument();
+  });
+
+  it('prefers scalar samples when a series has both values and histograms', async () => {
+    vi.mocked(queryMetrics).mockResolvedValue({
+      ...metricData,
+      series: [
+        {
+          ...metricData.series[0],
+          histograms: [
+            { timestamp: 1_800_000_000, histogram: { count: '99', sum: '999', buckets: [] } },
+          ],
+        },
+      ],
+    });
+
+    renderWithProviders(<MetricsExplorer />);
+
+    expect(await screen.findByText('42 messages/s')).toBeInTheDocument();
+    expect(screen.queryByText('999 messages/s')).not.toBeInTheDocument();
+    expect(screen.queryByText('直方图')).not.toBeInTheDocument();
   });
 
   it('queries the selected data source through the datasource endpoint', async () => {


### PR DESCRIPTION
## What is the purpose of the change

The Metrics Explorer chart only read `series.values`, so a PromQL query that returned native histograms (no scalar samples) was plotted as the empty state even though data existed.

## Brief changelog

- `toNumericSamples` now falls back to the series' histogram samples when no scalar values are present
- each histogram contributes a trend point: the observed `sum` in the metric's unit, falling back to the observation `count` when the sum is blank or non-finite (a blank field parses to `0`, so it is treated as missing)
- scalar samples still take precedence when both are present
- series drawn from histograms are marked with a "Histogram" tag in the legend, and the empty-state copy now reads "No samples" / "暂无数据"

## How was this patch verified

- web: `MetricsExplorer.test.tsx` 15/15 (histogram-only renders from sums, blank sum falls back to count, scalar-over-histogram precedence, empty state); full `vitest run` 642/642; `tsc -b` and `eslint` clean

Fixes #2492
