### PR TITLE
fix(csv): align resource name validation with RocketMQ rules

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -754,8 +754,8 @@ const translations: Record<string, Record<Lang, string>> = {
   },
   'topic.topicNamePlaceholder': { zh: '请输入 Topic 名称', en: 'Enter topic name' },
   'topic.topicNameRule': {
-    zh: '仅支持字母、数字、下划线、中划线、斜杠和星号',
-    en: 'Only letters, numbers, underscore, hyphen, slash and asterisk',
+    zh: '仅支持字母、数字、下划线、短横线、% 和 |',
+    en: 'Only letters, numbers, underscore, hyphen, % and |',
   },
   'topic.topicNameRequired': { zh: '请输入 Topic 名称', en: 'Please enter topic name' },
   'topic.queueExtra': { zh: '每个 Broker 节点 8 个队列', en: '8 queues per Broker node' },

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -85,6 +85,8 @@ import {
 import { useInstanceFilter } from '../../hooks/useInstanceFilter';
 import {
   parseCsvTable,
+  RESOURCE_NAME_MAX_LENGTH,
+  RESOURCE_NAME_PATTERN,
   validateConsumerGroupCsvImport,
   type ResourceImportRow,
 } from '../../utils/resourceCsvImport';
@@ -1607,8 +1609,12 @@ const ConsumerPageContent = ({
             rules={[
               { required: true, message: '请输入 Group 名称' },
               {
-                pattern: /^[a-zA-Z][a-zA-Z0-9_-]*$/,
-                message: '名称以字母开头，仅包含字母、数字、下划线和短横线',
+                pattern: RESOURCE_NAME_PATTERN,
+                message: '仅支持字母、数字、下划线、短横线、% 和 |',
+              },
+              {
+                max: RESOURCE_NAME_MAX_LENGTH.group,
+                message: `名称不能超过 ${RESOURCE_NAME_MAX_LENGTH.group} 个字符`,
               },
             ]}
           >

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -74,6 +74,8 @@ import { useInstanceFilter } from '../../hooks/useInstanceFilter';
 import type { Instance } from '../../api/instance';
 import {
   parseCsvTable,
+  RESOURCE_NAME_MAX_LENGTH,
+  RESOURCE_NAME_PATTERN,
   validateTopicCsvImport,
   type ResourceImportRow,
 } from '../../utils/resourceCsvImport';
@@ -1329,8 +1331,12 @@ const TopicPage = () => {
             rules={[
               { required: true, message: '请输入 Topic 名称' },
               {
-                pattern: /^[a-zA-Z0-9_\-/*]+$/,
-                message: '仅支持字母、数字、下划线、中划线、斜杠和星号',
+                pattern: RESOURCE_NAME_PATTERN,
+                message: '仅支持字母、数字、下划线、短横线、% 和 |',
+              },
+              {
+                max: RESOURCE_NAME_MAX_LENGTH.topic,
+                message: `名称不能超过 ${RESOURCE_NAME_MAX_LENGTH.topic} 个字符`,
               },
             ]}
           >

--- a/web/src/utils/resourceCsvImport.test.ts
+++ b/web/src/utils/resourceCsvImport.test.ts
@@ -20,6 +20,7 @@ import {
   parseCsvTable,
   RESOURCE_IMPORT_ROW_LIMIT,
   validateConsumerGroupCsvImport,
+  validateResourceName,
   validateTopicCsvImport,
 } from './resourceCsvImport';
 
@@ -124,5 +125,46 @@ describe('resourceCsvImport', () => {
       subscribedTopics: [],
       instanceId: 'instance-2',
     });
+  });
+
+  it('aligns topic and group names with the RocketMQ validators', () => {
+    const topicStatus = (name: string) =>
+      validateTopicCsvImport(parseCsvTable(['"Name"', `"${name}"`].join('\n'))).rows[0].status;
+    const groupStatus = (name: string) =>
+      validateConsumerGroupCsvImport(parseCsvTable(['"Name"', `"${name}"`].join('\n'))).rows[0]
+        .status;
+
+    // RocketMQ accepts % and | in both topic and group names
+    expect(topicStatus('100%topic')).toBe('pending');
+    expect(topicStatus('topic|pipe')).toBe('pending');
+    expect(groupStatus('cg|pipe')).toBe('pending');
+    // Groups may start with a digit (no leading-letter rule)
+    expect(groupStatus('1cg')).toBe('pending');
+    // / and * are not part of the RocketMQ name character set
+    expect(topicStatus('topic/with-slash')).toBe('invalid');
+    expect(topicStatus('topic*star')).toBe('invalid');
+  });
+
+  it('applies the RocketMQ length caps to imported names', () => {
+    const topicStatus = (name: string) =>
+      validateTopicCsvImport(parseCsvTable(['"Name"', `"${name}"`].join('\n'))).rows[0].status;
+    const groupStatus = (name: string) =>
+      validateConsumerGroupCsvImport(parseCsvTable(['"Name"', `"${name}"`].join('\n'))).rows[0]
+        .status;
+
+    expect(topicStatus('t'.repeat(127))).toBe('pending');
+    expect(topicStatus('t'.repeat(128))).toBe('invalid');
+    expect(groupStatus('g'.repeat(120))).toBe('pending');
+    expect(groupStatus('g'.repeat(121))).toBe('invalid');
+  });
+
+  it('reports the RocketMQ-oriented name error messages', () => {
+    expect(validateResourceName('', 'topic')).toBe('Name 不能为空');
+    expect(validateResourceName('a'.repeat(128), 'topic')).toBe('Name 长度不能超过 127 个字符');
+    expect(validateResourceName('a'.repeat(121), 'group')).toBe('Name 长度不能超过 120 个字符');
+    expect(validateResourceName('bad/name', 'topic')).toBe(
+      'Name 仅支持字母、数字、下划线、短横线、% 和 |',
+    );
+    expect(validateResourceName('ok-name|100%', 'group')).toBeNull();
   });
 });

--- a/web/src/utils/resourceCsvImport.ts
+++ b/web/src/utils/resourceCsvImport.ts
@@ -44,8 +44,28 @@ interface ParsedCsvRow {
 }
 
 const FORMULA_SAFE_PREFIX_PATTERN = /^'(?=[=+\-@\t\r\n])/;
-const TOPIC_NAME_PATTERN = /^[a-zA-Z0-9_\-/*]+$/;
-const GROUP_NAME_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+// Aligned with RocketMQ's TopicValidator/GroupValidator: a shared character set (letters,
+// digits, underscore, hyphen, % and |) with per-kind length caps. Topics cap at 127 and
+// consumer groups at 120; both may start with a digit or symbol, so no leading-letter rule.
+export const RESOURCE_NAME_PATTERN = /^[%|a-zA-Z0-9_-]+$/;
+export const RESOURCE_NAME_MAX_LENGTH = { topic: 127, group: 120 } as const;
+
+export type ResourceNameKind = keyof typeof RESOURCE_NAME_MAX_LENGTH;
+
+export const validateResourceName = (name: string, kind: ResourceNameKind): string | null => {
+  if (!name) {
+    return 'Name 不能为空';
+  }
+  const maxLength = RESOURCE_NAME_MAX_LENGTH[kind];
+  if (name.length > maxLength) {
+    return `Name 长度不能超过 ${maxLength} 个字符`;
+  }
+  if (!RESOURCE_NAME_PATTERN.test(name)) {
+    return 'Name 仅支持字母、数字、下划线、短横线、% 和 |';
+  }
+  return null;
+};
 
 const TOPIC_TYPES = new Set(['NORMAL', 'FIFO', 'DELAY', 'TRANSACTION', 'LITE']);
 const TOPIC_PERMISSIONS = new Set(['RW', 'RO', 'WO']);
@@ -260,10 +280,9 @@ export const validateTopicCsvImport = (
     const duplicateMessage = duplicateMessages.get(record.lineNumber);
     if (duplicateMessage) rowErrors.push(duplicateMessage);
 
-    if (!name) {
-      rowErrors.push('Name 不能为空');
-    } else if (!TOPIC_NAME_PATTERN.test(name)) {
-      rowErrors.push('Name 仅支持字母、数字、下划线、中划线、斜杠和星号');
+    const nameError = validateResourceName(name, 'topic');
+    if (nameError) {
+      rowErrors.push(nameError);
     }
     if (!TOPIC_TYPES.has(type)) {
       rowErrors.push(`Type 不支持：${type}`);
@@ -319,10 +338,9 @@ export const validateConsumerGroupCsvImport = (
     const duplicateMessage = duplicateMessages.get(record.lineNumber);
     if (duplicateMessage) rowErrors.push(duplicateMessage);
 
-    if (!name) {
-      rowErrors.push('Name 不能为空');
-    } else if (!GROUP_NAME_PATTERN.test(name)) {
-      rowErrors.push('Name 需以字母开头，仅包含字母、数字、下划线和短横线');
+    const nameError = validateResourceName(name, 'group');
+    if (nameError) {
+      rowErrors.push(nameError);
     }
     if (!GROUP_SUBSCRIPTION_MODES.has(subscriptionMode)) {
       rowErrors.push(`Subscription Mode 不支持：${subscriptionMode}`);


### PR DESCRIPTION
## What is the purpose of the change

The CSV importer's name rules diverged from RocketMQ's own validators: topic names accepted `/` and `*` but rejected the `%` and `|` characters RocketMQ supports, consumer group names had to start with a letter, and neither kind had a length limit. The same name could be rejected by the import but accepted by the broker, or vice versa.

## Brief changelog

- new shared `validateResourceName` used by both the topic and group CSV imports: the RocketMQ character set `[%|a-zA-Z0-9_-]`, with the Topic cap of 127 and the group cap of 120
- consumer group names may now start with a digit or symbol, matching RocketMQ
- the inline Topic/Group create forms and the stale `topic.topicNameRule` translation now reference the same pattern and caps, so the UI and the importer agree
- tests cover `%`, `|`, digit-leading groups, rejected `/` and `*`, and the 127/128 and 120/121 length boundaries

## How was this patch verified

- web: `resourceCsvImport.test.ts` 12/12; Topic/Consumer page tests green; full `vitest run` 642/642; `tsc -b` and `eslint` clean

Fixes #2493
