### PR TITLE
fix(cluster): bound timed-out NameServer registry probes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -35,6 +35,7 @@ import org.apache.rocketmq.studio.common.domain.enums.FlushDiskType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.ops.audit.AuditService;
 import org.apache.rocketmq.studio.provider.apache.RocketMQBrokerConfigService;
+import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -42,10 +43,6 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -53,18 +50,28 @@ import java.util.concurrent.TimeUnit;
 public class ClusterService {
 
     private static final long REGISTRY_PROBE_TIMEOUT_SECONDS = 15;
-
-    private static final ExecutorService REGISTRY_PROBE_EXECUTOR = Executors.newCachedThreadPool(runnable -> {
-        Thread thread = new Thread(runnable, "nameserver-registry-probe");
-        thread.setDaemon(true);
-        return thread;
-    });
+    private static final int REGISTRY_PROBE_MAX_CONCURRENCY = 8;
+    private static final int REGISTRY_PROBE_QUEUE_CAPACITY = 32;
 
     private final ClusterRepository clusterRepository;
     private final ClusterProvider clusterProvider;
     private final RocketMQBrokerConfigService brokerConfigService;
     private final AuditService auditService;
     private final NameserverRegistryService registryService;
+
+    // Bounded so blocked probes cannot accumulate threads; replaceable in unit tests.
+    private RegistryProbeRunner registryProbeRunner = new RegistryProbeRunner(
+            REGISTRY_PROBE_MAX_CONCURRENCY, REGISTRY_PROBE_QUEUE_CAPACITY,
+            REGISTRY_PROBE_TIMEOUT_SECONDS * 1000L);
+
+    void setRegistryProbeRunner(RegistryProbeRunner registryProbeRunner) {
+        this.registryProbeRunner = registryProbeRunner;
+    }
+
+    @PreDestroy
+    void closeRegistryProbeRunner() {
+        registryProbeRunner.close();
+    }
 
     public List<ClusterVO> listClusters() {
         log.info("Listing all clusters");
@@ -82,25 +89,13 @@ public class ClusterService {
      * logged and skipped without affecting the other entries.
      */
     public List<ClusterVO> listRegistryClusters() {
-        List<NameserverRegistryVO> entries = registryService.list();
-        if (entries.isEmpty()) {
+        List<NameserverRegistryVO> probeable = registryService.list().stream()
+                .filter(entry -> entry.getNamesrvAddr() != null && !entry.getNamesrvAddr().isBlank())
+                .toList();
+        if (probeable.isEmpty()) {
             return List.of();
         }
-        List<CompletableFuture<List<ClusterVO>>> futures = entries.stream()
-                .filter(entry -> entry.getNamesrvAddr() != null && !entry.getNamesrvAddr().isBlank())
-                .map(entry -> CompletableFuture
-                        .supplyAsync(() -> probeRegistryEntry(entry), REGISTRY_PROBE_EXECUTOR)
-                        .orTimeout(REGISTRY_PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                        .exceptionally(ex -> {
-                            log.warn("NameServer registry probe timed out or failed for {} ({}): {}",
-                                    entry.getName(), entry.getNamesrvAddr(), ex.getMessage());
-                            return List.of();
-                        }))
-                .toList();
-        return futures.stream()
-                .map(CompletableFuture::join)
-                .flatMap(List::stream)
-                .toList();
+        return registryProbeRunner.probeAll(probeable, this::probeRegistryEntry);
     }
 
     private List<ClusterVO> probeRegistryEntry(NameserverRegistryVO entry) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RegistryProbeRunner.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RegistryProbeRunner.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.cluster.nameserver.NameserverRegistryVO;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Bounded, closeable executor that runs NameServer registry probes concurrently.
+ *
+ * <p>Replaces an unbounded cached thread pool so that probes blocked on an unreachable
+ * NameServer cannot accumulate threads without limit. Each probe is cancelled (its worker
+ * interrupted) when the deadline is reached so the pool thread is released, and a saturated
+ * queue degrades the offending entry to unavailable instead of growing the pool.</p>
+ */
+@Slf4j
+class RegistryProbeRunner implements AutoCloseable {
+
+    private static final long KEEP_ALIVE_SECONDS = 60L;
+
+    private final ThreadPoolExecutor executor;
+    private final long timeoutMillis;
+    private final int maxConcurrency;
+
+    RegistryProbeRunner(int maxConcurrency, int queueCapacity, long timeoutMillis) {
+        this.maxConcurrency = maxConcurrency;
+        this.timeoutMillis = timeoutMillis;
+        this.executor = new ThreadPoolExecutor(
+                maxConcurrency,
+                maxConcurrency,
+                KEEP_ALIVE_SECONDS,
+                TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(queueCapacity),
+                runnable -> {
+                    Thread thread = new Thread(runnable, "nameserver-registry-probe");
+                    thread.setDaemon(true);
+                    return thread;
+                },
+                new ThreadPoolExecutor.AbortPolicy());
+        // Let idle workers (including core) time out so a quiet registry holds no threads.
+        this.executor.allowCoreThreadTimeOut(true);
+    }
+
+    /** Probes a single registry entry; may block on the underlying admin client. */
+    interface ProbeFunction {
+        List<ClusterVO> probe(NameserverRegistryVO entry) throws Exception;
+    }
+
+    /**
+     * Probes every entry concurrently, bounded by the pool. A rejected (saturated), timed-out
+     * or failing entry contributes an empty result without affecting the others.
+     */
+    List<ClusterVO> probeAll(List<NameserverRegistryVO> entries, ProbeFunction function) {
+        return entries.stream()
+                .map(entry -> probeOne(entry, function))
+                .map(CompletableFuture::join)
+                .flatMap(List::stream)
+                .toList();
+    }
+
+    private CompletableFuture<List<ClusterVO>> probeOne(NameserverRegistryVO entry, ProbeFunction function) {
+        CompletableFuture<List<ClusterVO>> result = new CompletableFuture<>();
+        Future<?> task;
+        try {
+            task = executor.submit(() -> {
+                try {
+                    result.complete(function.probe(entry));
+                } catch (Exception exception) {
+                    result.completeExceptionally(exception);
+                }
+            });
+        } catch (RejectedExecutionException rejected) {
+            // Queue saturated: degrade this entry to unavailable instead of growing the pool.
+            log.warn("NameServer registry probe rejected for {} ({}): executor saturated",
+                    entry.getName(), entry.getNamesrvAddr());
+            return CompletableFuture.completedFuture(List.of());
+        }
+        return result
+                .orTimeout(timeoutMillis, TimeUnit.MILLISECONDS)
+                .whenComplete((value, error) -> {
+                    if (error instanceof TimeoutException) {
+                        // Interrupt the worker so the blocked probe releases its pool thread.
+                        task.cancel(true);
+                    }
+                })
+                .exceptionally(error -> {
+                    log.warn("NameServer registry probe failed for {} ({}): {}",
+                            entry.getName(), entry.getNamesrvAddr(), rootMessage(error));
+                    return List.of();
+                });
+    }
+
+    int activeCount() {
+        return executor.getActiveCount();
+    }
+
+    int poolSize() {
+        return executor.getPoolSize();
+    }
+
+    int queuedTaskCount() {
+        return executor.getQueue().size();
+    }
+
+    @Override
+    public void close() {
+        executor.shutdownNow();
+    }
+
+    private static String rootMessage(Throwable error) {
+        Throwable current = error;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        String message = current.getMessage();
+        return message == null || message.isBlank()
+                ? current.getClass().getSimpleName()
+                : message;
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceRegistryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceRegistryTest.java
@@ -28,8 +28,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -93,5 +97,73 @@ class ClusterServiceRegistryTest {
                 NameserverRegistryVO.builder().id(1L).name("no-addr").namesrvAddr(" ").build()));
 
         assertThat(clusterService.listRegistryClusters()).isEmpty();
+    }
+
+    @Test
+    void listRegistryClustersShouldBoundProbeThreadsWhenProbesBlockTest() throws Exception {
+        int maxConcurrency = 4;
+        when(registryService.list()).thenReturn(List.of(
+                NameserverRegistryVO.builder().id(1L).name("ns-1").namesrvAddr("ns-1:9876").build(),
+                NameserverRegistryVO.builder().id(2L).name("ns-2").namesrvAddr("ns-2:9876").build(),
+                NameserverRegistryVO.builder().id(3L).name("ns-3").namesrvAddr("ns-3:9876").build(),
+                NameserverRegistryVO.builder().id(4L).name("ns-4").namesrvAddr("ns-4:9876").build()));
+
+        CountDownLatch block = new CountDownLatch(1);
+        AtomicInteger probes = new AtomicInteger();
+        when(clusterProvider.discoverClustersAt(anyString())).thenAnswer(invocation -> {
+            probes.incrementAndGet();
+            try {
+                block.await();
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+            }
+            return List.of();
+        });
+
+        try (RegistryProbeRunner runner = new RegistryProbeRunner(maxConcurrency, 8, 150)) {
+            clusterService.setRegistryProbeRunner(runner);
+
+            // Two refresh rounds with every probe blocked: a cached thread pool would
+            // accumulate a fresh blocked thread per entry per round.
+            assertThat(clusterService.listRegistryClusters()).isEmpty();
+            assertThat(clusterService.listRegistryClusters()).isEmpty();
+
+            // The pool never grows past its bound and both rounds actually ran every probe.
+            assertThat(runner.poolSize()).isLessThanOrEqualTo(maxConcurrency);
+            assertThat(runner.activeCount()).isLessThanOrEqualTo(maxConcurrency);
+            assertThat(probes).hasValue(8);
+        } finally {
+            block.countDown();
+        }
+    }
+
+    @Test
+    void listRegistryClustersShouldDegradeSaturatedProbeQueueWithoutThrowingTest() throws Exception {
+        // One worker plus a one-slot queue: the third concurrent probe must be rejected
+        // and degraded to unavailable rather than growing the pool or failing the request.
+        when(registryService.list()).thenReturn(List.of(
+                NameserverRegistryVO.builder().id(1L).name("ns-1").namesrvAddr("ns-1:9876").build(),
+                NameserverRegistryVO.builder().id(2L).name("ns-2").namesrvAddr("ns-2:9876").build(),
+                NameserverRegistryVO.builder().id(3L).name("ns-3").namesrvAddr("ns-3:9876").build()));
+
+        CountDownLatch block = new CountDownLatch(1);
+        when(clusterProvider.discoverClustersAt(anyString())).thenAnswer(invocation -> {
+            try {
+                block.await();
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+            }
+            return List.of();
+        });
+
+        try (RegistryProbeRunner runner = new RegistryProbeRunner(1, 1, 150)) {
+            clusterService.setRegistryProbeRunner(runner);
+
+            assertThatCode(() -> assertThat(clusterService.listRegistryClusters()).isEmpty())
+                    .doesNotThrowAnyException();
+            assertThat(runner.poolSize()).isLessThanOrEqualTo(1);
+        } finally {
+            block.countDown();
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

`listRegistryClusters` fanned its NameServer probes out onto an unbounded cached thread pool. `CompletableFuture.orTimeout` only completed the wrapper future, so a probe blocked on an unreachable NameServer kept its worker thread, and every refresh of the cluster list accumulated more blocked threads.

## Brief changelog

- new bounded, closeable `RegistryProbeRunner`: a fixed-size worker pool with a bounded queue replaces the unbounded cached thread pool
- when a probe exceeds its deadline the worker is explicitly cancelled (interrupted) so the pool thread is released, instead of leaking behind the timed-out future
- a saturated queue degrades the offending registry entry to unavailable (logged) rather than throwing or growing the pool
- the runner is shut down on Spring context close; idle workers (including core) time out so a quiet registry holds no threads
- the admin clients the probes drive already carry a 5s RPC timeout (`MqAdminExtFactory`), so released workers don't pile up behind hung calls

## How was this patch verified

- server: `ClusterServiceRegistryTest` 5/5, including two new tests that block every probe and assert the pool never grows past its bound across repeated refreshes, and that a saturated queue degrades without throwing; full `mvn test` ran 1500 tests with only the 7 pre-existing environment failures in the CLI agent tests (missing `sh` binary on a Windows machine, identical on the clean base)

Fixes #2472
