### PR TITLE
fix(instance): do not recreate instances deleted during update

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
@@ -114,7 +114,11 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
     @Transactional
     public InstanceVO save(InstanceVO instance) {
         RmqInstance entity = toEntity(instance);
-        if (entity.getId() != null && instanceMapper.selectById(entity.getId()) != null) {
+        if (entity.getId() != null) {
+            // A non-null id identifies an existing instance, so the update path must only
+            // update. If the row vanished (concurrent delete), a zero-row update is a
+            // conflict; re-inserting here would resurrect the deleted instance under its
+            // old id.
             if (instanceMapper.updateById(entity) == 0) {
                 throw new BusinessException(409,
                         "Instance update was not applied: " + entity.getId());

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
@@ -185,9 +185,8 @@ class MybatisPlusInstanceRepositoryTest {
     }
 
     @Test
-    void saveShouldInsertWhenInstanceAbsent() {
-        InstanceVO vo = vo(5L, "instance-proxy-2", InstanceType.PROXY_CLUSTER);
-        when(instanceMapper.selectById(5L)).thenReturn(null);
+    void saveShouldInsertWhenInstanceIdIsAbsent() {
+        InstanceVO vo = vo(null, "instance-proxy-2", InstanceType.PROXY_CLUSTER);
 
         repository.save(vo);
 
@@ -200,7 +199,6 @@ class MybatisPlusInstanceRepositoryTest {
     @Test
     void saveShouldUpdateWhenInstanceExists() {
         InstanceVO vo = vo(5L, "instance-proxy-2", InstanceType.PROXY_CLUSTER);
-        when(instanceMapper.selectById(5L)).thenReturn(entity(5L, "instance-proxy-2", InstanceType.PROXY_CLUSTER));
         when(instanceMapper.updateById(any(RmqInstance.class))).thenReturn(1);
 
         repository.save(vo);
@@ -210,16 +208,17 @@ class MybatisPlusInstanceRepositoryTest {
     }
 
     @Test
-    void saveShouldReportALostConcurrentUpdate() {
+    void saveShouldNotResurrectAnInstanceDeletedDuringUpdate() {
+        // The service read the instance (id 5) and another request deleted it before this
+        // write: the update touches zero rows and must fail instead of re-inserting id 5.
         InstanceVO vo = vo(5L, "instance-proxy-2", InstanceType.PROXY_CLUSTER);
-        when(instanceMapper.selectById(5L))
-                .thenReturn(entity(5L, "instance-proxy-2", InstanceType.PROXY_CLUSTER));
         when(instanceMapper.updateById(any(RmqInstance.class))).thenReturn(0);
 
         assertThatThrownBy(() -> repository.save(vo))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Instance update was not applied: 5")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(409));
+        verify(instanceMapper, never()).insert(any(RmqInstance.class));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

`save()` re-queried the row and fell back to an insert whenever the lookup came up empty. An instance that another request deleted between the service read and this write was resurrected under its old id, and the caller recorded a success audit for an instance that was "deleted".

## Brief changelog

- a non-null id now always takes the update path in `MybatisPlusInstanceRepository.save`; a zero-row update (the row vanished) is reported as a 409 instead of an insert
- a null id still inserts, so creation is unchanged
- tests updated: the absent-row case now asserts the 409 and that no insert happens, and the plain-insert test uses a null id

## How was this patch verified

- server: `MybatisPlusInstanceRepositoryTest` 16/16 and `InstanceServiceTest` 68/68 green; full `mvn test` ran 1526 tests with only the 7 pre-existing environment failures in the CLI agent tests (missing `sh` binary on a Windows machine, identical on the clean base)

Fixes #2494
