### PR TITLE
fix(topic): normalize unavailable LiteTopic quotas

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicQuota.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicQuota.java
@@ -38,14 +38,14 @@ public class LiteTopicQuota {
     private Double maxCreationRate;
 
     public double getUsageRate() {
-        if (maxTopicCount == null || maxTopicCount == 0 || currentTopicCount == null) {
+        if (maxTopicCount == null || maxTopicCount <= 0 || currentTopicCount == null) {
             return 0.0;
         }
         return (double) currentTopicCount / maxTopicCount;
     }
 
     public double getSessionUsageRate() {
-        if (maxSessionCount == null || maxSessionCount == 0 || currentSessionCount == null) {
+        if (maxSessionCount == null || maxSessionCount <= 0 || currentSessionCount == null) {
             return 0.0;
         }
         return (double) currentSessionCount / maxSessionCount;
@@ -57,12 +57,12 @@ public class LiteTopicQuota {
 
     public boolean isQuotaExceeded() {
         // Guard against unset fields, mirroring getUsageRate; an unconfigured max is not exceeded.
-        return maxTopicCount != null && currentTopicCount != null
+        return maxTopicCount != null && maxTopicCount > 0 && currentTopicCount != null
                 && currentTopicCount >= maxTopicCount;
     }
 
     public Integer getRemainingQuota() {
-        if (maxTopicCount == null) {
+        if (maxTopicCount == null || maxTopicCount <= 0) {
             return 0;
         }
         return Math.max(0, maxTopicCount - (currentTopicCount == null ? 0 : currentTopicCount));

--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
@@ -25,12 +25,34 @@ class LiteTopicQuotaTest {
     }
 
     @Test
-    void quotaShouldBeExceededWhenCurrentReachesMax() {
+    void nonPositiveLimitsShouldRemainUnavailableInsteadOfExceeded() {
+        LiteTopicQuota quota = new LiteTopicQuota();
+        quota.setMaxTopicCount(0);
+        quota.setCurrentTopicCount(1);
+        quota.setMaxSessionCount(-1);
+        quota.setCurrentSessionCount(1);
+
+        assertThat(quota.getUsageRate()).isZero();
+        assertThat(quota.getSessionUsageRate()).isZero();
+        assertThat(quota.isQuotaExceeded()).isFalse();
+        assertThat(quota.getRemainingQuota()).isZero();
+    }
+
+    @Test
+    void quotaShouldBeExceededOnlyAtOrAbovePositiveMax() {
         LiteTopicQuota quota = new LiteTopicQuota();
         quota.setMaxTopicCount(10);
-        quota.setCurrentTopicCount(10);
 
+        quota.setCurrentTopicCount(9);
+        assertThat(quota.isQuotaExceeded()).isFalse();
+        assertThat(quota.getRemainingQuota()).isEqualTo(1);
+
+        quota.setCurrentTopicCount(10);
         assertThat(quota.isQuotaExceeded()).isTrue();
+
+        quota.setCurrentTopicCount(11);
+        assertThat(quota.isQuotaExceeded()).isTrue();
+        assertThat(quota.getRemainingQuota()).isZero();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- treat null, zero, and negative LiteTopic maxima as unavailable
- keep usage, remaining-quota, and exceeded calculations consistent
- cover unavailable, below-limit, at-limit, and over-limit states

## Why

The rate helpers already treat a zero maximum as unavailable, but `isQuotaExceeded()` reported every non-negative count as exceeded when the maximum was zero. The model therefore exposed contradictory computed quota state.

## Validation

- `mvn -q -Dtest=LiteTopicQuotaTest test`
- `mvn -q -DskipTests package`
- `git diff --check`

Fixes #2535