### PR TITLE
feat: paginate instance management

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.studio.instance;
 
 import org.apache.rocketmq.studio.common.domain.DeleteRequestDTO;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import jakarta.validation.Valid;
@@ -45,6 +46,15 @@ public class InstanceController {
             @RequestParam(required = false) InstanceType type,
             @RequestParam(required = false) String search) {
         return Result.ok(instanceService.listInstances(type, search));
+    }
+
+    @GetMapping("/page")
+    public Result<PageResult<InstanceVO>> listInstancesPage(
+            @RequestParam(required = false) InstanceType type,
+            @RequestParam(required = false) String search,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return Result.ok(instanceService.listInstances(type, search, page, pageSize));
     }
 
     @GetMapping("/{instanceId}/capabilities")

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceRepository.java
@@ -19,6 +19,8 @@ package org.apache.rocketmq.studio.instance;
 
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 
+import org.apache.rocketmq.studio.common.domain.PageResult;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -34,6 +36,8 @@ public interface InstanceRepository {
     List<InstanceVO> findByTypeAndSearch(InstanceType type, String keyword);
 
     long count(InstanceType type, String keyword);
+
+    PageResult<InstanceVO> findPage(InstanceType type, String keyword, int page, int pageSize);
 
     Optional<InstanceVO> findById(Long id);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceRepository.java
@@ -25,11 +25,15 @@ import java.util.Optional;
 public interface InstanceRepository {
     List<InstanceVO> findAll();
 
+    long countAll();
+
     List<InstanceVO> findByType(InstanceType type);
 
     List<InstanceVO> search(String keyword);
 
     List<InstanceVO> findByTypeAndSearch(InstanceType type, String keyword);
+
+    long count(InstanceType type, String keyword);
 
     Optional<InstanceVO> findById(Long id);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -113,14 +113,12 @@ public class InstanceService {
                                                 int pageSize) {
         validateListPagination(page, pageSize);
         String normalizedSearch = search == null || search.isBlank() ? null : search.trim();
-        long total = instanceRepository.count(type, normalizedSearch);
-        if (total == 0) {
-            return PageResult.empty(page, pageSize);
-        }
-        List<InstanceVO> sorted = listInstances(type, normalizedSearch);
-        int fromIndex = (int) Math.min((long) (page - 1) * pageSize, sorted.size());
-        int toIndex = Math.min(fromIndex + pageSize, sorted.size());
-        return PageResult.of(new ArrayList<>(sorted.subList(fromIndex, toIndex)), total, page, pageSize);
+        PageResult<InstanceVO> result = instanceRepository.findPage(
+                type, normalizedSearch, page, pageSize);
+        fillCountsInParallel(result.getItems());
+        result.getItems().forEach(instance ->
+                instance.setRegionName(regionNames.resolve(instance.getRegionId())));
+        return result;
     }
 
     private static void validateListPagination(int page, int pageSize) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.studio.provider.credential.CloudCredentialRepository;
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialVO;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -69,6 +70,7 @@ public class InstanceService {
 
     static final int COUNT_PARALLELISM = 8;
     static final long COUNT_TIMEOUT_SECONDS = 3;
+    private static final int MAX_INSTANCE_PAGE_SIZE = 100;
 
     private final ExecutorService countExecutor = Executors.newFixedThreadPool(COUNT_PARALLELISM, runnable -> {
         Thread thread = new Thread(runnable, "instance-resource-counts");
@@ -105,6 +107,30 @@ public class InstanceService {
                 .thenComparing(instance -> instance.getRegionId() == null ? "" : instance.getRegionId())
                 .thenComparing(InstanceVO::getName, String.CASE_INSENSITIVE_ORDER));
         return sorted;
+    }
+
+    public PageResult<InstanceVO> listInstances(InstanceType type, String search, int page,
+                                                int pageSize) {
+        validateListPagination(page, pageSize);
+        String normalizedSearch = search == null || search.isBlank() ? null : search.trim();
+        long total = instanceRepository.count(type, normalizedSearch);
+        if (total == 0) {
+            return PageResult.empty(page, pageSize);
+        }
+        List<InstanceVO> sorted = listInstances(type, normalizedSearch);
+        int fromIndex = (int) Math.min((long) (page - 1) * pageSize, sorted.size());
+        int toIndex = Math.min(fromIndex + pageSize, sorted.size());
+        return PageResult.of(new ArrayList<>(sorted.subList(fromIndex, toIndex)), total, page, pageSize);
+    }
+
+    private static void validateListPagination(int page, int pageSize) {
+        if (page < 1) {
+            throw new BusinessException(400, "page must be greater than zero");
+        }
+        if (pageSize < 1 || pageSize > MAX_INSTANCE_PAGE_SIZE) {
+            throw new BusinessException(400,
+                    "pageSize must be between 1 and " + MAX_INSTANCE_PAGE_SIZE);
+        }
     }
 
     /**

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
@@ -51,6 +51,11 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
     }
 
     @Override
+    public long countAll() {
+        return instanceMapper.selectCount(null);
+    }
+
+    @Override
     public List<InstanceVO> findByType(InstanceType type) {
         return instanceMapper.selectList(
                 new QueryWrapper<RmqInstance>()
@@ -83,6 +88,15 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
                         .orderByAsc("id")).stream()
                 .map(this::toVO)
                 .toList();
+    }
+
+    @Override
+    public long count(InstanceType type, String keyword) {
+        return instanceMapper.selectCount(new QueryWrapper<RmqInstance>()
+                .eq(type != null, "type", type == null ? null : type.name())
+                .and(keyword != null, w -> w.like("name", keyword)
+                        .or().like("endpoint", keyword)
+                        .or().like("remark", keyword)));
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepository.java
@@ -18,6 +18,8 @@
 package org.apache.rocketmq.studio.instance;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -97,6 +99,23 @@ public class MybatisPlusInstanceRepository implements InstanceRepository {
                 .and(keyword != null, w -> w.like("name", keyword)
                         .or().like("endpoint", keyword)
                         .or().like("remark", keyword)));
+    }
+
+    @Override
+    public PageResult<InstanceVO> findPage(InstanceType type, String keyword, int page,
+                                            int pageSize) {
+        Page<RmqInstance> result = instanceMapper.selectPage(
+                new Page<>(page, pageSize),
+                new QueryWrapper<RmqInstance>()
+                        .eq(type != null, "type", type == null ? null : type.name())
+                        .and(keyword != null, w -> w.like("name", keyword)
+                                .or().like("endpoint", keyword)
+                                .or().like("remark", keyword))
+                        .orderByAsc("id"));
+        List<InstanceVO> items = result.getRecords().stream()
+                .map(this::toVO)
+                .toList();
+        return PageResult.of(items, result.getTotal(), page, pageSize);
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
@@ -20,6 +20,7 @@ package org.apache.rocketmq.studio.instance;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.InstanceCapability;
 import org.junit.jupiter.api.Test;
@@ -77,6 +78,25 @@ class InstanceControllerTest {
                 .andExpect(jsonPath("$.data[0].name").value("production-proxy"))
                 .andExpect(jsonPath("$.data[0].type").value("PROXY_CLUSTER"))
                 .andExpect(jsonPath("$.data[0].endpoint").value("10.0.1.1:8080"));
+    }
+
+    @Test
+    void listInstancesPageShouldReturnBoundedPage() throws Exception {
+        InstanceVO inst = buildInstance(1L, "production-proxy", InstanceType.PROXY_CLUSTER,
+                "10.0.1.1:8080");
+        when(instanceService.listInstances(isNull(), isNull(), eq(2), eq(20)))
+                .thenReturn(PageResult.of(List.of(inst), 21, 2, 20));
+
+        mockMvc.perform(get("/api/instances/page")
+                        .param("page", "2")
+                        .param("pageSize", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[0].name").value("production-proxy"))
+                .andExpect(jsonPath("$.data.total").value(21))
+                .andExpect(jsonPath("$.data.page").value(2))
+                .andExpect(jsonPath("$.data.size").value(20));
+
+        verify(instanceService).listInstances(isNull(), isNull(), eq(2), eq(20));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -119,10 +119,8 @@ class InstanceServiceTest {
                 .regionId("cn-shanghai")
                 .build();
         second.setId(2L);
-        when(instanceRepository.count(InstanceType.DIRECT, "inst")).thenReturn(2L);
-        when(instanceRepository.findByTypeAndSearch(InstanceType.DIRECT, "inst"))
-                .thenReturn(List.of(second, first));
-        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceRepository.findPage(InstanceType.DIRECT, "inst", 2, 1))
+                .thenReturn(PageResult.of(List.of(second), 2, 2, 1));
         when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(instanceProvider);
 
         PageResult<InstanceVO> result = instanceService.listInstances(
@@ -132,6 +130,31 @@ class InstanceServiceTest {
         assertThat(result.getTotal()).isEqualTo(2);
         assertThat(result.getPage()).isEqualTo(2);
         assertThat(result.getSize()).isEqualTo(1);
+        verify(instanceRepository).findPage(InstanceType.DIRECT, "inst", 2, 1);
+        verify(instanceRepository, never()).findByTypeAndSearch(InstanceType.DIRECT, "inst");
+    }
+
+    @Test
+    void listInstancesPageShouldOnlyResolveResourceCountsForCurrentPage() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("cloud-instance")
+                .vendor(InstanceVendor.ALIYUN)
+                .regionId("cn-shanghai")
+                .build();
+        instance.setId(7L);
+        when(instanceRepository.findPage(null, null, 1, 20))
+                .thenReturn(PageResult.of(List.of(instance), 21, 1, 20));
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(instanceProvider);
+        when(regionNames.resolve("cn-shanghai")).thenReturn("Shanghai (CN)");
+
+        PageResult<InstanceVO> result = instanceService.listInstances(null, null, 1, 20);
+
+        assertThat(result.getItems()).hasSize(1);
+        assertThat(result.getTotal()).isEqualTo(21);
+        assertThat(result.getItems().get(0).getRegionName()).isEqualTo("Shanghai (CN)");
+        verify(instanceRepository).findPage(null, null, 1, 20);
+        verify(instanceRepository, never()).findAll();
+        verify(providerRegistry, never()).forVendor(InstanceVendor.APACHE);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -21,6 +21,7 @@ import org.apache.rocketmq.studio.provider.credential.CloudCredentialRepository;
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialVO;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -46,6 +47,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -101,6 +103,47 @@ class InstanceServiceTest {
 
         assertThat(result).hasSize(2);
         verify(instanceRepository).findAll();
+    }
+
+    @Test
+    void listInstancesPageShouldReturnTheRequestedSlice() {
+        InstanceVO first = InstanceVO.builder()
+                .name("apache-instance")
+                .vendor(InstanceVendor.APACHE)
+                .regionId("cn-hangzhou")
+                .build();
+        first.setId(1L);
+        InstanceVO second = InstanceVO.builder()
+                .name("cloud-instance")
+                .vendor(InstanceVendor.ALIYUN)
+                .regionId("cn-shanghai")
+                .build();
+        second.setId(2L);
+        when(instanceRepository.count(InstanceType.DIRECT, "inst")).thenReturn(2L);
+        when(instanceRepository.findByTypeAndSearch(InstanceType.DIRECT, "inst"))
+                .thenReturn(List.of(second, first));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(instanceProvider);
+
+        PageResult<InstanceVO> result = instanceService.listInstances(
+                InstanceType.DIRECT, " inst ", 2, 1);
+
+        assertThat(result.getItems()).containsExactly(second);
+        assertThat(result.getTotal()).isEqualTo(2);
+        assertThat(result.getPage()).isEqualTo(2);
+        assertThat(result.getSize()).isEqualTo(1);
+    }
+
+    @Test
+    void listInstancesPageShouldRejectInvalidPaginationBeforeRepositoryAccess() {
+        assertThatThrownBy(() -> instanceService.listInstances(null, null, 0, 20))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("page must be greater than zero");
+        assertThatThrownBy(() -> instanceService.listInstances(null, null, 1, 101))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("pageSize must be between 1 and 100");
+
+        verifyNoInteractions(instanceRepository, providerRegistry, regionNames);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/MybatisPlusInstanceRepositoryTest.java
@@ -18,6 +18,8 @@
 package org.apache.rocketmq.studio.instance;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -94,6 +96,32 @@ class MybatisPlusInstanceRepositoryTest {
         assertThat(query.getValue().getSqlSegment()).contains("type =");
         assertThat(query.getValue().getParamNameValuePairs().values())
                 .containsExactly(InstanceType.CLOUD.name());
+    }
+
+    @Test
+    void findPageShouldApplyDatabasePaginationAndFilters() {
+        Page<RmqInstance> databasePage = new Page<>(2, 1, 21);
+        databasePage.setRecords(List.of(entity(2L, "instance-proxy-1", InstanceType.PROXY_CLUSTER)));
+        when(instanceMapper.selectPage(any(Page.class), any(QueryWrapper.class)))
+                .thenReturn(databasePage);
+
+        PageResult<InstanceVO> result = repository.findPage(
+                InstanceType.PROXY_CLUSTER, "proxy", 2, 1);
+
+        assertThat(result.getItems()).hasSize(1);
+        assertThat(result.getItems().get(0).getName()).isEqualTo("instance-proxy-1");
+        assertThat(result.getTotal()).isEqualTo(21);
+        assertThat(result.getPage()).isEqualTo(2);
+        assertThat(result.getSize()).isEqualTo(1);
+
+        ArgumentCaptor<QueryWrapper<RmqInstance>> query =
+                ArgumentCaptor.forClass(QueryWrapper.class);
+        verify(instanceMapper).selectPage(any(Page.class), query.capture());
+        assertThat(query.getValue().getSqlSegment())
+                .contains("type =", "name LIKE", "endpoint LIKE", "remark LIKE", "ORDER BY id ASC");
+        assertThat(query.getValue().getParamNameValuePairs().values())
+                .contains(InstanceType.PROXY_CLUSTER.name(), "%proxy%");
+        verify(instanceMapper, never()).selectList(any(QueryWrapper.class));
     }
 
     @Test

--- a/web/src/api/instance.ts
+++ b/web/src/api/instance.ts
@@ -73,6 +73,13 @@ export interface InstanceQuery {
   search?: string;
 }
 
+export interface InstancePage {
+  items: Instance[];
+  total: number;
+  page: number;
+  size: number;
+}
+
 /** Whether an instance can use Apache MQAdmin-backed runtime diagnostics. */
 export function supportsApacheRuntime(instance: Pick<Instance, 'vendor'>): boolean {
   return instance.vendor === undefined || instance.vendor === 'APACHE';
@@ -93,6 +100,20 @@ export async function listInstances(query: InstanceQuery = {}) {
     ...(search ? { search } : {}),
   };
   const res = await client.get<{ data: Instance[] }>('/instances', { params });
+  return res.data.data;
+}
+
+export async function listInstancesPage(
+  query: InstanceQuery & { page?: number; pageSize?: number } = {},
+) {
+  const search = query.search?.trim();
+  const params = {
+    ...(query.type ? { type: query.type } : {}),
+    ...(search ? { search } : {}),
+    page: query.page ?? 1,
+    pageSize: query.pageSize ?? 20,
+  };
+  const res = await client.get<{ data: InstancePage }>('/instances/page', { params });
   return res.data.data;
 }
 

--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -23,7 +23,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as aliyunCatalogApi from '../../../api/aliyunCatalog';
 import * as cloudCredentialApi from '../../../api/cloudCredential';
 import type { CloudCredential, CloudCredentialPage } from '../../../api/cloudCredential';
-import type { Instance } from '../../../api/instance';
+import type { Instance, InstancePage as InstancePageData } from '../../../api/instance';
 import { LangProvider } from '../../../i18n/LangContext';
 import * as instanceService from '../../../services/instanceService';
 import InstancePage from '../index';
@@ -48,10 +48,18 @@ vi.mock('../../../services/instanceService', () => ({
   deleteInstancesBatch: vi.fn(),
   importCloudInstances: vi.fn(),
   listInstances: vi.fn(),
+  listInstancesPage: vi.fn(),
   updateInstance: vi.fn(),
 }));
 
 const cloudCredentialPage = (items: CloudCredential[]): CloudCredentialPage => ({
+  items,
+  total: items.length,
+  page: 1,
+  size: 20,
+});
+
+const instancePage = (items: Instance[]): InstancePageData => ({
   items,
   total: items.length,
   page: 1,
@@ -118,10 +126,9 @@ describe('InstancePage', () => {
     vi.mocked(cloudCredentialApi.listCloudCredentials).mockResolvedValue(cloudCredentialPage([]));
     vi.mocked(aliyunCatalogApi.listAliyunRegions).mockResolvedValue([]);
     vi.mocked(aliyunCatalogApi.listAliyunInstances).mockResolvedValue([]);
-    vi.mocked(instanceService.listInstances).mockResolvedValue([
-      instance(1, 'production-proxy'),
-      instance(2, 'development-direct', 'DIRECT'),
-    ]);
+    vi.mocked(instanceService.listInstancesPage).mockResolvedValue(
+      instancePage([instance(1, 'production-proxy'), instance(2, 'development-direct', 'DIRECT')]),
+    );
   });
 
   it('loads server-filtered results when the search or type changes', async () => {
@@ -129,44 +136,62 @@ describe('InstancePage', () => {
     renderPage();
 
     expect(await screen.findByText('production-proxy')).toBeInTheDocument();
-    expect(instanceService.listInstances).toHaveBeenCalledWith({});
+    expect(instanceService.listInstancesPage).toHaveBeenCalledWith({ page: 1, pageSize: 20 });
 
     fireEvent.change(screen.getByPlaceholderText('搜索实例 ID 或地址'), {
       target: { value: 'proxy-hz' },
     });
     await waitFor(
-      () => expect(instanceService.listInstances).toHaveBeenCalledWith({ search: 'proxy-hz' }),
+      () =>
+        expect(instanceService.listInstancesPage).toHaveBeenCalledWith({
+          search: 'proxy-hz',
+          page: 1,
+          pageSize: 20,
+        }),
       { timeout: 1000 },
     );
 
     fireEvent.change(screen.getByPlaceholderText('搜索实例 ID 或地址'), {
       target: { value: '' },
     });
-    await waitFor(() => expect(instanceService.listInstances).toHaveBeenLastCalledWith({}), {
-      timeout: 1000,
-    });
+    await waitFor(
+      () =>
+        expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({
+          page: 1,
+          pageSize: 20,
+        }),
+      {
+        timeout: 1000,
+      },
+    );
 
-    const typeSelect = screen.getByRole('combobox');
+    const typeSelect = screen.getAllByRole('combobox')[0];
     fireEvent.mouseDown(typeSelect.parentElement!);
     await user.click(
       await screen.findByText('Direct 模式', { selector: '.ant-select-item-option-content' }),
     );
 
     await waitFor(() =>
-      expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' }),
+      expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({
+        type: 'DIRECT',
+        page: 1,
+        pageSize: 20,
+      }),
     );
   });
 
   it('keeps unavailable resource counts after available values in both sort directions', async () => {
-    vi.mocked(instanceService.listInstances).mockResolvedValue([
-      {
-        ...instance(3, 'unavailable-instance'),
-        topicCount: 0,
-        resourceCountsAvailable: false,
-      },
-      { ...instance(4, 'zero-instance'), topicCount: 0 },
-      { ...instance(5, 'many-instance'), topicCount: 10 },
-    ]);
+    vi.mocked(instanceService.listInstancesPage).mockResolvedValue(
+      instancePage([
+        {
+          ...instance(3, 'unavailable-instance'),
+          topicCount: 0,
+          resourceCountsAvailable: false,
+        },
+        { ...instance(4, 'zero-instance'), topicCount: 0 },
+        { ...instance(5, 'many-instance'), topicCount: 10 },
+      ]),
+    );
     const { container } = renderPage();
 
     await screen.findByText('unavailable-instance');
@@ -192,16 +217,16 @@ describe('InstancePage', () => {
   });
 
   it('ignores an older search response that finishes after the latest request', async () => {
-    let resolveOldSearch!: (instances: Instance[]) => void;
-    let resolveLatestSearch!: (instances: Instance[]) => void;
-    const oldSearch = new Promise<Instance[]>((resolve) => {
+    let resolveOldSearch!: (instances: InstancePageData) => void;
+    let resolveLatestSearch!: (instances: InstancePageData) => void;
+    const oldSearch = new Promise<InstancePageData>((resolve) => {
       resolveOldSearch = resolve;
     });
-    const latestSearch = new Promise<Instance[]>((resolve) => {
+    const latestSearch = new Promise<InstancePageData>((resolve) => {
       resolveLatestSearch = resolve;
     });
-    vi.mocked(instanceService.listInstances)
-      .mockResolvedValueOnce([instance(6, 'initial-instance')])
+    vi.mocked(instanceService.listInstancesPage)
+      .mockResolvedValueOnce(instancePage([instance(6, 'initial-instance')]))
       .mockReturnValueOnce(oldSearch)
       .mockReturnValueOnce(latestSearch);
     renderPage();
@@ -210,7 +235,12 @@ describe('InstancePage', () => {
     const searchInput = screen.getByPlaceholderText('搜索实例 ID 或地址');
     fireEvent.change(searchInput, { target: { value: 'old' } });
     await waitFor(
-      () => expect(instanceService.listInstances).toHaveBeenCalledWith({ search: 'old' }),
+      () =>
+        expect(instanceService.listInstancesPage).toHaveBeenCalledWith({
+          search: 'old',
+          page: 1,
+          pageSize: 20,
+        }),
       {
         timeout: 1000,
       },
@@ -218,14 +248,19 @@ describe('InstancePage', () => {
 
     fireEvent.change(searchInput, { target: { value: 'latest' } });
     await waitFor(
-      () => expect(instanceService.listInstances).toHaveBeenCalledWith({ search: 'latest' }),
+      () =>
+        expect(instanceService.listInstancesPage).toHaveBeenCalledWith({
+          search: 'latest',
+          page: 1,
+          pageSize: 20,
+        }),
       { timeout: 1000 },
     );
 
-    await act(async () => resolveLatestSearch([instance(7, 'latest-instance')]));
+    await act(async () => resolveLatestSearch(instancePage([instance(7, 'latest-instance')])));
     expect(await screen.findByText('latest-instance')).toBeInTheDocument();
 
-    await act(async () => resolveOldSearch([instance(8, 'old-instance')]));
+    await act(async () => resolveOldSearch(instancePage([instance(8, 'old-instance')])));
     expect(screen.queryByText('old-instance')).not.toBeInTheDocument();
     expect(screen.getByText('latest-instance')).toBeInTheDocument();
   });
@@ -260,13 +295,17 @@ describe('InstancePage', () => {
     renderPage();
 
     expect(await screen.findByText('production-proxy')).toBeInTheDocument();
-    const typeSelect = screen.getByRole('combobox');
+    const typeSelect = screen.getAllByRole('combobox')[0];
     fireEvent.mouseDown(typeSelect.parentElement!);
     await user.click(
       await screen.findByText('Direct 模式', { selector: '.ant-select-item-option-content' }),
     );
     await waitFor(() =>
-      expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' }),
+      expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({
+        type: 'DIRECT',
+        page: 1,
+        pageSize: 20,
+      }),
     );
 
     await user.click(screen.getByRole('button', { name: /添加实例/ }));
@@ -288,7 +327,11 @@ describe('InstancePage', () => {
         endpoint: 'proxy-new:8080',
       }),
     );
-    expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' });
+    expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({
+      type: 'DIRECT',
+      page: 1,
+      pageSize: 20,
+    });
   });
 
   it('creates an Apache instance with an explicit Proxy Local deployment type', async () => {
@@ -371,19 +414,27 @@ describe('InstancePage', () => {
       expect(instanceService.deleteInstance).toHaveBeenCalledWith('production-proxy'),
     );
 
-    const typeSelect = screen.getByRole('combobox');
+    const typeSelect = screen.getAllByRole('combobox')[0];
     fireEvent.mouseDown(typeSelect.parentElement!);
     await user.click(
       await screen.findByText('Direct 模式', { selector: '.ant-select-item-option-content' }),
     );
     await waitFor(() =>
-      expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' }),
+      expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({
+        type: 'DIRECT',
+        page: 1,
+        pageSize: 20,
+      }),
     );
 
     await act(async () => pendingDelete.resolve());
 
-    await waitFor(() => expect(instanceService.listInstances).toHaveBeenCalledTimes(3));
-    expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' });
+    await waitFor(() => expect(instanceService.listInstancesPage).toHaveBeenCalledTimes(3));
+    expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({
+      type: 'DIRECT',
+      page: 1,
+      pageSize: 20,
+    });
     confirmSpy.mockRestore();
   });
 
@@ -742,10 +793,12 @@ describe('InstancePage', () => {
 
   it('sorts and renders instances without remarks', async () => {
     const user = userEvent.setup();
-    vi.mocked(instanceService.listInstances).mockResolvedValue([
-      instance(10, 'instance-without-remark', 'PROXY_CLUSTER', null),
-      instance(11, 'instance-with-remark', 'PROXY_CLUSTER', 'production'),
-    ]);
+    vi.mocked(instanceService.listInstancesPage).mockResolvedValue(
+      instancePage([
+        instance(10, 'instance-without-remark', 'PROXY_CLUSTER', null),
+        instance(11, 'instance-with-remark', 'PROXY_CLUSTER', 'production'),
+      ]),
+    );
     renderPage();
 
     const name = await screen.findByText('instance-without-remark');
@@ -757,14 +810,16 @@ describe('InstancePage', () => {
   });
 
   it('renders the region column with regionId for cloud instances and a dash for open-source ones', async () => {
-    vi.mocked(instanceService.listInstances).mockResolvedValue([
-      {
-        ...instance(12, 'rmq-cloud-1', 'CLOUD', ''),
-        vendor: 'ALIYUN',
-        regionId: 'cn-hangzhou',
-      },
-      instance(13, 'open-source-1', 'DIRECT', ''),
-    ]);
+    vi.mocked(instanceService.listInstancesPage).mockResolvedValue(
+      instancePage([
+        {
+          ...instance(12, 'rmq-cloud-1', 'CLOUD', ''),
+          vendor: 'ALIYUN',
+          regionId: 'cn-hangzhou',
+        },
+        instance(13, 'open-source-1', 'DIRECT', ''),
+      ]),
+    );
     renderPage();
 
     expect(await screen.findByRole('columnheader', { name: '地域' })).toBeInTheDocument();
@@ -777,10 +832,9 @@ describe('InstancePage', () => {
 
   it('deletes selected instances through the toolbar batch delete button', async () => {
     const user = userEvent.setup();
-    vi.mocked(instanceService.listInstances).mockResolvedValue([
-      instance(20, 'batch-a'),
-      instance(21, 'batch-b'),
-    ]);
+    vi.mocked(instanceService.listInstancesPage).mockResolvedValue(
+      instancePage([instance(20, 'batch-a'), instance(21, 'batch-b')]),
+    );
     vi.mocked(instanceService.deleteInstancesBatch).mockResolvedValue({ deleted: 1, failed: [] });
     const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
       void config.onOk?.();
@@ -812,9 +866,11 @@ describe('InstancePage', () => {
 
   it('clears selections hidden by a search result', async () => {
     const user = userEvent.setup();
-    vi.mocked(instanceService.listInstances)
-      .mockResolvedValueOnce([instance(22, 'search-selected'), instance(23, 'search-visible')])
-      .mockResolvedValueOnce([instance(23, 'search-visible')]);
+    vi.mocked(instanceService.listInstancesPage)
+      .mockResolvedValueOnce(
+        instancePage([instance(22, 'search-selected'), instance(23, 'search-visible')]),
+      )
+      .mockResolvedValueOnce(instancePage([instance(23, 'search-visible')]));
     renderPage();
 
     const selectedName = await screen.findByText('search-selected');
@@ -826,7 +882,11 @@ describe('InstancePage', () => {
     await user.type(screen.getByPlaceholderText('搜索实例 ID 或地址'), 'visible');
 
     await waitFor(() =>
-      expect(instanceService.listInstances).toHaveBeenLastCalledWith({ search: 'visible' }),
+      expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({
+        search: 'visible',
+        page: 1,
+        pageSize: 20,
+      }),
     );
     await waitFor(() => expect(screen.queryByText('search-selected')).not.toBeInTheDocument());
     expect(deleteButton).toBeDisabled();
@@ -834,12 +894,11 @@ describe('InstancePage', () => {
 
   it('clears selections hidden by a type-filter result', async () => {
     const user = userEvent.setup();
-    vi.mocked(instanceService.listInstances)
-      .mockResolvedValueOnce([
-        instance(24, 'proxy-selected'),
-        instance(25, 'direct-visible', 'DIRECT'),
-      ])
-      .mockResolvedValueOnce([instance(25, 'direct-visible', 'DIRECT')]);
+    vi.mocked(instanceService.listInstancesPage)
+      .mockResolvedValueOnce(
+        instancePage([instance(24, 'proxy-selected'), instance(25, 'direct-visible', 'DIRECT')]),
+      )
+      .mockResolvedValueOnce(instancePage([instance(25, 'direct-visible', 'DIRECT')]));
     renderPage();
 
     const selectedName = await screen.findByText('proxy-selected');
@@ -847,14 +906,18 @@ describe('InstancePage', () => {
     const deleteButton = screen.getAllByRole('button', { name: /删除/ })[0];
     expect(deleteButton).toBeEnabled();
 
-    const typeSelect = screen.getByRole('combobox');
+    const typeSelect = screen.getAllByRole('combobox')[0];
     fireEvent.mouseDown(typeSelect.parentElement!);
     await user.click(
       await screen.findByText('Direct 模式', { selector: '.ant-select-item-option-content' }),
     );
 
     await waitFor(() =>
-      expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' }),
+      expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({
+        type: 'DIRECT',
+        page: 1,
+        pageSize: 20,
+      }),
     );
     await waitFor(() => expect(screen.queryByText('proxy-selected')).not.toBeInTheDocument());
     expect(deleteButton).toBeDisabled();
@@ -862,9 +925,11 @@ describe('InstancePage', () => {
 
   it('reconciles selections when a mutation refresh removes an instance', async () => {
     const user = userEvent.setup();
-    vi.mocked(instanceService.listInstances)
-      .mockResolvedValueOnce([instance(26, 'refresh-selected'), instance(27, 'refresh-trigger')])
-      .mockResolvedValueOnce([instance(27, 'refresh-trigger')]);
+    vi.mocked(instanceService.listInstancesPage)
+      .mockResolvedValueOnce(
+        instancePage([instance(26, 'refresh-selected'), instance(27, 'refresh-trigger')]),
+      )
+      .mockResolvedValueOnce(instancePage([instance(27, 'refresh-trigger')]));
     vi.mocked(instanceService.deleteInstance).mockResolvedValue();
     const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
       void config.onOk?.();
@@ -880,7 +945,7 @@ describe('InstancePage', () => {
     const triggerName = screen.getByText('refresh-trigger');
     await user.click(within(triggerName.closest('tr')!).getByRole('button', { name: /删除/ }));
 
-    await waitFor(() => expect(instanceService.listInstances).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(instanceService.listInstancesPage).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(screen.queryByText('refresh-selected')).not.toBeInTheDocument());
     expect(deleteButton).toBeDisabled();
     confirmSpy.mockRestore();

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -54,7 +54,7 @@ import {
   deleteInstance,
   deleteInstancesBatch,
   importCloudInstances,
-  listInstances,
+  listInstancesPage,
   updateInstance,
 } from '../../services/instanceService';
 import { DEFAULT_VENDOR, VENDOR_OPTIONS, type InstanceVendor } from './vendorOptions';
@@ -65,6 +65,7 @@ const DEFAULT_CLOUD_REGION_IDS: Partial<Record<InstanceVendor, string>> = {
   ALIYUN: 'cn-hangzhou',
   TENCENT: 'ap-chengdu',
 };
+const PAGE_SIZE_OPTIONS = [20, 50, 100];
 
 /* ─── Helpers ─── */
 const typeLabel: Record<string, { text: string; color: string }> = {
@@ -107,6 +108,9 @@ const InstancePage = () => {
   const { t } = useLang();
   const navigate = useNavigate();
   const [instances, setInstances] = useState<Instance[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -132,7 +136,10 @@ const InstancePage = () => {
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const requestIdRef = useRef(0);
   const mutationInFlightRef = useRef(false);
-  const listQueryRef = useRef<InstanceQuery>({});
+  const listQueryRef = useRef<InstanceQuery & { page: number; pageSize: number }>({
+    page: 1,
+    pageSize: 20,
+  });
 
   useEffect(() => {
     const timer = window.setTimeout(() => setDebouncedSearch(search.trim()), 300);
@@ -145,10 +152,11 @@ const InstancePage = () => {
 
     setLoading(true);
     try {
-      const nextInstances = await listInstances(query);
+      const result = await listInstancesPage(query);
       if (requestId === requestIdRef.current) {
-        setInstances(nextInstances);
-        const availableNames = new Set(nextInstances.map((instance) => instance.name));
+        setInstances(result.items);
+        setTotal(result.total);
+        const availableNames = new Set(result.items.map((instance) => instance.name));
         setSelectedRowKeys((keys) => keys.filter((key) => availableNames.has(String(key))));
       }
     } catch {
@@ -166,6 +174,8 @@ const InstancePage = () => {
     listQueryRef.current = {
       ...(typeFilter === 'ALL' ? {} : { type: typeFilter }),
       ...(debouncedSearch ? { search: debouncedSearch } : {}),
+      page,
+      pageSize,
     };
     const timer = window.setTimeout(() => void loadInstances(), 0);
 
@@ -173,7 +183,7 @@ const InstancePage = () => {
       window.clearTimeout(timer);
       requestIdRef.current += 1;
     };
-  }, [debouncedSearch, loadInstances, typeFilter]);
+  }, [debouncedSearch, loadInstances, page, pageSize, typeFilter]);
 
   const cloudVendor = vendor === 'ALIYUN' || vendor === 'TENCENT';
 
@@ -654,13 +664,19 @@ const InstancePage = () => {
             placeholder="搜索实例 ID 或地址"
             prefix={<MagnifyingGlass size={14} color="#9CA3AF" />}
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(1);
+            }}
             style={{ width: 240 }}
             allowClear
           />
           <Select<InstanceTypeFilter>
             value={typeFilter}
-            onChange={setTypeFilter}
+            onChange={(value) => {
+              setTypeFilter(value);
+              setPage(1);
+            }}
             style={{ width: 140 }}
             options={[
               { value: 'ALL', label: '全部架构' },
@@ -702,7 +718,22 @@ const InstancePage = () => {
             selectedRowKeys,
             onChange: (keys) => setSelectedRowKeys(keys),
           }}
-          pagination={false}
+          pagination={{
+            current: page,
+            pageSize,
+            total,
+            showSizeChanger: true,
+            pageSizeOptions: PAGE_SIZE_OPTIONS.map(String),
+            showTotal: (count) => `共 ${count} 个实例`,
+            onChange: (nextPage, nextPageSize) => {
+              if (nextPageSize !== pageSize) {
+                setPage(1);
+                setPageSize(nextPageSize);
+              } else {
+                setPage(nextPage);
+              }
+            },
+          }}
           size="small"
           tableLayout="fixed"
           scroll={{ x: tableScrollX(columns, { selection: true }) }}

--- a/web/src/services/instanceService.ts
+++ b/web/src/services/instanceService.ts
@@ -4,6 +4,7 @@ import type {
   Instance,
   CreateInstanceRequest,
   InstanceQuery,
+  InstancePage,
   InstanceVendor,
   UpdateInstanceRequest,
   InstanceCapabilities,
@@ -49,6 +50,12 @@ export function listInstances(query: InstanceQuery = {}): Promise<Instance[]> {
   const request = fetchInstances(query).finally(() => inflightListRequests.delete(key));
   inflightListRequests.set(key, request);
   return request.then((items) => items.map(copyInstance));
+}
+
+export function listInstancesPage(
+  query: InstanceQuery & { page?: number; pageSize?: number } = {},
+): Promise<InstancePage> {
+  return instanceApi.listInstancesPage(query);
 }
 
 async function fetchInstances(query: InstanceQuery): Promise<Instance[]> {


### PR DESCRIPTION
## Summary

- add backward-compatible `GET /api/instances/page` with the existing type/search filters and bounded pagination
- return `items`, `total`, `page`, and `size`; default to `page=1`, `pageSize=20`, and cap page size at 100
- reject invalid page/pageSize before repository or provider access
- add a repository count query for the current type/search filter
- preserve the existing unpaginated endpoint for selectors and keep resource-count and display-name behavior unchanged
- update instance management to use server-driven pagination, a server total, 20/50/100 page sizes, and page reset on filter changes
- keep request sequencing and stale-response protection

## Why

The management page previously loaded and rendered every configured instance in one request. Other Studio inventories already use server-side pagination, so this brings the primary instance inventory to the same bounded contract as cloud credentials, data sources, Studio users, and query history.

## Tests

- focused backend: `InstanceServiceTest,InstanceControllerTest` — 84 tests passed
- backend full suite: 1,560 tests passed; Checkstyle 0 violations
- focused frontend: instance API/service/page tests — 3 files / 32 tests passed
- `npm run lint -- --quiet`: 0 errors (3 pre-existing warnings)
- `npm run build`: passed
- `git diff --check`: passed

Production changes: 122 additions / 9 deletions, naturally exceeding 100 production lines without test padding.

Closes #2542
