### PR TITLE
[Studio] fix: enforce Tencent ACL role boundaries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -185,11 +185,12 @@ public class AclService {
         if (isTencentInstance(instanceId)) {
             return tencentAclService.updateUser(instanceId, user.toAclUserVO());
         }
-        if (user.getId() == null) {
+        if (!StringUtils.hasText(user.getId())) {
             throw new BusinessException(400, "ACL user id is required");
         }
-        log.info("Updating ACL user id={}, username={}", user.getId(), user.getUsername());
-        AclUserVO existing = aclRepository.findUserById(user.getId())
+        Long userId = EntityIds.parseId(user.getId());
+        log.info("Updating ACL user id={}, username={}", userId, user.getUsername());
+        AclUserVO existing = aclRepository.findUserById(userId)
                 .orElseThrow(() -> new BusinessException(404, "ACL user not found: " + user.getId()));
         if (user.getUsername() != null && !StringUtils.hasText(user.getUsername())) {
             throw new BusinessException(400, "ACL username is required");

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/UpdateAclRuleDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/UpdateAclRuleDTO.java
@@ -17,15 +17,14 @@
 package org.apache.rocketmq.studio.instance.acl;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
 public class UpdateAclRuleDTO {
-    @NotNull(message = "id is required")
-    private Long id;
+    @NotBlank(message = "id is required")
+    private String id;
     @NotBlank(message = "principal is required")
     private String principal;
     @NotBlank(message = "resource is required")
@@ -41,7 +40,7 @@ public class UpdateAclRuleDTO {
 
     public AclRuleVO toAclRuleVO() {
         return AclRuleVO.builder()
-                .id(id)
+                .id(numericIdOrNull())
                 .principal(principal)
                 .resource(resource)
                 .resourceType(resourceType)
@@ -51,5 +50,16 @@ public class UpdateAclRuleDTO {
                 .scope(scope)
                 .aclVersion(aclVersion)
                 .build();
+    }
+
+    private Long numericIdOrNull() {
+        if (id == null || id.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(id.trim());
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/UpdateAclUserDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/UpdateAclUserDTO.java
@@ -16,15 +16,15 @@
  */
 package org.apache.rocketmq.studio.instance.acl;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
 public class UpdateAclUserDTO {
-    @NotNull(message = "id is required")
-    private Long id;
+    @NotBlank(message = "id is required")
+    private String id;
     private String username;
     /**
      * Null when the admin flag was not part of the partial update, in which case the existing
@@ -41,12 +41,23 @@ public class UpdateAclUserDTO {
 
     public AclUserVO toAclUserVO() {
         return AclUserVO.builder()
-                .id(id)
+                .id(numericIdOrNull())
                 .username(username)
                 .admin(admin != null && admin)
                 .permRead(permRead)
                 .permWrite(permWrite)
                 .clusters(clusters)
                 .build();
+    }
+
+    private Long numericIdOrNull() {
+        if (id == null || id.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(id.trim());
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentAclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentAclService.java
@@ -219,8 +219,9 @@ public class TencentAclService {
     public AclRuleVO createRule(String instanceId, AclRuleVO rule) {
         Context context = resolve(instanceId);
         String principal = requireRulePrincipal(rule);
-        boolean permRead = hasAction(rule, "SUB");
-        boolean permWrite = hasAction(rule, "PUB");
+        requireClusterWideAllowRule(rule);
+        boolean permRead = hasPermissionAction(rule, "SUB");
+        boolean permWrite = hasPermissionAction(rule, "PUB");
         ModifyRoleRequest request = new ModifyRoleRequest();
         request.setInstanceId(context.cloudInstanceId());
         request.setRole(principal);
@@ -259,6 +260,28 @@ public class TencentAclService {
     private static boolean hasAction(AclRuleVO rule, String action) {
         return rule.getActions() != null && rule.getActions().stream()
                 .anyMatch(a -> action.equalsIgnoreCase(a));
+    }
+
+    private static boolean hasPermissionAction(AclRuleVO rule, String action) {
+        return hasAction(rule, "ALL") || hasAction(rule, action);
+    }
+
+    private static void requireClusterWideAllowRule(AclRuleVO rule) {
+        if (!isOptionalValue(rule.getResourceType(), RESOURCE_TYPE)
+                || !isOptionalValue(rule.getResource(), RESOURCE)
+                || !isOptionalValue(rule.getResourcePattern(), RESOURCE_PATTERN)
+                || !isOptionalValue(rule.getScope(), SCOPE)) {
+            throw new BusinessException(400,
+                    "Tencent Cloud roles only support cluster-wide ACL rules on resource *");
+        }
+        if (!isOptionalValue(rule.getDecision(), DECISION)) {
+            throw new BusinessException(400,
+                    "Tencent Cloud roles only support ALLOW ACL rules");
+        }
+    }
+
+    private static boolean isOptionalValue(String actual, String expected) {
+        return !StringUtils.hasText(actual) || expected.equalsIgnoreCase(actual.trim());
     }
 
     private static AclRuleVO toRule(String principal, boolean permRead, boolean permWrite) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclControllerTest.java
@@ -221,6 +221,45 @@ class AclControllerTest {
     }
 
     @Test
+    void updateRuleShouldAcceptTencentRoleNameIdentifier() throws Exception {
+        AclRuleVO updated = AclRuleVO.builder()
+                .principal("reader-role")
+                .resource("*")
+                .resourceType("Cluster")
+                .resourcePattern("LITERAL")
+                .actions(List.of("SUB"))
+                .decision("ALLOW")
+                .scope("cluster")
+                .aclVersion("1.0")
+                .build();
+        when(aclService.updateRule(any(AclRuleVO.class), eq("tencent-rmq"))).thenReturn(updated);
+
+        mockMvc.perform(post("/api/acl/rules/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id": "reader-role",
+                                  "principal": "reader-role",
+                                  "resource": "*",
+                                  "resourceType": "Cluster",
+                                  "resourcePattern": "LITERAL",
+                                  "actions": ["SUB"],
+                                  "decision": "ALLOW",
+                                  "scope": "cluster",
+                                  "instanceId": "tencent-rmq"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.principal").value("reader-role"))
+                .andExpect(jsonPath("$.data.resource").value("*"));
+
+        ArgumentCaptor<AclRuleVO> captor = ArgumentCaptor.forClass(AclRuleVO.class);
+        verify(aclService).updateRule(captor.capture(), eq("tencent-rmq"));
+        assertThat(captor.getValue().getId()).isNull();
+        assertThat(captor.getValue().getPrincipal()).isEqualTo("reader-role");
+    }
+
+    @Test
     void updateRuleShouldReturnNotFoundForUnknownId() throws Exception {
         AclRuleVO input = AclRuleVO.builder()
                 .id(999L)
@@ -365,7 +404,7 @@ class AclControllerTest {
     @Test
     void updateUserShouldReturnMaskedUpdatedUser() throws Exception {
         UpdateAclUserDTO input = new UpdateAclUserDTO();
-        input.setId(1L);
+        input.setId("1");
         input.setUsername("admin");
         input.setAdmin(false);
         AclUserVO updated = AclUserVO.builder()
@@ -387,6 +426,39 @@ class AclControllerTest {
                 .andExpect(jsonPath("$.data.accessKey").value("acce****3456"))
                 .andExpect(jsonPath("$.data.secretKey").value("secr****7654"))
                 .andExpect(jsonPath("$.data.admin").value(false));
+    }
+
+    @Test
+    void updateUserShouldAcceptTencentRoleNameIdentifier() throws Exception {
+        AclUserVO updated = AclUserVO.builder()
+                .username("reader-role")
+                .accessKey("acce****3456")
+                .secretKey("secr****7654")
+                .admin(false)
+                .permRead(true)
+                .permWrite(false)
+                .build();
+        when(aclService.updateUser(any(UpdateAclUserDTO.class), eq("tencent-rmq"))).thenReturn(updated);
+
+        mockMvc.perform(post("/api/acl/users/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "id": "reader-role",
+                                  "username": "reader-role",
+                                  "permRead": true,
+                                  "permWrite": false,
+                                  "instanceId": "tencent-rmq"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.username").value("reader-role"))
+                .andExpect(jsonPath("$.data.permRead").value(true));
+
+        ArgumentCaptor<UpdateAclUserDTO> captor = ArgumentCaptor.forClass(UpdateAclUserDTO.class);
+        verify(aclService).updateUser(captor.capture(), eq("tencent-rmq"));
+        assertThat(captor.getValue().getId()).isEqualTo("reader-role");
+        assertThat(captor.getValue().getUsername()).isEqualTo("reader-role");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -474,7 +474,7 @@ class AclServiceTest {
     @Test
     void updateUserShouldSaveExistingUser() {
         UpdateAclUserDTO input = new UpdateAclUserDTO();
-        input.setId(1L);
+        input.setId("1");
         input.setUsername("newuser");
         input.setAdmin(true);
 
@@ -507,7 +507,7 @@ class AclServiceTest {
                 .clusters(List.of("cluster-a"))
                 .build();
         UpdateAclUserDTO input = new UpdateAclUserDTO();
-        input.setId(1L);
+        input.setId("1");
         input.setUsername("renamed");
         // admin intentionally left null: the existing admin flag must survive the partial update.
 
@@ -526,7 +526,7 @@ class AclServiceTest {
     @Test
     void updateUserShouldRejectBlankUsernameWithoutSaving() {
         UpdateAclUserDTO input = new UpdateAclUserDTO();
-        input.setId(1L);
+        input.setId("1");
         input.setUsername("   ");
 
         when(aclRepository.findUserById(1L)).thenReturn(Optional.of(existingUser));
@@ -541,7 +541,7 @@ class AclServiceTest {
     @Test
     void updateUserShouldThrowWhenUserDoesNotExist() {
         UpdateAclUserDTO input = new UpdateAclUserDTO();
-        input.setId(999L);
+        input.setId("999");
         input.setUsername("ghost");
 
         when(aclRepository.findUserById(999L)).thenReturn(Optional.empty());
@@ -556,7 +556,7 @@ class AclServiceTest {
     @Test
     void updateUserShouldRejectConcurrentDeletion() {
         UpdateAclUserDTO input = new UpdateAclUserDTO();
-        input.setId(1L);
+        input.setId("1");
         input.setUsername("renamed");
         when(aclRepository.findUserById(1L)).thenReturn(Optional.of(existingUser));
         when(aclRepository.replaceUser(any(AclUserVO.class))).thenReturn(Optional.empty());
@@ -640,7 +640,7 @@ class AclServiceTest {
         AclUserVO listed = aclService.listUsers(null).get(0);
 
         UpdateAclUserDTO update = new UpdateAclUserDTO();
-        update.setId(listed.getId());
+        update.setId(String.valueOf(listed.getId()));
         update.setUsername("orders-admin");
         update.setAdmin(true);
         update.setClusters(listed.getClusters());

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentAclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentAclServiceTest.java
@@ -23,6 +23,7 @@ import com.tencentcloudapi.trocket.v20230308.models.RoleItem;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.instance.acl.AclRuleVO;
 import org.apache.rocketmq.studio.instance.acl.AclUserVO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -149,5 +151,64 @@ class TencentAclServiceTest {
                 .build()))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("ACL user not found: ghost-role");
+    }
+
+    @Test
+    void createRuleShouldExpandAllActionToReadAndWritePermissionsTest() throws Exception {
+        AclRuleVO rule = AclRuleVO.builder()
+                .principal("reader-role")
+                .resource("*")
+                .resourceType("Cluster")
+                .resourcePattern("LITERAL")
+                .actions(List.of("ALL"))
+                .decision("ALLOW")
+                .scope("cluster")
+                .build();
+
+        AclRuleVO created = service.createRule(INSTANCE_ID, rule);
+
+        ArgumentCaptor<ModifyRoleRequest> requestCaptor = ArgumentCaptor.forClass(ModifyRoleRequest.class);
+        verify(client).ModifyRole(requestCaptor.capture());
+        ModifyRoleRequest request = requestCaptor.getValue();
+        assertThat(request.getRole()).isEqualTo("reader-role");
+        assertThat(request.getPermRead()).isTrue();
+        assertThat(request.getPermWrite()).isTrue();
+        assertThat(created.getActions()).containsExactly("PUB", "SUB");
+    }
+
+    @Test
+    void createRuleShouldRejectResourceScopedTencentRulesTest() {
+        AclRuleVO rule = AclRuleVO.builder()
+                .principal("reader-role")
+                .resource("orders-*")
+                .resourceType("Topic")
+                .resourcePattern("PREFIX")
+                .actions(List.of("SUB"))
+                .decision("ALLOW")
+                .scope("cluster")
+                .build();
+
+        assertThatThrownBy(() -> service.createRule(INSTANCE_ID, rule))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Tencent Cloud roles only support cluster-wide ACL rules on resource *")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+    }
+
+    @Test
+    void createRuleShouldRejectDenyTencentRulesTest() {
+        AclRuleVO rule = AclRuleVO.builder()
+                .principal("reader-role")
+                .resource("*")
+                .resourceType("Cluster")
+                .resourcePattern("LITERAL")
+                .actions(List.of("SUB"))
+                .decision("DENY")
+                .scope("cluster")
+                .build();
+
+        assertThatThrownBy(() -> service.createRule(INSTANCE_ID, rule))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Tencent Cloud roles only support ALLOW ACL rules")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
     }
 }

--- a/web/src/api/acl.test.ts
+++ b/web/src/api/acl.test.ts
@@ -25,6 +25,7 @@ import {
   deleteAclRule,
   deleteAclUser,
   examineBrokerClusterAclConfig,
+  getAclUserCredentials,
   listAclRules,
   updateAclRule,
   updateAclUser,
@@ -138,6 +139,41 @@ describe('ACL API contract', () => {
     await expect(updateAclUser({ id: user.id, admin: true })).resolves.toEqual(user);
     await expect(deleteAclRule(rule.id)).resolves.toBeUndefined();
     await expect(deleteAclUser(user.id)).resolves.toBeUndefined();
+  });
+
+  it('passes Tencent role names as ACL entity identifiers', async () => {
+    mock.onPost('/acl/rules/delete').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ id: 'reader-role', instanceId: 'tencent-rmq' });
+      return [200, { code: 200 }];
+    });
+    mock.onPost('/acl/users/delete').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ id: 'reader-role', instanceId: 'tencent-rmq' });
+      return [200, { code: 200 }];
+    });
+    mock.onGet('/acl/users/reader-role/credentials').reply((config) => {
+      expect(config.params).toEqual({ instanceId: 'tencent-rmq' });
+      return [
+        200,
+        {
+          code: 200,
+          data: {
+            id: 'reader-role',
+            username: 'reader-role',
+            accessKey: 'ak',
+            secretKey: 'sk',
+            admin: false,
+            clusters: ['rmq-cloud'],
+          },
+        },
+      ];
+    });
+
+    await expect(deleteAclRule('reader-role', 'tencent-rmq')).resolves.toBeUndefined();
+    await expect(deleteAclUser('reader-role', 'tencent-rmq')).resolves.toBeUndefined();
+    await expect(getAclUserCredentials('reader-role', 'tencent-rmq')).resolves.toMatchObject({
+      username: 'reader-role',
+      secretKey: 'sk',
+    });
   });
 
   it('fetches cluster ACL config by clusterId', async () => {

--- a/web/src/api/acl.ts
+++ b/web/src/api/acl.ts
@@ -8,8 +8,10 @@ export interface PageResult<T> {
   size: number;
 }
 
+export type AclEntityId = number | string;
+
 export interface AclRule {
-  id: number;
+  id: AclEntityId;
   principal: string;
   resource: string;
   resourceType: string;
@@ -46,7 +48,7 @@ export interface AclUserPage {
 }
 
 export interface AclUser {
-  id: number;
+  id: AclEntityId;
   username: string;
   accessKey: string;
   secretKey: string;
@@ -72,7 +74,7 @@ export async function updateAclRule(data: Partial<AclRule> & { instanceId?: stri
   return res.data.data;
 }
 
-export async function deleteAclRule(id: number, instanceId?: string) {
+export async function deleteAclRule(id: AclEntityId, instanceId?: string) {
   await client.post('/acl/rules/delete', { id, instanceId });
 }
 
@@ -86,9 +88,9 @@ export async function pageAclUsers(params: AclUserQuery & { page: number; pageSi
   return res.data.data;
 }
 
-export async function getAclUserCredentials(id: number, instanceId?: string) {
+export async function getAclUserCredentials(id: AclEntityId, instanceId?: string) {
   const res = await client.get<{ data: AclUser }>(
-    `/acl/users/${encodeURIComponent(id)}/credentials`,
+    `/acl/users/${encodeURIComponent(String(id))}/credentials`,
     { params: { instanceId } },
   );
   return res.data.data;
@@ -104,7 +106,7 @@ export async function updateAclUser(data: Partial<AclUser> & { instanceId?: stri
   return res.data.data;
 }
 
-export async function deleteAclUser(id: number, instanceId?: string) {
+export async function deleteAclUser(id: AclEntityId, instanceId?: string) {
   await client.post('/acl/users/delete', { id, instanceId });
 }
 

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -395,6 +395,14 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: '它们尚不会下发到所选 RocketMQ 实例。实例级 ACL Provider 接入完成前，请在集群侧管理实际 ACL 策略。',
     en: 'They are not applied to the selected RocketMQ instance. Manage the effective ACL policy on the cluster until instance-scoped provider support is available.',
   },
+  'acl.tencentRoleNotice': {
+    zh: '当前 ACL 用户和规则由 Tencent Cloud Role 实时驱动',
+    en: 'Current ACL users and rules are backed by Tencent Cloud roles',
+  },
+  'acl.tencentRoleDescription': {
+    zh: 'Tencent Cloud Role 只支持集群级允许规则，资源固定为 *，权限通过 PUB/SUB 映射为写/读角色权限。',
+    en: 'Tencent Cloud roles only support cluster-wide allow rules on resource *, with PUB/SUB mapped to write/read role permissions.',
+  },
   'acl.addRule': { zh: '添加规则', en: 'Add Rule' },
   'acl.addUser': { zh: '添加用户', en: 'Add User' },
   'acl.ruleTab': { zh: 'ACL 规则', en: 'ACL Rules' },

--- a/web/src/pages/instance/__tests__/AclPage.test.tsx
+++ b/web/src/pages/instance/__tests__/AclPage.test.tsx
@@ -21,6 +21,7 @@ import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AclRule, AclUser } from '../../../api/acl';
 import { LangProvider } from '../../../i18n/LangContext';
 import * as aclService from '../../../services/aclService';
 import * as instanceService from '../../../services/instanceService';
@@ -195,6 +196,118 @@ describe('ACL page', () => {
     expect(await screen.findByTestId('acl-local-metadata-notice')).toHaveTextContent(
       '当前 ACL 规则和用户仅保存为 Studio 本地元数据',
     );
+  });
+
+  it('uses Tencent role names for role-backed ACL rules and users', async () => {
+    const user = userEvent.setup();
+    vi.mocked(instanceService.listInstances).mockResolvedValue([
+      {
+        id: 21,
+        name: 'tencent-rmq',
+        type: 'CLOUD',
+        endpoint: 'vpc.tencent:8080',
+        vendor: 'TENCENT',
+        cloudInstanceId: 'rmq-cloud',
+        remark: '',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        gmtCreate: '',
+        gmtModified: '',
+      },
+    ]);
+    vi.mocked(aclService.listAclRules).mockResolvedValue({
+      items: [
+        {
+          principal: 'reader-role',
+          resource: '*',
+          resourceType: 'Cluster',
+          resourcePattern: 'LITERAL',
+          actions: ['PUB'],
+          decision: 'ALLOW',
+          scope: 'cluster',
+          aclVersion: '1.0',
+          gmtCreate: '2026-07-23T00:00:00Z',
+        } as AclRule,
+      ],
+      total: 1,
+      page: 1,
+      size: 20,
+    });
+    vi.mocked(aclService.pageAclUsers).mockResolvedValue({
+      items: [
+        {
+          username: 'reader-role',
+          accessKey: 'acce****3456',
+          secretKey: 'secr****7654',
+          admin: false,
+          clusters: ['rmq-cloud'],
+          gmtCreate: '2026-07-23T00:00:00Z',
+        } as AclUser,
+      ],
+      total: 1,
+      page: 1,
+      size: 20,
+    });
+    vi.mocked(aclService.updateAclRule).mockResolvedValue({
+      id: 'reader-role',
+      principal: 'reader-role',
+      resource: '*',
+      resourceType: 'Cluster',
+      resourcePattern: 'LITERAL',
+      actions: ['PUB', 'SUB'],
+      decision: 'ALLOW',
+      scope: 'cluster',
+      aclVersion: '1.0',
+      gmtCreate: '2026-07-23T00:00:00Z',
+    });
+    vi.mocked(aclService.getAclUserCredentials).mockResolvedValue({
+      id: 'reader-role',
+      username: 'reader-role',
+      accessKey: 'full-access-key',
+      secretKey: 'full-secret-key',
+      admin: false,
+      clusters: ['rmq-cloud'],
+      gmtCreate: '2026-07-23T00:00:00Z',
+    });
+
+    renderWithProviders(<AclPage />, '/instance/tencent-rmq/acl');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('acl-local-metadata-notice')).toHaveTextContent(
+        'Tencent Cloud Role',
+      ),
+    );
+    const ruleRow = await screen.findByRole('row', { name: /reader-role/ });
+    await user.click(within(ruleRow).getByRole('button', { name: /编辑/ }));
+    const ruleDialog = await screen.findByRole('dialog');
+    expect(within(ruleDialog).getByLabelText('资源名称')).toBeDisabled();
+    await user.click(within(ruleDialog).getByLabelText('订阅 (SUB)'));
+    await user.click(within(ruleDialog).getByRole('button', { name: /保\s*存/ }));
+
+    await waitFor(() => expect(aclService.updateAclRule).toHaveBeenCalledTimes(1));
+    expect(aclService.updateAclRule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'reader-role',
+        principal: 'reader-role',
+        resource: '*',
+        resourceType: 'Cluster',
+        resourcePattern: 'LITERAL',
+        decision: 'ALLOW',
+        scope: 'cluster',
+        instanceId: 'tencent-rmq',
+      }),
+    );
+
+    await user.click(screen.getByText('用户管理'));
+    const userRow = await screen.findByRole('row', { name: /reader-role/ });
+    const secretCell = within(userRow).getByText('••••••••••••').closest('td');
+    expect(secretCell).not.toBeNull();
+    await user.click(within(secretCell as HTMLElement).getByRole('button'));
+
+    await waitFor(() =>
+      expect(aclService.getAclUserCredentials).toHaveBeenCalledWith('reader-role', 'tencent-rmq'),
+    );
+    expect(await within(userRow).findByText('full-secret-key')).toBeInTheDocument();
   });
 
   it('renders backend users on the user tab', async () => {

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -67,6 +67,7 @@ import type { AclRule, AclUser, AclClusterConfig, PlainAccessConfig } from '../.
 import { useInstanceFilter } from '../../hooks/useInstanceFilter';
 import { tableScrollX } from '../../utils/table';
 
+type AclEntityId = AclRule['id'];
 type AclRuleFormValues = Pick<
   AclRule,
   'principal' | 'resource' | 'resourceType' | 'resourcePattern' | 'actions' | 'decision' | 'scope'
@@ -75,6 +76,7 @@ type AclUserFormValues = Pick<AclUser, 'username' | 'admin' | 'clusters'>;
 
 const normalizeRule = (rule: AclRule): AclRule => ({
   ...rule,
+  id: rule.id ?? rule.principal,
   principal: rule.principal ?? '',
   resource: rule.resource ?? '',
   resourceType: rule.resourceType ?? '',
@@ -90,6 +92,7 @@ const normalizeRule = (rule: AclRule): AclRule => ({
 
 const normalizeUser = (user: AclUser): AclUser => ({
   ...user,
+  id: user.id ?? user.username,
   username: user.username ?? '',
   accessKey: user.accessKey ?? '',
   secretKey: user.secretKey ?? '',
@@ -117,6 +120,8 @@ const AclPageContent = ({
 }: AclPageContentProps) => {
   const { t } = useLang();
   const hasSelectedInstance = Boolean(selectedInstanceId);
+  const selectedInstance = instances.find((instance) => instance.name === selectedInstanceId);
+  const tencentRoleMode = selectedInstance?.vendor === 'TENCENT';
 
   /* ─── State ─── */
   const [rules, setRules] = useState<AclRule[]>([]);
@@ -153,12 +158,12 @@ const AclPageContent = ({
   const [userForm] = Form.useForm();
 
   // Secret key reveal
-  const [revealedKeys, setRevealedKeys] = useState<Set<number>>(new Set());
-  const [adminUpdatingIds, setAdminUpdatingIds] = useState<Set<number>>(() => new Set());
-  const adminUpdateInFlightRef = useRef<Set<number>>(new Set());
-  const revealRequestGenerationRef = useRef<Record<number, number>>({});
+  const [revealedKeys, setRevealedKeys] = useState<Set<AclEntityId>>(new Set());
+  const [adminUpdatingIds, setAdminUpdatingIds] = useState<Set<AclEntityId>>(() => new Set());
+  const adminUpdateInFlightRef = useRef<Set<AclEntityId>>(new Set());
+  const revealRequestGenerationRef = useRef<Record<string, number>>({});
   const [credentialsByUser, setCredentialsByUser] = useState<
-    Record<number, { accessKey: string; secretKey: string }>
+    Record<string, { accessKey: string; secretKey: string }>
   >({});
 
   // Cluster ACL config (examineBrokerClusterAclConfig)
@@ -256,7 +261,9 @@ const AclPageContent = ({
     setEditingRule(null);
     ruleForm.resetFields();
     ruleForm.setFieldsValue({
-      resourcePattern: 'PREFIX',
+      resourceType: tencentRoleMode ? 'Cluster' : undefined,
+      resource: tencentRoleMode ? '*' : undefined,
+      resourcePattern: tencentRoleMode ? 'LITERAL' : 'PREFIX',
       actions: ['PUB'],
       decision: 'ALLOW',
       scope: 'cluster',
@@ -281,18 +288,28 @@ const AclPageContent = ({
   const handleRuleSubmit = async () => {
     try {
       const values = (await ruleForm.validateFields()) as AclRuleFormValues;
+      const normalizedValues = tencentRoleMode
+        ? {
+            ...values,
+            resourceType: 'Cluster',
+            resource: '*',
+            resourcePattern: 'LITERAL',
+            decision: 'ALLOW',
+            scope: 'cluster',
+          }
+        : values;
       setRuleSubmitting(true);
       if (editingRule) {
         await updateAclRule({
           ...editingRule,
-          ...values,
+          ...normalizedValues,
           instanceId: selectedInstanceId,
         });
         message.success(t('acl.ruleUpdated'));
       } else {
         await createAclRule({
-          ...values,
-          aclVersion: '2.0',
+          ...normalizedValues,
+          aclVersion: tencentRoleMode ? '1.0' : '2.0',
           instanceId: selectedInstanceId,
         });
         setRulePage(1);
@@ -308,7 +325,7 @@ const AclPageContent = ({
     }
   };
 
-  const handleDeleteRule = async (id: number) => {
+  const handleDeleteRule = async (id: AclEntityId) => {
     try {
       await deleteAclRule(id, selectedInstanceId);
       if (rules.length === 1 && rulePage > 1) {
@@ -323,10 +340,11 @@ const AclPageContent = ({
   };
 
   /* ─── User helpers ─── */
-  const toggleRevealKey = async (userId: number) => {
+  const toggleRevealKey = async (userId: AclEntityId) => {
+    const userKey = String(userId);
     const revealing = !revealedKeys.has(userId);
-    const revealGeneration = (revealRequestGenerationRef.current[userId] ?? 0) + 1;
-    revealRequestGenerationRef.current[userId] = revealGeneration;
+    const revealGeneration = (revealRequestGenerationRef.current[userKey] ?? 0) + 1;
+    revealRequestGenerationRef.current[userKey] = revealGeneration;
     setRevealedKeys((prev) => {
       const next = new Set(prev);
       if (next.has(userId)) {
@@ -336,19 +354,19 @@ const AclPageContent = ({
       }
       return next;
     });
-    if (!revealing || credentialsByUser[userId]) return;
+    if (!revealing || credentialsByUser[userKey]) return;
     try {
       const credentials = await getAclUserCredentials(userId, selectedInstanceId);
-      if (revealRequestGenerationRef.current[userId] !== revealGeneration) return;
+      if (revealRequestGenerationRef.current[userKey] !== revealGeneration) return;
       setCredentialsByUser((prev) => ({
         ...prev,
-        [userId]: {
+        [userKey]: {
           accessKey: credentials.accessKey,
           secretKey: credentials.secretKey,
         },
       }));
     } catch {
-      if (revealRequestGenerationRef.current[userId] !== revealGeneration) return;
+      if (revealRequestGenerationRef.current[userKey] !== revealGeneration) return;
       setRevealedKeys((prev) => {
         const next = new Set(prev);
         next.delete(userId);
@@ -409,7 +427,7 @@ const AclPageContent = ({
     }
   };
 
-  const handleDeleteUser = async (id: number) => {
+  const handleDeleteUser = async (id: AclEntityId) => {
     try {
       await deleteAclUser(id, selectedInstanceId);
       setUsers((prev) => prev.filter((u) => u.id !== id));
@@ -420,6 +438,7 @@ const AclPageContent = ({
   };
 
   const handleToggleAdmin = async (user: AclUser, checked: boolean) => {
+    if (tencentRoleMode) return;
     if (adminUpdateInFlightRef.current.has(user.id)) return;
     adminUpdateInFlightRef.current.add(user.id);
     setAdminUpdatingIds((current) => new Set(current).add(user.id));
@@ -705,7 +724,7 @@ const AclPageContent = ({
       sorter: (a, b) => a.accessKey.localeCompare(b.accessKey),
       render: (text: string, record: AclUser) => {
         const revealed = revealedKeys.has(record.id);
-        const fullAccessKey = credentialsByUser[record.id]?.accessKey ?? text;
+        const fullAccessKey = credentialsByUser[String(record.id)]?.accessKey ?? text;
         return (
           <Space size={8}>
             <Typography.Text
@@ -725,7 +744,7 @@ const AclPageContent = ({
       width: 240,
       render: (_: string, record: AclUser) => {
         const revealed = revealedKeys.has(record.id);
-        const secret = credentialsByUser[record.id]?.secretKey;
+        const secret = credentialsByUser[String(record.id)]?.secretKey;
         return (
           <Space size={8}>
             <Typography.Text
@@ -755,7 +774,7 @@ const AclPageContent = ({
           checked={val}
           size="small"
           loading={adminUpdatingIds.has(record.id)}
-          disabled={adminUpdatingIds.has(record.id)}
+          disabled={tencentRoleMode || adminUpdatingIds.has(record.id)}
           onChange={(checked) => handleToggleAdmin(record, checked)}
         />
       ),
@@ -935,8 +954,10 @@ const AclPageContent = ({
 
       <InfoBanner
         data-testid="acl-local-metadata-notice"
-        title={t('acl.localMetadataNotice')}
-        description={t('acl.localMetadataDescription')}
+        title={t(tencentRoleMode ? 'acl.tencentRoleNotice' : 'acl.localMetadataNotice')}
+        description={t(
+          tencentRoleMode ? 'acl.tencentRoleDescription' : 'acl.localMetadataDescription',
+        )}
       />
 
       <Card variant="borderless" styles={{ body: { padding: 0 } }}>
@@ -1250,11 +1271,16 @@ const AclPageContent = ({
           >
             <Select
               placeholder={t('acl.selectResourceType')}
-              options={[
-                { value: 'Topic', label: 'Topic' },
-                { value: 'Group', label: 'Group' },
-                { value: 'Cluster', label: 'Cluster' },
-              ]}
+              disabled={tencentRoleMode}
+              options={
+                tencentRoleMode
+                  ? [{ value: 'Cluster', label: 'Cluster' }]
+                  : [
+                      { value: 'Topic', label: 'Topic' },
+                      { value: 'Group', label: 'Group' },
+                      { value: 'Cluster', label: 'Cluster' },
+                    ]
+              }
             />
           </Form.Item>
 
@@ -1265,11 +1291,11 @@ const AclPageContent = ({
               { required: true, message: t('acl.inputRequired', { field: t('acl.resourceName') }) },
             ]}
           >
-            <Input placeholder={t('acl.resourceNamePlaceholder')} />
+            <Input placeholder={t('acl.resourceNamePlaceholder')} disabled={tencentRoleMode} />
           </Form.Item>
 
           <Form.Item name="resourcePattern" label={t('acl.matchPattern')}>
-            <Radio.Group>
+            <Radio.Group disabled={tencentRoleMode}>
               <Radio.Button value="LITERAL">{t('acl.literal')}</Radio.Button>
               <Radio.Button value="PREFIX">{t('acl.prefix')}</Radio.Button>
             </Radio.Group>
@@ -1292,7 +1318,7 @@ const AclPageContent = ({
           </Form.Item>
 
           <Form.Item name="decision" label={t('acl.decision')}>
-            <Radio.Group>
+            <Radio.Group disabled={tencentRoleMode}>
               <Radio.Button value="ALLOW">
                 <span style={{ color: '#52c41a' }}>{t('acl.allowDesc')}</span>
               </Radio.Button>
@@ -1305,6 +1331,7 @@ const AclPageContent = ({
           <Form.Item name="scope" label={t('acl.effectScope')}>
             <Select
               placeholder={t('acl.selectEffectScope')}
+              disabled={tencentRoleMode}
               options={[{ value: 'cluster', label: t('acl.clusterScope') }]}
             />
           </Form.Item>
@@ -1339,7 +1366,11 @@ const AclPageContent = ({
           </Form.Item>
 
           <Form.Item name="admin" label={t('acl.admin')} valuePropName="checked">
-            <Switch checkedChildren={t('common.yes')} unCheckedChildren={t('common.no')} />
+            <Switch
+              checkedChildren={t('common.yes')}
+              unCheckedChildren={t('common.no')}
+              disabled={tencentRoleMode}
+            />
           </Form.Item>
 
           <Form.Item name="clusters" label={t('acl.associatedClusters')}>
@@ -1347,6 +1378,7 @@ const AclPageContent = ({
               mode="tags"
               tokenSeparators={[',']}
               allowClear
+              disabled={tencentRoleMode}
               options={instances.map((instance) => ({
                 value: instance.cloudInstanceId ?? instance.name,
                 label: instance.name,

--- a/web/src/services/aclService.ts
+++ b/web/src/services/aclService.ts
@@ -1,6 +1,7 @@
 import { isMockMode } from './dataMode';
 import * as aclApi from '../api/acl';
 import type {
+  AclEntityId,
   AclRule,
   PageResult,
   AclRuleQuery,
@@ -107,7 +108,10 @@ export async function pageAclUsers(params: {
   return aclApi.pageAclUsers(params);
 }
 
-export async function getAclUserCredentials(id: number, instanceId?: string): Promise<AclUser> {
+export async function getAclUserCredentials(
+  id: AclEntityId,
+  instanceId?: string,
+): Promise<AclUser> {
   if (isMockMode()) {
     const user = aclUsersState.find((u) => u.id === id);
     if (!user) throw new Error(`ACL user not found: ${id}`);
@@ -155,7 +159,7 @@ export async function updateAclRule(
   return aclApi.updateAclRule(data);
 }
 
-export async function deleteAclRule(id: number, instanceId?: string): Promise<void> {
+export async function deleteAclRule(id: AclEntityId, instanceId?: string): Promise<void> {
   if (isMockMode()) {
     const idx = aclRulesState.findIndex((rule) => rule.id === id);
     if (idx >= 0) aclRulesState.splice(idx, 1);
@@ -200,7 +204,7 @@ export async function updateAclUser(
   return aclApi.updateAclUser(data);
 }
 
-export async function deleteAclUser(id: number, instanceId?: string): Promise<void> {
+export async function deleteAclUser(id: AclEntityId, instanceId?: string): Promise<void> {
   if (isMockMode()) {
     const idx = aclUsersState.findIndex((user) => user.id === id);
     if (idx >= 0) aclUsersState.splice(idx, 1);


### PR DESCRIPTION
## What is the purpose of the change

Prevent Tencent Cloud role-backed ACL operations from accepting rule shapes that Tencent roles cannot represent. Tencent roles only support cluster-wide allow rules on `*`, so the backend now rejects unsupported resource-scoped or deny rules instead of silently mapping them to role permissions. The ACL page also uses role names as stable identifiers for Tencent roles, where no local numeric ACL row exists.

## Brief changelog

- Validate Tencent ACL rule creation/update against the cluster-wide role contract and map `ALL` to read/write permissions.
- Allow ACL update/delete/credential APIs to carry cloud role-name identifiers while preserving numeric IDs for local ACL rows.
- Constrain the Tencent ACL UI to role-backed fields and cover role-name rule/user flows with focused tests.

## Verifying this change

- `mvn -q -Dtest=AclServiceTest,AclControllerTest,TencentAclServiceTest test`
- `mvn -q checkstyle:check -DskipTests`
- `npm test -- --run src/pages/instance/__tests__/AclPage.test.tsx src/api/acl.test.ts src/services/aclService.test.ts`
- `npx eslint src/pages/instance/acl.tsx src/pages/instance/__tests__/AclPage.test.tsx src/api/acl.ts src/api/acl.test.ts src/services/aclService.ts --max-warnings=0`
- `npm run build`