### PR TITLE
[Studio] feat: query producer connections across active groups

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionService.java
@@ -38,7 +38,7 @@ public class ProducerConnectionService {
                 instanceId, topic, producerGroup);
         String normalizedInstanceId = requireFilter(instanceId, "instanceId");
         String normalizedTopic = requireFilter(topic, "topic");
-        String normalizedProducerGroup = requireFilter(producerGroup, "producerGroup");
+        String normalizedProducerGroup = normalizeOptionalFilter(producerGroup);
         return clientProvider.findProducerConnections(normalizedInstanceId, normalizedTopic, normalizedProducerGroup)
                 .stream()
                 .map(this::toProducerConnection)
@@ -58,6 +58,8 @@ public class ProducerConnectionService {
         return ProducerConnectionVO.builder()
                 .clientId(connection.getClientId())
                 .clientAddr(connection.getAddress())
+                .topic(connection.getGroupOrTopic())
+                .producerGroup(connection.getProducerGroup())
                 .language(connection.getLanguage() == null ? null : connection.getLanguage().name())
                 .versionDesc(connection.getVersion())
                 .build();

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionVO.java
@@ -28,6 +28,8 @@ import lombok.NoArgsConstructor;
 public class ProducerConnectionVO {
     private String clientId;
     private String clientAddr;
+    private String topic;
+    private String producerGroup;
     private String language;
     private String versionDesc;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerController.java
@@ -49,7 +49,6 @@ public class ProducerController {
             @RequestParam(required = false) String producerGroup) {
         requireParameter(instanceId, "instanceId");
         requireParameter(topic, "topic");
-        requireParameter(producerGroup, "producerGroup");
         return new ProducerConnectionResultVO(
                 producerConnectionService.listConnections(instanceId, topic, producerGroup));
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -130,6 +130,35 @@ public class RocketMQClientProvider implements ClientProvider {
     }
 
     private List<ClientConnectionVO> findProducerConnections(MQAdminExt adminExt, String topic, String producerGroup) {
+        if (producerGroup == null || producerGroup.isBlank()) {
+            return findProducerConnectionsForActiveGroups(adminExt, topic);
+        }
+        return findProducerConnectionsForGroup(adminExt, topic, producerGroup);
+    }
+
+    private List<ClientConnectionVO> findProducerConnectionsForActiveGroups(MQAdminExt adminExt, String topic) {
+        List<String> producerGroups = findProducerGroups(adminExt, topic, null, Integer.MAX_VALUE);
+        if (producerGroups.isEmpty()) {
+            return List.of();
+        }
+        List<ClientConnectionVO> connections = new ArrayList<>();
+        int successfulGroupQueries = 0;
+        for (String producerGroup : producerGroups) {
+            try {
+                connections.addAll(findProducerConnectionsForGroup(adminExt, topic, producerGroup));
+                successfulGroupQueries++;
+            } catch (BusinessException e) {
+                log.warn("Failed to query producer connections for group={}, skipping", producerGroup, e);
+            }
+        }
+        if (successfulGroupQueries == 0) {
+            throw new BusinessException(502, "Failed to query producer connections from all groups");
+        }
+        return connections;
+    }
+
+    private List<ClientConnectionVO> findProducerConnectionsForGroup(
+            MQAdminExt adminExt, String topic, String producerGroup) {
         try {
             ProducerConnection producerConnection =
                     adminExt.examineProducerConnectionInfo(producerGroup, topic);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionServiceTest.java
@@ -62,6 +62,8 @@ class ProducerConnectionServiceTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getClientId()).isEqualTo("producer-1");
         assertThat(result.get(0).getClientAddr()).isEqualTo("10.0.0.1:38888");
+        assertThat(result.get(0).getTopic()).isEqualTo("order-topic");
+        assertThat(result.get(0).getProducerGroup()).isEqualTo("pg-order");
         assertThat(result.get(0).getLanguage()).isEqualTo("Java");
         assertThat(result.get(0).getVersionDesc()).isEqualTo("5.1.0");
         verify(clientProvider).findProducerConnections("instance-1", "order-topic", "pg-order");
@@ -77,12 +79,15 @@ class ProducerConnectionServiceTest {
     }
 
     @Test
-    void listConnectionsShouldRejectMissingProducerGroup() {
-        assertThatThrownBy(() -> producerConnectionService.listConnections("instance-1", "order-topic", null))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("producerGroup is required")
-                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
-        verifyNoInteractions(clientProvider);
+    void listConnectionsShouldAllowMissingProducerGroupForAllGroupScan() {
+        when(clientProvider.findProducerConnections("instance-1", "order-topic", null))
+                .thenReturn(List.of());
+
+        List<ProducerConnectionVO> result =
+                producerConnectionService.listConnections("instance-1", "order-topic", " ");
+
+        assertThat(result).isEmpty();
+        verify(clientProvider).findProducerConnections("instance-1", "order-topic", null);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerControllerTest.java
@@ -64,6 +64,8 @@ class ProducerControllerTest {
         ProducerConnectionVO connection = ProducerConnectionVO.builder()
                 .clientId("producer-1")
                 .clientAddr("10.0.0.1:38888")
+                .topic("order-topic")
+                .producerGroup("pg-order")
                 .language("Java")
                 .versionDesc("5.1.0")
                 .build();
@@ -78,6 +80,8 @@ class ProducerControllerTest {
                 .andExpect(jsonPath("$.connectionSet").isArray())
                 .andExpect(jsonPath("$.connectionSet[0].clientId").value("producer-1"))
                 .andExpect(jsonPath("$.connectionSet[0].clientAddr").value("10.0.0.1:38888"))
+                .andExpect(jsonPath("$.connectionSet[0].topic").value("order-topic"))
+                .andExpect(jsonPath("$.connectionSet[0].producerGroup").value("pg-order"))
                 .andExpect(jsonPath("$.connectionSet[0].language").value("Java"))
                 .andExpect(jsonPath("$.connectionSet[0].versionDesc").value("5.1.0"))
                 .andExpect(jsonPath("$.summary.totalConnections").value(1))
@@ -101,15 +105,19 @@ class ProducerControllerTest {
     }
 
     @Test
-    void listConnectionsShouldRequireProducerGroup() throws Exception {
+    void listConnectionsShouldAllowMissingProducerGroup() throws Exception {
+        when(producerConnectionService.listConnections("instance-1", "order-topic", null))
+                .thenReturn(List.of());
+
         mockMvc.perform(get("/api/producer/connection")
                         .param("instanceId", "instance-1")
                         .param("topic", "order-topic"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(400))
-                .andExpect(jsonPath("$.message").value("producerGroup is required"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.connectionSet").isArray())
+                .andExpect(jsonPath("$.summary.totalConnections").value(0))
+                .andExpect(jsonPath("$.summary.readiness").value("UNAVAILABLE"));
 
-        verifyNoInteractions(producerConnectionService);
+        verify(producerConnectionService).listConnections("instance-1", "order-topic", null);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
@@ -282,6 +282,60 @@ class RocketMQClientProviderTest {
     }
 
     @Test
+    void producerQueryWithoutGroupScansActiveProducerGroups() throws Exception {
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo("127.0.0.1:10911"));
+        when(adminExt.getAllProducerInfo("127.0.0.1:10911"))
+                .thenReturn(new ProducerTableInfo(Map.of(
+                        "pg-order", List.of(producerInfo("producer-order", "10.0.0.1:1000")),
+                        "pg-payment", List.of(producerInfo("producer-payment", "10.0.0.2:1000")))));
+        ProducerConnection orderConnection = new ProducerConnection();
+        orderConnection.setConnectionSet(new HashSet<>(List.of(
+                connection("producer-order", "10.0.0.1:1000"))));
+        ProducerConnection paymentConnection = new ProducerConnection();
+        paymentConnection.setConnectionSet(new HashSet<>(List.of(
+                connection("producer-payment", "10.0.0.2:1000"))));
+        when(adminExt.examineProducerConnectionInfo("pg-order", "TopicA"))
+                .thenReturn(orderConnection);
+        when(adminExt.examineProducerConnectionInfo("pg-payment", "TopicA"))
+                .thenReturn(paymentConnection);
+
+        List<ClientConnectionVO> connections = provider.findProducerConnections("instance-a", "TopicA", null);
+
+        assertThat(connections)
+                .extracting(ClientConnectionVO::getProducerGroup)
+                .containsExactly("pg-order", "pg-payment");
+        assertThat(connections)
+                .extracting(ClientConnectionVO::getGroupOrTopic)
+                .containsOnly("TopicA");
+        verify(adminExt).getAllProducerInfo("127.0.0.1:10911");
+        verify(adminExt).examineProducerConnectionInfo("pg-order", "TopicA");
+        verify(adminExt).examineProducerConnectionInfo("pg-payment", "TopicA");
+    }
+
+    @Test
+    void producerQueryWithoutGroupReturnsPartialResultsWhenOneGroupFails() throws Exception {
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo("127.0.0.1:10911"));
+        when(adminExt.getAllProducerInfo("127.0.0.1:10911"))
+                .thenReturn(new ProducerTableInfo(Map.of(
+                        "pg-order", List.of(producerInfo("producer-order", "10.0.0.1:1000")),
+                        "pg-payment", List.of(producerInfo("producer-payment", "10.0.0.2:1000")))));
+        ProducerConnection paymentConnection = new ProducerConnection();
+        paymentConnection.setConnectionSet(new HashSet<>(List.of(
+                connection("producer-payment", "10.0.0.2:1000"))));
+        when(adminExt.examineProducerConnectionInfo("pg-order", "TopicA"))
+                .thenThrow(new IllegalStateException("broker unavailable"));
+        when(adminExt.examineProducerConnectionInfo("pg-payment", "TopicA"))
+                .thenReturn(paymentConnection);
+
+        List<ClientConnectionVO> connections = provider.findProducerConnections("instance-a", "TopicA", null);
+
+        assertThat(connections).singleElement().satisfies(connection -> {
+            assertThat(connection.getClientId()).isEqualTo("producer-payment");
+            assertThat(connection.getProducerGroup()).isEqualTo("pg-payment");
+        });
+    }
+
+    @Test
     void exactProducerQueryTranslatesAdminFailureToBadGateway() throws Exception {
         when(adminExt.examineProducerConnectionInfo("pg-order", "TopicA"))
                 .thenThrow(new IllegalStateException("broker unavailable"));

--- a/web/src/api/producer.test.ts
+++ b/web/src/api/producer.test.ts
@@ -95,6 +95,8 @@ describe('Producer API', () => {
       {
         clientId: 'producer-1',
         clientAddr: '192.168.1.10',
+        topic: 'order-events',
+        producerGroup: 'order-producer',
         language: 'JAVA',
         versionDesc: '5.1.0',
       },
@@ -115,8 +117,36 @@ describe('Producer API', () => {
     const result = await queryProducerConnection('instance-1', 'order-events', 'order-producer');
     expect(result.connectionSet).toHaveLength(2);
     expect(result.connectionSet[0].clientId).toBe('producer-1');
+    expect(result.connectionSet[0].producerGroup).toBe('order-producer');
     expect(result.summary.totalConnections).toBe(2);
     expect(result.summary.readiness).toBe('READY');
+  });
+
+  it('queries producer connections without a producer group for all-group scans', async () => {
+    mock.onGet('/producer/connection').reply((config) => {
+      expect(config.params.topic).toBe('order-events');
+      expect(config.params.instanceId).toBe('instance-1');
+      expect(config.params.producerGroup).toBeUndefined();
+      return [
+        200,
+        {
+          connectionSet: [
+            {
+              clientId: 'producer-1',
+              clientAddr: '192.168.1.10',
+              topic: 'order-events',
+              producerGroup: 'pg-order',
+              language: 'JAVA',
+              versionDesc: '5.1.0',
+            },
+          ],
+        },
+      ];
+    });
+
+    const result = await queryProducerConnection('instance-1', 'order-events');
+    expect(result.connectionSet[0].producerGroup).toBe('pg-order');
+    expect(result.summary.totalConnections).toBe(1);
   });
 
   it('handles empty producer connections', async () => {

--- a/web/src/api/producer.ts
+++ b/web/src/api/producer.ts
@@ -21,6 +21,8 @@ import client from './client';
 export interface ProducerConnection {
   clientId: string;
   clientAddr: string;
+  topic?: string;
+  producerGroup?: string;
   language: string;
   versionDesc: string;
 }
@@ -178,7 +180,7 @@ export async function fetchProducerGroups(
 export async function queryProducerConnection(
   instanceId: string,
   topic: string,
-  producerGroup: string,
+  producerGroup?: string,
 ): Promise<ProducerConnectionResult> {
   const res = await client.get<ProducerConnectionResponse>('/producer/connection', {
     params: { instanceId, topic, producerGroup },

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1238,6 +1238,10 @@ const translations: Record<string, Record<Lang, string>> = {
   'producer.language': { zh: '语言', en: 'Language' },
   'producer.selectTopic': { zh: '请选择 Topic', en: 'Select a topic' },
   'producer.inputGroup': { zh: '请输入生产者组', en: 'Input producer group' },
+  'producer.inputGroupOptional': {
+    zh: '输入生产者组，留空查询全部活跃组',
+    en: 'Input producer group, or leave empty for all active groups',
+  },
   'producer.fetchTopicFailed': { zh: '获取 Topic 列表失败', en: 'Failed to fetch topic list' },
   'producer.fetchConnectionFailed': {
     zh: '获取生产者连接失败',

--- a/web/src/pages/studio/Producer.tsx
+++ b/web/src/pages/studio/Producer.tsx
@@ -187,7 +187,7 @@ const ProducerPage = () => {
     }
   };
 
-  const onFinish = async (values: { selectedTopic: string; producerGroup: string }) => {
+  const onFinish = async (values: { selectedTopic: string; producerGroup?: string }) => {
     if (queryInFlightRef.current !== null) return;
     if (!selectedInstanceId) {
       message.error('Select an instance before querying producer connections.');
@@ -227,6 +227,13 @@ const ProducerPage = () => {
 
   const columns = [
     { title: 'Client ID', dataIndex: 'clientId', key: 'clientId', align: 'center' as const },
+    {
+      title: 'Producer Group',
+      dataIndex: 'producerGroup',
+      key: 'producerGroup',
+      align: 'center' as const,
+      render: (value?: string) => value || '-',
+    },
     {
       title: t('common.address'),
       dataIndex: 'clientAddr',
@@ -276,8 +283,8 @@ const ProducerPage = () => {
     const rows = connectionList.map((connection) => ({
       ...connection,
       instanceId: selectedInstanceId ?? '',
-      topic: selectedTopic,
-      producerGroup,
+      topic: connection.topic ?? selectedTopic,
+      producerGroup: connection.producerGroup ?? producerGroup,
       readiness: connectionSummary?.readiness,
       warnings,
     }));
@@ -330,14 +337,10 @@ const ProducerPage = () => {
               options={topicList.map((topic) => ({ value: topic, label: topic }))}
             />
           </Form.Item>
-          <Form.Item
-            label="PRODUCER GROUP"
-            name="producerGroup"
-            rules={[{ required: true, whitespace: true, message: t('producer.inputGroup') }]}
-          >
+          <Form.Item label="PRODUCER GROUP" name="producerGroup">
             <AutoComplete
               allowClear
-              placeholder={t('producer.inputGroup')}
+              placeholder={t('producer.inputGroupOptional')}
               style={{ width: 300 }}
               options={producerGroups.map((group) => ({ value: group }))}
               onFocus={() => {
@@ -435,7 +438,9 @@ const ProducerPage = () => {
         <Table
           dataSource={connectionList}
           columns={columns}
-          rowKey={(record) => `${record.clientId}:${record.clientAddr}`}
+          rowKey={(record) =>
+            `${record.producerGroup ?? ''}:${record.clientId}:${record.clientAddr}`
+          }
           pagination={false}
           bordered
           size="middle"

--- a/web/src/pages/studio/__tests__/Producer.test.tsx
+++ b/web/src/pages/studio/__tests__/Producer.test.tsx
@@ -219,7 +219,19 @@ describe('ProducerPage', () => {
     expect(screen.getByText('就绪')).toBeInTheDocument();
   });
 
-  it('does not query without a producer group', async () => {
+  it('queries all active producer groups when producer group is empty', async () => {
+    vi.mocked(queryProducerConnection).mockResolvedValue(
+      producerResult([
+        {
+          clientId: 'producer-all-1',
+          clientAddr: '192.168.1.10',
+          topic: 'order-events',
+          producerGroup: 'pg-order',
+          language: 'JAVA',
+          versionDesc: '5.1.0',
+        },
+      ]),
+    );
     const user = userEvent.setup();
     renderWithProviders(<ProducerPage />);
 
@@ -231,10 +243,11 @@ describe('ProducerPage', () => {
     );
     await user.click(screen.getByRole('button', { name: /搜索/ }));
 
-    expect(
-      await screen.findByText('请输入生产者组', { selector: '.ant-form-item-explain-error' }),
-    ).toBeInTheDocument();
-    expect(queryProducerConnection).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(queryProducerConnection).toHaveBeenCalledWith('instance-1', 'order-events', undefined);
+    });
+    expect(await screen.findByText('producer-all-1')).toBeInTheDocument();
+    expect(screen.getByText('pg-order')).toBeInTheDocument();
   });
 
   it('renders producer connection warnings from the summary', async () => {
@@ -307,6 +320,8 @@ describe('ProducerPage', () => {
         {
           clientId: '@producer-a',
           clientAddr: '192.168.1.10',
+          topic: 'order-events',
+          producerGroup: 'order-producer',
           language: 'JAVA',
           versionDesc: '5.1.0',
         },


### PR DESCRIPTION
## What is the purpose of the change

Allow Producer Connection diagnostics to query all active producer groups for a selected Topic when the user does not already know the exact producer group. The backend now scans active groups and queries each group for the selected Topic, while preserving the existing exact group query path.

## Brief changelog

- Make `producerGroup` optional for producer connection queries and scan active producer groups when it is omitted.
- Include `topic` and `producerGroup` in producer connection results so all-group diagnostics remain traceable.
- Let the Producer Connection page submit empty producer group searches and show/export the returned group per connection.

## Verifying this change

- `mvn -q -Dtest=ProducerConnectionServiceTest,ProducerControllerTest,RocketMQClientProviderTest test`
- `mvn -q checkstyle:check -DskipTests`
- `npm test -- --run src/pages/studio/__tests__/Producer.test.tsx src/api/producer.test.ts`
- `npx eslint src/pages/studio/Producer.tsx src/pages/studio/__tests__/Producer.test.tsx src/api/producer.ts src/api/producer.test.ts --max-warnings=0`
- `npm run build`