### PR TITLE
fix(ci): use policy-approved Docker action revisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
       - name: Build frontend Docker image (cached)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./web
           push: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build frontend Docker image (cached)
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./web
           push: false


### PR DESCRIPTION
Closes #2549

## Summary

- replace the two floating Docker Actions tags with immutable revisions listed in Apache's approved Actions patterns
- preserve the frontend Docker build configuration and GitHub Actions cache behavior

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"`
- `git diff --check`

This allows CI to initialize the frontend Docker build job under the repository Actions policy.