### PR TITLE
fix(web): tolerate incomplete certificate metadata

### DIFF
--- a/web/src/api/cluster.ts
+++ b/web/src/api/cluster.ts
@@ -136,13 +136,13 @@ export interface K8sCertInfo {
   id: number;
   k8sId: string;
   cluster: string;
-  type: string;
-  issuer: string;
-  notBefore: string;
-  notAfter: string;
-  status: string;
+  type: string | null;
+  issuer: string | null;
+  notBefore: string | null;
+  notAfter: string | null;
+  status: string | null;
   daysRemaining: number;
-  san: string[];
+  san: string[] | null;
   certPem?: string;
   keyPem?: string;
 }

--- a/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
@@ -43,6 +43,18 @@ const certs: K8sCertInfo[] = [
     san: ['broker.prod.example.com'],
   },
   {
+    id: 3,
+    k8sId: 'metadata-only-tls',
+    cluster: 'legacy-cluster',
+    type: null,
+    issuer: null,
+    notBefore: null,
+    notAfter: null,
+    status: null,
+    daysRemaining: 0,
+    san: null,
+  },
+  {
     id: 2,
     k8sId: 'rocketmq-staging-tls',
     cluster: 'staging-cluster',
@@ -95,6 +107,18 @@ describe('K8sCertsPage', () => {
     expect(screen.queryByText('broker.prod.example.com')).not.toBeInTheDocument();
     expect(screen.queryByText('命名空间')).not.toBeInTheDocument();
     expect(screen.queryByText('SAN')).not.toBeInTheDocument();
+  });
+
+  it('renders and sorts incomplete certificate metadata safely', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('metadata-only-tls');
+    await user.click(screen.getByRole('columnheader', { name: /签发者/ }));
+    await user.click(screen.getByRole('columnheader', { name: /到期时间/ }));
+
+    expect(screen.getByText('metadata-only-tls')).toBeInTheDocument();
+    expect(screen.getAllByText('-').length).toBeGreaterThan(0);
   });
 
   it('explains that certificate records are Studio-local metadata', async () => {

--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -156,14 +156,14 @@ const K8sCertsPage = () => {
       dataIndex: 'type',
       key: 'type',
       width: 110,
-      sorter: (a, b) => a.type.localeCompare(b.type),
-      render: (type: string) => {
+      sorter: (a, b) => (a.type ?? '').localeCompare(b.type ?? ''),
+      render: (type: string | null) => {
         const colorMap: Record<string, string> = {
           TLS: 'blue',
           mTLS: 'purple',
           ServiceAccount: 'orange',
         };
-        return <Tag color={colorMap[type] ?? 'default'}>{type}</Tag>;
+        return type ? <Tag color={colorMap[type] ?? 'default'}>{type}</Tag> : '-';
       },
     },
     {
@@ -171,7 +171,8 @@ const K8sCertsPage = () => {
       dataIndex: 'issuer',
       key: 'issuer',
       width: 180,
-      sorter: (a, b) => a.issuer.localeCompare(b.issuer),
+      sorter: (a, b) => (a.issuer ?? '').localeCompare(b.issuer ?? ''),
+      render: (issuer: string | null) => issuer || '-',
       ellipsis: true,
     },
     {
@@ -179,8 +180,8 @@ const K8sCertsPage = () => {
       dataIndex: 'notAfter',
       key: 'notAfter',
       width: 170,
-      sorter: (a, b) => new Date(a.notAfter).getTime() - new Date(b.notAfter).getTime(),
-      render: (iso: string) => (
+      sorter: (a, b) => (Date.parse(a.notAfter ?? '') || 0) - (Date.parse(b.notAfter ?? '') || 0),
+      render: (iso: string | null) => (
         <Text type="secondary" style={{ fontSize: 14 }}>
           {formatDateTime(iso)}
         </Text>
@@ -208,15 +209,15 @@ const K8sCertsPage = () => {
       dataIndex: 'status',
       key: 'status',
       width: 100,
-      sorter: (a, b) => a.status.localeCompare(b.status),
-      render: (status: string) => {
+      sorter: (a, b) => (a.status ?? '').localeCompare(b.status ?? ''),
+      render: (status: string | null) => {
         const map: Record<string, { color: string; label: string }> = {
           valid: { color: 'green', label: '有效' },
           expiring: { color: 'orange', label: '即将过期' },
           expired: { color: 'red', label: '已过期' },
         };
-        const cfg = map[status] ?? { color: 'default', label: status };
-        return <Tag color={cfg.color}>{cfg.label}</Tag>;
+        const cfg = status ? map[status] ?? { color: 'default', label: status } : null;
+        return cfg ? <Tag color={cfg.color}>{cfg.label}</Tag> : '-';
       },
     },
     {

--- a/web/src/services/clusterService.ts
+++ b/web/src/services/clusterService.ts
@@ -142,7 +142,9 @@ export async function getNameServerConfigDiff(
 }
 
 export async function listK8sCerts(): Promise<K8sCertInfo[]> {
-  if (isMockMode()) return mockCertStore.map((cert) => ({ ...cert, san: [...cert.san] }));
+  if (isMockMode()) {
+    return mockCertStore.map((cert) => ({ ...cert, san: cert.san ? [...cert.san] : cert.san }));
+  }
   return clusterApi.listK8sCerts();
 }
 
@@ -164,7 +166,7 @@ export async function createK8sCert(data: Partial<K8sCertInfo>): Promise<K8sCert
       san: [...(data.san ?? [])],
     };
     mockCertStore.push(cert);
-    return { ...cert, san: [...cert.san] };
+    return { ...cert, san: cert.san ? [...cert.san] : cert.san };
   }
   return clusterApi.createK8sCert(data);
 }
@@ -174,7 +176,7 @@ export async function updateK8sCert(data: Partial<K8sCertInfo>): Promise<K8sCert
     const existing = mockCertStore.find((cert) => cert.id === data.id);
     if (!existing) throw new Error(`Certificate not found: ${data.id}`);
     Object.assign(existing, data, { san: data.san ? [...data.san] : existing.san });
-    return { ...existing, san: [...existing.san] };
+    return { ...existing, san: existing.san ? [...existing.san] : existing.san };
   }
   return clusterApi.updateK8sCert(data);
 }
@@ -192,7 +194,7 @@ export async function renewK8sCert(id: number): Promise<K8sCertInfo> {
       status: 'valid',
       daysRemaining: Math.round((notAfter.getTime() - now.getTime()) / (24 * 60 * 60 * 1000)),
     });
-    return { ...existing, san: [...existing.san] };
+    return { ...existing, san: existing.san ? [...existing.san] : existing.san };
   }
   return clusterApi.renewK8sCert(id);
 }


### PR DESCRIPTION
## Summary

- align the K8s certificate API type with nullable metadata returned by the backend
- render and sort missing type, issuer, expiration, and status values safely
- preserve nullable SAN metadata when cloning certificates in mock mode
- cover an incomplete certificate row and its sortable columns

## Why

Metadata-only and legacy certificate records can omit issuer and other parsed certificate fields. The table previously called string/date sort logic on those values directly, so sorting an incomplete row could break the inventory page.

## Validation

- `npm test -- --run src/pages/cluster/__tests__/K8sCertsPage.test.tsx` (7 tests passed)
- `npm run build`
- `npx eslint src/api/cluster.ts src/services/clusterService.ts src/pages/cluster/certs.tsx src/pages/cluster/__tests__/K8sCertsPage.test.tsx --max-warnings=0`
- `git diff --check`

Closes #2556.