### PR TITLE
fix(message): reject negative queue coordinates

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -91,6 +91,12 @@ public class MessageService {
         if (!StringUtils.hasText(brokerName)) {
             throw new BusinessException(400, "brokerName is required");
         }
+        if (queueId < 0) {
+            throw new BusinessException(400, "queueId must not be negative");
+        }
+        if (offset < 0) {
+            throw new BusinessException(400, "offset must not be negative");
+        }
         return messageProvider.pullMessageAtOffset(instanceId, topic, brokerName, queueId, offset);
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -28,6 +28,22 @@ import static org.mockito.Mockito.when;
 class MessageServiceTest {
 
     @Test
+    void rejectsNegativeQueueCoordinatesBeforeCallingProvider() {
+        MessageProvider provider = mock(MessageProvider.class);
+        MessageService service = new MessageService(provider, mock(InstanceProviderRegistry.class),
+                mock(QueryHistoryService.class));
+
+        assertThatThrownBy(() -> service.pullMessageAtOffset("instance-a", "TopicA", "broker-a", -1, 0))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("queueId must not be negative");
+        assertThatThrownBy(() -> service.pullMessageAtOffset("instance-a", "TopicA", "broker-a", 0, -1))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("offset must not be negative");
+
+        verifyNoInteractions(provider);
+    }
+
+    @Test
     void rejectsKeyQueryWithoutTopicBeforeCallingProvider() {
         MessageProvider provider = mock(MessageProvider.class);
         InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);


### PR DESCRIPTION
## Summary

- reject negative queue IDs before the queue browser invokes its provider
- reject negative queue offsets at the same service boundary
- verify invalid coordinates never reach the message provider

## Why

A queue ID and physical queue offset cannot be negative. Passing those values through to the RocketMQ client turned invalid user input into downstream provider errors instead of a stable client-facing 400 response.

## Validation

- `mvn -Dtest=MessageServiceTest test`
- Maven Checkstyle (0 violations)
- `git diff --check`

Closes #2557.