### PR TITLE
fix(acl): prevent Tencent rule page overflow

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -396,7 +396,7 @@ public class AclService {
 
     private static PageResult<AclRuleVO> paginateRules(List<AclRuleVO> rules, int page, int pageSize) {
         int total = rules.size();
-        int fromIndex = Math.min((page - 1) * pageSize, total);
+        int fromIndex = (int) Math.min(Pagination.pageOffset(page, pageSize), total);
         int toIndex = Math.min(fromIndex + pageSize, total);
         return PageResult.of(rules.subList(fromIndex, toIndex), total, page, pageSize);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -188,6 +188,25 @@ class AclServiceTest {
     }
 
     @Test
+    void listRulesShouldReturnEmptyPageWhenTencentPageOffsetExceedsIntegerRange() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("tencent-instance")
+                .vendor(InstanceVendor.TENCENT)
+                .type(InstanceType.CLOUD)
+                .build();
+        when(instanceRepository.findByIdentifier("tencent-instance")).thenReturn(Optional.of(instance));
+        when(tencentAclService.listRules("tencent-instance", null)).thenReturn(List.of(
+                AclRuleVO.builder().principal("role-a").resource("topic-a").build()));
+
+        PageResult<AclRuleVO> result = aclService.listRules(null, null, null, null, null,
+                "tencent-instance", Integer.MAX_VALUE, 100);
+
+        assertThat(result.getItems()).isEmpty();
+        assertThat(result.getTotal()).isEqualTo(1);
+        assertThat(result.getPage()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
     void createRuleShouldSetIdAndTimestamp() {
         AclRuleVO input = AclRuleVO.builder()
                 .principal("user1")


### PR DESCRIPTION
## Summary

- use the shared long-safe pagination offset for in-memory Tencent ACL rules
- return an empty page when the requested offset is beyond the available rules
- cover `Integer.MAX_VALUE` page input with the maximum supported page size

## Why

The previous `(page - 1) * pageSize` calculation used `int` arithmetic. Large but valid page values overflowed to a negative index and caused `subList` to fail instead of returning the normal empty-page response.

## Validation

- `mvn -Dtest=AclServiceTest test`
- Maven Checkstyle (0 violations)
- `git diff --check`

Closes #2558.