### PR TITLE
fix(acl): validate plain permission entries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -177,6 +177,8 @@ public class MybatisPlusAclRepository implements AclRepository {
     @Override
     @Transactional
     public PlainAccessConfigVO createAndUpdatePlainAccessConfig(PlainAccessConfigVO config) {
+        validatePermissionEntries(config.getTopicPerms(), "topicPerms");
+        validatePermissionEntries(config.getGroupPerms(), "groupPerms");
         List<RmqAclUser> existingAccounts = userMapper.selectList(
                 new QueryWrapper<RmqAclUser>().eq("access_key", config.getAccessKey()));
         if (existingAccounts.size() > 1) {
@@ -354,6 +356,19 @@ public class MybatisPlusAclRepository implements AclRepository {
             return null;
         }
         return new String[]{entry.substring(0, idx).trim(), entry.substring(idx + 1).trim()};
+    }
+
+    private static void validatePermissionEntries(List<String> entries, String field) {
+        if (entries == null) {
+            return;
+        }
+        for (int index = 0; index < entries.size(); index++) {
+            String[] parts = splitPerm(entries.get(index));
+            if (parts == null || parts[0].isBlank() || parts[1].isBlank()) {
+                throw new BusinessException(400,
+                        field + "[" + index + "] must use non-blank resource=permission format");
+            }
+        }
     }
 
     // ── Mapping ────────────────────────────────────────────────────

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
@@ -48,6 +48,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,6 +62,22 @@ class MybatisPlusAclRepositoryTest {
 
     @InjectMocks
     private MybatisPlusAclRepository repository;
+
+    @Test
+    void upsertShouldRejectMalformedPermissionEntriesBeforeMutatingAccount() {
+        PlainAccessConfigVO config = PlainAccessConfigVO.builder()
+                .accessKey("svc-x")
+                .secretKey("secret-x")
+                .topicPerms(List.of("orders=PUB", "missing-permission"))
+                .build();
+
+        assertThatThrownBy(() -> repository.createAndUpdatePlainAccessConfig(config))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topicPerms[1] must use non-blank resource=permission format")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+
+        verifyNoInteractions(userMapper, ruleMapper);
+    }
 
     @Test
     void findRulePageShouldApplyFiltersAndPreserveFilteredTotal() {


### PR DESCRIPTION
## Summary

- validate plain ACL topic and group permission entries before repository access
- require a non-blank `resource=permission` structure and identify the failing field/index
- prove malformed input produces a 400 response without any mapper interaction

## Why

Plain ACL upserts replace an account's per-resource rules. Malformed entries were silently skipped during replacement, so a successful update could unexpectedly discard an existing permission. Failing before any mutation keeps the previous account and rules intact.

## Validation

- `mvn -Dtest=MybatisPlusAclRepositoryTest test` (16 tests passed)
- Maven Checkstyle (0 violations)
- `git diff --check`

Closes #2559.