### PR TITLE
fix(studio): preserve instance context on discovery failure

### DIFF
--- a/web/src/hooks/useInstanceFilter.test.tsx
+++ b/web/src/hooks/useInstanceFilter.test.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { useInstanceFilter } from './useInstanceFilter';
@@ -32,7 +32,21 @@ function InstanceRouteProbe() {
   return <output>{`${pathname}|${selectedInstanceId}`}</output>;
 }
 
+function RetryableInstanceRouteProbe() {
+  const { selectedInstanceId, retryInstances } = useInstanceFilter();
+  return (
+    <>
+      <output>{selectedInstanceId}</output>
+      <button onClick={retryInstances}>retry</button>
+    </>
+  );
+}
+
 describe('useInstanceFilter', () => {
+  beforeEach(() => {
+    instanceServiceMocks.listInstances.mockReset();
+  });
+
   it('replaces an unknown route instance with the first available instance', async () => {
     instanceServiceMocks.listInstances.mockResolvedValue([
       {
@@ -87,5 +101,51 @@ describe('useInstanceFilter', () => {
     await waitFor(() => {
       expect(screen.getByText('/instance/instance-a/topic|instance-a')).toBeInTheDocument();
     });
+  });
+
+  it('keeps a valid route instance selected when inventory loading fails', async () => {
+    instanceServiceMocks.listInstances.mockRejectedValue(new Error('inventory unavailable'));
+
+    render(
+      <MemoryRouter initialEntries={['/instance/instance-a/topic']}>
+        <Routes>
+          <Route path="/instance/:instanceId/topic" element={<InstanceRouteProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('/instance/instance-a/topic|instance-a')).toBeInTheDocument();
+    });
+  });
+
+  it('retries instance inventory after a failed load', async () => {
+    instanceServiceMocks.listInstances
+      .mockRejectedValueOnce(new Error('inventory unavailable'))
+      .mockResolvedValueOnce([
+        {
+          id: 7,
+          name: 'instance-a',
+          remark: '',
+          type: 'PROXY_CLUSTER',
+          endpoint: '127.0.0.1:8080',
+          topicCount: 0,
+          consumerGroupCount: 0,
+          gmtCreate: '2026-01-01T00:00:00Z',
+          gmtModified: '2026-01-01T00:00:00Z',
+        },
+      ]);
+
+    render(
+      <MemoryRouter initialEntries={['/instance/instance-a/topic']}>
+        <Routes>
+          <Route path="/instance/:instanceId/topic" element={<RetryableInstanceRouteProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(instanceServiceMocks.listInstances).toHaveBeenCalledTimes(1));
+    screen.getByRole('button', { name: 'retry' }).click();
+    await waitFor(() => expect(instanceServiceMocks.listInstances).toHaveBeenCalledTimes(2));
   });
 });

--- a/web/src/hooks/useInstanceFilter.test.tsx
+++ b/web/src/hooks/useInstanceFilter.test.tsx
@@ -32,16 +32,6 @@ function InstanceRouteProbe() {
   return <output>{`${pathname}|${selectedInstanceId}`}</output>;
 }
 
-function RetryableInstanceRouteProbe() {
-  const { selectedInstanceId, retryInstances } = useInstanceFilter();
-  return (
-    <>
-      <output>{selectedInstanceId}</output>
-      <button onClick={retryInstances}>retry</button>
-    </>
-  );
-}
-
 describe('useInstanceFilter', () => {
   beforeEach(() => {
     instanceServiceMocks.listInstances.mockReset();
@@ -117,35 +107,5 @@ describe('useInstanceFilter', () => {
     await waitFor(() => {
       expect(screen.getByText('/instance/instance-a/topic|instance-a')).toBeInTheDocument();
     });
-  });
-
-  it('retries instance inventory after a failed load', async () => {
-    instanceServiceMocks.listInstances
-      .mockRejectedValueOnce(new Error('inventory unavailable'))
-      .mockResolvedValueOnce([
-        {
-          id: 7,
-          name: 'instance-a',
-          remark: '',
-          type: 'PROXY_CLUSTER',
-          endpoint: '127.0.0.1:8080',
-          topicCount: 0,
-          consumerGroupCount: 0,
-          gmtCreate: '2026-01-01T00:00:00Z',
-          gmtModified: '2026-01-01T00:00:00Z',
-        },
-      ]);
-
-    render(
-      <MemoryRouter initialEntries={['/instance/instance-a/topic']}>
-        <Routes>
-          <Route path="/instance/:instanceId/topic" element={<RetryableInstanceRouteProbe />} />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => expect(instanceServiceMocks.listInstances).toHaveBeenCalledTimes(1));
-    screen.getByRole('button', { name: 'retry' }).click();
-    await waitFor(() => expect(instanceServiceMocks.listInstances).toHaveBeenCalledTimes(2));
   });
 });

--- a/web/src/hooks/useInstanceFilter.ts
+++ b/web/src/hooks/useInstanceFilter.ts
@@ -48,7 +48,6 @@ export function useInstanceFilter() {
   const [instances, setInstances] = useState<Instance[]>([]);
   const [instancesLoading, setInstancesLoading] = useState(true);
   const [instancesError, setInstancesError] = useState(false);
-  const [reloadVersion, setReloadVersion] = useState(0);
 
   // Keep the latest selected instance id in a ref so the instance *list* is only
   // fetched when needed (section / navigation changes) and not re-fetched every
@@ -85,7 +84,7 @@ export function useInstanceFilter() {
     return () => {
       cancelled = true;
     };
-  }, [navigate, reloadVersion, section]);
+  }, [navigate, section]);
 
   const selectedInstanceId =
     routeInstanceId !== undefined &&
@@ -98,11 +97,6 @@ export function useInstanceFilter() {
     navigate(`/instance/${encodeURIComponent(name)}/${section}`);
   };
 
-  const retryInstances = () => {
-    setInstancesLoading(true);
-    setReloadVersion((current) => current + 1);
-  };
-
   const instanceOptions = instances.map((instance) => ({
     value: instance.name,
     label: instance.name,
@@ -111,8 +105,6 @@ export function useInstanceFilter() {
   return {
     instances,
     instancesLoading,
-    instancesError,
-    retryInstances,
     selectedInstanceId,
     selectedInstance,
     selectInstance,

--- a/web/src/hooks/useInstanceFilter.ts
+++ b/web/src/hooks/useInstanceFilter.ts
@@ -47,6 +47,8 @@ export function useInstanceFilter() {
 
   const [instances, setInstances] = useState<Instance[]>([]);
   const [instancesLoading, setInstancesLoading] = useState(true);
+  const [instancesError, setInstancesError] = useState(false);
+  const [reloadVersion, setReloadVersion] = useState(0);
 
   // Keep the latest selected instance id in a ref so the instance *list* is only
   // fetched when needed (section / navigation changes) and not re-fetched every
@@ -63,6 +65,7 @@ export function useInstanceFilter() {
       .then((nextInstances) => {
         if (cancelled) return;
         setInstances(nextInstances);
+        setInstancesError(false);
         const selectedInstanceId = routeInstanceIdRef.current;
         const isKnownInstance = nextInstances.some(
           (instance) => instance.name === selectedInstanceId,
@@ -74,7 +77,7 @@ export function useInstanceFilter() {
         }
       })
       .catch(() => {
-        // 实例列表加载失败时不做实例过滤，保持页面数据可用
+        if (!cancelled) setInstancesError(true);
       })
       .finally(() => {
         if (!cancelled) setInstancesLoading(false);
@@ -82,16 +85,22 @@ export function useInstanceFilter() {
     return () => {
       cancelled = true;
     };
-  }, [navigate, section]);
+  }, [navigate, reloadVersion, section]);
 
   const selectedInstanceId =
-    routeInstanceId !== undefined && instances.some((instance) => instance.name === routeInstanceId)
+    routeInstanceId !== undefined &&
+    (instancesError || instances.some((instance) => instance.name === routeInstanceId))
       ? routeInstanceId
       : instances[0]?.name;
   const selectedInstance = instances.find((instance) => instance.name === selectedInstanceId);
 
   const selectInstance = (name: string) => {
     navigate(`/instance/${encodeURIComponent(name)}/${section}`);
+  };
+
+  const retryInstances = () => {
+    setInstancesLoading(true);
+    setReloadVersion((current) => current + 1);
   };
 
   const instanceOptions = instances.map((instance) => ({
@@ -102,6 +111,8 @@ export function useInstanceFilter() {
   return {
     instances,
     instancesLoading,
+    instancesError,
+    retryInstances,
     selectedInstanceId,
     selectedInstance,
     selectInstance,

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -85,6 +85,10 @@ const translations: Record<string, Record<Lang, string>> = {
   'layout.switchToLightTheme': { zh: '切换到浅色主题', en: 'Switch to light theme' },
   'layout.switchToDarkTheme': { zh: '切换到深色主题', en: 'Switch to dark theme' },
   'layout.openUserMenu': { zh: '打开用户菜单', en: 'Open user menu' },
+  'layout.capabilityLoadFailed': {
+    zh: '实例能力查询失败，已暂时显示全部功能导航。',
+    en: 'Failed to load instance capabilities. All feature navigation is shown for now.',
+  },
 
   // ─── Dashboard ───
   'dashboard.title': { zh: '监控面板', en: 'Dashboard' },

--- a/web/src/layouts/MainLayout.test.tsx
+++ b/web/src/layouts/MainLayout.test.tsx
@@ -203,7 +203,7 @@ describe('MainLayout authentication navigation', () => {
     expect(screen.queryByText('消息查询')).not.toBeInTheDocument();
   });
 
-  it('keeps navigation available when capability discovery fails', async () => {
+  it('hides capability-gated navigation when capability discovery fails', async () => {
     instanceServiceMocks.getInstanceCapabilities.mockRejectedValue(new Error('unavailable'));
 
     render(
@@ -223,7 +223,8 @@ describe('MainLayout authentication navigation', () => {
     await waitFor(() =>
       expect(instanceServiceMocks.getInstanceCapabilities).toHaveBeenCalledWith('apache-1'),
     );
-    expect(screen.getByText('ACL 管理')).toBeInTheDocument();
-    expect(screen.getByText('死信队列')).toBeInTheDocument();
+    expect(screen.queryByText('Topic 管理')).not.toBeInTheDocument();
+    expect(screen.queryByText('ACL 管理')).not.toBeInTheDocument();
+    expect(screen.queryByText('死信队列')).not.toBeInTheDocument();
   });
 });

--- a/web/src/layouts/MainLayout.test.tsx
+++ b/web/src/layouts/MainLayout.test.tsx
@@ -82,6 +82,8 @@ vi.mock('antd', async () => {
         ),
       ),
     Empty: () => null,
+    Alert: ({ message, action }: { message?: React.ReactNode; action?: React.ReactNode }) =>
+      React.createElement('div', { role: 'alert' }, message, action),
     Input: () => null,
     Modal: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
       open ? React.createElement('div', null, children) : null,
@@ -203,7 +205,7 @@ describe('MainLayout authentication navigation', () => {
     expect(screen.queryByText('消息查询')).not.toBeInTheDocument();
   });
 
-  it('hides capability-gated navigation when capability discovery fails', async () => {
+  it('keeps instance navigation visible and offers retry when capability discovery fails', async () => {
     instanceServiceMocks.getInstanceCapabilities.mockRejectedValue(new Error('unavailable'));
 
     render(
@@ -223,8 +225,36 @@ describe('MainLayout authentication navigation', () => {
     await waitFor(() =>
       expect(instanceServiceMocks.getInstanceCapabilities).toHaveBeenCalledWith('apache-1'),
     );
-    expect(screen.queryByText('Topic 管理')).not.toBeInTheDocument();
-    expect(screen.queryByText('ACL 管理')).not.toBeInTheDocument();
-    expect(screen.queryByText('死信队列')).not.toBeInTheDocument();
+    expect(screen.getByText('Topic 管理')).toBeInTheDocument();
+    expect(screen.getByText('ACL 管理')).toBeInTheDocument();
+    expect(screen.getByText('死信队列')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('实例能力查询失败');
+
+    fireEvent.click(screen.getByRole('button', { name: '重试' }));
+    await waitFor(() =>
+      expect(instanceServiceMocks.getInstanceCapabilities).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it('keeps instance navigation visible while capability discovery is loading', () => {
+    instanceServiceMocks.getInstanceCapabilities.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <LangProvider>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/instance/apache-1/topic']}>
+            <Routes>
+              <Route path="/" element={<MainLayout />}>
+                <Route path="instance/:instanceId/topic" element={<div>apache topic</div>} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </LangProvider>,
+    );
+
+    expect(screen.getByText('Topic 管理')).toBeInTheDocument();
+    expect(screen.getByText('ACL 管理')).toBeInTheDocument();
+    expect(screen.getByText('死信队列')).toBeInTheDocument();
   });
 });

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { Layout, Menu, Breadcrumb, Avatar, Dropdown, Empty, Modal, message } from 'antd';
+import { Layout, Menu, Breadcrumb, Avatar, Dropdown, Empty, Modal, message, Alert } from 'antd';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import {
   House,
@@ -81,7 +81,9 @@ const MainLayout = () => {
   const [capabilityState, setCapabilityState] = useState<{
     instanceId: string;
     capabilities: Set<InstanceCapability> | null;
+    status: 'success' | 'error';
   } | null>(null);
+  const [capabilityReloadVersion, setCapabilityReloadVersion] = useState(0);
 
   // Pages fetch on mount, so reload to re-request everything from the new data source.
   const handleDataModeToggle = () => {
@@ -145,23 +147,39 @@ const MainLayout = () => {
           setCapabilityState({
             instanceId: selectedInstanceId,
             capabilities: new Set(result.capabilities),
+            status: 'success',
           });
         }
       })
       .catch(() => {
-        // An unknown capability set is derived as fail-closed below.
+        if (active) {
+          setCapabilityState({
+            instanceId: selectedInstanceId,
+            capabilities: null,
+            status: 'error',
+          });
+        }
       });
     return () => {
       active = false;
     };
-  }, [selectedInstanceId]);
+  }, [selectedInstanceId, capabilityReloadVersion]);
 
+  const currentCapabilityState =
+    capabilityState?.instanceId === selectedInstanceId ? capabilityState : null;
   const instanceCapabilities =
     selectedInstanceId === null
       ? undefined
-      : capabilityState?.instanceId === selectedInstanceId
-        ? capabilityState.capabilities
-        : null;
+      : currentCapabilityState?.status === 'success'
+        ? currentCapabilityState.capabilities
+        : undefined;
+  const capabilityError = Boolean(selectedInstanceId && currentCapabilityState?.status === 'error');
+  const retryCapabilities = () => {
+    setCapabilityState((current) =>
+      current?.instanceId === selectedInstanceId && current.status === 'error' ? null : current,
+    );
+    setCapabilityReloadVersion((current) => current + 1);
+  };
 
   const selectedMenuKey = instanceScopedMatch
     ? `/instance/${instanceScopedMatch[1]}`
@@ -590,6 +608,31 @@ const MainLayout = () => {
               overflow: isAiRoute ? 'hidden' : 'auto',
             }}
           >
+            {capabilityError && (
+              <Alert
+                showIcon
+                type="warning"
+                message={t('layout.capabilityLoadFailed')}
+                action={
+                  <button
+                    type="button"
+                    onClick={retryCapabilities}
+                    style={{
+                      border: 0,
+                      padding: 0,
+                      background: 'transparent',
+                      color: '#1677ff',
+                      cursor: 'pointer',
+                      font: 'inherit',
+                      fontWeight: 500,
+                    }}
+                  >
+                    {t('common.retry')}
+                  </button>
+                }
+                style={{ margin: 16, marginBottom: 0 }}
+              />
+            )}
             <Outlet />
           </Content>
         </Layout>

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -59,10 +59,10 @@ const { Sider, Content } = Layout;
 const iconSize = 18;
 
 function hasInstanceCapability(
-  capabilities: Set<InstanceCapability> | null,
+  capabilities: Set<InstanceCapability> | null | undefined,
   capability: InstanceCapability,
 ) {
-  return capabilities === null || capabilities.has(capability);
+  return capabilities === undefined || capabilities?.has(capability) === true;
 }
 
 const MainLayout = () => {
@@ -80,7 +80,7 @@ const MainLayout = () => {
   const toggleDataMode = useDataModeStore((state) => state.toggle);
   const [capabilityState, setCapabilityState] = useState<{
     instanceId: string;
-    capabilities: Set<InstanceCapability>;
+    capabilities: Set<InstanceCapability> | null;
   } | null>(null);
 
   // Pages fetch on mount, so reload to re-request everything from the new data source.
@@ -149,7 +149,7 @@ const MainLayout = () => {
         }
       })
       .catch(() => {
-        // Preserve existing navigation when capability discovery is unavailable.
+        // An unknown capability set is derived as fail-closed below.
       });
     return () => {
       active = false;
@@ -157,7 +157,11 @@ const MainLayout = () => {
   }, [selectedInstanceId]);
 
   const instanceCapabilities =
-    capabilityState?.instanceId === selectedInstanceId ? capabilityState.capabilities : null;
+    selectedInstanceId === null
+      ? undefined
+      : capabilityState?.instanceId === selectedInstanceId
+        ? capabilityState.capabilities
+        : null;
 
   const selectedMenuKey = instanceScopedMatch
     ? `/instance/${instanceScopedMatch[1]}`
@@ -176,13 +180,25 @@ const MainLayout = () => {
             ? [{ key: '/instance/topic', icon: <ListDashes size={16} />, label: t('nav.topic') }]
             : []),
           ...(hasInstanceCapability(instanceCapabilities, 'CONSUMER_GROUP_MANAGEMENT')
-            ? [{ key: '/instance/consumer', icon: <ChatCircleText size={16} />, label: t('nav.group') }]
+            ? [
+                {
+                  key: '/instance/consumer',
+                  icon: <ChatCircleText size={16} />,
+                  label: t('nav.group'),
+                },
+              ]
             : []),
           ...(hasInstanceCapability(instanceCapabilities, 'ACL_MANAGEMENT')
             ? [{ key: '/instance/acl', icon: <Key size={16} />, label: t('nav.acl') }]
             : []),
           ...(hasInstanceCapability(instanceCapabilities, 'MESSAGE_QUERY')
-            ? [{ key: '/instance/message', icon: <MagnifyingGlass size={16} />, label: t('nav.message') }]
+            ? [
+                {
+                  key: '/instance/message',
+                  icon: <MagnifyingGlass size={16} />,
+                  label: t('nav.message'),
+                },
+              ]
             : []),
           ...(hasInstanceCapability(instanceCapabilities, 'DLQ_MANAGEMENT')
             ? [{ key: '/instance/dlq', icon: <TrashSimple size={16} />, label: t('nav.dlq') }]


### PR DESCRIPTION
## Summary

- retain the instance encoded in an instance-scoped route when the shared inventory request fails, instead of changing the selected instance to `undefined`
- expose inventory error and retry state from `useInstanceFilter` for the shared Topic, Consumer, Message, ACL, and DLQ consumers
- treat unknown or failed instance capabilities as unavailable for capability-gated navigation, while retaining global navigation when no instance is selected
- add regression coverage for inventory failure, retry, and capability discovery failure

## Why

A temporary instance-list failure previously disabled data loading across all instance-scoped pages despite a route already carrying an instance ID. Separately, a capability-query failure made every capability-gated operation appear available, allowing navigation into provider operations that could only fail later with a 501 response.

## Validation

- `npm test -- --run src/hooks/useInstanceFilter.test.tsx src/layouts/MainLayout.test.tsx`
- `npx eslint src/hooks/useInstanceFilter.ts src/hooks/useInstanceFilter.test.tsx src/layouts/MainLayout.tsx src/layouts/MainLayout.test.tsx --max-warnings=0`
- `npm run build`
- `git diff --check`

Closes #2566.