### PR TITLE
fix(message): surface body encoding and truncation metadata

### DIFF
--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -10,10 +10,16 @@ export interface MessageRecord {
   queueId: number | null;
   queueOffset: number | null;
   body: string;
+  /** How `body` is encoded: "UTF-8" for text, "BASE64" for binary payloads. */
+  bodyEncoding?: string | null;
+  /** True when the backend clipped the body to its display limit. */
+  bodyTruncated?: boolean;
   storeTime: number | string;
   bornHost: string;
   storeHost: string;
   properties: Record<string, string>;
+  /** True when some properties were dropped by the backend display limit. */
+  propertiesTruncated?: boolean;
   size: number;
 }
 

--- a/web/src/pages/instance/__tests__/MessageBodyEncoding.test.tsx
+++ b/web/src/pages/instance/__tests__/MessageBodyEncoding.test.tsx
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { App } from 'antd';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MessageRecord } from '../../../api/message';
+import { LangProvider } from '../../../i18n/LangContext';
+
+const messageServiceMocks = vi.hoisted(() => ({
+  getMessageTrace: vi.fn(),
+  queryMessages: vi.fn(),
+}));
+const topicServiceMocks = vi.hoisted(() => ({
+  listTopics: vi.fn(),
+}));
+const instanceFilterMocks = vi.hoisted(() => ({
+  useInstanceFilter: vi.fn(),
+}));
+const downloadMocks = vi.hoisted(() => ({
+  downloadBlob: vi.fn(),
+}));
+
+vi.mock('../../../services/messageService', () => ({
+  ...messageServiceMocks,
+  queryMessagePage: (params: Record<string, unknown>) =>
+    Promise.resolve(messageServiceMocks.queryMessages(params)).then((items: MessageRecord[]) => ({
+      items,
+      total: items.length,
+      page: 1,
+      size: 50,
+      resultMayBeTruncated: false,
+    })),
+}));
+vi.mock('../../../hooks/useInstanceFilter', () => instanceFilterMocks);
+vi.mock('../../../services/instanceService', () => ({
+  listInstances: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../../../services/topicService', () => topicServiceMocks);
+vi.mock('../../../utils/download', () => downloadMocks);
+
+import MessagePage from '../message';
+
+const baseRecord: Omit<MessageRecord, 'msgId' | 'topic' | 'body' | 'bodyEncoding'> = {
+  tag: 'tag',
+  key: 'key-1',
+  brokerName: 'broker-a',
+  queueId: 0,
+  queueOffset: 0,
+  bodyTruncated: false,
+  storeTime: '2026-07-31T00:00:00Z',
+  bornHost: '127.0.0.1:1000',
+  storeHost: '127.0.0.1:10911',
+  properties: {},
+  propertiesTruncated: false,
+  size: 64,
+};
+
+const binaryMessage: MessageRecord = {
+  ...baseRecord,
+  msgId: 'binary-msg',
+  topic: 'image-upload',
+  body: 'AAEC AQIBAA==',
+  bodyEncoding: 'BASE64',
+  bodyTruncated: true,
+  propertiesTruncated: true,
+};
+
+const textMessage: MessageRecord = {
+  ...baseRecord,
+  msgId: 'text-msg',
+  topic: 'order-create',
+  body: '{"orderId":42}',
+  bodyEncoding: 'UTF-8',
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <App>
+      <LangProvider>
+        <MemoryRouter>{ui}</MemoryRouter>
+      </LangProvider>
+    </App>,
+  );
+
+describe('Message body encoding and truncation metadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    messageServiceMocks.getMessageTrace.mockResolvedValue(null);
+    messageServiceMocks.queryMessages.mockResolvedValue([binaryMessage, textMessage]);
+    topicServiceMocks.listTopics.mockResolvedValue([
+      { name: 'image-upload' },
+      { name: 'order-create' },
+    ]);
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 1,
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 1, label: 'Instance A' }],
+    });
+  });
+
+  const lastElement = <T,>(elements: T[]): T => elements[elements.length - 1]!;
+
+  const queryCurrentInstance = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(lastElement(screen.getAllByRole('combobox')));
+    await user.click(lastElement(await screen.findAllByText('image-upload')));
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+    await screen.findByText('binary-msg');
+    await screen.findByText('text-msg');
+  };
+
+  it('warns about truncated bodies and properties and marks Base64 bodies in the detail view', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<MessagePage />);
+    await queryCurrentInstance(user);
+
+    const detailButtons = await screen.findAllByRole('button', { name: /详情/ });
+    await user.click(detailButtons[0]);
+
+    expect(await screen.findByText('Base64')).toBeInTheDocument();
+    expect(screen.getByText('消息体超过展示上限，下方内容已被截断')).toBeInTheDocument();
+    expect(screen.getByText('消息属性数量或长度超限，部分属性未完整展示')).toBeInTheDocument();
+    expect(screen.getByText('AAEC AQIBAA==')).toBeInTheDocument();
+  });
+
+  it('keeps plain text bodies free of encoding warnings', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<MessagePage />);
+    await queryCurrentInstance(user);
+
+    const detailButtons = await screen.findAllByRole('button', { name: /详情/ });
+    await user.click(detailButtons[1]);
+
+    await screen.findByText(/orderId/);
+    expect(screen.queryByText('Base64')).not.toBeInTheDocument();
+    expect(screen.queryByText('消息体超过展示上限，下方内容已被截断')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('消息属性数量或长度超限，部分属性未完整展示'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('downloads Base64 bodies as plain text and UTF-8 bodies as JSON', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<MessagePage />);
+    await queryCurrentInstance(user);
+
+    const downloadButtons = await screen.findAllByRole('button', { name: /下载/ });
+    await user.click(downloadButtons[0]);
+    await waitFor(() => expect(downloadMocks.downloadBlob).toHaveBeenCalledTimes(1));
+    const binaryCall = downloadMocks.downloadBlob.mock.calls[0];
+    expect(binaryCall[1]).toBe('binary-msg.txt');
+    expect(binaryCall[0].type).toBe('text/plain');
+    await expect(binaryCall[0].text()).resolves.toBe('AAEC AQIBAA==');
+
+    await user.click(downloadButtons[1]);
+    await waitFor(() => expect(downloadMocks.downloadBlob).toHaveBeenCalledTimes(2));
+    const textCall = downloadMocks.downloadBlob.mock.calls[1];
+    expect(textCall[1]).toBe('text-msg.json');
+    expect(textCall[0].type).toBe('application/json');
+    await expect(textCall[0].text()).resolves.toContain('"orderId": 42');
+  });
+});

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -124,6 +124,9 @@ const formatTimeMs = (value: number | string): string => {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`;
 };
 
+const isBase64Body = (record: MessageRecord): boolean =>
+  (record.bodyEncoding ?? '').toUpperCase() === 'BASE64';
+
 const formatBody = (body: string): string => {
   try {
     return JSON.stringify(JSON.parse(body), null, 2);
@@ -420,8 +423,16 @@ const MessagePageContent = ({
   };
 
   const handleDownload = (record: MessageRecord) => {
-    const blob = new Blob([formatBody(record.body)], { type: 'application/json' });
-    downloadBlob(blob, `${record.msgId}.json`);
+    if (isBase64Body(record)) {
+      // Binary payloads arrive Base64-encoded; keep the encoding as plain text
+      // instead of forcing the encoded string through the JSON formatter.
+      downloadBlob(new Blob([record.body], { type: 'text/plain' }), `${record.msgId}.txt`);
+    } else {
+      downloadBlob(
+        new Blob([formatBody(record.body)], { type: 'application/json' }),
+        `${record.msgId}.json`,
+      );
+    }
     message.success('消息下载成功');
   };
 
@@ -616,9 +627,28 @@ const MessagePageContent = ({
               <span style={{ fontFamily: 'monospace' }}>{formatTimeMs(selectedMsg.storeTime)}</span>
             </Descriptions.Item>
           </Descriptions>
-          <Typography.Title level={5} style={{ marginBottom: 8 }}>
-            消息体
-          </Typography.Title>
+          {selectedMsg.bodyTruncated && (
+            <Alert
+              showIcon
+              type="warning"
+              message="消息体超过展示上限，下方内容已被截断"
+              style={{ marginBottom: 12 }}
+            />
+          )}
+          {selectedMsg.propertiesTruncated && (
+            <Alert
+              showIcon
+              type="warning"
+              message="消息属性数量或长度超限，部分属性未完整展示"
+              style={{ marginBottom: 12 }}
+            />
+          )}
+          <Flex align="center" gap={8} style={{ marginBottom: 8 }}>
+            <Typography.Title level={5} style={{ marginBottom: 0 }}>
+              消息体
+            </Typography.Title>
+            {isBase64Body(selectedMsg) && <Tag color="geekblue">Base64</Tag>}
+          </Flex>
           <Paragraph
             copyable
             style={{


### PR DESCRIPTION
## What is the purpose of the change

The backend already reports `bodyEncoding`, `bodyTruncated` and `propertiesTruncated` on every message record, but the frontend type dropped all three fields. Base64-encoded binary bodies were therefore rendered and downloaded as if they were complete plain text: the detail view pretty-printed the encoded string as JSON, and the download button always wrote a `.json` file.

## Brief changelog

- complete the `MessageRecord` type with the three metadata fields
- the detail view now shows truncation warnings for clipped bodies and property maps, and marks Base64 bodies with a tag
- downloads pick the content and extension from the encoding: Base64 bodies are saved verbatim as `.txt`, UTF-8 bodies keep the JSON pretty-printing behavior

## How was this patch verified

- new `MessageBodyEncoding` page tests (3/3 green): detail warnings for truncated body/properties and the Base64 marker, no warnings for plain UTF-8 bodies, and download content/extension per encoding
- `web/src/api/message.test.ts` 7/7 green; `tsc -b` and `eslint` clean
- remaining MessagePage test failures are pre-existing on the base branch (recent-query button removed in a later refactor)

Fixes #2501