### PR TITLE
fix(topic): allow clearing persisted topic remarks

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -353,8 +353,12 @@ public class RocketMQAdminClientImpl implements AdminClient {
                     if (topic.getType() != null) {
                         existing.setTopicType(topic.getType().name());
                     }
-                    if (StringUtils.hasText(topic.getRemark())) {
-                        existing.setRemark(topic.getRemark());
+                    // Distinguish "remark not submitted" (null: keep the stored value) from
+                    // "remark submitted blank" (clear it); a hasText() guard treated both the
+                    // same, so users could never remove a persisted remark.
+                    if (topic.getRemark() != null) {
+                        String remark = topic.getRemark().trim();
+                        existing.setRemark(remark.isEmpty() ? null : remark);
                     }
                     existing.setGmtModified(LocalDateTime.now());
                     topicMapper.updateById(existing);
@@ -366,6 +370,11 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 topic.setId(existing == null ? null : existing.getId());
                 topic.setWriteQueues(writeQueues);
                 topic.setReadQueues(readQueues);
+                // Echo the persisted remark (kept, replaced or cleared) so the response
+                // matches the stored state instead of the raw request value.
+                if (existing != null) {
+                    topic.setRemark(existing.getRemark());
+                }
                 return topic;
             } catch (BusinessException e) {
                 recordAudit("UPDATE_TOPIC", topicName, e.getMessage(), "FAILED");

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -422,6 +422,42 @@ class RocketMQAdminClientImplTest {
     }
 
     @Test
+    void updateTopicClearsRemarkWhenBlankSubmitted() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqTopic.class);
+        RmqTopic existing = new RmqTopic();
+        existing.setRemark("old remark");
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithMaster());
+        when(topicMapper.selectOne(any())).thenReturn(existing);
+
+        TopicVO topic = new TopicVO();
+        topic.setName("orders");
+        topic.setRemark("   ");
+
+        TopicVO updated = adminClient.updateTopic(topic);
+
+        assertThat(existing.getRemark()).isNull();
+        assertThat(updated.getRemark()).isNull();
+        verify(topicMapper).updateById(existing);
+    }
+
+    @Test
+    void updateTopicKeepsRemarkWhenNotSubmitted() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqTopic.class);
+        RmqTopic existing = new RmqTopic();
+        existing.setRemark("old remark");
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithMaster());
+        when(topicMapper.selectOne(any())).thenReturn(existing);
+
+        TopicVO topic = new TopicVO();
+        topic.setName("orders");
+
+        TopicVO updated = adminClient.updateTopic(topic);
+
+        assertThat(existing.getRemark()).isEqualTo("old remark");
+        assertThat(updated.getRemark()).isEqualTo("old remark");
+    }
+
+    @Test
     void topicWritesSendMessageTypeAttributeToBroker() throws Exception {
         TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqTopic.class);
         when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithMaster());


### PR DESCRIPTION
﻿## What is the purpose of the change

``updateTopic`` only wrote the remark when ``StringUtils.hasText()`` passed, so submitting a blank value behaved exactly like not submitting one and the stored remark could never be removed.

## Brief changelog

- treat a null remark as "not submitted" (keep the stored value) and a submitted blank/whitespace remark as "clear" (store null), trimming the value in between
- echo the persisted remark back on the response so the returned VO reflects the stored state instead of the raw request value

## How was this patch verified

- ``RocketMQAdminClientImplTest`` 37/37 green, including two new cases: blank submission clears the stored remark, omitted remark keeps it
- ``TopicControllerTest`` 14/14 and ``MetadataServiceTest`` 21/21 green on JDK 21

Fixes #2497
