### PR TITLE
fix(trace): map failed trace nodes to the error step status

### DIFF
--- a/web/src/api/message.test.ts
+++ b/web/src/api/message.test.ts
@@ -18,7 +18,12 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { consumeMessageDirectly, getMessageTrace, queryMessagePage, queryMessages } from './message';
+import {
+  consumeMessageDirectly,
+  getMessageTrace,
+  queryMessagePage,
+  queryMessages,
+} from './message';
 
 const mock = new MockAdapter(client);
 
@@ -123,6 +128,49 @@ describe('message API', () => {
       .reply(200, { code: 200, data: trace });
 
     await expect(getMessageTrace('msg-1', 'instance-1', 'orders')).resolves.toEqual(trace);
+  });
+
+  it('maps backend trace node statuses to Ant Design step statuses', async () => {
+    const trace = {
+      nodes: [
+        {
+          title: 'Produce',
+          timestamp: 1784246400000,
+          status: 'failed',
+          costTime: 1,
+          description: 'x',
+        },
+        {
+          title: 'Consume',
+          timestamp: 1784246400000,
+          status: 'finish',
+          costTime: 1,
+          description: 'x',
+        },
+        {
+          title: 'In flight',
+          timestamp: 1784246400000,
+          status: 'process',
+          costTime: 1,
+          description: 'x',
+        },
+        {
+          title: 'Unknown',
+          timestamp: 1784246400000,
+          status: 'something-else',
+          costTime: 1,
+          description: 'x',
+        },
+      ],
+      consumerStatus: [],
+    };
+    mock
+      .onGet('/messages/msg-2/trace', { params: { instanceId: 'instance-1' } })
+      .reply(200, { code: 200, data: trace });
+
+    const mapped = await getMessageTrace('msg-2', 'instance-1');
+    expect(mapped.nodes.map((node) => node.status)).toEqual(['error', 'finish', 'process', 'wait']);
+    expect(mapped.consumerStatus).toEqual([]);
   });
 
   it('encodes message IDs before requesting trace records', async () => {

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -139,6 +139,18 @@ export async function queryMessagePage(
   return { ...res.data.data, items: sortMessagesByStoreTimeDesc(res.data.data.items) };
 }
 
+// The backend reports business statuses ("finish" | "failed") on trace nodes,
+// while the Ant Design Steps component only understands
+// 'error' | 'wait' | 'process' | 'finish'. Map at the API boundary so the UI
+// never sees a status it cannot render.
+const mapTraceNodeStatus = (status: unknown): TraceNode['status'] => {
+  if (status === 'failed') return 'error';
+  if (status === 'finish' || status === 'process' || status === 'error' || status === 'wait') {
+    return status;
+  }
+  return 'wait';
+};
+
 export async function getMessageTrace(
   msgId: string,
   instanceId?: string,
@@ -153,7 +165,14 @@ export async function getMessageTrace(
     `/messages/${encodeURIComponent(msgId)}/trace`,
     { params },
   );
-  return res.data.data;
+  const trace = res.data.data;
+  return {
+    ...trace,
+    nodes: (trace.nodes ?? []).map((node) => ({
+      ...node,
+      status: mapTraceNodeStatus(node.status),
+    })),
+  };
 }
 
 export async function consumeMessageDirectly(data: DirectConsumeMessageRequest) {


### PR DESCRIPTION
## What is the purpose of the change

The backend reports business statuses on trace nodes (``"finish" | "failed"``), while the frontend ``TraceNode`` type and the Ant Design Steps component only understand ``'error' | 'wait' | 'process' | 'finish'``. A failed produce/consume/recall step therefore carried status ``"failed"`` into the Steps items and never rendered as the red error state.

## Brief changelog

- map node statuses at the API boundary in ``getMessageTrace``: ``"failed"`` becomes ``"error"``, the four known step statuses pass through, and any unknown status degrades to ``"wait"`` instead of a forced cast

## How was this patch verified

- new ``message API`` test asserts the mapping (failed -> error, finish/process pass through, unknown -> wait); ``web/src/api/message.test.ts`` 6/6 and ``web/src/services/messageService.test.ts`` 5/5 green
- ``tsc -b`` and ``eslint``/``prettier`` clean on the touched files

Fixes #2502