### PR TITLE
[Studio] feat: filter observability asset catalogs

### DIFF
--- a/web/src/components/AlertRuleAssetList.tsx
+++ b/web/src/components/AlertRuleAssetList.tsx
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { Alert, App, Button, Modal, Space, Table, Tag, Typography } from 'antd';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, App, Button, Input, Modal, Select, Space, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { ArrowClockwise, DownloadSimple, Eye } from '@phosphor-icons/react';
 import { useLang } from '../i18n/LangContext';
@@ -40,6 +40,8 @@ export const AlertRuleAssetList: React.FC = () => {
   const { t } = useLang();
   const { message } = App.useApp();
   const [assets, setAssets] = useState<AlertRuleAssetInfo[]>([]);
+  const [searchText, setSearchText] = useState('');
+  const [selectedSeverities, setSelectedSeverities] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const [viewing, setViewing] = useState<AlertRuleAssetInfo | null>(null);
@@ -49,6 +51,30 @@ export const AlertRuleAssetList: React.FC = () => {
   const listRequestId = useRef(0);
   const viewRequestId = useRef(0);
   const [exportingNames, setExportingNames] = useState<Set<string>>(() => new Set());
+
+  const severityOptions = useMemo(
+    () =>
+      Array.from(new Set(assets.flatMap((asset) => asset.severities || [])))
+        .sort((a, b) => a.localeCompare(b))
+        .map((severity) => ({ label: severity.toUpperCase(), value: severity })),
+    [assets],
+  );
+
+  const filteredAssets = useMemo(() => {
+    const normalizedSearch = searchText.trim().toLowerCase();
+    return assets.filter((asset) => {
+      const matchesSearch =
+        !normalizedSearch ||
+        [asset.name, asset.group]
+          .filter(Boolean)
+          .some((value) => value.toLowerCase().includes(normalizedSearch));
+      const matchesSeverity =
+        selectedSeverities.length === 0 ||
+        selectedSeverities.some((severity) => (asset.severities || []).includes(severity));
+
+      return matchesSearch && matchesSeverity;
+    });
+  }, [assets, searchText, selectedSeverities]);
 
   const loadAssets = useCallback(async () => {
     const requestId = ++listRequestId.current;
@@ -182,6 +208,27 @@ export const AlertRuleAssetList: React.FC = () => {
 
   return (
     <div>
+      <Space style={{ marginBottom: 12 }}>
+        <Input.Search
+          allowClear
+          placeholder={t('alertAssets.searchPlaceholder')}
+          value={searchText}
+          onChange={(event) => setSearchText(event.target.value)}
+          onSearch={setSearchText}
+          style={{ width: 280 }}
+        />
+        <Select
+          allowClear
+          mode="multiple"
+          maxTagCount="responsive"
+          options={severityOptions}
+          placeholder={t('alertAssets.allSeverities')}
+          value={selectedSeverities}
+          onChange={setSelectedSeverities}
+          style={{ minWidth: 220 }}
+        />
+      </Space>
+
       {loadError && (
         <Alert
           showIcon
@@ -202,7 +249,7 @@ export const AlertRuleAssetList: React.FC = () => {
 
       <Table
         columns={columns}
-        dataSource={assets}
+        dataSource={filteredAssets}
         loading={loading}
         rowKey="name"
         pagination={false}

--- a/web/src/components/GrafanaDashboardList.tsx
+++ b/web/src/components/GrafanaDashboardList.tsx
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { Alert, App, Button, Modal, Space, Table, Tag, Typography } from 'antd';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, App, Button, Input, Modal, Select, Space, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { ArrowClockwise, DownloadSimple, Eye } from '@phosphor-icons/react';
 import { useLang } from '../i18n/LangContext';
@@ -35,6 +35,8 @@ export const GrafanaDashboardList: React.FC = () => {
   const { t } = useLang();
   const { message } = App.useApp();
   const [dashboards, setDashboards] = useState<GrafanaDashboardInfo[]>([]);
+  const [searchText, setSearchText] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const [viewing, setViewing] = useState<GrafanaDashboardInfo | null>(null);
@@ -45,6 +47,30 @@ export const GrafanaDashboardList: React.FC = () => {
   const viewRequestId = useRef(0);
   const [exportingUids, setExportingUids] = useState<Set<string>>(() => new Set());
   const [exportingAll, setExportingAll] = useState(false);
+
+  const tagOptions = useMemo(
+    () =>
+      Array.from(new Set(dashboards.flatMap((dashboard) => dashboard.tags || [])))
+        .sort((a, b) => a.localeCompare(b))
+        .map((tag) => ({ label: tag, value: tag })),
+    [dashboards],
+  );
+
+  const filteredDashboards = useMemo(() => {
+    const normalizedSearch = searchText.trim().toLowerCase();
+    return dashboards.filter((dashboard) => {
+      const matchesSearch =
+        !normalizedSearch ||
+        [dashboard.uid, dashboard.title, dashboard.description, ...(dashboard.tags || [])]
+          .filter(Boolean)
+          .some((value) => value.toLowerCase().includes(normalizedSearch));
+      const matchesTags =
+        selectedTags.length === 0 ||
+        selectedTags.every((tag) => (dashboard.tags || []).includes(tag));
+
+      return matchesSearch && matchesTags;
+    });
+  }, [dashboards, searchText, selectedTags]);
 
   const loadDashboards = useCallback(async () => {
     const requestId = ++listRequestId.current;
@@ -186,6 +212,24 @@ export const GrafanaDashboardList: React.FC = () => {
   return (
     <div>
       <Space style={{ marginBottom: 12 }}>
+        <Input.Search
+          allowClear
+          placeholder={t('grafana.searchPlaceholder')}
+          value={searchText}
+          onChange={(event) => setSearchText(event.target.value)}
+          onSearch={setSearchText}
+          style={{ width: 280 }}
+        />
+        <Select
+          allowClear
+          mode="multiple"
+          maxTagCount="responsive"
+          options={tagOptions}
+          placeholder={t('grafana.allTags')}
+          value={selectedTags}
+          onChange={setSelectedTags}
+          style={{ minWidth: 220 }}
+        />
         <Button
           icon={<DownloadSimple size={16} />}
           loading={exportingAll}
@@ -216,7 +260,7 @@ export const GrafanaDashboardList: React.FC = () => {
 
       <Table
         columns={columns}
-        dataSource={dashboards}
+        dataSource={filteredDashboards}
         loading={loading}
         rowKey="uid"
         pagination={false}

--- a/web/src/components/__tests__/AlertRuleAssetList.test.tsx
+++ b/web/src/components/__tests__/AlertRuleAssetList.test.tsx
@@ -17,6 +17,7 @@
 
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { App as AntdApp } from 'antd';
 import AlertRuleAssetList from '../AlertRuleAssetList';
 import { LangProvider } from '../../i18n/LangContext';
@@ -81,6 +82,29 @@ describe('AlertRuleAssetList', () => {
     expect(screen.getByText('rocketmq-consumer-lag-high')).toBeInTheDocument();
   });
 
+  it('filters assets by search text and severity', async () => {
+    vi.mocked(alertRuleAssetService.listAlertRuleAssets).mockResolvedValue(sampleAssets);
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const { container } = renderWithProviders(<AlertRuleAssetList />);
+
+    expect(await screen.findByText('rocketmq-broker-down')).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText(/Search alert|搜索告警/), 'consumer');
+
+    expect(screen.getByText('rocketmq-consumer-lag-high')).toBeInTheDocument();
+    expect(screen.queryByText('rocketmq-broker-down')).not.toBeInTheDocument();
+
+    await user.clear(screen.getByPlaceholderText(/Search alert|搜索告警/));
+    await user.click(container.querySelector('.ant-select-selector') as Element);
+    await user.click(
+      await screen.findByText('CRITICAL', { selector: '.ant-select-item-option-content' }),
+    );
+
+    expect(screen.getByText('rocketmq-broker-down')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText('rocketmq-consumer-lag-high')).not.toBeInTheDocument(),
+    );
+  }, 10_000);
   it('keeps a failed list request visible and recovers when retried', async () => {
     vi.mocked(alertRuleAssetService.listAlertRuleAssets)
       .mockRejectedValueOnce(new Error('temporary failure'))

--- a/web/src/components/__tests__/GrafanaDashboardList.test.tsx
+++ b/web/src/components/__tests__/GrafanaDashboardList.test.tsx
@@ -41,9 +41,9 @@ const dashboards = [
     uid: 'rocketmq-overview',
     title: 'RocketMQ Cluster Overview',
     description: 'Overview',
-    tags: ['rocketmq'],
+    tags: ['overview', 'rocketmq'],
   },
-  { uid: 'rocketmq-broker', title: 'RocketMQ Broker', description: 'Broker', tags: ['rocketmq'] },
+  { uid: 'rocketmq-broker', title: 'RocketMQ Broker', description: 'Broker', tags: ['broker'] },
 ];
 
 const dashboardModel = {
@@ -52,6 +52,15 @@ const dashboardModel = {
   schemaVersion: 39,
   panels: [{ id: 1, title: 'Messages In TPS', type: 'timeseries' }],
 };
+
+const renderDashboardList = () =>
+  render(
+    <App>
+      <LangProvider>
+        <GrafanaDashboardList />
+      </LangProvider>
+    </App>,
+  );
 
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
@@ -100,6 +109,25 @@ describe('GrafanaDashboardList', () => {
     expect(screen.getByText('RocketMQ Broker')).toBeInTheDocument();
   });
 
+  it('filters dashboards by search text and tags', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const { container } = renderDashboardList();
+    const overviewCell = await screen.findByText('RocketMQ Cluster Overview');
+    expect(overviewCell).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText(/Search dashboard|搜索看板/), 'broker');
+    const brokerCell = screen.getByText('RocketMQ Broker');
+    expect(brokerCell).toBeInTheDocument();
+    expect(screen.queryByText('RocketMQ Cluster Overview')).not.toBeInTheDocument();
+
+    await user.clear(screen.getByPlaceholderText(/Search dashboard|搜索看板/));
+    await user.click(container.querySelector('.ant-select-selector') as Element);
+    await user.click(
+      await screen.findByText('overview', { selector: '.ant-select-item-option-content' }),
+    );
+
+    expect(screen.getByText('RocketMQ Cluster Overview')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('RocketMQ Broker')).not.toBeInTheDocument());
+  }, 10_000);
   it('keeps a failed list request visible and recovers when retried', async () => {
     vi.mocked(listGrafanaDashboards)
       .mockRejectedValueOnce(new Error('temporary failure'))
@@ -252,9 +280,11 @@ describe('GrafanaDashboardList', () => {
     );
 
     await screen.findByText('RocketMQ Cluster Overview');
+    await user.type(screen.getByPlaceholderText(/Search dashboard|搜索看板/), 'broker');
     await user.click(screen.getByRole('button', { name: /Export all|导出全部/ }));
 
     await waitFor(() => expect(exportGrafanaDashboards).toHaveBeenCalledTimes(1));
+    expect(exportGrafanaDashboard).not.toHaveBeenCalled();
     expect(downloadedFilename).toBe('rocketmq-grafana-dashboards.zip');
     expect(createObjectURL).toHaveBeenCalledTimes(1);
     expect(clickSpy).toHaveBeenCalled();

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1139,6 +1139,11 @@ const translations: Record<string, Record<Lang, string>> = {
   'grafana.title': { zh: 'Grafana 看板', en: 'Grafana Dashboards' },
   'grafana.description': { zh: '说明', en: 'Description' },
   'grafana.tags': { zh: '标签', en: 'Tags' },
+  'grafana.searchPlaceholder': {
+    zh: '搜索看板标题、UID、说明或标签',
+    en: 'Search dashboard title, UID, description or tag',
+  },
+  'grafana.allTags': { zh: '全部标签', en: 'All tags' },
   'grafana.loadFailed': { zh: '加载看板失败', en: 'Failed to load dashboards' },
   'grafana.exported': { zh: '看板已导出', en: 'Dashboard exported' },
   'grafana.exportFailed': { zh: '导出看板失败', en: 'Failed to export dashboard' },
@@ -1151,6 +1156,11 @@ const translations: Record<string, Record<Lang, string>> = {
   'alertAssets.group': { zh: '规则组', en: 'Group' },
   'alertAssets.ruleCount': { zh: '规则数', en: 'Rules' },
   'alertAssets.severity': { zh: '级别', en: 'Severity' },
+  'alertAssets.searchPlaceholder': {
+    zh: '搜索告警名称或规则组',
+    en: 'Search alert name or group',
+  },
+  'alertAssets.allSeverities': { zh: '全部级别', en: 'All severities' },
   'alertAssets.loadFailed': { zh: '加载告警规则失败', en: 'Failed to load alert rules' },
   'alertAssets.exported': { zh: '告警规则已导出', en: 'Alert rule exported' },
   'alertAssets.exportFailed': { zh: '导出告警规则失败', en: 'Failed to export alert rule' },


### PR DESCRIPTION
## What is the purpose of the change

Add local search and filter controls to Studio observability asset catalogs so users can quickly narrow Grafana dashboards and alert rule assets before previewing or exporting a specific asset.

## Brief changelog

- Add dashboard search by title, UID, description, and tag, plus multi-tag filtering.
- Add alert rule asset search by name/group, plus severity filtering.
- Add zh/en labels and regression coverage for both catalog filters.
- Keep the existing Grafana "Export all" action exporting the full catalog.

## Verifying this change

- npm test -- src/components/__tests__/GrafanaDashboardList.test.tsx src/components/__tests__/AlertRuleAssetList.test.tsx
- npm run build
- npm run lint