### PR TITLE
fix: paginate Apache consumer groups in the database

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
@@ -18,7 +18,6 @@ package org.apache.rocketmq.studio.instance.topic;
 
 import org.apache.rocketmq.studio.provider.apache.AdminClient;
 import org.apache.rocketmq.studio.provider.apache.MetadataProvider;
-import org.apache.rocketmq.studio.common.util.Pagination;
 import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -186,12 +185,13 @@ public class MetadataService {
     public PageResult<ConsumerGroupVO> listConsumerGroupsPage(String instanceId, String clusterId, String search,
                                                               int page, int pageSize) {
         validatePagination(page, pageSize);
-
-        List<ConsumerGroupVO> groups = listConsumerGroups(instanceId, clusterId, search);
-        int total = groups.size();
-        int from = (int) Math.min(Pagination.pageOffset(page, pageSize), total);
-        int to = Math.min(from + pageSize, total);
-        return PageResult.of(groups.subList(from, to), total, page, pageSize);
+        instanceId = normalizeInstanceId(instanceId);
+        if (!StringUtils.hasText(instanceId) && StringUtils.hasText(clusterId)) {
+            return metadataProvider.listConsumerGroupsPage(normalizeFilter(clusterId),
+                    normalizeFilter(search), page, pageSize);
+        }
+        return resolve(instanceId).listConsumerGroupsPage(instanceId, normalizeFilter(search),
+                page, pageSize);
     }
 
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
@@ -86,6 +86,16 @@ public interface InstanceProvider {
 
     List<ConsumerGroupVO> listConsumerGroups(String instanceId, String search);
 
+    default PageResult<ConsumerGroupVO> listConsumerGroupsPage(String instanceId, String search,
+            int page, int pageSize) {
+        List<ConsumerGroupVO> groups = listConsumerGroups(instanceId, search);
+        int total = groups.size();
+        long offset = Pagination.pageOffset(page, pageSize);
+        int from = (int) Math.min(offset, total);
+        int to = from + (int) Math.min(pageSize, total - from);
+        return PageResult.of(groups.subList(from, to), total, page, pageSize);
+    }
+
     ConsumerGroupVO createConsumerGroup(String instanceId, ConsumerGroupVO group);
 
     void deleteConsumerGroup(String instanceId, String groupName);

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/MetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/MetadataProvider.java
@@ -56,6 +56,21 @@ public interface MetadataProvider {
         return listConsumerGroups(clusterId, search);
     }
 
+    default PageResult<ConsumerGroupVO> listConsumerGroupsPage(String clusterId, String search,
+            int page, int pageSize) {
+        List<ConsumerGroupVO> groups = listConsumerGroups(clusterId, search);
+        int total = groups.size();
+        long offset = Pagination.pageOffset(page, pageSize);
+        int from = (int) Math.min(offset, total);
+        int to = from + (int) Math.min(pageSize, total - from);
+        return PageResult.of(groups.subList(from, to), total, page, pageSize);
+    }
+
+    default PageResult<ConsumerGroupVO> listConsumerGroupsPage(String instanceId, String clusterId,
+            String search, int page, int pageSize) {
+        return listConsumerGroupsPage(clusterId, search, page, pageSize);
+    }
+
     List<BrokerRouteVO> getTopicRoutes(String instanceId, String name);
     List<TopicConsumerVO> getTopicConsumers(String instanceId, String name);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -227,27 +227,26 @@ public class RocketMQMetadataProvider implements MetadataProvider {
 
         List<ConsumerGroupVO> result = new ArrayList<>();
         for (RmqGroup entity : groupMapper.selectList(query)) {
-            ConsumerGroupVO vo = new ConsumerGroupVO();
-            vo.setId(entity.getId());
-            vo.setName(entity.getName());
-            vo.setClusterId(entity.getClusterId());
-            vo.setInstanceId(entity.getInstanceId());
-            // consumeType stores the real ConsumeType ("CLUSTERING"/"BROADCASTING"); messageModel
-            // holds the subscription mode ("Push"/"Pop") and is not a ConsumeType.
-            vo.setConsumeType(parseConsumeType(entity.getConsumeType()));
-            // messageModel stores the subscription mode ("Push"/"Pop"); surface it so read paths
-            // (web detail, AI rmq.group.list) never see a null subscriptionMode.
-            vo.setSubscriptionMode(parseSubscriptionMode(entity.getMessageModel()));
-            vo.setRetryMaxTimes(entity.getMaxRetry() == null ? 0 : entity.getMaxRetry());
-            vo.setGmtCreate(entity.getGmtCreate());
-            vo.setGmtModified(entity.getGmtModified());
-
-            // Live stats (online clients, lag, delay) are enriched in parallel below with a
-            // bounded executor and per-group timeout instead of blocking the listing.
-            result.add(vo);
+            result.add(toConsumerGroupVO(entity));
         }
         enrichLiveStats(instanceId, result);
         return result;
+    }
+
+    @Override
+    public PageResult<ConsumerGroupVO> listConsumerGroupsPage(String instanceId, String clusterId,
+            String search, int page, int pageSize) {
+        LambdaQueryWrapper<RmqGroup> query = new LambdaQueryWrapper<RmqGroup>()
+                .eq(instanceId != null, RmqGroup::getInstanceId, normalizeMetadataScope(instanceId))
+                .eq(StringUtils.hasText(clusterId), RmqGroup::getClusterId, clusterId)
+                .like(StringUtils.hasText(search), RmqGroup::getName, search)
+                .orderByAsc(RmqGroup::getName, RmqGroup::getId);
+        Page<RmqGroup> result = groupMapper.selectPage(new Page<>(page, pageSize), query);
+        List<ConsumerGroupVO> groups = result.getRecords().stream()
+                .map(this::toConsumerGroupVO)
+                .toList();
+        enrichLiveStats(instanceId, groups);
+        return PageResult.of(groups, result.getTotal(), page, pageSize);
     }
 
     private static final int ONLINE_ENRICHMENT_THREADS = 8;
@@ -263,6 +262,24 @@ public class RocketMQMetadataProvider implements MetadataProvider {
     @jakarta.annotation.PreDestroy
     void shutdownOnlineEnrichmentExecutor() {
         onlineEnrichmentExecutor.shutdownNow();
+    }
+
+    private ConsumerGroupVO toConsumerGroupVO(RmqGroup entity) {
+        ConsumerGroupVO vo = new ConsumerGroupVO();
+        vo.setId(entity.getId());
+        vo.setName(entity.getName());
+        vo.setClusterId(entity.getClusterId());
+        vo.setInstanceId(entity.getInstanceId());
+        // consumeType stores the real ConsumeType ("CLUSTERING"/"BROADCASTING"); messageModel
+        // holds the subscription mode ("Push"/"Pop") and is not a ConsumeType.
+        vo.setConsumeType(parseConsumeType(entity.getConsumeType()));
+        // messageModel stores the subscription mode ("Push"/"Pop"); surface it so read paths
+        // (web detail, AI rmq.group.list) never see a null subscriptionMode.
+        vo.setSubscriptionMode(parseSubscriptionMode(entity.getMessageModel()));
+        vo.setRetryMaxTimes(entity.getMaxRetry() == null ? 0 : entity.getMaxRetry());
+        vo.setGmtCreate(entity.getGmtCreate());
+        vo.setGmtModified(entity.getGmtModified());
+        return vo;
     }
 
     private void enrichLiveStats(String instanceId, List<ConsumerGroupVO> groups) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
@@ -287,14 +287,10 @@ class MetadataServiceTest {
 
     @Test
     void listConsumerGroupsPageShouldPaginateFromOneBasedIndexes() {
-        ConsumerGroupVO first = new ConsumerGroupVO();
-        first.setName("cg-a");
-        ConsumerGroupVO second = new ConsumerGroupVO();
-        second.setName("cg-b");
         ConsumerGroupVO third = new ConsumerGroupVO();
         third.setName("cg-c");
-        when(apacheProvider.listConsumerGroups("instance-a", "order"))
-                .thenReturn(List.of(first, second, third));
+        when(apacheProvider.listConsumerGroupsPage("instance-a", "order", 2, 2))
+                .thenReturn(PageResult.of(List.of(third), 3, 2, 2));
 
         PageResult<ConsumerGroupVO> result =
                 metadataService.listConsumerGroupsPage("instance-a", null, "order", 2, 2);
@@ -303,23 +299,23 @@ class MetadataServiceTest {
         assertThat(result.getTotal()).isEqualTo(3);
         assertThat(result.getPage()).isEqualTo(2);
         assertThat(result.getSize()).isEqualTo(2);
-        verify(apacheProvider).listConsumerGroups("instance-a", "order");
+        verify(apacheProvider).listConsumerGroupsPage("instance-a", "order", 2, 2);
+        verify(apacheProvider, org.mockito.Mockito.never()).listConsumerGroups("instance-a", "order");
     }
 
     @Test
     void listConsumerGroupsPageShouldReturnEmptyItemsWhenPageStartsPastFilteredTotal() {
-        ConsumerGroupVO first = new ConsumerGroupVO();
-        first.setName("cg-a");
-        when(metadataProvider.listConsumerGroups("cluster-1", "order")).thenReturn(List.of(first));
+        when(metadataProvider.listConsumerGroupsPage("cluster-1", "order", 2, 1))
+                .thenReturn(PageResult.empty(2, 1));
 
         PageResult<ConsumerGroupVO> result =
                 metadataService.listConsumerGroupsPage(null, "cluster-1", "order", 2, 1);
 
         assertThat(result.getItems()).isEmpty();
-        assertThat(result.getTotal()).isEqualTo(1);
+        assertThat(result.getTotal()).isZero();
         assertThat(result.getPage()).isEqualTo(2);
         assertThat(result.getSize()).isEqualTo(1);
-        verify(metadataProvider).listConsumerGroups("cluster-1", "order");
+        verify(metadataProvider).listConsumerGroupsPage("cluster-1", "order", 2, 1);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
@@ -19,6 +19,8 @@ package org.apache.rocketmq.studio.provider.apache;
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.common.message.MessageQueue;
@@ -195,6 +197,41 @@ class RocketMQMetadataProviderTest {
                 org.mockito.ArgumentCaptor.forClass(LambdaQueryWrapper.class);
         verify(groupMapper, times(1)).selectList(captor.capture());
         assertThat(captor.getValue().getSqlSegment()).contains("instance_id", "cluster_id");
+    }
+
+    @Test
+    void listConsumerGroupsPageShouldUseDatabasePaginationAndStableOrdering() {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqGroup.class);
+        RmqGroup entity = new RmqGroup();
+        entity.setId(21L);
+        entity.setName("group-b");
+        entity.setInstanceId("instance-a");
+        entity.setClusterId("cluster-1");
+        entity.setConsumeType("CLUSTERING");
+        entity.setMessageModel("Pop");
+        entity.setMaxRetry(5);
+        Page<RmqGroup> databasePage = new Page<>(2, 1, 21);
+        databasePage.setRecords(List.of(entity));
+        when(groupMapper.selectPage(any(Page.class), any(LambdaQueryWrapper.class))).thenReturn(databasePage);
+        RocketMQMetadataProvider provider = newProvider();
+
+        PageResult<ConsumerGroupVO> result = provider.listConsumerGroupsPage(
+                "instance-a", "cluster-1", "group", 2, 1);
+
+        assertThat(result.getItems()).hasSize(1);
+        assertThat(result.getItems().get(0).getName()).isEqualTo("group-b");
+        assertThat(result.getItems().get(0).getSubscriptionMode()).isEqualTo(SubscriptionMode.Pop);
+        assertThat(result.getTotal()).isEqualTo(21);
+        assertThat(result.getPage()).isEqualTo(2);
+        assertThat(result.getSize()).isEqualTo(1);
+
+        org.mockito.ArgumentCaptor<LambdaQueryWrapper<RmqGroup>> captor =
+                org.mockito.ArgumentCaptor.forClass(LambdaQueryWrapper.class);
+        verify(groupMapper).selectPage(any(Page.class), captor.capture());
+        assertThat(captor.getValue().getSqlSegment())
+                .contains("instance_id", "cluster_id", "ORDER BY name ASC,id ASC");
+        verify(groupMapper, never()).selectList(any());
+        verify(runtimeAdminClientResolver, times(2)).execute(eq("instance-a"), any());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add a paginated consumer-group contract to `InstanceProvider` and `MetadataProvider`
- implement Apache consumer-group pagination with MyBatis-Plus `selectPage`
- apply the same instance / cluster / search filters in SQL
- use deterministic `name ASC, id ASC` ordering
- enrich live online/lag/delay data only for the returned page items
- make `MetadataService.listConsumerGroupsPage(...)` delegate to the provider page method instead of loading and slicing the full list
- keep the existing unpaginated `GET /api/groups` contract unchanged
- extract shared `RmqGroup -> ConsumerGroupVO` mapping so full-list and paginated reads cannot drift

## Why

`GET /api/groups/page` currently calls the full `listConsumerGroups(...)` path, reads every matching `rmq_group` row, performs live enrichment for every group, then slices one page in memory. With thousands of groups, each page request is O(total groups), including admin/API fan-out. Topics already paginate at the database layer; this makes the adjacent consumer-group inventory consistent and bounded by page size.

## Tests

- focused: `MetadataServiceTest, RocketMQMetadataProviderTest, ConsumerGroupControllerTest` — 72 tests passed
- Checkstyle: 0 violations
- `git diff --check`: passed
- full backend suite also ran; its only 2 failures are pre-existing in `RocketMQMessageProviderTest` and reproduce on untouched upstream `14da4b95` (verified by stashing this change), so they are unrelated to this PR

Closes #2578
