### PR TITLE
fix: paginate Apache ACL users in the database

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclRepository.java
@@ -37,6 +37,8 @@ public interface AclRepository {
 
     List<AclUserVO> findUsers();
 
+    PageResult<AclUserVO> findUserPage(String keyword, int page, int pageSize);
+
     Optional<AclUserVO> findUserById(Long id);
 
     AclUserVO saveUser(AclUserVO user);

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/AclService.java
@@ -149,19 +149,25 @@ public class AclService {
         if (page < 1 || pageSize < 1 || pageSize > 100) {
             throw new BusinessException(400, "page must be >= 1 and pageSize must be between 1 and 100");
         }
-        String query = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
-        List<AclUserVO> users = (isTencentInstance(instanceId)
-                ? tencentAclService.listUsers(instanceId) : aclRepository.findUsers()).stream()
+        if (isTencentInstance(instanceId)) {
+            String query = keyword == null ? "" : keyword.trim().toLowerCase(Locale.ROOT);
+            List<AclUserVO> users = tencentAclService.listUsers(instanceId).stream()
                 .filter(user -> query.isEmpty()
                         || containsIgnoreCase(user.getUsername(), query)
                         || containsIgnoreCase(user.getAccessKey(), query))
                 .sorted(Comparator.comparing(AclUserVO::getGmtCreate, Comparator.nullsLast(Comparator.reverseOrder()))
                         .thenComparing(AclUserVO::getId, Comparator.nullsLast(Comparator.naturalOrder())))
                 .toList();
-        int from = (int) Math.min(Pagination.pageOffset(page, pageSize), users.size());
-        int to = Math.min(from + pageSize, users.size());
-        return PageResult.of(users.subList(from, to).stream().map(this::maskCredentials).toList(),
-                users.size(), page, pageSize);
+            int from = (int) Math.min(Pagination.pageOffset(page, pageSize), users.size());
+            int to = Math.min(from + pageSize, users.size());
+            return PageResult.of(
+                    users.subList(from, to).stream().map(this::maskCredentials).toList(),
+                    users.size(), page, pageSize);
+        }
+        PageResult<AclUserVO> result = aclRepository.findUserPage(
+                StringUtils.hasText(keyword) ? keyword.trim() : null, page, pageSize);
+        return PageResult.of(result.getItems().stream().map(this::maskCredentials).toList(),
+                result.getTotal(), result.getPage(), result.getSize());
     }
 
 

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -105,10 +105,11 @@ public class MybatisPlusAclRepository implements AclRepository {
 
     @Override
     public PageResult<AclUserVO> findUserPage(String keyword, int page, int pageSize) {
+        String search = StringUtils.hasText(keyword) ? keyword.trim().toLowerCase() : null;
         QueryWrapper<RmqAclUser> query = new QueryWrapper<RmqAclUser>()
-                .and(StringUtils.hasText(keyword), w -> w
-                        .like("username", keyword)
-                        .or().like("access_key", keyword))
+                .and(search != null, w -> w
+                        .like("username", search)
+                        .or().like("access_key", search))
                 .orderByDesc("gmt_create")
                 .orderByDesc("id");
         IPage<RmqAclUser> mapperPage = userMapper.selectPage(new Page<>(page, pageSize), query);

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -104,6 +104,22 @@ public class MybatisPlusAclRepository implements AclRepository {
     }
 
     @Override
+    public PageResult<AclUserVO> findUserPage(String keyword, int page, int pageSize) {
+        QueryWrapper<RmqAclUser> query = new QueryWrapper<RmqAclUser>()
+                .and(StringUtils.hasText(keyword), w -> w
+                        .like("username", keyword)
+                        .or().like("access_key", keyword))
+                .orderByDesc("gmt_create")
+                .orderByDesc("id");
+        IPage<RmqAclUser> mapperPage = userMapper.selectPage(new Page<>(page, pageSize), query);
+        List<AclUserVO> items = mapperPage.getRecords().stream()
+                .map(MybatisPlusAclRepository::toUserVO)
+                .collect(Collectors.toList());
+        return PageResult.of(items, mapperPage.getTotal(), (int) mapperPage.getCurrent(),
+                (int) mapperPage.getSize());
+    }
+
+    @Override
     public Optional<AclUserVO> findUserById(Long id) {
         if (id == null) {
             return Optional.empty();

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/AclServiceTest.java
@@ -188,6 +188,33 @@ class AclServiceTest {
     }
 
     @Test
+    void pageUsersShouldUseDatabasePaginationForApacheUsers() {
+        AclUserVO user = AclUserVO.builder()
+                .id(1L)
+                .username("orders")
+                .accessKey("access-key-123456")
+                .secretKey("secret-key-987654")
+                .admin(false)
+                .clusters(List.of("cluster-a"))
+                .gmtCreate(LocalDateTime.now())
+                .build();
+        when(aclRepository.findUserPage("orders", 2, 20))
+                .thenReturn(PageResult.of(List.of(user), 21, 2, 20));
+
+        PageResult<AclUserVO> result = aclService.pageUsers(null, 2, 20, " orders ");
+
+        assertThat(result.getItems()).singleElement().satisfies(listed -> {
+            assertThat(listed.getUsername()).isEqualTo("orders");
+            assertThat(listed.getAccessKey()).isEqualTo("acce****3456");
+            assertThat(listed.getSecretKey()).isEqualTo("secr****7654");
+        });
+        assertThat(result.getTotal()).isEqualTo(21);
+        verify(aclRepository).findUserPage("orders", 2, 20);
+        verify(aclRepository, never()).findUsers();
+        verifyNoInteractions(instanceRepository, tencentAclService);
+    }
+
+    @Test
     void listRulesShouldReturnEmptyPageWhenTencentPageOffsetExceedsIntegerRange() {
         InstanceVO instance = InstanceVO.builder()
                 .name("tencent-instance")

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
@@ -117,7 +117,7 @@ class MybatisPlusAclRepositoryTest {
     }
 
     @Test
-    void findUserPageShouldApplyKeywordFiltersAndDatabasePagination() {
+    void findUserPageShouldNormalizeKeywordFiltersAndApplyDatabasePagination() {
         RmqAclUser entity = new RmqAclUser();
         entity.setId(11L);
         entity.setUsername("user-orders");
@@ -130,7 +130,7 @@ class MybatisPlusAclRepositoryTest {
                 .setTotal(51);
         when(userMapper.selectPage(any(IPage.class), any(Wrapper.class))).thenReturn(mapperPage);
 
-        PageResult<AclUserVO> result = repository.findUserPage("orders", 3, 20);
+        PageResult<AclUserVO> result = repository.findUserPage(" ORDERS ", 3, 20);
 
         ArgumentCaptor<IPage<RmqAclUser>> pageCaptor = ArgumentCaptor.forClass(IPage.class);
         ArgumentCaptor<Wrapper<RmqAclUser>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
@@ -147,6 +147,8 @@ class MybatisPlusAclRepositoryTest {
         });
         assertThat(queryCaptor.getValue().getSqlSegment())
                 .contains("username", "access_key", "ORDER BY gmt_create DESC,id DESC");
+        assertThat(((QueryWrapper<RmqAclUser>) queryCaptor.getValue()).getParamNameValuePairs())
+                .containsValue("%orders%");
         verify(userMapper, never()).selectList(any(QueryWrapper.class));
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
@@ -117,6 +117,40 @@ class MybatisPlusAclRepositoryTest {
     }
 
     @Test
+    void findUserPageShouldApplyKeywordFiltersAndDatabasePagination() {
+        RmqAclUser entity = new RmqAclUser();
+        entity.setId(11L);
+        entity.setUsername("user-orders");
+        entity.setAccessKey("access-key-orders");
+        entity.setSecretKey(CredentialUtils.encodeBase64("secret-key"));
+        entity.setAdmin(false);
+        entity.setGmtCreate(LocalDateTime.of(2026, 8, 20, 9, 30));
+        Page<RmqAclUser> mapperPage = new Page<RmqAclUser>(3, 20)
+                .setRecords(List.of(entity))
+                .setTotal(51);
+        when(userMapper.selectPage(any(IPage.class), any(Wrapper.class))).thenReturn(mapperPage);
+
+        PageResult<AclUserVO> result = repository.findUserPage("orders", 3, 20);
+
+        ArgumentCaptor<IPage<RmqAclUser>> pageCaptor = ArgumentCaptor.forClass(IPage.class);
+        ArgumentCaptor<Wrapper<RmqAclUser>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(userMapper).selectPage(pageCaptor.capture(), queryCaptor.capture());
+        assertThat(pageCaptor.getValue().getCurrent()).isEqualTo(3);
+        assertThat(pageCaptor.getValue().getSize()).isEqualTo(20);
+        assertThat(result.getTotal()).isEqualTo(51);
+        assertThat(result.getPage()).isEqualTo(3);
+        assertThat(result.getSize()).isEqualTo(20);
+        assertThat(result.getItems()).singleElement().satisfies(user -> {
+            assertThat(user.getUsername()).isEqualTo("user-orders");
+            assertThat(user.getAccessKey()).isEqualTo("access-key-orders");
+            assertThat(user.getSecretKey()).isEqualTo("secret-key");
+        });
+        assertThat(queryCaptor.getValue().getSqlSegment())
+                .contains("username", "access_key", "ORDER BY gmt_create DESC,id DESC");
+        verify(userMapper, never()).selectList(any(QueryWrapper.class));
+    }
+
+    @Test
     void replaceRuleShouldReturnEmptyWhenConcurrentDeleteWins() {
         RmqAclRule existing = new RmqAclRule();
         existing.setId(1L);


### PR DESCRIPTION
## Summary

- add `AclRepository.findUserPage(keyword, page, pageSize)`
- implement Apache ACL user pagination with MyBatis-Plus `selectPage`
- apply username/access-key keyword filtering in SQL
- use deterministic `gmt_create DESC, id DESC` ordering
- decode and mask credentials only for the returned page
- make `AclService.pageUsers` use the repository page for Apache instances
- keep Tencent role discovery unchanged, since Tencent roles are collected from a remote paginated API and have no local database rows
- keep the existing unpaginated user endpoint unchanged

## Why

`GET /api/acl/users/page` currently reads every `rmq_acl_user` row, decodes every secret, filters/sorts in memory, and then slices one page. ACL rules already paginate in SQL, so this makes the adjacent user inventory consistent and bounds page cost by pageSize rather than total account count.

## Tests

- focused: `AclServiceTest, MybatisPlusAclRepositoryTest, AclControllerTest` — 108 tests passed
- Checkstyle: 0 violations
- `git diff --check`: passed

Closes #2582
