### PR TITLE
[Studio] feat: export Broker cluster topology

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -17,7 +17,13 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Table, Button, Tag, Tabs, Card, Space, Switch, Progress, Spin, App, Select } from 'antd';
-import { ArrowClockwise, Cloud, ChartBar, PlugsConnected } from '@phosphor-icons/react';
+import {
+  ArrowClockwise,
+  Cloud,
+  ChartBar,
+  DownloadSimple,
+  PlugsConnected,
+} from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
 import { listClusters } from '../../services/clusterService';
 import { isMockMode } from '../../services/dataMode';
@@ -25,9 +31,11 @@ import type { ClusterInfo } from '../../api/cluster';
 import { supportsApacheRuntime, type Instance } from '../../api/instance';
 import { listInstances } from '../../services/instanceService';
 import { useVisiblePolling } from '../../hooks/useVisiblePolling';
+import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 // ─── Types ──────────────────────────────────────────────────────
 type NodeStatus = 'running' | 'readonly' | 'maintenance' | 'unknown';
+type ClusterTabKey = 'nameserver' | 'broker' | 'proxy';
 
 const REFRESH_INTERVAL_MS = 2000;
 
@@ -64,6 +72,36 @@ interface ProxyRecord {
   grpcPort: string;
   connections: number;
 }
+
+const BROKER_EXPORT_COLUMNS: CsvColumn<BrokerRecord>[] = [
+  { header: 'Cluster', value: (broker) => broker.k8sCluster },
+  { header: 'Broker Name', value: (broker) => broker.brokerName },
+  { header: 'Status', value: (broker) => broker.status },
+  { header: 'Version', value: (broker) => broker.version },
+  { header: 'Disk Usage', value: (broker) => broker.diskUsage },
+  { header: 'Address', value: (broker) => broker.address },
+  { header: 'TPS In', value: (broker) => broker.tpsIn },
+  { header: 'TPS Out', value: (broker) => broker.tpsOut },
+];
+
+const NAMESERVER_EXPORT_COLUMNS: CsvColumn<NameServerRecord>[] = [
+  { header: 'Cluster', value: (nameServer) => nameServer.k8sCluster },
+  { header: 'NameServer Name', value: (nameServer) => nameServer.name },
+  { header: 'Status', value: (nameServer) => nameServer.status },
+  { header: 'Version', value: (nameServer) => nameServer.version },
+  { header: 'Address', value: (nameServer) => nameServer.address },
+  { header: 'Connections', value: (nameServer) => nameServer.connections },
+];
+
+const PROXY_EXPORT_COLUMNS: CsvColumn<ProxyRecord>[] = [
+  { header: 'Cluster', value: (proxy) => proxy.k8sCluster },
+  { header: 'Proxy Name', value: (proxy) => proxy.name },
+  { header: 'Status', value: (proxy) => proxy.status },
+  { header: 'Version', value: (proxy) => proxy.version },
+  { header: 'HTTP Address', value: (proxy) => proxy.address },
+  { header: 'gRPC Address', value: (proxy) => proxy.grpcPort },
+  { header: 'Connections', value: (proxy) => proxy.connections },
+];
 
 // ─── Helpers ────────────────────────────────────────────────────
 const normalizeStatus = (status: string): NodeStatus => {
@@ -145,7 +183,7 @@ function mapClusters(clusters: ClusterInfo[]): {
 // ─── Component ──────────────────────────────────────────────────
 const BrokerClusterPage = () => {
   const [autoRefresh, setAutoRefresh] = useState(false);
-  const [activeTab, setActiveTab] = useState('broker');
+  const [activeTab, setActiveTab] = useState<ClusterTabKey>('broker');
   const [loading, setLoading] = useState(false);
   const [brokerData, setBrokerData] = useState<BrokerRecord[]>([]);
   const [nameServerData, setNameServerData] = useState<NameServerRecord[]>([]);
@@ -258,6 +296,32 @@ const BrokerClusterPage = () => {
       </div>
     );
   };
+
+  function handleExport() {
+    const today = new Date().toISOString().slice(0, 10);
+    if (activeTab === 'nameserver') {
+      downloadCsv(
+        `rocketmq-nameserver-topology-${today}.csv`,
+        buildCsv(NAMESERVER_EXPORT_COLUMNS, nameServerData),
+      );
+      return;
+    }
+    if (activeTab === 'proxy') {
+      downloadCsv(
+        `rocketmq-proxy-topology-${today}.csv`,
+        buildCsv(PROXY_EXPORT_COLUMNS, proxyData),
+      );
+      return;
+    }
+    downloadCsv(
+      `rocketmq-broker-topology-${today}.csv`,
+      buildCsv(BROKER_EXPORT_COLUMNS, brokerData),
+    );
+  }
+  const exportDisabled =
+    (activeTab === 'nameserver' && nameServerData.length === 0) ||
+    (activeTab === 'proxy' && proxyData.length === 0) ||
+    (activeTab === 'broker' && brokerData.length === 0);
 
   const brokerColumns = [
     {
@@ -461,6 +525,14 @@ const BrokerClusterPage = () => {
             style={{ minWidth: 180 }}
             options={instances.map((instance) => ({ value: instance.name, label: instance.name }))}
           />
+          <Button
+            icon={<DownloadSimple size={14} />}
+            size="small"
+            disabled={exportDisabled}
+            onClick={handleExport}
+          >
+            {t('common.export')}
+          </Button>
           <Switch
             checked={autoRefresh}
             onChange={setAutoRefresh}
@@ -481,7 +553,7 @@ const BrokerClusterPage = () => {
         >
           <Tabs
             activeKey={activeTab}
-            onChange={setActiveTab}
+            onChange={(key) => setActiveTab(key as ClusterTabKey)}
             items={[
               {
                 key: 'nameserver',

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -23,6 +23,7 @@ import { LangProvider } from '../../../i18n/LangContext';
 import { listClusters } from '../../../services/clusterService';
 import { listInstances } from '../../../services/instanceService';
 import type { ClusterInfo } from '../../../api/cluster';
+import { downloadCsv } from '../../../utils/download';
 import BrokerCluster from '../BrokerCluster';
 
 vi.mock('../../../services/clusterService', () => ({
@@ -32,6 +33,15 @@ vi.mock('../../../services/clusterService', () => ({
 vi.mock('../../../services/instanceService', () => ({
   listInstances: vi.fn(),
 }));
+
+vi.mock('../../../utils/download', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../../utils/download')>('../../../utils/download');
+  return {
+    ...actual,
+    downloadCsv: vi.fn(),
+  };
+});
 
 // Mock matchMedia for antd responsive components
 beforeAll(() => {
@@ -173,6 +183,29 @@ describe('BrokerCluster Page', () => {
     expect(listClusters).toHaveBeenCalledWith('instance-1');
   });
 
+  it('exports only the currently selected topology tab', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<BrokerCluster />);
+    await screen.findByText('broker-api-a');
+
+    await user.click(screen.getByRole('button', { name: '导出' }));
+
+    expect(downloadCsv).toHaveBeenCalledTimes(1);
+    const [brokerFilename, brokerCsv] = vi.mocked(downloadCsv).mock.calls[0];
+    expect(brokerFilename).toMatch(/^rocketmq-broker-topology-\d{4}-\d{2}-\d{2}\.csv$/);
+    expect(brokerCsv).toContain('"broker-api-a"');
+    expect(brokerCsv).toContain('"broker-api-b"');
+    expect(brokerCsv).not.toContain('"nameserver-api-a"');
+
+    await user.click(screen.getByText('NameServer 管理'));
+    await user.click(screen.getByRole('button', { name: '导出' }));
+
+    expect(downloadCsv).toHaveBeenCalledTimes(2);
+    const [nameServerFilename, nameServerCsv] = vi.mocked(downloadCsv).mock.calls[1];
+    expect(nameServerFilename).toMatch(/^rocketmq-nameserver-topology-\d{4}-\d{2}-\d{2}\.csv$/);
+    expect(nameServerCsv).toContain('"nameserver-api-a"');
+    expect(nameServerCsv).not.toContain('"broker-api-a"');
+  }, 10_000);
   it('does not fall back to an unscoped cluster query when instance discovery fails', async () => {
     vi.mocked(listInstances).mockRejectedValueOnce(new Error('instance discovery failed'));
     renderWithProviders(<BrokerCluster />);


### PR DESCRIPTION
## What is the purpose of the change

Add CSV export for the Studio Broker Cluster topology view so operators can download the current Broker, NameServer, or Proxy topology snapshot from the active tab.

## Brief changelog

- Add tab-aware topology CSV export for Broker, NameServer, and Proxy rows.
- Reuse the existing CSV builder/download utility.
- Disable export when the active topology tab has no rows.
- Add regression coverage for exporting only the currently selected topology tab.

## Verifying this change

- npm test -- src/pages/studio/__tests__/BrokerCluster.test.tsx
- npm run build
- npm run lint