### PR TITLE
feat: paginate alert rules

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRepository.java
@@ -18,9 +18,18 @@ package org.apache.rocketmq.studio.ops.alert;
 
 
 import java.util.List;
+import java.util.Optional;
+
+import org.apache.rocketmq.studio.common.domain.PageResult;
 
 public interface AlertRepository {
     List<AlertRuleVO> findAllRules();
+
+    PageResult<AlertRuleVO> findRulePage(String search, Boolean enabled, int page, int pageSize);
+
+    Optional<AlertRuleVO> findRuleById(Long id);
+
+    List<AlertRuleVO> findRulesByIds(List<Long> ids);
 
     AlertRuleVO saveRule(AlertRuleVO rule);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleController.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.domain.Result;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -38,6 +40,15 @@ public class AlertRuleController {
     @GetMapping
     public Result<List<AlertRuleVO>> listRules() {
         return Result.ok(alertService.listRules());
+    }
+
+    @GetMapping("/page")
+    public Result<PageResult<AlertRuleVO>> listRulesPage(
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) Boolean enabled,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return Result.ok(alertService.listRules(search, enabled, page, pageSize));
     }
 
     @GetMapping("/export")

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -17,7 +17,9 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.springframework.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -49,6 +51,15 @@ public class AlertService {
     public List<AlertRuleVO> listRules() {
         log.info("Listing all alert rules");
         return alertRepository.findAllRules();
+    }
+
+    public PageResult<AlertRuleVO> listRules(String search, Boolean enabled, int page,
+                                             int pageSize) {
+        validateRulePagination(page, pageSize);
+        String normalizedSearch = StringUtils.hasText(search) ? search.trim() : null;
+        log.info("Listing alert rules, search={}, enabled={}, page={}, pageSize={}",
+                normalizedSearch, enabled, page, pageSize);
+        return alertRepository.findRulePage(normalizedSearch, enabled, page, pageSize);
     }
 
     public String exportPrometheusRulesYaml() {
@@ -128,10 +139,7 @@ public class AlertService {
     public AlertRuleVO toggleRule(Long id, boolean enabled) {
         log.info("Toggling alert rule id={}, enabled={}", id, enabled);
         validateRuleId(id);
-        List<AlertRuleVO> rules = alertRepository.findAllRules();
-        AlertRuleVO rule = rules.stream()
-                .filter(r -> Objects.equals(r.getId(), id))
-                .findFirst()
+        AlertRuleVO rule = alertRepository.findRuleById(id)
                 .orElseThrow(() -> new org.apache.rocketmq.studio.common.exception.BusinessException(404, "Alert rule not found: " + id));
         rule.setEnabled(enabled);
         AlertRuleVO saved = alertRepository.saveRule(rule);
@@ -152,7 +160,7 @@ public class AlertService {
     public AlertRuleBulkResultVO bulkToggleRules(List<Long> ids, boolean enabled) {
         List<Long> normalizedIds = normalizeBulkIds(ids);
         Map<Long, AlertRuleVO> rulesById = new LinkedHashMap<>();
-        for (AlertRuleVO rule : alertRepository.findAllRules()) {
+        for (AlertRuleVO rule : alertRepository.findRulesByIds(normalizedIds)) {
             rulesById.put(rule.getId(), rule);
         }
         List<Long> succeeded = new ArrayList<>();
@@ -216,6 +224,15 @@ public class AlertService {
             }
         }
         return normalized;
+    }
+
+    private static void validateRulePagination(int page, int pageSize) {
+        if (page < 1) {
+            throw new BusinessException(400, "page must be greater than zero");
+        }
+        if (pageSize < 1 || pageSize > 100) {
+            throw new BusinessException(400, "pageSize must be between 1 and 100");
+        }
     }
 
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -17,6 +17,8 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.AlertLevel;
 import org.apache.rocketmq.studio.persistence.entity.RmqAlertRule;
 import org.apache.rocketmq.studio.persistence.entity.RmqSystemAlert;
@@ -31,6 +33,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -48,6 +51,45 @@ public class MybatisPlusAlertRepository implements AlertRepository {
         return ruleMapper.selectList(new QueryWrapper<RmqAlertRule>().orderByAsc("name")).stream()
                 .map(MybatisPlusAlertRepository::toRuleVO)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public PageResult<AlertRuleVO> findRulePage(String search, Boolean enabled,
+                                                 int page, int pageSize) {
+        QueryWrapper<RmqAlertRule> query = ruleQuery(search, enabled);
+        Page<RmqAlertRule> result = ruleMapper.selectPage(new Page<>(page, pageSize), query);
+        List<AlertRuleVO> items = result.getRecords().stream()
+                .map(MybatisPlusAlertRepository::toRuleVO)
+                .toList();
+        return PageResult.of(items, result.getTotal(), page, pageSize);
+    }
+
+    @Override
+    public Optional<AlertRuleVO> findRuleById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(ruleMapper.selectById(id))
+                .map(MybatisPlusAlertRepository::toRuleVO);
+    }
+
+    @Override
+    public List<AlertRuleVO> findRulesByIds(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        return ruleMapper.selectList(new QueryWrapper<RmqAlertRule>()
+                        .in("id", ids))
+                .stream()
+                .map(MybatisPlusAlertRepository::toRuleVO)
+                .toList();
+    }
+
+    private QueryWrapper<RmqAlertRule> ruleQuery(String search, Boolean enabled) {
+        return new QueryWrapper<RmqAlertRule>()
+                .like(StringUtils.hasText(search), "name", search)
+                .eq(enabled != null, "enabled", enabled)
+                .orderByAsc("name", "id");
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleControllerTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -66,6 +67,31 @@ class AlertRuleControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data[0].id").value(1))
                 .andExpect(jsonPath("$.data[0].enabled").value(true));
+    }
+
+    @Test
+    void listRulesPageShouldPassFiltersAndReturnPageContract() throws Exception {
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .id(1L)
+                .name("High Lag")
+                .enabled(true)
+                .build();
+        when(alertService.listRules("lag", true, 2, 20))
+                .thenReturn(PageResult.of(List.of(rule), 21, 2, 20));
+
+        mockMvc.perform(get("/api/alert-rules/page")
+                        .param("search", "lag")
+                        .param("enabled", "true")
+                        .param("page", "2")
+                        .param("pageSize", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.total").value(21))
+                .andExpect(jsonPath("$.data.page").value(2))
+                .andExpect(jsonPath("$.data.size").value(20))
+                .andExpect(jsonPath("$.data.items[0].id").value(1));
+
+        verify(alertService).listRules("lag", true, 2, 20);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.ops.alert;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.AlertLevel;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
@@ -31,10 +32,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -82,6 +85,32 @@ class AlertServiceTest {
         List<AlertRuleVO> result = alertService.listRules();
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void listRulesShouldNormalizeSearchAndDelegateFiltersToRepository() {
+        PageResult<AlertRuleVO> repositoryPage = PageResult.of(List.of(), 0, 2, 20);
+        when(alertRepository.findRulePage("lag", true, 2, 20)).thenReturn(repositoryPage);
+
+        PageResult<AlertRuleVO> result = alertService.listRules("  lag  ", true, 2, 20);
+
+        assertThat(result).isSameAs(repositoryPage);
+        verify(alertRepository).findRulePage("lag", true, 2, 20);
+    }
+
+    @Test
+    void listRulesShouldRejectInvalidPaginationBeforeRepositoryAccess() {
+        assertThatThrownBy(() -> alertService.listRules("lag", true, 0, 20))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("page must be greater than zero");
+        assertThatThrownBy(() -> alertService.listRules("lag", true, 1, 0))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("pageSize must be between 1 and 100");
+        assertThatThrownBy(() -> alertService.listRules("lag", true, 1, 101))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("pageSize must be between 1 and 100");
+
+        verify(alertRepository, never()).findRulePage(any(), any(), anyInt(), anyInt());
     }
 
     @Test
@@ -641,7 +670,7 @@ class AlertServiceTest {
     @Test
     void toggleRuleShouldEnableRule() {
         AlertRuleVO existing = AlertRuleVO.builder().id(1L).name("CPU Alert").enabled(false).build();
-        when(alertRepository.findAllRules()).thenReturn(List.of(existing));
+        when(alertRepository.findRuleById(1L)).thenReturn(Optional.of(existing));
         when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         AlertRuleVO result = alertService.toggleRule(1L, true);
@@ -655,7 +684,7 @@ class AlertServiceTest {
     @Test
     void toggleRuleShouldDisableRule() {
         AlertRuleVO existing = AlertRuleVO.builder().id(1L).name("CPU Alert").enabled(true).build();
-        when(alertRepository.findAllRules()).thenReturn(List.of(existing));
+        when(alertRepository.findRuleById(1L)).thenReturn(Optional.of(existing));
         when(alertRepository.saveRule(any(AlertRuleVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         AlertRuleVO result = alertService.toggleRule(1L, false);
@@ -671,11 +700,12 @@ class AlertServiceTest {
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
 
         verify(alertRepository, never()).findAllRules();
+        verify(alertRepository, never()).findRuleById(any());
     }
 
     @Test
-    void toggleRuleShouldIgnorePersistedRulesWithNullIds() {
-        when(alertRepository.findAllRules()).thenReturn(List.of(AlertRuleVO.builder().name("corrupt").build()));
+    void toggleRuleShouldUseADirectIdLookupWhenRuleIsMissing() {
+        when(alertRepository.findRuleById(999L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> alertService.toggleRule(999L, true))
                 .isInstanceOf(BusinessException.class)
@@ -684,7 +714,7 @@ class AlertServiceTest {
 
     @Test
     void toggleRuleShouldThrowWhenRuleNotFound() {
-        when(alertRepository.findAllRules()).thenReturn(Collections.emptyList());
+        when(alertRepository.findRuleById(999L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> alertService.toggleRule(999L, true))
                 .isInstanceOf(BusinessException.class)
@@ -724,7 +754,7 @@ class AlertServiceTest {
     @Test
     void bulkToggleShouldDeduplicateIdsAndReportMissingRules() {
         AlertRuleVO rule = AlertRuleVO.builder().id(1L).name("High CPU").enabled(false).build();
-        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+        when(alertRepository.findRulesByIds(List.of(1L, 999L))).thenReturn(List.of(rule));
         when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(true);
 
         AlertRuleBulkResultVO result = alertService.bulkToggleRules(
@@ -740,7 +770,7 @@ class AlertServiceTest {
     @Test
     void bulkToggleShouldReportRulesDeletedConcurrentlyInsteadOfRecreatingThem() {
         AlertRuleVO rule = AlertRuleVO.builder().id(1L).name("High CPU").enabled(false).build();
-        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+        when(alertRepository.findRulesByIds(List.of(1L))).thenReturn(List.of(rule));
         when(alertRepository.replaceRule(any(AlertRuleVO.class))).thenReturn(false);
 
         AlertRuleBulkResultVO result = alertService.bulkToggleRules(List.of(1L), true);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -18,12 +18,16 @@ package org.apache.rocketmq.studio.ops.alert;
 
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.persistence.entity.RmqAlertRule;
 import org.apache.rocketmq.studio.persistence.entity.RmqSystemAlert;
 import org.apache.rocketmq.studio.persistence.mapper.RmqAlertRuleMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqSystemAlertMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -58,6 +62,72 @@ class MybatisPlusAlertRepositoryTest {
         when(ruleMapper.updateById(any(RmqAlertRule.class))).thenReturn(0);
 
         assertThat(repository.replaceRule(rule)).isFalse();
+    }
+
+    @Test
+    void findRulePageShouldApplyFiltersOrderingAndDatabasePagination() {
+        RmqAlertRule entity = new RmqAlertRule();
+        entity.setId(1L);
+        entity.setName("High Lag");
+        entity.setEnabled(true);
+        entity.setChannels("email");
+        Page<RmqAlertRule> mapperPage = new Page<RmqAlertRule>(3, 20)
+                .setRecords(List.of(entity))
+                .setTotal(51);
+        when(ruleMapper.selectPage(any(IPage.class), any(Wrapper.class))).thenReturn(mapperPage);
+
+        PageResult<AlertRuleVO> result = repository.findRulePage("lag", true, 3, 20);
+
+        ArgumentCaptor<IPage<RmqAlertRule>> pageCaptor = ArgumentCaptor.forClass(IPage.class);
+        ArgumentCaptor<Wrapper<RmqAlertRule>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(ruleMapper).selectPage(pageCaptor.capture(), queryCaptor.capture());
+        assertThat(pageCaptor.getValue().getCurrent()).isEqualTo(3);
+        assertThat(pageCaptor.getValue().getSize()).isEqualTo(20);
+        assertThat(result.getTotal()).isEqualTo(51);
+        assertThat(result.getPage()).isEqualTo(3);
+        assertThat(result.getSize()).isEqualTo(20);
+        assertThat(result.getItems()).singleElement()
+                .satisfies(rule -> {
+                    assertThat(rule.getId()).isEqualTo(1L);
+                    assertThat(rule.getName()).isEqualTo("High Lag");
+                    assertThat(rule.isEnabled()).isTrue();
+                });
+        QueryWrapper<RmqAlertRule> query = (QueryWrapper<RmqAlertRule>) queryCaptor.getValue();
+        query.getCustomSqlSegment();
+        assertThat(query.getSqlSegment())
+                .contains("name", "enabled", "ORDER BY name ASC,id ASC");
+        assertThat(query.getParamNameValuePairs())
+                .containsValue("%lag%")
+                .containsValue(true);
+        verify(ruleMapper, never()).selectList(any());
+    }
+
+    @Test
+    void findRuleByIdShouldUsePrimaryKeyLookupWithoutFullListRead() {
+        RmqAlertRule entity = new RmqAlertRule();
+        entity.setId(9L);
+        entity.setName("High Lag");
+        entity.setEnabled(true);
+        when(ruleMapper.selectById(9L)).thenReturn(entity);
+
+        assertThat(repository.findRuleById(9L)).hasValueSatisfying(rule ->
+                assertThat(rule.getId()).isEqualTo(9L));
+        assertThat(repository.findRuleById(null)).isEmpty();
+        verify(ruleMapper, never()).selectList(any());
+    }
+
+    @Test
+    void findRulesByIdsShouldUseBoundedIdQuery() {
+        RmqAlertRule entity = new RmqAlertRule();
+        entity.setId(1L);
+        entity.setName("High Lag");
+        entity.setEnabled(true);
+        when(ruleMapper.selectList(any(Wrapper.class))).thenReturn(List.of(entity));
+
+        assertThat(repository.findRulesByIds(List.of(1L, 2L))).singleElement()
+                .satisfies(rule -> assertThat(rule.getId()).isEqualTo(1L));
+        assertThat(repository.findRulesByIds(null)).isEmpty();
+        assertThat(repository.findRulesByIds(List.of())).isEmpty();
     }
 
     @Test

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -21,6 +21,13 @@ export interface AlertRuleBulkResult {
   updatedRules: AlertRule[];
 }
 
+export interface AlertRulePage {
+  items: AlertRule[];
+  total: number;
+  page: number;
+  size: number;
+}
+
 // Matches mock/dashboard.ts systemAlerts
 export interface SystemAlert {
   id: number;
@@ -67,6 +74,16 @@ export interface AuditQuery {
 // ─── Alert Rules ────────────────────────────────────────────────
 export async function listAlertRules() {
   const res = await client.get<{ data: AlertRule[] }>('/alert-rules');
+  return res.data.data;
+}
+
+export async function listAlertRulesPage(params: {
+  search?: string;
+  enabled?: boolean;
+  page?: number;
+  pageSize?: number;
+}) {
+  const res = await client.get<{ data: AlertRulePage }>('/alert-rules/page', { params });
   return res.data.data;
 }
 

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -229,6 +229,7 @@ const translations: Record<string, Record<Lang, string>> = {
   },
   'alerts.totalRules': { zh: '规则总数', en: 'Total Rules' },
   'alerts.enabled': { zh: '已启用', en: 'Enabled' },
+  'alerts.disabled': { zh: '已禁用', en: 'Disabled' },
   'alerts.triggered24h': { zh: '24h 触发', en: 'Triggered (24h)' },
   'alerts.newRule': { zh: '新建规则', en: 'New Rule' },
   'alerts.ruleName': { zh: '规则名称', en: 'Rule Name' },

--- a/web/src/pages/ops/__tests__/AlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/AlertsPage.test.tsx
@@ -25,14 +25,14 @@ import AlertsPage from '../alerts';
 import {
   bulkDeleteAlertRules,
   bulkToggleAlertRules,
-  listAlertRules,
+  listAlertRulesPage,
   toggleAlertRule,
 } from '../../../services/opsService';
 
 vi.mock('../../../services/opsService', () => ({
   createAlertRule: vi.fn(),
   deleteAlertRule: vi.fn(),
-  listAlertRules: vi.fn(),
+  listAlertRulesPage: vi.fn(),
   toggleAlertRule: vi.fn(),
   bulkToggleAlertRules: vi.fn(),
   bulkDeleteAlertRules: vi.fn(),
@@ -110,7 +110,12 @@ function getRuleRow(ruleName: string) {
 describe('AlertsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(listAlertRules).mockResolvedValue(alertRules.map(cloneRule));
+    vi.mocked(listAlertRulesPage).mockResolvedValue({
+      items: alertRules.map(cloneRule),
+      total: alertRules.length,
+      page: 1,
+      size: 20,
+    });
     vi.mocked(toggleAlertRule).mockImplementation(async (id, enabled) => {
       const rule = alertRules.find((item) => item.id === id);
       if (!rule) throw new Error(`Rule not found: ${id}`);
@@ -158,10 +163,58 @@ describe('AlertsPage', () => {
     expect(within(getRuleRow('Consumer lag')).getByRole('checkbox')).not.toBeChecked();
   });
 
-  it('keeps only failed alert rules selected after a partial bulk failure', async () => {
-    vi.mocked(listAlertRules).mockResolvedValue(
-      alertRules.map((rule) => ({ ...cloneRule(rule), enabled: true })),
+  it('loads a server-side page and filters by status and search', async () => {
+    vi.mocked(listAlertRulesPage).mockClear();
+    vi.mocked(listAlertRulesPage).mockResolvedValue({
+      items: [cloneRule(alertRules[0])],
+      total: 21,
+      page: 2,
+      size: 20,
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('Broker disk usage');
+    expect(listAlertRulesPage).toHaveBeenLastCalledWith({
+      enabled: undefined,
+      page: 1,
+      pageSize: 20,
+      search: undefined,
+    });
+
+    await user.type(screen.getByPlaceholderText('搜索规则名称或指标'), 'disk');
+    await waitFor(() =>
+      expect(listAlertRulesPage).toHaveBeenLastCalledWith({
+        enabled: undefined,
+        page: 1,
+        pageSize: 20,
+        search: 'disk',
+      }),
     );
+
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(
+      await screen.findByText('已启用', { selector: '.ant-select-item-option-content' }),
+    );
+    await waitFor(() =>
+      expect(listAlertRulesPage).toHaveBeenLastCalledWith({
+        enabled: true,
+        page: 1,
+        pageSize: 20,
+        search: 'disk',
+      }),
+    );
+    expect(screen.getByText('规则总数')).toBeInTheDocument();
+    expect(screen.getByText('21')).toBeInTheDocument();
+  });
+
+  it('keeps only failed alert rules selected after a partial bulk failure', async () => {
+    vi.mocked(listAlertRulesPage).mockResolvedValue({
+      items: alertRules.map((rule) => ({ ...cloneRule(rule), enabled: true })),
+      total: alertRules.length,
+      page: 1,
+      size: 20,
+    });
     vi.mocked(bulkToggleAlertRules).mockResolvedValue({
       succeededIds: [1],
       failures: { '2': 'network error' },

--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState, type Key } from 'react';
+import { useCallback, useEffect, useRef, useState, type Key } from 'react';
 import { Plus, Pencil, Trash } from '@phosphor-icons/react';
 import {
   Button,
@@ -43,7 +43,7 @@ import {
   bulkDeleteAlertRules,
   bulkToggleAlertRules,
   deleteAlertRule,
-  listAlertRules,
+  listAlertRulesPage,
   toggleAlertRule,
   updateAlertRule,
 } from '../../services/opsService';
@@ -66,6 +66,11 @@ const AlertsPage = () => {
   const { t } = useLang();
   const { token } = theme.useToken();
   const [rules, setRules] = useState<AlertRule[]>([]);
+  const [totalRules, setTotalRules] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [search, setSearch] = useState('');
+  const [enabledFilter, setEnabledFilter] = useState<'all' | 'enabled' | 'disabled'>('all');
   const [loading, setLoading] = useState(true);
   const [modalVisible, setModalVisible] = useState(false);
   const [editingRule, setEditingRule] = useState<AlertRule | null>(null);
@@ -74,6 +79,7 @@ const AlertsPage = () => {
   const [selectedRuleIds, setSelectedRuleIds] = useState<Key[]>([]);
   const [bulkAction, setBulkAction] = useState<'enable' | 'disable' | 'delete' | null>(null);
   const [form] = Form.useForm();
+  const requestIdRef = useRef(0);
 
   const channelLabels: Record<string, string> = {
     dingtalk: 'DingTalk',
@@ -81,24 +87,35 @@ const AlertsPage = () => {
     sms: 'SMS',
   };
 
-  useEffect(() => {
-    let cancelled = false;
-
-    void listAlertRules()
-      .then((nextRules) => {
-        if (!cancelled) setRules(nextRules);
-      })
-      .catch(() => {
-        if (!cancelled) message.error('告警规则加载失败，请稍后重试');
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
+  const loadRules = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
+    try {
+      const result = await listAlertRulesPage({
+        search: search.trim() || undefined,
+        enabled: enabledFilter === 'all' ? undefined : enabledFilter === 'enabled',
+        page,
+        pageSize,
       });
+      if (requestId !== requestIdRef.current) return;
+      setRules(result.items);
+      setTotalRules(result.total);
+    } catch {
+      if (requestId === requestIdRef.current) {
+        message.error('告警规则加载失败，请稍后重试');
+      }
+    } finally {
+      if (requestId === requestIdRef.current) setLoading(false);
+    }
+  }, [enabledFilter, page, pageSize, search]);
 
+  useEffect(() => {
+    const timer = window.setTimeout(() => void loadRules(), 0);
     return () => {
-      cancelled = true;
+      window.clearTimeout(timer);
+      requestIdRef.current += 1;
     };
-  }, []);
+  }, [loadRules]);
 
   const enabledCount = rules.filter((r) => r.enabled).length;
   const selectedCount = selectedRuleIds.length;
@@ -165,7 +182,6 @@ const AlertsPage = () => {
       if (updatedRules.size > 0) {
         setRules((previous) => previous.map((rule) => updatedRules.get(rule.id) ?? rule));
       }
-
       setSelectedRuleIds(failedIds.map(Number));
 
       if (failedIds.length === 0) {
@@ -212,6 +228,7 @@ const AlertsPage = () => {
           const succeeded = new Set(result.succeededIds);
           const failedIds = Object.keys(result.failures);
           setRules((previous) => previous.filter((rule) => !succeeded.has(rule.id)));
+          setTotalRules((previous) => Math.max(previous - result.succeededIds.length, 0));
           setSelectedRuleIds(failedIds.map(Number));
           if (failedIds.length === 0) message.success(t('alerts.bulkDeleteSuccess'));
           else
@@ -364,9 +381,7 @@ const AlertsPage = () => {
           <Flex gap={16}>
             <Flex align="center" gap={4}>
               <span style={{ fontSize: 14, color: '#999' }}>{t('alerts.totalRules')}</span>
-              <span style={{ fontSize: 18, fontWeight: 600, color: '#3b82f6' }}>
-                {rules.length}
-              </span>
+              <span style={{ fontSize: 18, fontWeight: 600, color: '#3b82f6' }}>{totalRules}</span>
             </Flex>
             <Flex align="center" gap={4}>
               <span style={{ fontSize: 14, color: '#999' }}>{t('alerts.enabled')}</span>
@@ -402,7 +417,30 @@ const AlertsPage = () => {
             borderBottom: `1px solid ${token.colorBorderSecondary}`,
           }}
         >
-          <span style={{ color: token.colorTextSecondary }}>
+          <Input.Search
+            allowClear
+            placeholder="搜索规则名称或指标"
+            style={{ width: 260 }}
+            value={search}
+            onChange={(event) => {
+              setPage(1);
+              setSearch(event.target.value);
+            }}
+          />
+          <Select
+            value={enabledFilter}
+            onChange={(value) => {
+              setPage(1);
+              setEnabledFilter(value);
+            }}
+            style={{ width: 130 }}
+            options={[
+              { value: 'all', label: t('common.all') },
+              { value: 'enabled', label: t('alerts.enabled') },
+              { value: 'disabled', label: t('alerts.disabled') },
+            ]}
+          />
+          <span style={{ color: token.colorTextSecondary, marginLeft: 8 }}>
             {t('alerts.selectedRules', { count: selectedCount })}
           </span>
           <Flex gap={8}>
@@ -440,7 +478,22 @@ const AlertsPage = () => {
           size="small"
           loading={loading}
           rowSelection={rowSelection}
-          pagination={false}
+          pagination={{
+            current: page,
+            pageSize,
+            total: totalRules,
+            showSizeChanger: true,
+            pageSizeOptions: ['20', '50', '100'],
+            showTotal: (count) => `${t('common.total')} ${count}`,
+            onChange: (nextPage, nextPageSize) => {
+              if (nextPageSize !== pageSize) {
+                setPage(1);
+                setPageSize(nextPageSize);
+              } else {
+                setPage(nextPage);
+              }
+            },
+          }}
           scroll={{ x: tableScrollX(columns, { selection: true }) }}
         />
       </Card>

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -5,6 +5,7 @@ import * as opsApi from '../api/ops';
 import type {
   AlertRule,
   AlertRuleBulkResult,
+  AlertRulePage,
   SystemAlert,
   AuditQuery,
   AuditRecord,
@@ -99,6 +100,31 @@ function formatAuditCsv(records: AuditRecord[]): string {
 export async function listAlertRules(): Promise<AlertRule[]> {
   if (isMockMode()) return alertRulesState.map(copyAlertRule);
   return opsApi.listAlertRules();
+}
+
+export async function listAlertRulesPage(
+  query: { search?: string; enabled?: boolean; page?: number; pageSize?: number } = {},
+): Promise<AlertRulePage> {
+  if (!isMockMode()) return opsApi.listAlertRulesPage(query);
+  const search = query.search?.trim().toLowerCase();
+  const rules = alertRulesState
+    .filter((rule) => !query.enabled || rule.enabled === query.enabled)
+    .filter(
+      (rule) =>
+        !search ||
+        rule.name.toLowerCase().includes(search) ||
+        rule.metric.toLowerCase().includes(search),
+    )
+    .map(copyAlertRule);
+  const page = query.page ?? 1;
+  const pageSize = query.pageSize ?? 20;
+  const from = Math.min((page - 1) * pageSize, rules.length);
+  return {
+    items: rules.slice(from, from + pageSize),
+    total: rules.length,
+    page,
+    size: pageSize,
+  };
 }
 
 export async function createAlertRule(data: Partial<AlertRule>): Promise<AlertRule> {


### PR DESCRIPTION
Closes #2589

## Summary

- add `GET /api/alert-rules/page` with name search, enabled filter, bounded page, and bounded page size
- apply filtering and deterministic `name ASC, id ASC` ordering in SQL through MyBatis-Plus `Page`
- reject invalid page/pageSize before repository access
- preserve the unpaginated endpoint for export and existing callers
- replace full-inventory reads in `toggleRule` with direct `findRuleById`
- resolve bulk-toggle IDs with an ID-bounded `findRulesByIds` query
- wire the Alert Rules page to server-driven pagination, search, enabled filtering, server total, and stale-response protection
- add mock-mode support for the same page/filter contract

## Why

The page previously fetched every rule and rendered it with `pagination={false}`. Toggling one rule also scanned the complete inventory, and bulk toggle read all rules to resolve a small ID list. This makes the read path bounded by page size and makes targeted mutations use targeted lookups.

## Tests

- focused backend: `AlertServiceTest, AlertRuleControllerTest, MybatisPlusAlertRepositoryTest` — 80 tests passed, Checkstyle 0 violations
- focused frontend: `AlertsPage.test.tsx, opsService.test.ts, ops.test.ts` — 3 files / 32 tests passed
- backend full suite: 1,632 tests run; only the 2 pre-existing `RocketMQMessageProviderTest` failures remain, reproduced earlier on untouched upstream `14da4b95`
- `npm run lint -- --quiet`: 0 errors, 2 pre-existing warnings
- `npm run build`: passed
- `git diff --check`: passed

Production changes: 176 additions / 48 deletions across backend and frontend, naturally exceeding 100 production lines without test padding.

## Note

I also checked open PR #2533. Its later commits already contain a broader native-alerting implementation with alert-rule pagination, but that PR is still open and has been rebased several times. This PR is intentionally scoped to the current upstream code path, avoids the unrelated native-alerting domain changes, and provides a smaller standalone fix. If maintainers prefer to land #2533 first, this PR can be rebased or closed as superseded.