### PR TITLE
fix: sequence client connection requests

### DIFF
--- a/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { App } from 'antd';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -138,6 +138,16 @@ const renderWithProviders = (ui: React.ReactElement) =>
       <LangProvider>{ui}</LangProvider>
     </App>,
   );
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
 
 describe('Clients page', () => {
   it('returns to the first page when the connection search changes', async () => {
@@ -390,6 +400,63 @@ describe('Clients page', () => {
     expect(await screen.findByText('Cluster ns-audit is unavailable')).toBeInTheDocument();
     expect(screen.queryByText('order-svc-0@10.0.1.12:49152')).not.toBeInTheDocument();
     expect(within(screen.getByTestId('connection-total')).getByText('0')).toBeInTheDocument();
+  });
+
+  it('ignores a stale connection response after switching nameservers', async () => {
+    const user = userEvent.setup();
+    const stale = deferred<ClientConnection[]>();
+    const latest = deferred<ClientConnection[]>();
+    vi.mocked(connectionsService.listConnections)
+      .mockImplementationOnce(() => stale.promise)
+      .mockImplementationOnce(() => latest.promise);
+
+    renderWithProviders(<ClientsPage />);
+
+    await user.click(screen.getByRole('combobox', { name: 'NameServer' }));
+    await user.click(
+      await screen.findByText('rocketmq2 (namesrv-2:9876)', {
+        selector: '.ant-select-item-option-content',
+      }),
+    );
+
+    await waitFor(() =>
+      expect(connectionsService.listConnections).toHaveBeenLastCalledWith({
+        namesrvAddr: 'namesrv-2:9876',
+      }),
+    );
+
+    await act(async () => {
+      latest.resolve(connections);
+      stale.resolve([{ ...connection, clientId: 'stale-client@10.0.1.99:49160' }]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText('stale-client@10.0.1.99:49160')).not.toBeInTheDocument();
+    expect(within(screen.getByTestId('connection-total')).getByText('3')).toBeInTheDocument();
+  });
+
+  it('ignores a stale registry response after a retry', async () => {
+    const user = userEvent.setup();
+    const stale = deferred<ClusterInfo[]>();
+    vi.mocked(clusterService.listRegistryClusters)
+      .mockRejectedValueOnce(new Error('Unable to load registry clusters'))
+      .mockImplementationOnce(() => stale.promise);
+
+    renderWithProviders(<ClientsPage />);
+
+    expect(await screen.findByText('Unable to load registry clusters')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /重\s*试/ }));
+    await waitFor(() =>
+      expect(clusterService.listRegistryClusters).toHaveBeenNthCalledWith(2),
+    );
+
+    await act(async () => {
+      stale.resolve([]);
+    });
+
+    expect(screen.queryByText('Unable to load registry clusters')).not.toBeInTheDocument();
+    expect(connectionsService.listConnections).toHaveBeenCalledTimes(0);
   });
 
   it('surfaces registry discovery failures and allows retrying', async () => {

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Button,
@@ -137,6 +137,8 @@ const ClientsPage = () => {
   const [columnFilters, setColumnFilters] = useState<ClientTableFilters>({});
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
+  const registryRequestRef = useRef(0);
+  const connectionRequestRef = useRef(0);
 
   const selectedCluster = registryClusters.find((cluster) => cluster.endpoint === selectedEndpoint);
 
@@ -150,6 +152,7 @@ const ClientsPage = () => {
   );
 
   const handleNameserverChange = (endpoint: string) => {
+    connectionRequestRef.current += 1;
     setCurrentPage(1);
     setSelectedEndpoint(endpoint);
     setConnections([]);
@@ -160,11 +163,11 @@ const ClientsPage = () => {
   };
 
   useEffect(() => {
-    let cancelled = false;
+    const requestId = ++registryRequestRef.current;
 
     void listRegistryClusters()
       .then((nextClusters) => {
-        if (cancelled) return;
+        if (registryRequestRef.current !== requestId) return;
         setRegistryClusters(nextClusters);
         setSelectedEndpoint((current) => {
           if (current && nextClusters.some((cluster) => cluster.endpoint === current)) {
@@ -175,38 +178,35 @@ const ClientsPage = () => {
         setLoadError(null);
       })
       .catch((error) => {
-        if (cancelled) return;
+        if (registryRequestRef.current !== requestId) return;
         setRegistryClusters([]);
         setSelectedEndpoint(undefined);
         setConnections([]);
         setLoadError(getLoadErrorMessage(error));
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (registryRequestRef.current === requestId) setLoading(false);
       });
-
-    return () => {
-      cancelled = true;
-    };
   }, [registryLoadKey]);
 
   useEffect(() => {
-    let cancelled = false;
+    const requestId = ++connectionRequestRef.current;
     if (!selectedEndpoint || !selectedCluster) {
-      return () => {
-        cancelled = true;
-      };
+      return;
     }
+    void Promise.resolve().then(() => {
+      if (connectionRequestRef.current === requestId) setLoading(true);
+    });
 
     void listConnections({ namesrvAddr: selectedEndpoint })
       .then((nextConnections) => {
-        if (!cancelled) {
+        if (connectionRequestRef.current === requestId) {
           setConnections(nextConnections);
           setLoadError(null);
         }
       })
       .catch((error) => {
-        if (!cancelled) {
+        if (connectionRequestRef.current === requestId) {
           setConnections([]);
           setClusterFilter('ALL');
           setSelectedConnection(null);
@@ -214,13 +214,17 @@ const ClientsPage = () => {
         }
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (connectionRequestRef.current === requestId) setLoading(false);
       });
-
-    return () => {
-      cancelled = true;
-    };
   }, [connectionLoadKey, selectedEndpoint, selectedCluster]);
+
+  useEffect(
+    () => () => {
+      registryRequestRef.current += 1;
+      connectionRequestRef.current += 1;
+    },
+    [],
+  );
 
   /* ─── Cluster options using nsClusterName ─── */
   const clusterOptions = useMemo(() => {


### PR DESCRIPTION
Closes #2593

## Summary

- sequence registry discovery with a request-generation ref
- sequence NameServer connection queries with a separate request-generation ref
- ignore stale registry and connection success, error, and loading updates
- enter loading state when a connection request starts, without synchronous setState in the effect body
- keep existing retry, NameServer switching, statistics, CSV export, and detail dialog behavior

## Why

Each effect previously used an independent local `cancelled` flag. That only prevented updates after unmount; it did not distinguish an older in-flight request from the latest one. A slow registry response could overwrite newer retry data, and a slow connection response could replace the connections for a newly selected NameServer.

## Tests

- focused: `ClientsPage.test.tsx` — 15 tests passed
- `npm run lint -- --quiet`: 0 errors, 2 pre-existing warnings
- `npm run build`: passed
- `git diff --check`: passed

Production changes: 24 additions / 20 deletions. The full PR is 92 additions / 21 deletions. This is a genuine correctness fix, but production changed lines are below the separate 100-line target, so the tracking ledger records it as a candidate rather than a complete group.