### PR TITLE
fix: avoid duplicate cluster broker config reads

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -42,11 +42,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -81,7 +83,7 @@ public class ClusterService {
         log.info("Listing all clusters");
         List<ClusterVO> discovered = clusterProvider.discoverClusters();
         if (discovered != null && !discovered.isEmpty()) {
-            discovered.forEach(this::enrichWithLiveConfig);
+            enrichDiscoveredClusters(discovered, null);
             return discovered;
         }
         return List.of();
@@ -122,7 +124,7 @@ public class ClusterService {
         log.info("Listing clusters for instance: {}", instanceId);
         List<ClusterVO> discovered = clusterProvider.discoverClusters(instanceId);
         if (discovered != null && !discovered.isEmpty()) {
-            discovered.forEach(cluster -> enrichWithLiveConfig(cluster, instanceId));
+            enrichDiscoveredClusters(discovered, instanceId);
             return discovered;
         }
         return List.of();
@@ -191,9 +193,35 @@ public class ClusterService {
     }
 
     private void enrichWithLiveConfig(ClusterVO cluster, String instanceId) {
+        enrichWithLiveConfig(cluster, instanceId, Set.of());
+    }
+
+    /**
+     * Enriches a discovered cluster list without repeating broker-config reads for the same
+     * broker address. Multiple registry entries can expose the same underlying clusters;
+     * once an address fails, later duplicates should use the persisted fallback immediately.
+     */
+    private void enrichDiscoveredClusters(List<ClusterVO> clusters, String instanceId) {
+        Set<String> attemptedAddresses = new LinkedHashSet<>();
+        for (ClusterVO cluster : clusters) {
+            if (cluster == null) {
+                continue;
+            }
+            enrichWithLiveConfig(cluster, instanceId, attemptedAddresses);
+            if (cluster.getBrokers() != null) {
+                cluster.getBrokers().stream()
+                        .map(BrokerVO::getAddr)
+                        .filter(address -> address != null && !address.isEmpty())
+                        .forEach(attemptedAddresses::add);
+            }
+        }
+    }
+
+    private void enrichWithLiveConfig(ClusterVO cluster, String instanceId, Set<String> attemptedAddresses) {
         if (cluster.getBrokers() != null) {
             for (BrokerVO broker : cluster.getBrokers()) {
-                if (broker.getAddr() != null && !broker.getAddr().isEmpty()) {
+                if (broker.getAddr() != null && !broker.getAddr().isEmpty()
+                        && !attemptedAddresses.contains(broker.getAddr())) {
                     try {
                         cluster.setConfig(brokerConfigService.getBrokerConfig(broker.getAddr(), instanceId));
                         return;

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -146,6 +146,39 @@ class ClusterServiceTest {
     }
 
     @Test
+    void listClustersShouldNotRepeatBrokerConfigReadsForDuplicateBrokers() {
+        ClusterVO duplicateCluster = ClusterVO.builder()
+                .name("duplicate-cluster")
+                .status(ClusterStatus.warning)
+                .brokers(List.of(BrokerVO.builder()
+                        .name("broker-0")
+                        .addr("10.0.0.1:10911")
+                        .build()))
+                .build();
+        duplicateCluster.setId("cluster-2");
+        sampleCluster.setConfig(null);
+        when(clusterProvider.discoverClusters()).thenReturn(List.of(sampleCluster, duplicateCluster));
+        when(brokerConfigService.getBrokerConfig("10.0.0.1:10911", null))
+                .thenThrow(new BusinessException(502, "broker unavailable"));
+        when(clusterRepository.findById("cluster-1"))
+                .thenReturn(Optional.of(ClusterVO.builder()
+                        .config(ClusterConfigVO.builder().maxMessageSize(1024).build())
+                        .build()));
+        when(clusterRepository.findById("cluster-2"))
+                .thenReturn(Optional.of(ClusterVO.builder()
+                        .config(ClusterConfigVO.builder().maxMessageSize(2048).build())
+                        .build()));
+
+        List<ClusterVO> result = clusterService.listClusters();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getConfig().getMaxMessageSize()).isEqualTo(1024);
+        assertThat(result.get(1).getConfig().getMaxMessageSize()).isEqualTo(2048);
+        verify(brokerConfigService, org.mockito.Mockito.times(1))
+                .getBrokerConfig("10.0.0.1:10911", null);
+    }
+
+    @Test
     void updateClusterConfigShouldRejectDifferentDefaultReadAndWriteQueueNums() {
         UpdateConfigDTO command = UpdateConfigDTO.builder()
                 .id("cluster-1")


### PR DESCRIPTION
Closes #2595

## Summary

- enrich a discovery result with one shared attempted-broker-address set
- attempt each distinct broker address at most once per discovery call
- let duplicate clusters referencing an unavailable broker use their persisted-config fallback immediately
- preserve existing single-cluster detail enrichment behavior
- add a regression test with two discovered clusters sharing one unavailable broker

## Why

Each discovered cluster previously performed live broker-config enrichment independently. Discovery can return multiple registry views containing the same broker; when that broker was unavailable, every duplicate repeated the same failing admin call before falling back.

## Tests

- focused: `ClusterServiceTest` — 39 tests passed, Checkstyle 0 violations
- backend full suite: 1,627 tests run; only the 2 pre-existing `RocketMQMessageProviderTest` failures remain
- `git diff --check`: passed

Production changes: 31 additions / 3 deletions. The full PR is 64 additions / 3 deletions. This is a real efficiency/fallback fix, but production changed lines are below the separate 100-line target, so the tracking ledger records it as a candidate rather than a complete group.