### PR TITLE
fix: sequence cluster inventory requests

### DIFF
--- a/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
@@ -757,4 +757,35 @@ describe('Cluster page', () => {
 
     expect(clusterServiceMocks.listClusters).toHaveBeenCalledTimes(1);
   });
+
+  it('ignores stale registry-cluster and nameserver responses', async () => {
+    const staleClusters = deferred<ClusterInfo[]>();
+    const latestClusters = deferred<ClusterInfo[]>();
+    clusterServiceMocks.listRegistryClusters
+      .mockImplementationOnce(() => staleClusters.promise)
+      .mockImplementationOnce(() => latestClusters.promise);
+
+    renderWithProviders(<ClusterPage />);
+    await flushPromises();
+    fireEvent.click(screen.getByRole('button', { name: '刷新' }));
+    await flushPromises();
+
+    await act(async () => {
+      staleClusters.resolve([buildCluster({ connections: 501 })]);
+      await staleClusters.promise;
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText('501')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Proxy 管理/ }));
+
+    await act(async () => {
+      latestClusters.resolve([buildCluster({ connections: 502 })]);
+      await latestClusters.promise;
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('502')).toBeInTheDocument();
+  });
 });

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -129,76 +129,74 @@ const ClusterPage = () => {
   const [selectedProxy, setSelectedProxy] = useState<ProxyDetail | null>(null);
   const [configForm] = Form.useForm();
 
-  const loadNsRegistry = useCallback(async () => {
-    try {
-      setNsRegistry(await listNameserverRegistry());
-    } catch {
-      setNsRegistry([]);
-    }
-  }, []);
-
-  useEffect(() => {
-    let active = true;
-    listNameserverRegistry()
-      .then((entries) => {
-        if (active) setNsRegistry(entries);
-      })
-      .catch(() => {
-        if (active) setNsRegistry([]);
-      });
-    return () => {
-      active = false;
-    };
-  }, []);
-
   const [k8sIdOptions, setK8sIdOptions] = useState<string[]>([]);
 
   const [registryClusters, setRegistryClusters] = useState<ClusterInfo[]>([]);
   const [registryLoading, setRegistryLoading] = useState(true);
+  const nsRegistryRequestRef = useRef(0);
+  const registryClustersRequestRef = useRef(0);
+  const k8sCertsRequestRef = useRef(0);
 
   const loadRegistryClusters = useCallback(async () => {
-    setRegistryLoading(true);
+    const requestId = ++registryClustersRequestRef.current;
+    void Promise.resolve().then(() => {
+      if (registryClustersRequestRef.current === requestId) setRegistryLoading(true);
+    });
     try {
-      setRegistryClusters(await listRegistryClusters());
+      const nextClusters = await listRegistryClusters();
+      if (registryClustersRequestRef.current === requestId) {
+        setRegistryClusters(nextClusters);
+      }
     } catch {
-      setRegistryClusters([]);
+      if (registryClustersRequestRef.current === requestId) {
+        setRegistryClusters([]);
+      }
     } finally {
-      setRegistryLoading(false);
+      if (registryClustersRequestRef.current === requestId) {
+        setRegistryLoading(false);
+      }
     }
   }, []);
 
   useEffect(() => {
-    let active = true;
-    listRegistryClusters()
-      .then((next) => {
-        if (active) setRegistryClusters(next);
-      })
-      .catch(() => {
-        if (active) setRegistryClusters([]);
-      })
-      .finally(() => {
-        if (active) setRegistryLoading(false);
-      });
-    return () => {
-      active = false;
-    };
+    void Promise.resolve().then(loadRegistryClusters);
+  }, [loadRegistryClusters]);
+
+  const loadNsRegistry = useCallback(async () => {
+    const requestId = ++nsRegistryRequestRef.current;
+    try {
+      const entries = await listNameserverRegistry();
+      if (nsRegistryRequestRef.current === requestId) setNsRegistry(entries);
+    } catch {
+      if (nsRegistryRequestRef.current === requestId) setNsRegistry([]);
+    }
   }, []);
 
   useEffect(() => {
-    let active = true;
+    void Promise.resolve().then(loadNsRegistry);
+  }, [loadNsRegistry]);
+
+  useEffect(() => {
+    const requestId = ++k8sCertsRequestRef.current;
     listK8sCerts()
       .then((certs) => {
-        if (active) {
+        if (k8sCertsRequestRef.current === requestId) {
           setK8sIdOptions([...new Set(certs.map((cert) => cert.k8sId).filter(Boolean))]);
         }
       })
       .catch(() => {
-        if (active) setK8sIdOptions([]);
+        if (k8sCertsRequestRef.current === requestId) setK8sIdOptions([]);
       });
-    return () => {
-      active = false;
-    };
   }, []);
+
+  useEffect(
+    () => () => {
+      nsRegistryRequestRef.current += 1;
+      registryClustersRequestRef.current += 1;
+      k8sCertsRequestRef.current += 1;
+    },
+    [],
+  );
 
   const [nsCreateModalOpen, setNsCreateModalOpen] = useState(false);
   const [nsModalMode, setNsModalMode] = useState<'create' | 'edit'>('create');


### PR DESCRIPTION
Closes #2597

## Summary

- sequence NameServer registry requests with a request-generation ref
- sequence registry-discovered cluster requests and their loading/error/data updates
- sequence K8s certificate option requests
- ignore stale auxiliary inventory responses after a newer refresh starts
- preserve the existing instance-cluster refresh coordinator, registry mutations, tabs, and polling behavior

## Why

The main instance-cluster polling loop already coordinates foreground/background refreshes, but the NameServer registry, registry-cluster inventory, and K8s certificate option effects still used independent local `cancelled` flags. Those flags only protect unmount; a slow earlier response could overwrite a newer refresh triggered by the global Refresh button.

## Tests

- focused: `ClusterPage.test.tsx` — 17 tests passed
- `npm run lint -- --quiet`: 0 errors, 2 pre-existing warnings
- `npm run build`: passed
- `git diff --check`: passed

Production changes: 44 additions / 46 deletions. The full PR is 75 additions / 46 deletions. This is a genuine correctness fix, but production changed lines are below the separate 100-line target, so the tracking ledger records it as a candidate rather than a complete group.