### PR TITLE
fix: sequence DLQ group requests

### DIFF
--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -487,4 +487,29 @@ describe('DLQ page', () => {
     expect(within(retryDialog as HTMLElement).getByText('-cg-"payment"')).toBeInTheDocument();
     expect(messageService.listDLQGroups).toHaveBeenCalledTimes(2);
   });
+
+  it('ignores a stale group response after changing instances', async () => {
+    let resolveFirstInstance!: (page: DLQGroupPage) => void;
+    vi.mocked(messageService.listDLQGroups)
+      .mockImplementationOnce(
+        () =>
+          new Promise<DLQGroupPage>((resolve) => {
+            resolveFirstInstance = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(pageOf([secondDlqGroup]));
+    const user = userEvent.setup();
+    renderWithProviders(<DLQPage />);
+
+    await user.click(screen.getAllByRole('combobox')[0]);
+    await user.click(
+      await screen.findByText('instance-2', { selector: '.ant-select-item-option-content' }),
+    );
+    expect(await screen.findByText('-cg-"payment"')).toBeInTheDocument();
+
+    await act(async () => resolveFirstInstance(pageOf([dlqGroup])));
+
+    expect(screen.queryByText('cg-order')).not.toBeInTheDocument();
+    expect(screen.getByText('-cg-"payment"')).toBeInTheDocument();
+  });
 });

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -142,6 +142,7 @@ const DLQPage = () => {
   const [detailError, setDetailError] = useState<string | null>(null);
   const detailRequestIdRef = useRef(0);
   const retryRequestIdRef = useRef(0);
+  const groupRequestIdRef = useRef(0);
 
   useEffect(
     () => () => {
@@ -175,16 +176,14 @@ const DLQPage = () => {
   }
 
   useEffect(() => {
-    let cancelled = false;
+    const requestId = ++groupRequestIdRef.current;
 
     if (!selectedInstanceId) {
       void Promise.resolve().then(() => {
-        if (cancelled) return;
+        if (groupRequestIdRef.current !== requestId) return;
         setLoading(false);
       });
-      return () => {
-        cancelled = true;
-      };
+      return;
     }
 
     // Clear `loading` inside the same callback as the data updates so rows and
@@ -192,7 +191,7 @@ const DLQPage = () => {
     // visible for a render while the spin overlay still blocks pointer events.
     void listDLQGroups(selectedInstanceId, search || undefined, page, pageSize)
       .then((result) => {
-        if (!cancelled) {
+        if (groupRequestIdRef.current === requestId) {
           setGroups(result.items);
           setTotal(result.total);
           setLoadError(null);
@@ -206,16 +205,19 @@ const DLQPage = () => {
         }
       })
       .catch((error) => {
-        if (!cancelled) {
+        if (groupRequestIdRef.current === requestId) {
           setLoadError(getErrorMessage(error, DEFAULT_LOAD_ERROR));
           setLoading(false);
         }
       });
-
-    return () => {
-      cancelled = true;
-    };
   }, [refreshKey, selectedInstanceId, search, page, pageSize]);
+
+  useEffect(
+    () => () => {
+      groupRequestIdRef.current += 1;
+    },
+    [],
+  );
 
   const selectedGroups = useMemo(() => {
     const selected = new Set(selectedGroupNames);


### PR DESCRIPTION
Closes #2599

## Summary

- sequence the DLQ group inventory with a request-generation ref
- ignore stale success and error responses after instance, search, pagination, or refresh changes
- keep loading-state updates tied to the latest request
- preserve the existing instance-scope reset, detail request sequencing, and retry request sequencing
- add a regression test where a stale response from the previous instance cannot replace the current instance’s groups

## Why

The group inventory previously used a local `cancelled` flag. That only protected unmount; it could not distinguish a slow earlier request from the latest one. The detail drawer and retry flow already had request-generation guards, leaving the main inventory inconsistent and vulnerable to stale writes.

## Tests

- focused: `DLQPage.test.tsx` — 16 tests passed
- `npm run lint -- --quiet`: 0 errors, 2 pre-existing warnings
- `npm run build`: passed
- `git diff --check`: passed

Production changes: 13 additions / 11 deletions. The full PR is 38 additions / 11 deletions. This is a genuine correctness fix, but production changed lines are below the separate 100-line target, so the tracking ledger records it as a candidate rather than a complete group.