### PR TITLE
fix: record message query history once per page set

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -42,12 +42,20 @@ public class MessageService {
 
     public List<MessageRecordVO> queryMessages(
             String instanceId, String topic, String msgId, String tag, String key, Long startTime, Long endTime) {
+        return queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime, true);
+    }
+
+    private List<MessageRecordVO> queryMessages(
+            String instanceId, String topic, String msgId, String tag, String key,
+            Long startTime, Long endTime, boolean recordHistory) {
         validateTopicQueryWindow(topic, msgId, key, startTime, endTime);
         log.info("Querying messages: topic={}, msgId={}, tag={}, key={}", topic, msgId, tag, key);
         List<MessageRecordVO> result = providerRegistry.byInstanceId(instanceId)
                 .map(provider -> provider.queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime))
                 .orElseGet(() -> messageProvider.queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime));
-        recordMessageQuery(instanceId, topic, msgId, tag, key, startTime, endTime, result.size());
+        if (recordHistory) {
+            recordMessageQuery(instanceId, topic, msgId, tag, key, startTime, endTime, result.size());
+        }
         return result;
     }
 
@@ -56,7 +64,8 @@ public class MessageService {
         if (page < 1 || pageSize < 1 || pageSize > MAX_PAGE_SIZE) {
             throw new BusinessException(400, "page must be positive and pageSize must be between 1 and 200");
         }
-        List<MessageRecordVO> result = queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime);
+        List<MessageRecordVO> result = queryMessages(
+                instanceId, topic, msgId, tag, key, startTime, endTime, page == 1);
         long offset = (long) (page - 1) * pageSize;
         int from = (int) Math.min(offset, result.size());
         int to = Math.min(from + pageSize, result.size());

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -186,4 +186,25 @@ class MessageServiceTest {
         assertThat(page.getTotal()).isEqualTo(200);
         assertThat(page.isResultMayBeTruncated()).isTrue();
     }
+
+    @Test
+    void pageQueryRecordsHistoryOnlyForTheFirstPage() {
+        MessageProvider provider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        QueryHistoryService history = mock(QueryHistoryService.class);
+        MessageService service = new MessageService(provider, registry, history, mock(OperationAuditService.class));
+        when(registry.byInstanceId("instance-a")).thenReturn(Optional.empty());
+        when(provider.queryMessages("instance-a", "TopicA", null, null, null, 1000L, 2000L))
+                .thenReturn(List.of(MessageRecordVO.builder().msgId("msg-1").build()));
+
+        service.queryMessagesPage("instance-a", "TopicA", null, null, null,
+                1000L, 2000L, 1, 50);
+        service.queryMessagesPage("instance-a", "TopicA", null, null, null,
+                1000L, 2000L, 2, 50);
+
+        verify(provider, org.mockito.Mockito.times(2))
+                .queryMessages("instance-a", "TopicA", null, null, null, 1000L, 2000L);
+        verify(history, org.mockito.Mockito.times(1)).recordMessageQuery(
+                "instance-a", "TOPIC", "TopicA", null, null, null, 1000L, 2000L, 1);
+    }
 }


### PR DESCRIPTION
Closes #2601

## Summary

- keep message-query history recording for direct queries
- record history only for the first page of a paginated message query
- keep provider query and page slicing behavior unchanged
- add a focused test that first and later pages both query the provider, while only page 1 writes history

## Why

Every paginated request previously reused the direct query path, which records a history row after each provider query. Paging through one result therefore created duplicate `rmq_message_query` rows and inflated server history/summary counts.

## Tests

- focused: `MessageServiceTest, MessageControllerTest` — 15 tests passed, Checkstyle 0 violations
- backend full suite: 1,627 tests run; only the 2 known pre-existing `RocketMQMessageProviderTest` failures remain
- `git diff --check`: passed

Production changes: 11 additions / 2 deletions. The full PR is 32 additions / 2 deletions. This is a real correctness/data-quality fix, but production changed lines are below the separate 100-line target, so the tracking ledger records it as a candidate rather than a complete group.