### PR TITLE
Fix alert duration export grammar

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTO.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 @Data
 public class AlertRuleRequestDTO {
+    static final String PROMETHEUS_DURATION_REGEXP = "(?:[0-9]+(?:ms|s|m|h|d|w|y))+";
+
     private Long id;
     @NotBlank(message = "name is required")
     private String name;
@@ -34,7 +36,7 @@ public class AlertRuleRequestDTO {
     private String operator;
     private double threshold;
     private String thresholdUnit;
-    @Pattern(regexp = "(?:[0-9]+(?:ms|s|m|h|d|w|y))+", message = "duration is invalid")
+    @Pattern(regexp = PROMETHEUS_DURATION_REGEXP, message = "duration is invalid")
     private String duration;
     @Pattern(regexp = "LAST|MAX|MIN|AVG|SUM", flags = Pattern.Flag.CASE_INSENSITIVE,
             message = "aggregation is invalid")

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertService.java
@@ -46,7 +46,8 @@ public class AlertService {
 
     private static final Set<String> VALID_OPERATORS = Set.of(">", ">=", "<", "<=", "==", "!=", "UNAVAILABLE");
     private static final Pattern METRIC_NAME_PATTERN = Pattern.compile("^[a-zA-Z_:][a-zA-Z0-9_:]*$");
-    private static final Pattern DURATION_PATTERN = Pattern.compile("^\\d+(ms|s|m|h|d|w|y)$");
+    private static final Pattern DURATION_PATTERN = Pattern.compile(
+            "^" + AlertRuleRequestDTO.PROMETHEUS_DURATION_REGEXP + "$");
 
     private final AlertRepository alertRepository;
     private final AlertStateRepository alertStateRepository;

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTOTest.java
@@ -42,6 +42,15 @@ class AlertRuleRequestDTOTest {
     }
 
     @Test
+    void durationShouldAcceptCompositePrometheusDurationTest() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName("High Lag");
+        request.setDuration("1h30m");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+
+    @Test
     void toAlertRuleVOShouldTrimAndDeduplicateChannelsInInputOrderTest() {
         AlertRuleRequestDTO request = new AlertRuleRequestDTO();
         request.setName("High Lag");

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceTest.java
@@ -242,6 +242,24 @@ class AlertServiceTest {
     }
 
     @Test
+    void exportPrometheusRulesYamlShouldPreserveCompositePrometheusDurationTest() {
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .name("High Lag Alert")
+                .metric("rocketmq_consumer_lag_messages")
+                .operator(">")
+                .threshold(5000)
+                .duration("1h30m")
+                .description("Lag too high")
+                .enabled(true)
+                .build();
+        when(alertRepository.findAllRules()).thenReturn(List.of(rule));
+
+        String result = alertService.exportPrometheusRulesYaml();
+
+        assertThat(result).contains("for: 1h30m").doesNotContain("for: 5m");
+    }
+
+    @Test
     void exportPrometheusRulesYamlShouldExcludeNativeClusterRulesTest() {
         AlertRuleVO legacy = AlertRuleVO.builder()
                 .name("High Lag Alert")


### PR DESCRIPTION
## Summary
- share the Prometheus duration grammar between `AlertRuleRequestDTO` validation and `AlertService` export validation
- preserve valid composite durations like `1h30m` in exported Prometheus YAML instead of falling back to `5m`
- add backend regression coverage for DTO validation and YAML export

Fixes #2604

## Tests
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=AlertRuleRequestDTOTest,AlertServiceTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest='org.apache.rocketmq.studio.ops.alert.*Test' test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -DskipTests package`