### PR TITLE
Fix alert rule form value contract

### DIFF
--- a/web/src/pages/ops/__tests__/alerts.test.ts
+++ b/web/src/pages/ops/__tests__/alerts.test.ts
@@ -20,8 +20,8 @@ import { attachThresholdUnit } from '../alertRulePayload';
 
 describe('attachThresholdUnit', () => {
   it('derives the threshold unit from the selected metric', () => {
-    expect(attachThresholdUnit({ metric: 'Broker 离线', threshold: 1 })).toEqual({
-      metric: 'Broker 离线',
+    expect(attachThresholdUnit({ metric: 'rocketmq_broker_offline', threshold: 1 })).toEqual({
+      metric: 'rocketmq_broker_offline',
       threshold: 1,
       thresholdUnit: '个',
     });
@@ -30,14 +30,23 @@ describe('attachThresholdUnit', () => {
   it('overwrites stale units when a metric changes', () => {
     expect(
       attachThresholdUnit({
-        metric: '消费堆积量',
+        metric: 'rocketmq_consumer_lag_messages',
         threshold: 100,
         thresholdUnit: '%',
       }),
     ).toEqual({
-      metric: '消费堆积量',
+      metric: 'rocketmq_consumer_lag_messages',
       threshold: 100,
       thresholdUnit: '条',
+    });
+  });
+
+  it('normalizes legacy display values before submitting them to the backend', () => {
+    expect(attachThresholdUnit({ metric: '磁盘使用率', duration: '5分钟', threshold: 85 })).toEqual({
+      metric: 'rocketmq_disk_use_ratio',
+      duration: '5m',
+      threshold: 85,
+      thresholdUnit: '%',
     });
   });
 });

--- a/web/src/pages/ops/alertRulePayload.ts
+++ b/web/src/pages/ops/alertRulePayload.ts
@@ -15,19 +15,49 @@
  * limitations under the License.
  */
 
-export const thresholdUnits: Record<string, string> = {
-  磁盘使用率: '%',
-  消费堆积量: '条',
-  'TPS 异常': 'TPS',
-  'Broker 离线': '个',
-  'Proxy 连接数': '个',
+export const legacyMetricValues: Record<string, string> = {
+  磁盘使用率: 'rocketmq_disk_use_ratio',
+  消费堆积量: 'rocketmq_consumer_lag_messages',
+  'TPS 异常': 'rocketmq_tps',
+  'Broker 离线': 'rocketmq_broker_offline',
+  'Proxy 连接数': 'rocketmq_proxy_connections',
 };
 
-export function attachThresholdUnit<T extends { metric: string }>(
+const legacyDurationValues: Record<string, string> = {
+  '1分钟': '1m',
+  '5分钟': '5m',
+  '15分钟': '15m',
+  '30分钟': '30m',
+};
+
+export const thresholdUnits: Record<string, string> = {
+  rocketmq_disk_use_ratio: '%',
+  rocketmq_consumer_lag_messages: '条',
+  rocketmq_tps: 'TPS',
+  rocketmq_broker_offline: '个',
+  rocketmq_proxy_connections: '个',
+};
+
+export function normalizeMetric(metric: string): string {
+  return legacyMetricValues[metric] ?? metric;
+}
+
+export function normalizeDuration(duration: string): string {
+  return legacyDurationValues[duration] ?? duration;
+}
+
+export function attachThresholdUnit<T extends { metric: string; duration?: string }>(
   values: T,
-): T & { thresholdUnit: string } {
+): Omit<T, 'metric' | 'duration'> & {
+  metric: string;
+  duration?: string;
+  thresholdUnit: string;
+} {
+  const metric = normalizeMetric(values.metric);
   return {
     ...values,
-    thresholdUnit: thresholdUnits[values.metric] ?? '',
+    metric,
+    ...(values.duration === undefined ? {} : { duration: normalizeDuration(values.duration) }),
+    thresholdUnit: thresholdUnits[metric] ?? '',
   };
 }

--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -61,6 +61,7 @@ import {
   testAlertRule,
   updateAlertRule,
 } from '../../services/opsService';
+import { attachThresholdUnit, normalizeDuration, normalizeMetric } from './alertRulePayload';
 import { tableScrollX } from '../../utils/table';
 import { formatDateTime } from '../../utils/format';
 import { listInstances } from '../../services/instanceService';
@@ -340,7 +341,11 @@ const AlertsPage = ({ domain = 'CLUSTER' }: AlertsPageProps) => {
 
   const openEditModal = (rule: AlertRule) => {
     setEditingRule(rule);
-    form.setFieldsValue(rule);
+    form.setFieldsValue({
+      ...rule,
+      metric: normalizeMetric(rule.metric),
+      duration: normalizeDuration(rule.duration),
+    });
     setSelectedInstanceId(rule.instanceId);
     if (rule.instanceId?.trim()) {
       void loadMetricCapabilities(rule.instanceId, false);
@@ -355,7 +360,12 @@ const AlertsPage = ({ domain = 'CLUSTER' }: AlertsPageProps) => {
     setTestResult(null);
     setSelectedInstanceId(rule.instanceId);
     const { id: _id, lastTriggered: _lastTriggered, ...copy } = rule;
-    form.setFieldsValue({ ...copy, name: t('alerts.duplicateName', { name: rule.name }) });
+    form.setFieldsValue({
+      ...copy,
+      name: t('alerts.duplicateName', { name: rule.name }),
+      metric: normalizeMetric(copy.metric),
+      duration: normalizeDuration(copy.duration),
+    });
     if (rule.instanceId?.trim()) {
       void loadMetricCapabilities(rule.instanceId, false);
     } else {
@@ -615,8 +625,8 @@ const AlertsPage = ({ domain = 'CLUSTER' }: AlertsPageProps) => {
     try {
       const values = await form.validateFields();
       const payload = {
-        ...values,
-        ...(nativeRatioMetrics.has(values.metric) ? { thresholdUnit: '%' } : {}),
+        ...attachThresholdUnit(values),
+        ...(nativeRatioMetrics.has(normalizeMetric(values.metric)) ? { thresholdUnit: '%' } : {}),
       } as Partial<AlertRule>;
       setSubmitting(true);
       if (editingRule) {
@@ -649,8 +659,8 @@ const AlertsPage = ({ domain = 'CLUSTER' }: AlertsPageProps) => {
     try {
       const values = await form.validateFields();
       const payload = {
-        ...values,
-        ...(nativeRatioMetrics.has(values.metric) ? { thresholdUnit: '%' } : {}),
+        ...attachThresholdUnit(values),
+        ...(nativeRatioMetrics.has(normalizeMetric(values.metric)) ? { thresholdUnit: '%' } : {}),
       } as Partial<AlertRule>;
       setTesting(true);
       const result = await (domain === 'CLUSTER'


### PR DESCRIPTION
## Summary
- keep localized metric and duration labels while submitting Prometheus-compatible identifiers and durations
- preserve threshold units for normalized metrics
- normalize legacy display values when editing older rules
- add regression coverage for payload normalization

Fixes #2603

## Tests
- `cd web && npm test -- --run src/pages/ops/__tests__/alerts.test.ts src/pages/ops/__tests__/AlertsPage.test.tsx`
- `cd web && npm run build`