### PR TITLE
[Studio] feat: export studio users

### DIFF
--- a/web/src/api/studioUsers.test.ts
+++ b/web/src/api/studioUsers.test.ts
@@ -18,10 +18,11 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import client from './client';
-import { listStudioUsers } from './studioUsers';
+import { listAllStudioUsers as loadStudioUsersForExport, listStudioUsers } from './studioUsers';
 
 const mock = new MockAdapter(client);
-
+const exportQuery = { search: 'op', admin: false };
+const exportRequestParams = [1, 2].map((page) => ({ ...exportQuery, page, pageSize: 100 }));
 describe('studio users API', () => {
   beforeEach(() => mock.reset());
   afterEach(() => mock.reset());
@@ -58,5 +59,34 @@ describe('studio users API', () => {
       page: 2,
       pageSize: 20,
     });
+  });
+
+  it('loads all export pages with the maximum supported page size', async () => {
+    mock.onGet('/studio-users').reply((config) => {
+      const currentPage = config.params?.page;
+      const pageItems =
+        currentPage === 1
+          ? [{ id: 7, username: 'operator', admin: false, enabled: true }]
+          : [{ id: 8, username: 'admin', admin: true, enabled: false }];
+      return [
+        200,
+        {
+          code: 200,
+          data: {
+            items: pageItems,
+            total: 2,
+            page: currentPage,
+            size: 100,
+          },
+        },
+      ];
+    });
+    const exportedUsers = await loadStudioUsersForExport(exportQuery);
+    expect(exportedUsers.map((user) => user.username)).toEqual(['operator', 'admin']);
+    expect(mock.history.get).toHaveLength(2);
+    expect(mock.history.get.map((request) => request.params)).toEqual([
+      exportRequestParams[0],
+      exportRequestParams[1],
+    ]);
   });
 });

--- a/web/src/api/studioUsers.ts
+++ b/web/src/api/studioUsers.ts
@@ -16,6 +16,8 @@
  */
 import client from './client';
 
+const STUDIO_USER_EXPORT_PAGE_SIZE = 100;
+const STUDIO_USER_MAX_EXPORT_PAGES = 100;
 export interface StudioUser {
   id: number;
   username: string;
@@ -41,6 +43,8 @@ export interface StudioUserQuery {
   pageSize?: number;
 }
 
+type StudioUserExportQuery = Omit<StudioUserQuery, 'page' | 'pageSize'>;
+type CreateStudioUserRequest = Pick<StudioUser, 'username' | 'admin'> & { password: string };
 export async function listStudioUsers(query: StudioUserQuery = {}) {
   const response = await client.get<{ data: StudioUserPage }>('/studio-users', {
     params: query,
@@ -48,13 +52,32 @@ export async function listStudioUsers(query: StudioUserQuery = {}) {
   return response.data.data;
 }
 
-export async function createStudioUser(request: { username: string; password: string; admin: boolean }) {
+export const listAllStudioUsers = async (
+  query: StudioUserExportQuery = {},
+): Promise<StudioUser[]> => {
+  const allUsers: StudioUser[] = [];
+  let page = 1;
+  while (page <= STUDIO_USER_MAX_EXPORT_PAGES) {
+    const result = await listStudioUsers({
+      ...query,
+      page,
+      pageSize: STUDIO_USER_EXPORT_PAGE_SIZE,
+    });
+    allUsers.push(...result.items);
+    const total = result.total ?? allUsers.length;
+    if (result.items.length === 0 || allUsers.length >= total) return allUsers;
+    page += 1;
+  }
+  throw new Error(`Studio user export exceeded ${STUDIO_USER_MAX_EXPORT_PAGES} pages`);
+};
+export async function createStudioUser(request: CreateStudioUserRequest) {
   const response = await client.post<{ data: StudioUser }>('/studio-users', request);
   return response.data.data;
 }
 
 export async function setStudioUserEnabled(userId: number, enabled: boolean) {
-  const response = await client.post<{ data: StudioUser }>(`/studio-users/${userId}/status`, { enabled });
+  const statusPath = `/studio-users/${userId}/status`;
+  const response = await client.post<{ data: StudioUser }>(statusPath, { enabled });
   return response.data.data;
 }
 

--- a/web/src/pages/studio/UserManagement.tsx
+++ b/web/src/pages/studio/UserManagement.tsx
@@ -30,19 +30,21 @@ import {
   message,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { Key, Plus } from '@phosphor-icons/react';
+import { DownloadSimple, Key, Plus } from '@phosphor-icons/react';
 import { useNavigate } from 'react-router-dom';
 import PageHeader from '../../components/PageHeader';
 import InfoBanner from '../../components/InfoBanner';
 import { changePassword } from '../../api/auth';
 import {
   createStudioUser,
+  listAllStudioUsers as exportStudioUsers,
   listStudioUsers,
   resetStudioUserPassword,
   setStudioUserEnabled,
   type StudioUser,
 } from '../../api/studioUsers';
 import useAuthStore from '../../stores/authStore';
+import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 interface CreateFormValues {
   username: string;
@@ -61,6 +63,15 @@ const PAGE_SIZE_OPTIONS = [20, 50, 100];
 type RoleFilter = 'admin' | 'reader';
 type StatusFilter = 'enabled' | 'disabled';
 
+const STUDIO_USER_EXPORT_COLUMNS: CsvColumn<StudioUser>[] = [
+  { header: 'User ID', value: (user) => user.id },
+  { header: 'Username', value: (user) => user.username },
+  { header: 'Role', value: (user) => (user.admin ? 'Admin' : 'User') },
+  { header: 'Status', value: (user) => (user.enabled ? 'Enabled' : 'Disabled') },
+  { header: 'Password Changed At', value: (user) => dateTime(user.passwordChangedAt) },
+  { header: 'Created At', value: (user) => dateTime(user.gmtCreate) },
+  { header: 'Modified At', value: (user) => dateTime(user.gmtModified) },
+];
 const UserManagementPage = () => {
   const navigate = useNavigate();
   const admin = useAuthStore((state) => state.admin);
@@ -77,6 +88,7 @@ const UserManagementPage = () => {
   const [loading, setLoading] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [passwordTarget, setPasswordTarget] = useState<StudioUser | null>(null);
+  const [userExporting, setUserExporting] = useState(false);
   const [createForm] = Form.useForm<CreateFormValues>();
   const [passwordForm] = Form.useForm<PasswordFormValues>();
   const requestSeqRef = useRef(0);
@@ -179,7 +191,27 @@ const UserManagementPage = () => {
       message.error('修改密码失败');
     }
   };
-
+  const openCreateUserModal = () => setCreateOpen(true);
+  const handleExportUsers = useCallback(async () => {
+    if (!admin) return;
+    setUserExporting(true);
+    try {
+      const exportedUsers = await exportStudioUsers({
+        search: search.trim() || undefined,
+        admin: roleFilter === undefined ? undefined : roleFilter === 'admin',
+        enabled: statusFilter === undefined ? undefined : statusFilter === 'enabled',
+      });
+      const today = new Date().toISOString().slice(0, 10);
+      downloadCsv(
+        `rocketmq-studio-users-${today}.csv`,
+        buildCsv(STUDIO_USER_EXPORT_COLUMNS, exportedUsers),
+      );
+      message.success(`已导出 ${exportedUsers.length} 个用户`);
+    } catch {
+      message.error('导出用户列表失败，请稍后重试');
+    }
+    setUserExporting(false);
+  }, [admin, roleFilter, search, statusFilter]);
   const columns: ColumnsType<StudioUser> = [
     { title: '用户名', dataIndex: 'username' },
     { title: '用户 ID', dataIndex: 'id', width: 100 },
@@ -221,9 +253,19 @@ const UserManagementPage = () => {
         subtitle="Studio 本地账号、会话与密码管理"
         extra={
           admin ? (
-            <Button type="primary" icon={<Plus size={16} />} onClick={() => setCreateOpen(true)}>
-              新建用户
-            </Button>
+            <Space>
+              <Button
+                icon={<DownloadSimple size={16} />}
+                disabled={loading || total === 0}
+                loading={userExporting}
+                onClick={() => void handleExportUsers()}
+              >
+                导出
+              </Button>
+              <Button type="primary" icon={<Plus size={16} />} onClick={openCreateUserModal}>
+                新建用户
+              </Button>
+            </Space>
           ) : undefined
         }
       />

--- a/web/src/pages/studio/__tests__/UserManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/UserManagement.test.tsx
@@ -18,26 +18,38 @@
 import { App } from 'antd';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { listStudioUsers } from '../../../api/studioUsers';
+import {
+  listAllStudioUsers as downloadStudioUsers,
+  listStudioUsers,
+} from '../../../api/studioUsers';
+import { downloadCsv } from '../../../utils/download';
 import UserManagementPage from '../UserManagement';
 
+type MockAuthState = { admin: boolean; userId: number; logout: () => void };
 vi.mock('../../../api/studioUsers', () => ({
   createStudioUser: vi.fn(),
+  listAllStudioUsers: vi.fn(),
   listStudioUsers: vi.fn(),
   resetStudioUserPassword: vi.fn(),
   setStudioUserEnabled: vi.fn(),
 }));
 
 vi.mock('../../../stores/authStore', () => ({
-  default: (
-    selector: (state: { admin: boolean; userId: number; logout: () => void }) => unknown,
-  ) =>
+  default: (selector: (state: MockAuthState) => unknown) =>
     selector({ admin: true, userId: 1, logout: vi.fn() }),
 }));
 
-const page = {
+vi.mock('../../../utils/download', async () => {
+  const downloadModule =
+    await vi.importActual<typeof import('../../../utils/download')>('../../../utils/download');
+  return {
+    ...downloadModule,
+    downloadCsv: vi.fn(),
+  };
+});
+const studioUserPage = {
   items: [
     {
       id: 7,
@@ -63,6 +75,18 @@ const renderPage = () =>
     </MemoryRouter>,
   );
 
+const selectOption = async (user: UserEvent, comboboxName: string, optionText: string) => {
+  await user.click(screen.getByRole('combobox', { name: comboboxName }));
+  const option = await screen.findByText(optionText, {
+    selector: '.ant-select-item-option-content',
+  });
+  await user.click(option);
+};
+const applyAdminDisabledFilter = async (user: UserEvent, keyword = 'ops') => {
+  await user.type(screen.getByPlaceholderText('搜索用户名'), keyword);
+  await selectOption(user, '按权限筛选', '管理员');
+  await selectOption(user, '按状态筛选', '已禁用');
+};
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -82,7 +106,8 @@ beforeAll(() => {
 describe('UserManagementPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(listStudioUsers).mockResolvedValue(page);
+    vi.mocked(listStudioUsers).mockResolvedValue(studioUserPage);
+    vi.mocked(downloadStudioUsers).mockResolvedValue(studioUserPage.items);
   });
 
   it('loads a bounded first page and renders the server total', async () => {
@@ -104,11 +129,7 @@ describe('UserManagementPage', () => {
     renderPage();
     await screen.findByText('operator');
 
-    await user.type(screen.getByPlaceholderText('搜索用户名'), 'ops');
-    await user.click(screen.getByRole('combobox', { name: '按权限筛选' }));
-    await user.click(await screen.findByText('管理员', { selector: '.ant-select-item-option-content' }));
-    await user.click(screen.getByRole('combobox', { name: '按状态筛选' }));
-    await user.click(await screen.findByText('已禁用', { selector: '.ant-select-item-option-content' }));
+    await applyAdminDisabledFilter(user);
 
     await waitFor(() =>
       expect(listStudioUsers).toHaveBeenLastCalledWith({
@@ -119,5 +140,21 @@ describe('UserManagementPage', () => {
         pageSize: 20,
       }),
     );
+  });
+
+  it('exports all users that match the active filters', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderPage();
+    await screen.findByText('operator');
+    await applyAdminDisabledFilter(user, 'ops');
+    await user.click(screen.getByRole('button', { name: '导出' }));
+    const expectedExportQuery = { search: 'ops', admin: true, enabled: false };
+    await waitFor(() => expect(downloadStudioUsers).toHaveBeenCalledWith(expectedExportQuery));
+    expect(downloadCsv).toHaveBeenCalledTimes(1);
+    const [exportFilename, exportedCsv] = vi.mocked(downloadCsv).mock.calls[0];
+    expect(exportFilename).toMatch(/^rocketmq-studio-users-\d{4}-\d{2}-\d{2}\.csv$/);
+    expect(exportedCsv).toContain('"operator"');
+    expect(exportedCsv).toContain('"User"');
+    expect(exportedCsv).toContain('"Enabled"');
   });
 });


### PR DESCRIPTION
## What is the purpose of the change

Add CSV export for the Studio user management list so administrators can download users that match the active search, role, and status filters.

## Brief changelog

- Add a paged Studio user export API helper.
- Add an export action to Studio user management.
- Export user ID, username, role, status, password changed time, created time, and modified time.
- Add regression coverage for filtered export and paged export loading.

## Verifying this change

- npm test -- src/api/studioUsers.test.ts src/pages/studio/__tests__/UserManagement.test.tsx
- npm run build
- npm run lint
- npx prettier --check src/api/studioUsers.ts src/api/studioUsers.test.ts src/pages/studio/UserManagement.tsx src/pages/studio/__tests__/UserManagement.test.tsx
- git diff --check