### PR TITLE
[Studio] feat: filter proxy nodes

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1341,6 +1341,11 @@ const translations: Record<string, Record<Lang, string>> = {
   'proxy.totalConnections': { zh: '总连接数', en: 'Total Connections' },
   'proxy.totalTps': { zh: '总 TPS', en: 'Total TPS' },
   'proxy.nodes': { zh: 'Proxy 节点', en: 'Proxy Nodes' },
+  'proxy.nodeFilter': { zh: '筛选 Proxy 节点', en: 'Filter Proxy nodes' },
+  'proxy.nodeFilterPlaceholder': {
+    zh: '筛选地址、状态或版本',
+    en: 'Filter address, status or version',
+  },
   'proxy.viewConfig': { zh: '查看配置', en: 'View Config' },
   'proxy.nodeConfig': { zh: '节点配置', en: 'Node Configuration' },
   'proxy.current': { zh: '当前', en: 'Current' },

--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Card,
   Table,
@@ -45,6 +45,7 @@ import {
   Warning,
   Plus,
   Trash,
+  MagnifyingGlass,
 } from '@phosphor-icons/react';
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
@@ -78,6 +79,7 @@ const ProxyPage: React.FC = () => {
   const [selectedNode, setSelectedNode] = useState<ProxyNode | null>(null);
   const [configModalOpen, setConfigModalOpen] = useState(false);
   const [newProxyAddress, setNewProxyAddress] = useState('');
+  const [nodeFilter, setNodeFilter] = useState('');
   const [addressMutationLoading, setAddressMutationLoading] = useState(false);
   const [removingProxyAddress, setRemovingProxyAddress] = useState<string | null>(null);
   const [clusterId, setClusterId] = useState<string>(
@@ -294,6 +296,38 @@ const ProxyPage: React.FC = () => {
       </Tag>
     );
   };
+
+  const proxyStatusLabel = useCallback(
+    (status: string) => {
+      const map: Record<string, string> = {
+        healthy: t('proxy.healthy'),
+        unhealthy: t('proxy.unhealthy'),
+        warning: t('proxy.warning'),
+        error: t('proxy.statusError'),
+        offline: t('proxy.statusOffline'),
+        unknown: t('common.na'),
+      };
+      return map[status] || map.unknown;
+    },
+    [t],
+  );
+
+  const filteredProxyNodes = useMemo(() => {
+    const keyword = nodeFilter.trim().toLowerCase();
+    if (!keyword) return proxyNodes;
+    return proxyNodes.filter((node) =>
+      [
+        node.address,
+        node.status,
+        proxyStatusLabel(node.status),
+        node.version,
+        node.uptime,
+        node.isSelected ? t('proxy.current') : '',
+      ]
+        .filter((value): value is string => Boolean(value))
+        .some((value) => value.toLowerCase().includes(keyword)),
+    );
+  }, [nodeFilter, proxyNodes, proxyStatusLabel, t]);
 
   const renderUnavailable = () => <Text type="secondary">{t('common.na')}</Text>;
 
@@ -516,8 +550,24 @@ const ProxyPage: React.FC = () => {
           title={t('proxy.nodes')}
           variant="borderless"
           style={{ borderRadius: 8, marginBottom: 24 }}
+          extra={
+            <Input
+              allowClear
+              aria-label={t('proxy.nodeFilter')}
+              placeholder={t('proxy.nodeFilterPlaceholder')}
+              prefix={<MagnifyingGlass size={14} />}
+              value={nodeFilter}
+              onChange={(event) => setNodeFilter(event.target.value)}
+              style={{ width: 260 }}
+            />
+          }
         >
-          <Table columns={columns} dataSource={proxyNodes} pagination={false} size="middle" />
+          <Table
+            columns={columns}
+            dataSource={filteredProxyNodes}
+            pagination={false}
+            size="middle"
+          />
         </Card>
       </Spin>
 

--- a/web/src/pages/studio/__tests__/Proxy.test.tsx
+++ b/web/src/pages/studio/__tests__/Proxy.test.tsx
@@ -21,6 +21,7 @@ import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import {
   addProxyAddress,
+  getProxyTopology,
   queryProxyHomePage,
   reloadProxyConfig,
   removeProxyAddress,
@@ -30,6 +31,7 @@ import ProxyPage from '../Proxy';
 
 vi.mock('../../../api/proxy', () => ({
   addProxyAddress: vi.fn(),
+  getProxyTopology: vi.fn(),
   queryProxyHomePage: vi.fn(),
   reloadProxyConfig: vi.fn(),
   removeProxyAddress: vi.fn(),
@@ -78,6 +80,7 @@ describe('ProxyPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(queryProxyHomePage).mockResolvedValue(proxyHome);
+    vi.mocked(getProxyTopology).mockResolvedValue([]);
     vi.mocked(addProxyAddress).mockResolvedValue(proxyHome);
     vi.mocked(reloadProxyConfig).mockResolvedValue({
       success: true,
@@ -209,6 +212,48 @@ describe('ProxyPage', () => {
     await waitFor(() => expect(removeProxyAddress).toHaveBeenCalledWith('10.0.0.10:8081'));
     expect(screen.queryByText('10.0.0.10:8081')).not.toBeInTheDocument();
     expect(await screen.findByText('Proxy 地址已删除')).toBeInTheDocument();
+  });
+
+  it('filters Proxy nodes by address and status label', async () => {
+    const user = userEvent.setup();
+    vi.mocked(queryProxyHomePage).mockResolvedValueOnce({
+      proxyAddrList: ['127.0.0.1:8081', '10.0.0.10:8081'],
+      currentProxyAddr: '127.0.0.1:8081',
+    });
+    vi.mocked(getProxyTopology).mockResolvedValueOnce([
+      {
+        proxyAddr: '127.0.0.1:8081',
+        status: 'UP',
+        grpcPort: 8081,
+        remotingPort: null,
+        grpcReachable: true,
+        remotingReachable: false,
+        latencyMs: 3,
+      },
+      {
+        proxyAddr: '10.0.0.10:8081',
+        status: 'DOWN',
+        grpcPort: 8081,
+        remotingPort: null,
+        grpcReachable: false,
+        remotingReachable: false,
+        latencyMs: 0,
+      },
+    ]);
+
+    renderPage();
+    expect(await screen.findByText('127.0.0.1:8081')).toBeInTheDocument();
+    expect(screen.getByText('10.0.0.10:8081')).toBeInTheDocument();
+
+    const filter = screen.getByRole('textbox', { name: '筛选 Proxy 节点' });
+    await user.type(filter, '10.0.0.10');
+    expect(screen.queryByText('127.0.0.1:8081')).not.toBeInTheDocument();
+    expect(screen.getByText('10.0.0.10:8081')).toBeInTheDocument();
+
+    await user.clear(filter);
+    await user.type(filter, '不健康');
+    expect(screen.queryByText('127.0.0.1:8081')).not.toBeInTheDocument();
+    expect(screen.getByText('10.0.0.10:8081')).toBeInTheDocument();
   });
 
   it('keeps the latest Proxy list when an older refresh resolves last', async () => {


### PR DESCRIPTION
## What is the purpose of the change

Add local filtering for the Studio Proxy node table so operators can quickly narrow nodes by address, status, version, uptime, or the current-node marker.

## Brief changelog

- Add a localized Proxy node filter input.
- Filter the Proxy node table without reloading backend topology data.
- Match node address, status code, translated status label, version, uptime, and current-node marker.
- Add regression coverage for address and status-label filtering.

## Verifying this change

- npm test -- src/pages/studio/__tests__/Proxy.test.tsx
- npm run build
- npm run lint
- npx prettier --check src/pages/studio/Proxy.tsx src/pages/studio/__tests__/Proxy.test.tsx src/i18n/translations.ts
- git diff --check