### PR TITLE
Fix Tencent cloud inventory pagination

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
@@ -43,7 +43,6 @@ import java.util.Locale;
 public class TencentCatalogService implements CloudCatalogProvider {
 
     static final int PAGE_SIZE = 100;
-    static final int MAX_PAGES = 100;
     static final List<CloudRegionVO> SUPPORTED_REGIONS = List.of(
             region("ap-guangzhou", "Guangzhou"),
             region("ap-shenzhen-fsi", "Shenzhen Finance"),
@@ -83,9 +82,9 @@ public class TencentCatalogService implements CloudCatalogProvider {
         requireId(credentialId, "credentialId");
         requireNonBlank(regionId, "regionId");
         List<CloudInstanceOptionVO> instances = new ArrayList<>();
-        for (int page = 0; page < MAX_PAGES; page++) {
+        for (long offset = 0L; ; offset += PAGE_SIZE) {
             DescribeInstanceListRequest request = new DescribeInstanceListRequest();
-            request.setOffset((long) page * PAGE_SIZE);
+            request.setOffset(offset);
             request.setLimit((long) PAGE_SIZE);
             DescribeInstanceListResponse response = clientFactory.call(credentialId, regionId,
                     client -> client.DescribeInstanceList(request));
@@ -102,11 +101,15 @@ public class TencentCatalogService implements CloudCatalogProvider {
                     instances.add(option);
                 }
             }
-            if (data.length < PAGE_SIZE) {
+            if (data.length < PAGE_SIZE || hasFetchedAll(offset, response.getTotalCount())) {
                 break;
             }
         }
         return instances;
+    }
+
+    private static boolean hasFetchedAll(long offset, Long totalCount) {
+        return totalCount != null && totalCount >= 0L && offset + PAGE_SIZE >= totalCount;
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -409,10 +409,10 @@ public class TencentInstanceProvider implements InstanceProvider {
     private List<ConsumerGroupVO> listConsumerGroups(String instanceId, String search, boolean enrichTimes) {
         Context context = resolve(instanceId);
         List<ConsumerGroupVO> groups = new ArrayList<>();
-        for (int page = 0; page < MAX_PAGES; page++) {
+        for (long offset = 0L; ; offset += PAGE_SIZE) {
             DescribeConsumerGroupListRequest request = new DescribeConsumerGroupListRequest();
             request.setInstanceId(context.cloudInstanceId());
-            request.setOffset((long) page * PAGE_SIZE);
+            request.setOffset(offset);
             request.setLimit((long) PAGE_SIZE);
             DescribeConsumerGroupListResponse response = clientFactory.call(context.credentialId(), context.regionId(),
                     client -> client.DescribeConsumerGroupList(request));
@@ -432,7 +432,7 @@ public class TencentInstanceProvider implements InstanceProvider {
                     groups.add(group);
                 }
             }
-            if (data.length < PAGE_SIZE) {
+            if (data.length < PAGE_SIZE || hasFetchedAll(offset, PAGE_SIZE, response.getTotalCount())) {
                 break;
             }
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
@@ -17,9 +17,11 @@
 package org.apache.rocketmq.studio.provider.tencent;
 
 import com.tencentcloudapi.trocket.v20230308.models.DescribeInstanceListResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeInstanceListRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeInstanceResponse;
 import com.tencentcloudapi.trocket.v20230308.models.Endpoint;
 import com.tencentcloudapi.trocket.v20230308.models.InstanceItem;
+import com.tencentcloudapi.trocket.v20230308.TrocketClient;
 import org.apache.rocketmq.studio.provider.CloudInstanceDetailVO;
 import org.apache.rocketmq.studio.provider.CloudInstanceOptionVO;
 import org.apache.rocketmq.studio.provider.CloudRegionVO;
@@ -34,6 +36,9 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,11 +50,18 @@ class TencentCatalogServiceTest {
     @Mock
     private TencentClientFactory clientFactory;
 
+    @Mock
+    private TrocketClient client;
+
     private TencentCatalogService service;
 
     @BeforeEach
     void setUp() {
         service = new TencentCatalogService(clientFactory);
+        lenient().when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any())).thenAnswer(invocation -> {
+            TencentClientFactory.TencentCall<Object> action = invocation.getArgument(2);
+            return action.execute(client);
+        });
     }
 
     @Test
@@ -119,6 +131,48 @@ class TencentCatalogServiceTest {
         assertThat(instances).singleElement()
                 .extracting(CloudInstanceOptionVO::getInstanceId)
                 .isEqualTo("rmq-valid");
+    }
+
+    @Test
+    void listCloudInstancesShouldContinuePastTenThousandRecordsWhenTotalCountRequiresItTest() throws Exception {
+        InstanceItem item = new InstanceItem();
+        item.setInstanceId("rmq-page");
+        item.setInstanceName("page");
+        when(client.DescribeInstanceList(any())).thenAnswer(invocation -> {
+            DescribeInstanceListRequest request = invocation.getArgument(0);
+            DescribeInstanceListResponse response = new DescribeInstanceListResponse();
+            response.setTotalCount(10_001L);
+            response.setData(request.getOffset() < 10_000L
+                    ? java.util.stream.IntStream.range(0, 100).mapToObj(index -> item).toArray(InstanceItem[]::new)
+                    : new InstanceItem[]{item});
+            return response;
+        });
+
+        List<CloudInstanceOptionVO> instances = service.listCloudInstances(CREDENTIAL_ID, REGION, null);
+
+        assertThat(instances).hasSize(10_001);
+        org.mockito.ArgumentCaptor<DescribeInstanceListRequest> captor =
+                org.mockito.ArgumentCaptor.forClass(DescribeInstanceListRequest.class);
+        verify(client, times(101)).DescribeInstanceList(captor.capture());
+        assertThat(captor.getAllValues().get(100).getOffset()).isEqualTo(10_000L);
+    }
+
+    @Test
+    void listCloudInstancesShouldStopAtExactlyTenThousandRecordsWhenTotalCountIsReachedTest() throws Exception {
+        InstanceItem item = new InstanceItem();
+        item.setInstanceId("rmq-page");
+        item.setInstanceName("page");
+        when(client.DescribeInstanceList(any())).thenAnswer(invocation -> {
+            DescribeInstanceListResponse response = new DescribeInstanceListResponse();
+            response.setTotalCount(10_000L);
+            response.setData(java.util.stream.IntStream.range(0, 100)
+                    .mapToObj(index -> item)
+                    .toArray(InstanceItem[]::new));
+            return response;
+        });
+
+        assertThat(service.listCloudInstances(CREDENTIAL_ID, REGION, null)).hasSize(10_000);
+        verify(client, times(100)).DescribeInstanceList(any());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -537,6 +537,28 @@ class TencentInstanceProviderTest {
     }
 
     @Test
+    void listConsumerGroupsShouldContinuePastTenThousandRecordsWhenTotalCountRequiresItTest() throws Exception {
+        ConsumeGroupItem item = new ConsumeGroupItem();
+        item.setConsumerGroup("GID_page");
+        when(client.DescribeConsumerGroupList(any())).thenAnswer(invocation -> {
+            DescribeConsumerGroupListRequest request = invocation.getArgument(0);
+            DescribeConsumerGroupListResponse response = new DescribeConsumerGroupListResponse();
+            response.setTotalCount(10_001L);
+            response.setData(request.getOffset() < 10_000L
+                    ? IntStream.range(0, 100).mapToObj(index -> item).toArray(ConsumeGroupItem[]::new)
+                    : new ConsumeGroupItem[]{item});
+            return response;
+        });
+
+        assertThat(provider.listConsumerGroups(STUDIO_INSTANCE_ID, "does-not-match")).isEmpty();
+
+        ArgumentCaptor<DescribeConsumerGroupListRequest> captor =
+                ArgumentCaptor.forClass(DescribeConsumerGroupListRequest.class);
+        verify(client, times(101)).DescribeConsumerGroupList(captor.capture());
+        assertThat(captor.getAllValues().get(100).getOffset()).isEqualTo(10_000L);
+    }
+
+    @Test
     void createConsumerGroupShouldCallTencentOpenApiTest() throws Exception {
         when(client.CreateConsumerGroup(any())).thenReturn(null);
         ConsumerGroupVO group = new ConsumerGroupVO();


### PR DESCRIPTION
## Summary
- use Tencent `TotalCount` to continue cloud-instance and consumer-group inventory pagination beyond the historical 10,000-record cap
- retain short-page termination when the upstream response omits a total
- cover exact 10,000 and 10,001 record boundaries

Fixes #2609

## Tests
- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) mvn -q -Dtest=TencentCatalogServiceTest,TencentInstanceProviderTest test`
- `JAVA_HOME=$( /usr/libexec/java_home -v 21 ) mvn -q -DskipTests package`