### PR TITLE
[Studio] feat: export LiteTopic list

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1677,6 +1677,14 @@ const translations: Record<string, Record<Lang, string>> = {
   'liteTopic.fetchSessionFailed': { zh: '获取会话详情失败', en: 'Failed to fetch session detail' },
   'liteTopic.extendTtlSuccess': { zh: 'TTL 延长成功', en: 'TTL extended successfully' },
   'liteTopic.extendTtlFailed': { zh: 'TTL 延长失败', en: 'Failed to extend TTL' },
+  'liteTopic.exportSuccess': {
+    zh: '已导出 {total} 条 LiteTopic',
+    en: 'Exported {total} LiteTopics',
+  },
+  'liteTopic.exportFailed': {
+    zh: '导出 LiteTopic 失败，请稍后重试',
+    en: 'Failed to export LiteTopics',
+  },
   'liteTopic.total': { zh: '共 {total} 条记录', en: 'Total {total} records' },
   'liteTopic.defaultTtl': { zh: '默认 TTL', en: 'Default TTL' },
   'liteTopic.maxTtl': { zh: '最大 TTL', en: 'Max TTL' },

--- a/web/src/pages/studio/LiteTopic.tsx
+++ b/web/src/pages/studio/LiteTopic.tsx
@@ -45,6 +45,7 @@ import {
   PencilSimple,
   Gauge,
   Info,
+  DownloadSimple,
 } from '@phosphor-icons/react';
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
@@ -58,6 +59,7 @@ import {
   type LiteTopicItem,
   type LiteTopicSession,
 } from '../../api/liteTopic';
+import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 const formatDuration = (ms: number | undefined | null): string => {
   if (ms == null) return '-';
@@ -79,6 +81,24 @@ const getProgressStatus = (percent: number): 'exception' | 'active' | 'normal' =
 };
 
 const knownTTLStatuses = new Set(['ACTIVE', 'EXPIRING_SOON', 'EXPIRED']);
+
+interface LiteTopicExportRow extends LiteTopicItem {
+  ttlStatusLabel: string;
+  sessionCount: number;
+}
+
+const LITE_TOPIC_EXPORT_COLUMNS: CsvColumn<LiteTopicExportRow>[] = [
+  { header: 'Namespace', value: (item) => item.namespace },
+  { header: 'Topic Pattern', value: (item) => item.topicPattern },
+  { header: 'Topic Count', value: (item) => item.topicCount },
+  { header: 'Consumer Count', value: (item) => item.consumerCount },
+  { header: 'Total Backlog', value: (item) => item.totalBacklog },
+  { header: 'Average TTL', value: (item) => formatDuration(item.averageTTL) },
+  { header: 'TTL Status', value: (item) => item.ttlStatusLabel },
+  { header: 'Last Active Time', value: (item) => formatTime(item.lastActiveTime) },
+  { header: 'Session Count', value: (item) => item.sessionCount },
+  { header: 'Session IDs', value: (item) => item.sessionIds?.join(';') },
+];
 
 const collectNamespaces = (items: LiteTopicItem[]): string[] => {
   const namespaces = new Map<string, string>();
@@ -310,6 +330,15 @@ const LiteTopicPage: React.FC = () => {
     return <Tag color={cfg.color}>{cfg.label}</Tag>;
   };
 
+  const getTTLStatusLabel = (status: string | undefined) => {
+    const map: Record<string, string> = {
+      ACTIVE: t('liteTopic.active'),
+      EXPIRING_SOON: t('liteTopic.expiringSoon'),
+      EXPIRED: t('liteTopic.expired'),
+    };
+    return map[status || ''] || t('liteTopic.unknown');
+  };
+
   const filteredTopicList = topicList.filter((item) => {
     if (!ttlStatusFilter) return true;
     if (ttlStatusFilter === 'UNKNOWN') {
@@ -320,6 +349,21 @@ const LiteTopicPage: React.FC = () => {
 
   const lastPage = Math.max(1, Math.ceil(filteredTopicList.length / pageSize));
   const clampedCurrentPage = Math.min(currentPage, lastPage);
+
+  const handleExport = () => {
+    try {
+      const rows = filteredTopicList.map((item) => ({
+        ...item,
+        ttlStatusLabel: getTTLStatusLabel(item.ttlStatus),
+        sessionCount: item.sessionIds?.length ?? 0,
+      }));
+      const filename = `rocketmq-lite-topics-${new Date().toISOString().slice(0, 10)}.csv`;
+      downloadCsv(filename, buildCsv(LITE_TOPIC_EXPORT_COLUMNS, rows));
+      message.success(t('liteTopic.exportSuccess', { total: rows.length }));
+    } catch {
+      message.error(t('liteTopic.exportFailed'));
+    }
+  };
 
   // ─── Columns ─────────────────────────────────────────────────
 
@@ -724,9 +768,19 @@ const LiteTopicPage: React.FC = () => {
       <PageHeader
         title={t('liteTopic.title')}
         extra={
-          <Button icon={<ArrowClockwise size={14} />} size="small" onClick={handleRefresh}>
-            {t('common.refresh')}
-          </Button>
+          <Space>
+            <Button
+              icon={<DownloadSimple size={14} />}
+              size="small"
+              disabled={loading || filteredTopicList.length === 0}
+              onClick={handleExport}
+            >
+              {t('common.export')}
+            </Button>
+            <Button icon={<ArrowClockwise size={14} />} size="small" onClick={handleRefresh}>
+              {t('common.refresh')}
+            </Button>
+          </Space>
         }
       />
 

--- a/web/src/pages/studio/__tests__/LiteTopic.test.tsx
+++ b/web/src/pages/studio/__tests__/LiteTopic.test.tsx
@@ -21,6 +21,7 @@ import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
 import type { LiteTopicItem, LiteTopicQuota } from '../../../api/liteTopic';
+import { downloadCsv } from '../../../utils/download';
 import LiteTopic from '../LiteTopic';
 
 const apiMocks = vi.hoisted(() => ({
@@ -32,6 +33,15 @@ const apiMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../../api/liteTopic', () => apiMocks);
+
+vi.mock('../../../utils/download', async () => {
+  const downloadModule =
+    await vi.importActual<typeof import('../../../utils/download')>('../../../utils/download');
+  return {
+    ...downloadModule,
+    downloadCsv: vi.fn(),
+  };
+});
 
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
@@ -258,6 +268,44 @@ describe('LiteTopic Page', () => {
     expect(screen.getByText('unknown-*')).toBeInTheDocument();
     expect(screen.getByText('missing-status-*')).toBeInTheDocument();
     expect(apiMocks.queryLiteTopicList).toHaveBeenCalledTimes(initialListRequestCount);
+  });
+
+  it('exports the current LiteTopic filter result', async () => {
+    apiMocks.queryLiteTopicList.mockResolvedValue([
+      {
+        namespace: 'default',
+        topicPattern: '=active-*',
+        topicCount: 3,
+        consumerCount: 2,
+        totalBacklog: 12,
+        averageTTL: 60000,
+        ttlStatus: 'ACTIVE',
+        lastActiveTime: 1893456000000,
+        sessionIds: ['session-1', 'session-2'],
+      },
+      {
+        namespace: 'default',
+        topicPattern: 'expired-*',
+        ttlStatus: 'EXPIRED',
+      },
+    ]);
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(await screen.findByText('=active-*')).toBeInTheDocument();
+    await user.click(screen.getByRole('combobox', { name: '状态' }));
+    await user.click(
+      await screen.findByText('活跃', { selector: '.ant-select-item-option-content' }),
+    );
+    await user.click(screen.getByRole('button', { name: '导出' }));
+
+    expect(downloadCsv).toHaveBeenCalledTimes(1);
+    const [filename, csv] = vi.mocked(downloadCsv).mock.calls[0];
+    expect(filename).toMatch(/^rocketmq-lite-topics-\d{4}-\d{2}-\d{2}\.csv$/);
+    expect(csv).toContain('"Namespace","Topic Pattern","Topic Count"');
+    expect(csv).toContain('"default","\'=active-*","3","2","12","1.0min","活跃"');
+    expect(csv).toContain('"session-1;session-2"');
+    expect(csv).not.toContain('expired-*');
   });
 
   it('keeps an early filtered display while a delayed bootstrap supplies namespace options', async () => {


### PR DESCRIPTION
## What is the purpose of the change

Add CSV export for the Studio LiteTopic list so operators can download the current filtered result for offline review.

## Brief changelog

- Add a LiteTopic export action to the page header.
- Export namespace, topic pattern, topic count, consumer count, backlog, TTL, status, last active time, and sessions.
- Reuse the current pattern, namespace, and TTL-status filtered list.
- Add regression coverage for filtered LiteTopic export.

## Verifying this change

- npm test -- src/pages/studio/__tests__/LiteTopic.test.tsx
- npm run build
- npm run lint
- npx prettier --check src/pages/studio/LiteTopic.tsx src/pages/studio/__tests__/LiteTopic.test.tsx src/i18n/translations.ts
- git diff --check