### PR TITLE
Fix producer connection-drop alert expression

### DIFF
--- a/server/scripts/gen_alert_rule_yaml.py
+++ b/server/scripts/gen_alert_rule_yaml.py
@@ -58,7 +58,7 @@ RULES = [
      'histogram_quantile(0.99, rate(rocketmq_dispatch_latency_bucket[5m])) > 1', "5m", "warning", "topic",
      "Dispatch latency high", "99th percentile dispatch latency is above 1 second."),
     ("rocketmq-client-connection-drop", "RocketMQClientConnectionDrop", "rocketmq-client.rules",
-     'changes(rocketmq_producer_count[5m]) < -5', "5m", "warning", "client",
+     'delta(rocketmq_producer_count[5m]) < -5', "5m", "warning", "client",
      "Client connections dropped", "More than 5 producer connections dropped in 5 minutes."),
     ("rocketmq-client-timeout", "RocketMQClientTimeout", "rocketmq-client.rules",
      'rocketmq_send_to_client_latency > 3000', "5m", "warning", "client",

--- a/server/src/main/resources/alerts/rocketmq-client-connection-drop.yaml
+++ b/server/src/main/resources/alerts/rocketmq-client-connection-drop.yaml
@@ -6,7 +6,7 @@ groups:
   - name: rocketmq-client.rules
     rules:
       - alert: RocketMQClientConnectionDrop
-        expr: changes(rocketmq_producer_count[5m]) < -5
+        expr: delta(rocketmq_producer_count[5m]) < -5
         for: 5m
         labels:
           severity: warning

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetServiceTest.java
@@ -24,6 +24,8 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -101,6 +103,28 @@ class AlertRuleAssetServiceTest {
         assertTrue(hasCritical, "expected at least one critical rule");
         assertTrue(hasBroker, "expected at least one broker rule");
     }
+
+    @Test
+    void clientConnectionDropRuleShouldUseSignedGaugeDelta() {
+        PrometheusAlertRule rule = service.loadDefaultRules().stream()
+                .filter(r -> "RocketMQClientConnectionDrop".equals(r.alert()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected bundled client connection drop rule"));
+
+        assertEquals("delta(rocketmq_producer_count[5m]) < -5", rule.expr());
+        assertFalse(rule.expr().contains("changes(rocketmq_producer_count[5m]) < -5"),
+                "changes() counts value transitions and cannot produce a negative drop");
+    }
+
+    @Test
+    void generatorShouldUseSameTriggerableClientConnectionDropExpression() throws IOException {
+        String generator = Files.readString(Path.of("scripts", "gen_alert_rule_yaml.py"));
+
+        assertTrue(generator.contains("'delta(rocketmq_producer_count[5m]) < -5'"));
+        assertFalse(generator.contains("'changes(rocketmq_producer_count[5m]) < -5'"),
+                "generator must not recreate a non-triggerable changes() drop rule");
+    }
+
     @Test
     void assetLoadingShouldSkipEmptyAndNonObjectYaml() {
         AlertRuleAssetService service = serviceWithResources(

--- a/web/src/mock/alertRuleAssets.ts
+++ b/web/src/mock/alertRuleAssets.ts
@@ -138,7 +138,7 @@ export const mockAlertRuleAssets: MockAlertRuleAsset[] = [
       'rocketmq-client-connection-drop',
       'rocketmq-client.rules',
       'RocketMQClientConnectionDrop',
-      'changes(rocketmq_producer_count[5m]) < -5',
+      'delta(rocketmq_producer_count[5m]) < -5',
       'warning',
     ),
   },

--- a/web/src/services/alertRuleAssetService.test.ts
+++ b/web/src/services/alertRuleAssetService.test.ts
@@ -54,6 +54,14 @@ describe('alertRuleAssetService (mock mode)', () => {
     expect(yaml).toContain('RocketMQBrokerDown');
   });
 
+  it('uses a triggerable producer connection drop expression in mock assets', async () => {
+    mode.mock = true;
+    const yaml = await getAlertRuleAsset('rocketmq-client-connection-drop');
+
+    expect(yaml).toContain('expr: delta(rocketmq_producer_count[5m]) < -5');
+    expect(yaml).not.toContain('changes(rocketmq_producer_count[5m]) < -5');
+  });
+
   it('throws for an unknown asset', async () => {
     mode.mock = true;
     await expect(getAlertRuleAsset('does-not-exist')).rejects.toThrow();


### PR DESCRIPTION
## Summary
- replace the impossible negative `changes()` predicate with a signed `delta()` expression for producer-connection drops
- synchronize the rule generator, bundled YAML, and frontend mock
- add backend and frontend regression coverage

Fixes #2614

## Tests
- `cd server && JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=AlertRuleAssetServiceTest test`
- `cd web && npm test -- alertRuleAssetService.test.ts`
- `cd web && npm run build`
- `python3 -m py_compile server/scripts/gen_alert_rule_yaml.py`