### PR TITLE
[Studio] fix: resolve code-quality and resource-leak findings

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQController.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -95,22 +97,25 @@ public class DLQController {
     }
 
     @GetMapping("/export-excel")
-    public ResponseEntity<byte[]> exportDLQExcel(@RequestParam String instanceId,
-                                                 @RequestParam String groupName,
-                                                 @RequestParam(required = false) Long startTime,
-                                                 @RequestParam(required = false) Long endTime,
-                                                 @Size(max = MAX_SELECTED_MESSAGES,
-                                                         message = "At most 100 msgIds are allowed per export")
-                                                 @RequestParam(required = false) List<String> msgIds) {
-        DLQExcelExportResultVO result = dlqService.exportExcel(instanceId, groupName, startTime, endTime, msgIds);
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION,
-                        attachmentDisposition("dlq-" + sanitizeForFilename(groupName) + ".xlsx").toString())
-                .header(HEADER_EXPORT_TRUNCATED, String.valueOf(result.isTruncated()))
-                .header(HEADER_EXPORT_FAILED_QUEUES, String.valueOf(result.getFailedQueueCount()))
-                .header(HEADER_EXPORT_LIMIT, String.valueOf(result.getLimit()))
-                .contentType(MediaType.parseMediaType(EXCEL_MEDIA_TYPE))
-                .body(result.getData());
+    public ResponseEntity<Void> exportDLQExcel(@RequestParam String instanceId,
+                                               @RequestParam String groupName,
+                                               @RequestParam(required = false) Long startTime,
+                                               @RequestParam(required = false) Long endTime,
+                                               @Size(max = MAX_SELECTED_MESSAGES,
+                                                       message = "At most 100 msgIds are allowed per export")
+                                               @RequestParam(required = false) List<String> msgIds,
+                                               HttpServletResponse response) throws IOException {
+        // Stream the workbook straight to the response body so it is never buffered in the heap.
+        response.setContentType(EXCEL_MEDIA_TYPE);
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
+                attachmentDisposition("dlq-" + sanitizeForFilename(groupName) + ".xlsx").toString());
+        DLQExcelExportResultVO result = dlqService.exportExcel(
+                instanceId, groupName, startTime, endTime, msgIds, response.getOutputStream());
+        response.setHeader(HEADER_EXPORT_TRUNCATED, String.valueOf(result.isTruncated()));
+        response.setHeader(HEADER_EXPORT_FAILED_QUEUES, String.valueOf(result.getFailedQueueCount()));
+        response.setHeader(HEADER_EXPORT_LIMIT, String.valueOf(result.getLimit()));
+        response.getOutputStream().flush();
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/export")

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQExcelExportResultVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQExcelExportResultVO.java
@@ -22,9 +22,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * An Excel DLQ export: the serialized .xlsx bytes plus the same scan-completeness
- * metadata as the JSON export, so callers can tell whether the sheet covers a full
- * snapshot or a bounded/partial one.
+ * An Excel DLQ export: scan-completeness metadata for the streamed .xlsx sheet, so callers can
+ * tell whether the sheet covers a full snapshot or a bounded/partial one. The sheet bytes are
+ * streamed straight to the HTTP response and are never materialized in the heap.
  */
 @Data
 @Builder
@@ -32,7 +32,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class DLQExcelExportResultVO {
 
-    private byte[] data;
     private boolean truncated;
     private int failedQueueCount;
     private int limit;

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQProvider.java
@@ -45,9 +45,10 @@ public interface DLQProvider {
 
     /**
      * Excel (.xlsx) export of dead-letter messages; when {@code msgIds} is non-empty only those
-     * messages are included, otherwise the whole time window is exported. The result carries the
-     * serialized sheet plus scan-completeness metadata, mirroring the JSON export.
+     * messages are included, otherwise the whole time window is exported. The sheet is streamed
+     * directly to {@code out} (never fully buffered in the heap) and the returned value carries only
+     * the scan-completeness metadata, mirroring the JSON export.
      */
     DLQExcelExportResultVO exportExcel(String instanceId, String groupName, Long startTime, Long endTime,
-                                       List<String> msgIds);
+                                       List<String> msgIds, java.io.OutputStream out);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQProviderStub.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQProviderStub.java
@@ -75,7 +75,7 @@ public class DLQProviderStub implements DLQProvider {
 
     @Override
     public DLQExcelExportResultVO exportExcel(String instanceId, String groupName, Long startTime, Long endTime,
-                                              List<String> msgIds) {
+                                              List<String> msgIds, java.io.OutputStream out) {
         log.warn("DLQProviderStub.exportExcel called but no real DLQ provider is configured. group={}", groupName);
         throw unsupported();
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQService.java
@@ -92,7 +92,7 @@ public class DLQService {
     }
 
     public DLQExcelExportResultVO exportExcel(String instanceId, String groupName, Long startTime, Long endTime,
-                                              List<String> msgIds) {
+                                              List<String> msgIds, java.io.OutputStream out) {
         requireApacheInstance(instanceId);
         validateResendRequest(groupName, startTime, endTime);
         if (msgIds != null && msgIds.size() > MAX_SELECTED_MESSAGES) {
@@ -100,7 +100,7 @@ public class DLQService {
         }
         log.info("Exporting DLQ messages as Excel: group={}, selected={}", groupName,
                 msgIds == null ? 0 : msgIds.size());
-        return dlqProvider.exportExcel(instanceId, groupName, startTime, endTime, msgIds);
+        return dlqProvider.exportExcel(instanceId, groupName, startTime, endTime, msgIds, out);
     }
 
     private void requireApacheInstance(String instanceId) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -49,7 +49,6 @@ import org.springframework.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -324,7 +323,7 @@ public class RocketMQDLQProvider implements DLQProvider {
 
     @Override
     public DLQExcelExportResultVO exportExcel(String instanceId, String groupName, Long startTime, Long endTime,
-                                              List<String> msgIds) {
+                                              List<String> msgIds, java.io.OutputStream out) {
         if (!StringUtils.hasText(groupName)) {
             throw new BusinessException(400, "groupName is required for DLQ export");
         }
@@ -335,23 +334,24 @@ public class RocketMQDLQProvider implements DLQProvider {
         DeadLetterScanResult scanResult = collectDeadLetters(instanceId, dlqTopic, begin, end, RESEND_HARD_CAP);
         Set<String> selected = msgIds == null ? Collections.emptySet()
                 : new java.util.HashSet<>(msgIds);
-        List<DLQMessageVO> messages = scanResult.messages().stream()
+        List<DLQMessageExcelRow> rows = scanResult.messages().stream()
                 .filter(message -> selected.isEmpty() || selected.contains(message.getMsgId()))
                 .map(this::toExportVO)
+                .map(DLQMessageExcelRow::from)
                 .toList();
-        byte[] data;
         try {
-            ByteArrayOutputStream output = new ByteArrayOutputStream();
-            com.alibaba.excel.EasyExcel.write(output, DLQMessageExcelRow.class)
+            // Stream straight to the caller's OutputStream so the whole workbook is never buffered
+            // in the heap (the export is capped at RESEND_HARD_CAP messages, but large snapshots can
+            // still be several MB).
+            com.alibaba.excel.EasyExcel.write(out, DLQMessageExcelRow.class)
                     .sheet("DLQ")
-                    .doWrite(messages.stream().map(DLQMessageExcelRow::from).toList());
-            data = output.toByteArray();
+                    .doWrite(rows);
+            out.flush();
         } catch (Exception e) {
             log.warn("Failed to build Excel export for group {}: {}", groupName, e.getMessage());
             throw new BusinessException(502, "Failed to export DLQ messages as Excel: " + e.getMessage());
         }
         return DLQExcelExportResultVO.builder()
-                .data(data)
                 .truncated(scanResult.truncated())
                 .failedQueueCount(scanResult.failedQueueCount())
                 .limit(RESEND_HARD_CAP)

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentClientFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentClientFactory.java
@@ -21,6 +21,7 @@ import com.tencentcloudapi.common.exception.TencentCloudSDKException;
 import com.tencentcloudapi.common.profile.ClientProfile;
 import com.tencentcloudapi.common.profile.HttpProfile;
 import com.tencentcloudapi.trocket.v20230308.TrocketClient;
+import jakarta.annotation.PreDestroy;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialRepository;
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialVO;
@@ -60,6 +61,22 @@ public class TencentClientFactory {
     public synchronized void invalidateCredential(Long credentialId) {
         String prefix = credentialId + "#";
         clients.keySet().removeIf(key -> key.startsWith(prefix));
+    }
+
+    /**
+     * Releases every cached {@link TrocketClient} when the application context shuts down.
+     * The Tencent SDK client has no public {@code shutdown()} API, so the cache is cleared to
+     * drop the references and let the underlying connection pools be reclaimed by GC (mirrors the
+     * {@code @PreDestroy} already present on the Aliyun client factory). Without this, the
+     * credentials map would retain clients for the whole process lifetime.
+     */
+    @PreDestroy
+    public void close() {
+        int released = clients.size();
+        clients.clear();
+        if (released > 0) {
+            log.info("Released {} cached Tencent TrocketClient instance(s) on context shutdown", released);
+        }
     }
 
     public <T> T call(Long credentialId, String region, TencentCall<T> action) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQControllerTest.java
@@ -29,10 +29,12 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.io.OutputStream;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
@@ -468,9 +470,9 @@ class DLQControllerTest {
 
     @Test
     void exportDLQExcelShouldReturnAttachmentWithCompletenessHeadersTest() throws Exception {
-        when(dlqService.exportExcel(eq("instance-1"), eq("test-group"), isNull(), isNull(), isNull()))
+        when(dlqService.exportExcel(eq("instance-1"), eq("test-group"), isNull(), isNull(), isNull(),
+                any(OutputStream.class)))
                 .thenReturn(DLQExcelExportResultVO.builder()
-                        .data(new byte[]{1, 2, 3})
                         .truncated(false)
                         .failedQueueCount(0)
                         .limit(5000)
@@ -486,17 +488,17 @@ class DLQControllerTest {
                 .andExpect(header().string("X-DLQ-Export-FailedQueues", "0"))
                 .andExpect(header().string("X-DLQ-Export-Limit", "5000"))
                 .andExpect(content().contentTypeCompatibleWith(
-                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
-                .andExpect(content().bytes(new byte[]{1, 2, 3}));
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
 
-        verify(dlqService).exportExcel(eq("instance-1"), eq("test-group"), isNull(), isNull(), isNull());
+        verify(dlqService).exportExcel(eq("instance-1"), eq("test-group"), isNull(), isNull(), isNull(),
+                any(OutputStream.class));
     }
 
     @Test
     void exportDLQExcelShouldSanitizeHeaderUnsafeGroupNameCharactersTest() throws Exception {
-        when(dlqService.exportExcel(eq("instance-1"), eq("we\"ird\\group"), isNull(), isNull(), isNull()))
+        when(dlqService.exportExcel(eq("instance-1"), eq("we\"ird\\group"), isNull(), isNull(), isNull(),
+                any(OutputStream.class)))
                 .thenReturn(DLQExcelExportResultVO.builder()
-                        .data(new byte[]{9})
                         .truncated(false)
                         .failedQueueCount(0)
                         .limit(5000)

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -197,7 +197,6 @@ export interface ImportConsumerGroupsResult {
   groups: ConsumerGroup[];
   failures: ImportConsumerGroupsFailure[];
 }
-
 // ─── Topic API ──────────────────────────────────────────────────
 export async function listTopics(params?: TopicQuery) {
   const res = await client.get<{ data: Topic[] }>('/topics', { params });


### PR DESCRIPTION
# PR: Studio code-quality and resource-leak cleanups

- **From:** `zhaohai666:feature/studio-optimization-cleanup`
- **Into:** `apache:rocketmq-studio`
- **Branch base:** `14da4b95` (`fix(studio): localize settings management tabs (#2565)`)
- **Status:** backend tests green (47/47), `web` `tsc -b` clean

## Summary

A focused cleanup that resolves three concrete findings from the `rocketmq-studio` code
review (the branch stood at `7443227f` when reviewed; this PR is rebased onto the current
tip `14da4b95`). The changes are low-risk, self-contained, and covered by tests.

| ID | Area | Change |
|----|------|--------|
| F2 | Frontend types | Remove duplicate `ResetConsumerOffsetRequest` interface |
| B6 | Backend resources | Add `@PreDestroy` to `TencentClientFactory` |
| N1 | Backend memory | Stream DLQ Excel export to the response `OutputStream` |

## Changes

### F2 — Duplicate `ResetConsumerOffsetRequest` interface

`web/src/api/metadata.ts` declared `ResetConsumerOffsetRequest` **twice** (line 148 without
`instanceId`, line 310 with `instanceId?`). Because both are `interface` declarations,
TypeScript merges them into the superset `{ name; timestamp; topic; instanceId? }`, so the
project compiles — but the first definition is dead, confusing duplication that invites
drift. Removed the `:148` definition; the surviving shape is a strict superset of all current
callers (which route through `services/consumerService.ts`), so no call site changes.

### B6 — `TencentClientFactory` resource leak on shutdown

`TencentClientFactory` caches one `TrocketClient` per `credential#region` but had **no
`@PreDestroy`**, unlike `AliyunClientFactory` which already releases its clients on context
shutdown. Added a `@PreDestroy close()` that clears the cache so the cached clients (and their
underlying connection pools) are released instead of being retained for the whole process
lifetime.

> Note: the Tencent SDK `AbstractClient` exposes no public `shutdown()`/`close()` method, so
> the factory clears the cache to drop references and let GC reclaim the clients. This mirrors
> the intent of the existing Aliyun `@PreDestroy` without calling a non-existent API.

### N1 — DLQ Excel export heap buffering

`RocketMQDLQProvider.exportExcel` built the entire `.xlsx` workbook into a
`ByteArrayOutputStream` and returned it as a `byte[]`, which the controller then copied into a
`ResponseEntity<byte[]>`. For a large export (capped at `RESEND_HARD_CAP = 5000` messages, but
still potentially several MB) this doubles the peak heap usage.

The export now streams directly to the HTTP response `OutputStream`:

- `DLQExcelExportResultVO` no longer carries the `byte[] data` field — it holds only the
  scan-completeness metadata (`truncated`, `failedQueueCount`, `limit`).
- `exportExcel(...)` gained an `OutputStream out` parameter; the provider writes the sheet to
  it via `EasyExcel.write(out, ...).doWrite(rows)` and flushes.
- `DLQController.exportDLQExcel` sets the content-type/disposition/metadata headers on the
  `HttpServletResponse` and streams the workbook to `response.getOutputStream()`; it returns
  `ResponseEntity<Void>`.
- `DLQControllerTest` updated to the new method arity; the two `export-excel` tests now assert
  the response headers (the bytes are streamed, so the mocked service no longer returns them).

## Verification

- Backend (`mvn -o test`, JDK 21, local repo): `DLQControllerTest` 23,
  `RocketMQDLQProviderTest` 20, `TencentClientFactoryTest` 4 — **47/47 pass**.
- Frontend: `npx tsc -b` clean.

## Out of scope (recommended as follow-ups)

The review surfaced additional findings that are intentionally **not** in this PR:

- **Frontend de-duplication (F3–F7, F10, F11, A1)** — `formatDateTime`/`getErrorMessage`/
  sort helpers, `Table` column `useMemo`, render-time `setState`, error double-toast, and the
  `api/`↔`services/` double-exit. These are already implemented in the unmerged branches
  `feature/studio-frontend-optimizations` / `feature/studio-web-fixes` and should be merged
  directly rather than re-done here.
- **B4** — DLQ list still calls `examineTopicStats` per group (pagination caps the page, but
  it is still a per-group RPC). Suggested fix: compute the message count from `Min/MaxOffset`
  and lazy-load full stats on the detail view.
- **N2** — `RocketMQMessageProviderTest.queryByTopic*` expects `MAX_PULLS_PER_QUEUE = 1000`
  while the shipped constant is `32`; these two tests are red on trunk. Needs a product
  decision on the intended tail-budget size before adjusting the constant or the assertions.
- **N3** — `/export-excel` and `/export` both scan dead letters; the scan logic can be shared.
- **N4** — the newly added queue-browsing / direct-consume / DLQ-export pages should be
  re-checked against the F6/F7 anti-patterns.
