### PR TITLE
test(studio): restore topic query tail-budget coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,26 @@ jobs:
       - name: Build backend
         run: mvn -B -ntp clean package -DskipTests
 
+  backend-test:
+    name: Backend Tests (Java 21)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21 (Dragonwell)
+        uses: actions/setup-java@v4
+        with:
+          distribution: dragonwell
+          java-version: "21"
+          cache: maven
+
+      - name: Run backend tests
+        run: mvn -B -ntp test
+
   frontend-build:
     name: Frontend Build (Node 20)
     runs-on: ubuntu-latest

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -79,6 +79,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class RocketMQMessageProviderTest {
 
+    private static final long TOPIC_TAIL_SCAN_BUDGET = 32L * 32;
+
     @Mock
     private DefaultMQAdminExt adminExt;
 
@@ -618,7 +620,7 @@ class RocketMQMessageProviderTest {
         assertThat(messages).hasSize(200);
         assertThat(messages.get(0).getMsgId()).isEqualTo("msg-39999");
         assertThat(messages.get(199).getMsgId()).isEqualTo("msg-39800");
-        verify(pullConsumer).pull(queue, "*", 8_000L, 32);
+        verify(pullConsumer).pull(queue, "*", maxOffsetExclusive - TOPIC_TAIL_SCAN_BUDGET, 32);
         verify(pullConsumer, never()).pull(queue, "*", 0L, 32);
     }
 
@@ -643,8 +645,9 @@ class RocketMQMessageProviderTest {
 
         assertThat(messages).hasSize(200);
         assertThat(pulledOffsets).isNotEmpty();
-        assertThat(pulledOffsets.get(0)).isEqualTo(18_000L);
-        assertThat(pulledOffsets).allMatch(offset -> offset >= 18_000L);
+        long expectedFirstOffset = maxOffsetExclusive - TOPIC_TAIL_SCAN_BUDGET;
+        assertThat(pulledOffsets.get(0)).isEqualTo(expectedFirstOffset);
+        assertThat(pulledOffsets).allMatch(offset -> offset >= expectedFirstOffset);
     }
 
     private MQClientAPIImpl mockOffsetLookupClient() {


### PR DESCRIPTION
## Summary

Closes #2620.

- Align the two topic-query tail-budget regressions with the current 32 pulls x 32 messages per queue policy.
- Add a dedicated Java 21 backend-test CI job while retaining the existing package job.

## Verification

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q test
```

Passed: 1,626 tests, 0 failures, 0 errors.

Also validated the two repaired regressions directly and checked the workflow YAML.
