### PR TITLE
[Studio] feat: export data sources

### DIFF
--- a/web/src/api/settings.test.ts
+++ b/web/src/api/settings.test.ts
@@ -21,6 +21,7 @@ import client from './client';
 import {
   createDataSource,
   deleteDataSource,
+  listAllDataSources,
   listDataSources,
   testDataSource,
   updateDataSource,
@@ -56,6 +57,40 @@ describe('data sources API', () => {
     await expect(listDataSources()).resolves.toEqual([source]);
     await expect(createDataSource({ name: source.name })).resolves.toEqual(source);
     await expect(updateDataSource(source)).resolves.toEqual(source);
+  });
+
+  it('loads all data source export pages with the maximum supported page size', async () => {
+    mock.onGet('/settings/datasources/page').reply((config) => {
+      const page = config.params.page;
+      expect(config.params.search).toBe('prom');
+      expect(config.params.type).toBe('Prometheus');
+      expect(config.params.pageSize).toBe(100);
+      return [
+        200,
+        {
+          code: 200,
+          data: {
+            items:
+              page === 1
+                ? [source]
+                : [
+                    {
+                      ...source,
+                      key: 'source-2',
+                      name: 'Prometheus backup',
+                    },
+                  ],
+            total: 2,
+            page,
+            size: 100,
+          },
+        },
+      ];
+    });
+
+    await expect(listAllDataSources({ search: 'prom', type: 'Prometheus' })).resolves.toHaveLength(
+      2,
+    );
   });
 
   it('uses a key query parameter for deletion and sends test auth details', async () => {

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -64,6 +64,9 @@ export interface DataSourcePage {
   size: number;
 }
 
+const DATA_SOURCE_EXPORT_PAGE_SIZE = 100;
+const DATA_SOURCE_MAX_EXPORT_PAGES = 100;
+
 // ─── General Settings ───────────────────────────────────────────
 export async function getGeneralSettings() {
   const res = await client.get<{ data: GeneralSettings }>('/settings/general');
@@ -101,6 +104,27 @@ export async function listDataSourcesPage(params: {
     params,
   });
   return res.data.data;
+}
+
+export async function listAllDataSources(params: { search?: string; type?: string } = {}) {
+  const allDataSources: DataSource[] = [];
+  let page = 1;
+
+  while (page <= DATA_SOURCE_MAX_EXPORT_PAGES) {
+    const result = await listDataSourcesPage({
+      ...params,
+      page,
+      pageSize: DATA_SOURCE_EXPORT_PAGE_SIZE,
+    });
+    allDataSources.push(...result.items);
+    const total = result.total ?? allDataSources.length;
+    if (result.items.length === 0 || allDataSources.length >= total) {
+      return allDataSources;
+    }
+    page += 1;
+  }
+
+  throw new Error(`Data source export exceeded ${DATA_SOURCE_MAX_EXPORT_PAGES} pages`);
 }
 
 export async function createDataSource(data: Partial<DataSource>) {

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -713,6 +713,14 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: '删除数据源失败，请稍后重试',
     en: 'Failed to delete data source. Please try again later.',
   },
+  'settings.dataSourceExported': {
+    zh: '已导出 {total} 个数据源',
+    en: 'Exported {total} data sources',
+  },
+  'settings.dataSourceExportFailed': {
+    zh: '导出数据源失败，请稍后重试',
+    en: 'Failed to export data sources. Please try again later.',
+  },
   'settings.instances': { zh: '适用实例', en: 'Applicable instances' },
   'settings.global': { zh: '全局', en: 'Global' },
   'settings.authentication': { zh: '认证方式', en: 'Authentication' },

--- a/web/src/pages/settings/DataSourceTab.tsx
+++ b/web/src/pages/settings/DataSourceTab.tsx
@@ -30,7 +30,7 @@ import {
   Typography,
   message,
 } from 'antd';
-import { MagnifyingGlass } from '@phosphor-icons/react';
+import { DownloadSimple, MagnifyingGlass } from '@phosphor-icons/react';
 import { ApiOutlined, DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 
@@ -39,6 +39,7 @@ import StatusBadge from '../../components/StatusBadge';
 import {
   createDataSource,
   deleteDataSource,
+  listAllDataSources,
   listDataSourcesPage,
   testDataSource,
   updateDataSource,
@@ -47,6 +48,7 @@ import type { DataSource } from '../../api/settings';
 import { STATUS_MAP } from '../../constants/theme';
 import { listInstances } from '../../services/instanceService';
 import type { Instance } from '../../api/instance';
+import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 const { Text } = Typography;
 
@@ -73,6 +75,20 @@ const DATA_SOURCE_TYPE_OPTIONS = [
 const PAGE_SIZE_OPTIONS = [20, 50, 100];
 
 type DataSourceFormValues = Partial<DataSource>;
+
+interface DataSourceExportRow extends DataSource {
+  instanceNames: string;
+  statusLabel: string;
+}
+
+const DATA_SOURCE_EXPORT_COLUMNS: CsvColumn<DataSourceExportRow>[] = [
+  { header: 'Name', value: (source) => source.name },
+  { header: 'Type', value: (source) => source.type },
+  { header: 'URL', value: (source) => source.url },
+  { header: 'Applicable Instances', value: (source) => source.instanceNames },
+  { header: 'Authentication', value: (source) => source.auth },
+  { header: 'Status', value: (source) => source.statusLabel },
+];
 
 const secretFieldNames = ['username', 'password', 'bearerToken'] as const;
 const authNeedsSecret = (auth?: string) => auth === 'Basic Auth' || auth === 'Bearer Token';
@@ -108,6 +124,7 @@ export const DataSourceTab = () => {
   const authValue = Form.useWatch('auth', dsForm);
   const [testingKeys, setTestingKeys] = useState<Set<string>>(() => new Set());
   const [submitting, setSubmitting] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const requestSeqRef = useRef(0);
 
   useEffect(() => {
@@ -259,6 +276,45 @@ export const DataSourceTab = () => {
     }
   };
 
+  const formatInstanceIds = (instanceIds: string[] | undefined) => {
+    if (!instanceIds?.length) return t('settings.global');
+    return instanceIds
+      .map(
+        (instanceId) =>
+          instances.find(
+            (instance) => instance.name === instanceId || String(instance.id) === instanceId,
+          )?.name ?? instanceId,
+      )
+      .join('、');
+  };
+
+  const formatStatus = (status: DataSource['status']) => {
+    if (!status || !STATUS_MAP[status]) return t('settings.dataSourceNotTested');
+    return t(STATUS_MAP[status].labelKey);
+  };
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const exported = await listAllDataSources({
+        search: debouncedSearch,
+        type: typeFilter,
+      });
+      const rows = exported.map((source) => ({
+        ...source,
+        instanceNames: formatInstanceIds(source.instanceIds),
+        statusLabel: formatStatus(source.status),
+      }));
+      const filename = `rocketmq-data-sources-${new Date().toISOString().slice(0, 10)}.csv`;
+      downloadCsv(filename, buildCsv(DATA_SOURCE_EXPORT_COLUMNS, rows));
+      message.success(t('settings.dataSourceExported', { total: rows.length }));
+    } catch {
+      message.error(t('settings.dataSourceExportFailed'));
+    } finally {
+      setExporting(false);
+    }
+  };
+
   const columns: ColumnsType<DataSource> = [
     { title: t('common.name'), dataIndex: 'name', key: 'name' },
     {
@@ -272,17 +328,7 @@ export const DataSourceTab = () => {
       title: t('settings.instances'),
       dataIndex: 'instanceIds',
       key: 'instanceIds',
-      render: (instanceIds: string[] | undefined) => {
-        if (!instanceIds?.length) return t('settings.global');
-        return instanceIds
-          .map(
-            (instanceId) =>
-              instances.find(
-                (instance) => instance.name === instanceId || String(instance.id) === instanceId,
-              )?.name ?? instanceId,
-          )
-          .join('、');
-      },
+      render: formatInstanceIds,
     },
     { title: t('settings.authentication'), dataIndex: 'auth', key: 'auth' },
     {
@@ -362,9 +408,24 @@ export const DataSourceTab = () => {
             options={DATA_SOURCE_TYPE_OPTIONS}
           />
         </Flex>
-        <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal} disabled={loading}>
-          {t('settings.addDataSource')}
-        </Button>
+        <Space>
+          <Button
+            icon={<DownloadSimple size={14} />}
+            onClick={() => void handleExport()}
+            loading={exporting}
+            disabled={loading || total === 0}
+          >
+            {t('common.export')}
+          </Button>
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={openCreateModal}
+            disabled={loading}
+          >
+            {t('settings.addDataSource')}
+          </Button>
+        </Space>
       </Flex>
 
       <Table<DataSource>

--- a/web/src/pages/settings/__tests__/DataSourceTab.test.tsx
+++ b/web/src/pages/settings/__tests__/DataSourceTab.test.tsx
@@ -20,20 +20,36 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import type { DataSource, DataSourcePage } from '../../../api/settings';
-import { createDataSource, listDataSourcesPage, testDataSource } from '../../../api/settings';
+import {
+  createDataSource,
+  listAllDataSources,
+  listDataSourcesPage,
+  testDataSource,
+} from '../../../api/settings';
 import { LangProvider } from '../../../i18n/LangContext';
 import { LANGUAGE_STORAGE_KEY } from '../../../i18n/languagePreference';
+import { downloadCsv } from '../../../utils/download';
 import { DataSourceTab } from '../DataSourceTab';
 
 vi.mock('../../../api/settings', () => ({
   createDataSource: vi.fn(),
   deleteDataSource: vi.fn(),
   getGeneralSettings: vi.fn(),
+  listAllDataSources: vi.fn(),
   listDataSourcesPage: vi.fn(),
   saveGeneralSettings: vi.fn(),
   testDataSource: vi.fn(),
   updateDataSource: vi.fn(),
 }));
+
+vi.mock('../../../utils/download', async () => {
+  const downloadModule =
+    await vi.importActual<typeof import('../../../utils/download')>('../../../utils/download');
+  return {
+    ...downloadModule,
+    downloadCsv: vi.fn(),
+  };
+});
 
 const sources: DataSource[] = [
   {
@@ -91,6 +107,7 @@ describe('DataSourceTab', () => {
     vi.clearAllMocks();
     localStorage.removeItem(LANGUAGE_STORAGE_KEY);
     vi.mocked(listDataSourcesPage).mockResolvedValue(sourcePage);
+    vi.mocked(listAllDataSources).mockResolvedValue(sources);
   });
 
   it('keeps data source creation disabled until the initial list is ready', async () => {
@@ -216,6 +233,55 @@ describe('DataSourceTab', () => {
     await waitFor(() => {
       expect(buttons[1]).not.toHaveClass('ant-btn-loading');
     });
+  });
+
+  it('exports all data sources that match the active filters without secrets', async () => {
+    vi.mocked(listAllDataSources).mockResolvedValue([
+      {
+        ...sources[1],
+        instanceIds: ['instance-1'],
+        username: 'hidden-user',
+        password: 'hidden-password',
+        bearerToken: 'hidden-token',
+      },
+    ]);
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <LangProvider>
+        <App>
+          <DataSourceTab />
+        </App>
+      </LangProvider>,
+    );
+
+    await screen.findByText('Prometheus prod');
+    await user.type(screen.getByPlaceholderText('搜索数据源名称'), 'prom');
+    await selectFilterOption(user, '全部类型', 'Thanos');
+    await waitFor(() =>
+      expect(listDataSourcesPage).toHaveBeenLastCalledWith({
+        search: 'prom',
+        type: 'Thanos',
+        page: 1,
+        pageSize: 20,
+      }),
+    );
+
+    await user.click(screen.getByRole('button', { name: '导出' }));
+
+    await waitFor(() =>
+      expect(listAllDataSources).toHaveBeenCalledWith({
+        search: 'prom',
+        type: 'Thanos',
+      }),
+    );
+    const [filename, csv] = vi.mocked(downloadCsv).mock.calls[0];
+    expect(filename).toMatch(/^rocketmq-data-sources-\d{4}-\d{2}-\d{2}\.csv$/);
+    expect(csv).toContain('"Name","Type","URL","Applicable Instances","Authentication","Status"');
+    expect(csv).toContain('"Thanos DR","Thanos","http://thanos:10902"');
+    expect(csv).toContain('"Bearer Token"');
+    expect(csv).not.toContain('hidden-user');
+    expect(csv).not.toContain('hidden-password');
+    expect(csv).not.toContain('hidden-token');
   });
 
   it('submits basic auth credentials when testing from the modal', async () => {
@@ -426,4 +492,15 @@ async function selectAntdOption(
     return element;
   });
   await user.click(within(popup).getByRole('option', { name: option }));
+}
+
+async function selectFilterOption(
+  user: ReturnType<typeof userEvent.setup>,
+  placeholder: string,
+  option: string,
+) {
+  await user.click(screen.getByText(placeholder));
+  await user.click(
+    await screen.findByText(option, { selector: '.ant-select-item-option-content' }),
+  );
 }


### PR DESCRIPTION
## What is the purpose of the change

Add CSV export for Studio data source settings so operators can download data sources matching the active search and type filters without exporting credentials.

## Brief changelog

- Add a paged data source export helper.
- Add an export action to the Data Source settings tab.
- Export name, type, URL, applicable instances, authentication mode, and status.
- Keep username, password, and bearer token out of exported CSV data.
- Add regression coverage for filtered export and paged export loading.

## Verifying this change

- npm test -- src/api/settings.test.ts src/pages/settings/__tests__/DataSourceTab.test.tsx
- npm run build
- npm run lint
- npx prettier --check src/api/settings.ts src/api/settings.test.ts src/pages/settings/DataSourceTab.tsx src/pages/settings/__tests__/DataSourceTab.test.tsx src/i18n/translations.ts
- git diff --check