### PR TITLE
fix(provider): tolerate null topic route queues

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -102,7 +102,10 @@ public class RocketMQAdminClientImpl implements AdminClient {
                 if (routeData == null || routeData.getQueueDatas() == null || routeData.getQueueDatas().isEmpty()) {
                     throw new BusinessException(404, "Topic not found: " + name);
                 }
-                var qd = routeData.getQueueDatas().get(0);
+                var qd = routeData.getQueueDatas().stream()
+                        .filter(queueData -> queueData != null)
+                        .findFirst()
+                        .orElseThrow(() -> new BusinessException(404, "Topic not found: " + name));
                 TopicVO vo = new TopicVO();
                 vo.setName(name);
                 vo.setWriteQueues(qd.getWriteQueueNums());

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -29,6 +29,8 @@ import org.apache.rocketmq.remoting.protocol.admin.OffsetWrapper;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.route.QueueData;
+import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.remoting.protocol.subscription.SubscriptionGroupConfig;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
@@ -56,6 +58,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -116,6 +119,34 @@ class RocketMQAdminClientImplTest {
                 invocation.<MqClientPool.ClientAction<DefaultMQProducer, Object>>getArgument(1).apply(sendProducer));
         adminClient = new RocketMQAdminClientImpl(adminFactory, properties, topicMapper, groupMapper, auditService,
                 runtimeAdminClientResolver, clientPool);
+    }
+
+    @Test
+    void getTopicUsesFirstUsableQueueData() throws Exception {
+        QueueData queueData = new QueueData();
+        queueData.setReadQueueNums(4);
+        queueData.setWriteQueueNums(6);
+        TopicRouteData routeData = new TopicRouteData();
+        routeData.setQueueDatas(Arrays.asList(null, queueData));
+        when(adminExt.examineTopicRouteInfo("orders")).thenReturn(routeData);
+
+        TopicVO topic = adminClient.getTopic("orders");
+
+        assertThat(topic.getName()).isEqualTo("orders");
+        assertThat(topic.getReadQueues()).isEqualTo(4);
+        assertThat(topic.getWriteQueues()).isEqualTo(6);
+    }
+
+    @Test
+    void getTopicReturnsNotFoundWhenAllQueueDataIsNull() throws Exception {
+        TopicRouteData routeData = new TopicRouteData();
+        routeData.setQueueDatas(java.util.Collections.singletonList(null));
+        when(adminExt.examineTopicRouteInfo("orders")).thenReturn(routeData);
+
+        assertThatThrownBy(() -> adminClient.getTopic("orders"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Topic not found: orders")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- skip null queue entries when reading topic route metadata
- keep using later valid queue metadata in partially populated route responses
- return the existing 404 response when a route contains no usable queue entry
- add regression coverage for partial and fully unusable routes

## Testing

- `mvn -Dtest=RocketMQAdminClientImplTest test` (37 tests passed; Checkstyle passed)

Closes #2624