### PR TITLE
[Studio] fix: reset metrics data source when instance scope changes

### DIFF
--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -402,6 +402,11 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
       ),
     [dataSources, instanceId],
   );
+  const availableDataSourceKeysRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    availableDataSourceKeysRef.current = new Set(availableDataSources.map((source) => source.key));
+  }, [availableDataSources]);
 
   const loadMetrics = useCallback(
     async (metric: MetricMapping | undefined, range: (typeof RANGE_OPTIONS)[number]) => {
@@ -417,7 +422,11 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
       setQueryLoading(true);
       setQueryError(null);
       try {
-        const currentDataSourceKey = dataSourceKeyRef.current;
+        const selectedDataSourceKey = dataSourceKeyRef.current;
+        const currentDataSourceKey =
+          selectedDataSourceKey && availableDataSourceKeysRef.current.has(selectedDataSourceKey)
+            ? selectedDataSourceKey
+            : '';
         const credentials =
           dataSourceCredentialsRef.current?.key === currentDataSourceKey
             ? dataSourceCredentialsRef.current
@@ -554,12 +563,15 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
       window.setTimeout(() => {
         // Keep the ref in sync with the state; queries read the ref, so a stale key would
         // keep hitting the de-registered data source while the UI shows the default.
+        dataSourceCredentialsRef.current = null;
         dataSourceKeyRef.current = '';
         setDataSourceKey('');
         setData(null);
+        setPendingDataSource(null);
+        void loadMetrics(selectedMetric, selectedRange);
       }, 0);
     }
-  }, [availableDataSources, dataSourceKey]);
+  }, [availableDataSources, dataSourceKey, loadMetrics, selectedMetric, selectedRange]);
 
   const pendingAuthMode = pendingDataSource
     ? getDataSourceAuthMode(pendingDataSource.auth)

--- a/web/src/components/__tests__/MetricsExplorer.test.tsx
+++ b/web/src/components/__tests__/MetricsExplorer.test.tsx
@@ -508,4 +508,58 @@ describe('MetricsExplorer', () => {
     expect(screen.getByText('Instance A Prometheus')).toBeInTheDocument();
     expect(screen.queryByText('Instance B Prometheus')).not.toBeInTheDocument();
   });
+
+  it('falls back to the default source when the selected data source leaves the instance scope', async () => {
+    const user = userEvent.setup();
+    vi.mocked(listDataSources).mockResolvedValue([
+      {
+        key: 'ds-instance-a',
+        name: 'Instance A Prometheus',
+        type: 'Prometheus',
+        url: '',
+        auth: 'None',
+        status: 'healthy',
+        instanceIds: ['instance-1'],
+      },
+    ]);
+
+    const view = renderWithProviders(<MetricsExplorer instanceId="instance-1" />);
+
+    await screen.findByRole('combobox', { name: '数据源' });
+    await user.click(screen.getByRole('combobox', { name: '数据源' }));
+    await user.click(
+      await screen.findByText('Instance A Prometheus', {
+        selector: '.ant-select-item-option-content',
+      }),
+    );
+
+    await waitFor(() =>
+      expect(queryByDataSource).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'ds-instance-a',
+          instanceId: 'instance-1',
+        }),
+      ),
+    );
+    const dataSourceQueriesBeforeScopeChange = vi.mocked(queryByDataSource).mock.calls.length;
+    const defaultQueriesBeforeScopeChange = vi.mocked(queryMetrics).mock.calls.length;
+
+    view.rerender(
+      <App>
+        <LangProvider>
+          <MetricsExplorer instanceId="instance-2" />
+        </LangProvider>
+      </App>,
+    );
+
+    await waitFor(() =>
+      expect(vi.mocked(queryMetrics).mock.calls.length).toBeGreaterThan(
+        defaultQueriesBeforeScopeChange,
+      ),
+    );
+    expect(vi.mocked(queryByDataSource).mock.calls).toHaveLength(
+      dataSourceQueriesBeforeScopeChange,
+    );
+    expect(screen.getAllByTitle('默认数据源').length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## What is the purpose of the change

Reset Metrics Explorer to the default Prometheus source when the selected data source is no longer available for the active instance, so metric refreshes do not keep using an out-of-scope data source or leave the chart cleared.

## Brief changelog

- Track the data sources available to the current instance.
- Fall back to the default source when the selected data source leaves the active instance scope.
- Clear temporary data-source credentials and pending auth state during fallback.
- Add regression coverage for instance-scope datasource fallback.

## Verifying this change

- npm test -- src/components/__tests__/MetricsExplorer.test.tsx
- npm run lint
- npm run build
- npx prettier --check src/components/MetricsExplorer.tsx src/components/__tests__/MetricsExplorer.test.tsx
- git diff --check