### PR TITLE
[studio] feat: enable Tencent cloud one-click instance import

### DIFF
--- a/web/src/api/instance.test.ts
+++ b/web/src/api/instance.test.ts
@@ -22,6 +22,7 @@ import {
   createInstance,
   deleteInstance,
   getInstanceCapabilities,
+  importCloudInstances,
   listInstances,
   supportsApacheRuntime,
   updateInstance,
@@ -107,6 +108,18 @@ describe('instance API', () => {
     });
 
     await expect(getInstanceCapabilities('instance/proxy')).resolves.toEqual(capabilities);
+  });
+
+  it('posts cloud import requests for cloud vendors', async () => {
+    const result = { discovered: 4, imported: 1, skipped: 3, failed: [] };
+    mock.onPost('/instances/import-cloud').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ vendor: 'TENCENT', credentialId: 201 });
+      return [200, { code: 200, data: result }];
+    });
+
+    await expect(importCloudInstances({ vendor: 'TENCENT', credentialId: 201 })).resolves.toEqual(
+      result,
+    );
   });
 
   it('identifies instances supported by Apache MQAdmin runtime APIs', () => {

--- a/web/src/api/instance.ts
+++ b/web/src/api/instance.ts
@@ -134,7 +134,10 @@ export async function deleteInstancesBatch(ids: string[]) {
   return res.data.data;
 }
 
-export async function importCloudInstances(data: { vendor: InstanceVendor; credentialId: number }) {
+export async function importCloudInstances(data: {
+  vendor: Exclude<InstanceVendor, 'APACHE'>;
+  credentialId: number;
+}) {
   const res = await client.post<{ data: CloudImportResult }>('/instances/import-cloud', data);
   return res.data.data;
 }

--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -22,6 +22,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as aliyunCatalogApi from '../../../api/aliyunCatalog';
 import * as cloudCredentialApi from '../../../api/cloudCredential';
+import * as tencentCatalogApi from '../../../api/tencentCatalog';
 import type { CloudCredential, CloudCredentialPage } from '../../../api/cloudCredential';
 import type { Instance } from '../../../api/instance';
 import { LangProvider } from '../../../i18n/LangContext';
@@ -118,6 +119,8 @@ describe('InstancePage', () => {
     vi.mocked(cloudCredentialApi.listCloudCredentials).mockResolvedValue(cloudCredentialPage([]));
     vi.mocked(aliyunCatalogApi.listAliyunRegions).mockResolvedValue([]);
     vi.mocked(aliyunCatalogApi.listAliyunInstances).mockResolvedValue([]);
+    vi.mocked(tencentCatalogApi.listTencentRegions).mockResolvedValue([]);
+    vi.mocked(tencentCatalogApi.listTencentInstances).mockResolvedValue([]);
     vi.mocked(instanceService.listInstances).mockResolvedValue([
       instance(1, 'production-proxy'),
       instance(2, 'development-direct', 'DIRECT'),
@@ -451,6 +454,60 @@ describe('InstancePage', () => {
     );
     expect(
       await screen.findByText(/导入完成：共同步 3 个实例（新导入 2，已存在跳过 1）/),
+    ).toBeInTheDocument();
+  });
+
+  it('imports every Tencent instance of the credential via one-click import', async () => {
+    const user = userEvent.setup();
+    vi.mocked(cloudCredentialApi.listCloudCredentials).mockResolvedValue(
+      cloudCredentialPage([
+        {
+          id: 201,
+          name: 'tencent-prod-account',
+          vendor: 'TENCENT',
+          accessKey: 'AKID-prod',
+          gmtCreate: '2026-01-01T00:00:00Z',
+        },
+      ]),
+    );
+    vi.mocked(instanceService.importCloudInstances).mockResolvedValue({
+      discovered: 4,
+      imported: 1,
+      skipped: 3,
+      failed: [],
+    });
+
+    renderPage();
+    expect(await screen.findByText('production-proxy')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /添加实例/ }));
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('tab', { name: /Tencent 版/ }));
+    await waitFor(() =>
+      expect(cloudCredentialApi.listCloudCredentials).toHaveBeenLastCalledWith('TENCENT'),
+    );
+
+    const importButton = within(dialog).getByRole('button', { name: /一键导入/ });
+    expect(importButton).toBeDisabled();
+
+    const credentialSelect = within(dialog).getAllByRole('combobox')[0];
+    fireEvent.mouseDown(credentialSelect.parentElement!);
+    await user.click(
+      await screen.findByText(/tencent-prod-account/, {
+        selector: '.ant-select-item-option-content',
+      }),
+    );
+    await waitFor(() => expect(importButton).toBeEnabled());
+
+    await user.click(importButton);
+
+    await waitFor(() =>
+      expect(instanceService.importCloudInstances).toHaveBeenCalledWith({
+        vendor: 'TENCENT',
+        credentialId: 201,
+      }),
+    );
+    expect(
+      await screen.findByText(/导入完成：共同步 4 个实例（新导入 1，已存在跳过 3）/),
     ).toBeInTheDocument();
   });
 

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -723,7 +723,7 @@ const InstancePage = () => {
         width={520}
         footer={
           <Flex justify="flex-end" gap={8}>
-            {vendor === 'ALIYUN' && (
+            {cloudVendor && (
               <Tooltip title="遍历该凭据下全部地域，将所有云上实例导入（幂等，已存在的自动跳过），备注自动取自云上实例">
                 <Button
                   loading={importing}


### PR DESCRIPTION
## What is the purpose of the change

The cloud instance import endpoint already supports cloud vendors through the generic vendor-based import flow, but the add instance dialog only exposed one-click import on the Aliyun tab. This change makes the same batch import flow available for Tencent Cloud instances.

## Brief changelog

- Show the one-click import action for Tencent Cloud credentials.
- Restrict the frontend cloud import API type to non-Apache cloud vendors.
- Add coverage for Tencent one-click import and the cloud import request payload.

## Verifying this change

- npm run test -- src/pages/instance/__tests__/InstancePage.test.tsx src/api/instance.test.ts
- npx prettier --check src/api/instance.ts src/api/instance.test.ts src/pages/instance/index.tsx src/pages/instance/__tests__/InstancePage.test.tsx
- npx eslint src/api/instance.ts src/api/instance.test.ts src/pages/instance/index.tsx src/pages/instance/__tests__/InstancePage.test.tsx
- git diff --check
- npm run build