### PR TITLE
[Studio] fix: replace placeholder home footer links

### DIFF
--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -123,3 +123,19 @@ describe('HomePage LLM models', () => {
     expect(navigateMock).not.toHaveBeenCalled();
   });
 });
+
+describe('HomePage footer', () => {
+  it('links to RocketMQ documentation and community pages', () => {
+    renderHome();
+
+    const docsLink = screen.getByRole('link', { name: '文档中心' });
+    expect(docsLink).toHaveAttribute('href', 'https://rocketmq.apache.org/docs/');
+    expect(docsLink).toHaveAttribute('target', '_blank');
+    expect(docsLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    const communityLink = screen.getByRole('link', { name: 'RocketMQ 社区' });
+    expect(communityLink).toHaveAttribute('href', 'https://rocketmq.apache.org/');
+    expect(communityLink).toHaveAttribute('target', '_blank');
+    expect(communityLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -66,6 +66,9 @@ const ENGINE_OPTIONS = [
   { value: 'http', label: 'HTTP' },
 ];
 
+const ROCKETMQ_DOCS_URL = 'https://rocketmq.apache.org/docs/';
+const ROCKETMQ_COMMUNITY_URL = 'https://rocketmq.apache.org/';
+
 // 首页只暴露这些模型（token-plan 网关实际可对话的模型集），qwen3.8-max 为推荐项。
 const HOME_MODELS = [
   'qwen3.8-max',
@@ -566,22 +569,26 @@ const HomePage = () => {
         >
           <span className="pointer-events-auto">
             <a
-              href="#"
+              href={ROCKETMQ_DOCS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
               className="transition-colors hover:text-purple-500"
               style={{ textDecoration: 'none' }}
             >
-              文档中心
+              {t('home.docs')}
             </a>
             <span style={{ margin: '0 4px' }}>｜</span>
             <a
-              href="#"
+              href={ROCKETMQ_COMMUNITY_URL}
+              target="_blank"
+              rel="noopener noreferrer"
               className="transition-colors hover:text-purple-500"
               style={{ textDecoration: 'none' }}
             >
-              RocketMQ 社区
+              {t('home.community')}
             </a>
             <span style={{ margin: '0 4px' }}>｜</span>
-            <span>RocketMQ Studio 出品</span>
+            <span>{t('home.brand')}</span>
             <span style={{ margin: '0 4px' }}>｜</span>
             <span>
               当前版本 {__BUILD_TIME__} build({__BUILD_COMMIT__})


### PR DESCRIPTION
## What is the purpose of the change

Replace the Home page footer placeholder links with real Apache RocketMQ documentation and community URLs, and reuse the existing localized footer labels.

## Brief changelog

- Replace `href="#"` footer links with RocketMQ documentation and community links.
- Open external footer links in a new tab with `noopener noreferrer`.
- Add a Home page regression test for the footer links.

## Verifying this change

- `npm run test -- src/pages/home/__tests__/HomePage.test.tsx`
- `npx prettier --check src/pages/home/index.tsx src/pages/home/__tests__/HomePage.test.tsx`
- `npx eslint src/pages/home/index.tsx src/pages/home/__tests__/HomePage.test.tsx`
- `git diff --check`
- `npm run build`