### PR TITLE
fix: prevent directory traversal via date parameter in DashboardCollectServiceImpl

### DIFF
--- a/src/main/java/org/apache/rocketmq/dashboard/service/impl/DashboardCollectServiceImpl.java
+++ b/src/main/java/org/apache/rocketmq/dashboard/service/impl/DashboardCollectServiceImpl.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import jakarta.annotation.Resource;
 import org.apache.rocketmq.dashboard.config.RMQConfigure;
+import org.apache.rocketmq.dashboard.exception.ServiceException;
 import org.apache.rocketmq.dashboard.service.DashboardCollectService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +42,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 @Service
 public class DashboardCollectServiceImpl implements DashboardCollectService {
@@ -49,6 +51,14 @@ public class DashboardCollectServiceImpl implements DashboardCollectService {
     private RMQConfigure configure;
 
     private final static Logger log = LoggerFactory.getLogger(DashboardCollectServiceImpl.class);
+
+    private static final Pattern DATE_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}$");
+
+    private static void checkDateParam(String date) {
+        if (date != null && !date.isEmpty() && !DATE_PATTERN.matcher(date).matches()) {
+            throw new ServiceException(-1, "Invalid date format, expected yyyy-MM-dd");
+        }
+    }
 
     private LoadingCache<String, List<String>> brokerMap = CacheBuilder.newBuilder()
             .maximumSize(1000)
@@ -135,6 +145,7 @@ public class DashboardCollectServiceImpl implements DashboardCollectService {
 
     @Override
     public Map<String, List<String>> getBrokerCache(String date) {
+        checkDateParam(date);
         String dataLocationPath = configure.getDashboardCollectData();
         File file = new File(dataLocationPath + date + ".json");
         if (!file.exists()) {
@@ -146,6 +157,7 @@ public class DashboardCollectServiceImpl implements DashboardCollectService {
 
     @Override
     public Map<String, List<String>> getTopicCache(String date) {
+        checkDateParam(date);
         String dataLocationPath = configure.getDashboardCollectData();
         File file = new File(dataLocationPath + date + "_topic" + ".json");
         if (!file.exists()) {


### PR DESCRIPTION
## Problem

`DashboardCollectServiceImpl.getBrokerCache(date)` and `getTopicCache(date)` construct file paths by direct string concatenation: `new File(dataLocationPath + date + ".json")`. The `date` parameter originates from user input via `DashboardController` and is never validated, enabling directory traversal attacks (e.g., `../../xxx`).

Fixes #2625

## Changes

- Added `DATE_PATTERN` whitelist regex (`^\d{4}-\d{2}-\d{2}$`) matching the expected `yyyy-MM-dd` format
- Added `checkDateParam()` method that throws `ServiceException(-1, ...)` for invalid date values
- Called `checkDateParam(date)` at entry of both `getBrokerCache()` and `getTopicCache()`

## Verification

- Valid dates (`2024-01-01`) continue to work normally
- Invalid dates (`../../etc/passwd`, `abc`, `2024/01/01`) now return error responses
- Single file change, minimal surface area