### PR TITLE
fix(dlq): resolve selected messages by id

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.List;
 import java.util.Map;
@@ -241,7 +242,7 @@ public class RocketMQDLQProvider implements DLQProvider {
             throw new BusinessException(400, "At least one msgId is required for selected DLQ resend");
         }
         groupName = groupName.trim();
-        Set<String> selected = new java.util.HashSet<>();
+        Set<String> selected = new LinkedHashSet<>();
         for (String msgId : msgIds) {
             if (StringUtils.hasText(msgId)) {
                 selected.add(msgId.trim());
@@ -253,14 +254,21 @@ public class RocketMQDLQProvider implements DLQProvider {
 
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + groupName;
 
-        // Scan a wide window so the selected messages are found regardless of their store time.
-        long end = System.currentTimeMillis();
-        long begin = end - 7 * 24 * ONE_HOUR_MILLIS;
-        DeadLetterScanResult scanResult =
-                collectDeadLetters(instanceId, dlqTopic, begin, end, RESEND_HARD_CAP);
-        List<MessageExt> deadLetters = scanResult.messages().stream()
-                .filter(message -> selected.contains(message.getMsgId()))
-                .toList();
+        List<MessageExt> deadLetters = runtimeAdminClientResolver.execute(instanceId, admin -> {
+            List<MessageExt> resolved = new ArrayList<>(selected.size());
+            for (String msgId : selected) {
+                try {
+                    MessageExt deadLetter = admin.viewMessage(dlqTopic, msgId);
+                    if (deadLetter != null) {
+                        resolved.add(deadLetter);
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to resolve selected dead letter {} from {}: {}",
+                            msgId, dlqTopic, e.getMessage());
+                }
+            }
+            return resolved;
+        });
         int[] counts = {0, 0};
         if (!deadLetters.isEmpty()) {
             try {
@@ -293,6 +301,7 @@ public class RocketMQDLQProvider implements DLQProvider {
                 .resent(resent)
                 .failed(failed)
                 .outcome(outcome)
+                .scanIncomplete(!foundAll)
                 .build();
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -462,6 +462,53 @@ class RocketMQDLQProviderTest {
     }
 
     @Test
+    void resendSelectedMessagesLooksUpIdsWithoutAStoreTimeWindow() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        MessageExt oldDeadLetter = new MessageExt();
+        oldDeadLetter.setMsgId("old-msg");
+        oldDeadLetter.setTopic(dlqTopic);
+        oldDeadLetter.setBody(new byte[] {1});
+        oldDeadLetter.setStoreTimestamp(1L);
+        SendResult sendResult = new SendResult();
+        sendResult.setSendStatus(SendStatus.SEND_OK);
+
+        when(adminExt.viewMessage(dlqTopic, "old-msg")).thenReturn(oldDeadLetter);
+        when(dlqProducer.send(any(Message.class))).thenReturn(sendResult);
+
+        assertThat(provider.resendMessages(
+                "instance-a", "group-a", List.of("old-msg"), "target-topic"))
+                .extracting("matched", "resent", "failed", "outcome", "scanIncomplete")
+                .containsExactly(1, 1, 0, "SUCCESS", false);
+
+        verify(adminExt).viewMessage(dlqTopic, "old-msg");
+        verifyNoInteractions(pullConsumer);
+    }
+
+    @Test
+    void resendSelectedMessagesReportsMissingLookupsAsPartial() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        MessageExt found = new MessageExt();
+        found.setMsgId("found-msg");
+        found.setTopic(dlqTopic);
+        found.setBody(new byte[] {1});
+        SendResult sendResult = new SendResult();
+        sendResult.setSendStatus(SendStatus.SEND_OK);
+
+        when(adminExt.viewMessage(dlqTopic, "missing-msg"))
+                .thenThrow(new IllegalStateException("message not found"));
+        when(adminExt.viewMessage(dlqTopic, "found-msg")).thenReturn(found);
+        when(dlqProducer.send(any(Message.class))).thenReturn(sendResult);
+
+        assertThat(provider.resendMessages(
+                "instance-a", "group-a", List.of("missing-msg", "found-msg"), "target-topic"))
+                .extracting("matched", "resent", "failed", "outcome", "scanIncomplete")
+                .containsExactly(1, 1, 0, "PARTIAL", true);
+
+        verify(adminExt).viewMessage(dlqTopic, "missing-msg");
+        verify(adminExt).viewMessage(dlqTopic, "found-msg");
+    }
+
+    @Test
     void resendMessagesMarksAResultPartialWhenScanReachesHardCap() throws Exception {
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
         MessageQueue queue = new MessageQueue(dlqTopic, "broker-a", 0);


### PR DESCRIPTION
## Summary
- resolve selected DLQ messages directly by their IDs instead of rescanning a fixed seven-day window
- preserve request order while deduplicating IDs and continue past individual lookup failures
- mark incomplete selected lookups as partial and expose that through `scanIncomplete`

## Why
The selected resend endpoint already receives exact message IDs. Rescanning only the most recent seven days, with a 5,000-message cap, can miss an older selected message or one beyond the cap even though its ID is known.

## Tests
- `mvn -o -Dtest=RocketMQDLQProviderTest test` (22 tests passed)

Fixes #2635