### PR TITLE
fix(web): ignore stale consumer settings responses

### DIFF
--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -99,6 +99,14 @@ const groupPage = (
   ...overrides,
 });
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+};
+
 const renderWithProviders = (ui: React.ReactElement, initialEntry = '/instance/consumer') =>
   render(
     <App>
@@ -959,5 +967,64 @@ describe('Consumer page', () => {
         .filter(Boolean);
       expect(order).toEqual(['known', 'unknown']);
     });
+  });
+
+  it('ignores settings responses from a previously closed group modal', async () => {
+    const otherGroup = { ...group, name: 'other-cg' };
+    const firstSettings = deferred<{
+      groupName: string;
+      retryQueueNums: number;
+      retryMaxTimes: number;
+    }>();
+    const secondSettings = deferred<{
+      groupName: string;
+      retryQueueNums: number;
+      retryMaxTimes: number;
+    }>();
+    vi.mocked(consumerService.listConsumerGroupPage).mockResolvedValue(
+      groupPage([group, otherGroup]),
+    );
+    vi.mocked(consumerService.getConsumerGroupSettings)
+      .mockImplementationOnce(() => firstSettings.promise)
+      .mockImplementationOnce(() => secondSettings.promise);
+    const user = userEvent.setup();
+    renderWithProviders(<ConsumerPage />);
+
+    const firstRow = await screen.findByRole('row', { name: /remote-cg/ });
+    await user.click(within(firstRow).getByRole('button', { name: '详情' }));
+    const firstDialog = await screen.findByRole('dialog', { name: /remote-cg/ });
+    await user.click(within(firstDialog).getByRole('tab', { name: '配置' }));
+    await waitFor(() => {
+      expect(consumerService.getConsumerGroupSettings).toHaveBeenCalledWith(
+        'remote-cg',
+        'instance-1',
+      );
+    });
+
+    fireEvent.click(firstDialog.querySelector('.ant-modal-close') as HTMLElement);
+
+    const secondRow = screen.getByRole('row', { name: /other-cg/ });
+    await user.click(within(secondRow).getByRole('button', { name: '详情' }));
+    const secondDialog = await screen.findByRole('dialog', { name: /other-cg/ });
+    await user.click(within(secondDialog).getByRole('tab', { name: '配置' }));
+    await waitFor(() => {
+      expect(consumerService.getConsumerGroupSettings).toHaveBeenCalledWith(
+        'other-cg',
+        'instance-1',
+      );
+    });
+
+    await act(async () => {
+      secondSettings.resolve({ groupName: 'other-cg', retryQueueNums: 4, retryMaxTimes: 12 });
+    });
+    await waitFor(() => {
+      expect(within(secondDialog).getByLabelText('重试队列数')).toHaveValue('4');
+    });
+
+    await act(async () => {
+      firstSettings.resolve({ groupName: 'remote-cg', retryQueueNums: 1, retryMaxTimes: 16 });
+    });
+    expect(within(secondDialog).getByLabelText('重试队列数')).toHaveValue('4');
+    expect(within(secondDialog).getByLabelText('最大重试次数')).toHaveValue('12');
   });
 });

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -273,6 +273,7 @@ const ConsumerPageContent = ({
 
   const groupRequestIdRef = useRef(0);
   const stackRequestIdRef = useRef(0);
+  const settingsRequestIdRef = useRef(0);
 
   const [autoRefresh, setAutoRefresh] = useState(false);
   const silentRefreshRef = useRef(false);
@@ -433,15 +434,22 @@ const ConsumerPageContent = ({
 
   const loadGroupSettings = async (group: ConsumerGroup) => {
     if (!selectedInstanceId) return;
+    const requestId = ++settingsRequestIdRef.current;
     setSettingsGroup(group);
     setSettingsLoading(true);
     try {
       const settings = await getConsumerGroupSettings(group.name, selectedInstanceId);
-      settingsForm.setFieldsValue(settings);
+      if (requestId === settingsRequestIdRef.current) {
+        settingsForm.setFieldsValue(settings);
+      }
     } catch {
-      message.error('加载消费组配置失败，请稍后重试');
+      if (requestId === settingsRequestIdRef.current) {
+        message.error('加载消费组配置失败，请稍后重试');
+      }
     } finally {
-      setSettingsLoading(false);
+      if (requestId === settingsRequestIdRef.current) {
+        setSettingsLoading(false);
+      }
     }
   };
 
@@ -1263,10 +1271,12 @@ const ConsumerPageContent = ({
         }
         open={modalOpen}
         onCancel={() => {
+          settingsRequestIdRef.current += 1;
           setModalOpen(false);
           setSelectedGroup(null);
           setShowOnlyInconsistent(false);
           setSettingsGroup(null);
+          setSettingsLoading(false);
           settingsForm.resetFields();
         }}
         width={detailTab === 'progress' ? 1080 : 800}


### PR DESCRIPTION
## Summary
- sequence consumer group settings requests so only the latest modal can update the form
- invalidate pending settings requests when the detail modal closes
- ignore stale success, error, and loading callbacks and reset loading state on close
- cover an out-of-order response across two consumer groups

## Why
A delayed response for a previously closed group could overwrite the settings form of the group currently open. Saving then risked applying the old group's retry values to the current group.

## Tests
- targeted ConsumerPage retry-settings and stale-response tests (2 tests passed)
- `npm run build`

Fixes #2634
