### PR TITLE
fix(studio): disable mail health indicator unless SMTP health check is enabled

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -47,6 +47,11 @@ management:
           include: livenessState
         readiness:
           include: readinessState,db
+  health:
+    mail:
+      # SMTP is optional for native alerting; skip the SMTP connectivity probe
+      # unless explicitly enabled, so health stays UP when no SMTP host is configured.
+      enabled: ${STUDIO_ALERTING_SMTP_HEALTH_ENABLED:false}
 
 studio:
   cors:


### PR DESCRIPTION
Follow-up to #2533 (native alerting introduced spring-boot-starter-mail).

The auto-configured MailHealthIndicator probes the SMTP connection on /actuator/health. In deployments without STUDIO_ALERTING_SMTP_HOST this probe fails, dragging the aggregate health to DOWN even though the app and its readiness group (including db) are UP.

Make the mail health indicator opt-in via STUDIO_ALERTING_SMTP_HEALTH_ENABLED (default false). Enable it in environments where SMTP is configured.