### PR TITLE
fix(web): refresh deliveries with current filters

### DIFF
--- a/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
@@ -18,8 +18,17 @@ vi.mock('../../../services/instanceService', () => ({
 }));
 vi.mock('../../../services/opsService', () => ({
   listAlertDeliveriesPage: vi.fn(),
+  retryAlertDeliveries: vi.fn(),
   retryAlertDelivery: vi.fn(),
 }));
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+};
 
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
@@ -72,5 +81,70 @@ describe('NotificationDeliveriesPage', () => {
 
     await waitFor(() => expect(retryAlertDelivery).toHaveBeenCalledWith(7));
     await waitFor(() => expect(listAlertDeliveriesPage).toHaveBeenCalledTimes(2));
+  });
+
+  it('refreshes a completed retry with the latest filters', async () => {
+    const retry = deferred<void>();
+    vi.mocked(retryAlertDelivery).mockImplementation(() => retry.promise);
+    vi.mocked(listAlertDeliveriesPage).mockImplementation(async (query) =>
+      query?.status === 'DELIVERED'
+        ? {
+            items: [
+              {
+                id: 8,
+                alertId: 4,
+                alertTitle: 'Delivered notification',
+                channel: 'email',
+                status: 'DELIVERED',
+                attemptCount: 1,
+                createdAt: '2026-08-23T10:00:00',
+                deliveredAt: '2026-08-23T10:01:00',
+              },
+            ],
+            total: 1,
+            page: 1,
+            size: 20,
+          }
+        : {
+            items: [
+              {
+                id: 7,
+                alertId: 3,
+                alertTitle: 'Broker disk usage',
+                channel: 'dingtalk',
+                status: 'FAILED',
+                attemptCount: 5,
+                createdAt: '2026-08-23T10:00:00',
+                lastError: 'Webhook rejected the request',
+              },
+            ],
+            total: 1,
+            page: 1,
+            size: 20,
+          },
+    );
+    const user = userEvent.setup();
+    render(
+      <App>
+        <LangProvider>
+          <NotificationDeliveriesPage />
+        </LangProvider>
+      </App>,
+    );
+
+    await screen.findByText('Broker disk usage');
+    await user.click(screen.getByRole('button', { name: '重新投递' }));
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(await screen.findByText('DELIVERED'));
+    expect(await screen.findByText('Delivered notification')).toBeInTheDocument();
+
+    retry.resolve();
+
+    await waitFor(() => expect(listAlertDeliveriesPage).toHaveBeenCalledTimes(3));
+    expect(screen.getByText('Delivered notification')).toBeInTheDocument();
+    expect(screen.queryByText('Broker disk usage')).not.toBeInTheDocument();
+    expect(listAlertDeliveriesPage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: 'DELIVERED' }),
+    );
   });
 });

--- a/web/src/pages/ops/notificationDeliveries.tsx
+++ b/web/src/pages/ops/notificationDeliveries.tsx
@@ -55,16 +55,11 @@ const NotificationDeliveriesPage = () => {
   const [selectedDelivery, setSelectedDelivery] = useState<NotificationDeliveryRecord>();
   const [retryingIds, setRetryingIds] = useState<Set<number>>(() => new Set());
   const [retryingVisible, setRetryingVisible] = useState(false);
+  const [refreshNonce, setRefreshNonce] = useState(0);
 
   const refresh = () => {
     setLoading(true);
-    void listAlertDeliveriesPage({ channel, status, instanceId, page, pageSize })
-      .then((result) => {
-        setItems(result.items);
-        setTotal(result.total);
-      })
-      .catch(() => message.error(t('deliveries.loadFailed')))
-      .finally(() => setLoading(false));
+    setRefreshNonce((current) => current + 1);
   };
 
   const retryDelivery = async (record: NotificationDeliveryRecord) => {
@@ -133,7 +128,7 @@ const NotificationDeliveriesPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [channel, status, instanceId, page, pageSize, t]);
+  }, [channel, status, instanceId, page, pageSize, refreshNonce, t]);
 
   const resetPage = (change: () => void) => {
     setLoading(true);


### PR DESCRIPTION
### Summary

- refresh notification deliveries through the current query effect after a retry completes
- prevent a retry started under old filters from restoring stale results
- cover a status-filter change while the retry request is pending

### Tests

- npm exec vitest -- run src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
- npm exec prettier -- --check src/pages/ops/notificationDeliveries.tsx src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
- npm exec eslint -- src/pages/ops/notificationDeliveries.tsx src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
- npm run build

Closes #2646