### PR TITLE
fix(alert): reject overflowing rule durations

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleDuration.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleDuration.java
@@ -24,26 +24,30 @@ final class AlertRuleDuration {
         if (!StringUtils.hasText(value)) {
             return Duration.ZERO;
         }
-        Matcher matcher = PART.matcher(value.trim());
-        Duration result = Duration.ZERO;
-        int end = 0;
-        while (matcher.find()) {
-            if (matcher.start() != end) {
+        try {
+            Matcher matcher = PART.matcher(value.trim());
+            Duration result = Duration.ZERO;
+            int end = 0;
+            while (matcher.find()) {
+                if (matcher.start() != end) {
+                    throw invalid(value);
+                }
+                long amount;
+                try {
+                    amount = Long.parseLong(matcher.group(1));
+                } catch (NumberFormatException error) {
+                    throw invalid(value);
+                }
+                result = result.plus(toDuration(amount, matcher.group(2), value));
+                end = matcher.end();
+            }
+            if (end != value.trim().length()) {
                 throw invalid(value);
             }
-            long amount;
-            try {
-                amount = Long.parseLong(matcher.group(1));
-            } catch (NumberFormatException error) {
-                throw invalid(value);
-            }
-            result = result.plus(toDuration(amount, matcher.group(2), value));
-            end = matcher.end();
-        }
-        if (end != value.trim().length()) {
+            return result;
+        } catch (ArithmeticException error) {
             throw invalid(value);
         }
-        return result;
     }
 
     private static BusinessException invalid(String value) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRulePolicy.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRulePolicy.java
@@ -74,6 +74,8 @@ final class NativeAlertRulePolicy {
         if (StringUtils.hasText(rule.getTopic()) && !TOPIC_SCOPED_METRICS.contains(rule.getMetric())) {
             throw new BusinessException(400, "topic is not supported for metric " + rule.getMetric());
         }
+        AlertRuleDuration.parse(rule.getDuration());
+        AlertRuleDuration.parse(rule.getReminderInterval());
         if (rule.getConsecutiveSamples() < 1) {
             throw new BusinessException(400, "consecutiveSamples must be at least 1");
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleDurationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleDurationTest.java
@@ -6,16 +6,28 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AlertRuleDurationTest {
     @Test
     void parsesTheRuleDurationSyntaxTest() {
         assertThat(AlertRuleDuration.parse("1h30m")).isEqualTo(Duration.ofMinutes(90));
         assertThat(AlertRuleDuration.parse(null)).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    void rejectsDurationsThatOverflowTest() {
+        assertThatThrownBy(() -> AlertRuleDuration.parse("9223372036854775807y"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Invalid alert duration");
+        assertThatThrownBy(() -> AlertRuleDuration.parse("9223372036854775807s9223372036854775807s"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Invalid alert duration");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRulePolicyTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRulePolicyTest.java
@@ -107,6 +107,16 @@ class NativeAlertRulePolicyTest {
         }
     }
 
+    @Test
+    void rejectsOverflowingNativeRuleDurationsBeforePersistenceTest() {
+        assertThatThrownBy(() -> NativeAlertRulePolicy.validate(rule(AlertDomain.CLUSTER, "broker.availability")
+                .instanceId("local").duration("9223372036854775807y").build()))
+                .isInstanceOf(BusinessException.class).hasMessageContaining("Invalid alert duration");
+        assertThatThrownBy(() -> NativeAlertRulePolicy.validate(rule(AlertDomain.CLUSTER, "broker.availability")
+                .instanceId("local").reminderInterval("9223372036854775807y").build()))
+                .isInstanceOf(BusinessException.class).hasMessageContaining("Invalid alert duration");
+    }
+
     private static AlertRuleVO.AlertRuleVOBuilder rule(AlertDomain domain, String metric) {
         return AlertRuleVO.builder().domain(domain).name("Test rule").metric(metric).consecutiveSamples(1);
     }


### PR DESCRIPTION
### Summary

- convert duration arithmetic overflows into the existing invalid-duration business error
- parse native rule duration and reminder interval during validation, before persistence
- cover overflowing components, overflowing sums, and native rule validation boundaries

### Tests

- mvn -Dmaven.repo.local=D:/taiyi-maven-cache -Dtest=AlertRuleDurationTest,NativeAlertRulePolicyTest,NativeAlertProcessorTest test

Closes #2648