### PR TITLE
fix(alerts): terminate exports on empty pages

### DIFF
--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -10,7 +10,9 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LangProvider } from '../../../i18n/LangContext';
+import { LANGUAGE_STORAGE_KEY } from '../../../i18n/languagePreference';
 import { formatUtcDateTime } from '../../../utils/format';
+import { downloadCsv } from '../../../utils/download';
 import {
   acknowledgeAlert,
   createAlertSilence,
@@ -34,6 +36,12 @@ vi.mock('../../../services/opsService', () => ({
   createAlertSilence: vi.fn(),
   deleteAlertSilence: vi.fn(),
 }));
+
+vi.mock('../../../utils/download', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../../utils/download')>('../../../utils/download');
+  return { ...actual, downloadCsv: vi.fn() };
+});
 
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
@@ -87,6 +95,51 @@ describe('SystemAlertsPage', () => {
       size: 20,
     });
     vi.mocked(listAlertSilences).mockResolvedValue([]);
+  });
+
+  it('finishes an export when a later page is empty after the result set shrinks', async () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en');
+    vi.mocked(listSystemAlertsPage)
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 1,
+            level: 'error',
+            title: 'Broker unavailable',
+            description: 'broker a',
+            time: '2026-08-10 01:00',
+            acknowledged: false,
+          },
+        ],
+        total: 1,
+        page: 1,
+        size: 20,
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 1,
+            level: 'error',
+            title: 'Broker unavailable',
+            description: 'broker a',
+            time: '2026-08-10 01:00',
+            acknowledged: false,
+          },
+        ],
+        total: 200,
+        page: 1,
+        size: 100,
+      })
+      .mockResolvedValueOnce({ items: [], total: 200, page: 2, size: 100 });
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText('Broker unavailable');
+
+    await user.click(screen.getByRole('button', { name: 'Export CSV' }));
+
+    await waitFor(() => expect(downloadCsv).toHaveBeenCalledTimes(1));
+    expect(listSystemAlertsPage).toHaveBeenCalledTimes(3);
+    expect(listSystemAlertsPage).toHaveBeenLastCalledWith({ page: 2, pageSize: 100 });
   });
 
   it('renders an alert with an unknown backend level', async () => {

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -60,6 +60,9 @@ import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 const { Text } = Typography;
 
+const ALERT_EXPORT_PAGE_SIZE = 100;
+const ALERT_EXPORT_MAX_PAGES = 10_000;
+
 const normalizeAlertLevel = (level?: string | null) => (level ?? '').toLowerCase();
 const formatAlertTransition = (
   transition: SystemAlert['transition'] | undefined,
@@ -256,11 +259,27 @@ const SystemAlertsPage = () => {
     setExporting(true);
     try {
       const query = currentQuery();
-      const first = await listSystemAlertsPage({ ...query, page: 1, pageSize: 100 });
+      const first = await listSystemAlertsPage({
+        ...query,
+        page: 1,
+        pageSize: ALERT_EXPORT_PAGE_SIZE,
+      });
       const rows = [...first.items];
-      for (let currentPage = 2; rows.length < first.total; currentPage += 1) {
-        const result = await listSystemAlertsPage({ ...query, page: currentPage, pageSize: 100 });
+      let expectedTotal = first.total;
+      let currentPage = 2;
+      while (rows.length < expectedTotal) {
+        if (currentPage > ALERT_EXPORT_MAX_PAGES) {
+          throw new Error('System alert export exceeded the pagination limit');
+        }
+        const result = await listSystemAlertsPage({
+          ...query,
+          page: currentPage,
+          pageSize: ALERT_EXPORT_PAGE_SIZE,
+        });
+        if (result.items.length === 0) break;
         rows.push(...result.items);
+        expectedTotal = Math.min(expectedTotal, result.total);
+        currentPage += 1;
       }
       downloadCsv(
         `rocketmq-system-alerts-${new Date().toISOString().slice(0, 10)}.csv`,


### PR DESCRIPTION
## Summary
- stop system-alert CSV export when a fetched page is empty
- adjust the remaining export target when later responses report a smaller total
- add a finite page bound and regression coverage for a shrinking result set

## Tests
- `npm exec vitest -- run src/pages/ops/__tests__/SystemAlertsPage.test.tsx`
- `npm exec prettier -- --check src/pages/ops/systemAlerts.tsx src/pages/ops/__tests__/SystemAlertsPage.test.tsx`
- `npm exec eslint -- src/pages/ops/systemAlerts.tsx src/pages/ops/__tests__/SystemAlertsPage.test.tsx`
- `npm run build`

Closes #2651