### PR TITLE
fix(settings): save data sources without query credentials

### DIFF
--- a/web/src/pages/settings/DataSourceTab.tsx
+++ b/web/src/pages/settings/DataSourceTab.tsx
@@ -99,6 +99,14 @@ const testFieldNames = (auth?: string) => {
   return ['type', 'url', 'auth'];
 };
 
+const saveFieldNames: (keyof DataSourceFormValues)[] = [
+  'name',
+  'type',
+  'url',
+  'auth',
+  'instanceIds',
+];
+
 const withoutSecrets = (values: DataSourceFormValues): Partial<DataSource> => {
   const sanitized = { ...values };
   secretFieldNames.forEach((field) => {
@@ -233,7 +241,9 @@ export const DataSourceTab = () => {
 
   const handleSubmit = async () => {
     try {
-      const values = await dsForm.validateFields();
+      // Credentials are supplied per metrics query and are only used here by the
+      // connection test. Saving metadata must not require re-entering them.
+      const values = await dsForm.validateFields(saveFieldNames);
       const dataSourceValues = withoutSecrets(values);
       setSubmitting(true);
       const saved = editingDataSource

--- a/web/src/pages/settings/__tests__/DataSourceTab.test.tsx
+++ b/web/src/pages/settings/__tests__/DataSourceTab.test.tsx
@@ -25,6 +25,7 @@ import {
   listAllDataSources,
   listDataSourcesPage,
   testDataSource,
+  updateDataSource,
 } from '../../../api/settings';
 import { LangProvider } from '../../../i18n/LangContext';
 import { LANGUAGE_STORAGE_KEY } from '../../../i18n/languagePreference';
@@ -344,6 +345,36 @@ describe('DataSourceTab', () => {
         bearerToken: 'token-1',
       });
     });
+  });
+
+  it('updates authenticated data source metadata without requiring query credentials', async () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en');
+    vi.mocked(updateDataSource).mockResolvedValue({
+      ...sources[1],
+      name: 'Thanos primary',
+    });
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <App>
+        <DataSourceTab />
+      </App>,
+    );
+    await screen.findByText('Thanos DR');
+
+    const editButtons = screen.getAllByRole('button', { name: /edit/i });
+    await user.click(editButtons[1]);
+    const dialog = await screen.findByRole('dialog');
+    const nameInput = within(dialog).getByDisplayValue('Thanos DR');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Thanos primary');
+    await user.click(within(dialog).getByRole('button', { name: 'OK' }));
+
+    await waitFor(() =>
+      expect(updateDataSource).toHaveBeenCalledWith({
+        ...sources[1],
+        name: 'Thanos primary',
+      }),
+    );
   });
 
   it('creates and tests a Grafana Mimir data source', async () => {


### PR DESCRIPTION
## Summary
- validate only persisted data-source fields when saving metadata
- keep username, password, and bearer-token validation scoped to connection tests
- cover editing a bearer-token source without re-entering a token that would be discarded

## Tests
- `npm exec vitest -- run src/pages/settings/__tests__/DataSourceTab.test.tsx`
- `npm exec prettier -- --check src/pages/settings/DataSourceTab.tsx src/pages/settings/__tests__/DataSourceTab.test.tsx`
- `npm exec eslint -- src/pages/settings/DataSourceTab.tsx src/pages/settings/__tests__/DataSourceTab.test.tsx`
- `npm run build`

Closes #2653