### PR TITLE
fix(settings): lock credential submissions

### DIFF
--- a/web/src/pages/settings/CloudCredentialTab.tsx
+++ b/web/src/pages/settings/CloudCredentialTab.tsx
@@ -74,6 +74,7 @@ export const CloudCredentialTab = () => {
   const [form] = Form.useForm<CredentialFormValues>();
   const [submitting, setSubmitting] = useState(false);
   const requestSeqRef = useRef(0);
+  const submitInFlightRef = useRef(false);
 
   useEffect(() => {
     const timer = window.setTimeout(() => setDebouncedSearch(search.trim()), 300);
@@ -133,10 +134,14 @@ export const CloudCredentialTab = () => {
     setPage(1);
   };
 
-  const closeModal = () => {
+  const resetModal = () => {
     setModalOpen(false);
     setEditingCredential(null);
     form.resetFields();
+  };
+
+  const closeModal = () => {
+    if (!submitInFlightRef.current) resetModal();
   };
 
   const openCreateModal = () => {
@@ -156,9 +161,11 @@ export const CloudCredentialTab = () => {
   };
 
   const handleSubmit = async () => {
+    if (submitInFlightRef.current) return;
+    submitInFlightRef.current = true;
+    setSubmitting(true);
     try {
       const values = await form.validateFields();
-      setSubmitting(true);
       if (editingCredential) {
         const saved = await updateCloudCredential({
           id: editingCredential.id,
@@ -180,13 +187,14 @@ export const CloudCredentialTab = () => {
         message.success(t('settings.credentialAdded'));
       }
       await loadCredentials();
-      closeModal();
+      resetModal();
     } catch (error) {
       if (error && typeof error === 'object' && 'errorFields' in error) {
         return; // validation failure; antd already shows field-level errors
       }
       message.error(t('settings.credentialSaveFailed'));
     } finally {
+      submitInFlightRef.current = false;
       setSubmitting(false);
     }
   };
@@ -312,6 +320,10 @@ export const CloudCredentialTab = () => {
         onCancel={closeModal}
         onOk={() => void handleSubmit()}
         confirmLoading={submitting}
+        closable={!submitting}
+        maskClosable={!submitting}
+        keyboard={!submitting}
+        cancelButtonProps={{ disabled: submitting }}
         destroyOnHidden
       >
         {editingCredential && (

--- a/web/src/pages/settings/__tests__/CloudCredentialTab.test.tsx
+++ b/web/src/pages/settings/__tests__/CloudCredentialTab.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import type { CloudCredentialPage } from '../../../api/cloudCredential';
@@ -198,6 +198,44 @@ describe('CloudCredentialTab', () => {
     await waitFor(() =>
       expect(listCloudCredentials).toHaveBeenLastCalledWith(undefined, '', 1, 20),
     );
+  });
+
+  it('submits a credential only once and keeps the editor open while saving', async () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en');
+    const save = deferred<CloudCredentialPage['items'][number]>();
+    vi.mocked(createCloudCredential).mockReturnValue(save.promise);
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderTab();
+    await screen.findByText('aliyun-test');
+    await user.click(screen.getByRole('button', { name: /Add credential/ }));
+
+    const dialog = await screen.findByRole('dialog');
+    await user.type(
+      within(dialog).getByPlaceholderText('Example: Aliyun test account'),
+      'tencent-prod',
+    );
+    await user.click(within(dialog).getAllByRole('combobox')[0]);
+    await user.click(await screen.findByText('Tencent Cloud'));
+    await user.type(screen.getByPlaceholderText('LTAI...'), 'AKID000000009999');
+    await user.type(screen.getByPlaceholderText('Enter a SecretKey'), 'secret-9999');
+    const okButton = within(dialog).getByRole('button', { name: 'OK' });
+
+    fireEvent.click(okButton);
+    fireEvent.click(okButton);
+
+    await waitFor(() => expect(createCloudCredential).toHaveBeenCalledTimes(1));
+    expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    save.resolve({
+      id: 2,
+      name: 'tencent-prod',
+      vendor: 'TENCENT',
+      accessKey: 'AKID****9999',
+      gmtCreate: '2026-08-18T11:00:00',
+    });
+    await waitFor(() => expect(listCloudCredentials).toHaveBeenCalledTimes(2));
+    expect(createCloudCredential).toHaveBeenCalledTimes(1);
   });
 
   it('updates name and remark while keeping the secret unchanged when blank', async () => {


### PR DESCRIPTION
## Summary
- guard cloud-credential submissions synchronously before form validation
- keep modal dismissal paths disabled while a save request is pending
- add regression coverage for rapid duplicate OK actions against a deferred request

## Tests
- `npm exec vitest -- run src/pages/settings/__tests__/CloudCredentialTab.test.tsx`
- `npm exec prettier -- --check src/pages/settings/CloudCredentialTab.tsx src/pages/settings/__tests__/CloudCredentialTab.test.tsx`
- `npm exec eslint -- src/pages/settings/CloudCredentialTab.tsx src/pages/settings/__tests__/CloudCredentialTab.test.tsx`
- `npm run build`

Closes #2654