### PR TITLE
fix(studio): fetch all Aliyun consumer groups

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
@@ -301,7 +301,7 @@ public class AliyunInstanceProvider implements InstanceProvider {
     public List<ConsumerGroupVO> listConsumerGroups(String instanceId, String search) {
         Context ctx = resolve(instanceId);
         List<ListConsumerGroupsResponseBody.List> all = new ArrayList<>();
-        for (int page = 1; page <= AliyunConverters.MAX_PAGES; page++) {
+        for (int page = 1; ; page++) {
             ListConsumerGroupsRequest.Builder builder = ListConsumerGroupsRequest.builder()
                     .instanceId(ctx.cloudInstanceId())
                     .pageNumber(page)
@@ -319,7 +319,8 @@ public class AliyunInstanceProvider implements InstanceProvider {
                 break;
             }
             all.addAll(list);
-            if (list.size() < AliyunConverters.PAGE_SIZE) {
+            if (hasFetchedAll(page, AliyunConverters.PAGE_SIZE, data.getTotalCount())
+                    || list.size() < AliyunConverters.PAGE_SIZE) {
                 break;
             }
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -224,6 +224,73 @@ class AliyunInstanceProviderTest {
     }
 
     @Test
+    void listConsumerGroupsShouldFetchExactlyFiveFullPagesTest() {
+        stubInstance();
+        stubCallThrough();
+        when(asyncClient.listConsumerGroups(any(ListConsumerGroupsRequest.class))).thenAnswer(invocation -> {
+            ListConsumerGroupsRequest request = invocation.getArgument(0);
+            return CompletableFuture.completedFuture(groupsResponse(500L,
+                    groupIdsForPage(request.getPageNumber(), AliyunConverters.PAGE_SIZE)));
+        });
+
+        List<ConsumerGroupVO> groups = provider.listConsumerGroups(STUDIO_INSTANCE_ID, null);
+
+        assertThat(groups).hasSize(500);
+        ArgumentCaptor<ListConsumerGroupsRequest> captor =
+                ArgumentCaptor.forClass(ListConsumerGroupsRequest.class);
+        verify(asyncClient, times(5)).listConsumerGroups(captor.capture());
+        assertThat(captor.getAllValues()).extracting(ListConsumerGroupsRequest::getPageNumber)
+                .containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    void listConsumerGroupsShouldTraversePastLegacyFivePageCapTest() {
+        stubInstance();
+        stubCallThrough();
+        when(asyncClient.listConsumerGroups(any(ListConsumerGroupsRequest.class))).thenAnswer(invocation -> {
+            ListConsumerGroupsRequest request = invocation.getArgument(0);
+            int pageNumber = request.getPageNumber();
+            if (pageNumber <= 5) {
+                return CompletableFuture.completedFuture(groupsResponse(501L,
+                        groupIdsForPage(pageNumber, AliyunConverters.PAGE_SIZE)));
+            }
+            return CompletableFuture.completedFuture(groupsResponse(501L, "GID_500"));
+        });
+
+        List<ConsumerGroupVO> groups = provider.listConsumerGroups(STUDIO_INSTANCE_ID, null);
+
+        assertThat(groups).hasSize(501);
+        ArgumentCaptor<ListConsumerGroupsRequest> captor =
+                ArgumentCaptor.forClass(ListConsumerGroupsRequest.class);
+        verify(asyncClient, times(6)).listConsumerGroups(captor.capture());
+        assertThat(captor.getAllValues()).extracting(ListConsumerGroupsRequest::getPageNumber)
+                .containsExactly(1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    void listConsumerGroupsShouldStopOnShortPageWhenTotalCountIsMissingTest() {
+        stubInstance();
+        stubCallThrough();
+        when(asyncClient.listConsumerGroups(any(ListConsumerGroupsRequest.class))).thenAnswer(invocation -> {
+            ListConsumerGroupsRequest request = invocation.getArgument(0);
+            if (request.getPageNumber() == 1) {
+                return CompletableFuture.completedFuture(groupsResponse(null,
+                        groupIdsForPage(1, AliyunConverters.PAGE_SIZE)));
+            }
+            return CompletableFuture.completedFuture(groupsResponse(null, "GID_100"));
+        });
+
+        List<ConsumerGroupVO> groups = provider.listConsumerGroups(STUDIO_INSTANCE_ID, null);
+
+        assertThat(groups).hasSize(101);
+        ArgumentCaptor<ListConsumerGroupsRequest> captor =
+                ArgumentCaptor.forClass(ListConsumerGroupsRequest.class);
+        verify(asyncClient, times(2)).listConsumerGroups(captor.capture());
+        assertThat(captor.getAllValues()).extracting(ListConsumerGroupsRequest::getPageNumber)
+                .containsExactly(1, 2);
+    }
+
+    @Test
     void getGroupProgressShouldMapLagRowsTest() {
         stubInstance();
         stubCallThrough();
@@ -702,6 +769,12 @@ class AliyunInstanceProviderTest {
                                 .build())
                         .build())
                 .build();
+    }
+
+    private static String[] groupIdsForPage(int pageNumber, int pageSize) {
+        return IntStream.range(0, pageSize)
+                .mapToObj(index -> "GID_" + ((pageNumber - 1) * pageSize + index))
+                .toArray(String[]::new);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- remove the legacy five-page cap from Aliyun consumer group listing
- stop by upstream totalCount when available, or by short/empty page when totalCount is unavailable
- add exact 500, 501, and missing-total short-page regression coverage

## Related

Closes #2667

This refreshes the closed #2442 / #2449 fix against the current rocketmq-studio branch.

## Verification

- RED: `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=AliyunInstanceProviderTest test` failed before the implementation with `Expected size: 501 but was: 500`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=AliyunInstanceProviderTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q test`
- `git diff --check`