### PR TITLE
fix(studio): tolerate incomplete client metadata

### DIFF
--- a/web/src/api/connections.ts
+++ b/web/src/api/connections.ts
@@ -2,11 +2,11 @@ import client from './client';
 
 // Matches mock/clients.ts
 export interface ClientConnection {
-  clientId: string;
+  clientId?: string | null;
   type: string;
   groupOrTopic: string;
   protocol: string;
-  address: string;
+  address?: string | null;
   language: string;
   version: string;
   connectedAt?: string | null;

--- a/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
@@ -249,6 +249,24 @@ describe('Clients page', () => {
     expect(screen.queryByText('audit-svc-0@10.0.2.10:49154')).toBeNull();
   });
 
+  it('keeps incomplete client metadata searchable by address', async () => {
+    const user = userEvent.setup();
+    vi.mocked(connectionsService.listConnections).mockResolvedValue([
+      {
+        ...connection,
+        clientId: null,
+        address: '10.0.1.99:49152',
+        partial: true,
+      } as unknown as ClientConnection,
+    ]);
+    renderWithProviders(<ClientsPage />);
+
+    await screen.findByText('10.0.1.99:49152');
+    await user.type(screen.getByPlaceholderText('搜索 Client ID 或地址'), '10.0.1.99');
+
+    expect(screen.getByText('10.0.1.99:49152')).toBeInTheDocument();
+  });
+
   it('exports the currently filtered client connections as CSV', async () => {
     const createObjectURL = vi.fn((blob: Blob | MediaSource) => {
       expect(blob).toBeInstanceOf(Blob);
@@ -447,9 +465,7 @@ describe('Clients page', () => {
 
     expect(await screen.findByText('Unable to load registry clusters')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /重\s*试/ }));
-    await waitFor(() =>
-      expect(clusterService.listRegistryClusters).toHaveBeenNthCalledWith(2),
-    );
+    await waitFor(() => expect(clusterService.listRegistryClusters).toHaveBeenNthCalledWith(2));
 
     await act(async () => {
       stale.resolve([]);

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -118,6 +118,11 @@ function getLoadErrorMessage(error: unknown): string {
   return DEFAULT_LOAD_ERROR;
 }
 
+const includesNormalized = (value: string | null | undefined, normalizedSearch: string) =>
+  (value ?? '').toLowerCase().includes(normalizedSearch);
+
+const displayMetadata = (value: string | null | undefined) => value || '-';
+
 /* ═══════════════════════════════════════════
    ClientsPage
    ═══════════════════════════════════════════ */
@@ -249,7 +254,7 @@ const ClientsPage = () => {
     const instances = Array.from(
       new Map(
         clusterConnections.map((connection) => [
-          `${connection.type}:${connection.clientId}`,
+          `${connection.type}:${connection.clientId ?? connection.address ?? connection.groupOrTopic}`,
           connection,
         ]),
       ).values(),
@@ -270,8 +275,8 @@ const ClientsPage = () => {
     const normalizedSearch = search.toLowerCase();
     return clusterConnections.filter(
       (connection) =>
-        connection.clientId.toLowerCase().includes(normalizedSearch) ||
-        connection.address?.toLowerCase().includes(normalizedSearch),
+        includesNormalized(connection.clientId, normalizedSearch) ||
+        includesNormalized(connection.address, normalizedSearch),
     );
   }, [clusterConnections, search]);
 
@@ -319,16 +324,16 @@ const ClientsPage = () => {
       key: 'clientId',
       width: 260,
       ellipsis: true,
-      render: (id: string) => (
+      render: (id?: string | null) => (
         <Text
-          copyable
+          copyable={Boolean(id)}
           style={{
             fontSize: 14,
             fontFamily: 'monospace',
             whiteSpace: 'nowrap',
           }}
         >
-          {id}
+          {displayMetadata(id)}
         </Text>
       ),
     },
@@ -379,8 +384,8 @@ const ClientsPage = () => {
       dataIndex: 'address',
       key: 'address',
       width: 180,
-      render: (addr: string) => (
-        <Text style={{ fontSize: 14, fontFamily: 'monospace' }}>{addr}</Text>
+      render: (addr?: string | null) => (
+        <Text style={{ fontSize: 14, fontFamily: 'monospace' }}>{displayMetadata(addr)}</Text>
       ),
     },
     {
@@ -588,7 +593,7 @@ const ClientsPage = () => {
           columns={columns}
           dataSource={filtered}
           rowKey={(connection) =>
-            `${connection.type}:${connection.clientId}:${connection.groupOrTopic}`
+            `${connection.type}:${connection.clientId ?? ''}:${connection.address ?? ''}:${connection.groupOrTopic}`
           }
           loading={loading}
           onChange={(pagination, filters, _sorter, extra) => {
@@ -612,7 +617,9 @@ const ClientsPage = () => {
       </Card>
 
       <Modal
-        title={t('clients.detailTitle', { id: selectedConnection?.clientId ?? '' })}
+        title={t('clients.detailTitle', {
+          id: displayMetadata(selectedConnection?.clientId),
+        })}
         open={Boolean(selectedConnection)}
         onCancel={() => setSelectedConnection(null)}
         footer={<Button onClick={() => setSelectedConnection(null)}>{t('common.close')}</Button>}
@@ -623,7 +630,7 @@ const ClientsPage = () => {
           <Descriptions column={1} bordered size="small">
             <Descriptions.Item label={t('clients.clientId')}>
               <Text copyable style={{ fontFamily: 'monospace' }}>
-                {selectedConnection.clientId}
+                {displayMetadata(selectedConnection.clientId)}
               </Text>
             </Descriptions.Item>
             <Descriptions.Item label={t('clients.cluster')}>
@@ -641,7 +648,9 @@ const ClientsPage = () => {
               </Tag>
             </Descriptions.Item>
             <Descriptions.Item label={t('common.address')}>
-              <Text style={{ fontFamily: 'monospace' }}>{selectedConnection.address}</Text>
+              <Text style={{ fontFamily: 'monospace' }}>
+                {displayMetadata(selectedConnection.address)}
+              </Text>
             </Descriptions.Item>
             <Descriptions.Item label={t('clients.language')}>
               <Tag color={languageConfig[selectedConnection.language]?.color ?? 'default'}>


### PR DESCRIPTION
## Summary

- Treat Client Connections `clientId` and `address` as nullable at the frontend API boundary.
- Keep search, table rendering, detail dialog, and row keys resilient when RocketMQ returns incomplete client metadata.
- Add a regression test covering a connection with missing `clientId` that is still searchable by address.

Closes #2663

## Verification

- RED: `npm test -- src/pages/cluster/__tests__/ClientsPage.test.tsx` failed before the fix with `TypeError: Cannot read properties of null (reading toLowerCase)` at `clients.tsx:273`.
- GREEN: `npm test -- src/pages/cluster/__tests__/ClientsPage.test.tsx` -> 16 passed.
- `npm test -- src/api/connections.test.ts src/services/connectionsService.test.ts` -> 6 passed.
- `npm test` -> 100 files passed, 737 tests passed.
- `npm run build` -> passed (`tsc -b && vite build`).
- TypeScript diagnostics on modified files -> 0 errors.