### PR TITLE
[Studio][Performance] Add query history access path indexes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistorySchemaMigration.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistorySchemaMigration.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+/** Adds query-history indexes to Studio databases created before the index contract was added. */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueryHistorySchemaMigration implements ApplicationRunner {
+    private static final List<Index> INDEXES = List.of(
+            new Index("rmq_instance_message", "idx_message_query_owner_lookup",
+                    "queried_by, cluster_id, gmt_create, id"),
+            new Index("rmq_instance_message", "idx_message_query_owner_type_lookup",
+                    "queried_by, cluster_id, query_type, gmt_create, id"),
+            new Index("rmq_instance_trace", "idx_trace_query_owner_lookup",
+                    "queried_by, cluster_id, gmt_create, id"));
+
+    private final DataSource dataSource;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        try (Connection connection = dataSource.getConnection(); Statement statement = connection.createStatement()) {
+            DatabaseMetaData metadata = connection.getMetaData();
+            String catalog = connection.getCatalog();
+            for (Index index : INDEXES) {
+                ensureIndex(metadata, catalog, statement, index);
+            }
+        }
+    }
+
+    private static void ensureIndex(DatabaseMetaData metadata, String catalog, Statement statement, Index index)
+            throws Exception {
+        if (!hasTable(metadata, catalog, index.table()) || hasIndex(metadata, catalog, index.table(), index.name())) {
+            return;
+        }
+        try {
+            log.info("Adding query history index {}.{}", index.table(), index.name());
+            statement.executeUpdate("CREATE INDEX " + index.name() + " ON " + index.table()
+                    + " (" + index.columns() + ")");
+        } catch (SQLException failure) {
+            if (!hasIndex(metadata, catalog, index.table(), index.name())) {
+                throw failure;
+            }
+        }
+    }
+
+    private static boolean hasTable(DatabaseMetaData metadata, String catalog, String table) throws Exception {
+        try (ResultSet tables = metadata.getTables(catalog, null, table, new String[] {"TABLE"})) {
+            return tables.next();
+        }
+    }
+
+    private static boolean hasIndex(DatabaseMetaData metadata, String catalog, String table, String index)
+            throws Exception {
+        try (ResultSet indexes = metadata.getIndexInfo(catalog, null, table, false, false)) {
+            while (indexes.next()) {
+                if (index.equalsIgnoreCase(indexes.getString("INDEX_NAME"))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private record Index(String table, String name, String columns) {
+    }
+}

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -149,6 +149,8 @@ CREATE TABLE IF NOT EXISTS rmq_instance_message (
   queried_by VARCHAR(128),
   PRIMARY KEY (`id`),
   INDEX idx_message_query_gmt_create (gmt_create),
+  INDEX idx_message_query_owner_lookup (queried_by, cluster_id, gmt_create, id),
+  INDEX idx_message_query_owner_type_lookup (queried_by, cluster_id, query_type, gmt_create, id),
   INDEX idx_topic (topic)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -165,7 +167,8 @@ CREATE TABLE IF NOT EXISTS rmq_instance_trace (
   queried_by VARCHAR(128),
   PRIMARY KEY (`id`),
   INDEX idx_msg_id (msg_id),
-  INDEX idx_trace_query_gmt_create (gmt_create)
+  INDEX idx_trace_query_gmt_create (gmt_create),
+  INDEX idx_trace_query_owner_lookup (queried_by, cluster_id, gmt_create, id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 8. 操作审计日志（所有写操作）

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistorySchemaIndexTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistorySchemaIndexTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryHistorySchemaIndexTest {
+    @Test
+    void freshSchemaCreatesUserScopedHistoryIndexesTest() throws Exception {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:query-history-schema-indexes;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE");
+        dataSource.setUser("sa");
+
+        try (Connection connection = dataSource.getConnection()) {
+            ScriptUtils.executeSqlScript(connection, new ClassPathResource("db/schema.sql"));
+        }
+
+        try (Connection connection = dataSource.getConnection()) {
+            assertThat(indexColumns(connection, "rmq_instance_message", "idx_message_query_owner_lookup"))
+                    .containsExactly("queried_by", "cluster_id", "gmt_create", "id");
+            assertThat(indexColumns(connection, "rmq_instance_message", "idx_message_query_owner_type_lookup"))
+                    .containsExactly("queried_by", "cluster_id", "query_type", "gmt_create", "id");
+            assertThat(indexColumns(connection, "rmq_instance_trace", "idx_trace_query_owner_lookup"))
+                    .containsExactly("queried_by", "cluster_id", "gmt_create", "id");
+        }
+    }
+
+    @Test
+    void migrationAddsUserScopedHistoryIndexesToExistingTablesTest() throws Exception {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:query-history-schema-index-migration;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE");
+        dataSource.setUser("sa");
+
+        try (Connection connection = dataSource.getConnection(); Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE rmq_instance_message ("
+                    + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
+                    + "gmt_create DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, "
+                    + "query_type VARCHAR(32) NOT NULL, "
+                    + "cluster_id VARCHAR(255), "
+                    + "queried_by VARCHAR(128))");
+            statement.execute("CREATE TABLE rmq_instance_trace ("
+                    + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
+                    + "gmt_create DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, "
+                    + "cluster_id VARCHAR(255), "
+                    + "queried_by VARCHAR(128))");
+        }
+
+        QueryHistorySchemaMigration migration = new QueryHistorySchemaMigration(dataSource);
+        migration.run(new DefaultApplicationArguments());
+        migration.run(new DefaultApplicationArguments());
+
+        try (Connection connection = dataSource.getConnection()) {
+            assertThat(indexColumns(connection, "rmq_instance_message", "idx_message_query_owner_lookup"))
+                    .containsExactly("queried_by", "cluster_id", "gmt_create", "id");
+            assertThat(indexColumns(connection, "rmq_instance_message", "idx_message_query_owner_type_lookup"))
+                    .containsExactly("queried_by", "cluster_id", "query_type", "gmt_create", "id");
+            assertThat(indexColumns(connection, "rmq_instance_trace", "idx_trace_query_owner_lookup"))
+                    .containsExactly("queried_by", "cluster_id", "gmt_create", "id");
+        }
+    }
+
+    private static List<String> indexColumns(Connection connection, String tableName, String indexName) throws Exception {
+        try (Statement statement = connection.createStatement();
+                ResultSet result = statement.executeQuery("SELECT column_name FROM information_schema.index_columns "
+                        + "WHERE table_name = '" + tableName + "' AND index_name = '" + indexName + "' "
+                        + "ORDER BY ordinal_position")) {
+            List<String> columns = new ArrayList<>();
+            while (result.next()) {
+                columns.add(result.getString(1));
+            }
+            return columns;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add user-scoped composite indexes for message and trace query history so the main drawer/list and summary access paths can filter by requester and instance, then read recent rows in `gmt_create, id` order without scanning unrelated users' history.

Closes #2665

## Changes

- Add fresh-schema indexes:
  - `rmq_instance_message(queried_by, cluster_id, gmt_create, id)` for the main `MessageQueryHistoryDrawer` path, which does not pass `queryType`.
  - `rmq_instance_message(queried_by, cluster_id, query_type, gmt_create, id)` for requests that do filter by `queryType`.
  - `rmq_instance_trace(queried_by, cluster_id, gmt_create, id)`.
- Add `QueryHistorySchemaMigration` to backfill the same indexes for existing Studio databases through the current idempotent startup migration pattern.
- Add schema contract tests for fresh schema creation and existing-table migration, including index column order and repeated migration idempotency.

## Compatibility with #1374

This branch does not depend on #1374 because Flyway is not present on the current `rocketmq-studio` baseline. The change follows the existing `schema.sql` plus startup `ApplicationRunner` upgrade style. If a versioned Flyway migration path lands later, these index definitions can be moved into a formal migration without changing the index contract.

## Verification

- RED: `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=QueryHistorySchemaIndexTest test` failed before implementation because the expected indexes were missing.
- Review RED: after adding the `idx_message_query_owner_type_lookup` assertions first, `QueryHistorySchemaIndexTest` failed until schema and migration were updated.
- Targeted: `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=QueryHistorySchemaIndexTest,QueryHistoryServiceTest,QueryHistoryServiceIntegrationTest,QueryHistoryControllerTest,DemoDataSqlCompatibilityTest test` passed, 15 tests.
- Full backend: `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn test` passed, 1790 tests.
- `git diff --check` passed.

## MySQL EXPLAIN note

A real MySQL 8 EXPLAIN run was attempted but the local environment has no running MySQL service and Docker daemon is unavailable:

- `mysql` TCP/socket connection failed.
- `brew services list` reports `mysql stopped`.
- `docker ps` cannot connect to the Docker daemon.
