### PR TITLE
[Studio][Performance] Page alert silences and bound active matching

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSchemaMigration.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSchemaMigration.java
@@ -105,6 +105,7 @@ public class AlertSchemaMigration implements ApplicationRunner {
             new Index("rmq_metric_snapshot", "idx_metric_snapshot_lookup", "instance_id, metric_key, collected_at"),
             new Index("rmq_metric_snapshot", "idx_metric_snapshot_retention", "collected_at"),
             new Index("rmq_alert_silence", "idx_alert_silence_active", "starts_at, ends_at"),
+            new Index("rmq_alert_silence", "idx_alert_silence_expiry", "ends_at, starts_at"),
             new Index("rmq_alert_silence", "idx_alert_silence_scope", "domain, rule_id, instance_id"),
             new Index("rmq_alert_notification_outbox", "idx_alert_notification_ready", "status, next_attempt_at"),
             new Index("rmq_alert_rule", "uk_alert_rule_semantic_fingerprint", "semantic_fingerprint", true),

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceController.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.ops.alert;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.Result;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -38,6 +40,12 @@ public class AlertSilenceController {
     @GetMapping
     public Result<List<AlertSilenceVO>> list() {
         return Result.ok(silenceService.list());
+    }
+
+    @GetMapping("/page")
+    public Result<PageResult<AlertSilenceVO>> listPage(@RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return Result.ok(silenceService.listPage(page, pageSize));
     }
 
     @PostMapping

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceRepository.java
@@ -16,12 +16,19 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
+import org.apache.rocketmq.studio.common.domain.PageResult;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface AlertSilenceRepository {
     AlertSilenceVO save(AlertSilenceVO silence);
 
     List<AlertSilenceVO> findAll();
+
+    PageResult<AlertSilenceVO> findPage(int page, int pageSize);
+
+    List<AlertSilenceVO> findActiveCandidates(AlertDomain domain, Long ruleId, String instanceId, LocalDateTime now);
 
     boolean deleteById(Long id);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceService.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.ops.alert;
 import lombok.RequiredArgsConstructor;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.auth.AuthenticatedUserContext;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.springframework.stereotype.Service;
 
@@ -31,11 +32,18 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class AlertSilenceService {
+    private static final int MAX_PAGE_SIZE = 100;
+
     private final AlertSilenceRepository repository;
     private final OperationAuditService operationAuditService;
 
     public List<AlertSilenceVO> list() {
         return repository.findAll();
+    }
+
+    public PageResult<AlertSilenceVO> listPage(int page, int pageSize) {
+        validatePagination(page, pageSize);
+        return repository.findPage(page, pageSize);
     }
 
     public AlertSilenceVO create(CreateAlertSilenceDTO request) {
@@ -87,10 +95,19 @@ public class AlertSilenceService {
     public LocalDateTime activeUntil(AlertRuleVO rule, String instanceId, Map<String, String> labels,
             LocalDateTime now) {
         AlertDomain domain = rule.getDomain() == null ? AlertDomain.BUSINESS : rule.getDomain();
-        return repository.findAll().stream()
+        return repository.findActiveCandidates(domain, rule.getId(), instanceId, now).stream()
                 .filter(silence -> matches(silence, rule.getId(), domain, instanceId,
                         labels == null ? Map.of() : labels, now))
                 .map(AlertSilenceVO::getEndsAt).max(LocalDateTime::compareTo).orElse(null);
+    }
+
+    private static void validatePagination(int page, int pageSize) {
+        if (page < 1) {
+            throw new BusinessException(400, "page must be positive");
+        }
+        if (pageSize < 1 || pageSize > MAX_PAGE_SIZE) {
+            throw new BusinessException(400, "pageSize must be between 1 and " + MAX_PAGE_SIZE);
+        }
     }
 
     private static boolean matches(AlertSilenceVO silence, Long ruleId, AlertDomain domain, String instanceId,

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepository.java
@@ -17,13 +17,17 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.persistence.entity.RmqAlertSilence;
 import org.apache.rocketmq.studio.persistence.mapper.RmqAlertSilenceMapper;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -47,6 +51,35 @@ public class MybatisPlusAlertSilenceRepository implements AlertSilenceRepository
         return mapper.selectList(new QueryWrapper<RmqAlertSilence>()
                         .orderByDesc("ends_at").orderByDesc("id"))
                 .stream().map(this::toVo).toList();
+    }
+
+    @Override
+    public PageResult<AlertSilenceVO> findPage(int page, int pageSize) {
+        IPage<RmqAlertSilence> mapperPage = mapper.selectPage(new Page<>(page, pageSize),
+                new QueryWrapper<RmqAlertSilence>().orderByDesc("ends_at").orderByDesc("id"));
+        return PageResult.of(mapperPage.getRecords().stream().map(this::toVo).toList(), mapperPage.getTotal(),
+                (int) mapperPage.getCurrent(), (int) mapperPage.getSize());
+    }
+
+    @Override
+    public List<AlertSilenceVO> findActiveCandidates(AlertDomain domain, Long ruleId, String instanceId,
+            LocalDateTime now) {
+        QueryWrapper<RmqAlertSilence> query = new QueryWrapper<RmqAlertSilence>()
+                .le("starts_at", now)
+                .gt("ends_at", now)
+                .and(scope -> scope.isNull("domain").or().eq("domain", domain.name()));
+        if (ruleId == null) {
+            query.isNull("rule_id");
+        } else {
+            query.and(scope -> scope.isNull("rule_id").or().eq("rule_id", ruleId));
+        }
+        if (instanceId == null) {
+            query.isNull("instance_id");
+        } else {
+            query.and(scope -> scope.isNull("instance_id").or().eq("instance_id", instanceId));
+        }
+        query.orderByDesc("ends_at").orderByDesc("id");
+        return mapper.selectList(query).stream().map(this::toVo).toList();
     }
 
     @Override

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -334,6 +334,7 @@ CREATE TABLE IF NOT EXISTS rmq_alert_silence (
   `created_by` VARCHAR(128) NOT NULL,
   PRIMARY KEY (`id`),
   INDEX idx_alert_silence_active (`starts_at`, `ends_at`),
+  INDEX idx_alert_silence_expiry (`ends_at`, `starts_at`),
   INDEX idx_alert_silence_scope (`domain`, `rule_id`, `instance_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSchemaMigrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSchemaMigrationTest.java
@@ -57,5 +57,13 @@ class AlertSchemaMigrationTest {
             result.next();
             assertThat(result.getInt(1)).isEqualTo(3);
         }
+
+        try (Connection connection = dataSource.getConnection(); Statement statement = connection.createStatement();
+                ResultSet result = statement.executeQuery("SELECT COUNT(*) FROM information_schema.indexes "
+                        + "WHERE table_name = 'rmq_alert_silence' "
+                        + "AND index_name = 'idx_alert_silence_expiry'")) {
+            result.next();
+            assertThat(result.getInt(1)).isGreaterThan(0);
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceControllerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AlertSilenceController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AlertSilenceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AlertSilenceService silenceService;
+
+    @Test
+    void listPageShouldReturnPageResultTest() throws Exception {
+        AlertSilenceVO silence = AlertSilenceVO.builder()
+                .id(12L)
+                .domain(AlertDomain.CLUSTER)
+                .startsAt(LocalDateTime.of(2026, 8, 22, 9, 0))
+                .endsAt(LocalDateTime.of(2026, 8, 22, 10, 0))
+                .createdBy("admin")
+                .build();
+        when(silenceService.listPage(2, 10)).thenReturn(PageResult.of(List.of(silence), 31, 2, 10));
+
+        mockMvc.perform(get("/api/alert-silences/page")
+                        .param("page", "2")
+                        .param("pageSize", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.items[0].id").value(12))
+                .andExpect(jsonPath("$.data.items[0].domain").value("CLUSTER"))
+                .andExpect(jsonPath("$.data.total").value(31))
+                .andExpect(jsonPath("$.data.page").value(2))
+                .andExpect(jsonPath("$.data.size").value(10));
+
+        verify(silenceService).listPage(eq(2), eq(10));
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceServiceTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.audit.OperationAuditService;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,7 +67,12 @@ class AlertSilenceServiceTest {
         assertThat(captured.getValue().getInstanceId()).isEqualTo("local");
         assertThat(captured.getValue().getStartsAt()).isEqualTo(start);
         assertThat(created.getId()).isEqualTo(7L);
-        when(repository.findAll()).thenReturn(List.of(created));
+        when(repository.findActiveCandidates(AlertDomain.BUSINESS, 3L, "local", start.plusMinutes(1)))
+                .thenReturn(List.of(created));
+        when(repository.findActiveCandidates(AlertDomain.BUSINESS, 3L, "other", start.plusMinutes(1)))
+                .thenReturn(List.of());
+        when(repository.findActiveCandidates(AlertDomain.BUSINESS, 3L, "local", end))
+                .thenReturn(List.of());
 
         AlertRuleVO rule = AlertRuleVO.builder().id(3L).domain(AlertDomain.BUSINESS).build();
         assertThat(service.isActive(rule, "local", start.plusMinutes(1))).isTrue();
@@ -108,12 +114,51 @@ class AlertSilenceServiceTest {
         AlertSilenceVO silence = AlertSilenceVO.builder().domain(AlertDomain.CLUSTER).ruleId(5L)
                 .instanceId("local").labels(Map.of("brokerName", "broker-a"))
                 .startsAt(now.minusMinutes(1)).endsAt(now.plusMinutes(1)).createdBy("admin").build();
-        when(repository.findAll()).thenReturn(List.of(silence));
+        when(repository.findActiveCandidates(AlertDomain.CLUSTER, 5L, "local", now)).thenReturn(List.of(silence));
 
         AlertRuleVO rule = AlertRuleVO.builder().id(5L).domain(AlertDomain.CLUSTER).build();
         assertThat(service.isActive(rule, "local", Map.of("brokerName", "broker-a", "cluster", "Default"), now))
                 .isTrue();
         assertThat(service.isActive(rule, "local", Map.of("brokerName", "broker-b"), now)).isFalse();
         assertThat(service.isActive(rule, "local", Map.of(), now)).isFalse();
+    }
+
+    @Test
+    void listPageShouldValidateAndDelegateToRepositoryPaginationTest() {
+        AlertSilenceService service = new AlertSilenceService(repository, operationAuditService);
+        AlertSilenceVO silence = AlertSilenceVO.builder().id(11L).reason("deploy").build();
+        when(repository.findPage(2, 25)).thenReturn(PageResult.of(List.of(silence), 51, 2, 25));
+
+        PageResult<AlertSilenceVO> page = service.listPage(2, 25);
+
+        assertThat(page.getTotal()).isEqualTo(51);
+        assertThat(page.getItems()).singleElement()
+                .satisfies(item -> assertThat(item.getId()).isEqualTo(11L));
+        org.mockito.Mockito.verify(repository).findPage(2, 25);
+        org.mockito.Mockito.verify(repository, org.mockito.Mockito.never()).findAll();
+    }
+
+    @Test
+    void activeUntilShouldQueryScopedActiveCandidatesBeforeLabelMatchingTest() {
+        AlertSilenceService service = new AlertSilenceService(repository, operationAuditService);
+        LocalDateTime now = LocalDateTime.of(2026, 8, 22, 10, 0);
+        AlertRuleVO rule = AlertRuleVO.builder().id(9L).domain(AlertDomain.CLUSTER).build();
+        AlertSilenceVO wrongLabel = AlertSilenceVO.builder().id(1L).domain(AlertDomain.CLUSTER).ruleId(9L)
+                .instanceId("local").labels(Map.of("brokerName", "broker-b"))
+                .startsAt(now.minusMinutes(5)).endsAt(now.plusMinutes(10)).createdBy("admin").build();
+        AlertSilenceVO firstMatch = AlertSilenceVO.builder().id(2L).domain(AlertDomain.CLUSTER).ruleId(9L)
+                .instanceId("local").labels(Map.of("brokerName", "broker-a"))
+                .startsAt(now.minusMinutes(5)).endsAt(now.plusMinutes(10)).createdBy("admin").build();
+        AlertSilenceVO overlappingMatch = AlertSilenceVO.builder().id(3L).domain(AlertDomain.CLUSTER)
+                .labels(Map.of("brokerName", "broker-a"))
+                .startsAt(now.minusMinutes(1)).endsAt(now.plusMinutes(30)).createdBy("admin").build();
+        when(repository.findActiveCandidates(AlertDomain.CLUSTER, 9L, "local", now))
+                .thenReturn(List.of(wrongLabel, firstMatch, overlappingMatch));
+
+        LocalDateTime activeUntil = service.activeUntil(rule, "local", Map.of("brokerName", "broker-a"), now);
+
+        assertThat(activeUntil).isEqualTo(now.plusMinutes(30));
+        org.mockito.Mockito.verify(repository).findActiveCandidates(AlertDomain.CLUSTER, 9L, "local", now);
+        org.mockito.Mockito.verify(repository, org.mockito.Mockito.never()).findAll();
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.persistence.entity.RmqAlertSilence;
+import org.apache.rocketmq.studio.persistence.mapper.RmqAlertSilenceMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MybatisPlusAlertSilenceRepositoryTest {
+
+    @Mock
+    private RmqAlertSilenceMapper mapper;
+
+    @Test
+    void findPageShouldUseDatabasePaginationAndStableInventoryOrderingTest() {
+        MybatisPlusAlertSilenceRepository repository = new MybatisPlusAlertSilenceRepository(
+                mapper, new ObjectMapper());
+        RmqAlertSilence entity = new RmqAlertSilence();
+        entity.setId(9L);
+        entity.setReason("maintenance");
+        Page<RmqAlertSilence> mapperPage = new Page<RmqAlertSilence>(3, 20)
+                .setRecords(List.of(entity))
+                .setTotal(41);
+        when(mapper.selectPage(any(IPage.class), any(Wrapper.class))).thenReturn(mapperPage);
+
+        PageResult<AlertSilenceVO> result = repository.findPage(3, 20);
+
+        ArgumentCaptor<IPage<RmqAlertSilence>> pageCaptor = ArgumentCaptor.forClass(IPage.class);
+        ArgumentCaptor<Wrapper<RmqAlertSilence>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(mapper).selectPage(pageCaptor.capture(), queryCaptor.capture());
+        assertThat(pageCaptor.getValue().getCurrent()).isEqualTo(3);
+        assertThat(pageCaptor.getValue().getSize()).isEqualTo(20);
+        assertThat(result.getTotal()).isEqualTo(41);
+        assertThat(result.getItems()).singleElement()
+                .satisfies(silence -> assertThat(silence.getReason()).isEqualTo("maintenance"));
+        QueryWrapper<RmqAlertSilence> query = (QueryWrapper<RmqAlertSilence>) queryCaptor.getValue();
+        query.getCustomSqlSegment();
+        assertThat(query.getSqlSegment()).contains("ORDER BY ends_at DESC,id DESC");
+        verify(mapper, never()).selectList(any());
+    }
+
+    @Test
+    void findActiveCandidatesShouldFilterTimeAndWildcardScopeInSqlTest() {
+        MybatisPlusAlertSilenceRepository repository = new MybatisPlusAlertSilenceRepository(
+                mapper, new ObjectMapper());
+        LocalDateTime now = LocalDateTime.of(2026, 8, 22, 10, 0);
+        RmqAlertSilence entity = new RmqAlertSilence();
+        entity.setId(7L);
+        entity.setDomain(AlertDomain.CLUSTER.name());
+        entity.setRuleId(5L);
+        entity.setInstanceId("local");
+        entity.setStartsAt(now.minusMinutes(1));
+        entity.setEndsAt(now.plusMinutes(1));
+        entity.setCreatedBy("admin");
+        when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of(entity));
+
+        List<AlertSilenceVO> candidates = repository.findActiveCandidates(
+                AlertDomain.CLUSTER, 5L, "local", now);
+
+        assertThat(candidates).singleElement()
+                .satisfies(silence -> assertThat(silence.getId()).isEqualTo(7L));
+        ArgumentCaptor<Wrapper<RmqAlertSilence>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(mapper).selectList(queryCaptor.capture());
+        QueryWrapper<RmqAlertSilence> query = (QueryWrapper<RmqAlertSilence>) queryCaptor.getValue();
+        query.getCustomSqlSegment();
+        assertThat(query.getSqlSegment())
+                .contains("starts_at", "ends_at", "domain IS NULL", "rule_id IS NULL", "instance_id IS NULL")
+                .contains("ORDER BY ends_at DESC,id DESC");
+        assertThat(query.getParamNameValuePairs())
+                .containsValue(now)
+                .containsValue(AlertDomain.CLUSTER.name())
+                .containsValue(5L)
+                .containsValue("local");
+    }
+}

--- a/web/src/api/ops.test.ts
+++ b/web/src/api/ops.test.ts
@@ -44,6 +44,7 @@ import {
   clearAcknowledgedAlerts,
   listAlertDeliveries,
   listAlertSilences,
+  listAlertSilencesPage,
   createAlertSilence,
   deleteAlertSilence,
   listAuditRecords,
@@ -367,9 +368,19 @@ describe('Ops API - System Alerts & Audit', () => {
       createdBy: 'admin',
     };
     mock.onGet('/alert-silences').reply(200, { code: 200, data: [silence] });
+    mock.onGet('/alert-silences/page').reply((config) => {
+      expect(config.params).toEqual({ page: 2, pageSize: 10 });
+      return [200, { code: 200, data: { items: [silence], total: 21, page: 2, size: 10 } }];
+    });
     mock.onPost('/alert-silences').reply(200, { code: 200, data: silence });
     mock.onDelete('/alert-silences/2').reply(200, { code: 200 });
     await expect(listAlertSilences()).resolves.toEqual([silence]);
+    await expect(listAlertSilencesPage({ page: 2, pageSize: 10 })).resolves.toEqual({
+      items: [silence],
+      total: 21,
+      page: 2,
+      size: 10,
+    });
     await expect(createAlertSilence(silence)).resolves.toEqual(silence);
     await expect(deleteAlertSilence(2)).resolves.toBeUndefined();
   });

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -145,6 +145,11 @@ export interface NotificationDeliveryQuery {
   pageSize?: number;
 }
 
+export interface AlertSilenceQuery {
+  page?: number;
+  pageSize?: number;
+}
+
 export interface AlertSilence {
   id: number;
   domain?: 'BUSINESS' | 'CLUSTER' | null;
@@ -355,6 +360,13 @@ export async function listAlertDeliveriesPage(params: NotificationDeliveryQuery 
 
 export async function listAlertSilences() {
   const res = await client.get<{ data: AlertSilence[] }>('/alert-silences');
+  return res.data.data;
+}
+
+export async function listAlertSilencesPage(params: AlertSilenceQuery = {}) {
+  const res = await client.get<{ data: PageResult<AlertSilence> }>('/alert-silences/page', {
+    params,
+  });
   return res.data.data;
 }
 

--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -17,7 +17,9 @@ import {
   listAlertDeliveries,
   listRelatedSystemAlerts,
   retryAlertDelivery,
+  deleteAlertSilence,
   listAlertSilences,
+  listAlertSilencesPage,
   listSystemAlertsPage,
 } from '../../../services/opsService';
 import SystemAlertsPage from '../systemAlerts';
@@ -31,6 +33,7 @@ vi.mock('../../../services/opsService', () => ({
   listRelatedSystemAlerts: vi.fn().mockResolvedValue([]),
   retryAlertDelivery: vi.fn(),
   listAlertSilences: vi.fn(),
+  listAlertSilencesPage: vi.fn(),
   createAlertSilence: vi.fn(),
   deleteAlertSilence: vi.fn(),
 }));
@@ -87,6 +90,7 @@ describe('SystemAlertsPage', () => {
       size: 20,
     });
     vi.mocked(listAlertSilences).mockResolvedValue([]);
+    vi.mocked(listAlertSilencesPage).mockResolvedValue({ items: [], total: 0, page: 1, size: 10 });
   });
 
   it('renders an alert with an unknown backend level', async () => {
@@ -391,16 +395,21 @@ describe('SystemAlertsPage', () => {
   });
 
   it('shows maintenance windows and creates a scoped silence', async () => {
-    vi.mocked(listAlertSilences).mockResolvedValue([
-      {
-        id: 9,
-        domain: 'CLUSTER',
-        instanceId: 'local',
-        startsAt: '2026-08-10T01:00',
-        endsAt: '2026-08-10T02:00',
-        createdBy: 'admin',
-      },
-    ]);
+    vi.mocked(listAlertSilencesPage).mockResolvedValue({
+      items: [
+        {
+          id: 9,
+          domain: 'CLUSTER',
+          instanceId: 'local',
+          startsAt: '2026-08-10T01:00',
+          endsAt: '2026-08-10T02:00',
+          createdBy: 'admin',
+        },
+      ],
+      total: 11,
+      page: 1,
+      size: 10,
+    });
     vi.mocked(createAlertSilence).mockResolvedValue({
       id: 10,
       domain: 'BUSINESS',
@@ -413,6 +422,7 @@ describe('SystemAlertsPage', () => {
 
     await user.click(await screen.findByRole('button', { name: '维护窗口' }));
     expect(await screen.findByText(/CLUSTER.*local/)).toBeInTheDocument();
+    expect(listAlertSilencesPage).toHaveBeenCalledWith({ page: 1, pageSize: 10 });
 
     await user.type(screen.getByLabelText('规则 ID'), '42');
     await user.type(screen.getByLabelText('标签范围'), 'brokerName=broker-a,topic=orders');
@@ -430,6 +440,70 @@ describe('SystemAlertsPage', () => {
           endsAt: new Date('2026-08-11T02:00:00').toISOString(),
         }),
       );
+      expect(listAlertSilencesPage).toHaveBeenLastCalledWith({ page: 1, pageSize: 10 });
+    });
+  });
+
+  it('loads maintenance windows by page and backs up after deleting the last page item', async () => {
+    vi.mocked(listAlertSilencesPage)
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 9,
+            domain: 'CLUSTER',
+            instanceId: 'local',
+            startsAt: '2026-08-10T01:00',
+            endsAt: '2026-08-10T02:00',
+            createdBy: 'admin',
+          },
+        ],
+        total: 11,
+        page: 1,
+        size: 10,
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 10,
+            domain: 'BUSINESS',
+            instanceId: 'remote',
+            startsAt: '2026-08-11T01:00',
+            endsAt: '2026-08-11T02:00',
+            createdBy: 'admin',
+          },
+        ],
+        total: 11,
+        page: 2,
+        size: 10,
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 9,
+            domain: 'CLUSTER',
+            instanceId: 'local',
+            startsAt: '2026-08-10T01:00',
+            endsAt: '2026-08-10T02:00',
+            createdBy: 'admin',
+          },
+        ],
+        total: 10,
+        page: 1,
+        size: 10,
+      });
+    vi.mocked(deleteAlertSilence).mockResolvedValue();
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: '维护窗口' }));
+    await user.click(await screen.findByRole('listitem', { name: '2' }));
+    expect(await screen.findByText(/BUSINESS.*remote/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /结\s*束/ }));
+
+    await waitFor(() => {
+      expect(deleteAlertSilence).toHaveBeenCalledWith(10);
+      expect(listAlertSilencesPage).toHaveBeenLastCalledWith({ page: 1, pageSize: 10 });
     });
   });
 });

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -45,7 +45,7 @@ import {
   listSystemAlertsPage,
   createAlertSilence,
   deleteAlertSilence,
-  listAlertSilences,
+  listAlertSilencesPage,
 } from '../../services/opsService';
 import type {
   AlertSilence,
@@ -155,8 +155,11 @@ const SystemAlertsPage = () => {
   const [silencesVisible, setSilencesVisible] = useState(false);
   const [silences, setSilences] = useState<AlertSilence[]>([]);
   const [loadingSilences, setLoadingSilences] = useState(false);
+  const [silencePage, setSilencePage] = useState(1);
+  const [silenceTotal, setSilenceTotal] = useState(0);
   const [savingSilence, setSavingSilence] = useState(false);
   const [deletingSilenceId, setDeletingSilenceId] = useState<number | null>(null);
+  const silencePageSize = 10;
   const [silenceForm] = Form.useForm();
 
   const currentQuery = () => {
@@ -325,10 +328,13 @@ const SystemAlertsPage = () => {
     }
   };
 
-  const loadSilences = async () => {
+  const loadSilences = async (nextPage = silencePage) => {
     setLoadingSilences(true);
     try {
-      setSilences(await listAlertSilences());
+      const result = await listAlertSilencesPage({ page: nextPage, pageSize: silencePageSize });
+      setSilences(result.items);
+      setSilenceTotal(result.total);
+      setSilencePage(result.page);
     } catch {
       message.error(t('sysAlerts.silenceLoadFailed'));
     } finally {
@@ -337,8 +343,9 @@ const SystemAlertsPage = () => {
   };
 
   const openSilences = () => {
+    setSilencePage(1);
     setSilencesVisible(true);
-    void loadSilences();
+    void loadSilences(1);
   };
 
   const createSilence = async () => {
@@ -369,7 +376,8 @@ const SystemAlertsPage = () => {
       };
       await createAlertSilence(request);
       silenceForm.resetFields();
-      await loadSilences();
+      setSilencePage(1);
+      await loadSilences(1);
       message.success(t('sysAlerts.silenceCreated'));
     } catch {
       message.error(t('sysAlerts.silenceCreateFailed'));
@@ -382,7 +390,9 @@ const SystemAlertsPage = () => {
     setDeletingSilenceId(id);
     try {
       await deleteAlertSilence(id);
-      await loadSilences();
+      const nextPage = silences.length === 1 && silencePage > 1 ? silencePage - 1 : silencePage;
+      setSilencePage(nextPage);
+      await loadSilences(nextPage);
       message.success(t('sysAlerts.silenceEnded'));
     } catch {
       message.error(t('sysAlerts.silenceEndFailed'));
@@ -856,6 +866,17 @@ const SystemAlertsPage = () => {
                 )}
               </Flex>
             ))}
+            {silenceTotal > silencePageSize && (
+              <Pagination
+                size="small"
+                current={silencePage}
+                pageSize={silencePageSize}
+                total={silenceTotal}
+                showSizeChanger={false}
+                style={{ alignSelf: 'flex-end', marginTop: 8 }}
+                onChange={(nextPage) => void loadSilences(nextPage)}
+              />
+            )}
           </Flex>
         </Spin>
       </Modal>

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -21,6 +21,7 @@ import type {
   NotificationDeliveryBulkRetryResult,
   NotificationDeliveryQuery,
   NotificationDeliveryRecord,
+  AlertSilenceQuery,
   AlertSilence,
   CreateAlertSilence,
 } from '../api/ops';
@@ -435,6 +436,19 @@ export async function listAlertDeliveriesPage(
 export async function listAlertSilences(): Promise<AlertSilence[]> {
   if (isMockMode()) return alertSilencesState.map((silence) => ({ ...silence }));
   return opsApi.listAlertSilences();
+}
+
+export async function listAlertSilencesPage(
+  params: AlertSilenceQuery = {},
+): Promise<PageResult<AlertSilence>> {
+  if (!isMockMode()) return opsApi.listAlertSilencesPage(params);
+  const page = params.page ?? 1;
+  const pageSize = params.pageSize ?? 10;
+  const start = (page - 1) * pageSize;
+  const items = alertSilencesState
+    .slice(start, start + pageSize)
+    .map((silence) => ({ ...silence }));
+  return { items, total: alertSilencesState.length, page, size: pageSize };
 }
 
 export async function createAlertSilence(data: CreateAlertSilence): Promise<AlertSilence> {


### PR DESCRIPTION
## Summary

Closes #2664.

This PR keeps the legacy full-list alert silence endpoint for compatibility, then adds a bounded paginated inventory endpoint and moves notification-time silence matching away from full-table reads.

## Changes

- Add GET /api/alert-silences/page returning PageResult<AlertSilenceVO> with page/pageSize validation.
- Wire the system alerts maintenance-window dialog to server-side pagination instead of loading the full silence inventory.
- Add repository pagination with stable ends_at DESC, id DESC ordering.
- Query active silence candidates in SQL by time window plus wildcard-compatible domain/rule/instance scope before preserving existing label matching in memory.
- Add idx_alert_silence_expiry (ends_at, starts_at) to fresh schema and startup migration so existing databases can add the hot-path expiry index idempotently.
- Cover controller, service, repository query contract, schema migration behavior, frontend API typing, and the paginated maintenance-window UI flow.

## Compatibility

- Existing GET /api/alert-silences remains available for current callers.
- Wildcard domain/rule/instance semantics are preserved.
- Overlapping matching windows still suppress delivery until the latest matching ends_at.
- The SQL scope predicates bound candidate rows without changing the existing in-memory label matcher semantics.

## Verification

- RED: JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=AlertSilenceServiceTest,MybatisPlusAlertSilenceRepositoryTest,AlertSilenceControllerTest test failed before implementation with missing listPage/findPage/findActiveCandidates symbols.
- RED: npm test -- src/pages/ops/__tests__/SystemAlertsPage.test.tsx failed before frontend API/page wiring with listAlertSilencesPage is not a function.
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=AlertSilenceServiceTest,MybatisPlusAlertSilenceRepositoryTest,AlertSilenceControllerTest,AlertSchemaMigrationTest test — passed, 10 tests.
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=AlertSilenceControllerTest,MybatisPlusAlertRepositoryTest,AlertRuleControllerTest,AlertServiceDefaultRulesTest,AlertRuleDurationTest,AlertNotificationSuppressionServiceTest,AlertRuleAssetControllerTest,MybatisPlusAlertSilenceRepositoryTest,ClusterAlertRuleControllerTest,AlertStateMachineTest,AlertFingerprintTest,NativeAlertProcessorTest,AlertRuleTransferServiceTest,AlertRuleEvaluatorTest,AlertRuleAssetServiceTest,AlertSchemaMigrationTest,NativeAlertRuleTestServiceTest,AlertRuleRequestDTOTest,AlertServiceTest,NotificationOutboxServiceTest,AlertRuleSemanticFingerprintTest,NativeAlertRulePolicyTest,AlertSilenceServiceTest,SystemAlertControllerTest,MybatisPlusAlertStateRepositoryTest,AlertNotificationTemplateTest,NativeAlertMetricCatalogServiceTest,NativeAlertRuleScopeMatcherTest test — passed, 221 tests.
- npm test -- src/api/ops.test.ts src/pages/ops/__tests__/SystemAlertsPage.test.tsx — passed, 2 files / 38 tests.
- npm run build — passed (tsc -b && vite build).
- git diff --check — passed.
