### PR TITLE
[Studio] feat: support Metrics Explorer history, series details, and CSV export

### DIFF
--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -17,29 +17,58 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  App,
   Alert,
   Button,
   Card,
+  Descriptions,
+  Drawer,
   Empty,
   Flex,
   Form,
   Input,
+  List,
   Modal,
   Segmented,
   Select,
   Skeleton,
+  Space,
   Spin,
+  Statistic,
+  Table,
   Tag,
   Tooltip,
   Typography,
 } from 'antd';
-import { ArrowsClockwise } from '@phosphor-icons/react';
+import type { ColumnsType } from 'antd/es/table';
+import { ArrowsClockwise, ClockCounterClockwise, DownloadSimple, Eye } from '@phosphor-icons/react';
 
 import { listDataSources } from '../api/settings';
 import { listMetricProfiles, queryByDataSource, queryMetrics } from '../api/metrics';
 import type { DataSource } from '../api/settings';
-import type { MetricData, MetricMapping, MetricProfile, MetricSeries } from '../api/metrics';
+import type { MetricData, MetricMapping, MetricProfile } from '../api/metrics';
 import { useLang } from '../i18n/LangContext';
+import { downloadCsv } from '../utils/download';
+import { tableScrollX } from '../utils/table';
+import {
+  buildMetricCsvFilename,
+  buildMetricCsvFromRows,
+  buildMetricCsvRows,
+  buildMetricSeriesDetailRows,
+  clearMetricsQueryHistory,
+  createMetricsQueryHistoryEntry,
+  loadMetricsQueryHistory,
+  mergeMetricsQueryHistory,
+  metricSeriesLabel,
+  saveMetricsQueryHistory,
+  summarizeMetricData,
+  toMetricSeriesSamples,
+  type MetricCsvContext,
+  type MetricResultSummary,
+  type MetricSeriesDetailRow,
+  type MetricsQueryHistoryEntry,
+  type NumericMetricSample,
+} from '../utils/metricsExplorerDiagnostics';
 
 const { Text, Title } = Typography;
 
@@ -61,62 +90,8 @@ const MAX_SERIES = 10;
 type RangeOption = (typeof RANGE_OPTIONS)[number];
 
 const PROFILE_STORAGE_KEY = 'rocketmq-studio.metric-profile';
-
-interface NumericSample {
-  timestamp: number;
-  value: number;
-}
-
-const sortAndStrip = (
-  samples: { timestamp: number; value: number; index: number }[],
-): NumericSample[] =>
-  samples
-    .filter((sample) => Number.isFinite(sample.timestamp) && Number.isFinite(sample.value))
-    .sort((left, right) => left.timestamp - right.timestamp || left.index - right.index)
-    .map(({ timestamp, value }) => ({ timestamp, value }));
-
-const toScalarSamples = (series: MetricSeries): NumericSample[] =>
-  sortAndStrip(
-    series.values.map((sample, index) => ({
-      timestamp: sample.timestamp,
-      value: Number(sample.value),
-      index,
-    })),
-  );
-
-// Native histograms carry no scalar samples. To avoid plotting them as "no data", derive a
-// trend value per histogram: the observed sum (in the metric's unit), falling back to the
-// observation count when the sum is absent or non-finite.
-const toHistogramSamples = (series: MetricSeries): NumericSample[] =>
-  sortAndStrip(
-    series.histograms.map((sample, index) => {
-      // An empty string parses to 0, so treat a blank field as missing rather than zero.
-      const sumText = sample.histogram.sum?.trim();
-      const countText = sample.histogram.count?.trim();
-      const sum = sumText ? Number(sumText) : Number.NaN;
-      const count = countText ? Number(countText) : Number.NaN;
-      const value = Number.isFinite(sum) ? sum : count;
-      return { timestamp: sample.timestamp, value, index };
-    }),
-  );
-
-const toNumericSamples = (
-  series: MetricSeries,
-): { samples: NumericSample[]; fromHistogram: boolean } => {
-  const scalar = toScalarSamples(series);
-  if (scalar.length > 0) {
-    return { samples: scalar, fromHistogram: false };
-  }
-  return { samples: toHistogramSamples(series), fromHistogram: true };
-};
-
-const seriesLabel = (series: MetricSeries, fallback: string) => {
-  const labels = Object.entries(series.labels)
-    .filter(([key]) => key !== '__name__')
-    .slice(0, 3)
-    .map(([key, value]) => `${key}=${value}`);
-  return labels.length > 0 ? labels.join(' / ') : series.labels.__name__ || fallback;
-};
+const CUSTOM_HISTORY_PROFILE_ID = '__custom__';
+const CUSTOM_HISTORY_METRIC_ID = 'custom';
 
 const formatMetricValue = (value: number) =>
   new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(value);
@@ -142,10 +117,10 @@ const MetricChart = ({
 }: MetricChartProps) => {
   const allSeries = data.series
     .map((series, index) => {
-      const { samples, fromHistogram } = toNumericSamples(series);
+      const { samples, fromHistogram } = toMetricSeriesSamples(series);
       return {
         color: SERIES_COLORS[index % SERIES_COLORS.length],
-        label: seriesLabel(series, metric.name),
+        label: metricSeriesLabel(series, metric.name),
         samples,
         fromHistogram,
       };
@@ -156,7 +131,7 @@ const MetricChart = ({
     return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={noSamples} />;
   }
 
-  const latestValue = (series: { samples: NumericSample[] }) =>
+  const latestValue = (series: { samples: NumericMetricSample[] }) =>
     series.samples[series.samples.length - 1].value;
   const hiddenCount = Math.max(0, allSeries.length - MAX_SERIES);
   const chartSeries =
@@ -316,10 +291,45 @@ interface DataSourceCredentials extends AuthFormValues {
   key: string;
 }
 
+interface QueryExecution {
+  data: MetricData;
+  dataSourceKey: string;
+  dataSourceName: string;
+  start: number;
+  end: number;
+  queriedAt: number;
+}
+
+interface PanelQueryMeta {
+  profileId: string;
+  profileName: string;
+  metric: MetricMapping;
+  range: RangeOption;
+  dataSourceKey: string;
+  dataSourceName: string;
+  start: number;
+  end: number;
+  queriedAt: number;
+  instanceId?: string;
+}
+
 interface PanelState {
   loading: boolean;
   data?: MetricData;
   error?: string;
+  query?: PanelQueryMeta;
+}
+
+interface DetailsPanelState {
+  metric: MetricMapping;
+  data: MetricData;
+  query?: PanelQueryMeta;
+}
+
+interface PendingAuthReplay {
+  profile: MetricProfile | undefined;
+  range: RangeOption;
+  customPromql?: string;
 }
 
 const getQueryErrorMessage = (error: unknown, fallback: string): string => {
@@ -379,6 +389,33 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
           connect: '连接',
           cancel: '取消',
           required: '此项为必填项',
+          history: '查询历史',
+          historyTitle: '指标查询历史',
+          noHistory: '暂无指标查询历史',
+          restore: '恢复',
+          clearHistory: '清空历史',
+          exportCsv: '导出 CSV',
+          exportDisabled: '暂无可导出的指标样本',
+          details: '序列明细',
+          detailsTitle: '指标序列明细',
+          unavailableHistory: '历史中的指标模板已不可用',
+          series: '序列',
+          samples: '样本',
+          scalarSamples: '标量样本',
+          histogramSamples: '直方图样本',
+          warnings: '告警',
+          source: '数据源',
+          latestSample: '最新样本',
+          labels: '标签',
+          sampleType: '样本类型',
+          value: '值',
+          firstSample: '最早样本',
+          lastSample: '最新样本',
+          queryWindow: '查询窗口',
+          queriedAt: '查询时间',
+          resultType: '结果类型',
+          instance: '实例',
+          protectedHistory: '该数据源需要重新认证',
         }
       : {
           title: 'Prometheus Metrics',
@@ -407,8 +444,36 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
           connect: 'Connect',
           cancel: 'Cancel',
           required: 'This field is required',
+          history: 'Query history',
+          historyTitle: 'Metric query history',
+          noHistory: 'No metric query history',
+          restore: 'Restore',
+          clearHistory: 'Clear history',
+          exportCsv: 'Export CSV',
+          exportDisabled: 'No metric samples to export',
+          details: 'Series details',
+          detailsTitle: 'Metric series details',
+          unavailableHistory: 'The metric profile in this history entry is unavailable',
+          series: 'Series',
+          samples: 'Samples',
+          scalarSamples: 'Scalar samples',
+          histogramSamples: 'Histogram samples',
+          warnings: 'Warnings',
+          source: 'Source',
+          latestSample: 'Latest sample',
+          labels: 'Labels',
+          sampleType: 'Sample type',
+          value: 'Value',
+          firstSample: 'First sample',
+          lastSample: 'Last sample',
+          queryWindow: 'Query window',
+          queriedAt: 'Queried at',
+          resultType: 'Result type',
+          instance: 'Instance',
+          protectedHistory: 'This data source requires authentication again',
         };
   const locale = lang === 'zh' ? 'zh-CN' : 'en-US';
+  const { message } = App.useApp();
   const [authForm] = Form.useForm<AuthFormValues>();
   const [profiles, setProfiles] = useState<MetricProfile[]>([]);
   const [profileId, setProfileId] = useState('');
@@ -423,6 +488,11 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
   const [dataSourceKey, setDataSourceKey] = useState('');
   const [dataSourcesLoading, setDataSourcesLoading] = useState(true);
   const [pendingDataSource, setPendingDataSource] = useState<DataSource | null>(null);
+  const [history, setHistory] = useState<MetricsQueryHistoryEntry[]>(() =>
+    loadMetricsQueryHistory(),
+  );
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [detailsPanel, setDetailsPanel] = useState<DetailsPanelState | null>(null);
   // Profile panels and the custom query panel are independent state domains, so each
   // flow tracks its own request generation: sharing one counter would let the two
   // bumpers in the same synchronous handler (e.g. the refresh action) invalidate
@@ -433,6 +503,8 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
   // the source uses the new key instead of a stale closure value.
   const dataSourceKeyRef = useRef(dataSourceKey);
   const dataSourceCredentialsRef = useRef<DataSourceCredentials | null>(null);
+  const dataSourceNamesRef = useRef<Map<string, string>>(new Map());
+  const pendingAuthReplayRef = useRef<PendingAuthReplay | null>(null);
 
   const selectedProfile = useMemo(
     () => profiles.find((profile) => profile.id === profileId),
@@ -454,11 +526,15 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
 
   useEffect(() => {
     availableDataSourceKeysRef.current = new Set(availableDataSources.map((source) => source.key));
+    dataSourceNamesRef.current = new Map(
+      availableDataSources.map((source) => [source.key, source.name]),
+    );
   }, [availableDataSources]);
 
   const runQuery = useCallback(
-    (promql: string, range: RangeOption): Promise<MetricData> => {
-      const end = Math.floor(Date.now() / 1000);
+    async (promql: string, range: RangeOption): Promise<QueryExecution> => {
+      const queriedAt = Date.now();
+      const end = Math.floor(queriedAt / 1000);
       const query = { metric: promql, start: end - range.seconds, end, step: range.step };
       const selectedDataSourceKey = dataSourceKeyRef.current;
       const currentDataSourceKey =
@@ -469,7 +545,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
         dataSourceCredentialsRef.current?.key === currentDataSourceKey
           ? dataSourceCredentialsRef.current
           : null;
-      return currentDataSourceKey
+      const data = currentDataSourceKey
         ? queryByDataSource({
             key: currentDataSourceKey,
             query,
@@ -481,8 +557,18 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
               : {}),
           })
         : queryMetrics(query);
+      return {
+        data: await data,
+        dataSourceKey: currentDataSourceKey,
+        dataSourceName:
+          dataSourceNamesRef.current.get(currentDataSourceKey) ??
+          (currentDataSourceKey || copy.defaultDataSource),
+        start: query.start,
+        end: query.end,
+        queriedAt,
+      };
     },
-    [instanceId],
+    [copy.defaultDataSource, instanceId],
   );
 
   const loadAll = useCallback(
@@ -496,12 +582,45 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
       await Promise.all(
         profile.metrics.map(async (metric) => {
           try {
-            const result = await runQuery(metric.promql, range);
+            const execution = await runQuery(metric.promql, range);
             if (currentRequest === panelRequestIdRef.current) {
+              const summary = summarizeMetricData(execution.data);
+              const query: PanelQueryMeta = {
+                profileId: profile.id,
+                profileName: profile.name,
+                metric,
+                range,
+                dataSourceKey: execution.dataSourceKey,
+                dataSourceName: execution.dataSourceName,
+                start: execution.start,
+                end: execution.end,
+                queriedAt: execution.queriedAt,
+                ...(instanceId !== undefined ? { instanceId } : {}),
+              };
+              const historyEntry = createMetricsQueryHistoryEntry({
+                profileId: profile.id,
+                profileName: profile.name,
+                metric,
+                rangeId: range.value,
+                rangeLabel: range.label,
+                step: range.step,
+                dataSourceKey: execution.dataSourceKey,
+                dataSourceName: execution.dataSourceName,
+                start: execution.start,
+                end: execution.end,
+                queriedAt: execution.queriedAt,
+                ...(instanceId !== undefined ? { instanceId } : {}),
+                summary,
+              });
               setPanels((previous) => ({
                 ...previous,
-                [metric.semanticMetric]: { loading: false, data: result },
+                [metric.semanticMetric]: { loading: false, data: execution.data, query },
               }));
+              setHistory((currentHistory) => {
+                const nextHistory = mergeMetricsQueryHistory(currentHistory, historyEntry);
+                saveMetricsQueryHistory(nextHistory);
+                return nextHistory;
+              });
             }
           } catch (error) {
             if (currentRequest === panelRequestIdRef.current) {
@@ -517,7 +636,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
         }),
       );
     },
-    [queryErrorFallback, runQuery],
+    [instanceId, queryErrorFallback, runQuery],
   );
 
   useEffect(() => {
@@ -567,9 +686,50 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
       setCustomPanel({ loading: true });
       setAppliedCustomPromql(trimmed);
       try {
-        const result = await runQuery(trimmed, range);
+        const execution = await runQuery(trimmed, range);
         if (currentRequest === customRequestIdRef.current) {
-          setCustomPanel({ loading: false, data: result });
+          const metric: MetricMapping = {
+            semanticMetric: CUSTOM_HISTORY_METRIC_ID,
+            name: copy.customTitle,
+            unit: '',
+            prometheusMetric: '',
+            promql: trimmed,
+            labels: [],
+          };
+          const summary = summarizeMetricData(execution.data);
+          const query: PanelQueryMeta = {
+            profileId: CUSTOM_HISTORY_PROFILE_ID,
+            profileName: copy.customTitle,
+            metric,
+            range,
+            dataSourceKey: execution.dataSourceKey,
+            dataSourceName: execution.dataSourceName,
+            start: execution.start,
+            end: execution.end,
+            queriedAt: execution.queriedAt,
+            ...(instanceId !== undefined ? { instanceId } : {}),
+          };
+          const historyEntry = createMetricsQueryHistoryEntry({
+            profileId: CUSTOM_HISTORY_PROFILE_ID,
+            profileName: copy.customTitle,
+            metric,
+            rangeId: range.value,
+            rangeLabel: range.label,
+            step: range.step,
+            dataSourceKey: execution.dataSourceKey,
+            dataSourceName: execution.dataSourceName,
+            start: execution.start,
+            end: execution.end,
+            queriedAt: execution.queriedAt,
+            ...(instanceId !== undefined ? { instanceId } : {}),
+            summary,
+          });
+          setCustomPanel({ loading: false, data: execution.data, query });
+          setHistory((currentHistory) => {
+            const nextHistory = mergeMetricsQueryHistory(currentHistory, historyEntry);
+            saveMetricsQueryHistory(nextHistory);
+            return nextHistory;
+          });
         }
       } catch (error) {
         if (currentRequest === customRequestIdRef.current) {
@@ -580,16 +740,22 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
         }
       }
     },
-    [queryErrorFallback, runQuery],
+    [copy.customTitle, instanceId, queryErrorFallback, runQuery],
   );
 
-  const activateDataSource = (nextKey: string, credentials?: AuthFormValues) => {
+  const activateDataSource = (
+    nextKey: string,
+    credentials?: AuthFormValues,
+    profile = selectedProfile,
+    range = selectedRange,
+    customPromqlToRun = appliedCustomPromql,
+  ) => {
     dataSourceCredentialsRef.current = credentials ? { key: nextKey, ...credentials } : null;
     dataSourceKeyRef.current = nextKey;
     setDataSourceKey(nextKey);
-    void loadAll(selectedProfile, selectedRange);
-    if (appliedCustomPromql) {
-      void runCustomQuery(appliedCustomPromql, selectedRange);
+    void loadAll(profile, range);
+    if (customPromqlToRun) {
+      void runCustomQuery(customPromqlToRun, range);
     }
   };
 
@@ -610,12 +776,21 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
       authMode === 'basic'
         ? { username: values.username, password: values.password }
         : { bearerToken: values.bearerToken };
-    activateDataSource(pendingDataSource.key, credentials);
+    const replay = pendingAuthReplayRef.current;
+    activateDataSource(
+      pendingDataSource.key,
+      credentials,
+      replay?.profile,
+      replay?.range ?? selectedRange,
+      replay?.customPromql ?? appliedCustomPromql,
+    );
+    pendingAuthReplayRef.current = null;
     setPendingDataSource(null);
     authForm.resetFields();
   };
 
   const handleAuthCancel = () => {
+    pendingAuthReplayRef.current = null;
     setPendingDataSource(null);
     authForm.resetFields();
   };
@@ -666,9 +841,285 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
   const pendingAuthMode = pendingDataSource
     ? getDataSourceAuthMode(pendingDataSource.auth)
     : 'none';
+  const visibleHistory = useMemo(
+    () =>
+      instanceId === undefined
+        ? history
+        : history.filter(
+            (entry) => entry.instanceId === undefined || entry.instanceId === instanceId,
+          ),
+    [history, instanceId],
+  );
+  const detailRows = useMemo(
+    () => (detailsPanel ? buildMetricSeriesDetailRows(detailsPanel.data, detailsPanel.metric) : []),
+    [detailsPanel],
+  );
+  // The details and CSV buttons only need to know whether any series produced samples, which
+  // summarizeMetricData already answers. Deriving it from the row builders instead would
+  // re-materialise every sample of every panel — plus a Date per CSV sample — on each render,
+  // including each keystroke in the custom query box.
+  const panelSummaries = useMemo(() => {
+    const summaries = new Map<string, MetricResultSummary>();
+    Object.entries(panels).forEach(([semanticMetric, state]) => {
+      if (state.data) {
+        summaries.set(semanticMetric, summarizeMetricData(state.data));
+      }
+    });
+    return summaries;
+  }, [panels]);
+  const customSummary = useMemo(
+    () => (customPanel?.data ? summarizeMetricData(customPanel.data) : undefined),
+    [customPanel?.data],
+  );
+
+  const formatSeconds = useCallback(
+    (timestamp?: number) =>
+      timestamp === undefined ? '-' : new Date(timestamp * 1000).toLocaleString(locale),
+    [locale],
+  );
+  const formatMillis = useCallback(
+    (timestamp?: number) =>
+      timestamp === undefined ? '-' : new Date(timestamp).toLocaleString(locale),
+    [locale],
+  );
+  const formatHistorySource = (entry: MetricsQueryHistoryEntry) =>
+    entry.dataSourceKey ? entry.dataSourceName || entry.dataSourceKey : copy.defaultDataSource;
+
+  const getCsvContext = useCallback(
+    (query?: PanelQueryMeta): MetricCsvContext => ({
+      profileName: query?.profileName ?? '',
+      sourceName: query?.dataSourceName || copy.defaultDataSource,
+      queryStart: query?.start,
+      queryEnd: query?.end,
+      queriedAt: query?.queriedAt,
+    }),
+    [copy.defaultDataSource],
+  );
+
+  const detailColumns = useMemo<ColumnsType<MetricSeriesDetailRow>>(
+    () => [
+      {
+        title: copy.series,
+        dataIndex: 'seriesLabel',
+        key: 'seriesLabel',
+        width: 220,
+        render: (value: string) => (
+          <Text ellipsis={{ tooltip: value }} style={{ maxWidth: 200 }}>
+            {value}
+          </Text>
+        ),
+      },
+      {
+        title: copy.labels,
+        dataIndex: 'labels',
+        key: 'labels',
+        width: 320,
+        render: (value: string) => (
+          <Text code copyable ellipsis={{ tooltip: value }} style={{ maxWidth: 300 }}>
+            {value}
+          </Text>
+        ),
+      },
+      {
+        title: copy.sampleType,
+        dataIndex: 'sampleType',
+        key: 'sampleType',
+        width: 130,
+        render: (value: MetricSeriesDetailRow['sampleType']) => (
+          <Tag color={value === 'histogram' ? 'purple' : 'blue'} style={{ marginInlineEnd: 0 }}>
+            {value === 'histogram' ? copy.histogram : 'scalar'}
+          </Tag>
+        ),
+      },
+      {
+        title: copy.samples,
+        dataIndex: 'sampleCount',
+        key: 'sampleCount',
+        width: 100,
+        sorter: (left, right) => left.sampleCount - right.sampleCount,
+      },
+      {
+        title: copy.latestSample,
+        dataIndex: 'latestTimestamp',
+        key: 'latestTimestamp',
+        width: 180,
+        render: (value?: number) => formatSeconds(value),
+      },
+      {
+        title: copy.value,
+        dataIndex: 'latestValue',
+        key: 'latestValue',
+        width: 120,
+        render: (value?: number) => (value === undefined ? '-' : formatMetricValue(value)),
+      },
+    ],
+    [
+      copy.histogram,
+      copy.labels,
+      copy.latestSample,
+      copy.sampleType,
+      copy.samples,
+      copy.series,
+      copy.value,
+      formatSeconds,
+    ],
+  );
+
+  const handleExportCsv = (metric: MetricMapping, data: MetricData, query?: PanelQueryMeta) => {
+    const rows = buildMetricCsvRows(data, metric, getCsvContext(query));
+    if (rows.length === 0) return;
+    downloadCsv(buildMetricCsvFilename(metric, query?.queriedAt), buildMetricCsvFromRows(rows));
+  };
+
+  const handleOpenDetails = (metric: MetricMapping, data: MetricData, query?: PanelQueryMeta) => {
+    setDetailsPanel({ metric, data, query });
+  };
+
+  const handleClearHistory = () => {
+    clearMetricsQueryHistory();
+    setHistory([]);
+  };
+
+  const restoreProtectedDataSource = (
+    dataSource: DataSource,
+    profile: MetricProfile | undefined,
+    range: RangeOption,
+    customPromqlToRun?: string,
+  ) => {
+    dataSourceCredentialsRef.current = null;
+    dataSourceKeyRef.current = dataSource.key;
+    pendingAuthReplayRef.current = { profile, range, customPromql: customPromqlToRun };
+    setDataSourceKey(dataSource.key);
+    setPendingDataSource(dataSource);
+    void message.info(copy.protectedHistory);
+  };
+
+  const handleRestoreHistory = (entry: MetricsQueryHistoryEntry) => {
+    const nextRange =
+      RANGE_OPTIONS.find((range) => range.value === entry.rangeId) ?? RANGE_OPTIONS[0];
+    const nextDataSource = entry.dataSourceKey
+      ? availableDataSources.find((source) => source.key === entry.dataSourceKey)
+      : undefined;
+    const nextDataSourceKey = nextDataSource?.key ?? '';
+    setRangeId(nextRange.value);
+    setHistoryOpen(false);
+
+    if (entry.profileId === CUSTOM_HISTORY_PROFILE_ID) {
+      setCustomPromql(entry.promql);
+      if (nextDataSource && getDataSourceAuthMode(nextDataSource.auth) !== 'none') {
+        restoreProtectedDataSource(nextDataSource, selectedProfile, nextRange, entry.promql);
+        return;
+      }
+      activateDataSource(nextDataSourceKey, undefined, selectedProfile, nextRange, entry.promql);
+      return;
+    }
+
+    const nextProfile = profiles.find((profile) => profile.id === entry.profileId);
+    if (!nextProfile) {
+      void message.warning(copy.unavailableHistory);
+      return;
+    }
+
+    localStorage.setItem(PROFILE_STORAGE_KEY, nextProfile.id);
+    setProfileId(nextProfile.id);
+    if (nextDataSource && getDataSourceAuthMode(nextDataSource.auth) !== 'none') {
+      restoreProtectedDataSource(nextDataSource, nextProfile, nextRange, appliedCustomPromql);
+      return;
+    }
+    activateDataSource(nextDataSourceKey, undefined, nextProfile, nextRange, appliedCustomPromql);
+  };
+
+  const renderMetricResult = (
+    metric: MetricMapping,
+    state: PanelState,
+    summary?: MetricResultSummary,
+  ) => {
+    if (!state.data || !summary) return null;
+    return (
+      <>
+        {state.data.warnings.map((warning) => (
+          <Alert
+            key={warning}
+            type="warning"
+            showIcon
+            message={warning}
+            style={{ marginBottom: 8 }}
+          />
+        ))}
+        <Flex gap={16} wrap="wrap" style={{ marginBottom: 12 }}>
+          <Statistic
+            title={copy.series}
+            value={`${summary.visibleSeriesCount}/${summary.seriesCount}`}
+            style={{ minWidth: 96 }}
+          />
+          <Statistic title={copy.samples} value={summary.sampleCount} style={{ minWidth: 96 }} />
+          <Statistic
+            title={copy.scalarSamples}
+            value={summary.scalarSampleCount}
+            style={{ minWidth: 110 }}
+          />
+          <Statistic
+            title={copy.histogramSamples}
+            value={summary.histogramSampleCount}
+            style={{ minWidth: 130 }}
+          />
+          <Statistic title={copy.warnings} value={summary.warningCount} style={{ minWidth: 96 }} />
+        </Flex>
+        <Descriptions
+          size="small"
+          column={{ xs: 1, sm: 2, md: 3 }}
+          style={{ marginBottom: 12 }}
+          items={[
+            {
+              key: 'source',
+              label: copy.source,
+              children: state.query?.dataSourceName || copy.defaultDataSource,
+            },
+            {
+              key: 'query-window',
+              label: copy.queryWindow,
+              children: `${formatSeconds(state.query?.start)} - ${formatSeconds(state.query?.end)}`,
+            },
+            {
+              key: 'queried-at',
+              label: copy.queriedAt,
+              children: formatMillis(state.query?.queriedAt),
+            },
+            {
+              key: 'first-sample',
+              label: copy.firstSample,
+              children: formatSeconds(summary.earliestTimestamp),
+            },
+            {
+              key: 'last-sample',
+              label: copy.lastSample,
+              children: formatSeconds(summary.latestTimestamp),
+            },
+            {
+              key: 'result-type',
+              label: copy.resultType,
+              children: state.data.resultType,
+            },
+          ]}
+        />
+        <MetricChart
+          data={state.data}
+          metric={metric}
+          locale={locale}
+          noSamples={copy.noSamples}
+          histogramLabel={copy.histogram}
+          histogramTooltip={copy.histogramTooltip}
+          hiddenSeriesText={copy.hiddenSeries}
+        />
+      </>
+    );
+  };
 
   const renderPanel = (metric: MetricMapping) => {
     const state = panels[metric.semanticMetric];
+    const data = state?.data;
+    const summary = panelSummaries.get(metric.semanticMetric);
+    const hasSamples = data !== undefined && (summary?.visibleSeriesCount ?? 0) > 0;
     return (
       <Card
         key={metric.semanticMetric}
@@ -679,6 +1130,28 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
             {metric.unit ? <Tag style={{ marginInlineEnd: 0 }}>{metric.unit}</Tag> : null}
           </Flex>
         }
+        extra={
+          <Space size={4}>
+            <Tooltip title={copy.details}>
+              <Button
+                aria-label={`${metric.name} ${copy.details}`}
+                size="small"
+                icon={<Eye size={16} />}
+                disabled={!hasSamples}
+                onClick={() => data && handleOpenDetails(metric, data, state?.query)}
+              />
+            </Tooltip>
+            <Tooltip title={hasSamples ? copy.exportCsv : copy.exportDisabled}>
+              <Button
+                aria-label={`${metric.name} ${copy.exportCsv}`}
+                size="small"
+                icon={<DownloadSimple size={16} />}
+                disabled={!hasSamples}
+                onClick={() => data && handleExportCsv(metric, data, state?.query)}
+              />
+            </Tooltip>
+          </Space>
+        }
       >
         {state?.loading ? (
           <Flex justify="center" style={{ minHeight: 200 }} align="center">
@@ -687,26 +1160,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
         ) : state?.error ? (
           <Alert type="error" showIcon message={state.error} />
         ) : state?.data ? (
-          <>
-            {state.data.warnings.map((warning) => (
-              <Alert
-                key={warning}
-                type="warning"
-                showIcon
-                message={warning}
-                style={{ marginBottom: 8 }}
-              />
-            ))}
-            <MetricChart
-              data={state.data}
-              metric={metric}
-              locale={locale}
-              noSamples={copy.noSamples}
-              histogramLabel={copy.histogram}
-              histogramTooltip={copy.histogramTooltip}
-              hiddenSeriesText={copy.hiddenSeries}
-            />
-          </>
+          renderMetricResult(metric, state, summary)
         ) : (
           <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={copy.noSamples} />
         )}
@@ -715,13 +1169,15 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
   };
 
   const customMetric: MetricMapping = {
-    semanticMetric: 'custom',
-    name: appliedCustomPromql || copy.customTitle,
+    semanticMetric: CUSTOM_HISTORY_METRIC_ID,
+    name: copy.customTitle,
     unit: '',
     prometheusMetric: '',
     promql: appliedCustomPromql,
     labels: [],
   };
+  const customData = customPanel?.data;
+  const customHasSamples = customData !== undefined && (customSummary?.visibleSeriesCount ?? 0) > 0;
 
   return (
     <section aria-labelledby="metrics-explorer-title" style={{ marginTop: 24 }}>
@@ -763,6 +1219,13 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
             onChange={(value) => handleRangeChange(value as RangeOption['value'])}
             options={RANGE_OPTIONS.map(({ label, value }) => ({ label, value }))}
           />
+          <Tooltip title={copy.history}>
+            <Button
+              aria-label={copy.history}
+              icon={<ClockCounterClockwise size={16} />}
+              onClick={() => setHistoryOpen(true)}
+            />
+          </Tooltip>
           <Tooltip title={copy.refresh}>
             <Button
               aria-label={copy.refresh}
@@ -792,15 +1255,40 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
             title={copy.customTitle}
             style={{ marginBottom: 16 }}
             extra={
-              <Button
-                type="primary"
-                size="small"
-                loading={Boolean(customPanel?.loading)}
-                disabled={!customPromql.trim()}
-                onClick={() => void runCustomQuery(customPromql, selectedRange)}
-              >
-                {copy.customRun}
-              </Button>
+              <Space size={4}>
+                <Tooltip title={copy.details}>
+                  <Button
+                    aria-label={`${copy.customTitle} ${copy.details}`}
+                    size="small"
+                    icon={<Eye size={16} />}
+                    disabled={!customHasSamples}
+                    onClick={() =>
+                      customData && handleOpenDetails(customMetric, customData, customPanel?.query)
+                    }
+                  />
+                </Tooltip>
+                <Tooltip title={customHasSamples ? copy.exportCsv : copy.exportDisabled}>
+                  <Button
+                    aria-label={`${copy.customTitle} ${copy.exportCsv}`}
+                    size="small"
+                    icon={<DownloadSimple size={16} />}
+                    disabled={!customHasSamples}
+                    onClick={() =>
+                      customData && handleExportCsv(customMetric, customData, customPanel?.query)
+                    }
+                  />
+                </Tooltip>
+                <Button
+                  aria-label={copy.customRun}
+                  type="primary"
+                  size="small"
+                  loading={Boolean(customPanel?.loading)}
+                  disabled={!customPromql.trim()}
+                  onClick={() => void runCustomQuery(customPromql, selectedRange)}
+                >
+                  {copy.customRun}
+                </Button>
+              </Space>
             }
           >
             <Input.TextArea
@@ -825,26 +1313,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
               ) : customPanel?.error ? (
                 <Alert type="error" showIcon message={customPanel.error} />
               ) : customPanel?.data ? (
-                <>
-                  {customPanel.data.warnings.map((warning) => (
-                    <Alert
-                      key={warning}
-                      type="warning"
-                      showIcon
-                      message={warning}
-                      style={{ marginBottom: 8 }}
-                    />
-                  ))}
-                  <MetricChart
-                    data={customPanel.data}
-                    metric={customMetric}
-                    locale={locale}
-                    noSamples={copy.noSamples}
-                    histogramLabel={copy.histogram}
-                    histogramTooltip={copy.histogramTooltip}
-                    hiddenSeriesText={copy.hiddenSeries}
-                  />
-                </>
+                renderMetricResult(customMetric, customPanel, customSummary)
               ) : (
                 <Text type="secondary">{copy.customEmpty}</Text>
               )}
@@ -862,6 +1331,118 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
           </div>
         </>
       )}
+      <Drawer
+        title={copy.historyTitle}
+        width={820}
+        open={historyOpen}
+        onClose={() => setHistoryOpen(false)}
+        destroyOnHidden
+        extra={
+          <Button size="small" disabled={visibleHistory.length === 0} onClick={handleClearHistory}>
+            {copy.clearHistory}
+          </Button>
+        }
+      >
+        {visibleHistory.length === 0 ? (
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={copy.noHistory} />
+        ) : (
+          <List
+            dataSource={visibleHistory}
+            renderItem={(entry) => (
+              <List.Item
+                actions={[
+                  <Button
+                    key="restore"
+                    size="small"
+                    type="link"
+                    onClick={() => handleRestoreHistory(entry)}
+                  >
+                    {copy.restore}
+                  </Button>,
+                ]}
+              >
+                <List.Item.Meta
+                  title={
+                    <Flex gap={8} wrap="wrap" align="center">
+                      <Text strong>{entry.metricName}</Text>
+                      <Tag>{entry.rangeLabel}</Tag>
+                      <Tag>{formatHistorySource(entry)}</Tag>
+                      {entry.instanceId ? (
+                        <Tag>{`${copy.instance}: ${entry.instanceId}`}</Tag>
+                      ) : null}
+                      <Tag>{`${entry.summary.sampleCount} ${copy.samples}`}</Tag>
+                    </Flex>
+                  }
+                  description={
+                    <Space direction="vertical" size={4} style={{ width: '100%' }}>
+                      <Text
+                        code
+                        copyable
+                        ellipsis={{ tooltip: entry.promql }}
+                        style={{ maxWidth: '100%' }}
+                      >
+                        {entry.promql}
+                      </Text>
+                      <Text type="secondary">
+                        {`${entry.profileName} · ${formatSeconds(entry.start)} - ${formatSeconds(
+                          entry.end,
+                        )} · ${formatMillis(entry.queriedAt)}`}
+                      </Text>
+                    </Space>
+                  }
+                />
+              </List.Item>
+            )}
+          />
+        )}
+      </Drawer>
+      <Drawer
+        title={
+          <Flex gap={8} wrap="wrap" align="center">
+            <span>{copy.detailsTitle}</span>
+            {detailsPanel?.metric.name ? <Tag>{detailsPanel.metric.name}</Tag> : null}
+          </Flex>
+        }
+        width={1080}
+        open={detailsPanel !== null}
+        onClose={() => setDetailsPanel(null)}
+        destroyOnHidden
+      >
+        {detailsPanel?.query ? (
+          <Descriptions
+            size="small"
+            column={{ xs: 1, sm: 2, md: 3 }}
+            style={{ marginBottom: 12 }}
+            items={[
+              {
+                key: 'source',
+                label: copy.source,
+                children: detailsPanel.query.dataSourceName || copy.defaultDataSource,
+              },
+              {
+                key: 'query-window',
+                label: copy.queryWindow,
+                children: `${formatSeconds(detailsPanel.query.start)} - ${formatSeconds(
+                  detailsPanel.query.end,
+                )}`,
+              },
+              {
+                key: 'queried-at',
+                label: copy.queriedAt,
+                children: formatMillis(detailsPanel.query.queriedAt),
+              },
+            ]}
+          />
+        ) : null}
+        <Table<MetricSeriesDetailRow>
+          rowKey="key"
+          size="small"
+          dataSource={detailRows}
+          columns={detailColumns}
+          pagination={{ pageSize: 8, showSizeChanger: false }}
+          scroll={{ x: tableScrollX(detailColumns) }}
+        />
+      </Drawer>
       <Modal
         title={copy.authTitle}
         open={pendingDataSource !== null}

--- a/web/src/components/__tests__/MetricsExplorer.test.tsx
+++ b/web/src/components/__tests__/MetricsExplorer.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { App } from 'antd';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -24,6 +24,11 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import { listDataSources } from '../../api/settings';
 import { listMetricProfiles, queryByDataSource, queryMetrics } from '../../api/metrics';
 import { LangProvider } from '../../i18n/LangContext';
+import { downloadCsv } from '../../utils/download';
+import {
+  METRICS_QUERY_HISTORY_STORAGE_KEY,
+  type MetricsQueryHistoryEntry,
+} from '../../utils/metricsExplorerDiagnostics';
 import MetricsExplorer from '../MetricsExplorer';
 
 vi.mock('../../api/settings', () => ({
@@ -35,6 +40,15 @@ vi.mock('../../api/metrics', () => ({
   queryByDataSource: vi.fn(),
   queryMetrics: vi.fn(),
 }));
+
+vi.mock('../../utils/download', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../utils/download')>('../../utils/download');
+  return {
+    ...actual,
+    downloadCsv: vi.fn(),
+  };
+});
 
 const profiles = [
   {
@@ -105,6 +119,37 @@ const histogramOnlyData = {
   warnings: [],
 };
 
+const createHistoryEntry = (
+  overrides: Partial<MetricsQueryHistoryEntry> = {},
+): MetricsQueryHistoryEntry => ({
+  id: 'history-consumer-lag',
+  profileId: 'rocketmq4-exporter',
+  profileName: 'RocketMQ 4.x Exporter',
+  metricId: 'consumer_lag_messages',
+  metricName: 'Consumer Lag Messages',
+  metricUnit: 'messages',
+  rangeId: '6h',
+  rangeLabel: '6h',
+  step: '2m',
+  dataSourceKey: '',
+  dataSourceName: '',
+  promql: 'sum(rocketmq_message_accumulation) by (cluster, group, topic)',
+  start: 1_799_978_400,
+  end: 1_800_000_000,
+  queriedAt: 1_800_000_000_000,
+  summary: {
+    seriesCount: 1,
+    visibleSeriesCount: 1,
+    sampleCount: 2,
+    scalarSampleCount: 2,
+    histogramSampleCount: 0,
+    warningCount: 0,
+    earliestTimestamp: 1_799_978_400,
+    latestTimestamp: 1_800_000_000,
+  },
+  ...overrides,
+});
+
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -123,6 +168,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
+  localStorage.clear();
   vi.mocked(listDataSources).mockResolvedValue([]);
   vi.mocked(listMetricProfiles).mockResolvedValue(profiles);
   vi.mocked(queryByDataSource).mockResolvedValue(metricData);
@@ -272,7 +318,7 @@ describe('MetricsExplorer', () => {
     await screen.findByRole('img', { name: 'Message In TPS time series' });
 
     await user.type(screen.getByLabelText('自定义查询'), 'sum(rocketmq_topic_number)');
-    await user.click(screen.getByRole('button', { name: /查\s*询/ }));
+    await user.click(screen.getByRole('button', { name: '查询' }));
 
     await waitFor(() =>
       expect(queryMetrics).toHaveBeenCalledWith({
@@ -285,21 +331,52 @@ describe('MetricsExplorer', () => {
     expect(await screen.findAllByText('cluster=prod / node_id=broker-a')).not.toHaveLength(0);
   });
 
-  it('reloads profile panels when refresh also reruns the applied custom query', async () => {
+  it('refreshes profile panels and the custom query independently', async () => {
     const user = userEvent.setup();
     renderWithProviders(<MetricsExplorer />);
-    await screen.findByRole('img', { name: 'Message In TPS time series' });
+    await screen.findByText('42 messages/s');
 
     await user.type(screen.getByLabelText('自定义查询'), 'sum(rocketmq_topic_number)');
-    await user.click(screen.getByRole('button', { name: /查\s*询/ }));
-    await screen.findAllByText('cluster=prod / node_id=broker-a');
+    await user.click(screen.getByRole('button', { name: '查询' }));
+
+    await waitFor(() =>
+      expect(queryMetrics).toHaveBeenCalledWith({
+        metric: 'sum(rocketmq_topic_number)',
+        start: 1_799_996_400,
+        end: 1_800_000_000,
+        step: '30s',
+      }),
+    );
+
+    const refreshedProfileData = {
+      ...metricData,
+      series: [
+        {
+          ...metricData.series[0],
+          values: [{ timestamp: 1_800_000_000, value: '77' }],
+        },
+      ],
+    };
+    const refreshedCustomData = {
+      ...metricData,
+      series: [
+        {
+          ...metricData.series[0],
+          labels: { cluster: 'prod', query: 'custom' },
+          values: [{ timestamp: 1_800_000_000, value: '9' }],
+        },
+      ],
+    };
+    vi.mocked(queryMetrics).mockImplementation((query) =>
+      Promise.resolve(
+        query.metric === 'sum(rocketmq_topic_number)' ? refreshedCustomData : refreshedProfileData,
+      ),
+    );
 
     await user.click(screen.getByRole('button', { name: '刷新全部面板' }));
 
-    expect(
-      await screen.findByRole('img', { name: 'Message In TPS time series' }, { timeout: 3000 }),
-    ).toBeInTheDocument();
-    expect(screen.getByText('42 messages/s')).toBeInTheDocument();
+    expect(await screen.findByText('77 messages/s')).toBeInTheDocument();
+    expect(screen.getByText('cluster=prod / query=custom')).toBeInTheDocument();
   });
 
   it('queries the first metric when the version profile changes', async () => {
@@ -655,5 +732,199 @@ describe('MetricsExplorer', () => {
       dataSourceQueriesBeforeScopeChange,
     );
     expect(screen.getAllByTitle('默认数据源').length).toBeGreaterThan(0);
+  });
+
+  it('exports the clicked metric panel as CSV', async () => {
+    const user = userEvent.setup();
+    const consumerLagData = {
+      resultType: 'matrix',
+      series: [
+        {
+          labels: { cluster: 'prod', group: 'group-a', topic: 'topic-a' },
+          values: [{ timestamp: 1_800_000_000, value: '101' }],
+          histograms: [],
+        },
+      ],
+      warnings: [],
+    };
+    vi.mocked(listMetricProfiles).mockResolvedValue([
+      {
+        ...profiles[0],
+        metrics: [
+          profiles[0].metrics[0],
+          {
+            semanticMetric: 'consumer_lag_messages',
+            name: 'Consumer Lag Messages',
+            unit: 'messages',
+            prometheusMetric: 'rocketmq_consumer_lag_messages',
+            promql: 'sum(rocketmq_consumer_lag_messages) by (cluster, group, topic)',
+            labels: ['cluster', 'group', 'topic'],
+          },
+        ],
+      },
+    ]);
+    vi.mocked(queryMetrics).mockImplementation((query) =>
+      Promise.resolve(
+        query.metric.includes('rocketmq_consumer_lag_messages') ? consumerLagData : metricData,
+      ),
+    );
+
+    renderWithProviders(<MetricsExplorer />);
+
+    await screen.findByText('101 messages');
+    await user.click(screen.getByRole('button', { name: 'Consumer Lag Messages 导出 CSV' }));
+
+    expect(downloadCsv).toHaveBeenCalledTimes(1);
+    const [filename, csv] = vi.mocked(downloadCsv).mock.calls[0];
+    expect(filename).toMatch(/^rocketmq-studio-metrics-consumer-lag-messages-/);
+    expect(csv).toContain('"Consumer Lag Messages"');
+    expect(csv).toContain('"cluster=prod / group=group-a / topic=topic-a"');
+    expect(csv).not.toContain('"Message In TPS"');
+  });
+
+  it('opens series details from the clicked metric panel', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<MetricsExplorer />);
+
+    await screen.findByRole('img', { name: 'Message In TPS time series' });
+    await user.click(screen.getByRole('button', { name: 'Message In TPS 序列明细' }));
+
+    const detailsDialog = await screen.findByRole('dialog', { name: /指标序列明细/ });
+    expect(within(detailsDialog).getByText('scalar')).toBeInTheDocument();
+    expect(
+      within(detailsDialog).getByText('{"cluster":"prod","node_id":"broker-a"}'),
+    ).toBeInTheDocument();
+    expect(within(detailsDialog).getByText('42')).toBeInTheDocument();
+  });
+
+  it('restores profile, range, and source from query history', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(METRICS_QUERY_HISTORY_STORAGE_KEY, JSON.stringify([createHistoryEntry()]));
+
+    renderWithProviders(<MetricsExplorer />);
+
+    await screen.findByRole('img', { name: 'Message In TPS time series' });
+    await user.click(screen.getByRole('button', { name: '查询历史' }));
+
+    const historyDialog = await screen.findByRole('dialog', { name: '指标查询历史' });
+    const historyItem = within(historyDialog)
+      .getByText('Consumer Lag Messages')
+      .closest('.ant-list-item');
+    expect(historyItem).not.toBeNull();
+    await user.click(within(historyItem as HTMLElement).getByRole('button', { name: '恢复' }));
+
+    await waitFor(() =>
+      expect(queryMetrics).toHaveBeenLastCalledWith({
+        metric: 'sum(rocketmq_message_accumulation) by (cluster, group, topic)',
+        start: 1_799_978_400,
+        end: 1_800_000_000,
+        step: '2m',
+      }),
+    );
+    expect(screen.getByText('Consumer Lag Messages')).toBeInTheDocument();
+  });
+
+  it('filters query history from other instances and shows the current instance context', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(
+      METRICS_QUERY_HISTORY_STORAGE_KEY,
+      JSON.stringify([
+        createHistoryEntry({
+          id: 'history-instance-a',
+          metricName: 'Instance A Lag',
+          instanceId: 'instance-a',
+        }),
+        createHistoryEntry({
+          id: 'history-instance-b',
+          metricName: 'Instance B Lag',
+          instanceId: 'instance-b',
+        }),
+      ]),
+    );
+
+    renderWithProviders(<MetricsExplorer instanceId="instance-a" />);
+
+    await screen.findByRole('img', { name: 'Message In TPS time series' });
+    await user.click(screen.getByRole('button', { name: '查询历史' }));
+
+    const historyDialog = await screen.findByRole('dialog', { name: '指标查询历史' });
+    expect(within(historyDialog).getByText('Instance A Lag')).toBeInTheDocument();
+    expect(within(historyDialog).getAllByText('实例: instance-a').length).toBeGreaterThan(0);
+    expect(within(historyDialog).queryByText('Instance B Lag')).not.toBeInTheDocument();
+  });
+
+  it('requires credentials again when restoring a protected data source history item', async () => {
+    const user = userEvent.setup();
+    vi.mocked(listDataSources).mockResolvedValue([
+      {
+        key: 'ds-basic',
+        name: 'Protected Prometheus',
+        type: 'Prometheus',
+        url: '',
+        auth: 'Basic Auth',
+        status: 'healthy',
+      },
+    ]);
+    localStorage.setItem(
+      METRICS_QUERY_HISTORY_STORAGE_KEY,
+      JSON.stringify([
+        createHistoryEntry({
+          id: 'history-protected-source',
+          profileId: 'rocketmq5-native',
+          profileName: 'RocketMQ 5.x Native',
+          metricId: 'message_in_tps',
+          metricName: 'Message In TPS',
+          metricUnit: 'messages/s',
+          rangeId: '1h',
+          rangeLabel: '1h',
+          step: '30s',
+          dataSourceKey: 'ds-basic',
+          dataSourceName: 'Protected Prometheus',
+          promql: 'sum(rate(rocketmq_messages_in_total[1m])) by (cluster, node_id)',
+          start: 1_799_996_400,
+        }),
+      ]),
+    );
+
+    renderWithProviders(<MetricsExplorer />);
+
+    const sourceSelect = await screen.findByRole('combobox', { name: '数据源' });
+    await user.click(sourceSelect);
+    await screen.findByText('Protected Prometheus', {
+      selector: '.ant-select-item-option-content',
+    });
+    await user.keyboard('{Escape}');
+    await user.click(screen.getByRole('button', { name: '查询历史' }));
+
+    const historyDialog = await screen.findByRole('dialog', { name: '指标查询历史' });
+    const historyItem = within(historyDialog)
+      .getByText('Protected Prometheus')
+      .closest('.ant-list-item');
+    expect(historyItem).not.toBeNull();
+    await user.click(within(historyItem as HTMLElement).getByRole('button', { name: '恢复' }));
+
+    // rc-util's useId returns a constant 'test-id' under NODE_ENV=test, so the query-history
+    // tooltip and this modal share one aria-labelledby target and the modal's accessible name
+    // resolves to the tooltip text. Scope by the modal root instead of role + name.
+    const authDialog = (await screen.findByText('数据源认证')).closest('.ant-modal') as HTMLElement;
+    await user.type(within(authDialog).getByLabelText('用户名'), 'metrics-reader');
+    await user.type(within(authDialog).getByLabelText('密码'), 'secret-value');
+    await user.click(within(authDialog).getByRole('button', { name: /连\s*接/ }));
+
+    await waitFor(() =>
+      expect(queryByDataSource).toHaveBeenCalledWith({
+        key: 'ds-basic',
+        username: 'metrics-reader',
+        password: 'secret-value',
+        instanceId: undefined,
+        query: {
+          metric: 'sum(rate(rocketmq_messages_in_total[1m])) by (cluster, node_id)',
+          start: 1_799_996_400,
+          end: 1_800_000_000,
+          step: '30s',
+        },
+      }),
+    );
+    expect(localStorage.getItem(METRICS_QUERY_HISTORY_STORAGE_KEY)).not.toContain('secret-value');
   });
 });

--- a/web/src/utils/metricsExplorerDiagnostics.test.ts
+++ b/web/src/utils/metricsExplorerDiagnostics.test.ts
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { MetricData, MetricMapping } from '../api/metrics';
+import {
+  METRICS_QUERY_HISTORY_LIMIT,
+  METRICS_QUERY_HISTORY_STORAGE_KEY,
+  buildMetricCsv,
+  buildMetricCsvFilename,
+  buildMetricCsvRows,
+  buildMetricSeriesDetailRows,
+  clearMetricsQueryHistory,
+  createMetricsQueryHistoryEntry,
+  loadMetricsQueryHistory,
+  mergeMetricsQueryHistory,
+  metricSeriesLabel,
+  saveMetricsQueryHistory,
+  stableLabelsText,
+  summarizeMetricData,
+  toMetricSeriesSamples,
+} from './metricsExplorerDiagnostics';
+
+const metric: MetricMapping = {
+  semanticMetric: 'message_in_tps',
+  name: 'Message In TPS',
+  unit: 'messages/s',
+  prometheusMetric: 'rocketmq_messages_in_total',
+  promql: 'sum(rate(rocketmq_messages_in_total[1m])) by (cluster, node_id)',
+  labels: ['cluster', 'node_id'],
+};
+
+const metricData: MetricData = {
+  resultType: 'matrix',
+  series: [
+    {
+      labels: { node_id: 'broker-a', cluster: 'prod' },
+      values: [
+        { timestamp: 1_800_000_000, value: '42' },
+        { timestamp: 1_799_996_400, value: '40' },
+        { timestamp: 1_799_996_401, value: 'NaN' },
+      ],
+      histograms: [],
+    },
+    {
+      labels: { cluster: 'prod', node_id: 'broker-b' },
+      values: [],
+      histograms: [
+        { timestamp: 1_799_996_400, histogram: { count: '10', sum: '250', buckets: [] } },
+        { timestamp: 1_800_000_000, histogram: { count: '20', sum: '600', buckets: [] } },
+      ],
+    },
+  ],
+  warnings: ['partial response'],
+};
+
+const createHistoryEntry = (
+  overrides: Partial<ReturnType<typeof createMetricsQueryHistoryEntry>>,
+) =>
+  createMetricsQueryHistoryEntry({
+    profileId: overrides.profileId ?? 'rocketmq5-native',
+    profileName: overrides.profileName ?? 'RocketMQ 5.x Native',
+    metric,
+    rangeId: overrides.rangeId ?? '1h',
+    rangeLabel: overrides.rangeLabel ?? '1h',
+    step: overrides.step ?? '30s',
+    dataSourceKey: overrides.dataSourceKey ?? '',
+    dataSourceName: overrides.dataSourceName ?? '',
+    start: overrides.start ?? 1_799_996_400,
+    end: overrides.end ?? 1_800_000_000,
+    queriedAt: overrides.queriedAt ?? 1_800_000_000_000,
+    summary: overrides.summary ?? summarizeMetricData(metricData),
+  });
+
+describe('metrics explorer diagnostics', () => {
+  it('sorts scalar samples and ignores non-numeric values', () => {
+    const samples = toMetricSeriesSamples(metricData.series[0]);
+
+    expect(samples.fromHistogram).toBe(false);
+    expect(samples.samples.map((sample) => sample.timestamp)).toEqual([
+      1_799_996_400, 1_800_000_000,
+    ]);
+    expect(samples.samples.map((sample) => sample.value)).toEqual([40, 42]);
+  });
+
+  it('derives histogram-only samples from sums and falls back to counts', () => {
+    const histogramOnly = toMetricSeriesSamples({
+      labels: { cluster: 'prod' },
+      values: [],
+      histograms: [
+        { timestamp: 1, histogram: { count: '10', sum: '', buckets: [] } },
+        { timestamp: 2, histogram: { count: '20', sum: '600', buckets: [] } },
+      ],
+    });
+
+    expect(histogramOnly.fromHistogram).toBe(true);
+    expect(histogramOnly.samples).toMatchObject([
+      { timestamp: 1, value: 10, histogramCount: 10 },
+      { timestamp: 2, value: 600, histogramCount: 20, histogramSum: 600 },
+    ]);
+  });
+
+  it('builds stable labels, readable series labels, summaries, and detail rows', () => {
+    expect(stableLabelsText({ node_id: 'broker-a', cluster: 'prod' })).toBe(
+      '{"cluster":"prod","node_id":"broker-a"}',
+    );
+    expect(metricSeriesLabel(metricData.series[0], metric.name)).toBe(
+      'cluster=prod / node_id=broker-a',
+    );
+
+    expect(summarizeMetricData(metricData)).toEqual({
+      seriesCount: 2,
+      visibleSeriesCount: 2,
+      sampleCount: 4,
+      scalarSampleCount: 2,
+      histogramSampleCount: 2,
+      warningCount: 1,
+      earliestTimestamp: 1_799_996_400,
+      latestTimestamp: 1_800_000_000,
+    });
+
+    expect(buildMetricSeriesDetailRows(metricData, metric)).toMatchObject([
+      {
+        seriesIndex: 1,
+        sampleType: 'scalar',
+        sampleCount: 2,
+        latestTimestamp: 1_800_000_000,
+        latestValue: 42,
+      },
+      {
+        seriesIndex: 2,
+        sampleType: 'histogram',
+        sampleCount: 2,
+        latestTimestamp: 1_800_000_000,
+        latestValue: 600,
+        histogramCount: 20,
+        histogramSum: 600,
+      },
+    ]);
+  });
+
+  it('exports scalar and histogram samples as formula-safe CSV rows', () => {
+    const dangerousMetric = { ...metric, name: '=Message In TPS' };
+    const rows = buildMetricCsvRows(metricData, dangerousMetric, {
+      profileName: 'RocketMQ 5.x Native',
+      sourceName: 'Prometheus prod',
+      queryStart: 1_799_996_400,
+      queryEnd: 1_800_000_000,
+      queriedAt: 1_800_000_000_000,
+    });
+    const csv = buildMetricCsv(metricData, dangerousMetric, {
+      profileName: 'RocketMQ 5.x Native',
+      sourceName: 'Prometheus prod',
+    });
+
+    expect(rows).toHaveLength(4);
+    expect(rows[2]).toMatchObject({
+      sampleType: 'histogram',
+      value: 250,
+      histogramCount: 10,
+      histogramSum: 250,
+    });
+    expect(csv).toContain('"\'=Message In TPS"');
+    expect(csv).toContain('"histogram"');
+    expect(csv).toContain('"2027-01-15T07:00:00.000Z"');
+  });
+
+  it('creates deterministic CSV filenames from metric identity', () => {
+    expect(buildMetricCsvFilename(metric, 1_800_000_000_000)).toBe(
+      'rocketmq-studio-metrics-message-in-tps-2027-01-15T08-00-00-000Z.csv',
+    );
+  });
+
+  it('loads, saves, clears, deduplicates, and limits query history without credentials', () => {
+    localStorage.clear();
+    const first = createHistoryEntry({ queriedAt: 1 });
+    const duplicate = createHistoryEntry({ queriedAt: 2 });
+    const distinct = Array.from({ length: METRICS_QUERY_HISTORY_LIMIT + 1 }, (_, index) =>
+      createHistoryEntry({
+        rangeId: `${index + 1}h`,
+        rangeLabel: `${index + 1}h`,
+        queriedAt: 100 + index,
+      }),
+    );
+
+    const merged = distinct.reduce(
+      (current, entry) => mergeMetricsQueryHistory(current, entry),
+      mergeMetricsQueryHistory([first], duplicate),
+    );
+
+    expect(merged).toHaveLength(METRICS_QUERY_HISTORY_LIMIT);
+    expect(merged.find((entry) => entry.queriedAt === 1)).toBeUndefined();
+    expect(saveMetricsQueryHistory(merged)).toBe(true);
+    expect(localStorage.getItem(METRICS_QUERY_HISTORY_STORAGE_KEY)).not.toContain('password');
+    expect(loadMetricsQueryHistory()[0].queriedAt).toBe(112);
+    expect(clearMetricsQueryHistory()).toBe(true);
+    expect(loadMetricsQueryHistory()).toEqual([]);
+  });
+
+  // The unavailable-storage fallbacks are covered by browserStorage.test.ts, which is where
+  // the try/catch now lives, so this only asserts the malformed-payload path.
+  it('ignores malformed persisted history entries', () => {
+    localStorage.clear();
+    localStorage.setItem(METRICS_QUERY_HISTORY_STORAGE_KEY, '{"broken"');
+
+    expect(loadMetricsQueryHistory()).toEqual([]);
+  });
+});

--- a/web/src/utils/metricsExplorerDiagnostics.ts
+++ b/web/src/utils/metricsExplorerDiagnostics.ts
@@ -1,0 +1,485 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MetricData, MetricMapping, MetricSeries } from '../api/metrics';
+import { readLocalStorage, removeLocalStorage, writeLocalStorage } from './browserStorage';
+import { buildCsv } from './download';
+
+export const METRICS_QUERY_HISTORY_STORAGE_KEY = 'rocketmq-studio-metrics-query-history';
+export const METRICS_QUERY_HISTORY_LIMIT = 12;
+
+export type MetricSampleKind = 'scalar' | 'histogram';
+
+export interface NumericMetricSample {
+  timestamp: number;
+  value: number;
+  kind: MetricSampleKind;
+  index: number;
+  histogramCount?: number;
+  histogramSum?: number;
+}
+
+export interface MetricSeriesSamples {
+  samples: NumericMetricSample[];
+  fromHistogram: boolean;
+}
+
+export interface MetricResultSummary {
+  seriesCount: number;
+  visibleSeriesCount: number;
+  sampleCount: number;
+  scalarSampleCount: number;
+  histogramSampleCount: number;
+  warningCount: number;
+  earliestTimestamp?: number;
+  latestTimestamp?: number;
+}
+
+export interface MetricCsvContext {
+  profileName: string;
+  sourceName: string;
+  queryStart?: number;
+  queryEnd?: number;
+  queriedAt?: number;
+}
+
+export interface MetricCsvRow {
+  profileName: string;
+  sourceName: string;
+  metricName: string;
+  prometheusMetric: string;
+  promql: string;
+  resultType: string;
+  unit: string;
+  seriesIndex: number;
+  seriesLabel: string;
+  labels: string;
+  sampleType: MetricSampleKind;
+  timestamp: number;
+  timestampIso: string;
+  value: number;
+  histogramCount?: number;
+  histogramSum?: number;
+  queryStart?: number;
+  queryEnd?: number;
+  queriedAt?: number;
+}
+
+export interface MetricSeriesDetailRow {
+  key: string;
+  seriesIndex: number;
+  seriesLabel: string;
+  labels: string;
+  sampleType: MetricSampleKind;
+  sampleCount: number;
+  latestTimestamp?: number;
+  latestValue?: number;
+  histogramCount?: number;
+  histogramSum?: number;
+}
+
+export interface MetricsQueryHistoryEntry {
+  id: string;
+  profileId: string;
+  profileName: string;
+  metricId: string;
+  metricName: string;
+  metricUnit: string;
+  rangeId: string;
+  rangeLabel: string;
+  step: string;
+  dataSourceKey: string;
+  dataSourceName: string;
+  promql: string;
+  start: number;
+  end: number;
+  queriedAt: number;
+  instanceId?: string;
+  summary: MetricResultSummary;
+}
+
+interface MetricsQueryHistoryInput {
+  profileId: string;
+  profileName: string;
+  metric: MetricMapping;
+  rangeId: string;
+  rangeLabel: string;
+  step: string;
+  dataSourceKey: string;
+  dataSourceName: string;
+  start: number;
+  end: number;
+  queriedAt: number;
+  instanceId?: string;
+  summary: MetricResultSummary;
+}
+
+const finiteNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const sortedEntries = (labels: Record<string, string>) =>
+  Object.entries(labels).sort(([left], [right]) => left.localeCompare(right));
+
+export const stableLabelsText = (labels: Record<string, string>) =>
+  JSON.stringify(Object.fromEntries(sortedEntries(labels)));
+
+export const metricSeriesLabel = (series: MetricSeries, fallback: string) => {
+  const labels = sortedEntries(series.labels)
+    .filter(([key]) => key !== '__name__')
+    .slice(0, 3)
+    .map(([key, value]) => `${key}=${value}`);
+  return labels.length > 0 ? labels.join(' / ') : series.labels.__name__ || fallback;
+};
+
+const sortMetricSamples = (samples: NumericMetricSample[]) =>
+  samples
+    .filter((sample) => Number.isFinite(sample.timestamp) && Number.isFinite(sample.value))
+    .sort((left, right) => left.timestamp - right.timestamp || left.index - right.index);
+
+const toScalarSamples = (series: MetricSeries): NumericMetricSample[] =>
+  sortMetricSamples(
+    series.values.map((sample, index) => ({
+      timestamp: sample.timestamp,
+      value: Number(sample.value),
+      kind: 'scalar',
+      index,
+    })),
+  );
+
+// Native histograms carry no scalar samples. To keep diagnostics usable, derive
+// a trend value from the observed sum and fall back to observation count.
+const toHistogramSamples = (series: MetricSeries): NumericMetricSample[] =>
+  sortMetricSamples(
+    series.histograms.map((sample, index) => {
+      const sum = finiteNumber(sample.histogram.sum);
+      const count = finiteNumber(sample.histogram.count);
+      return {
+        timestamp: sample.timestamp,
+        value: sum ?? count ?? Number.NaN,
+        kind: 'histogram',
+        index,
+        ...(count !== undefined ? { histogramCount: count } : {}),
+        ...(sum !== undefined ? { histogramSum: sum } : {}),
+      };
+    }),
+  );
+
+export const toMetricSeriesSamples = (series: MetricSeries): MetricSeriesSamples => {
+  const scalar = toScalarSamples(series);
+  if (scalar.length > 0) {
+    return { samples: scalar, fromHistogram: false };
+  }
+  return { samples: toHistogramSamples(series), fromHistogram: true };
+};
+
+export const summarizeMetricData = (data: MetricData): MetricResultSummary => {
+  let scalarSampleCount = 0;
+  let histogramSampleCount = 0;
+  let visibleSeriesCount = 0;
+  let earliestTimestamp: number | undefined;
+  let latestTimestamp: number | undefined;
+
+  data.series.forEach((series) => {
+    const { samples, fromHistogram } = toMetricSeriesSamples(series);
+    if (samples.length === 0) return;
+    visibleSeriesCount += 1;
+    if (fromHistogram) {
+      histogramSampleCount += samples.length;
+    } else {
+      scalarSampleCount += samples.length;
+    }
+    samples.forEach((sample) => {
+      earliestTimestamp =
+        earliestTimestamp === undefined
+          ? sample.timestamp
+          : Math.min(earliestTimestamp, sample.timestamp);
+      latestTimestamp =
+        latestTimestamp === undefined
+          ? sample.timestamp
+          : Math.max(latestTimestamp, sample.timestamp);
+    });
+  });
+
+  return {
+    seriesCount: data.series.length,
+    visibleSeriesCount,
+    sampleCount: scalarSampleCount + histogramSampleCount,
+    scalarSampleCount,
+    histogramSampleCount,
+    warningCount: data.warnings.length,
+    ...(earliestTimestamp !== undefined ? { earliestTimestamp } : {}),
+    ...(latestTimestamp !== undefined ? { latestTimestamp } : {}),
+  };
+};
+
+export const buildMetricCsvRows = (
+  data: MetricData,
+  metric: MetricMapping,
+  context: MetricCsvContext,
+): MetricCsvRow[] =>
+  data.series.flatMap((series, seriesIndex) => {
+    const { samples } = toMetricSeriesSamples(series);
+    const seriesLabel = metricSeriesLabel(series, metric.name);
+    const labels = stableLabelsText(series.labels);
+    return samples.map((sample) => ({
+      profileName: context.profileName,
+      sourceName: context.sourceName,
+      metricName: metric.name,
+      prometheusMetric: metric.prometheusMetric,
+      promql: metric.promql,
+      resultType: data.resultType,
+      unit: metric.unit,
+      seriesIndex: seriesIndex + 1,
+      seriesLabel,
+      labels,
+      sampleType: sample.kind,
+      timestamp: sample.timestamp,
+      timestampIso: new Date(sample.timestamp * 1000).toISOString(),
+      value: sample.value,
+      histogramCount: sample.histogramCount,
+      histogramSum: sample.histogramSum,
+      queryStart: context.queryStart,
+      queryEnd: context.queryEnd,
+      queriedAt: context.queriedAt,
+    }));
+  });
+
+export const buildMetricCsvFromRows = (rows: MetricCsvRow[]) =>
+  buildCsv(
+    [
+      { header: 'Profile', value: (row: MetricCsvRow) => row.profileName },
+      { header: 'Source', value: (row: MetricCsvRow) => row.sourceName },
+      { header: 'Metric', value: (row: MetricCsvRow) => row.metricName },
+      { header: 'Prometheus Metric', value: (row: MetricCsvRow) => row.prometheusMetric },
+      { header: 'PromQL', value: (row: MetricCsvRow) => row.promql },
+      { header: 'Result Type', value: (row: MetricCsvRow) => row.resultType },
+      { header: 'Series Index', value: (row: MetricCsvRow) => row.seriesIndex },
+      { header: 'Series', value: (row: MetricCsvRow) => row.seriesLabel },
+      { header: 'Labels', value: (row: MetricCsvRow) => row.labels },
+      { header: 'Sample Type', value: (row: MetricCsvRow) => row.sampleType },
+      { header: 'Timestamp', value: (row: MetricCsvRow) => row.timestamp },
+      { header: 'Timestamp ISO', value: (row: MetricCsvRow) => row.timestampIso },
+      { header: 'Value', value: (row: MetricCsvRow) => row.value },
+      { header: 'Unit', value: (row: MetricCsvRow) => row.unit },
+      { header: 'Histogram Count', value: (row: MetricCsvRow) => row.histogramCount },
+      { header: 'Histogram Sum', value: (row: MetricCsvRow) => row.histogramSum },
+      { header: 'Query Start', value: (row: MetricCsvRow) => row.queryStart },
+      { header: 'Query End', value: (row: MetricCsvRow) => row.queryEnd },
+      { header: 'Queried At', value: (row: MetricCsvRow) => row.queriedAt },
+    ],
+    rows,
+  );
+
+export const buildMetricCsv = (
+  data: MetricData,
+  metric: MetricMapping,
+  context: MetricCsvContext,
+) => buildMetricCsvFromRows(buildMetricCsvRows(data, metric, context));
+
+const slugify = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+
+export const buildMetricCsvFilename = (metric: MetricMapping, timestamp = Date.now()) => {
+  const slug = slugify(metric.semanticMetric || metric.name) || 'metric';
+  const suffix = new Date(timestamp).toISOString().replace(/[:.]/g, '-');
+  return `rocketmq-studio-metrics-${slug}-${suffix}.csv`;
+};
+
+export const buildMetricSeriesDetailRows = (
+  data: MetricData,
+  metric: MetricMapping,
+): MetricSeriesDetailRow[] =>
+  data.series.map((series, seriesIndex) => {
+    const { samples, fromHistogram } = toMetricSeriesSamples(series);
+    const latest = samples[samples.length - 1];
+    return {
+      key: `${seriesIndex}-${stableLabelsText(series.labels)}`,
+      seriesIndex: seriesIndex + 1,
+      seriesLabel: metricSeriesLabel(series, metric.name),
+      labels: stableLabelsText(series.labels),
+      sampleType: fromHistogram ? 'histogram' : 'scalar',
+      sampleCount: samples.length,
+      latestTimestamp: latest?.timestamp,
+      latestValue: latest?.value,
+      histogramCount: latest?.histogramCount,
+      histogramSum: latest?.histogramSum,
+    };
+  });
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const readString = (record: Record<string, unknown>, key: string) =>
+  typeof record[key] === 'string' ? record[key] : '';
+
+const readOptionalString = (record: Record<string, unknown>, key: string) =>
+  typeof record[key] === 'string' ? record[key] : undefined;
+
+const readNumber = (record: Record<string, unknown>, key: string) => {
+  const value = record[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+};
+
+const readOptionalNumber = (record: Record<string, unknown>, key: string) => {
+  const value = record[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+};
+
+const restoreSummary = (value: unknown): MetricResultSummary => {
+  if (!isRecord(value)) {
+    return {
+      seriesCount: 0,
+      visibleSeriesCount: 0,
+      sampleCount: 0,
+      scalarSampleCount: 0,
+      histogramSampleCount: 0,
+      warningCount: 0,
+    };
+  }
+  return {
+    seriesCount: readNumber(value, 'seriesCount'),
+    visibleSeriesCount: readNumber(value, 'visibleSeriesCount'),
+    sampleCount: readNumber(value, 'sampleCount'),
+    scalarSampleCount: readNumber(value, 'scalarSampleCount'),
+    histogramSampleCount: readNumber(value, 'histogramSampleCount'),
+    warningCount: readNumber(value, 'warningCount'),
+    earliestTimestamp: readOptionalNumber(value, 'earliestTimestamp'),
+    latestTimestamp: readOptionalNumber(value, 'latestTimestamp'),
+  };
+};
+
+const restoreHistoryEntry = (value: unknown): MetricsQueryHistoryEntry | null => {
+  if (!isRecord(value)) return null;
+  const metricId = readString(value, 'metricId');
+  const profileId = readString(value, 'profileId');
+  const promql = readString(value, 'promql');
+  if (!metricId || !profileId || !promql) return null;
+  return {
+    id: readString(value, 'id') || `${profileId}:${metricId}:${readNumber(value, 'queriedAt')}`,
+    profileId,
+    profileName: readString(value, 'profileName'),
+    metricId,
+    metricName: readString(value, 'metricName'),
+    metricUnit: readString(value, 'metricUnit'),
+    rangeId: readString(value, 'rangeId') || '1h',
+    rangeLabel: readString(value, 'rangeLabel') || '1h',
+    step: readString(value, 'step'),
+    dataSourceKey: readString(value, 'dataSourceKey'),
+    dataSourceName: readString(value, 'dataSourceName'),
+    promql,
+    start: readNumber(value, 'start'),
+    end: readNumber(value, 'end'),
+    queriedAt: readNumber(value, 'queriedAt'),
+    instanceId: readOptionalString(value, 'instanceId'),
+    summary: restoreSummary(value.summary),
+  };
+};
+
+export const loadMetricsQueryHistory = (): MetricsQueryHistoryEntry[] => {
+  const raw = readLocalStorage(METRICS_QUERY_HISTORY_STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map(restoreHistoryEntry)
+      .filter((entry): entry is MetricsQueryHistoryEntry => entry !== null)
+      .sort((left, right) => right.queriedAt - left.queriedAt)
+      .slice(0, METRICS_QUERY_HISTORY_LIMIT);
+  } catch {
+    return [];
+  }
+};
+
+export const saveMetricsQueryHistory = (entries: MetricsQueryHistoryEntry[]) =>
+  writeLocalStorage(METRICS_QUERY_HISTORY_STORAGE_KEY, JSON.stringify(entries));
+
+export const clearMetricsQueryHistory = () => removeLocalStorage(METRICS_QUERY_HISTORY_STORAGE_KEY);
+
+export const createMetricsQueryHistoryEntry = ({
+  profileId,
+  profileName,
+  metric,
+  rangeId,
+  rangeLabel,
+  step,
+  dataSourceKey,
+  dataSourceName,
+  start,
+  end,
+  queriedAt,
+  instanceId,
+  summary,
+}: MetricsQueryHistoryInput): MetricsQueryHistoryEntry => ({
+  id: [
+    profileId,
+    metric.semanticMetric,
+    rangeId,
+    dataSourceKey || 'default',
+    instanceId || 'global',
+    queriedAt,
+  ].join(':'),
+  profileId,
+  profileName,
+  metricId: metric.semanticMetric,
+  metricName: metric.name,
+  metricUnit: metric.unit,
+  rangeId,
+  rangeLabel,
+  step,
+  dataSourceKey,
+  dataSourceName,
+  promql: metric.promql,
+  start,
+  end,
+  queriedAt,
+  ...(instanceId !== undefined ? { instanceId } : {}),
+  summary,
+});
+
+const historyIdentity = (entry: MetricsQueryHistoryEntry) =>
+  [
+    entry.profileId,
+    entry.metricId,
+    entry.rangeId,
+    entry.dataSourceKey || 'default',
+    entry.instanceId || 'global',
+    entry.promql,
+  ].join('\n');
+
+export const mergeMetricsQueryHistory = (
+  entries: MetricsQueryHistoryEntry[],
+  entry: MetricsQueryHistoryEntry,
+  limit = METRICS_QUERY_HISTORY_LIMIT,
+) => {
+  const duplicateKey = historyIdentity(entry);
+  return [entry, ...entries.filter((item) => historyIdentity(item) !== duplicateKey)].slice(
+    0,
+    limit,
+  );
+};


### PR DESCRIPTION
## What is the purpose of the change

Improve the Metrics Explorer diagnostic workflow by keeping reusable query history, summarizing the active metric result, exposing per-series sample details, and exporting the current time-series result to CSV without storing data source credentials.

## Brief changelog

- Added Metrics Explorer query history with restore support for profile, metric, range, and data source context.
- Added current result summary and series detail drawer for labels, sample type, sample count, latest timestamp, and latest value.
- Added CSV export for scalar and native histogram-derived metric samples.
- Added regression coverage for diagnostics helpers, CSV output, history persistence, protected data source restore, and component interactions.

## Verifying this change

- `cd web && npm run test -- MetricsExplorer.test.tsx metricsExplorerDiagnostics.test.ts`
- `cd web && npm exec prettier -- --check src/components/MetricsExplorer.tsx src/components/metricsExplorerDiagnostics.ts src/components/metricsExplorerDiagnostics.test.ts src/components/__tests__/MetricsExplorer.test.tsx`
- `cd web && npm exec eslint -- src/components/MetricsExplorer.tsx src/components/metricsExplorerDiagnostics.ts src/components/metricsExplorerDiagnostics.test.ts src/components/__tests__/MetricsExplorer.test.tsx --max-warnings=0`
- `cd web && npm run build`
- `git diff --check`