### PR TITLE
fix(studio): page Tencent ACL inventories by total count

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentAclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentAclService.java
@@ -53,7 +53,6 @@ import java.util.List;
 public class TencentAclService {
 
     static final int PAGE_SIZE = 100;
-    static final int MAX_PAGES = 100;
     static final String ACL_VERSION = "1.0";
     static final String RESOURCE_TYPE = "Cluster";
     static final String RESOURCE = "*";
@@ -67,23 +66,20 @@ public class TencentAclService {
     public List<AclUserVO> listUsers(String instanceId) {
         Context context = resolve(instanceId);
         List<AclUserVO> users = new ArrayList<>();
-        for (int page = 0; page < MAX_PAGES; page++) {
-            DescribeRoleListRequest request = new DescribeRoleListRequest();
-            request.setInstanceId(context.cloudInstanceId());
-            request.setOffset((long) page * PAGE_SIZE);
-            request.setLimit((long) PAGE_SIZE);
-            DescribeRoleListResponse response = clientFactory.call(context.credentialId(),
-                    context.regionId(), client -> client.DescribeRoleList(request));
+        long fetched = 0L;
+        for (long offset = 0L; ; offset += PAGE_SIZE) {
+            DescribeRoleListResponse response = describeRoles(context, offset);
             RoleItem[] data = response == null ? null : response.getData();
             if (data == null || data.length == 0) {
                 break;
             }
+            fetched += data.length;
             for (RoleItem role : data) {
                 if (role != null && StringUtils.hasText(role.getRoleName())) {
                     users.add(toUser(role, context.cloudInstanceId()));
                 }
             }
-            if (data.length < PAGE_SIZE) {
+            if (isLastRolePage(data.length, fetched, response.getTotalCount())) {
                 break;
             }
         }
@@ -94,17 +90,14 @@ public class TencentAclService {
         Context context = resolve(instanceId);
         String requestedPrincipal = StringUtils.hasText(principal) ? principal.trim() : null;
         List<AclRuleVO> rules = new ArrayList<>();
-        for (int page = 0; page < MAX_PAGES; page++) {
-            DescribeRoleListRequest request = new DescribeRoleListRequest();
-            request.setInstanceId(context.cloudInstanceId());
-            request.setOffset((long) page * PAGE_SIZE);
-            request.setLimit((long) PAGE_SIZE);
-            DescribeRoleListResponse response = clientFactory.call(context.credentialId(),
-                    context.regionId(), client -> client.DescribeRoleList(request));
+        long fetched = 0L;
+        for (long offset = 0L; ; offset += PAGE_SIZE) {
+            DescribeRoleListResponse response = describeRoles(context, offset);
             RoleItem[] data = response == null ? null : response.getData();
             if (data == null || data.length == 0) {
                 break;
             }
+            fetched += data.length;
             for (RoleItem role : data) {
                 if (role == null || !StringUtils.hasText(role.getRoleName())) {
                     continue;
@@ -115,7 +108,7 @@ public class TencentAclService {
                 }
                 rules.add(toRule(role));
             }
-            if (data.length < PAGE_SIZE) {
+            if (isLastRolePage(data.length, fetched, response.getTotalCount())) {
                 break;
             }
         }
@@ -178,27 +171,37 @@ public class TencentAclService {
     }
 
     private RoleItem findRole(Context context, String roleName) {
-        for (int page = 0; page < MAX_PAGES; page++) {
-            DescribeRoleListRequest request = new DescribeRoleListRequest();
-            request.setInstanceId(context.cloudInstanceId());
-            request.setOffset((long) page * PAGE_SIZE);
-            request.setLimit((long) PAGE_SIZE);
-            DescribeRoleListResponse response = clientFactory.call(context.credentialId(),
-                    context.regionId(), client -> client.DescribeRoleList(request));
+        long fetched = 0L;
+        for (long offset = 0L; ; offset += PAGE_SIZE) {
+            DescribeRoleListResponse response = describeRoles(context, offset);
             RoleItem[] data = response == null ? null : response.getData();
             if (data == null || data.length == 0) {
                 break;
             }
+            fetched += data.length;
             for (RoleItem role : data) {
                 if (role != null && roleName.equals(role.getRoleName())) {
                     return role;
                 }
             }
-            if (data.length < PAGE_SIZE) {
+            if (isLastRolePage(data.length, fetched, response.getTotalCount())) {
                 break;
             }
         }
         throw new BusinessException(404, "ACL user not found: " + roleName);
+    }
+
+    private DescribeRoleListResponse describeRoles(Context context, long offset) {
+        DescribeRoleListRequest request = new DescribeRoleListRequest();
+        request.setInstanceId(context.cloudInstanceId());
+        request.setOffset(offset);
+        request.setLimit((long) PAGE_SIZE);
+        return clientFactory.call(context.credentialId(),
+                context.regionId(), client -> client.DescribeRoleList(request));
+    }
+
+    private static boolean isLastRolePage(int returned, long fetched, Long totalCount) {
+        return returned < PAGE_SIZE || totalCount != null && totalCount >= 0L && fetched >= totalCount;
     }
 
     public void deleteUser(String instanceId, String username) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -276,6 +276,10 @@ public class TencentInstanceProvider implements InstanceProvider {
         return totalCount != null && totalCount >= 0L && offset + pageSize >= totalCount;
     }
 
+    private static boolean hasFetchedAll(long fetched, Long totalCount) {
+        return totalCount != null && totalCount >= 0L && fetched >= totalCount;
+    }
+
     private static PageResult<TopicVO> paginate(List<TopicVO> topics, int page, int pageSize) {
         int total = topics.size();
         long offset = Pagination.pageOffset(page, pageSize);
@@ -935,11 +939,12 @@ public class TencentInstanceProvider implements InstanceProvider {
 
     private List<SubscriptionData> listTopicSubscriptionsByGroup(Context context, String groupName) {
         List<SubscriptionData> all = new ArrayList<>();
-        for (int page = 0; page < MAX_PAGES; page++) {
+        long fetched = 0L;
+        for (long offset = 0L; ; offset += PAGE_SIZE) {
             DescribeTopicListByGroupRequest request = new DescribeTopicListByGroupRequest();
             request.setInstanceId(context.cloudInstanceId());
             request.setConsumerGroup(groupName);
-            request.setOffset((long) page * PAGE_SIZE);
+            request.setOffset(offset);
             request.setLimit((long) PAGE_SIZE);
             DescribeTopicListByGroupResponse response = clientFactory.call(context.credentialId(), context.regionId(),
                     client -> client.DescribeTopicListByGroup(request));
@@ -947,8 +952,9 @@ public class TencentInstanceProvider implements InstanceProvider {
             if (data == null || data.length == 0) {
                 break;
             }
+            fetched += data.length;
             all.addAll(Arrays.asList(data));
-            if (data.length < PAGE_SIZE) {
+            if (data.length < PAGE_SIZE || hasFetchedAll(fetched, response.getTotalCount())) {
                 break;
             }
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentAclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentAclServiceTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.provider.tencent;
 
 import com.tencentcloudapi.trocket.v20230308.TrocketClient;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeRoleListRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeRoleListResponse;
 import com.tencentcloudapi.trocket.v20230308.models.ModifyRoleRequest;
 import com.tencentcloudapi.trocket.v20230308.models.RoleItem;
@@ -34,6 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -41,6 +43,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -108,6 +111,66 @@ class TencentAclServiceTest {
                 .containsExactly("reader-role");
         assertThat(service.getUserCredentials(INSTANCE_ID, "  reader-role  ").getUsername())
                 .isEqualTo("reader-role");
+    }
+
+    @Test
+    void listUsersShouldFetchExactlyTenThousandTencentRolesTest() throws Exception {
+        when(client.DescribeRoleList(any())).thenAnswer(invocation -> {
+            DescribeRoleListRequest request = invocation.getArgument(0);
+            DescribeRoleListResponse response = new DescribeRoleListResponse();
+            response.setTotalCount(10000L);
+            response.setData(rolePage(request.getOffset(), request.getLimit(), 10000));
+            return response;
+        });
+
+        assertThat(service.listUsers(INSTANCE_ID)).hasSize(10000);
+        verify(client, times(100)).DescribeRoleList(any());
+    }
+
+    @Test
+    void listRulesShouldFetchPastLegacyTenThousandTencentRoleCapTest() throws Exception {
+        when(client.DescribeRoleList(any())).thenAnswer(invocation -> {
+            DescribeRoleListRequest request = invocation.getArgument(0);
+            DescribeRoleListResponse response = new DescribeRoleListResponse();
+            response.setTotalCount(10001L);
+            response.setData(rolePage(request.getOffset(), request.getLimit(), 10001));
+            return response;
+        });
+
+        assertThat(service.listRules(INSTANCE_ID, null)).hasSize(10001);
+        verify(client, times(101)).DescribeRoleList(any());
+    }
+
+    @Test
+    void updateUserShouldFindRolePastLegacyTenThousandTencentRoleCapTest() throws Exception {
+        when(client.DescribeRoleList(any())).thenAnswer(invocation -> {
+            DescribeRoleListRequest request = invocation.getArgument(0);
+            DescribeRoleListResponse response = new DescribeRoleListResponse();
+            response.setTotalCount(10001L);
+            response.setData(rolePage(request.getOffset(), request.getLimit(), 10001));
+            return response;
+        });
+
+        AclUserVO updated = service.updateUser(INSTANCE_ID, AclUserVO.builder()
+                .username("role-10000")
+                .build());
+
+        assertThat(updated.getUsername()).isEqualTo("role-10000");
+        verify(client, times(101)).DescribeRoleList(any());
+        verify(client).ModifyRole(any());
+    }
+
+    @Test
+    void listUsersShouldStopOnShortPageWhenTencentTotalCountIsMissingTest() throws Exception {
+        when(client.DescribeRoleList(any())).thenAnswer(invocation -> {
+            DescribeRoleListRequest request = invocation.getArgument(0);
+            DescribeRoleListResponse response = new DescribeRoleListResponse();
+            response.setData(rolePage(request.getOffset(), request.getLimit(), 150));
+            return response;
+        });
+
+        assertThat(service.listUsers(INSTANCE_ID)).hasSize(150);
+        verify(client, times(2)).DescribeRoleList(any());
     }
 
     @Test
@@ -210,5 +273,22 @@ class TencentAclServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Tencent Cloud roles only support ALLOW ACL rules")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+    }
+
+    private static RoleItem[] rolePage(Long offset, Long limit, int total) {
+        int start = offset == null ? 0 : offset.intValue();
+        int size = Math.min(limit == null ? TencentAclService.PAGE_SIZE : limit.intValue(),
+                Math.max(total - start, 0));
+        return IntStream.range(0, size)
+                .mapToObj(index -> role("role-" + (start + index)))
+                .toArray(RoleItem[]::new);
+    }
+
+    private static RoleItem role(String name) {
+        RoleItem role = new RoleItem();
+        role.setRoleName(name);
+        role.setPermRead(true);
+        role.setPermWrite(false);
+        return role;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -30,6 +30,7 @@ import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageTraceRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageTraceResponse;
 import com.tencentcloudapi.trocket.v20230308.models.MessageItem;
 import com.tencentcloudapi.trocket.v20230308.models.MessageTraceItem;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupListRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListRequest;
@@ -615,6 +616,47 @@ class TencentInstanceProviderTest {
     }
 
     @Test
+    void getGroupSubscriptionsShouldFetchExactlyTenThousandTencentSubscriptionsTest() throws Exception {
+        when(client.DescribeTopicListByGroup(any())).thenAnswer(invocation -> {
+            DescribeTopicListByGroupRequest request = invocation.getArgument(0);
+            DescribeTopicListByGroupResponse response = new DescribeTopicListByGroupResponse();
+            response.setTotalCount(10000L);
+            response.setData(subscriptionPage(request.getOffset(), request.getLimit(), 10000));
+            return response;
+        });
+
+        assertThat(provider.getGroupSubscriptions(STUDIO_INSTANCE_ID, "GID_test")).hasSize(10000);
+        verify(client, times(100)).DescribeTopicListByGroup(any());
+    }
+
+    @Test
+    void getGroupProgressShouldFetchPastLegacyTenThousandTencentSubscriptionCapTest() throws Exception {
+        when(client.DescribeTopicListByGroup(any())).thenAnswer(invocation -> {
+            DescribeTopicListByGroupRequest request = invocation.getArgument(0);
+            DescribeTopicListByGroupResponse response = new DescribeTopicListByGroupResponse();
+            response.setTotalCount(10001L);
+            response.setData(subscriptionPage(request.getOffset(), request.getLimit(), 10001));
+            return response;
+        });
+
+        assertThat(provider.getGroupProgress(STUDIO_INSTANCE_ID, "GID_test")).hasSize(10001);
+        verify(client, times(101)).DescribeTopicListByGroup(any());
+    }
+
+    @Test
+    void getGroupSubscriptionsShouldStopOnShortPageWhenTencentTotalCountIsMissingTest() throws Exception {
+        when(client.DescribeTopicListByGroup(any())).thenAnswer(invocation -> {
+            DescribeTopicListByGroupRequest request = invocation.getArgument(0);
+            DescribeTopicListByGroupResponse response = new DescribeTopicListByGroupResponse();
+            response.setData(subscriptionPage(request.getOffset(), request.getLimit(), 150));
+            return response;
+        });
+
+        assertThat(provider.getGroupSubscriptions(STUDIO_INSTANCE_ID, "GID_test")).hasSize(150);
+        verify(client, times(2)).DescribeTopicListByGroup(any());
+    }
+
+    @Test
     void resetOffsetShouldCallTencentOpenApiTest() throws Exception {
         when(client.ResetConsumerGroupOffset(any())).thenReturn(null);
 
@@ -643,6 +685,22 @@ class TencentInstanceProviderTest {
         subscription.setConsumeType("CLUSTERING");
         subscription.setMessageModel("CLUSTERING");
         return subscription;
+    }
+
+    private static SubscriptionData[] subscriptionPage(Long offset, Long limit, int total) {
+        int start = offset == null ? 0 : offset.intValue();
+        int size = Math.min(limit == null ? TencentInstanceProvider.PAGE_SIZE : limit.intValue(),
+                Math.max(total - start, 0));
+        return IntStream.range(0, size)
+                .mapToObj(index -> {
+                    SubscriptionData subscription = subscription("GID_test");
+                    subscription.setTopic("topic-" + (start + index));
+                    subscription.setSubString("*");
+                    subscription.setExpressionType("TAG");
+                    subscription.setConsumerLag((long) start + index);
+                    return subscription;
+                })
+                .toArray(SubscriptionData[]::new);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- remove the legacy 100-page ceiling from Tencent ACL role listings
- use Tencent `TotalCount` to continue ACL role and topic-subscription paging past 10,000 records
- retain short-page termination when Tencent omits `TotalCount`
- cover listUsers, listRules, findRole, getGroupProgress and getGroupSubscriptions at 10,000/10,001 boundaries

Closes #2678

## Scope

#2610 covers Tencent cloud-instance and consumer-group inventories. This PR covers the separate ACL role and group-subscription pagination paths.

## Verification

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=TencentAclServiceTest,TencentInstanceProviderTest test` (52 tests)
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest='org.apache.rocketmq.studio.provider.tencent.*Test' test` (62 tests)
- `git diff --check origin/rocketmq-studio...HEAD`
- Full `mvn test` is currently blocked by the pre-existing `AlertSchemaMigrationTest` failure on `origin/rocketmq-studio`: `rmq_instance_message` is missing from that migration test fixture.
