### PR TITLE
[Studio][Performance] Add scope indexes for metric snapshots

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSchemaMigration.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSchemaMigration.java
@@ -103,6 +103,10 @@ public class AlertSchemaMigration implements ApplicationRunner {
             new Column("rmq_alert_notification_outbox", "message_content", "TEXT"));
     private static final List<Index> INDEXES = List.of(
             new Index("rmq_metric_snapshot", "idx_metric_snapshot_lookup", "instance_id, metric_key, collected_at"),
+            new Index("rmq_metric_snapshot", "idx_metric_snapshot_scope_cluster",
+                    "instance_id, metric_key, domain, labels_hash, cluster_id, availability, collected_at"),
+            new Index("rmq_metric_snapshot", "idx_metric_snapshot_scope_global",
+                    "instance_id, metric_key, domain, labels_hash, availability, collected_at"),
             new Index("rmq_metric_snapshot", "idx_metric_snapshot_retention", "collected_at"),
             new Index("rmq_alert_silence", "idx_alert_silence_active", "starts_at, ends_at"),
             new Index("rmq_alert_silence", "idx_alert_silence_scope", "domain, rule_id, instance_id"),

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -288,6 +288,8 @@ CREATE TABLE IF NOT EXISTS rmq_metric_snapshot (
   `collected_at` DATETIME NOT NULL,
   PRIMARY KEY (`id`),
   INDEX idx_metric_snapshot_lookup (`instance_id`, `metric_key`, `collected_at`),
+  INDEX idx_metric_snapshot_scope_cluster (`instance_id`, `metric_key`, `domain`, `labels_hash`, `cluster_id`, `availability`, `collected_at`),
+  INDEX idx_metric_snapshot_scope_global (`instance_id`, `metric_key`, `domain`, `labels_hash`, `availability`, `collected_at`),
   INDEX idx_metric_snapshot_retention (`collected_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSchemaMigrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSchemaMigrationTest.java
@@ -9,10 +9,17 @@ package org.apache.rocketmq.studio.ops.alert;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,5 +64,64 @@ class AlertSchemaMigrationTest {
             result.next();
             assertThat(result.getInt(1)).isEqualTo(3);
         }
+    }
+
+    @Test
+    void createsScopeCompleteMetricSnapshotIndexesWhenMigratingExistingTablesTest() throws Exception {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:alert-schema-migration-indexes;MODE=MySQL;DB_CLOSE_DELAY=-1;"
+                + "DATABASE_TO_LOWER=TRUE");
+        dataSource.setUser("sa");
+        try (Connection connection = dataSource.getConnection(); Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE rmq_alert_rule (id BIGINT PRIMARY KEY, name VARCHAR(128))");
+            statement.execute("CREATE TABLE rmq_system_alert (id BIGINT PRIMARY KEY, time TIMESTAMP)");
+        }
+
+        AlertSchemaMigration migration = new AlertSchemaMigration(dataSource);
+        migration.run(new DefaultApplicationArguments());
+        migration.run(new DefaultApplicationArguments());
+
+        try (Connection connection = dataSource.getConnection()) {
+            assertThat(indexColumns(connection, "rmq_metric_snapshot", "idx_metric_snapshot_scope_cluster"))
+                    .containsExactly("instance_id", "metric_key", "domain", "labels_hash", "cluster_id",
+                            "availability", "collected_at");
+            assertThat(indexColumns(connection, "rmq_metric_snapshot", "idx_metric_snapshot_scope_global"))
+                    .containsExactly("instance_id", "metric_key", "domain", "labels_hash", "availability",
+                            "collected_at");
+            assertThat(indexColumns(connection, "rmq_metric_snapshot", "idx_metric_snapshot_retention"))
+                    .containsExactly("collected_at");
+        }
+    }
+
+    @Test
+    void freshSchemaCreatesScopeCompleteMetricSnapshotIndexesTest() throws Exception {
+        try (Connection connection = DriverManager.getConnection(
+                "jdbc:h2:mem:alert-fresh-schema-indexes;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_LOWER=TRUE",
+                "sa", "")) {
+            ScriptUtils.executeSqlScript(connection, new ClassPathResource("db/schema.sql"));
+
+            assertThat(indexColumns(connection, "rmq_metric_snapshot", "idx_metric_snapshot_scope_cluster"))
+                    .containsExactly("instance_id", "metric_key", "domain", "labels_hash", "cluster_id",
+                            "availability", "collected_at");
+            assertThat(indexColumns(connection, "rmq_metric_snapshot", "idx_metric_snapshot_scope_global"))
+                    .containsExactly("instance_id", "metric_key", "domain", "labels_hash", "availability",
+                            "collected_at");
+            assertThat(indexColumns(connection, "rmq_metric_snapshot", "idx_metric_snapshot_retention"))
+                    .containsExactly("collected_at");
+        }
+    }
+
+    private static List<String> indexColumns(Connection connection, String table, String index) throws SQLException {
+        DatabaseMetaData metadata = connection.getMetaData();
+        List<String> columns = new ArrayList<>();
+        try (ResultSet indexes = metadata.getIndexInfo(connection.getCatalog(), null, table, false, false)) {
+            while (indexes.next()) {
+                String indexName = indexes.getString("INDEX_NAME");
+                if (indexName != null && indexName.equalsIgnoreCase(index)) {
+                    columns.add(indexes.getString("COLUMN_NAME"));
+                }
+            }
+        }
+        return columns;
     }
 }


### PR DESCRIPTION
## Summary
- add separate metric snapshot lookup indexes for cluster-scoped and global native alert aggregation
- keep the collected_at retention index for snapshot cleanup
- cover both fresh schema.sql and AlertSchemaMigration idempotent upgrade behavior

## MySQL query-plan expectation
Native alert aggregation filters by instance_id, metric_key, domain, labels_hash, availability and collected_at. Cluster-scoped rules also filter cluster_id. The new indexes keep all equality predicates before collected_at for both query shapes:
- cluster-scoped: instance_id, metric_key, domain, labels_hash, cluster_id, availability, collected_at
- global: instance_id, metric_key, domain, labels_hash, availability, collected_at

This avoids using one cluster_id-first index for global rules, where the missing cluster_id predicate would prevent later equality/range parts from being used effectively.

Closes #2682

## Verification
- RED: JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=AlertSchemaMigrationTest test failed before implementation because both new indexes were missing
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=AlertSchemaMigrationTest,DemoDataSqlCompatibilityTest test
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -DskipTests compile
- git diff --check
- MySQL 8.0 temporary container executed server/src/main/resources/db/schema.sql and verified INFORMATION_SCHEMA.STATISTICS column order for idx_metric_snapshot_scope_cluster, idx_metric_snapshot_scope_global and idx_metric_snapshot_retention