### PR TITLE
[Studio][Performance] Bound history cleanup deletes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryProperties.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryProperties.java
@@ -31,4 +31,14 @@ public class QueryHistoryProperties {
      * Number of days query records are retained. A non-positive value disables cleanup.
      */
     private int retentionDays = 90;
+
+    /**
+     * Maximum expired records deleted per database statement.
+     */
+    private int cleanupBatchSize = 500;
+
+    /**
+     * Maximum delete batches performed by one scheduled cleanup pass.
+     */
+    private int cleanupMaxBatches = 20;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
@@ -16,8 +16,8 @@
  */
 package org.apache.rocketmq.studio.instance.message;
 
-import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,10 +38,17 @@ import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 
 @Slf4j
 @Service
 public class QueryHistoryService {
+
+    private static final int DEFAULT_CLEANUP_BATCH_SIZE = 500;
+    private static final int MAX_CLEANUP_BATCH_SIZE = 5_000;
+    private static final int DEFAULT_CLEANUP_MAX_BATCHES = 20;
+    private static final int MAX_CLEANUP_MAX_BATCHES = 100;
 
     private final RmqMessageQueryMapper messageQueryMapper;
     private final RmqTraceQueryMapper traceQueryMapper;
@@ -239,8 +246,7 @@ public class QueryHistoryService {
 
     private void deleteExpiredMessageQueries(LocalDateTime cutoff) {
         try {
-            int deleted = messageQueryMapper.delete(Wrappers.<RmqMessageQuery>query()
-                    .lt("gmt_create", cutoff));
+            int deleted = deleteExpiredInBatches(messageQueryMapper, RmqMessageQuery::getId, cutoff);
             log.debug("Purged {} expired message query records", deleted);
         } catch (RuntimeException e) {
             log.warn("Failed to purge expired message query records: {}", e.getMessage());
@@ -249,12 +255,50 @@ public class QueryHistoryService {
 
     private void deleteExpiredTraceQueries(LocalDateTime cutoff) {
         try {
-            int deleted = traceQueryMapper.delete(Wrappers.<RmqTraceQuery>query()
-                    .lt("gmt_create", cutoff));
+            int deleted = deleteExpiredInBatches(traceQueryMapper, RmqTraceQuery::getId, cutoff);
             log.debug("Purged {} expired trace query records", deleted);
         } catch (RuntimeException e) {
             log.warn("Failed to purge expired trace query records: {}", e.getMessage());
         }
+    }
+
+    private <T> int deleteExpiredInBatches(BaseMapper<T> mapper, Function<T, Long> idExtractor,
+                                          LocalDateTime cutoff) {
+        int batchSize = boundedPositive(properties.getCleanupBatchSize(),
+                DEFAULT_CLEANUP_BATCH_SIZE, MAX_CLEANUP_BATCH_SIZE);
+        int maxBatches = boundedPositive(properties.getCleanupMaxBatches(),
+                DEFAULT_CLEANUP_MAX_BATCHES, MAX_CLEANUP_MAX_BATCHES);
+        int totalDeleted = 0;
+        for (int batch = 0; batch < maxBatches; batch++) {
+            List<T> expired = mapper.selectList(new QueryWrapper<T>()
+                    .select("id")
+                    .lt("gmt_create", cutoff)
+                    .orderByAsc("gmt_create", "id")
+                    .last("LIMIT " + batchSize));
+            if (expired.isEmpty()) {
+                break;
+            }
+            List<Long> ids = expired.stream()
+                    .map(idExtractor)
+                    .filter(Objects::nonNull)
+                    .toList();
+            if (ids.isEmpty()) {
+                break;
+            }
+            int deleted = mapper.deleteByIds(ids);
+            totalDeleted += deleted;
+            if (deleted < batchSize) {
+                break;
+            }
+        }
+        return totalDeleted;
+    }
+
+    private static int boundedPositive(int value, int defaultValue, int maxValue) {
+        if (value <= 0) {
+            return defaultValue;
+        }
+        return Math.min(value, maxValue);
     }
 
     private static LocalDateTime latestOf(LocalDateTime left, LocalDateTime right) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditRepository.java
@@ -29,5 +29,5 @@ public interface AuditRepository {
 
     void save(AuditRecordVO record);
 
-    int deleteBefore(LocalDateTime cutoff);
+    int deleteBefore(LocalDateTime cutoff, int batchSize, int maxBatches);
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditService.java
@@ -37,6 +37,8 @@ public class AuditService {
 
     private static final int MAX_PAGE_SIZE = 100;
     private static final int MAX_EXPORT_RECORDS = 10_000;
+    private static final int CLEANUP_BATCH_SIZE = 500;
+    private static final int CLEANUP_MAX_BATCHES = 20;
     private static final String CSV_HEADER =
             "timestamp,operator,operationType,resourceType,target,clusterId,detail,result,errorMessage\r\n";
 
@@ -118,7 +120,7 @@ public class AuditService {
         }
         log.info("Cleaning up audit logs older than {} days", beforeDays);
         LocalDateTime cutoff = LocalDateTime.now().minusDays(beforeDays);
-        return auditRepository.deleteBefore(cutoff);
+        return auditRepository.deleteBefore(cutoff, CLEANUP_BATCH_SIZE, CLEANUP_MAX_BATCHES);
     }
 
     private void validatePagination(int page, int pageSize) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
@@ -95,9 +95,31 @@ public class MybatisPlusAuditRepository implements AuditRepository {
     }
 
     @Override
-    public int deleteBefore(LocalDateTime cutoff) {
-        return Math.toIntExact(auditMapper.delete(
-                new QueryWrapper<RmqOperationAudit>().lt("gmt_create", cutoff)));
+    public int deleteBefore(LocalDateTime cutoff, int batchSize, int maxBatches) {
+        int totalDeleted = 0;
+        for (int batch = 0; batch < maxBatches; batch++) {
+            List<RmqOperationAudit> expired = auditMapper.selectList(new QueryWrapper<RmqOperationAudit>()
+                    .select("id")
+                    .lt("gmt_create", cutoff)
+                    .orderByAsc("gmt_create", "id")
+                    .last("LIMIT " + batchSize));
+            if (expired.isEmpty()) {
+                break;
+            }
+            List<Long> ids = expired.stream()
+                    .map(RmqOperationAudit::getId)
+                    .filter(Objects::nonNull)
+                    .toList();
+            if (ids.isEmpty()) {
+                break;
+            }
+            int deleted = auditMapper.deleteByIds(ids);
+            totalDeleted += deleted;
+            if (deleted < batchSize) {
+                break;
+            }
+        }
+        return totalDeleted;
     }
 
     private List<String> findDistinctValues(List<Map<String, Object>> rows, String column) {

--- a/server/src/main/resources/db/schema.sql
+++ b/server/src/main/resources/db/schema.sql
@@ -149,7 +149,7 @@ CREATE TABLE IF NOT EXISTS rmq_instance_message (
   cluster_id VARCHAR(255),
   queried_by VARCHAR(128),
   PRIMARY KEY (`id`),
-  INDEX idx_message_query_gmt_create (gmt_create),
+  INDEX idx_message_query_cleanup (gmt_create, id),
   INDEX idx_topic (topic)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -166,7 +166,7 @@ CREATE TABLE IF NOT EXISTS rmq_instance_trace (
   queried_by VARCHAR(128),
   PRIMARY KEY (`id`),
   INDEX idx_msg_id (msg_id),
-  INDEX idx_trace_query_gmt_create (gmt_create)
+  INDEX idx_trace_query_cleanup (gmt_create, id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 8. 操作审计日志（所有写操作）
@@ -183,7 +183,7 @@ CREATE TABLE IF NOT EXISTS rmq_operation_audit (
   error_message TEXT,
   operator VARCHAR(128),
   PRIMARY KEY (`id`),
-  INDEX idx_gmt_create (gmt_create),
+  INDEX idx_operation_audit_cleanup (gmt_create, id),
   INDEX idx_resource (resource_type, resource_name),
   INDEX idx_operation (operation)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
@@ -33,11 +33,13 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -83,17 +85,70 @@ class QueryHistoryServiceTest {
     @Test
     void purgesBothQueryHistoriesUsingConfiguredRetention() {
         properties.setRetentionDays(7);
-        when(messageQueryMapper.delete(any())).thenReturn(2);
-        when(traceQueryMapper.delete(any())).thenReturn(3);
+        when(messageQueryMapper.selectList(any())).thenReturn(List.of());
+        when(traceQueryMapper.selectList(any())).thenReturn(List.of());
 
         service.purgeExpiredQueries();
 
         ArgumentCaptor<Wrapper<RmqMessageQuery>> messageCaptor = ArgumentCaptor.forClass(Wrapper.class);
         ArgumentCaptor<Wrapper<RmqTraceQuery>> traceCaptor = ArgumentCaptor.forClass(Wrapper.class);
-        verify(messageQueryMapper).delete(messageCaptor.capture());
-        verify(traceQueryMapper).delete(traceCaptor.capture());
-        assertThat(messageCaptor.getValue().getCustomSqlSegment()).contains("gmt_create");
-        assertThat(traceCaptor.getValue().getCustomSqlSegment()).contains("gmt_create");
+        verify(messageQueryMapper).selectList(messageCaptor.capture());
+        verify(traceQueryMapper).selectList(traceCaptor.capture());
+        assertThat(messageCaptor.getValue().getCustomSqlSegment())
+                .contains("gmt_create", "ORDER BY gmt_create ASC,id ASC", "LIMIT 500");
+        assertThat(traceCaptor.getValue().getCustomSqlSegment())
+                .contains("gmt_create", "ORDER BY gmt_create ASC,id ASC", "LIMIT 500");
+    }
+
+    @Test
+    void purgeExpiredQueriesDeletesMessageAndTraceHistoryInBoundedBatchesTest() {
+        properties.setRetentionDays(7);
+        properties.setCleanupBatchSize(2);
+        properties.setCleanupMaxBatches(3);
+        RmqMessageQuery message1 = messageQuery(1L);
+        RmqMessageQuery message2 = messageQuery(2L);
+        RmqMessageQuery message3 = messageQuery(3L);
+        RmqTraceQuery trace1 = traceQuery(11L);
+        RmqTraceQuery trace2 = traceQuery(12L);
+        when(messageQueryMapper.selectList(any()))
+                .thenReturn(List.of(message1, message2), List.of(message3));
+        when(traceQueryMapper.selectList(any()))
+                .thenReturn(List.of(trace1, trace2), List.of());
+        when(messageQueryMapper.deleteByIds(List.of(1L, 2L))).thenReturn(2);
+        when(messageQueryMapper.deleteByIds(List.of(3L))).thenReturn(1);
+        when(traceQueryMapper.deleteByIds(List.of(11L, 12L))).thenReturn(2);
+
+        service.purgeExpiredQueries();
+
+        ArgumentCaptor<Wrapper<RmqMessageQuery>> messageQueryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        ArgumentCaptor<Wrapper<RmqTraceQuery>> traceQueryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(messageQueryMapper, times(2)).selectList(messageQueryCaptor.capture());
+        verify(traceQueryMapper, times(2)).selectList(traceQueryCaptor.capture());
+        assertThat(messageQueryCaptor.getAllValues().get(0).getCustomSqlSegment())
+                .contains("gmt_create", "ORDER BY gmt_create ASC,id ASC", "LIMIT 2");
+        assertThat(traceQueryCaptor.getAllValues().get(0).getCustomSqlSegment())
+                .contains("gmt_create", "ORDER BY gmt_create ASC,id ASC", "LIMIT 2");
+        verify(messageQueryMapper).deleteByIds(List.of(1L, 2L));
+        verify(messageQueryMapper).deleteByIds(List.of(3L));
+        verify(traceQueryMapper).deleteByIds(List.of(11L, 12L));
+        verify(messageQueryMapper, never()).delete(any());
+        verify(traceQueryMapper, never()).delete(any());
+    }
+
+    @Test
+    void purgeExpiredQueriesContinuesTraceCleanupWhenMessageCleanupFailsTest() {
+        properties.setRetentionDays(7);
+        properties.setCleanupBatchSize(2);
+        properties.setCleanupMaxBatches(3);
+        when(messageQueryMapper.selectList(any())).thenThrow(new IllegalStateException("message db down"));
+        RmqTraceQuery trace = traceQuery(21L);
+        when(traceQueryMapper.selectList(any())).thenReturn(List.of(trace));
+        when(traceQueryMapper.deleteByIds(List.of(21L))).thenReturn(1);
+
+        service.purgeExpiredQueries();
+
+        verify(traceQueryMapper).selectList(any());
+        verify(traceQueryMapper).deleteByIds(List.of(21L));
     }
 
     @Test
@@ -164,5 +219,17 @@ class QueryHistoryServiceTest {
         verify(traceQueryMapper).selectCount(traceCountCaptor.capture());
         assertThat(messageCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
         assertThat(traceCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
+    }
+
+    private static RmqMessageQuery messageQuery(Long id) {
+        RmqMessageQuery query = new RmqMessageQuery();
+        query.setId(id);
+        return query;
+    }
+
+    private static RmqTraceQuery traceQuery(Long id) {
+        RmqTraceQuery query = new RmqTraceQuery();
+        query.setId(id);
+        return query;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
@@ -201,4 +201,14 @@ class AuditServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("beforeDays must not exceed 365");
     }
+
+    @Test
+    void cleanupLogsUsesBoundedRepositoryBatchesTest() {
+        when(auditRepository.deleteBefore(any(LocalDateTime.class), eq(500), eq(20))).thenReturn(500);
+
+        int deleted = auditService.cleanupLogs(90);
+
+        assertThat(deleted).isEqualTo(500);
+        verify(auditRepository).deleteBefore(any(LocalDateTime.class), eq(500), eq(20));
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
@@ -36,6 +36,8 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -107,4 +109,48 @@ class MybatisPlusAuditRepositoryTest {
                 .contains("GROUP BY operation,resource_type,cluster_id,result");
     }
 
+    @Test
+    void deleteBeforeShouldUseBoundedIdBatchesTest() {
+        RmqOperationAudit audit1 = auditRecord(1L);
+        RmqOperationAudit audit2 = auditRecord(2L);
+        RmqOperationAudit audit3 = auditRecord(3L);
+        when(auditMapper.selectList(any()))
+                .thenReturn(List.of(audit1, audit2), List.of(audit3));
+        when(auditMapper.deleteByIds(List.of(1L, 2L))).thenReturn(2);
+        when(auditMapper.deleteByIds(List.of(3L))).thenReturn(1);
+
+        int deleted = repository.deleteBefore(LocalDateTime.of(2026, 8, 1, 0, 0), 2, 5);
+
+        ArgumentCaptor<Wrapper<RmqOperationAudit>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(auditMapper, times(2)).selectList(queryCaptor.capture());
+        assertThat(queryCaptor.getAllValues().get(0).getSqlSegment())
+                .contains("gmt_create", "ORDER BY gmt_create ASC,id ASC", "LIMIT 2");
+        verify(auditMapper).deleteByIds(List.of(1L, 2L));
+        verify(auditMapper).deleteByIds(List.of(3L));
+        verify(auditMapper, never()).delete(any());
+        assertThat(deleted).isEqualTo(3);
+    }
+
+    @Test
+    void deleteBeforeShouldStopAfterConfiguredMaxBatchesTest() {
+        when(auditMapper.selectList(any()))
+                .thenReturn(List.of(auditRecord(1L), auditRecord(2L)))
+                .thenReturn(List.of(auditRecord(3L), auditRecord(4L)))
+                .thenReturn(List.of(auditRecord(5L), auditRecord(6L)));
+        when(auditMapper.deleteByIds(List.of(1L, 2L))).thenReturn(2);
+        when(auditMapper.deleteByIds(List.of(3L, 4L))).thenReturn(2);
+
+        int deleted = repository.deleteBefore(LocalDateTime.of(2026, 8, 1, 0, 0), 2, 2);
+
+        verify(auditMapper, times(2)).selectList(any());
+        verify(auditMapper).deleteByIds(List.of(1L, 2L));
+        verify(auditMapper).deleteByIds(List.of(3L, 4L));
+        assertThat(deleted).isEqualTo(4);
+    }
+
+    private static RmqOperationAudit auditRecord(Long id) {
+        RmqOperationAudit audit = new RmqOperationAudit();
+        audit.setId(id);
+        return audit;
+    }
 }


### PR DESCRIPTION
## Summary
- delete expired message query, trace query, and audit rows in bounded ID batches
- cap each cleanup pass so large inventories do not create one massive transaction
- align cleanup selectors with `(gmt_create, id)` schema indexes

## Tests
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=QueryHistoryServiceTest,MybatisPlusAuditRepositoryTest,AuditServiceTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q -Dtest=QueryHistoryServiceIntegrationTest,QueryHistoryControllerTest,AuditControllerTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -q test`

Closes #2683