### PR TITLE
fix(studio): refresh inventory pages after deletes

### DIFF
--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -294,6 +294,123 @@ describe('Consumer page', () => {
     message.destroy();
   });
 
+  it('reloads the server page after deleting one consumer group', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
+      void config.onOk?.();
+      return { destroy: vi.fn(), update: vi.fn() } as unknown as ReturnType<typeof Modal.confirm>;
+    });
+    vi.mocked(consumerService.deleteConsumerGroup).mockResolvedValue(undefined);
+    vi.mocked(consumerService.listConsumerGroupPage)
+      .mockResolvedValueOnce(groupPage([group]))
+      .mockResolvedValueOnce(groupPage([]));
+    renderWithProviders(<ConsumerPage />);
+
+    const row = await screen.findByRole('row', { name: /remote-cg/ });
+    await user.click(within(row).getByRole('button', { name: /删除/ }));
+
+    await waitFor(() =>
+      expect(consumerService.deleteConsumerGroup).toHaveBeenCalledWith('remote-cg', 'instance-1'),
+    );
+    await waitFor(() => expect(screen.queryByText('remote-cg')).not.toBeInTheDocument());
+    expect(screen.getByText('管理消费者组订阅关系与消费进度，共 0 个 Group')).toBeInTheDocument();
+    expect(consumerService.listConsumerGroupPage).toHaveBeenCalledTimes(2);
+    confirmSpy.mockRestore();
+  });
+
+  it('moves back from an emptied last consumer group page after batch deletion', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
+      void config.onOk?.();
+      return { destroy: vi.fn(), update: vi.fn() } as unknown as ReturnType<typeof Modal.confirm>;
+    });
+    const firstPage = Array.from({ length: 20 }, (_, index) => ({
+      ...group,
+      name: `cg-${String(index + 1).padStart(2, '0')}`,
+    }));
+    const lastGroup = { ...group, name: 'cg-21' };
+    let deletedLastPage = false;
+    vi.mocked(consumerService.listConsumerGroupPage).mockImplementation(async (params) => {
+      if (params?.page === 2) {
+        return groupPage(deletedLastPage ? [] : [lastGroup], {
+          total: deletedLastPage ? 20 : 21,
+          page: 2,
+          size: 20,
+        });
+      }
+      return groupPage(firstPage, { total: deletedLastPage ? 20 : 21, page: 1, size: 20 });
+    });
+    vi.mocked(consumerService.batchDeleteConsumerGroups).mockImplementation(async () => {
+      deletedLastPage = true;
+      return {
+        deleted: ['cg-21'],
+        failed: [],
+      };
+    });
+    renderWithProviders(<ConsumerPage />);
+
+    expect(await screen.findByText('cg-01')).toBeInTheDocument();
+    await user.click(document.querySelector('.ant-pagination-item-2') as HTMLElement);
+    expect(await screen.findByText('cg-21')).toBeInTheDocument();
+    await user.click(screen.getAllByRole('checkbox')[0]);
+    await user.click(screen.getByRole('button', { name: /删除 \(1\)$/ }));
+
+    await waitFor(() =>
+      expect(consumerService.batchDeleteConsumerGroups).toHaveBeenCalledWith(
+        ['cg-21'],
+        'instance-1',
+      ),
+    );
+    await waitFor(() => expect(screen.queryByText('cg-21')).not.toBeInTheDocument());
+    expect(screen.getByText('cg-01')).toBeInTheDocument();
+    expect(consumerService.listConsumerGroupPage).toHaveBeenLastCalledWith({
+      instanceId: 'instance-1',
+      search: undefined,
+      page: 1,
+      pageSize: 20,
+    });
+    confirmSpy.mockRestore();
+  });
+
+  it('keeps failed consumer groups selected after a partially successful batch deletion', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
+      void config.onOk?.();
+      return { destroy: vi.fn(), update: vi.fn() } as unknown as ReturnType<typeof Modal.confirm>;
+    });
+    const groups = ['cg-01', 'cg-02', 'cg-03'].map((name) => ({ ...group, name }));
+    vi.mocked(consumerService.listConsumerGroupPage)
+      .mockResolvedValueOnce(groupPage(groups))
+      .mockResolvedValueOnce(groupPage([{ ...group, name: 'cg-02' }]));
+    vi.mocked(consumerService.batchDeleteConsumerGroups).mockResolvedValue({
+      deleted: ['cg-01', 'cg-03'],
+      failed: ['cg-02'],
+    });
+    renderWithProviders(<ConsumerPage />);
+
+    expect(await screen.findByText('cg-01')).toBeInTheDocument();
+    await user.click(screen.getAllByRole('checkbox')[0]);
+    await user.click(screen.getByRole('button', { name: /删除 \(3\)$/ }));
+
+    await waitFor(() =>
+      expect(consumerService.batchDeleteConsumerGroups).toHaveBeenCalledWith(
+        ['cg-01', 'cg-02', 'cg-03'],
+        'instance-1',
+      ),
+    );
+    await waitFor(() => expect(screen.queryByText('cg-01')).not.toBeInTheDocument());
+    expect(screen.getByText('cg-02')).toBeInTheDocument();
+    expect(screen.queryByText('cg-03')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /删除 \(1\)$/ })).toBeInTheDocument();
+    expect(consumerService.listConsumerGroupPage).toHaveBeenLastCalledWith({
+      instanceId: 'instance-1',
+      search: undefined,
+      page: 1,
+      pageSize: 20,
+    });
+    confirmSpy.mockRestore();
+  });
+
   it('submits the canonical global delivery order type', async () => {
     const user = userEvent.setup();
     const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {

--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -19,7 +19,7 @@ import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vite
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { App } from 'antd';
+import { App, Modal } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
 import type { BrokerRoute, Topic } from '../../../api/metadata';
 import { parseMessageProperties } from '../../../utils/messageProperties';
@@ -191,6 +191,7 @@ describe('TopicPage', () => {
   });
 
   afterEach(() => {
+    Modal.destroyAll();
     vi.clearAllMocks();
   });
 
@@ -411,7 +412,20 @@ describe('TopicPage', () => {
 
   it('keeps failed topics selected after a partially successful batch deletion', async () => {
     const user = userEvent.setup();
-    mockTopicsList(buildTopics(3));
+    const remainingTopics = [buildTopics(3)[1]];
+    topicServiceMocks.listTopicsPage
+      .mockResolvedValueOnce({
+        items: buildTopics(3),
+        total: 3,
+        page: 1,
+        size: 20,
+      })
+      .mockResolvedValueOnce({
+        items: remainingTopics,
+        total: 1,
+        page: 1,
+        size: 20,
+      });
     topicServiceMocks.batchDeleteTopics.mockResolvedValue({
       deleted: ['topic-01', 'topic-03'],
       failed: ['topic-02'],
@@ -430,6 +444,104 @@ describe('TopicPage', () => {
     expect(screen.queryByText('topic-03')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /删除 \(1\)$/ })).toBeInTheDocument();
     expect(screen.getByText('已删除 2 个 Topic，1 个删除失败')).toBeInTheDocument();
+    expect(topicServiceMocks.listTopicsPage).toHaveBeenLastCalledWith({
+      instanceId: 'instance-proxy-1',
+      type: undefined,
+      search: undefined,
+      page: 1,
+      pageSize: 20,
+    });
+  });
+
+  it('reloads the server page after deleting one topic', async () => {
+    const user = userEvent.setup();
+    const topic = buildTopics(1)[0];
+    topicServiceMocks.listTopicsPage
+      .mockResolvedValueOnce({
+        items: [topic],
+        total: 1,
+        page: 1,
+        size: 20,
+      })
+      .mockResolvedValueOnce({
+        items: [],
+        total: 0,
+        page: 1,
+        size: 20,
+      });
+    topicServiceMocks.deleteTopic.mockResolvedValue(undefined);
+    renderWithProviders();
+
+    const row = await screen.findByRole('row', { name: /topic-01/ });
+    await user.click(within(row).getByRole('button', { name: /删除/ }));
+    const dialog = (await screen.findByText(/确定要删除 Topic「topic-01」/)).closest(
+      '.ant-modal',
+    ) as HTMLElement;
+    await user.click(within(dialog).getByRole('button', { name: /删\s*除/ }));
+
+    await waitFor(() =>
+      expect(topicServiceMocks.deleteTopic).toHaveBeenCalledWith('topic-01', 'instance-proxy-1'),
+    );
+    await waitFor(() => expect(screen.queryByText('topic-01')).not.toBeInTheDocument());
+    expect(screen.getByText('共 0 个 Topic')).toBeInTheDocument();
+    expect(topicServiceMocks.listTopicsPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('moves back from an emptied last topic page after batch deletion', async () => {
+    const user = userEvent.setup();
+    const firstPage = buildTopics(20);
+    const secondPage = [buildTopics(21)[20]];
+    let deletedLastPage = false;
+    topicServiceMocks.listTopicsPage.mockImplementation(async (params) => {
+      if (params.page === 2) {
+        return {
+          items: deletedLastPage ? [] : secondPage,
+          total: deletedLastPage ? 20 : 21,
+          page: 2,
+          size: 20,
+        };
+      }
+      return {
+        items: firstPage,
+        total: deletedLastPage ? 20 : 21,
+        page: 1,
+        size: 20,
+      };
+    });
+    topicServiceMocks.batchDeleteTopics.mockImplementation(async () => {
+      deletedLastPage = true;
+      return {
+        deleted: ['topic-21'],
+        failed: [],
+      };
+    });
+    renderWithProviders();
+
+    expect(await screen.findByText('topic-01')).toBeInTheDocument();
+    await user.click(document.querySelector('.ant-pagination-item-2') as HTMLElement);
+    expect(await screen.findByText('topic-21')).toBeInTheDocument();
+    await user.click(screen.getAllByRole('checkbox')[0]);
+    await user.click(screen.getByRole('button', { name: /删除 \(1\)$/ }));
+    const dialog = (await screen.findByText(/确定要删除选中的 1 个 Topic/)).closest(
+      '.ant-modal',
+    ) as HTMLElement;
+    await user.click(within(dialog).getByRole('button', { name: /删\s*除/ }));
+
+    await waitFor(() =>
+      expect(topicServiceMocks.batchDeleteTopics).toHaveBeenCalledWith(
+        ['topic-21'],
+        'instance-proxy-1',
+      ),
+    );
+    await waitFor(() => expect(screen.queryByText('topic-21')).not.toBeInTheDocument());
+    expect(screen.getByText('topic-01')).toBeInTheDocument();
+    expect(topicServiceMocks.listTopicsPage).toHaveBeenLastCalledWith({
+      instanceId: 'instance-proxy-1',
+      type: undefined,
+      search: undefined,
+      page: 1,
+      pageSize: 20,
+    });
   });
 
   it('filters topics by the instance from the route and shows its endpoint', async () => {

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -303,6 +303,40 @@ const ConsumerPageContent = ({
   }, []);
   const selectedGroupName = selectedGroup?.name;
 
+  const loadConsumerGroupPage = useCallback(
+    async (pageToLoad = page, pageSizeToLoad = pageSize, silent = false) => {
+      if (!selectedInstanceId) return undefined;
+      const requestId = ++groupRequestIdRef.current;
+      if (!silent) setLoading(true);
+      try {
+        const result = await listConsumerGroupPage({
+          instanceId: selectedInstanceId,
+          search: search.trim() || undefined,
+          page: pageToLoad,
+          pageSize: pageSizeToLoad,
+        });
+        if (requestId === groupRequestIdRef.current) {
+          setGroups(result.items);
+          setTotalGroups(result.total);
+        }
+        return requestId === groupRequestIdRef.current ? result : undefined;
+      } catch {
+        if (requestId === groupRequestIdRef.current) message.error(t('consumer.fetchListFailed'));
+        return undefined;
+      } finally {
+        if (requestId === groupRequestIdRef.current) setLoading(false);
+      }
+    },
+    [t, selectedInstanceId, search, page, pageSize],
+  );
+
+  const reloadConsumerGroupPageAfterDelete = useCallback(async () => {
+    const result = await loadConsumerGroupPage(page, pageSize);
+    if (result && page > 1 && result.items.length === 0 && result.total > 0) {
+      setPage(page - 1);
+    }
+  }, [loadConsumerGroupPage, page, pageSize]);
+
   useEffect(() => {
     if (!selectedInstanceId) {
       groupRequestIdRef.current += 1;
@@ -318,32 +352,13 @@ const ConsumerPageContent = ({
     }
     const silent = silentRefreshRef.current;
     silentRefreshRef.current = false;
-    const requestId = ++groupRequestIdRef.current;
     const timer = window.setTimeout(() => {
-      if (!silent) setLoading(true);
-      void listConsumerGroupPage({
-        instanceId: selectedInstanceId,
-        search: search.trim() || undefined,
-        page,
-        pageSize,
-      })
-        .then((result) => {
-          if (requestId === groupRequestIdRef.current) {
-            setGroups(result.items);
-            setTotalGroups(result.total);
-          }
-        })
-        .catch(() => {
-          if (requestId === groupRequestIdRef.current) message.error(t('consumer.fetchListFailed'));
-        })
-        .finally(() => {
-          if (requestId === groupRequestIdRef.current) setLoading(false);
-        });
+      void loadConsumerGroupPage(page, pageSize, silent);
     }, 0);
     return () => {
       window.clearTimeout(timer);
     };
-  }, [t, selectedInstanceId, search, page, pageSize, instancesLoading, refreshKey]);
+  }, [selectedInstanceId, page, pageSize, instancesLoading, refreshKey, loadConsumerGroupPage]);
 
   useEffect(() => {
     if (!autoRefresh || !selectedInstanceId) {
@@ -939,7 +954,7 @@ const ConsumerPageContent = ({
                 cancelText: '取消',
                 onOk: async () => {
                   await deleteConsumerGroup(record.name, selectedInstanceId || undefined);
-                  setGroups((prev) => prev.filter((group) => group.name !== record.name));
+                  await reloadConsumerGroupPageAfterDelete();
                   setSelectedRowKeys((prev) => prev.filter((key) => key !== record.name));
                   message.success(`消费组 ${record.name} 已删除`);
                 },
@@ -1340,14 +1355,12 @@ const ConsumerPageContent = ({
                       names,
                       selectedInstanceId || undefined,
                     );
-                    setGroups((prev) => prev.filter((g) => !deleted.includes(g.name)));
+                    if (deleted.length > 0) await reloadConsumerGroupPageAfterDelete();
                     if (failed.length > 0) {
                       message.warning(
                         `已删除 ${deleted.length} 个，失败 ${failed.length} 个：${failed.join(', ')}`,
                       );
-                      setSelectedRowKeys((prev) =>
-                        prev.filter((key) => !deleted.includes(String(key))),
-                      );
+                      setSelectedRowKeys(failed);
                     } else {
                       message.success(`已删除 ${deleted.length} 个 Group`);
                       setSelectedRowKeys([]);

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -355,6 +355,42 @@ const TopicPage = () => {
   const consumersRequestIdRef = useRef(0);
   const createInFlightRef = useRef(false);
 
+  const loadTopicPage = useCallback(
+    async (pageToLoad = tablePage, pageSizeToLoad = tablePageSize) => {
+      if (!selectedInstanceId) return undefined;
+      const requestId = ++topicRequestIdRef.current;
+      setLoading(true);
+      try {
+        const result = await listTopicsPage({
+          instanceId: selectedInstanceId,
+          type: typeFilter || undefined,
+          search: searchText.trim() || undefined,
+          page: pageToLoad,
+          pageSize: pageSizeToLoad,
+        });
+        if (requestId === topicRequestIdRef.current) {
+          setTopics(result.items);
+          setTotalTopics(result.total);
+        }
+        return requestId === topicRequestIdRef.current ? result : undefined;
+      } catch {
+        if (requestId === topicRequestIdRef.current)
+          message.error('Topic 列表加载失败，请稍后重试');
+        return undefined;
+      } finally {
+        if (requestId === topicRequestIdRef.current) setLoading(false);
+      }
+    },
+    [selectedInstanceId, typeFilter, searchText, tablePage, tablePageSize],
+  );
+
+  const reloadTopicPageAfterDelete = useCallback(async () => {
+    const result = await loadTopicPage(tablePage, tablePageSize);
+    if (result && tablePage > 1 && result.items.length === 0 && result.total > 0) {
+      setTablePage(tablePage - 1);
+    }
+  }, [loadTopicPage, tablePage, tablePageSize]);
+
   useEffect(() => {
     if (!selectedInstanceId) {
       topicRequestIdRef.current += 1;
@@ -368,35 +404,14 @@ const TopicPage = () => {
         window.clearTimeout(resetTimer);
       };
     }
-    const requestId = ++topicRequestIdRef.current;
     const timer = window.setTimeout(() => {
-      setLoading(true);
-      void listTopicsPage({
-        instanceId: selectedInstanceId,
-        type: typeFilter || undefined,
-        search: searchText.trim() || undefined,
-        page: tablePage,
-        pageSize: tablePageSize,
-      })
-        .then((result) => {
-          if (requestId === topicRequestIdRef.current) {
-            setTopics(result.items);
-            setTotalTopics(result.total);
-          }
-        })
-        .catch(() => {
-          if (requestId === topicRequestIdRef.current)
-            message.error('Topic 列表加载失败，请稍后重试');
-        })
-        .finally(() => {
-          if (requestId === topicRequestIdRef.current) setLoading(false);
-        });
+      void loadTopicPage(tablePage, tablePageSize);
     }, 0);
 
     return () => {
       window.clearTimeout(timer);
     };
-  }, [selectedInstanceId, typeFilter, searchText, tablePage, tablePageSize, instancesLoading]);
+  }, [selectedInstanceId, tablePage, tablePageSize, instancesLoading, loadTopicPage]);
 
   // ─── Filtered data ─────────────────────────────────────────────
   const filteredTopics = useMemo(
@@ -563,7 +578,7 @@ const TopicPage = () => {
         onOk: async () => {
           try {
             await deleteTopic(topic.name, selectedInstanceId || undefined);
-            setTopics((previous) => previous.filter((item) => item.name !== topic.name));
+            await reloadTopicPageAfterDelete();
             message.success(`Topic「${topic.name}」已删除`);
           } catch {
             message.error('删除 Topic 失败，请稍后重试');
@@ -1327,12 +1342,7 @@ const TopicPage = () => {
                         names,
                         selectedInstanceId || undefined,
                       );
-                      if (deleted.length > 0) {
-                        const deletedNames = new Set(deleted);
-                        setTopics((previous) =>
-                          previous.filter((topic) => !deletedNames.has(topic.name)),
-                        );
-                      }
+                      if (deleted.length > 0) await reloadTopicPageAfterDelete();
                       setSelectedRowKeys(failed);
 
                       if (failed.length === 0) {


### PR DESCRIPTION
## Summary
- reload Topic and Consumer Group server-backed pages after single and batch deletes
- move back from an emptied last page after successful deletion
- keep failed batch-delete rows selected after partial failures

Closes #2680

## Verification
- npm test -- src/pages/instance/__tests__/TopicPage.test.tsx src/pages/instance/__tests__/ConsumerPage.test.tsx
- npx eslint src/pages/instance/topic.tsx src/pages/instance/consumer.tsx src/pages/instance/__tests__/TopicPage.test.tsx src/pages/instance/__tests__/ConsumerPage.test.tsx
- npm run build