### PR TITLE
fix(studio): resolve stale native alerts after resources disappear

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/ClusterMetricsCollector.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/ClusterMetricsCollector.java
@@ -19,10 +19,15 @@ package org.apache.rocketmq.studio.cluster.metrics;
 import org.apache.rocketmq.studio.instance.InstanceVO;
 
 import java.util.List;
+import java.util.Set;
 
 /** Collects operational metrics for one Studio-managed instance. */
 public interface ClusterMetricsCollector {
     boolean supports(InstanceVO instance);
 
     List<MetricSample> collect(InstanceVO instance);
+
+    default Set<String> metricKeys() {
+        return Set.of();
+    }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/CollectorScheduler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/CollectorScheduler.java
@@ -20,6 +20,7 @@ import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.InstanceVO;
+import org.apache.rocketmq.studio.ops.alert.AlertDomain;
 import org.apache.rocketmq.studio.ops.alert.NativeAlertProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -35,6 +36,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Set;
 
 /** Runs independent, bounded collection jobs for each configured instance. */
 @Slf4j
@@ -123,7 +125,10 @@ public class CollectorScheduler {
     private void collectClusterMetrics(InstanceVO instance) {
         for (ClusterMetricsCollector collector : clusterCollectors) {
             try {
-                persist(collector.supports(instance) ? collector.collect(instance) : List.of());
+                if (collector.supports(instance)) {
+                    List<MetricSample> samples = collector.collect(instance);
+                    persist(AlertDomain.CLUSTER, instance, collector.metricKeys(), samples);
+                }
             } catch (RuntimeException error) {
                 log.warn("Native metric collector failed for instance {}: {}", instance.getName(), error.getMessage());
             }
@@ -133,23 +138,40 @@ public class CollectorScheduler {
     private void collectBusinessMetrics(InstanceVO instance) {
         for (BusinessMetricsCollector collector : businessCollectors) {
             try {
-                persist(collector.supports(instance) ? collector.collect(instance) : List.of());
+                if (collector.supports(instance)) {
+                    List<MetricSample> samples = collector.collect(instance);
+                    persist(AlertDomain.BUSINESS, instance, collector.metricKeys(), samples);
+                }
             } catch (RuntimeException error) {
                 log.warn("Native metric collector failed for instance {}: {}", instance.getName(), error.getMessage());
             }
         }
     }
 
-    private void persist(List<MetricSample> samples) {
-        if (!samples.isEmpty()) {
-            // Refresh immediately before persisting so a slow remote collection cannot write after lease loss.
-            if (!collectionLease.tryAcquire()) {
-                log.debug("Discarding native metric samples because the collection lease was lost");
-                return;
-            }
-            snapshotRepository.saveAll(samples);
-            alertProcessor.process(samples);
+    private void persist(AlertDomain domain, InstanceVO instance, Set<String> declaredMetricKeys,
+            List<MetricSample> samples) {
+        List<MetricSample> collected = samples == null ? List.of() : samples;
+        Set<String> scopeMetricKeys = metricKeys(declaredMetricKeys, collected);
+        if (scopeMetricKeys.isEmpty()) {
+            return;
         }
+        MetricCollectionScope actualScope = new MetricCollectionScope(domain, instance.getName(), scopeMetricKeys);
+        // Refresh immediately before persisting so a slow remote collection cannot write after lease loss.
+        if (!collectionLease.tryAcquire()) {
+            log.debug("Discarding native metric samples because the collection lease was lost");
+            return;
+        }
+        if (!collected.isEmpty()) {
+            snapshotRepository.saveAll(collected);
+        }
+        alertProcessor.processSuccessfulCollection(actualScope, collected);
+    }
+
+    private static Set<String> metricKeys(Set<String> declared, List<MetricSample> samples) {
+        if (declared != null && !declared.isEmpty()) {
+            return declared;
+        }
+        return samples.stream().map(MetricSample::metricKey).collect(java.util.stream.Collectors.toSet());
     }
 
     @PreDestroy

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricCollectionScope.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricCollectionScope.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import org.apache.rocketmq.studio.ops.alert.AlertDomain;
+
+import java.util.Objects;
+import java.util.Set;
+
+/** Identifies one successful native metric collection scope. */
+public record MetricCollectionScope(AlertDomain domain, String instanceId, Set<String> metricKeys) {
+    public MetricCollectionScope {
+        Objects.requireNonNull(domain, "domain is required");
+        if (instanceId == null || instanceId.isBlank()) {
+            throw new IllegalArgumentException("instanceId is required");
+        }
+        metricKeys = Set.copyOf(metricKeys == null ? Set.of() : metricKeys);
+        if (metricKeys.isEmpty() || metricKeys.stream().anyMatch(key -> key == null || key.isBlank())) {
+            throw new IllegalArgumentException("metricKeys must not be empty");
+        }
+    }
+
+    public boolean contains(MetricSample sample) {
+        return sample != null && domain == sample.domain() && instanceId.equals(sample.instanceId())
+                && metricKeys.contains(sample.metricKey());
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqBusinessMetricsCollector.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqBusinessMetricsCollector.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** Collects consumer-group lag directly from Studio's Apache instance provider. */
 @Slf4j
@@ -51,6 +52,11 @@ public class ApacheRocketMqBusinessMetricsCollector implements BusinessMetricsCo
     public boolean supports(InstanceVO instance) {
         return instance != null && (instance.getVendor() == null || instance.getVendor() == InstanceVendor.APACHE)
                 && instance.getName() != null;
+    }
+
+    @Override
+    public Set<String> metricKeys() {
+        return Set.of(CONSUMER_LAG_TOTAL, CONSUMER_LAG_MAX_QUEUE, CONSUMER_DELAY_SECONDS, TOPIC_BACKLOG_TOTAL);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqClusterMetricsCollector.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqClusterMetricsCollector.java
@@ -36,6 +36,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** Native Apache RocketMQ health collection through Studio's managed admin client. */
 @Slf4j
@@ -55,6 +56,12 @@ public class ApacheRocketMqClusterMetricsCollector implements ClusterMetricsColl
     public boolean supports(InstanceVO instance) {
         return instance != null && (instance.getVendor() == null || instance.getVendor() == InstanceVendor.APACHE)
                 && StringUtils.hasText(instance.getName()) && StringUtils.hasText(instance.getEndpoint());
+    }
+
+    @Override
+    public Set<String> metricKeys() {
+        return Set.of(NAMESERVER_AVAILABILITY, BROKER_AVAILABILITY, BROKER_DISK_USAGE_RATIO,
+                BROKER_JVM_HEAP_USAGE_RATIO, BROKER_SEND_QUEUE_USAGE_RATIO);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqDlqMetricsCollector.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqDlqMetricsCollector.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Component;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** Collects dead-letter message counts directly from the Apache DLQ provider. */
 @Slf4j
@@ -45,6 +46,11 @@ public class ApacheRocketMqDlqMetricsCollector implements BusinessMetricsCollect
     public boolean supports(InstanceVO instance) {
         return instance != null && (instance.getVendor() == null || instance.getVendor() == InstanceVendor.APACHE)
                 && instance.getName() != null;
+    }
+
+    @Override
+    public Set<String> metricKeys() {
+        return Set.of(DLQ_MESSAGE_COUNT);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqProxyMetricsCollector.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqProxyMetricsCollector.java
@@ -35,6 +35,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** Collects TCP reachability for Proxies discovered from the selected Studio instance. */
 @Slf4j
@@ -52,6 +53,11 @@ public class ApacheRocketMqProxyMetricsCollector implements ClusterMetricsCollec
     public boolean supports(InstanceVO instance) {
         return instance != null && (instance.getVendor() == null || instance.getVendor() == InstanceVendor.APACHE)
                 && StringUtils.hasText(instance.getName()) && StringUtils.hasText(instance.getEndpoint());
+    }
+
+    @Override
+    public Set<String> metricKeys() {
+        return Set.of(PROXY_AVAILABILITY);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/CloudRocketMqBusinessMetricsCollector.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/CloudRocketMqBusinessMetricsCollector.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** Collects cloud consumer lag using the provider's existing consumer progress API. */
 @Slf4j
@@ -50,6 +51,11 @@ public class CloudRocketMqBusinessMetricsCollector implements BusinessMetricsCol
     public boolean supports(InstanceVO instance) {
         return instance != null && (instance.getVendor() == InstanceVendor.ALIYUN
                 || instance.getVendor() == InstanceVendor.TENCENT) && instance.getName() != null;
+    }
+
+    @Override
+    public Set<String> metricKeys() {
+        return Set.of(CONSUMER_LAG_TOTAL, CONSUMER_LAG_MAX_QUEUE, TOPIC_BACKLOG_TOTAL);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/CloudRocketMqClusterMetricsCollector.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/collectors/CloudRocketMqClusterMetricsCollector.java
@@ -31,6 +31,7 @@ import org.springframework.util.StringUtils;
 
 import java.time.Instant;
 import java.util.Map;
+import java.util.Set;
 
 /** Collects the cloud provider's managed-instance lifecycle status for Aliyun and Tencent. */
 @Slf4j
@@ -47,6 +48,11 @@ public class CloudRocketMqClusterMetricsCollector implements ClusterMetricsColle
                 || instance.getVendor() == InstanceVendor.TENCENT) && StringUtils.hasText(instance.getName())
                 && instance.getCredentialId() != null && StringUtils.hasText(instance.getRegionId())
                 && StringUtils.hasText(instance.getCloudInstanceId());
+    }
+
+    @Override
+    public Set<String> metricKeys() {
+        return Set.of(CLOUD_INSTANCE_AVAILABILITY);
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/ActiveAlertState.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/ActiveAlertState.java
@@ -14,20 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.rocketmq.studio.cluster.metrics;
+package org.apache.rocketmq.studio.ops.alert;
 
-import org.apache.rocketmq.studio.instance.InstanceVO;
+import java.util.Map;
+import java.util.Objects;
 
-import java.util.List;
-import java.util.Set;
-
-/** Collects business-flow metrics for one Studio-managed instance. */
-public interface BusinessMetricsCollector {
-    boolean supports(InstanceVO instance);
-
-    List<MetricSample> collect(InstanceVO instance);
-
-    default Set<String> metricKeys() {
-        return Set.of();
+/** Persisted active state plus labels needed to emit a lifecycle recovery event. */
+public record ActiveAlertState(AlertStateKey key, AlertRuleState state, String instanceId, Map<String, String> labels) {
+    public ActiveAlertState {
+        Objects.requireNonNull(key, "key is required");
+        Objects.requireNonNull(state, "state is required");
+        if (instanceId == null || instanceId.isBlank()) {
+            throw new IllegalArgumentException("instanceId is required");
+        }
+        labels = Map.copyOf(labels == null ? Map.of() : labels);
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertStateRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertStateRepository.java
@@ -16,6 +16,8 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
+import org.apache.rocketmq.studio.cluster.metrics.MetricCollectionScope;
+
 import java.time.Instant;
 import java.util.Optional;
 import java.util.List;
@@ -36,6 +38,10 @@ public interface AlertStateRepository {
     boolean acknowledge(AlertStateKey key, Instant firedAt);
 
     void deleteByRuleId(Long ruleId);
+
+    default List<ActiveAlertState> findActive(MetricCollectionScope scope, List<AlertRuleVO> rules) {
+        return List.of();
+    }
 
     default List<AlertRuleRuntimeVO> findRuntimeByRuleIds(List<AlertRuleVO> rules) {
         return List.of();

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepository.java
@@ -17,24 +17,35 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.cluster.metrics.MetricCollectionScope;
 import org.apache.rocketmq.studio.persistence.entity.RmqAlertState;
+import org.apache.rocketmq.studio.persistence.entity.RmqSystemAlert;
 import org.apache.rocketmq.studio.persistence.mapper.RmqAlertStateMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqSystemAlertMapper;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
 public class MybatisPlusAlertStateRepository implements AlertStateRepository {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private final RmqAlertStateMapper mapper;
+    private final RmqSystemAlertMapper alertMapper;
 
     @Override
     public Optional<AlertRuleState> find(AlertStateKey key) {
@@ -83,6 +94,35 @@ public class MybatisPlusAlertStateRepository implements AlertStateRepository {
     }
 
     @Override
+    public List<ActiveAlertState> findActive(MetricCollectionScope scope, List<AlertRuleVO> rules) {
+        if (scope == null || rules == null || rules.isEmpty()) {
+            return List.of();
+        }
+        Set<String> metricKeys = scope.metricKeys();
+        Map<Long, AlertRuleVO> scopedRules = rules.stream()
+                .filter(rule -> rule.getId() != null)
+                .filter(AlertRuleVO::isEnabled)
+                .filter(rule -> ruleDomain(rule) == scope.domain())
+                .filter(rule -> metricKeys.contains(rule.getMetric()))
+                .filter(rule -> !StringUtils.hasText(rule.getInstanceId())
+                        || scope.instanceId().equals(rule.getInstanceId()))
+                .collect(Collectors.toMap(AlertRuleVO::getId, rule -> rule, (left, right) -> left));
+        if (scopedRules.isEmpty()) {
+            return List.of();
+        }
+        List<RmqAlertState> activeStates = mapper.selectList(new QueryWrapper<RmqAlertState>()
+                        .in("rule_id", scopedRules.keySet())
+                        .in("status", List.of(AlertStateStatus.FIRING.name(), AlertStateStatus.ACKED.name())));
+        Map<AlertStateKey, RmqSystemAlert> latestAlerts = findLatestAlerts(scope, activeStates);
+        return activeStates
+                .stream()
+                .map(state -> toActiveState(state, latestAlerts.get(new AlertStateKey(state.getRuleId(),
+                        state.getFingerprint()))))
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    @Override
     public List<AlertRuleRuntimeVO> findRuntimeByRuleIds(List<AlertRuleVO> rules) {
         Map<Long, AlertRuleVO> byId = rules.stream().filter(rule -> rule.getId() != null)
                 .collect(Collectors.toMap(AlertRuleVO::getId, rule -> rule));
@@ -97,6 +137,40 @@ public class MybatisPlusAlertStateRepository implements AlertStateRepository {
         return AlertRuleRuntimeVO.builder().ruleId(entity.getRuleId()).fingerprint(entity.getFingerprint())
                 .status(AlertStateStatus.valueOf(entity.getStatus())).consecutiveHits(entity.getConsecutiveHits() == null ? 0 : entity.getConsecutiveHits())
                 .currentValue(entity.getCurrentValue()).lastNotifiedAt(entity.getLastNotifiedAt()).nextReminderAt(next).build();
+    }
+
+    private Map<AlertStateKey, RmqSystemAlert> findLatestAlerts(MetricCollectionScope scope,
+            List<RmqAlertState> activeStates) {
+        if (activeStates.isEmpty()) {
+            return Map.of();
+        }
+        Set<Long> ruleIds = activeStates.stream().map(RmqAlertState::getRuleId).collect(Collectors.toSet());
+        Set<String> fingerprints = activeStates.stream().map(RmqAlertState::getFingerprint).collect(Collectors.toSet());
+        Set<AlertStateKey> activeKeys = activeStates.stream()
+                .map(state -> new AlertStateKey(state.getRuleId(), state.getFingerprint()))
+                .collect(Collectors.toCollection(HashSet::new));
+        return alertMapper.selectList(new QueryWrapper<RmqSystemAlert>()
+                        .in("rule_id", ruleIds)
+                        .in("fingerprint", fingerprints)
+                        .eq("domain", scope.domain().name())
+                        .eq("instance_id", scope.instanceId())
+                        .orderByDesc("time", "id"))
+                .stream()
+                .filter(alert -> activeKeys.contains(new AlertStateKey(alert.getRuleId(), alert.getFingerprint())))
+                .collect(Collectors.toMap(alert -> new AlertStateKey(alert.getRuleId(), alert.getFingerprint()),
+                        alert -> alert, (latest, ignored) -> latest));
+    }
+
+    private Optional<ActiveAlertState> toActiveState(RmqAlertState state, RmqSystemAlert alert) {
+        if (alert == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new ActiveAlertState(new AlertStateKey(state.getRuleId(), state.getFingerprint()),
+                toState(state), alert.getInstanceId(), readLabels(alert.getLabelsJson())));
+    }
+
+    private static AlertDomain ruleDomain(AlertRuleVO rule) {
+        return rule.getDomain() == null ? AlertDomain.BUSINESS : rule.getDomain();
     }
 
     private static void apply(RmqAlertState entity, AlertRuleState state) {
@@ -123,5 +197,16 @@ public class MybatisPlusAlertStateRepository implements AlertStateRepository {
 
     private static Instant toInstant(LocalDateTime value) {
         return value == null ? null : value.toInstant(ZoneOffset.UTC);
+    }
+
+    private static Map<String, String> readLabels(String labelsJson) {
+        if (!StringUtils.hasText(labelsJson)) {
+            return Map.of();
+        }
+        try {
+            return OBJECT_MAPPER.readValue(labelsJson, new TypeReference<>() { });
+        } catch (Exception error) {
+            throw new IllegalStateException("Unable to read alert labels", error);
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessor.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessor.java
@@ -20,18 +20,23 @@ import lombok.RequiredArgsConstructor;
 import org.apache.rocketmq.studio.cluster.metrics.MetricSample;
 import org.apache.rocketmq.studio.cluster.metrics.MetricSnapshotRepository;
 import org.apache.rocketmq.studio.cluster.metrics.MetricAvailability;
+import org.apache.rocketmq.studio.cluster.metrics.MetricCollectionScope;
 import org.apache.rocketmq.studio.common.domain.enums.AlertLevel;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.EnumMap;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /** Applies native samples to persisted rule state and emits only lifecycle transitions. */
 @Component
@@ -48,6 +53,27 @@ public class NativeAlertProcessor {
 
     @Transactional
     public void process(List<MetricSample> samples) {
+        processSamples(samples);
+    }
+
+    @Transactional
+    public void processSuccessfulCollection(MetricCollectionScope scope, List<MetricSample> samples) {
+        Objects.requireNonNull(scope, "scope is required");
+        List<MetricSample> collected = samples == null ? List.of() : samples;
+        processSamples(collected);
+        if (containsWholeScopeFailure(scope, collected)) {
+            return;
+        }
+        reconcileMissingActiveStates(scope, collected);
+    }
+
+    private static boolean containsWholeScopeFailure(MetricCollectionScope scope, List<MetricSample> samples) {
+        return samples.stream().filter(scope::contains)
+                .anyMatch(sample -> sample.availability() != MetricAvailability.AVAILABLE
+                        && sample.labels().isEmpty());
+    }
+
+    private void processSamples(List<MetricSample> samples) {
         Map<AlertDomain, List<AlertRuleVO>> rulesByDomain = new EnumMap<>(AlertDomain.class);
         for (MetricSample sample : samples) {
             for (AlertRuleVO rule : rulesByDomain.computeIfAbsent(sample.domain(), alertService::listRules)) {
@@ -75,36 +101,84 @@ public class NativeAlertProcessor {
                 }
                 if (update.transition() == AlertStateTransition.FIRING || update.transition() == AlertStateTransition.REMINDER
                         || update.transition() == AlertStateTransition.RESOLVED) {
-                    LocalDateTime eventTime = LocalDateTime.ofInstant(sample.collectedAt(), ZoneOffset.UTC);
-                    SystemAlertVO event = SystemAlertVO.builder().level(level(rule.getSeverity()))
-                            .title(rule.getName()).description(update.transition() + " " + sample.metricKey()
-                                    + " on " + sample.instanceId()).time(eventTime)
-                            .acknowledged(false).domain(sample.domain()).ruleId(rule.getId())
-                            .fingerprint(key.fingerprint()).transition(update.transition().name())
-                            .instanceId(sample.instanceId()).currentValue(update.state().currentValue())
-                            .labels(Map.copyOf(new TreeMap<>(sample.labels()))).build();
-                    boolean suppressNotification = shouldSuppress(sample.domain(), update.transition());
-                    if (suppressNotification) {
-                        Optional<SystemAlertVO> cause = notificationSuppressionService.findSuppressingClusterAlert(event);
-                        if (cause.isPresent()) {
-                            event.setNotificationSuppressed(true);
-                            event.setSuppressionCauseAlertId(cause.get().getId());
-                            event.setSuppressionReason("Suppressed by active cluster incident #" + cause.get().getId()
-                                    + ": " + cause.get().getTitle());
-                        }
-                    }
-                    SystemAlertVO savedEvent = alertRepository.saveAlert(event);
-                    if (savedEvent != null) {
-                        event = savedEvent;
-                    }
-                    if (update.transition() == AlertStateTransition.FIRING) {
-                        alertRepository.markRuleTriggered(rule.getId(), eventTime.toString());
-                    }
-                    if (!event.isNotificationSuppressed()) {
-                        notificationOutboxService.enqueue(event, rule, sample.labels());
-                    }
+                    emitLifecycleEvent(rule, key, update, sample.domain(), sample.instanceId(), sample.metricKey(),
+                            sample.labels(), sample.collectedAt());
                 }
             }
+        }
+    }
+
+    private void reconcileMissingActiveStates(MetricCollectionScope scope, List<MetricSample> samples) {
+        List<AlertRuleVO> rules = alertService.listRules(scope.domain()).stream()
+                .filter(rule -> rule.getId() != null)
+                .filter(AlertRuleVO::isEnabled)
+                .filter(rule -> scope.metricKeys().contains(rule.getMetric()))
+                .filter(rule -> rule.getInstanceId() == null || scope.instanceId().equals(rule.getInstanceId()))
+                .toList();
+        if (rules.isEmpty()) {
+            return;
+        }
+        Set<AlertStateKey> presentKeys = samples.stream()
+                .filter(scope::contains)
+                .flatMap(sample -> rules.stream()
+                        .filter(rule -> NativeAlertRuleScopeMatcher.matches(rule, sample))
+                        .map(rule -> new AlertStateKey(rule.getId(),
+                                AlertFingerprint.of(rule.getId(), sample.instanceId(), sample.labels()))))
+                .collect(Collectors.toSet());
+        Map<Long, AlertRuleVO> byId = rules.stream().collect(Collectors.toMap(AlertRuleVO::getId, rule -> rule));
+        Instant resolvedAt = samples.stream().filter(scope::contains).map(MetricSample::collectedAt).max(Instant::compareTo)
+                .orElseGet(Instant::now);
+        AlertEvaluationResult clear = new AlertEvaluationResult(true, false, null, MetricAvailability.AVAILABLE);
+        for (ActiveAlertState active : stateRepository.findActive(scope, rules)) {
+            if (presentKeys.contains(active.key())) {
+                continue;
+            }
+            AlertRuleVO rule = byId.get(active.key().ruleId());
+            if (rule == null) {
+                continue;
+            }
+            AlertStateUpdate update = stateMachine.advance(active.state(), clear,
+                    Math.max(1, rule.getConsecutiveSamples()), AlertRuleDuration.parse(rule.getDuration()),
+                    AlertRuleDuration.parse(rule.getReminderInterval()), resolvedAt);
+            if (update.transition() != AlertStateTransition.RESOLVED) {
+                continue;
+            }
+            if (!stateRepository.save(active.key(), update.state())) {
+                continue;
+            }
+            emitLifecycleEvent(rule, active.key(), update, scope.domain(), active.instanceId(), rule.getMetric(),
+                    active.labels(), resolvedAt);
+        }
+    }
+
+    private void emitLifecycleEvent(AlertRuleVO rule, AlertStateKey key, AlertStateUpdate update, AlertDomain domain,
+            String instanceId, String metricKey, Map<String, String> labels, Instant collectedAt) {
+        LocalDateTime eventTime = LocalDateTime.ofInstant(collectedAt, ZoneOffset.UTC);
+        Map<String, String> eventLabels = Map.copyOf(new TreeMap<>(labels == null ? Map.of() : labels));
+        SystemAlertVO event = SystemAlertVO.builder().level(level(rule.getSeverity()))
+                .title(rule.getName()).description(update.transition() + " " + metricKey + " on " + instanceId)
+                .time(eventTime).acknowledged(false).domain(domain).ruleId(rule.getId())
+                .fingerprint(key.fingerprint()).transition(update.transition().name()).instanceId(instanceId)
+                .currentValue(update.state().currentValue()).labels(eventLabels).build();
+        boolean suppressNotification = shouldSuppress(domain, update.transition());
+        if (suppressNotification) {
+            Optional<SystemAlertVO> cause = notificationSuppressionService.findSuppressingClusterAlert(event);
+            if (cause.isPresent()) {
+                event.setNotificationSuppressed(true);
+                event.setSuppressionCauseAlertId(cause.get().getId());
+                event.setSuppressionReason("Suppressed by active cluster incident #" + cause.get().getId()
+                        + ": " + cause.get().getTitle());
+            }
+        }
+        SystemAlertVO savedEvent = alertRepository.saveAlert(event);
+        if (savedEvent != null) {
+            event = savedEvent;
+        }
+        if (update.transition() == AlertStateTransition.FIRING) {
+            alertRepository.markRuleTriggered(rule.getId(), eventTime.toString());
+        }
+        if (!event.isNotificationSuppressed()) {
+            notificationOutboxService.enqueue(event, rule, eventLabels);
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/CollectorSchedulerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/CollectorSchedulerTest.java
@@ -102,7 +102,7 @@ class CollectorSchedulerTest {
         new CollectorScheduler(properties, instances, List.of(collector), List.of(), snapshots, processor, lease).collect();
 
         verify(snapshots).saveAll(List.of(sample));
-        verify(processor).process(List.of(sample));
+        verify(processor).processSuccessfulCollection(any(MetricCollectionScope.class), org.mockito.ArgumentMatchers.eq(List.of(sample)));
     }
 
     @Test
@@ -150,5 +150,47 @@ class CollectorSchedulerTest {
 
         verify(snapshots, never()).saveAll(any());
         verify(processor, never()).process(any());
+        verify(processor, never()).processSuccessfulCollection(any(MetricCollectionScope.class), any());
+    }
+
+    @Test
+    void doesNotReconcileCollectionScopeWhenCollectorFailsTest() {
+        AlertingProperties properties = new AlertingProperties();
+        InstanceRepository instances = mock(InstanceRepository.class);
+        ClusterMetricsCollector collector = mock(ClusterMetricsCollector.class);
+        MetricSnapshotRepository snapshots = mock(MetricSnapshotRepository.class);
+        NativeAlertProcessor processor = mock(NativeAlertProcessor.class);
+        AlertCollectionLease lease = mock(AlertCollectionLease.class);
+        InstanceVO instance = InstanceVO.builder().name("local").endpoint("localhost:9876").build();
+        when(instances.findAll()).thenReturn(List.of(instance));
+        when(collector.supports(instance)).thenReturn(true);
+        when(collector.collect(instance)).thenThrow(new IllegalStateException("collector failed"));
+        when(lease.tryAcquire()).thenReturn(true);
+
+        new CollectorScheduler(properties, instances, List.of(collector), List.of(), snapshots, processor, lease).collect();
+
+        verify(snapshots, never()).saveAll(any());
+        verify(processor, never()).processSuccessfulCollection(any(MetricCollectionScope.class), any());
+    }
+
+    @Test
+    void reconcilesSuccessfulEmptyCollectionWhenCollectorDeclaresMetricKeysTest() {
+        AlertingProperties properties = new AlertingProperties();
+        InstanceRepository instances = mock(InstanceRepository.class);
+        ClusterMetricsCollector collector = mock(ClusterMetricsCollector.class);
+        MetricSnapshotRepository snapshots = mock(MetricSnapshotRepository.class);
+        NativeAlertProcessor processor = mock(NativeAlertProcessor.class);
+        AlertCollectionLease lease = mock(AlertCollectionLease.class);
+        InstanceVO instance = InstanceVO.builder().name("local").endpoint("localhost:9876").build();
+        when(instances.findAll()).thenReturn(List.of(instance));
+        when(collector.supports(instance)).thenReturn(true);
+        when(collector.metricKeys()).thenReturn(java.util.Set.of("broker.availability"));
+        when(collector.collect(instance)).thenReturn(List.of());
+        when(lease.tryAcquire()).thenReturn(true);
+
+        new CollectorScheduler(properties, instances, List.of(collector), List.of(), snapshots, processor, lease).collect();
+
+        verify(snapshots, never()).saveAll(any());
+        verify(processor).processSuccessfulCollection(any(MetricCollectionScope.class), org.mockito.ArgumentMatchers.eq(List.of()));
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepositoryTest.java
@@ -6,17 +6,26 @@
  */
 package org.apache.rocketmq.studio.ops.alert;
 
+import org.apache.rocketmq.studio.cluster.metrics.MetricCollectionScope;
 import org.apache.rocketmq.studio.persistence.entity.RmqAlertState;
+import org.apache.rocketmq.studio.persistence.entity.RmqSystemAlert;
 import org.apache.rocketmq.studio.persistence.mapper.RmqAlertStateMapper;
+import org.apache.rocketmq.studio.persistence.mapper.RmqSystemAlertMapper;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,7 +38,8 @@ class MybatisPlusAlertStateRepositoryTest {
         existing.setVersion(3);
         existing.setStatus(AlertStateStatus.FIRING.name());
         when(mapper.selectOne(any())).thenReturn(existing);
-        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper);
+        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper,
+                mock(RmqSystemAlertMapper.class));
 
         repository.save(new AlertStateKey(4L, "fingerprint"), new AlertRuleState(AlertStateStatus.FIRING, 2,
                 10D, Instant.now(), Instant.now(), Instant.now(), null));
@@ -43,11 +53,92 @@ class MybatisPlusAlertStateRepositoryTest {
         Instant firedAt = Instant.parse("2026-08-22T12:00:00Z");
         when(mapper.acknowledgeFiring(eq(4L), eq("fingerprint"),
                 eq(LocalDateTime.ofInstant(firedAt, ZoneOffset.UTC)), any())).thenReturn(1);
-        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper);
+        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper,
+                mock(RmqSystemAlertMapper.class));
 
         repository.acknowledge(new AlertStateKey(4L, "fingerprint"), firedAt);
 
         verify(mapper).acknowledgeFiring(eq(4L), eq("fingerprint"),
                 eq(LocalDateTime.ofInstant(firedAt, ZoneOffset.UTC)), any());
+    }
+
+    @Test
+    void findsActiveStatesWithLabelsFromTheLatestAlertEventTest() {
+        RmqAlertStateMapper mapper = mock(RmqAlertStateMapper.class);
+        RmqAlertState state = new RmqAlertState();
+        state.setRuleId(4L);
+        state.setFingerprint("fingerprint");
+        state.setStatus(AlertStateStatus.ACKED.name());
+        state.setConsecutiveHits(1);
+        state.setCurrentValue(30D);
+        when(mapper.selectList(any())).thenReturn(List.of(state));
+        RmqSystemAlert alert = new RmqSystemAlert();
+        alert.setRuleId(4L);
+        alert.setFingerprint("fingerprint");
+        alert.setInstanceId("local");
+        alert.setLabelsJson("{\"consumerGroup\":\"orders\"}");
+        RmqSystemAlertMapper alertMapper = mock(RmqSystemAlertMapper.class);
+        when(alertMapper.selectList(any())).thenReturn(List.of(alert));
+        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper, alertMapper);
+        AlertRuleVO rule = AlertRuleVO.builder().id(4L).domain(AlertDomain.BUSINESS).enabled(true)
+                .instanceId("local").metric("consumer.lag.total").build();
+
+        List<ActiveAlertState> active = repository.findActive(new MetricCollectionScope(AlertDomain.BUSINESS,
+                "local", Set.of("consumer.lag.total")), List.of(rule));
+
+        assertThat(active).singleElement().satisfies(item -> {
+            assertThat(item.key()).isEqualTo(new AlertStateKey(4L, "fingerprint"));
+            assertThat(item.state().status()).isEqualTo(AlertStateStatus.ACKED);
+            assertThat(item.instanceId()).isEqualTo("local");
+            assertThat(item.labels()).isEqualTo(Map.of("consumerGroup", "orders"));
+        });
+        verify(alertMapper).selectList(any());
+        verify(alertMapper, never()).selectOne(any());
+    }
+
+    @Test
+    void findsActiveStatesWithOneLatestAlertMetadataQueryTest() {
+        RmqAlertStateMapper mapper = mock(RmqAlertStateMapper.class);
+        RmqAlertState first = activeState(4L, "fingerprint-a", AlertStateStatus.FIRING);
+        RmqAlertState second = activeState(5L, "fingerprint-b", AlertStateStatus.ACKED);
+        when(mapper.selectList(any())).thenReturn(List.of(first, second));
+        RmqSystemAlertMapper alertMapper = mock(RmqSystemAlertMapper.class);
+        RmqSystemAlert firstAlert = alert(4L, "fingerprint-a", "local", "{\"consumerGroup\":\"orders\"}");
+        RmqSystemAlert secondAlert = alert(5L, "fingerprint-b", "local", "{\"consumerGroup\":\"payments\"}");
+        RmqSystemAlert staleFirstAlert = alert(4L, "fingerprint-a", "local", "{\"consumerGroup\":\"old\"}");
+        when(alertMapper.selectList(any())).thenReturn(List.of(firstAlert, secondAlert, staleFirstAlert));
+        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper, alertMapper);
+        AlertRuleVO firstRule = AlertRuleVO.builder().id(4L).domain(AlertDomain.BUSINESS).enabled(true)
+                .instanceId("local").metric("consumer.lag.total").build();
+        AlertRuleVO secondRule = AlertRuleVO.builder().id(5L).domain(AlertDomain.BUSINESS).enabled(true)
+                .instanceId("local").metric("consumer.lag.total").build();
+
+        List<ActiveAlertState> active = repository.findActive(new MetricCollectionScope(AlertDomain.BUSINESS,
+                "local", Set.of("consumer.lag.total")), List.of(firstRule, secondRule));
+
+        assertThat(active).hasSize(2);
+        assertThat(active).extracting(item -> item.labels().get("consumerGroup"))
+                .containsExactly("orders", "payments");
+        verify(alertMapper, times(1)).selectList(any());
+        verify(alertMapper, never()).selectOne(any());
+    }
+
+    private static RmqAlertState activeState(Long ruleId, String fingerprint, AlertStateStatus status) {
+        RmqAlertState state = new RmqAlertState();
+        state.setRuleId(ruleId);
+        state.setFingerprint(fingerprint);
+        state.setStatus(status.name());
+        state.setConsecutiveHits(1);
+        state.setCurrentValue(30D);
+        return state;
+    }
+
+    private static RmqSystemAlert alert(Long ruleId, String fingerprint, String instanceId, String labelsJson) {
+        RmqSystemAlert alert = new RmqSystemAlert();
+        alert.setRuleId(ruleId);
+        alert.setFingerprint(fingerprint);
+        alert.setInstanceId(instanceId);
+        alert.setLabelsJson(labelsJson);
+        return alert;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessorTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.cluster.metrics.MetricAvailability;
+import org.apache.rocketmq.studio.cluster.metrics.MetricCollectionScope;
 import org.apache.rocketmq.studio.cluster.metrics.MetricSample;
 import org.apache.rocketmq.studio.cluster.metrics.MetricSnapshotRepository;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -301,6 +303,93 @@ class NativeAlertProcessorTest {
 
         verify(suppression, never()).findSuppressingClusterAlert(any());
         verify(outbox).enqueue(any(), org.mockito.ArgumentMatchers.same(rule), any());
+    }
+
+    @Test
+    void resolvesActiveFingerprintMissingFromSuccessfulCollectionScopeTest() {
+        AlertService service = mock(AlertService.class);
+        AlertRuleVO rule = rule("local", "orders", 1);
+        when(service.listRules(AlertDomain.BUSINESS)).thenReturn(List.of(rule));
+        MetricSample oldSample = sample("orders");
+        AlertStateKey oldKey = new AlertStateKey(rule.getId(),
+                AlertFingerprint.of(rule.getId(), oldSample.instanceId(), oldSample.labels()));
+        AlertRuleState firing = new AlertRuleState(AlertStateStatus.FIRING, 1, 20D,
+                oldSample.collectedAt().minusSeconds(60), oldSample.collectedAt().minusSeconds(60),
+                oldSample.collectedAt().minusSeconds(60), null);
+        ActiveAlertState active = new ActiveAlertState(oldKey, firing, oldSample.instanceId(), oldSample.labels());
+        AlertStateRepository states = mock(AlertStateRepository.class);
+        when(states.findActive(any(MetricCollectionScope.class), eq(List.of(rule)))).thenReturn(List.of(active));
+        when(states.save(eq(oldKey), any(AlertRuleState.class))).thenReturn(true);
+        AlertRepository alerts = mock(AlertRepository.class);
+        when(alerts.saveAlert(any(SystemAlertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        NotificationOutboxService outbox = mock(NotificationOutboxService.class);
+
+        new NativeAlertProcessor(service, new AlertRuleEvaluator(), new AlertStateMachine(), states,
+                mock(MetricSnapshotRepository.class), alerts, outbox, suppression())
+                .processSuccessfulCollection(new MetricCollectionScope(AlertDomain.BUSINESS, "local",
+                        java.util.Set.of("consumer.lag.total")), List.of());
+
+        org.mockito.ArgumentCaptor<AlertRuleState> state = org.mockito.ArgumentCaptor.forClass(AlertRuleState.class);
+        org.mockito.ArgumentCaptor<SystemAlertVO> event = org.mockito.ArgumentCaptor.forClass(SystemAlertVO.class);
+        verify(states).save(eq(oldKey), state.capture());
+        verify(alerts).saveAlert(event.capture());
+        assertThat(state.getValue().status()).isEqualTo(AlertStateStatus.RESOLVED);
+        assertThat(event.getValue().getTransition()).isEqualTo(AlertStateTransition.RESOLVED.name());
+        assertThat(event.getValue().getLabels()).isEqualTo(oldSample.labels());
+        verify(outbox).enqueue(any(SystemAlertVO.class), eq(rule), eq(oldSample.labels()));
+    }
+
+    @Test
+    void keepsActiveFingerprintWhenItAppearsInSuccessfulCollectionScopeTest() {
+        AlertService service = mock(AlertService.class);
+        AlertRuleVO rule = rule("local", "orders", 1);
+        when(service.listRules(AlertDomain.BUSINESS)).thenReturn(List.of(rule));
+        MetricSample current = sample("orders");
+        AlertStateKey key = new AlertStateKey(rule.getId(),
+                AlertFingerprint.of(rule.getId(), current.instanceId(), current.labels()));
+        AlertRuleState firing = new AlertRuleState(AlertStateStatus.FIRING, 1, 20D,
+                current.collectedAt().minusSeconds(60), current.collectedAt().minusSeconds(60),
+                current.collectedAt().minusSeconds(60), null);
+        ActiveAlertState active = new ActiveAlertState(key, firing, current.instanceId(), current.labels());
+        AlertStateRepository states = mock(AlertStateRepository.class);
+        when(states.find(key)).thenReturn(Optional.of(firing));
+        when(states.save(eq(key), any(AlertRuleState.class))).thenReturn(true);
+        when(states.findActive(any(MetricCollectionScope.class), eq(List.of(rule)))).thenReturn(List.of(active));
+        AlertRepository alerts = mock(AlertRepository.class);
+
+        new NativeAlertProcessor(service, new AlertRuleEvaluator(), new AlertStateMachine(), states,
+                mock(MetricSnapshotRepository.class), alerts, mock(NotificationOutboxService.class), suppression())
+                .processSuccessfulCollection(new MetricCollectionScope(AlertDomain.BUSINESS, "local",
+                        java.util.Set.of("consumer.lag.total")), List.of(current));
+
+        verify(alerts, never()).saveAlert(any(SystemAlertVO.class));
+    }
+
+    @Test
+    void doesNotResolveMissingActiveStateWhenCollectionReportsWholeScopeUnavailableTest() {
+        AlertService service = mock(AlertService.class);
+        AlertRuleVO rule = rule("local", "orders", 1);
+        when(service.listRules(AlertDomain.BUSINESS)).thenReturn(List.of(rule));
+        MetricSample oldSample = sample("orders");
+        AlertStateKey oldKey = new AlertStateKey(rule.getId(),
+                AlertFingerprint.of(rule.getId(), oldSample.instanceId(), oldSample.labels()));
+        ActiveAlertState active = new ActiveAlertState(oldKey,
+                new AlertRuleState(AlertStateStatus.FIRING, 1, 20D, oldSample.collectedAt().minusSeconds(60),
+                        oldSample.collectedAt().minusSeconds(60), oldSample.collectedAt().minusSeconds(60), null),
+                oldSample.instanceId(), oldSample.labels());
+        AlertStateRepository states = mock(AlertStateRepository.class);
+        when(states.findActive(any(MetricCollectionScope.class), eq(List.of(rule)))).thenReturn(List.of(active));
+        AlertRepository alerts = mock(AlertRepository.class);
+
+        new NativeAlertProcessor(service, new AlertRuleEvaluator(), new AlertStateMachine(), states,
+                mock(MetricSnapshotRepository.class), alerts, mock(NotificationOutboxService.class), suppression())
+                .processSuccessfulCollection(new MetricCollectionScope(AlertDomain.BUSINESS, "local",
+                        java.util.Set.of("consumer.lag.total")), List.of(new MetricSample("consumer.lag.total",
+                        AlertDomain.BUSINESS, "local", null, Map.of(), null, MetricAvailability.UNAVAILABLE,
+                        Instant.now(), "BUSINESS_METRICS_COLLECTION_FAILED")));
+
+        verify(states, never()).save(eq(oldKey), any(AlertRuleState.class));
+        verify(alerts, never()).saveAlert(any(SystemAlertVO.class));
     }
 
     private static AlertNotificationSuppressionService suppression() {


### PR DESCRIPTION
## Summary
- add an explicit native metric collection scope so completed collector passes can reconcile missing alert fingerprints
- resolve FIRING/ACKED native alert states when their monitored resource disappears from a successful full scope collection
- avoid false recovery for failed/partial collections, lease loss, and whole-scope unavailable samples
- preserve original alert labels for RESOLVED events and recovery notifications using the latest alert event metadata
- batch-load latest alert event metadata for active states to avoid per-state N+1 lookups during reconciliation

## Tests
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=MybatisPlusAlertStateRepositoryTest test
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=NativeAlertProcessorTest,CollectorSchedulerTest,MybatisPlusAlertStateRepositoryTest test
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest='org.apache.rocketmq.studio.ops.alert.*Test,org.apache.rocketmq.studio.cluster.metrics.*Test' test
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn test
- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -DskipTests package

Closes #2679