### PR TITLE
[ISSUE #2463][ISSUE #2465][ISSUE #2470] fix(server): normalize service boundary inputs

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
@@ -213,6 +213,9 @@ public class AuthService {
     public RmqStudioUser setUserEnabled(Long userId, boolean enabled) {
         requireDatabaseBacked();
         RmqStudioUser user = getUser(userId);
+        if (Boolean.valueOf(enabled).equals(user.getEnabled())) {
+            return user;
+        }
         if (!enabled && Boolean.TRUE.equals(user.getAdmin())) {
             // Lock the enabled administrator rows so concurrent disables serialize. A plain
             // count would let two requests both observe a count of 2 and disable everyone.

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffService.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Stream;
@@ -192,12 +193,26 @@ public class NameServerConfigDiffService {
                         .filter(node -> node != null)
                         .map(NameServerVO::getAddr);
         Stream<String> endpointAddresses = splitEndpoint(cluster.getEndpoint()).stream();
-        return Stream.concat(declared, endpointAddresses)
+        Map<String, String> uniqueAddresses = new LinkedHashMap<>();
+        Stream.concat(declared, endpointAddresses)
                 .filter(address -> address != null && !address.isBlank())
                 .map(String::trim)
-                .distinct()
+                .forEach(address -> uniqueAddresses.putIfAbsent(canonicalAddressKey(address), address));
+        return uniqueAddresses.values().stream()
                 .sorted()
                 .toList();
+    }
+
+    private String canonicalAddressKey(String address) {
+        int separator = address.lastIndexOf(':');
+        if (separator <= 0 || address.indexOf(':') != separator) {
+            return address;
+        }
+        String host = address.substring(0, separator);
+        if (host.indexOf('%') >= 0) {
+            return address;
+        }
+        return host.toLowerCase(Locale.ROOT) + address.substring(separator);
     }
 
     private String connectionEndpoint(ClusterVO cluster, List<String> addresses) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQService.java
@@ -56,51 +56,65 @@ public class DLQService {
     public DLQResendResultVO resendMessages(String instanceId, String groupName, Long startTime, Long endTime,
                                              String targetTopic) {
         requireApacheInstance(instanceId);
-        validateResendRequest(groupName, startTime, endTime);
-        log.info("Resending DLQ messages: group={}, targetTopic={}", groupName, targetTopic);
-        return dlqProvider.resendMessages(instanceId, groupName, startTime, endTime, targetTopic);
+        String normalizedGroupName = requireGroupName(groupName);
+        validateTimeRange(startTime, endTime);
+        String normalizedTargetTopic = normalizeOptional(targetTopic);
+        log.info("Resending DLQ messages: group={}, targetTopic={}",
+                normalizedGroupName, normalizedTargetTopic);
+        return dlqProvider.resendMessages(
+                instanceId, normalizedGroupName, startTime, endTime, normalizedTargetTopic);
     }
 
     public DLQExportResultVO exportMessages(String instanceId, String groupName, Long startTime, Long endTime,
                                             Integer maxCount) {
         requireApacheInstance(instanceId);
-        validateResendRequest(groupName, startTime, endTime);
-        log.info("Exporting DLQ messages: group={}, maxCount={}", groupName, maxCount);
-        return dlqProvider.exportMessages(instanceId, groupName, startTime, endTime, maxCount);
+        String normalizedGroupName = requireGroupName(groupName);
+        validateTimeRange(startTime, endTime);
+        log.info("Exporting DLQ messages: group={}, maxCount={}", normalizedGroupName, maxCount);
+        return dlqProvider.exportMessages(instanceId, normalizedGroupName, startTime, endTime, maxCount);
     }
 
     public PageResult<DLQMessageVO> listMessages(String instanceId, String groupName, Long startTime, Long endTime,
                                                  int page, int pageSize) {
         requireApacheInstance(instanceId);
-        validateResendRequest(groupName, startTime, endTime);
-        log.info("Listing DLQ messages: group={}, page={}, pageSize={}", groupName, page, pageSize);
-        return dlqProvider.listMessages(instanceId, groupName, startTime, endTime, page, pageSize);
+        String normalizedGroupName = requireGroupName(groupName);
+        validateTimeRange(startTime, endTime);
+        log.info("Listing DLQ messages: group={}, page={}, pageSize={}", normalizedGroupName, page, pageSize);
+        return dlqProvider.listMessages(
+                instanceId, normalizedGroupName, startTime, endTime, page, pageSize);
     }
 
     public DLQResendResultVO resendSelectedMessages(String instanceId, String groupName, List<String> msgIds,
                                                     String targetTopic) {
         requireApacheInstance(instanceId);
+        String normalizedGroupName = requireGroupName(groupName);
         if (msgIds == null || msgIds.isEmpty()) {
             throw new BusinessException(400, "At least one msgId is required");
         }
         if (msgIds.size() > MAX_SELECTED_MESSAGES) {
             throw new BusinessException(400, "At most 100 msgIds are allowed per resend");
         }
+        List<String> normalizedMsgIds = normalizeMsgIds(msgIds);
+        String normalizedTargetTopic = normalizeOptional(targetTopic);
         log.info("Resending selected DLQ messages: group={}, count={}, targetTopic={}",
-                groupName, msgIds.size(), targetTopic);
-        return dlqProvider.resendMessages(instanceId, groupName, msgIds, targetTopic);
+                normalizedGroupName, normalizedMsgIds.size(), normalizedTargetTopic);
+        return dlqProvider.resendMessages(
+                instanceId, normalizedGroupName, normalizedMsgIds, normalizedTargetTopic);
     }
 
     public DLQExcelExportResultVO exportExcel(String instanceId, String groupName, Long startTime, Long endTime,
                                               List<String> msgIds) {
         requireApacheInstance(instanceId);
-        validateResendRequest(groupName, startTime, endTime);
+        String normalizedGroupName = requireGroupName(groupName);
+        validateTimeRange(startTime, endTime);
         if (msgIds != null && msgIds.size() > MAX_SELECTED_MESSAGES) {
             throw new BusinessException(400, "At most 100 msgIds are allowed per export");
         }
-        log.info("Exporting DLQ messages as Excel: group={}, selected={}", groupName,
-                msgIds == null ? 0 : msgIds.size());
-        return dlqProvider.exportExcel(instanceId, groupName, startTime, endTime, msgIds);
+        List<String> normalizedMsgIds = msgIds == null ? null : normalizeMsgIds(msgIds);
+        log.info("Exporting DLQ messages as Excel: group={}, selected={}", normalizedGroupName,
+                normalizedMsgIds == null ? 0 : normalizedMsgIds.size());
+        return dlqProvider.exportExcel(
+                instanceId, normalizedGroupName, startTime, endTime, normalizedMsgIds);
     }
 
     private void requireApacheInstance(String instanceId) {
@@ -111,10 +125,29 @@ public class DLQService {
         });
     }
 
-    private void validateResendRequest(String groupName, Long startTime, Long endTime) {
+    private String requireGroupName(String groupName) {
         if (!StringUtils.hasText(groupName)) {
             throw new BusinessException(400, "groupName is required");
         }
+        return groupName.trim();
+    }
+
+    private String normalizeOptional(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    private List<String> normalizeMsgIds(List<String> msgIds) {
+        return msgIds.stream()
+                .map(msgId -> {
+                    if (!StringUtils.hasText(msgId)) {
+                        throw new BusinessException(400, "msgId must not be blank");
+                    }
+                    return msgId.trim();
+                })
+                .toList();
+    }
+
+    private void validateTimeRange(Long startTime, Long endTime) {
         if ((startTime == null) != (endTime == null)) {
             throw new BusinessException(400, "startTime and endTime must be provided together");
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceDatabaseTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceDatabaseTest.java
@@ -184,6 +184,21 @@ class AuthServiceDatabaseTest {
     }
 
     @Test
+    void settingTheCurrentEnabledStateShouldBeIdempotentTest() {
+        RmqStudioUser disabledAdmin = user(1L, "retired-admin", true, false, "password-1");
+        RmqStudioUser enabledOperator = user(2L, "operator", false, true, "password-1");
+        when(userMapper.selectById(1L)).thenReturn(disabledAdmin);
+        when(userMapper.selectById(2L)).thenReturn(enabledOperator);
+
+        assertThat(authService.setUserEnabled(1L, false)).isSameAs(disabledAdmin);
+        assertThat(authService.setUserEnabled(2L, true)).isSameAs(enabledOperator);
+
+        verify(userMapper, never()).selectList(any(Wrapper.class));
+        verify(userMapper, never()).updateById(any(RmqStudioUser.class));
+        verify(sessionMapper, never()).update(isNull(), any(Wrapper.class));
+    }
+
+    @Test
     void databaseAuthenticationThrottlesLastSeenWrites() {
         RmqStudioUser user = user(1L, "operator", false, true, "password-1");
         RmqStudioSession session = activeSession(10L, 1L,

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffServiceTest.java
@@ -218,6 +218,40 @@ class NameServerConfigDiffServiceTest {
     }
 
     @Test
+    void compareShouldDeduplicateDnsHostnamesIgnoringCase() throws Exception {
+        stubAdminFactory();
+        when(clusterService.getCluster("cluster-a")).thenReturn(cluster(
+                "ns.example.com:9876", List.of(nameServer("NS.EXAMPLE.COM:9876"))));
+        when(admin.getNameServerConfig(List.of("NS.EXAMPLE.COM:9876")))
+                .thenReturn(Map.of("NS.EXAMPLE.COM:9876", properties("listenPort", "9876")));
+
+        NameServerConfigDiffVO result = service.compare("cluster-a");
+
+        assertThat(result.getNodeCount()).isEqualTo(1);
+        assertThat(result.getReachableNodeCount()).isEqualTo(1);
+        verify(admin).getNameServerConfig(List.of("NS.EXAMPLE.COM:9876"));
+    }
+
+    @Test
+    void compareShouldPreserveIpv6ZoneCase() throws Exception {
+        stubAdminFactory();
+        String lowerZone = "[fe80::1%en0]:9876";
+        String upperZone = "[fe80::1%EN0]:9876";
+        when(clusterService.getCluster("cluster-a")).thenReturn(cluster(
+                upperZone, List.of(nameServer(lowerZone))));
+        when(admin.getNameServerConfig(List.of(lowerZone)))
+                .thenReturn(Map.of(lowerZone, properties("listenPort", "9876")));
+        when(admin.getNameServerConfig(List.of(upperZone)))
+                .thenReturn(Map.of(upperZone, properties("listenPort", "9876")));
+
+        NameServerConfigDiffVO result = service.compare("cluster-a");
+
+        assertThat(result.getNodeCount()).isEqualTo(2);
+        verify(admin).getNameServerConfig(List.of(lowerZone));
+        verify(admin).getNameServerConfig(List.of(upperZone));
+    }
+
+    @Test
     void compareShouldMarkTheCheckIncompleteWhenEveryNodeIsUnavailable() throws Exception {
         stubAdminFactory();
         when(clusterService.getCluster("cluster-a")).thenReturn(cluster(

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQServiceTest.java
@@ -90,6 +90,47 @@ class DLQServiceTest {
     }
 
     @Test
+    void actionsShouldNormalizeIdentifiersBeforeDelegatingTest() {
+        List<String> msgIds = List.of(" msg-1 ", " msg-2 ");
+
+        dlqService.resendMessages("instance-1", " group-1 ", 1000L, 2000L, " target-topic ");
+        dlqService.exportMessages("instance-1", " group-1 ", 1000L, 2000L, 100);
+        dlqService.listMessages("instance-1", " group-1 ", 1000L, 2000L, 1, 20);
+        dlqService.resendSelectedMessages("instance-1", " group-1 ", msgIds, " target-topic ");
+        dlqService.exportExcel("instance-1", " group-1 ", 1000L, 2000L, msgIds);
+
+        verify(dlqProvider).resendMessages(
+                "instance-1", "group-1", 1000L, 2000L, "target-topic");
+        verify(dlqProvider).exportMessages("instance-1", "group-1", 1000L, 2000L, 100);
+        verify(dlqProvider).listMessages("instance-1", "group-1", 1000L, 2000L, 1, 20);
+        verify(dlqProvider).resendMessages(
+                "instance-1", "group-1", List.of("msg-1", "msg-2"), "target-topic");
+        verify(dlqProvider).exportExcel(
+                "instance-1", "group-1", 1000L, 2000L, List.of("msg-1", "msg-2"));
+    }
+
+    @Test
+    void resendMessagesShouldTreatBlankTargetTopicAsAbsentTest() {
+        dlqService.resendMessages("instance-1", "group-1", 1000L, 2000L, "   ");
+
+        verify(dlqProvider).resendMessages("instance-1", "group-1", 1000L, 2000L, null);
+    }
+
+    @Test
+    void selectedActionsShouldRejectBlankMsgIdsTest() {
+        assertThatThrownBy(() -> dlqService.resendSelectedMessages(
+                "instance-1", "group-1", List.of("msg-1", " "), null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("msgId must not be blank");
+        assertThatThrownBy(() -> dlqService.exportExcel(
+                "instance-1", "group-1", null, null, List.of("msg-1", " ")))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("msgId must not be blank");
+
+        verifyNoInteractions(dlqProvider);
+    }
+
+    @Test
     void resendMessagesShouldAcceptNullTimeRange() {
         dlqService.resendMessages("instance-1", "group-1", null, null, "target-topic");
 


### PR DESCRIPTION
## Summary

- make repeated user enabled-state updates idempotent without database writes or session revocation
- deduplicate DNS NameServer addresses without hostname case sensitivity while preserving IPv6 zone semantics
- normalize DLQ group, target-topic, and selected message identifiers consistently before provider delegation
- keep each fix together with focused regression coverage in one cohesive backend-normalization change

## Root cause

The affected service methods validated logical values but continued to compare, log, or delegate the original unnormalized input. The auth path also performed state-change side effects when the stored enabled value already matched the requested value.

## Local verification

- Maven validate reached Checkstyle with 0 violations
- git diff --check
- scope check: 177 changed lines across 6 files

Java 21 unit tests were not run locally because this machine did not have the project-required JDK and both official SDK downloads were interrupted by the local proxy. The pull request is intentionally left for the automatically triggered Java 21 GitHub CI, per the submitter instruction.

Fixes #2463

Fixes #2465

Fixes #2470
