### PR TITLE
[ISSUE #2464] fix(aliyun): normalize catalog lookup inputs

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogService.java
@@ -83,14 +83,16 @@ public class AliyunCatalogService implements CloudCatalogProvider {
     public List<CloudInstanceOptionVO> listCloudInstances(Long credentialId, String regionId, String search) {
         requireId(credentialId, "credentialId");
         requireNonBlank(regionId, "regionId");
-        List<ListInstancesResponseBody.List> all = fetchAllInstances(credentialId, regionId);
+        String normalizedRegionId = regionId.strip();
+        String normalizedSearch = search == null ? null : search.strip();
+        List<ListInstancesResponseBody.List> all = fetchAllInstances(credentialId, normalizedRegionId);
         List<CloudInstanceOptionVO> options = new ArrayList<>();
         for (ListInstancesResponseBody.List item : all) {
             if (item == null) {
                 continue;
             }
             CloudInstanceOptionVO vo = AliyunConverters.toInstanceOptionVO(item);
-            if (matchesSearch(search, vo)) {
+            if (matchesSearch(normalizedSearch, vo)) {
                 options.add(vo);
             }
         }
@@ -102,13 +104,15 @@ public class AliyunCatalogService implements CloudCatalogProvider {
         requireId(credentialId, "credentialId");
         requireNonBlank(regionId, "regionId");
         requireNonBlank(cloudInstanceId, "cloudInstanceId");
-        GetInstanceRequest request = GetInstanceRequest.builder().instanceId(cloudInstanceId).build();
-        GetInstanceResponse response = clientFactory.call(credentialId, regionId,
+        String normalizedRegionId = regionId.strip();
+        String normalizedCloudInstanceId = cloudInstanceId.strip();
+        GetInstanceRequest request = GetInstanceRequest.builder().instanceId(normalizedCloudInstanceId).build();
+        GetInstanceResponse response = clientFactory.call(credentialId, normalizedRegionId,
                 client -> client.getInstance(request));
         GetInstanceResponseBody body = response == null ? null : response.getBody();
         GetInstanceResponseBody.Data data = body == null ? null : body.getData();
         if (data == null) {
-            throw new BusinessException(404, "Aliyun instance not found: " + cloudInstanceId);
+            throw new BusinessException(404, "Aliyun instance not found: " + normalizedCloudInstanceId);
         }
         return AliyunConverters.toInstanceDetailVO(data);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogServiceTest.java
@@ -167,6 +167,19 @@ class AliyunCatalogServiceTest {
     }
 
     @Test
+    void listCloudInstancesShouldNormalizeRegionAndSearchTest() {
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any()))
+                .thenReturn(instancesResponse(List.of(instanceRow("rmq-prod-001", "Production"))));
+
+        List<CloudInstanceOptionVO> result = service.listCloudInstances(
+                CREDENTIAL_ID, "  cn-hangzhou  ", "  production  ");
+
+        assertThat(result).extracting(CloudInstanceOptionVO::getInstanceName)
+                .containsExactly("Production");
+        verify(clientFactory).call(eq(CREDENTIAL_ID), eq(REGION), any());
+    }
+
+    @Test
     void listCloudInstancesShouldRequireRegionTest() {
         assertThatThrownBy(() -> service.listCloudInstances(CREDENTIAL_ID, " ", null))
                 .isInstanceOf(BusinessException.class)
@@ -210,6 +223,17 @@ class AliyunCatalogServiceTest {
         assertThat(detail.getEndpoints().get(0).getEndpointType()).isEqualTo("TCP_INTERNET");
         assertThat(detail.getEndpoints().get(1).getEndpointUrl())
                 .isEqualTo("rmq-cn-001-vpc.rmq.aliyuncs.com:8080");
+    }
+
+    @Test
+    void getCloudInstanceShouldNormalizeLookupIdentifiersTest() {
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any())).thenReturn(null);
+
+        assertThatThrownBy(() -> service.getCloudInstance(
+                CREDENTIAL_ID, "  cn-hangzhou  ", "  rmq-missing  "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Aliyun instance not found: rmq-missing");
+        verify(clientFactory).call(eq(CREDENTIAL_ID), eq(REGION), any());
     }
 
     private static List<ListInstancesResponseBody.List> instanceRows(int count, int idOffset) {


### PR DESCRIPTION
## Summary

- strip Aliyun region identifiers before catalog client calls
- normalize optional search text before local filtering
- send stripped cloud instance identifiers to the SDK and use them in not-found errors
- add regression coverage for whitespace-padded catalog inputs

## Root cause

The service rejected blank values but passed the original strings to the SDK and search filter, so otherwise valid identifiers with surrounding whitespace failed lookups.

## Local verification

- Maven validate reached Checkstyle with 0 violations
- git diff --check
- scope check: 38 changed lines across 2 files

AliyunCatalogServiceTest was not run locally because this machine did not have the project-required Java 21 SDK and both official SDK downloads were interrupted by the local proxy. The pull request is intentionally left for the automatically triggered Java 21 GitHub CI, per the submitter instruction.

Fixes #2464
