### PR TITLE
[ISSUE #2691] fix(message): reset query and trace lifecycle

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -37,13 +37,17 @@ const instanceFilterMocks = vi.hoisted(() => ({
 vi.mock('../../../services/messageService', () => ({
   ...serviceMocks,
   queryMessagePage: ({ page = 1, pageSize = 50, ...params }: Record<string, unknown>) =>
-    Promise.resolve(serviceMocks.queryMessages(params)).then((items) => ({
-      items,
-      total: items.length,
-      page,
-      size: pageSize,
-      resultMayBeTruncated: false,
-    })),
+    Promise.resolve(serviceMocks.queryMessages(params)).then((result) =>
+      Array.isArray(result)
+        ? {
+            items: result,
+            total: result.length,
+            page,
+            size: pageSize,
+            resultMayBeTruncated: false,
+          }
+        : result,
+    ),
 }));
 vi.mock('../../../hooks/useInstanceFilter', () => instanceFilterMocks);
 
@@ -165,6 +169,66 @@ describe('MessagePage async request ownership', () => {
     expect(screen.queryByText('late-after-reset')).not.toBeInTheDocument();
   });
 
+  it('resets pagination and the truncated-result warning', async () => {
+    serviceMocks.queryMessages.mockResolvedValue({
+      items: [createMessage('message-on-page-two')],
+      total: 101,
+      page: 2,
+      size: 50,
+      resultMayBeTruncated: true,
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await selectTopic(user);
+
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+    expect(await screen.findByText('message-on-page-two')).toBeInTheDocument();
+    expect(screen.getByText('共 101 条消息')).toBeInTheDocument();
+    expect(screen.getByText(/查询结果达到服务端扫描上限/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /重置/ }));
+
+    expect(screen.queryByText('message-on-page-two')).not.toBeInTheDocument();
+    expect(screen.queryByText('共 101 条消息')).not.toBeInTheDocument();
+    expect(screen.queryByText(/查询结果达到服务端扫描上限/)).not.toBeInTheDocument();
+    expect(document.querySelector('.ant-pagination-item-active')).not.toBeInTheDocument();
+  });
+
+  it('clears query state and invalidates an in-flight request when the query mode changes', async () => {
+    const lateQuery = createDeferred<MessageRecord[]>();
+    serviceMocks.queryMessages
+      .mockResolvedValueOnce({
+        items: [createMessage('topic-result')],
+        total: 101,
+        page: 2,
+        size: 50,
+        resultMayBeTruncated: true,
+      })
+      .mockReturnValueOnce(lateQuery.promise);
+    const user = userEvent.setup();
+    renderPage();
+    await selectTopic(user);
+
+    const queryButton = screen.getByRole('button', { name: /^search查询$/ });
+    await user.click(queryButton);
+    expect(await screen.findByText('topic-result')).toBeInTheDocument();
+    await user.click(queryButton);
+    await waitFor(() => expect(serviceMocks.queryMessages).toHaveBeenCalledTimes(2));
+
+    await user.click(screen.getByText('按 Message Key'));
+
+    expect(screen.queryByText('topic-result')).not.toBeInTheDocument();
+    expect(screen.queryByText('共 101 条消息')).not.toBeInTheDocument();
+    expect(screen.queryByText(/查询结果达到服务端扫描上限/)).not.toBeInTheDocument();
+    expect(document.querySelector('.ant-pagination-item-active')).not.toBeInTheDocument();
+    expect(document.querySelector('.ant-table-wrapper .ant-spin-spinning')).not.toBeInTheDocument();
+
+    await act(async () => {
+      lateQuery.resolve([createMessage('late-topic-result')]);
+    });
+    expect(screen.queryByText('late-topic-result')).not.toBeInTheDocument();
+  });
+
   it('clears query results and message details when the selected instance changes', async () => {
     serviceMocks.queryMessages.mockResolvedValue([createMessage('message-from-instance-a')]);
     let currentInstanceId = 1;
@@ -229,6 +293,34 @@ describe('MessagePage async request ownership', () => {
     expect(
       await within(dialog).findByText('Message query provider is not configured'),
     ).toBeInTheDocument();
+  });
+
+  it('loads a message trace lazily and reuses it for the same message', async () => {
+    serviceMocks.queryMessages.mockResolvedValue([createMessage('message-a')]);
+    serviceMocks.getMessageTrace.mockResolvedValue(createTrace('cached-trace'));
+    const user = userEvent.setup();
+    renderPage();
+    await selectTopic(user);
+
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+    const row = await screen.findByRole('row', { name: /message-a/ });
+    await user.click(within(row).getByRole('button', { name: /详情/ }));
+    let dialog = await screen.findByRole('dialog', { name: '消息详情' });
+    expect(serviceMocks.getMessageTrace).not.toHaveBeenCalled();
+
+    await user.click(within(dialog).getByText('消息轨迹'));
+    expect(await within(dialog).findByText('cached-trace description')).toBeInTheDocument();
+    expect(serviceMocks.getMessageTrace).toHaveBeenCalledTimes(1);
+    await user.click(within(dialog).getByText('消息内容'));
+    await user.click(within(dialog).getByText('消息轨迹'));
+    expect(serviceMocks.getMessageTrace).toHaveBeenCalledTimes(1);
+
+    await user.click(within(dialog).getByRole('button', { name: /关\s*闭/ }));
+    await user.click(within(row).getByRole('button', { name: /详情/ }));
+    dialog = await screen.findByRole('dialog', { name: '消息详情' });
+    await user.click(within(dialog).getByText('消息轨迹'));
+    expect(await within(dialog).findByText('cached-trace description')).toBeInTheDocument();
+    expect(serviceMocks.getMessageTrace).toHaveBeenCalledTimes(1);
   });
 
   it('requiresGroupAndClientBeforeDirectConsumeTest', async () => {

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -277,6 +277,7 @@ const MessagePageContent = ({
   const [directConsumeSubmitting, setDirectConsumeSubmitting] = useState(false);
   const queryGenerationRef = useRef(0);
   const traceGenerationRef = useRef(0);
+  const traceCacheRef = useRef(new Map<string, Promise<TraceRecord | null>>());
 
   useEffect(
     () => () => {
@@ -302,15 +303,29 @@ const MessagePageContent = ({
         : queryValidationError;
 
   /* ─── Handlers ─── */
+  const clearQueryResults = () => {
+    setMessages([]);
+    setMessageTotal(0);
+    setMessagePage(1);
+    setResultMayBeTruncated(false);
+    setQueryError(null);
+    setQueryLoading(false);
+  };
+
   const handleReset = () => {
     queryGenerationRef.current += 1;
     setSelectedTopic(undefined);
     setKeyInput('');
     setMsgIdInput('');
     setDateRange(getDefaultRange());
-    setMessages([]);
-    setQueryError(null);
-    setQueryLoading(false);
+    clearQueryResults();
+  };
+
+  const handleQueryModeChange = (mode: QueryMode) => {
+    if (mode === queryMode) return;
+    queryGenerationRef.current += 1;
+    setQueryMode(mode);
+    clearQueryResults();
   };
 
   const executeQuery = async (
@@ -375,7 +390,7 @@ const MessagePageContent = ({
       startTime: record.startTime,
       endTime: record.endTime,
     };
-    setQueryMode(mode);
+    handleQueryModeChange(mode);
     setSelectedTopic(record.topic);
     setKeyInput(record.messageKey || '');
     setMsgIdInput(record.msgId || '');
@@ -387,7 +402,7 @@ const MessagePageContent = ({
   };
 
   const replayTraceRecord = (record: TraceQueryHistory) => {
-    setQueryMode('msgid');
+    handleQueryModeChange('msgid');
     setSelectedTopic(record.topic);
     setMsgIdInput(record.msgId);
     setHistoryDrawerOpen(false);
@@ -397,21 +412,27 @@ const MessagePageContent = ({
   const handleVerifyConsume = () => {
     message.warning('消费验证接口尚未接入，无法确认该消息的真实消费状态');
   };
-  const openDetail = async (record: MessageRecord, tab = 'content') => {
+  const loadMessageTrace = async (record: MessageRecord) => {
     const requestGeneration = traceGenerationRef.current + 1;
     traceGenerationRef.current = requestGeneration;
-    setSelectedMsg(record);
-    setModalTab(tab);
-    setModalOpen(true);
     setTraceData(null);
     setTraceLoading(true);
     setTraceError(null);
-    if (tab === 'trace') {
-      setTraceQueryMode('msgid');
-      setTraceQueryValue(record.msgId);
+    setTraceQueryMode('msgid');
+    setTraceQueryValue(record.msgId);
+    const cacheKey = JSON.stringify([selectedInstanceId, record.topic, record.msgId]);
+    let traceRequest = traceCacheRef.current.get(cacheKey);
+    if (!traceRequest) {
+      traceRequest = getMessageTrace(record.msgId, selectedInstanceId, record.topic).catch(
+        (error) => {
+          traceCacheRef.current.delete(cacheKey);
+          throw error;
+        },
+      );
+      traceCacheRef.current.set(cacheKey, traceRequest);
     }
     try {
-      const result = await getMessageTrace(record.msgId, selectedInstanceId, record.topic);
+      const result = await traceRequest;
       if (traceGenerationRef.current !== requestGeneration) return;
       setTraceData(result);
       setTraceError(null);
@@ -424,6 +445,22 @@ const MessagePageContent = ({
         setTraceLoading(false);
       }
     }
+  };
+
+  const openDetail = (record: MessageRecord, tab = 'content') => {
+    traceGenerationRef.current += 1;
+    setSelectedMsg(record);
+    setModalTab(tab);
+    setModalOpen(true);
+    setTraceData(null);
+    setTraceLoading(false);
+    setTraceError(null);
+    if (tab === 'trace') void loadMessageTrace(record);
+  };
+
+  const handleModalTabChange = (tab: string) => {
+    setModalTab(tab);
+    if (tab === 'trace' && selectedMsg) void loadMessageTrace(selectedMsg);
   };
 
   const runTraceQuery = async () => {
@@ -826,7 +863,7 @@ const MessagePageContent = ({
             <Segmented
               options={QUERY_OPTIONS}
               value={queryMode}
-              onChange={(v) => setQueryMode(v as QueryMode)}
+              onChange={(v) => handleQueryModeChange(v as QueryMode)}
             />
           </Space>
 
@@ -1022,7 +1059,7 @@ const MessagePageContent = ({
           </Flex>
         }
       >
-        <Tabs activeKey={modalTab} onChange={setModalTab} items={modalTabs} />
+        <Tabs activeKey={modalTab} onChange={handleModalTabChange} items={modalTabs} />
       </Modal>
 
       <Modal


### PR DESCRIPTION
## Summary

- clear rows, totals, pagination, truncation warnings, errors, and loading state on Reset and query-mode changes
- invalidate in-flight queries when their view lifecycle ends
- load traces only when the Trace tab is opened and reuse the same message trace during the page lifecycle
- preserve existing late-response ownership guards and allow failed trace requests to retry

## Local verification

- MessagePage and MessagePageAsyncState: 23 tests passed
- targeted ESLint passed
- targeted Prettier check passed
- TypeScript and Vite production build passed
- git diff --check
- scope check: 173 changed lines across 2 files

The Vitest run emitted only the existing jsdom pseudo-element getComputedStyle warning.

Fixes #2691
