### PR TITLE
[ISSUE #2692] fix(deploy): align remote environment contracts

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -4,10 +4,10 @@ REMOTE_HOST=your-server-ip
 REMOTE_USER=root
 REMOTE_PATH=/opt/rocketmq-studio
 
-# Optional local server build settings. deploy.sh mounts this directory into
-# the Maven build container, so downloaded dependencies persist across builds.
+# Optional remote server build settings. The path is resolved on the remote
+# host and mounted into the Maven build container for dependency reuse.
 # MAVEN_CACHE_DIR=/home/your-user/.m2
-# MAVEN_IMAGE=maven:3.9.9-eclipse-temurin-21
+# MAVEN_IMAGE=maven:3.9.16-eclipse-temurin-21
 
 # Frontend public port
 PUBLIC_PORT=6789

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -9,7 +9,7 @@
 ```
 
 脚本自动完成：本地构建 → 导出镜像 → SCP 传输 → 远程加载 → 重启容器 → 验证。
-后端通过 Maven 容器构建，并默认挂载宿主机的 `~/.m2`，后续构建会复用已下载的依赖。
+后端通过目标机上的 Maven 容器构建，并默认挂载目标登录用户的 `~/.m2`，后续构建会复用已下载的依赖。
 
 ## 配置
 
@@ -23,10 +23,16 @@ PUBLIC_PORT=8080
 
 # 可选：自定义宿主机 Maven 缓存和构建镜像
 MAVEN_CACHE_DIR=/home/your-user/.m2
-MAVEN_IMAGE=maven:3.9.9-eclipse-temurin-21
+MAVEN_IMAGE=maven:3.9.16-eclipse-temurin-21
 ```
 
-`MAVEN_CACHE_DIR` 默认为当前用户的 `~/.m2`。如果其中存在 `settings.xml`，构建容器也会自动使用该配置。
+`REMOTE_PATH` 必须是不含空白、单引号或冒号的绝对路径。`MAVEN_CACHE_DIR` 也是目标机上的绝对路径
+（不含换行或冒号），默认为远程登录用户的 `~/.m2`；路径可以包含空格。脚本会将同一路径挂载为
+`/maven-cache`，如果其中存在 `settings.xml`，构建容器也会自动使用该配置。
+
+`deploy.sh` 以本地 `deploy/.env` 作为唯一部署配置，并随源码同步到远端
+`$REMOTE_PATH/deploy/.env`。Compose 启动同样读取该文件，因此首次部署不需要手工创建远端根目录
+`.env`。`PUBLIC_PORT` 同时控制 Compose 的前端端口映射和脚本的部署验证地址。
 
 ## 本地 Docker Compose
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -17,19 +17,29 @@ info() { echo -e "🚀 $*"; }
 warn() { echo -e "⚠️  $*"; }
 err()  { echo -e "❌ $*" >&2; exit 1; }
 
-if [[ -f "$SCRIPT_DIR/.env" ]]; then
-  set -a
-  # shellcheck disable=SC1091
-  source "$SCRIPT_DIR/.env"
-  set +a
-fi
+ENV_FILE="$SCRIPT_DIR/.env"
+[[ -f "$ENV_FILE" ]] || err "缺少 $ENV_FILE，请先复制 deploy/.env.example 并填写远程部署配置"
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
 
 [[ -n "${REMOTE_HOST:-}" ]] || err "REMOTE_HOST 未配置，请在 deploy/.env 中设置"
 REMOTE="${REMOTE_USER:-root}@$REMOTE_HOST"
 REMOTE_PATH="${REMOTE_PATH:-/opt/rocketmq-studio}"
 PUBLIC_PORT="${PUBLIC_PORT:-6789}"
 MAVEN_IMAGE="${MAVEN_IMAGE:-maven:3.9.16-eclipse-temurin-21}"
-SRC_TAR="/tmp/rocketmq-studio-src.tar.gz"
+MAVEN_CACHE_DIR="${MAVEN_CACHE_DIR:-}"
+REMOTE_MAVEN_CACHE_DIR=""
+SRC_TAR=""
+REMOTE_LOCK_DIR="$REMOTE_PATH/.rocketmq-studio-deploy.lock"
+LOCK_ACQUIRED="false"
+
+[[ "$REMOTE_PATH" == /* && "$REMOTE_PATH" != *[[:space:]\']* && "$REMOTE_PATH" != *:* ]] \
+  || err "REMOTE_PATH 必须是不含空白、单引号或冒号的绝对路径"
+if [[ ! "$PUBLIC_PORT" =~ ^[0-9]+$ ]] || ((PUBLIC_PORT < 1 || PUBLIC_PORT > 65535)); then
+  err "PUBLIC_PORT 必须是 1 到 65535 之间的端口"
+fi
 
 TARGET="${1:-all}"  # all | server | web
 case "$TARGET" in
@@ -37,22 +47,69 @@ case "$TARGET" in
   *) err "用法: $0 [all|server|web]" ;;
 esac
 
+# shellcheck disable=SC2029
 run_remote() { ssh "$REMOTE" "$@"; }
 
+remote_quote() {
+  local value="${1//\'/\'\\\'\'}"
+  printf "'%s'" "$value"
+}
+
+resolve_maven_cache_dir() {
+  if [[ -n "$MAVEN_CACHE_DIR" ]]; then
+    REMOTE_MAVEN_CACHE_DIR="$MAVEN_CACHE_DIR"
+  else
+    # shellcheck disable=SC2016
+    REMOTE_MAVEN_CACHE_DIR="$(run_remote 'printf %s "$HOME/.m2"')"
+  fi
+  [[ "$REMOTE_MAVEN_CACHE_DIR" == /* \
+      && "$REMOTE_MAVEN_CACHE_DIR" != *$'\n'* \
+      && "$REMOTE_MAVEN_CACHE_DIR" != *$'\r'* \
+      && "$REMOTE_MAVEN_CACHE_DIR" != *:* ]] \
+    || err "MAVEN_CACHE_DIR 必须是目标机上不含换行或冒号的绝对路径"
+}
+
+acquire_deploy_lock() {
+  local lock_dir
+  lock_dir="$(remote_quote "$REMOTE_LOCK_DIR")"
+  info "🔒 获取远端部署锁..."
+  if ! run_remote "mkdir $lock_dir"; then
+    err "已有部署正在操作 ${REMOTE}:${REMOTE_PATH}，请稍后重试"
+  fi
+  LOCK_ACQUIRED="true"
+  run_remote "printf '%s\n' '$$' > $(remote_quote "$REMOTE_LOCK_DIR/pid")"
+  log "远端部署锁已获取"
+}
+
+release_deploy_lock() {
+  [[ "$LOCK_ACQUIRED" == "true" ]] || return 0
+  if run_remote "rm -f $(remote_quote "$REMOTE_LOCK_DIR/pid") && rmdir $(remote_quote "$REMOTE_LOCK_DIR")"; then
+    LOCK_ACQUIRED="false"
+  else
+    warn "无法释放远端部署锁 $REMOTE_LOCK_DIR，请手动检查"
+    return 1
+  fi
+}
+
 check_prereqs() {
+  local remote_path
+  remote_path="$(remote_quote "$REMOTE_PATH")"
   info "🔎 检查前置条件..."
   for c in tar scp ssh; do command -v "$c" >/dev/null 2>&1 || err "本地缺少 $c"; done
   ssh -o ConnectTimeout=5 -o BatchMode=yes "$REMOTE" "echo ok" >/dev/null 2>&1 \
     || err "无法 SSH 连接到 $REMOTE（请确认免密登录已配置）"
   run_remote 'command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1' \
     || err "目标机缺少 docker 或 docker compose"
-  run_remote "test -f $REMOTE_PATH/.env" \
-    || err "目标机缺少 $REMOTE_PATH/.env（首次部署请按 SKILL.md 模式 A 步骤 1 初始化）"
+  run_remote "mkdir -p $remote_path"
+  if [[ "$TARGET" == "all" || "$TARGET" == "server" ]]; then
+    resolve_maven_cache_dir
+  fi
   log "前置条件通过"
 }
 
 package_source() {
   info "📦 本地打包源码..."
+  SRC_TAR="$(mktemp "${TMPDIR:-/tmp}/rocketmq-studio-src.XXXXXX")"
   tar czf "$SRC_TAR" -C "$PROJECT_DIR" \
     --exclude='web/node_modules' --exclude='web/dist' --exclude='server/target' \
     server web deploy
@@ -60,54 +117,66 @@ package_source() {
 }
 
 upload_source() {
+  local archive_name remote_env remote_path
+  archive_name="$(basename "$SRC_TAR")"
+  remote_env="$(remote_quote "$REMOTE_PATH/deploy/.env")"
+  remote_path="$(remote_quote "$REMOTE_PATH")"
   info "📤 传输源码到 $REMOTE:$REMOTE_PATH ..."
-  run_remote "mkdir -p $REMOTE_PATH"
   scp -q "$SRC_TAR" "$REMOTE:$REMOTE_PATH/"
-  run_remote "cd $REMOTE_PATH && rm -rf server web deploy && tar xzf $(basename "$SRC_TAR") && rm $(basename "$SRC_TAR")"
+  run_remote "cd $remote_path && rm -rf server web deploy && tar xzf $(remote_quote "$archive_name") && rm $(remote_quote "$archive_name")"
+  run_remote "test -f $remote_env" \
+    || err "源码包未包含 deploy/.env，无法使用本地部署配置启动远端服务"
   run_remote 'docker network inspect rocketmq_net >/dev/null 2>&1 || docker network create rocketmq_net'
   log "源码就位，rocketmq_net 网络就绪"
 }
 
 build_server() {
-  info "🏗️  目标机编译后端 JAR（复用 ~/.m2 缓存）..."
-  local settings_flag=""
-  if run_remote 'test -f ~/.m2/settings.xml'; then
+  local cache_settings cache_volume image remote_path server_volume settings_flag=""
+  cache_settings="$(remote_quote "$REMOTE_MAVEN_CACHE_DIR/settings.xml")"
+  cache_volume="$(remote_quote "$REMOTE_MAVEN_CACHE_DIR:/maven-cache")"
+  image="$(remote_quote "$MAVEN_IMAGE")"
+  remote_path="$(remote_quote "$REMOTE_PATH")"
+  server_volume="$(remote_quote "$REMOTE_PATH/server:/app")"
+  info "🏗️  目标机编译后端 JAR（复用 $REMOTE_MAVEN_CACHE_DIR 缓存）..."
+  if run_remote "test -f $cache_settings"; then
     settings_flag="-s /maven-cache/settings.xml"
   else
-    warn "目标机无 ~/.m2/settings.xml（国内机器请先配置 Maven 阿里源，见 SKILL.md 步骤 2）"
+    warn "目标机无 $REMOTE_MAVEN_CACHE_DIR/settings.xml，将使用 Maven 默认仓库配置"
   fi
-  run_remote "cd $REMOTE_PATH && docker run --rm -e HOME=/tmp \
-    --user \$(id -u):\$(id -g) \
-    -v \$PWD/server:/app -v \$HOME/.m2:/maven-cache -w /app \
-    $MAVEN_IMAGE \
+  run_remote "cd $remote_path && docker run --rm -e HOME=/tmp \
+    --user \"\$(id -u):\$(id -g)\" \
+    -v $server_volume -v $cache_volume -w /app \
+    $image \
     mvn -B -ntp $settings_flag -Dmaven.repo.local=/maven-cache/repository package -DskipTests"
   info "🏗️  构建 rocketmq-server 镜像（runtime-prebuilt）..."
-  run_remote "cd $REMOTE_PATH && docker build --target runtime-prebuilt -t rocketmq-server:latest server/"
+  run_remote "cd $remote_path && docker build --target runtime-prebuilt -t rocketmq-server:latest server/"
   log "rocketmq-server 镜像构建完成"
 }
 
 build_web() {
   local commit
   commit="$(git -C "$PROJECT_DIR" rev-parse --short HEAD 2>/dev/null || echo dev)"
-  info "🏗️  构建 rocketmq-web 镜像（VITE_GIT_COMMIT=$commit）..."
-  run_remote "cd $REMOTE_PATH && docker build --build-arg VITE_GIT_COMMIT=$commit -t rocketmq-web:latest web/"
+  info "🏗️  构建 rocketmq-web 镜像（VITE_GIT_COMMIT=${commit}）..."
+  run_remote "cd $(remote_quote "$REMOTE_PATH") && docker build --build-arg VITE_GIT_COMMIT=$commit -t rocketmq-web:latest web/"
   log "rocketmq-web 镜像构建完成"
 }
 
 start_services() {
+  local remote_path
+  remote_path="$(remote_quote "$REMOTE_PATH")"
   local services=()
   [[ "$TARGET" == "all" || "$TARGET" == "server" ]] && services+=("rocketmq-server")
   [[ "$TARGET" == "all" || "$TARGET" == "web" ]] && services+=("rocketmq-web")
   info "▶️  启动容器: ${services[*]} ..."
-  run_remote "cd $REMOTE_PATH && docker compose --env-file .env -f deploy/docker-compose.yml up -d ${services[*]}"
+  run_remote "cd $remote_path && docker compose --env-file deploy/.env -f deploy/docker-compose.yml up -d ${services[*]}"
   log "容器已启动"
 }
 
 verify() {
   info "🔍 验证部署..."
   if [[ "$TARGET" == "all" || "$TARGET" == "server" ]]; then
-    local i ok=""
-    for i in $(seq 1 30); do
+    local ok=""
+    for _ in $(seq 1 30); do
       if run_remote 'docker exec rocketmq-server curl -fsS http://localhost:8888/actuator/health' 2>/dev/null | grep -q '"UP"'; then
         ok="yes"; break
       fi
@@ -117,18 +186,27 @@ verify() {
     log "后端 actuator/health = UP"
   fi
   if [[ "$TARGET" == "all" || "$TARGET" == "web" ]]; then
-    local i code=""
-    for i in $(seq 1 12); do
+    local code=""
+    for _ in $(seq 1 12); do
       code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "http://$REMOTE_HOST:$PUBLIC_PORT/" 2>/dev/null || true)
       [[ "$code" == "200" ]] && break
       sleep 5
     done
-    [[ "$code" == "200" ]] && log "前端响应正常 (HTTP $code)" || warn "前端返回 HTTP $code"
+    if [[ "$code" == "200" ]]; then
+      log "前端响应正常 (HTTP $code)"
+    else
+      warn "前端返回 HTTP $code"
+    fi
   fi
   log "🎉 部署完成 → http://$REMOTE_HOST:$PUBLIC_PORT/"
 }
 
-cleanup() { rm -f "$SRC_TAR"; }
+cleanup() {
+  local status=$?
+  release_deploy_lock || true
+  [[ -z "$SRC_TAR" ]] || rm -f -- "$SRC_TAR"
+  return "$status"
+}
 trap cleanup EXIT
 
 main() {
@@ -137,6 +215,7 @@ main() {
   echo "  目标: $TARGET | 远程: $REMOTE:$REMOTE_PATH"
   echo "═══════════════════════════════════════════"
   check_prereqs
+  acquire_deploy_lock
   package_source
   upload_source
   [[ "$TARGET" == "all" || "$TARGET" == "server" ]] && build_server

--- a/deploy/deploy_test.sh
+++ b/deploy/deploy_test.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/rocketmq-deploy-test.XXXXXX")"
+PROJECT_ROOT="$TEST_ROOT/project"
+BIN_DIR="$TEST_ROOT/bin"
+STATE_DIR="$TEST_ROOT/state"
+LOG_DIR="$TEST_ROOT/log"
+first_pid=""
+mkdir -p "$PROJECT_ROOT/deploy" "$BIN_DIR" "$STATE_DIR" "$LOG_DIR"
+cp "$SCRIPT_DIR/deploy.sh" "$PROJECT_ROOT/deploy/deploy.sh"
+
+cleanup() {
+  if [[ -n "$first_pid" ]] && kill -0 "$first_pid" 2>/dev/null; then
+    : > "$TEST_ROOT/hold.release"
+    wait "$first_pid" || true
+  fi
+  rm -R "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+cat > "$PROJECT_ROOT/deploy/.env" <<'EOF'
+REMOTE_HOST=${TEST_REMOTE_HOST:?}
+REMOTE_USER=deployer
+REMOTE_PATH=${TEST_REMOTE_PATH:?}
+PUBLIC_PORT=${TEST_PUBLIC_PORT:-18080}
+MAVEN_CACHE_DIR=${TEST_MAVEN_CACHE_DIR-}
+MAVEN_IMAGE=maven:test
+EOF
+
+cat > "$BIN_DIR/ssh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+remote=""
+command=""
+while (($#)); do
+  case "$1" in
+    -o) shift 2 ;;
+    *@*) remote="$1"; shift; command="$*"; break ;;
+    *) shift ;;
+  esac
+done
+printf '%s\t%s\n' "$remote" "$command" >> "$STUB_LOG_DIR/ssh-commands"
+
+lock_path="$(printf '%s' "$command" | sed -n "s/.*'\([^']*\.rocketmq-studio-deploy.lock\)'.*/\1/p")"
+if [[ -n "$lock_path" ]]; then
+  lock_key="$(printf '%s:%s' "$remote" "$lock_path" | tr '/:@' '____')"
+  lock_dir="$STUB_STATE_DIR/$lock_key"
+  case "$command" in
+    mkdir\ *) mkdir "$lock_dir" ;;
+    *"rmdir "*) rm -f "$lock_dir/pid"; rmdir "$lock_dir" ;;
+    *"printf "*) printf '%s\n' owner > "$lock_dir/pid" ;;
+  esac
+  exit
+fi
+
+if [[ "$command" == *"rm -rf server web deploy"* && -n "${STUB_HOLD_FILE:-}" ]]; then
+  : > "$STUB_HOLD_FILE.ready"
+  while [[ ! -f "$STUB_HOLD_FILE.release" ]]; do /bin/sleep 0.02; done
+fi
+if [[ "$command" == *"actuator/health"* ]]; then
+  printf '%s\n' '{"status":"UP"}'
+fi
+if [[ "$command" == 'printf %s "$HOME/.m2"' ]]; then
+  printf '%s' '/home/deployer/.m2'
+fi
+EOF
+
+cat > "$BIN_DIR/tar" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+archive="$2"
+printf '%s\n' "$archive" >> "$STUB_LOG_DIR/tar-paths"
+printf '%s\n' "$*" >> "$STUB_LOG_DIR/tar-commands"
+: > "$archive"
+EOF
+
+cat > "$BIN_DIR/scp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$STUB_LOG_DIR/scp-commands"
+[[ "${STUB_FAIL_SCP:-0}" == "0" ]] || exit 42
+EOF
+
+cat > "$BIN_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+printf 200
+EOF
+
+chmod +x "$BIN_DIR/ssh" "$BIN_DIR/tar" "$BIN_DIR/scp" "$BIN_DIR/curl"
+
+run_deploy() {
+  env PATH="$BIN_DIR:$PATH" \
+    STUB_STATE_DIR="$STATE_DIR" STUB_LOG_DIR="$LOG_DIR" \
+    TEST_REMOTE_HOST=host-a TEST_REMOTE_PATH="$1" \
+    TEST_MAVEN_CACHE_DIR="${2-/srv/maven cache}" TEST_PUBLIC_PORT=18080 \
+    "$PROJECT_ROOT/deploy/deploy.sh" all
+}
+
+hold_file="$TEST_ROOT/hold"
+env PATH="$BIN_DIR:$PATH" \
+  STUB_STATE_DIR="$STATE_DIR" STUB_LOG_DIR="$LOG_DIR" STUB_HOLD_FILE="$hold_file" \
+  TEST_REMOTE_HOST=host-a TEST_REMOTE_PATH=/opt/studio \
+  TEST_MAVEN_CACHE_DIR="/srv/maven cache" TEST_PUBLIC_PORT=18080 \
+  "$PROJECT_ROOT/deploy/deploy.sh" all > "$LOG_DIR/first" 2>&1 &
+first_pid=$!
+
+for _ in $(seq 1 500); do
+  [[ -f "$hold_file.ready" ]] && break
+  /bin/sleep 0.02
+done
+[[ -f "$hold_file.ready" ]] || fail "first deployment did not reach the protected section"
+
+if run_deploy /opt/studio > "$LOG_DIR/same-target" 2>&1; then
+  fail "a concurrent deployment to the same remote target was not rejected"
+fi
+grep -q "已有部署正在操作" "$LOG_DIR/same-target" \
+  || fail "lock contention did not report a useful error"
+
+if ! run_deploy /opt/studio-b > "$LOG_DIR/different-target" 2>&1; then
+  sed -n '1,160p' "$LOG_DIR/different-target" >&2
+  fail "a different remote path was incorrectly blocked"
+fi
+
+: > "$hold_file.release"
+wait "$first_pid" || fail "first deployment did not finish successfully"
+first_pid=""
+
+if STUB_FAIL_SCP=1 run_deploy /opt/failing > "$LOG_DIR/failing" 2>&1; then
+  fail "stubbed upload failure unexpectedly succeeded"
+fi
+run_deploy /opt/failing > "$LOG_DIR/after-failure" 2>&1 \
+  || fail "the remote lock was not released after a failure"
+run_deploy /opt/default-cache "" > "$LOG_DIR/default-cache" 2>&1 \
+  || fail "the remote Maven cache default could not be resolved"
+
+[[ "$(sort -u "$LOG_DIR/tar-paths" | wc -l | tr -d ' ')" == "5" ]] \
+  || fail "deployments did not use unique source archives"
+while IFS= read -r archive; do
+  [[ ! -e "$archive" ]] || fail "temporary archive was not removed: $archive"
+done < "$LOG_DIR/tar-paths"
+[[ -z "$(find "$STATE_DIR" -mindepth 1 -print -quit)" ]] \
+  || fail "a remote lock remained after deployment"
+
+grep -Fq "test -f '/srv/maven cache/settings.xml'" "$LOG_DIR/ssh-commands" \
+  || fail "configured Maven cache was not used for settings.xml lookup"
+grep -Fq -- "-v '/srv/maven cache:/maven-cache'" "$LOG_DIR/ssh-commands" \
+  || fail "configured Maven cache was not mounted into the build container"
+grep -Fq -- "-s /maven-cache/settings.xml" "$LOG_DIR/ssh-commands" \
+  || fail "configured Maven settings were not passed to Maven"
+grep -Fq -- "-v '/home/deployer/.m2:/maven-cache'" "$LOG_DIR/ssh-commands" \
+  || fail "default remote Maven cache was not mounted into the build container"
+grep -Fq -- "--env-file deploy/.env" "$LOG_DIR/ssh-commands" \
+  || fail "remote Compose did not read the uploaded deploy/.env"
+if grep -Fq -- "--env-file .env" "$LOG_DIR/ssh-commands"; then
+  fail "remote Compose still reads the obsolete root .env"
+fi
+if grep -Fq "test -f '/opt/studio/.env'" "$LOG_DIR/ssh-commands"; then
+  fail "first deployment still requires an obsolete remote root .env"
+fi
+grep -Fq "server web deploy" "$LOG_DIR/tar-commands" \
+  || fail "deployment package omitted the deploy directory"
+
+command -v docker >/dev/null 2>&1 || fail "docker is required for Compose config validation"
+docker compose version >/dev/null 2>&1 || fail "docker compose is required for config validation"
+compose_config="$(PUBLIC_PORT=18080 docker compose -f "$SCRIPT_DIR/docker-compose.yml" config)"
+grep -Fq 'published: "18080"' <<< "$compose_config" \
+  || fail "PUBLIC_PORT did not control the rendered frontend port mapping"
+
+echo "PASS: deploy environment, cache, port, lock, and cleanup contracts"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -78,7 +78,7 @@ services:
     container_name: rocketmq-web
     restart: unless-stopped
     ports:
-      - "6789:80"
+      - "${PUBLIC_PORT:-6789}:80"
     depends_on:
       rocketmq-server:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- make PUBLIC_PORT control the rendered Compose port and deployment verification
- use packaged deploy/.env as the single local and remote deployment configuration source
- apply MAVEN_CACHE_DIR consistently to settings lookup, repository storage, and the Maven volume
- serialize deployments per remote target with unique archives and exit cleanup
- add an offline SSH, SCP, archive, port, cache, lock, and cleanup contract test
- align deployment documentation and examples with the implemented behavior

## Local verification

- shellcheck deploy/deploy.sh deploy/deploy_test.sh
- bash -n deploy/deploy.sh deploy/deploy_test.sh
- deploy/deploy_test.sh: passed
- PUBLIC_PORT=18080 docker compose config: passed and rendered published port 18080
- git diff --check
- scope check: 339 changed lines across 5 files

No container was started and no real SSH host was contacted. A hard process kill or abrupt remote disconnect can leave the target lock directory behind; operators should confirm no deployment is running before removing it.

Fixes #2692

Addresses #2473
