### PR TITLE
[ISSUE #2698] fix(metrics): validate query windows without overflow

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
@@ -138,13 +138,16 @@ public class MetricsService {
     }
 
     private void validateQueryWindow(MetricQueryDTO query) {
-        long rangeSeconds = query.getEnd() - query.getStart();
-        if (rangeSeconds <= 0) {
+        long start = query.getStart();
+        long end = query.getEnd();
+        if (end <= start) {
             throw badRequest("Metric query end must be later than start");
         }
-        if (rangeSeconds > MAX_RANGE_SECONDS) {
+        if (start <= Long.MAX_VALUE - MAX_RANGE_SECONDS
+                && end > start + MAX_RANGE_SECONDS) {
             throw badRequest("Metric query range must not exceed 31 days");
         }
+        long rangeSeconds = end - start;
         BigDecimal stepMillis = parseStepMillis(query.getStep());
         if (stepMillis.signum() <= 0) {
             throw badRequest("Metric query step must be positive");

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
@@ -245,6 +245,47 @@ class MetricsServiceTest {
     }
 
     @Test
+    void queryShouldRejectReversedWindowWhenTimestampSubtractionWouldOverflow() {
+        MetricQueryDTO query = MetricQueryDTO.builder()
+                .metric("rocketmq_messages_in_total")
+                .start(Long.MAX_VALUE)
+                .end(Long.MIN_VALUE)
+                .step("1m")
+                .build();
+
+        assertBadRequest(query, "Metric query end must be later than start");
+        verifyNoInteractions(metricsSource);
+    }
+
+    @Test
+    void queryShouldRejectOversizedWindowWhenTimestampSubtractionWouldOverflow() {
+        MetricQueryDTO query = MetricQueryDTO.builder()
+                .metric("rocketmq_messages_in_total")
+                .start(Long.MIN_VALUE)
+                .end(Long.MAX_VALUE)
+                .step("1h")
+                .build();
+
+        assertBadRequest(query, "Metric query range must not exceed 31 days");
+        verifyNoInteractions(metricsSource);
+    }
+
+    @Test
+    void queryShouldAcceptMaximumWindowNearTimestampUpperBound() {
+        MetricQueryDTO query = MetricQueryDTO.builder()
+                .metric("rocketmq_messages_in_total")
+                .start(Long.MAX_VALUE - 31L * 24 * 60 * 60)
+                .end(Long.MAX_VALUE)
+                .step("1h")
+                .build();
+        when(metricsSource.query(query)).thenReturn(emptyMetricData());
+
+        metricsService.query(query);
+
+        verify(metricsSource).query(query);
+    }
+
+    @Test
     void queryShouldRejectOversizedWindow() {
         MetricQueryDTO query = MetricQueryDTO.builder()
                 .metric("rocketmq_messages_in_total")


### PR DESCRIPTION
## Problem

Metric query window validation subtracted signed timestamps before checking ordering and range, so extreme values could overflow and bypass or misclassify validation.

## Changes

- compare query endpoints before duration arithmetic
- enforce the 31-day limit with an overflow-safe boundary check
- cover reversed, oversized, and exact-boundary extreme windows

## Local verification

- `git diff --check`
- PR scope check: 50 changed lines, 2 files, 1 commit
- Java tests were not run locally because this workspace does not have the project's Java 21 toolchain and no further SDK installation was attempted; the automatically triggered Java 21 PR checks are expected to run the regression test

No containers, full E2E suite, or remote workflow was started manually.

Fixes #2698
