### PR TITLE
[ISSUE #2699] fix(message): ignore time bounds for id lookup

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -115,28 +115,27 @@ public class RocketMQMessageProvider implements MessageProvider {
                                                  String topic, String msgId, String tag, String key,
                                                  Long startTime, Long endTime) {
 
+        if (StringUtils.hasText(msgId)) {
+            return queryByMsgId(adminExt, topic, msgId);
+        }
+
         long end = endTime != null ? endTime : System.currentTimeMillis();
         long begin = startTime != null ? startTime : end - ONE_HOUR_MILLIS;
         if (begin >= end) {
             throw new BusinessException(400, "Message query start time must be before end time");
         }
-
-        List<MessageRecordVO> result;
-        if (StringUtils.hasText(msgId)) {
-            result = queryByMsgId(adminExt, topic, msgId);
-        } else if (StringUtils.hasText(topic) && StringUtils.hasText(key)) {
-            result = queryByKey(adminExt, topic, key, tag, begin, end);
-        } else if (StringUtils.hasText(topic)) {
+        if (StringUtils.hasText(topic) && StringUtils.hasText(key)) {
+            return queryByKey(adminExt, topic, key, tag, begin, end);
+        }
+        if (StringUtils.hasText(topic)) {
             if (begin >= 0 && end >= 0 && end - begin > MAX_TOPIC_QUERY_WINDOW_MILLIS) {
                 throw new BusinessException(400, "Topic message query time range must not exceed 7 days");
             }
-            result = queryByTopic(instanceId, topic, tag, begin, end, DEFAULT_TOPIC_LIMIT);
-        } else {
-            log.warn("queryMessages requires at least one of msgId/topic, returning empty list");
-            return Collections.emptyList();
+            return queryByTopic(instanceId, topic, tag, begin, end, DEFAULT_TOPIC_LIMIT);
         }
 
-        return result;
+        log.warn("queryMessages requires at least one of msgId/topic, returning empty list");
+        return Collections.emptyList();
     }
 
     private List<MessageRecordVO> queryByMsgId(DefaultMQAdminExt adminExt, String topic, String msgId) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -230,6 +230,23 @@ class RocketMQMessageProviderTest {
     }
 
     @Test
+    void queryByMsgIdIgnoresUnrelatedTimeBounds() throws Exception {
+        MessageExt message = new MessageExt();
+        message.setMsgId("msg-1");
+        message.setTopic("TopicA");
+        when(adminExt.viewMessage("TopicA", "msg-1")).thenReturn(message);
+
+        assertThat(provider.queryMessages(
+                "instance-a", "TopicA", "msg-1", null, null, 200L, 100L))
+                .singleElement().extracting(MessageRecordVO::getMsgId).isEqualTo("msg-1");
+        assertThat(provider.queryMessages(
+                "instance-a", "TopicA", "msg-1", null, null, 100L, 100L))
+                .singleElement().extracting(MessageRecordVO::getMsgId).isEqualTo("msg-1");
+
+        verify(adminExt, times(2)).viewMessage("TopicA", "msg-1");
+    }
+
+    @Test
     void queryByMsgIdRejectsDecodedBrokerOutsideKnownTopology() throws Exception {
         String msgId = MessageDecoder.createMessageId(new InetSocketAddress("10.2.3.4", 10911), 12345L);
         when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithBrokerAddresses("172.30.10.100:10911"));


### PR DESCRIPTION
## Problem

The Apache message provider rejected equal or reversed timestamps before message-ID lookup even though that lookup does not consume either time bound.

## Changes

- return from the message-ID path before computing query time bounds
- preserve existing time validation for Key and Topic searches
- cover equal and reversed unused bounds with a provider regression test

## Local verification

- `git diff --check`
- PR scope check: 40 changed lines, 2 files, 1 commit
- Java tests were not run locally because this workspace does not have the project's Java 21 toolchain and no further SDK installation was attempted; the automatically triggered Java 21 PR checks are expected to run the regression test

No containers, full E2E suite, or remote workflow was started manually.

Fixes #2699
