### PR TITLE
[ISSUE #2700] fix(broker): trim flush disk configuration

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigService.java
@@ -116,7 +116,7 @@ public class RocketMQBrokerConfigService {
 
     private FlushDiskType parseFlushDiskType(String value) {
         try {
-            return FlushDiskType.valueOf(value);
+            return FlushDiskType.valueOf(value.trim());
         } catch (IllegalArgumentException e) {
             return FlushDiskType.ASYNC_FLUSH;
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigServiceTest.java
@@ -8,6 +8,7 @@ package org.apache.rocketmq.studio.provider.apache;
 
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.common.domain.enums.FlushDiskType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.ops.audit.AuditService;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
@@ -19,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Properties;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -26,6 +28,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RocketMQBrokerConfigServiceTest {
@@ -86,5 +89,22 @@ class RocketMQBrokerConfigServiceTest {
         verify(auditService).record(
                 "UPDATE_BROKER_CONFIG", "BROKER", "CLUSTER:cluster-a", "cluster-a",
                 "brokerAddr=broker-a:10911, config={}", "SUCCESS");
+    }
+
+    @Test
+    void trimsFlushDiskTypeWithoutChangingUnknownValueFallback() throws Exception {
+        Properties padded = new Properties();
+        padded.setProperty("flushDiskType", " SYNC_FLUSH ");
+        when(adminExt.getBrokerConfig("broker-a:10911")).thenReturn(padded);
+
+        assertThat(brokerConfigService.getBrokerConfig("broker-a:10911").getFlushDiskType())
+                .isEqualTo(FlushDiskType.SYNC_FLUSH);
+
+        Properties unknown = new Properties();
+        unknown.setProperty("flushDiskType", "future-mode");
+        when(adminExt.getBrokerConfig("broker-b:10911")).thenReturn(unknown);
+
+        assertThat(brokerConfigService.getBrokerConfig("broker-b:10911").getFlushDiskType())
+                .isEqualTo(FlushDiskType.ASYNC_FLUSH);
     }
 }


### PR DESCRIPTION
## Problem

A valid padded `flushDiskType` returned by a Broker was parsed as unknown and silently displayed as `ASYNC_FLUSH`.

## Changes

- trim the enum value at the broker configuration boundary
- keep the existing fallback for genuinely unknown values
- test padded `SYNC_FLUSH` and an unknown future value through the service API

## Local verification

- `git diff --check`
- PR scope check: 22 changed lines, 2 files, 1 commit
- Java tests were not run locally because this workspace does not have the project's Java 21 toolchain and no further SDK installation was attempted; the automatically triggered Java 21 PR checks are expected to run the regression test

No containers, full E2E suite, or remote workflow was started manually.

Fixes #2700
