### PR TITLE
[ISSUE #2701] fix(message): preserve commas in user properties

### DIFF
--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -1566,7 +1566,7 @@ const TopicPage = () => {
             />
             {propsMode === 'text' && (
               <Text type="secondary" style={{ fontSize: 14 }}>
-                支持 key=value，多个属性用换行或逗号分隔
+                支持 key=value，每行填写一个属性；属性值可以包含逗号
               </Text>
             )}
           </Flex>

--- a/web/src/utils/messageProperties.test.ts
+++ b/web/src/utils/messageProperties.test.ts
@@ -19,6 +19,28 @@ import { describe, expect, it } from 'vitest';
 import { parseMessageProperties } from './messageProperties';
 
 describe('parseMessageProperties', () => {
+  it('preserves commas and additional equals signs in property values', () => {
+    const result = parseMessageProperties(
+      'location=Beijing,China\nsignature=part-a=part-b\ntags=blue,green',
+    );
+
+    expect(result).toEqual({
+      properties: {
+        location: 'Beijing,China',
+        signature: 'part-a=part-b',
+        tags: 'blue,green',
+      },
+      errors: [],
+    });
+  });
+
+  it('supports Windows line endings and reports duplicate keys', () => {
+    const result = parseMessageProperties('traceId=first\r\ntenant=demo\r\ntraceId=second');
+
+    expect(result.properties).toEqual({ traceId: 'first', tenant: 'demo' });
+    expect(result.errors).toEqual(['属性名“traceId”重复']);
+  });
+
   it('preserves JavaScript object prototype property names', () => {
     const result = parseMessageProperties(
       '__proto__=trace-prototype\nconstructor=trace-constructor\ntoString=trace-string',

--- a/web/src/utils/messageProperties.ts
+++ b/web/src/utils/messageProperties.ts
@@ -20,11 +20,12 @@ interface ParsedProperties {
   errors: string[];
 }
 
-// 解析批量粘贴的用户属性串：key=value 按换行或逗号分隔，等号只取第一个
+// 解析批量粘贴的用户属性串：每行一个 key=value，等号只取第一个。
+// 逗号属于合法属性值，不能同时作为记录分隔符，否则会破坏地址、列表等常见值。
 export const parseMessageProperties = (text: string): ParsedProperties => {
   const entries = new Map<string, string>();
   const errors: string[] = [];
-  for (const line of text.split(/[\n,]+/)) {
+  for (const line of text.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     const eqIndex = trimmed.indexOf('=');


### PR DESCRIPTION
## Problem

Message user-property values containing commas were split into extra malformed records, corrupting valid values such as locations and lists.

## Changes

- define one `key=value` property per line
- preserve commas and additional equals signs inside values
- update the form guidance and cover CRLF and duplicate-key behavior

## Local verification

- `npm test -- --run src/utils/messageProperties.test.ts src/pages/instance/__tests__/TopicPage.test.tsx` — 2 files, 19 tests passed
- targeted ESLint passed
- targeted Prettier check passed
- `git diff --check`
- PR scope check: 29 changed lines, 3 files, 1 commit

No containers, full E2E suite, full repository build, or remote workflow was started manually.

Fixes #2701
