### PR TITLE
[ISSUE #2702] fix(auth): deduplicate login submissions

### DIFF
--- a/web/src/pages/login/index.test.tsx
+++ b/web/src/pages/login/index.test.tsx
@@ -60,6 +60,15 @@ describe('LoginPage', () => {
       </MemoryRouter>,
     );
 
+  const fillCredentials = () => {
+    fireEvent.change(screen.getByPlaceholderText('login.usernamePlaceholder'), {
+      target: { value: 'alice' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('login.passwordPlaceholder'), {
+      target: { value: 'secret' },
+    });
+  };
+
   it('renders the brand and an accessible theme toggle', () => {
     renderPage();
     expect(screen.getByText('RocketMQ Studio')).toBeTruthy();
@@ -71,17 +80,43 @@ describe('LoginPage', () => {
       user: { username: 'alice', userId: 42, admin: true },
     });
     renderPage();
-    fireEvent.change(screen.getByPlaceholderText('login.usernamePlaceholder'), {
-      target: { value: 'alice' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('login.passwordPlaceholder'), {
-      target: { value: 'secret' },
-    });
+    fillCredentials();
     fireEvent.click(screen.getByRole('button', { name: 'login.title' }));
 
     await waitFor(() => expect(loginStoreMock).toHaveBeenCalledWith('alice', 42, true));
     expect(loginApiMock).toHaveBeenCalledWith('alice', 'secret');
     expect(navigateMock).toHaveBeenCalledWith('/', { replace: true });
+  });
+
+  it('owns an in-flight login request synchronously and allows retry after failure', async () => {
+    let rejectFirst: ((reason?: unknown) => void) | undefined;
+    loginApiMock
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          rejectFirst = reject;
+        }),
+      )
+      .mockResolvedValueOnce({
+        user: { username: 'alice', userId: 42, admin: true },
+      });
+    renderPage();
+    fillCredentials();
+
+    const form = document.querySelector('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+    fireEvent.submit(form!);
+
+    await waitFor(() => expect(loginApiMock).toHaveBeenCalledTimes(1));
+    rejectFirst?.(new Error('temporary failure'));
+    const submitButton = document.querySelector<HTMLButtonElement>('button[type="submit"]');
+    expect(submitButton).not.toBeNull();
+    await waitFor(() => expect(submitButton!.disabled).toBe(false));
+
+    fireEvent.submit(form!);
+
+    await waitFor(() => expect(loginApiMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(loginStoreMock).toHaveBeenCalledWith('alice', 42, true));
   });
 
   it('keeps required-field validation and does not call the API on empty submit', async () => {

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
   LockOutlined,
   MoonOutlined,
@@ -40,6 +40,7 @@ interface LoginFormValues {
 
 const LoginPage = () => {
   const [loading, setLoading] = useState(false);
+  const loginInFlightRef = useRef(false);
   const [form] = Form.useForm<LoginFormValues>();
   const { t } = useLang();
   const { message } = App.useApp();
@@ -48,6 +49,10 @@ const LoginPage = () => {
   const { darkMode, toggleTheme } = useTheme();
 
   const onFinish = async (values: LoginFormValues) => {
+    // React state is applied on the next render, so it cannot prevent two submit
+    // events in the same tick. Own the request synchronously before awaiting it.
+    if (loginInFlightRef.current) return;
+    loginInFlightRef.current = true;
     setLoading(true);
     try {
       const data = await loginApi(values.username, values.password);
@@ -58,6 +63,7 @@ const LoginPage = () => {
       const errorMsg = err instanceof Error ? err.message : t('login.failed');
       message.error(errorMsg);
     } finally {
+      loginInFlightRef.current = false;
       setLoading(false);
     }
   };


### PR DESCRIPTION
## Problem

Two login submit events in the same React render could both call the authentication API because loading state was not yet visible to the second handler.

## Changes

- synchronously own the in-flight login request with a ref
- ignore duplicate submits while the request is pending
- release ownership after failure so a later retry remains available

## Local verification

- `npm test -- --run src/pages/login/index.test.tsx` — 1 file, 4 tests passed
- targeted ESLint passed
- targeted Prettier check passed
- `git diff --check`
- PR scope check: 55 changed lines, 2 files, 1 commit

No containers, full E2E suite, full repository build, or remote workflow was started manually.

Fixes #2702
