### PR TITLE
[ISSUE #2712] fix(ai): terminate stalled CLI availability probes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/CliAgentProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/CliAgentProvider.java
@@ -61,18 +61,29 @@ public abstract class CliAgentProvider implements AgentProvider {
 
     @Override
     public boolean available() {
+        Process process = null;
         try {
             ProcessBuilder builder = new ProcessBuilder("sh", "-c", "command -v " + binaryName());
             processEnvironment.apply(builder, Map.of());
-            Process process = builder.redirectErrorStream(true).start();
+            process = startAvailabilityProcess(builder.redirectErrorStream(true));
             boolean finished = process.waitFor(5, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+            }
             return finished && process.exitValue() == 0;
         } catch (IOException | InterruptedException exception) {
+            if (process != null) {
+                process.destroyForcibly();
+            }
             if (exception instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
             return false;
         }
+    }
+
+    protected Process startAvailabilityProcess(ProcessBuilder builder) throws IOException {
+        return builder.start();
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/CliAgentProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/CliAgentProviderTest.java
@@ -18,10 +18,15 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class CliAgentProviderTest {
 
-    private static final class FakeCli extends CliAgentProvider {
+    private static class FakeCli extends CliAgentProvider {
         private final String script;
         private final int outputLimitBytes;
         private final Map<String, String> environment;
@@ -89,6 +94,20 @@ class CliAgentProviderTest {
         }
     }
 
+    private static final class AvailabilityCli extends FakeCli {
+        private final Process process;
+
+        AvailabilityCli(Process process) {
+            super("echo unused");
+            this.process = process;
+        }
+
+        @Override
+        protected Process startAvailabilityProcess(ProcessBuilder builder) {
+            return process;
+        }
+    }
+
     @Test
     void completeSurvivesLargeStderrOutput() {
         // Write well over the 64 KiB pipe buffer to stderr, then print the completion on stdout.
@@ -152,5 +171,30 @@ class CliAgentProviderTest {
                 assertThat(environment).doesNotContainKey("SERVER_SECRET"));
         assertThat(processEnvironment.childEnvironments.get(1))
                 .containsEntry("PROVIDER_TOKEN", "request-token");
+    }
+
+    @Test
+    void availabilityDestroysProbeWhenItTimesOut() throws Exception {
+        Process process = mock(Process.class);
+        when(process.waitFor(anyLong(), eq(java.util.concurrent.TimeUnit.SECONDS))).thenReturn(false);
+
+        assertThat(new AvailabilityCli(process).available()).isFalse();
+
+        verify(process).destroyForcibly();
+    }
+
+    @Test
+    void availabilityDestroysProbeAndPreservesInterrupt() throws Exception {
+        Process process = mock(Process.class);
+        when(process.waitFor(anyLong(), eq(java.util.concurrent.TimeUnit.SECONDS)))
+                .thenThrow(new InterruptedException("test interrupt"));
+
+        try {
+            assertThat(new AvailabilityCli(process).available()).isFalse();
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            verify(process).destroyForcibly();
+        } finally {
+            Thread.interrupted();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- forcibly terminate CLI availability probes that exceed the timeout
- terminate the probe and preserve caller interrupt state on interruption
- cover both lifecycle paths with isolated process doubles

## Testing

- `git diff --check`
- PR scope check: 2 files, 59 changed lines
- Java tests not run locally per request; delegated to PR CI

Fixes #2712
