### PR TITLE
[ISSUE #2711] fix(settings): display actual build metadata

### DIFF
--- a/web/src/pages/settings/AboutTab.tsx
+++ b/web/src/pages/settings/AboutTab.tsx
@@ -24,7 +24,8 @@ export const AboutTab = () => (
   <div style={{ maxWidth: 800 }}>
     <Descriptions column={1} bordered size="small">
       <Descriptions.Item label="版本">0.1.0</Descriptions.Item>
-      <Descriptions.Item label="构建时间">2024-01-15 14:30:00</Descriptions.Item>
+      <Descriptions.Item label="构建提交">{__BUILD_COMMIT__}</Descriptions.Item>
+      <Descriptions.Item label="构建时间">{__BUILD_TIME__}</Descriptions.Item>
       <Descriptions.Item label="RocketMQ 支持版本">4.x / 5.x</Descriptions.Item>
       <Descriptions.Item label="前端框架">React 18 + Ant Design 5</Descriptions.Item>
       <Descriptions.Item label="后端框架">Spring Boot 3 + RocketMQ MCP Server</Descriptions.Item>
@@ -49,7 +50,8 @@ export const AboutTab = () => (
     <Divider />
 
     <Text type="secondary">
-      Copyright © 2024 Apache Software Foundation. Licensed under the Apache License, Version 2.0.
+      Copyright © {__BUILD_TIME__.slice(0, 4)} Apache Software Foundation. Licensed under the Apache
+      License, Version 2.0.
     </Text>
   </div>
 );

--- a/web/src/pages/settings/__tests__/AboutTab.test.tsx
+++ b/web/src/pages/settings/__tests__/AboutTab.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { AboutTab } from '../AboutTab';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+describe('AboutTab', () => {
+  it('renders the injected build metadata and build-year copyright', () => {
+    render(<AboutTab />);
+
+    expect(screen.getByText(__BUILD_COMMIT__)).toBeInTheDocument();
+    expect(screen.getByText(__BUILD_TIME__)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `Copyright © ${__BUILD_TIME__.slice(0, 4)} Apache Software Foundation. Licensed under the Apache License, Version 2.0.`,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('2024-01-15 14:30:00')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- show the injected build commit and build time in About settings
- derive the copyright year from build metadata
- cover the rendered metadata and removal of the stale timestamp

## Testing

- targeted Vitest: 2 files, 2 tests passed
- targeted ESLint and Prettier checks passed
- `npm run build` passed (8,022 modules)
- PR scope check: 2 files, 57 changed lines

Fixes #2711
