### PR TITLE
[ISSUE #2710] fix(auth): prefer explicit Bearer credentials

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthCookie.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthCookie.java
@@ -36,6 +36,12 @@ final class AuthCookie {
     }
 
     static String authorization(HttpServletRequest request, AuthProperties properties) {
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (hasBearerToken(authorization)) {
+            // API 客户端可能仍携带过期的浏览器 Cookie；显式 Bearer 凭据代表本次请求，
+            // 因此应优先使用。
+            return authorization;
+        }
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
@@ -46,7 +52,13 @@ final class AuthCookie {
             }
         }
         // API clients that explicitly requested a bearer token at login authenticate with this header.
-        return request.getHeader(HttpHeaders.AUTHORIZATION);
+        return authorization;
+    }
+
+    private static boolean hasBearerToken(String authorization) {
+        return authorization != null
+                && authorization.regionMatches(true, 0, TOKEN_PREFIX, 0, TOKEN_PREFIX.length())
+                && !authorization.substring(TOKEN_PREFIX.length()).isBlank();
     }
 
     static boolean requestsBearerToken(HttpServletRequest request) {

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCookieTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCookieTest.java
@@ -28,19 +28,42 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AuthCookieTest {
 
     @Test
-    void usesHttpOnlySecureCookieAndPrefersItOverAuthorizationHeader() {
+    void usesHttpOnlySecureCookie() {
         AuthProperties properties = new AuthProperties();
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setCookies(new Cookie("rmq_studio_session", "cookie-token"));
-        request.addHeader("Authorization", "Bearer header-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         AuthCookie.write(response, properties, "cookie-token", Duration.ofMinutes(30));
 
-        assertThat(AuthCookie.authorization(request, properties)).isEqualTo("Bearer cookie-token");
         assertThat(response.getHeader("Set-Cookie"))
                 .contains("HttpOnly")
                 .contains("Secure")
                 .contains("SameSite=Strict");
+    }
+
+    @Test
+    void prefersExplicitBearerTokenOverStaleCookie() {
+        AuthProperties properties = new AuthProperties();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("rmq_studio_session", "stale-cookie-token"));
+        request.addHeader("Authorization", "bearer current-header-token");
+
+        assertThat(AuthCookie.authorization(request, properties))
+                .isEqualTo("bearer current-header-token");
+    }
+
+    @Test
+    void fallsBackToCookieForEmptyOrNonBearerAuthorization() {
+        AuthProperties properties = new AuthProperties();
+        MockHttpServletRequest emptyHeaderRequest = new MockHttpServletRequest();
+        emptyHeaderRequest.setCookies(new Cookie("rmq_studio_session", "cookie-token"));
+        emptyHeaderRequest.addHeader("Authorization", "Bearer   ");
+        MockHttpServletRequest nonBearerRequest = new MockHttpServletRequest();
+        nonBearerRequest.setCookies(new Cookie("rmq_studio_session", "cookie-token"));
+        nonBearerRequest.addHeader("Authorization", "Basic credentials");
+
+        assertThat(AuthCookie.authorization(emptyHeaderRequest, properties))
+                .isEqualTo("Bearer cookie-token");
+        assertThat(AuthCookie.authorization(nonBearerRequest, properties))
+                .isEqualTo("Bearer cookie-token");
     }
 }


### PR DESCRIPTION
## Summary

- prefer a non-empty explicit Bearer credential over the session cookie
- retain cookie fallback for missing, blank-Bearer, and non-Bearer headers
- cover stale-cookie precedence and fallback behavior

## Testing

- `git diff --check`
- PR scope check: 2 files, 47 changed lines
- Java tests not run locally per request; delegated to PR CI

Fixes #2710
