### PR TITLE
[ISSUE #2709] fix(api): return 406 for unacceptable response types

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandler.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.studio.ops.ai.LlmGatewayException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -144,5 +145,17 @@ public class GlobalExceptionHandler {
             HttpMediaTypeNotSupportedException ex) {
         log.warn("Unsupported media type: {}", ex.getMessage());
         return Result.error(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value(), ex.getMessage());
+    }
+
+    /**
+     * Requests that cannot accept any available response representation must be
+     * reported as 406, not 500.
+     */
+    @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
+    @ResponseStatus(HttpStatus.NOT_ACCEPTABLE)
+    public Result<?> handleHttpMediaTypeNotAcceptableException(
+            HttpMediaTypeNotAcceptableException ex) {
+        log.warn("No acceptable response media type: {}", ex.getMessage());
+        return Result.error(HttpStatus.NOT_ACCEPTABLE.value(), ex.getMessage());
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandlerTest.java
@@ -20,11 +20,15 @@ import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.ops.ai.LlmGatewayException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -88,6 +92,13 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.code").value(405));
     }
 
+    @Test
+    void unacceptableResponseMediaTypeReturns406WithEnvelopeInsteadOf500() throws Exception {
+        mockMvc.perform(get("/test/not-acceptable"))
+                .andExpect(status().isNotAcceptable())
+                .andExpect(jsonPath("$.code").value(406));
+    }
+
     @RestController
     static class FailingController {
 
@@ -100,6 +111,11 @@ class GlobalExceptionHandlerTest {
         Result<Void> failLlm() {
             throw new LlmGatewayException(504, "llm.provider.timeout",
                     "LLM provider request timed out", "Retry later.");
+        }
+
+        @GetMapping("/test/not-acceptable")
+        Result<Void> failNotAcceptable() throws HttpMediaTypeNotAcceptableException {
+            throw new HttpMediaTypeNotAcceptableException(List.of(MediaType.APPLICATION_JSON));
         }
     }
 }


### PR DESCRIPTION
## Summary

- map `HttpMediaTypeNotAcceptableException` to HTTP 406
- keep the standard API result envelope with code 406
- add a MockMvc regression for status and envelope semantics

## Testing

- `git diff --check`
- PR scope check: 2 files, 29 changed lines
- Java tests not run locally per request; delegated to PR CI

Fixes #2709
