### PR TITLE
[ISSUE #2718] fix(ai): honor the configured API base for streaming

### DIFF
--- a/web/src/api/ai.test.ts
+++ b/web/src/api/ai.test.ts
@@ -17,6 +17,7 @@
 
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAiChatHistoryStore } from '../stores/aiChatHistoryStore';
 import client from './client';
 import {
   AiStreamError,
@@ -27,6 +28,10 @@ import {
   type AiExecuteRequest,
   type McpTool,
 } from './ai';
+
+vi.mock('../config', () => ({
+  API_BASE_URL: 'https://backend.example.com/studio-api',
+}));
 
 const mock = new MockAdapter(client);
 const encoder = new TextEncoder();
@@ -45,6 +50,8 @@ function streamResponse(chunks: string[], onCancel?: () => void): Response {
 describe('AI API', () => {
   beforeEach(() => {
     mock.reset();
+    localStorage.clear();
+    useAiChatHistoryStore.getState().clearHistories();
   });
 
   afterEach(() => {
@@ -53,7 +60,7 @@ describe('AI API', () => {
   });
 
   describe('chatStream (SSE)', () => {
-    it('sends browser cookies without reading browser storage', async () => {
+    it('uses the configured API base URL and sends browser cookies', async () => {
       const fetchMock = vi.fn().mockResolvedValue(streamResponse(['data: [DONE]\n\n']));
       vi.stubGlobal('fetch', fetchMock);
 
@@ -62,12 +69,35 @@ describe('AI API', () => {
       ).resolves.toBeUndefined();
 
       expect(fetchMock).toHaveBeenCalledWith(
-        '/api/ai/chat',
+        'https://backend.example.com/studio-api/ai/chat',
         expect.objectContaining({
           credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
         }),
       );
+    });
+
+    it('clears the current session when the stream request returns 401', async () => {
+      localStorage.setItem('rocketmq-studio-user', 'admin');
+      localStorage.setItem('rocketmq-studio-user-admin', 'true');
+      useAiChatHistoryStore.getState().startConversation('real', 'conversation-1');
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(JSON.stringify({ message: 'Unauthorized' }), {
+            status: 401,
+            statusText: 'Unauthorized',
+          }),
+        ),
+      );
+
+      await expect(
+        chatStream({ message: 'hello', mode: 'chat', model: 'stub' }, vi.fn()),
+      ).rejects.toMatchObject({ status: 401 });
+
+      expect(localStorage.getItem('rocketmq-studio-user')).toBeNull();
+      expect(localStorage.getItem('rocketmq-studio-user-admin')).toBeNull();
+      expect(useAiChatHistoryStore.getState().histories.real.conversations).toEqual([]);
     });
 
     it('reassembles an event split across network chunks', async () => {

--- a/web/src/api/ai.ts
+++ b/web/src/api/ai.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import client from './client';
+import { API_BASE_URL } from '../config';
+import client, { handleSessionUnauthorized } from './client';
 
 const MAX_SSE_EVENT_CHARS = 1024 * 1024;
 
@@ -187,7 +188,7 @@ export async function chatStream(
   signal?: AbortSignal,
   onEnhance?: (prompt: string) => void,
 ) {
-  const response = await fetch('/api/ai/chat', {
+  const response = await fetch(`${API_BASE_URL}/ai/chat`, {
     method: 'POST',
     credentials: 'include',
     headers: {
@@ -197,6 +198,9 @@ export async function chatStream(
     signal,
   });
 
+  if (response.status === 401) {
+    handleSessionUnauthorized();
+  }
   if (!response.ok) {
     throw await parseHttpError(response);
   }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -79,6 +79,12 @@ function isPublicAuthRequest(url?: string): boolean {
   }
 }
 
+export function handleSessionUnauthorized(): void {
+  clearAiChatHistories();
+  clearAuthSession();
+  window.location.href = '/login';
+}
+
 const client = axios.create({
   baseURL: API_BASE_URL,
   timeout: 30000,
@@ -97,9 +103,7 @@ client.interceptors.response.use(
   },
   (error) => {
     if (error.response?.status === 401 && !isPublicAuthRequest(error.config?.url)) {
-      clearAiChatHistories();
-      clearAuthSession();
-      window.location.href = '/login';
+      handleSessionUnauthorized();
       return Promise.reject(error);
     }
     if (isCorsRejection(error)) {


### PR DESCRIPTION
## Summary

- build the AI streaming endpoint from the shared API base URL
- share protected-request 401 session cleanup between Axios and Fetch
- cover absolute custom base URLs and unauthorized stream responses

## Testing

- targeted Vitest: 31 tests passed
- targeted ESLint and Prettier checks passed
- `npm run build` passed (8,022 modules)
- PR scope check: 3 files, 52 changed lines

Fixes #2718
