### PR TITLE
[ISSUE #2731] fix(web): route docs and SSE at the Nginx edge

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -18,7 +18,7 @@ server {
     #   brotli_comp_level 6;
     #   brotli_types text/plain text/css application/javascript application/json image/svg+xml;
 
-    # RESOLVER is injected by 15-resolver.sh (podman network gateway only).
+    # RESOLVER is injected by 15-resolver.envsh (podman network gateway only).
     # Variable proxy_pass re-resolves on every request, so a recreated
     # rocketmq-server container with a new IP is picked up without restarting
     # nginx.
@@ -50,6 +50,48 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Keep streaming configuration scoped to the only SSE endpoint. Other API
+    # responses retain the default proxy buffering and timeout behavior.
+    location = /api/ai/chat {
+        set $backend_ai_chat http://rocketmq-server:8888;
+        proxy_pass $backend_ai_chat;
+        proxy_buffering off;
+        proxy_read_timeout 360s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Springdoc endpoints live outside /api/ and must bypass the SPA fallback.
+    location = /api-docs {
+        set $backend_api_docs http://rocketmq-server:8888;
+        proxy_pass $backend_api_docs;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ^~ /api-docs/ {
+        set $backend_api_docs_assets http://rocketmq-server:8888;
+        proxy_pass $backend_api_docs_assets;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /swagger-ui.html {
+        set $backend_swagger_redirect http://rocketmq-server:8888;
+        proxy_pass $backend_swagger_redirect;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ^~ /swagger-ui/ {
+        set $backend_swagger_assets http://rocketmq-server:8888;
+        proxy_pass $backend_swagger_assets;
+        proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 

--- a/web/nginx_contract_test.sh
+++ b/web/nginx_contract_test.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+CONFIG=${1:-"$SCRIPT_DIR/nginx.conf"}
+
+fail() {
+    echo "nginx contract test failed: $*" >&2
+    exit 1
+}
+
+location_block() {
+    awk -v header="$1" '
+        index($0, header) { inside = 1 }
+        inside {
+            print
+            opened += gsub(/\{/, "{")
+            closed += gsub(/\}/, "}")
+            if (opened > 0 && opened == closed) exit
+        }
+    ' "$CONFIG"
+}
+
+require_directive() {
+    block=$(location_block "$1")
+    [ -n "$block" ] || fail "missing block: $1"
+    printf '%s\n' "$block" | grep -F "$2" >/dev/null \
+        || fail "$1 is missing: $2"
+}
+
+require_directive "location = /api-docs {" 'proxy_pass $backend_api_docs;'
+require_directive "location ^~ /api-docs/ {" 'proxy_pass $backend_api_docs_assets;'
+require_directive "location = /swagger-ui.html {" 'proxy_pass $backend_swagger_redirect;'
+require_directive "location ^~ /swagger-ui/ {" 'proxy_pass $backend_swagger_assets;'
+require_directive "location = /api/ai/chat {" 'proxy_buffering off;'
+require_directive "location = /api/ai/chat {" 'proxy_read_timeout 360s;'
+
+api_block=$(location_block "location /api/ {")
+printf '%s\n' "$api_block" | grep -F 'proxy_buffering off;' >/dev/null \
+    && fail "generic /api/ block must keep default buffering"
+printf '%s\n' "$api_block" | grep -F 'proxy_read_timeout' >/dev/null \
+    && fail "generic /api/ block must keep the default read timeout"
+
+[ "$(grep -F -c 'proxy_buffering off;' "$CONFIG")" -eq 1 ] \
+    || fail "proxy buffering must be disabled only for the SSE endpoint"
+[ "$(grep -F -c 'proxy_read_timeout 360s;' "$CONFIG")" -eq 1 ] \
+    || fail "extended read timeout must be scoped to the SSE endpoint"
+
+echo "nginx edge contract: PASS"


### PR DESCRIPTION
## Summary

- proxy Springdoc and Swagger UI routes instead of returning the SPA entrypoint
- disable buffering and extend read timeout only for `/api/ai/chat`
- add a static Nginx edge-contract regression

## Testing

- `sh -n web/nginx_contract_test.sh`
- `sh web/nginx_contract_test.sh`
- `git diff --check`
- PR scope check: 2 files, 98 changed lines
- `nginx -t` not run because Nginx is unavailable locally; PR CI/container validation remains

Fixes #2731
