### PR TITLE
[ISSUE #2729] fix(cluster): ignore stale modal request results

### DIFF
--- a/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
@@ -21,7 +21,11 @@ import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ClusterInfo } from '../../../api/cluster';
+import type {
+  ClusterInfo,
+  ClusterProbeResult,
+  NameServerConfigDiffResult,
+} from '../../../api/cluster';
 import { LangProvider } from '../../../i18n/LangContext';
 
 const clusterServiceMocks = vi.hoisted(() => ({
@@ -526,6 +530,105 @@ describe('Cluster page', () => {
     expect(
       within(dialog).getByText((content) => content.includes('rocketmq1-nameserver-1:9876: 12')),
     ).toBeInTheDocument();
+  });
+
+  it('does not reopen a closed NameServer config diff when its request finishes', async () => {
+    const pendingDiff = deferred<NameServerConfigDiffResult>();
+    clusterServiceMocks.listRegistryClusters.mockResolvedValue([
+      {
+        ...buildCluster(),
+        name: 'rocketmq1',
+        nsClusterName: 'rocketmq1',
+        endpoint: 'rocketmq1-nameserver:9876',
+        nameServers: [{ addr: 'rocketmq1-nameserver:9876', status: 'healthy' }],
+      },
+    ]);
+    clusterServiceMocks.getNameServerConfigDiff.mockReturnValue(pendingDiff.promise);
+    renderWithProviders(<ClusterPage />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /NameServer 管理/ }));
+    const row = await screen.findByRole('row', { name: /rocketmq1-nameserver:9876/ });
+    fireEvent.click(within(row).getByRole('button', { name: /配置差异/ }));
+    const dialog = await screen.findByRole('dialog', { name: /NameServer 配置差异/ });
+    fireEvent.click(within(dialog).getByRole('button', { name: /关\s*闭/ }));
+    await waitFor(() => expect(dialog).toHaveClass('ant-zoom-leave'));
+
+    await act(async () => {
+      pendingDiff.resolve({
+        cluster: 'rocketmq1',
+        complete: true,
+        driftDetected: false,
+        nodeCount: 1,
+        reachableNodeCount: 1,
+        comparedKeys: ['serverWorkerThreads'],
+        nodes: [{ address: 'rocketmq1-nameserver:9876', reachable: true }],
+        differences: [],
+      });
+      await pendingDiff.promise;
+    });
+
+    expect(dialog).toHaveClass('ant-zoom-leave');
+  });
+
+  it('keeps the latest connection result after closing and reopening the modal', async () => {
+    const staleProbe = deferred<ClusterProbeResult>();
+    const latestProbe = deferred<ClusterProbeResult>();
+    clusterServiceMocks.testClusterConnection
+      .mockReturnValueOnce(staleProbe.promise)
+      .mockReturnValueOnce(latestProbe.promise);
+    renderWithProviders(<ClusterPage />);
+
+    const openModal = async () => {
+      fireEvent.click(await screen.findByRole('button', { name: /新建集群/ }));
+      return screen.findByRole('dialog', { name: /测试集群连接/ });
+    };
+    let dialog = await openModal();
+    fireEvent.change(within(dialog).getByLabelText(/NameServer 地址/), {
+      target: { value: 'stale-nameserver:9876' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: /测试连接/ }));
+    await waitFor(() =>
+      expect(clusterServiceMocks.testClusterConnection).toHaveBeenCalledWith(
+        'stale-nameserver:9876',
+      ),
+    );
+    fireEvent.click(within(dialog).getByRole('button', { name: /关\s*闭/ }));
+
+    dialog = await openModal();
+    fireEvent.change(within(dialog).getByLabelText(/NameServer 地址/), {
+      target: { value: 'latest-nameserver:9876' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: /测试连接/ }));
+    await waitFor(() => expect(clusterServiceMocks.testClusterConnection).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      latestProbe.resolve({
+        connected: true,
+        namesrvAddr: 'latest-nameserver:9876',
+        clusterName: 'latest-cluster',
+        brokerCount: 1,
+        brokerNames: ['latest-broker'],
+        elapsedMillis: 10,
+        message: 'ok',
+      });
+      await latestProbe.promise;
+    });
+    expect(within(dialog).getByText('latest-cluster')).toBeInTheDocument();
+
+    await act(async () => {
+      staleProbe.resolve({
+        connected: true,
+        namesrvAddr: 'stale-nameserver:9876',
+        clusterName: 'stale-cluster',
+        brokerCount: 1,
+        brokerNames: ['stale-broker'],
+        elapsedMillis: 20,
+        message: 'ok',
+      });
+      await staleProbe.promise;
+    });
+    expect(within(dialog).getByText('latest-cluster')).toBeInTheDocument();
+    expect(within(dialog).queryByText('stale-cluster')).not.toBeInTheDocument();
   });
 
   it('polls the API after two seconds and renders only returned metrics', async () => {

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -152,6 +152,8 @@ const ClusterPage = () => {
   const nsRegistryRequestRef = useRef(0);
   const registryClustersRequestRef = useRef(0);
   const k8sCertsRequestRef = useRef(0);
+  const nsConfigDiffRequestRef = useRef(0);
+  const connectionTestRequestRef = useRef(0);
 
   const loadRegistryClusters = useCallback(async () => {
     const requestId = ++registryClustersRequestRef.current;
@@ -210,6 +212,8 @@ const ClusterPage = () => {
       nsRegistryRequestRef.current += 1;
       registryClustersRequestRef.current += 1;
       k8sCertsRequestRef.current += 1;
+      nsConfigDiffRequestRef.current += 1;
+      connectionTestRequestRef.current += 1;
     },
     [],
   );
@@ -311,6 +315,7 @@ const ClusterPage = () => {
 
   const openNameServerConfigDiff = useCallback(
     async (cluster: ClusterInfo) => {
+      const requestId = ++nsConfigDiffRequestRef.current;
       setNsConfigDiffState({
         open: true,
         loading: true,
@@ -319,6 +324,7 @@ const ClusterPage = () => {
       });
       try {
         const result = await getNameServerConfigDiff(cluster.id, selectedInstanceIdRef.current);
+        if (requestId !== nsConfigDiffRequestRef.current) return;
         setNsConfigDiffState({
           open: true,
           loading: false,
@@ -326,12 +332,18 @@ const ClusterPage = () => {
           result,
         });
       } catch {
+        if (requestId !== nsConfigDiffRequestRef.current) return;
         setNsConfigDiffState((current) => ({ ...current, loading: false }));
         message.error(t('cluster.nsConfigDiffFailed'));
       }
     },
     [t],
   );
+
+  const closeNameServerConfigDiff = useCallback(() => {
+    nsConfigDiffRequestRef.current += 1;
+    setNsConfigDiffState({ open: false, loading: false, cluster: null, result: null });
+  }, []);
 
   // ─── Connection test ──────────────────────────────────────────────────────
   const [connectModalOpen, setConnectModalOpen] = useState(false);
@@ -340,11 +352,14 @@ const ClusterPage = () => {
   const [connectForm] = Form.useForm();
 
   const openConnectModal = useCallback(() => {
+    connectionTestRequestRef.current += 1;
     setProbeResult(null);
+    setConnectTesting(false);
     setConnectModalOpen(true);
   }, []);
 
   const closeConnectModal = useCallback(() => {
+    connectionTestRequestRef.current += 1;
     setConnectModalOpen(false);
     setConnectTesting(false);
     setProbeResult(null);
@@ -352,22 +367,26 @@ const ClusterPage = () => {
   }, [connectForm]);
 
   const handleTestConnection = useCallback(async () => {
+    const requestId = ++connectionTestRequestRef.current;
     let namesrvAddr: string;
     try {
       ({ namesrvAddr } = await connectForm.validateFields());
     } catch {
       return;
     }
+    if (requestId !== connectionTestRequestRef.current) return;
     setConnectTesting(true);
     setProbeResult(null);
     try {
       const result = await testClusterConnection(namesrvAddr);
+      if (requestId !== connectionTestRequestRef.current) return;
       setProbeResult(result);
       message.success(t('cluster.testConnectionSuccess'));
     } catch {
+      if (requestId !== connectionTestRequestRef.current) return;
       message.error(t('cluster.testConnectionFailed'));
     } finally {
-      setConnectTesting(false);
+      if (requestId === connectionTestRequestRef.current) setConnectTesting(false);
     }
   }, [connectForm, t]);
 
@@ -797,18 +816,8 @@ const ClusterPage = () => {
       <Modal
         title={t('cluster.nsConfigDiffTitle', { name: titleName })}
         open={open}
-        onCancel={() =>
-          setNsConfigDiffState({ open: false, loading: false, cluster: null, result: null })
-        }
-        footer={
-          <Button
-            onClick={() =>
-              setNsConfigDiffState({ open: false, loading: false, cluster: null, result: null })
-            }
-          >
-            {t('common.close')}
-          </Button>
-        }
+        onCancel={closeNameServerConfigDiff}
+        footer={<Button onClick={closeNameServerConfigDiff}>{t('common.close')}</Button>}
         width={920}
         destroyOnHidden
       >


### PR DESCRIPTION
## Summary

- invalidate NameServer config-diff requests on close, replacement, and unmount
- apply separate ownership generations to cluster connection tests
- prevent stale results and notifications after modal close/reopen

## Testing

- Cluster page Vitest: 20 tests passed
- targeted ESLint and Prettier checks passed
- `npm run build` passed (8,022 modules)
- PR scope check: 2 files, 140 changed lines

Fixes #2729
