### PR TITLE
[ISSUE #2728] fix(mock): isolate alert rules by domain

### DIFF
--- a/web/src/services/opsService.test.ts
+++ b/web/src/services/opsService.test.ts
@@ -20,8 +20,11 @@ import type { AuditRecord } from '../api/ops';
 import { mockAuditRecords } from '../mock/audit';
 import {
   createAlertRule,
+  deleteAlertRule,
+  exportAlertRulesTransfer,
   exportAuditLogs,
   getAuditFilterOptions,
+  importAlertRulesTransfer,
   listAlertRules,
   listAlertRulesPage,
   listAuditRecords,
@@ -109,6 +112,73 @@ describe('ops service mock data', () => {
     const after = await listAlertRules();
     expect(after.map((rule) => rule.id)).toEqual(before.map((rule) => rule.id));
     expect(after.find((rule) => rule.id === 999999)).toBeUndefined();
+  });
+
+  it('keeps alert rule CRUD isolated between cluster and business domains', async () => {
+    const clusterRule = await createAlertRule(
+      { name: 'cluster-domain-rule', channels: ['email'] },
+      'CLUSTER',
+    );
+    const businessRule = await createAlertRule(
+      { name: 'business-domain-rule', channels: ['sms'] },
+      'BUSINESS',
+    );
+
+    expect((await listAlertRules('CLUSTER')).map((rule) => rule.name)).toContain(
+      'cluster-domain-rule',
+    );
+    expect((await listAlertRules('CLUSTER')).map((rule) => rule.name)).not.toContain(
+      'business-domain-rule',
+    );
+    expect((await listAlertRules('BUSINESS')).map((rule) => rule.name)).toContain(
+      'business-domain-rule',
+    );
+    expect((await listAlertRules('BUSINESS')).map((rule) => rule.name)).not.toContain(
+      'cluster-domain-rule',
+    );
+
+    await updateAlertRule({ ...businessRule, name: 'updated-business-domain-rule' }, 'BUSINESS');
+    expect((await listAlertRules('BUSINESS')).map((rule) => rule.name)).toContain(
+      'updated-business-domain-rule',
+    );
+    expect((await listAlertRules('CLUSTER')).map((rule) => rule.name)).not.toContain(
+      'updated-business-domain-rule',
+    );
+
+    await deleteAlertRule(clusterRule.id, 'CLUSTER');
+    expect((await listAlertRules('CLUSTER')).map((rule) => rule.id)).not.toContain(clusterRule.id);
+    expect((await listAlertRules('BUSINESS')).map((rule) => rule.id)).toContain(businessRule.id);
+    await deleteAlertRule(businessRule.id, 'BUSINESS');
+  });
+
+  it('imports and exports alert rules within the selected domain only', async () => {
+    const imported = await importAlertRulesTransfer(
+      {
+        version: 1,
+        domain: 'BUSINESS',
+        rules: [
+          {
+            name: 'business-transfer-rule',
+            metric: 'consumer.lag.total',
+            operator: '>',
+            threshold: 100,
+            duration: '5m',
+            channels: ['email'],
+            enabled: true,
+            description: 'business-only transfer',
+          },
+        ],
+      },
+      'BUSINESS',
+    );
+
+    expect((await exportAlertRulesTransfer('BUSINESS')).rules.map((rule) => rule.name)).toContain(
+      'business-transfer-rule',
+    );
+    expect(
+      (await exportAlertRulesTransfer('CLUSTER')).rules.map((rule) => rule.name),
+    ).not.toContain('business-transfer-rule');
+    await deleteAlertRule(imported[0].id, 'BUSINESS');
   });
 
   it('returns copied system alert rows', async () => {

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -29,7 +29,11 @@ import { mockAuditRecords } from '../mock/audit';
 import { systemAlerts as mockSystemAlerts } from '../mock/dashboard';
 
 let auditRecordsState = mockAuditRecords as unknown as AuditRecord[];
-const alertRulesState = mockAlertRules as unknown as AlertRule[];
+const initialAlertRules = mockAlertRules as unknown as AlertRule[];
+const alertRulesState: Record<AlertRuleDomain, AlertRule[]> = {
+  CLUSTER: initialAlertRules.map(copyAlertRule),
+  BUSINESS: initialAlertRules.map(copyAlertRule),
+};
 let alertSilencesState: AlertSilence[] = [];
 
 function copyAlertRule(rule: AlertRule): AlertRule {
@@ -112,7 +116,7 @@ function formatAuditCsv(records: AuditRecord[]): string {
 }
 
 export async function listAlertRules(domain: AlertRuleDomain = 'CLUSTER'): Promise<AlertRule[]> {
-  if (isMockMode()) return alertRulesState.map(copyAlertRule);
+  if (isMockMode()) return alertRulesState[domain].map(copyAlertRule);
   return opsApi.listAlertRules(domain);
 }
 export async function listAlertRulesPage(
@@ -124,7 +128,7 @@ export async function listAlertRulesPage(
   const search = query.search?.trim().toLowerCase();
   const page = Math.max(1, query.page ?? 1);
   const pageSize = Math.min(100, Math.max(1, query.pageSize ?? 20));
-  const filtered = alertRulesState
+  const filtered = alertRulesState[domain]
     .filter((rule) => query.enabled == null || rule.enabled === query.enabled)
     .filter(
       (rule) =>
@@ -149,7 +153,8 @@ export async function listAlertRuleRuntime(
 export async function exportAlertRulesTransfer(
   domain: AlertRuleDomain = 'CLUSTER',
 ): Promise<AlertRuleTransfer> {
-  if (isMockMode()) return { version: 1, domain, rules: alertRulesState.map(copyAlertRule) };
+  if (isMockMode())
+    return { version: 1, domain, rules: alertRulesState[domain].map(copyAlertRule) };
   return opsApi.exportAlertRulesTransfer(domain);
 }
 
@@ -163,7 +168,7 @@ export async function importAlertRulesTransfer(
     ...copyAlertRule(rule as AlertRule),
     id: startId + index,
   }));
-  alertRulesState.push(...imported);
+  alertRulesState[domain].push(...imported);
   return imported.map(copyAlertRule);
 }
 
@@ -236,7 +241,7 @@ export async function createAlertRule(
       ...data,
       channels: [...(data.channels ?? [])],
     };
-    alertRulesState.push(rule);
+    alertRulesState[domain].push(rule);
     return copyAlertRule(rule);
   }
   return opsApi.createAlertRule(data, domain);
@@ -247,10 +252,10 @@ export async function updateAlertRule(
   domain: AlertRuleDomain = 'CLUSTER',
 ): Promise<AlertRule> {
   if (isMockMode()) {
-    const index = alertRulesState.findIndex((rule) => rule.id === data.id);
+    const index = alertRulesState[domain].findIndex((rule) => rule.id === data.id);
     if (index < 0) throw new Error(`Alert rule not found: ${data.id}`);
     const rule = copyAlertRule(data);
-    alertRulesState[index] = rule;
+    alertRulesState[domain][index] = rule;
     return copyAlertRule(rule);
   }
   return opsApi.updateAlertRule(data, domain);
@@ -262,7 +267,7 @@ export async function toggleAlertRule(
   domain: AlertRuleDomain = 'CLUSTER',
 ): Promise<AlertRule> {
   if (isMockMode()) {
-    const rule = alertRulesState.find((item) => item.id === id);
+    const rule = alertRulesState[domain].find((item) => item.id === id);
     if (!rule) throw new Error(`Alert rule not found: ${id}`);
     rule.enabled = enabled;
     return copyAlertRule(rule);
@@ -275,8 +280,8 @@ export async function deleteAlertRule(
   domain: AlertRuleDomain = 'CLUSTER',
 ): Promise<void> {
   if (isMockMode()) {
-    const idx = alertRulesState.findIndex((rule) => rule.id === id);
-    if (idx >= 0) alertRulesState.splice(idx, 1);
+    const idx = alertRulesState[domain].findIndex((rule) => rule.id === id);
+    if (idx >= 0) alertRulesState[domain].splice(idx, 1);
     return;
   }
   return opsApi.deleteAlertRule(id, domain);
@@ -292,7 +297,7 @@ export async function bulkToggleAlertRules(
   const failures: Record<string, string> = {};
   const updatedRules: AlertRule[] = [];
   for (const id of [...new Set(ids)]) {
-    const rule = alertRulesState.find((item) => item.id === id);
+    const rule = alertRulesState[domain].find((item) => item.id === id);
     if (!rule) {
       failures[String(id)] = 'Alert rule not found';
       continue;
@@ -312,12 +317,12 @@ export async function bulkDeleteAlertRules(
   const succeededIds: number[] = [];
   const failures: Record<string, string> = {};
   for (const id of [...new Set(ids)]) {
-    const index = alertRulesState.findIndex((item) => item.id === id);
+    const index = alertRulesState[domain].findIndex((item) => item.id === id);
     if (index < 0) {
       failures[String(id)] = 'Alert rule not found';
       continue;
     }
-    alertRulesState.splice(index, 1);
+    alertRulesState[domain].splice(index, 1);
     succeededIds.push(id);
   }
   return { succeededIds, failures, updatedRules: [] };


### PR DESCRIPTION
## Summary

- store mock cluster and business alert rules independently
- route list, CRUD, bulk, import, and export operations through the selected domain
- copy nested channel arrays and cover isolated CRUD/transfer behavior

## Testing

- targeted Vitest: 13 tests passed
- targeted ESLint and Prettier checks passed
- `npm run build` passed (8,022 modules)
- PR scope check: 2 files, 103 changed lines

Fixes #2728
