### PR TITLE
[ISSUE #2730] fix(grafana): pack generated dashboard panels by width

### DIFF
--- a/server/scripts/gen_grafana_dashboards.py
+++ b/server/scripts/gen_grafana_dashboards.py
@@ -9,9 +9,9 @@ import json
 import os
 
 OUT_DIR = os.path.join(os.path.dirname(__file__), "..", "src", "main", "resources", "grafana")
-os.makedirs(OUT_DIR, exist_ok=True)
 
 DS = "${DS_PROMETHEUS}"
+GRID_WIDTH = 24
 
 
 def ts_panel(panel_id, title, expr, grid, y, legend=None, unit="short"):
@@ -63,7 +63,8 @@ def gauge_panel(panel_id, title, expr, grid, y, max_=100):
             "defaults": {
                 "unit": "percent",
                 "max": max_,
-                "custom": {"min": 0},
+                "min": 0,
+                "custom": {},
             },
             "overrides": [],
         },
@@ -131,17 +132,33 @@ def dashboard(uid, title, description, panels, vars_=None):
     }
 
 
-def y_stack(panels):
-    """Assign gridPos y offsets sequentially (2 per row of w=12)."""
+def layout_panels(panels):
+    """Return panels packed into rows without mutating the input definitions."""
+    laid_out = []
+    x = 0
     y = 0
-    for p in panels:
-        w = p["gridPos"]["w"]
-        p["gridPos"]["x"] = 0 if (panels.index(p) % 2 == 0 or w == 24) else 12
-        if w == 24:
-            p["gridPos"]["x"] = 0
-        p["gridPos"]["y"] = y
-        y += p["gridPos"]["h"]
-    return panels
+    row_height = 0
+    for panel in panels:
+        grid = panel["gridPos"]
+        width = grid["w"]
+        height = grid["h"]
+        if width <= 0 or width > GRID_WIDTH:
+            raise ValueError(f"panel width must be between 1 and {GRID_WIDTH}: {width}")
+        if height <= 0:
+            raise ValueError(f"panel height must be positive: {height}")
+        if x + width > GRID_WIDTH:
+            y += row_height
+            x = 0
+            row_height = 0
+
+        laid_out.append({**panel, "gridPos": {**grid, "x": x, "y": y}})
+        x += width
+        row_height = max(row_height, height)
+        if x == GRID_WIDTH:
+            y += row_height
+            x = 0
+            row_height = 0
+    return laid_out
 
 
 specs = []
@@ -281,13 +298,20 @@ specs.append((
     ],
 ))
 
-for uid, title, desc, panels in specs:
-    panels = y_stack(panels)
-    doc = dashboard(uid, title, desc, panels)
-    path = os.path.join(OUT_DIR, f"{uid}.json")
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(doc, f, indent=2, ensure_ascii=False)
-        f.write("\n")
-    print(f"wrote {path} ({len(panels)} panels)")
+def generate_dashboards(out_dir=OUT_DIR):
+    """Write all dashboard assets to ``out_dir`` in a deterministic order."""
+    os.makedirs(out_dir, exist_ok=True)
+    for uid, title, desc, panels in specs:
+        laid_out = layout_panels(panels)
+        doc = dashboard(uid, title, desc, laid_out)
+        path = os.path.join(out_dir, f"{uid}.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(doc, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        print(f"wrote {path} ({len(laid_out)} panels)")
 
-print(f"TOTAL dashboards: {len(specs)}")
+    print(f"TOTAL dashboards: {len(specs)}")
+
+
+if __name__ == "__main__":
+    generate_dashboards()

--- a/server/scripts/test_gen_grafana_dashboards.py
+++ b/server/scripts/test_gen_grafana_dashboards.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+"""Regression tests for the Grafana dashboard asset generator."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gen_grafana_dashboards import gauge_panel, layout_panels
+
+
+def panel(width, height):
+    return {"gridPos": {"w": width, "h": height, "x": 99, "y": 99}}
+
+
+class LayoutPanelsTest(unittest.TestCase):
+
+    def test_packs_panels_by_width_and_advances_by_tallest_panel(self):
+        panels = [panel(12, 8), panel(12, 8), panel(6, 6), panel(6, 8), panel(12, 6)]
+
+        laid_out = layout_panels(panels)
+
+        self.assertEqual(
+            [(item["gridPos"]["x"], item["gridPos"]["y"]) for item in laid_out],
+            [(0, 0), (12, 0), (0, 8), (6, 8), (12, 8)],
+        )
+        self.assertEqual(panels[0]["gridPos"]["x"], 99)
+        self.assertEqual(panels[0]["gridPos"]["y"], 99)
+
+    def test_starts_a_new_row_when_the_next_panel_does_not_fit(self):
+        laid_out = layout_panels([panel(8, 6), panel(8, 10), panel(12, 4)])
+
+        self.assertEqual(
+            [(item["gridPos"]["x"], item["gridPos"]["y"]) for item in laid_out],
+            [(0, 0), (8, 0), (0, 10)],
+        )
+
+    def test_rejects_invalid_dimensions(self):
+        with self.assertRaises(ValueError):
+            layout_panels([panel(25, 8)])
+        with self.assertRaises(ValueError):
+            layout_panels([panel(12, 0)])
+
+
+class GaugePanelTest(unittest.TestCase):
+
+    def test_places_minimum_in_field_defaults(self):
+        gauge = gauge_panel(1, "Disk", "metric", 12, 0)
+
+        defaults = gauge["fieldConfig"]["defaults"]
+        self.assertEqual(defaults["min"], 0)
+        self.assertNotIn("min", defaults["custom"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/src/main/resources/grafana/rocketmq-broker.json
+++ b/server/src/main/resources/grafana/rocketmq-broker.json
@@ -116,7 +116,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -158,7 +158,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {
@@ -200,7 +200,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {

--- a/server/src/main/resources/grafana/rocketmq-consumer.json
+++ b/server/src/main/resources/grafana/rocketmq-consumer.json
@@ -116,8 +116,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 6
+        "x": 6,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -159,7 +159,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {

--- a/server/src/main/resources/grafana/rocketmq-dlq.json
+++ b/server/src/main/resources/grafana/rocketmq-dlq.json
@@ -116,7 +116,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {

--- a/server/src/main/resources/grafana/rocketmq-jvm.json
+++ b/server/src/main/resources/grafana/rocketmq-jvm.json
@@ -116,7 +116,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -158,7 +158,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {
@@ -200,7 +200,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {

--- a/server/src/main/resources/grafana/rocketmq-latency.json
+++ b/server/src/main/resources/grafana/rocketmq-latency.json
@@ -116,7 +116,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {

--- a/server/src/main/resources/grafana/rocketmq-network.json
+++ b/server/src/main/resources/grafana/rocketmq-network.json
@@ -116,8 +116,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 6
+        "x": 6,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -159,7 +159,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {

--- a/server/src/main/resources/grafana/rocketmq-overview.json
+++ b/server/src/main/resources/grafana/rocketmq-overview.json
@@ -116,7 +116,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -158,7 +158,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 16
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {
@@ -200,8 +200,8 @@
       "gridPos": {
         "h": 6,
         "w": 6,
-        "x": 12,
-        "y": 22
+        "x": 6,
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {
@@ -243,8 +243,8 @@
       "gridPos": {
         "h": 6,
         "w": 6,
-        "x": 0,
-        "y": 28
+        "x": 12,
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {
@@ -286,8 +286,8 @@
       "gridPos": {
         "h": 6,
         "w": 6,
-        "x": 12,
-        "y": 34
+        "x": 18,
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {

--- a/server/src/main/resources/grafana/rocketmq-producer.json
+++ b/server/src/main/resources/grafana/rocketmq-producer.json
@@ -116,8 +116,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 6
+        "x": 6,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -159,7 +159,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {

--- a/server/src/main/resources/grafana/rocketmq-storage.json
+++ b/server/src/main/resources/grafana/rocketmq-storage.json
@@ -80,9 +80,8 @@
         "defaults": {
           "unit": "percent",
           "max": 100,
-          "custom": {
-            "min": 0
-          }
+          "min": 0,
+          "custom": {}
         },
         "overrides": []
       },
@@ -116,7 +115,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -158,7 +157,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {

--- a/server/src/main/resources/grafana/rocketmq-threadpool.json
+++ b/server/src/main/resources/grafana/rocketmq-threadpool.json
@@ -116,7 +116,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -158,7 +158,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {

--- a/server/src/main/resources/grafana/rocketmq-topic.json
+++ b/server/src/main/resources/grafana/rocketmq-topic.json
@@ -116,7 +116,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -158,7 +158,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {

--- a/server/src/main/resources/grafana/rocketmq-tps.json
+++ b/server/src/main/resources/grafana/rocketmq-tps.json
@@ -116,7 +116,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -158,7 +158,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 8
       },
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
## Summary

- pack generated panels left-to-right across the 24-column Grafana grid
- advance rows by their tallest panel without mutating source definitions
- emit gauge minimums in `fieldConfig.defaults.min` and regenerate all dashboard assets

## Testing

- Python unit tests: 4 passed from repository root and script directory
- 12 generated JSON files validated and matched deterministic regeneration
- `git diff --check`
- PR scope check: 14 files, 209 changed lines

Fixes #2730
