### PR TITLE
[ISSUE #2732] fix(export): deduplicate asset download requests

### DIFF
--- a/web/src/components/AlertRuleAssetList.tsx
+++ b/web/src/components/AlertRuleAssetList.tsx
@@ -50,6 +50,7 @@ export const AlertRuleAssetList: React.FC = () => {
   const mountedRef = useRef(true);
   const listRequestId = useRef(0);
   const viewRequestId = useRef(0);
+  const exportingNamesRef = useRef<Set<string>>(new Set());
   const [exportingNames, setExportingNames] = useState<Set<string>>(() => new Set());
 
   const severityOptions = useMemo(
@@ -135,7 +136,9 @@ export const AlertRuleAssetList: React.FC = () => {
   };
 
   const handleExport = async (info: AlertRuleAssetInfo) => {
-    setExportingNames((current) => new Set(current).add(info.name));
+    if (exportingNamesRef.current.has(info.name)) return;
+    exportingNamesRef.current.add(info.name);
+    setExportingNames(new Set(exportingNamesRef.current));
     try {
       const blob = await exportAlertRuleAsset(info.name);
       downloadBlob(blob, `${info.name}.yaml`);
@@ -143,11 +146,8 @@ export const AlertRuleAssetList: React.FC = () => {
     } catch {
       message.error(t('alertAssets.exportFailed'));
     } finally {
-      setExportingNames((current) => {
-        const next = new Set(current);
-        next.delete(info.name);
-        return next;
-      });
+      exportingNamesRef.current.delete(info.name);
+      if (mountedRef.current) setExportingNames(new Set(exportingNamesRef.current));
     }
   };
 

--- a/web/src/components/GrafanaDashboardList.tsx
+++ b/web/src/components/GrafanaDashboardList.tsx
@@ -45,6 +45,8 @@ export const GrafanaDashboardList: React.FC = () => {
   const mountedRef = useRef(true);
   const listRequestId = useRef(0);
   const viewRequestId = useRef(0);
+  const exportingUidsRef = useRef<Set<string>>(new Set());
+  const exportingAllRef = useRef(false);
   const [exportingUids, setExportingUids] = useState<Set<string>>(() => new Set());
   const [exportingAll, setExportingAll] = useState(false);
 
@@ -131,7 +133,9 @@ export const GrafanaDashboardList: React.FC = () => {
   };
 
   const handleExport = async (info: GrafanaDashboardInfo) => {
-    setExportingUids((current) => new Set(current).add(info.uid));
+    if (exportingUidsRef.current.has(info.uid)) return;
+    exportingUidsRef.current.add(info.uid);
+    setExportingUids(new Set(exportingUidsRef.current));
     try {
       const blob = await exportGrafanaDashboard(info.uid);
       downloadBlob(blob, `${info.uid}.json`);
@@ -139,15 +143,14 @@ export const GrafanaDashboardList: React.FC = () => {
     } catch {
       message.error(t('grafana.exportFailed'));
     } finally {
-      setExportingUids((current) => {
-        const next = new Set(current);
-        next.delete(info.uid);
-        return next;
-      });
+      exportingUidsRef.current.delete(info.uid);
+      if (mountedRef.current) setExportingUids(new Set(exportingUidsRef.current));
     }
   };
 
   const handleExportAll = async () => {
+    if (exportingAllRef.current) return;
+    exportingAllRef.current = true;
     setExportingAll(true);
     try {
       const download = await exportGrafanaDashboards();
@@ -156,7 +159,8 @@ export const GrafanaDashboardList: React.FC = () => {
     } catch {
       message.error(t('grafana.exportAllFailed'));
     } finally {
-      setExportingAll(false);
+      exportingAllRef.current = false;
+      if (mountedRef.current) setExportingAll(false);
     }
   };
 

--- a/web/src/components/__tests__/AlertRuleAssetList.test.tsx
+++ b/web/src/components/__tests__/AlertRuleAssetList.test.tsx
@@ -186,6 +186,24 @@ describe('AlertRuleAssetList', () => {
     });
   });
 
+  it('deduplicates an asset export before loading state renders', async () => {
+    vi.mocked(alertRuleAssetService.listAlertRuleAssets).mockResolvedValue(sampleAssets);
+    let resolveExport!: (value: Blob) => void;
+    vi.mocked(alertRuleAssetService.exportAlertRuleAsset).mockImplementation(
+      () => new Promise((resolve) => (resolveExport = resolve)),
+    );
+    renderWithProviders(<AlertRuleAssetList />);
+
+    const exportButtons = await screen.findAllByRole('button', { name: /导出|Export/ });
+    act(() => {
+      exportButtons[0].click();
+      exportButtons[0].click();
+    });
+
+    expect(alertRuleAssetService.exportAlertRuleAsset).toHaveBeenCalledTimes(1);
+    await act(async () => resolveExport(new Blob(['rules'])));
+  });
+
   it('downloads the yaml when Export is clicked', async () => {
     const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:url');
     const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});

--- a/web/src/components/__tests__/GrafanaDashboardList.test.tsx
+++ b/web/src/components/__tests__/GrafanaDashboardList.test.tsx
@@ -231,6 +231,44 @@ describe('GrafanaDashboardList', () => {
     });
   });
 
+  it('deduplicates a dashboard export before loading state renders', async () => {
+    let resolveExport!: (value: Blob) => void;
+    vi.mocked(exportGrafanaDashboard).mockImplementation(
+      () => new Promise((resolve) => (resolveExport = resolve)),
+    );
+    renderDashboardList();
+
+    await screen.findByText('RocketMQ Cluster Overview');
+    const exportButtons = screen.getAllByRole('button', { name: /^(Export|导出)$/ });
+    act(() => {
+      exportButtons[0].click();
+      exportButtons[0].click();
+    });
+
+    expect(exportGrafanaDashboard).toHaveBeenCalledTimes(1);
+    await act(async () => resolveExport(new Blob(['dashboard'])));
+  });
+
+  it('deduplicates bulk export before loading state renders', async () => {
+    let resolveExport!: (value: Awaited<ReturnType<typeof exportGrafanaDashboards>>) => void;
+    vi.mocked(exportGrafanaDashboards).mockImplementation(
+      () => new Promise((resolve) => (resolveExport = resolve)),
+    );
+    renderDashboardList();
+
+    await screen.findByText('RocketMQ Cluster Overview');
+    const exportAll = screen.getByRole('button', { name: /Export all|导出全部/ });
+    act(() => {
+      exportAll.click();
+      exportAll.click();
+    });
+
+    expect(exportGrafanaDashboards).toHaveBeenCalledTimes(1);
+    await act(async () =>
+      resolveExport({ blob: new Blob(['dashboards']), filename: 'dashboards.zip' }),
+    );
+  });
+
   it('exports a dashboard and triggers a download', async () => {
     const user = userEvent.setup();
     const createObjectURL = vi.fn().mockReturnValue('blob:grafana');


### PR DESCRIPTION
## Summary

- acquire synchronous request ownership for alert-rule and dashboard exports
- deduplicate bulk dashboard export before React loading state renders
- preserve concurrent exports for different rows

## Testing

- targeted Vitest: 19 tests passed
- targeted ESLint and Prettier checks passed
- `npm run build` passed (8,022 modules)
- PR scope check: 4 files, 86 changed lines

Fixes #2732
