### PR TITLE
fix(cluster): display broker disk usage as a percentage

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -276,7 +276,9 @@ public class RocketMQClusterProvider implements ClusterProvider {
                 try {
                     double parsedRatio = Double.parseDouble(diskRatio);
                     if (Double.isFinite(parsedRatio) && parsedRatio >= 0) {
-                        builder.diskUsage(parsedRatio);
+                        // RocketMQ exposes commitLogDiskRatio as a fraction in [0, 1],
+                        // while BrokerVO and the web progress bars use percentage points.
+                        builder.diskUsage(parsedRatio * 100D);
                     }
                 } catch (NumberFormatException ignored) {
                     // keep default

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
@@ -74,6 +74,22 @@ class RocketMQClusterProviderTest {
     }
 
     @Test
+    void discoverClustersShouldConvertDiskRatioToPercentage() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RocketMQClusterProvider provider = newProvider(adminExt);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        KVTable runtime = runtimeStats();
+        runtime.getTable().put("commitLogDiskRatio", "0.625");
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtime);
+
+        ClusterVO cluster = provider.discoverClusters().get(0);
+
+        assertThat(cluster.getBrokers()).singleElement()
+                .extracting(broker -> broker.getDiskUsage())
+                .isEqualTo(62.5D);
+    }
+
+    @Test
     void discoverClustersShouldPopulateSafeDefaults() throws Exception {
         DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
         RocketMQClusterProvider provider = newProvider(adminExt);


### PR DESCRIPTION
## Summary

- convert RocketMQ's fractional `commitLogDiskRatio` into percentage points before exposing broker runtime data
- preserve the existing rejection of negative and non-finite runtime values
- add a provider regression test for a 62.5% disk usage value

## Testing

- `mvn -Dtest=RocketMQClusterProviderTest test` (14 tests)
- Maven Checkstyle validation

Closes #2738