### PR TITLE
fix(studio): serialize user status mutations

### DIFF
--- a/web/src/pages/studio/UserManagement.tsx
+++ b/web/src/pages/studio/UserManagement.tsx
@@ -89,9 +89,11 @@ const UserManagementPage = () => {
   const [createOpen, setCreateOpen] = useState(false);
   const [passwordTarget, setPasswordTarget] = useState<StudioUser | null>(null);
   const [userExporting, setUserExporting] = useState(false);
+  const [mutatingUserIds, setMutatingUserIds] = useState<Set<number>>(() => new Set());
   const [createForm] = Form.useForm<CreateFormValues>();
   const [passwordForm] = Form.useForm<PasswordFormValues>();
   const requestSeqRef = useRef(0);
+  const mutatingUserIdsRef = useRef(new Set<number>());
 
   useEffect(() => {
     const timer = window.setTimeout(() => setDebouncedSearch(search.trim()), 300);
@@ -163,12 +165,18 @@ const UserManagementPage = () => {
   };
 
   const setEnabled = async (record: StudioUser, enabled: boolean) => {
+    if (mutatingUserIdsRef.current.has(record.id)) return;
+    mutatingUserIdsRef.current.add(record.id);
+    setMutatingUserIds(new Set(mutatingUserIdsRef.current));
     try {
       await setStudioUserEnabled(record.id, enabled);
       message.success(enabled ? '用户已启用' : '用户已禁用，全部会话已注销');
       await loadUsers();
     } catch {
       message.error('更新用户状态失败');
+    } finally {
+      mutatingUserIdsRef.current.delete(record.id);
+      setMutatingUserIds(new Set(mutatingUserIdsRef.current));
     }
   };
 
@@ -237,6 +245,7 @@ const UserManagementPage = () => {
           </Button>
           <Switch
             checked={record.enabled}
+            loading={mutatingUserIds.has(record.id)}
             checkedChildren="启用"
             unCheckedChildren="禁用"
             onChange={(enabled) => void setEnabled(record, enabled)}

--- a/web/src/pages/studio/__tests__/UserManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/UserManagement.test.tsx
@@ -17,12 +17,13 @@
 
 import { App } from 'antd';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent, { type UserEvent } from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import {
   listAllStudioUsers as downloadStudioUsers,
   listStudioUsers,
+  setStudioUserEnabled,
 } from '../../../api/studioUsers';
 import { downloadCsv } from '../../../utils/download';
 import UserManagementPage from '../UserManagement';
@@ -156,5 +157,24 @@ describe('UserManagementPage', () => {
     expect(exportedCsv).toContain('"operator"');
     expect(exportedCsv).toContain('"User"');
     expect(exportedCsv).toContain('"Enabled"');
+  });
+
+  it('does not overlap status updates for the same user', async () => {
+    let resolveUpdate!: () => void;
+    vi.mocked(setStudioUserEnabled).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUpdate = resolve;
+        }),
+    );
+    renderPage();
+
+    const toggle = await screen.findByRole('switch');
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+
+    expect(setStudioUserEnabled).toHaveBeenCalledTimes(1);
+    expect(setStudioUserEnabled).toHaveBeenCalledWith(7, false);
+    await act(async () => resolveUpdate());
   });
 });


### PR DESCRIPTION
## Summary

- serialize enable/disable mutations independently for each Studio user
- show the pending state on only the affected account switch
- add a regression test proving rapid repeated input starts one status request

## Testing

- `npm test -- src/pages/studio/__tests__/UserManagement.test.tsx` (4 tests)
- `npm exec eslint -- src/pages/studio/UserManagement.tsx src/pages/studio/__tests__/UserManagement.test.tsx`

Closes #2739