### PR TITLE
fix(cluster): reject malformed NameServer addresses

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParser.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParser.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.cluster.nameserver;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.commons.validator.routines.InetAddressValidator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,7 @@ public final class NamesrvAddrParser {
 
     private static final int MIN_PORT = 1;
     private static final int MAX_PORT = 65535;
+    private static final InetAddressValidator ADDRESS_VALIDATOR = InetAddressValidator.getInstance();
 
     private NamesrvAddrParser() {
     }
@@ -40,7 +42,7 @@ public final class NamesrvAddrParser {
             throw new BusinessException(400, "namesrvAddr must not be blank");
         }
         List<String> segments = new ArrayList<>();
-        for (String part : raw.split("[,;]")) {
+        for (String part : raw.split("[,;]", -1)) {
             String segment = part.trim();
             if (segment.isEmpty()) {
                 throw new BusinessException(400, "namesrvAddr contains an empty address segment");
@@ -86,18 +88,6 @@ public final class NamesrvAddrParser {
     }
 
     private static boolean isValidIpv6Literal(String ipv6) {
-        if (ipv6.isEmpty() || ipv6.chars().filter(ch -> ch == ':').count() < 2) {
-            return false;
-        }
-        for (char ch : ipv6.toCharArray()) {
-            boolean valid = ch == ':'
-                    || Character.isDigit(ch)
-                    || ch >= 'a' && ch <= 'f'
-                    || ch >= 'A' && ch <= 'F';
-            if (!valid) {
-                return false;
-            }
-        }
-        return true;
+        return ADDRESS_VALIDATOR.isValidInet6Address(ipv6);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParserTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParserTest.java
@@ -81,6 +81,16 @@ class NamesrvAddrParserTest {
     }
 
     @Test
+    void rejectsTrailingSeparatorsTest() {
+        assertThatThrownBy(() -> NamesrvAddrParser.normalize("ns1:9876,"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("empty address segment");
+        assertThatThrownBy(() -> NamesrvAddrParser.normalize("ns1:9876;"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("empty address segment");
+    }
+
+    @Test
     void rejectsMissingPortTest() {
         assertThatThrownBy(() -> NamesrvAddrParser.normalize("ns1"))
                 .isInstanceOf(BusinessException.class)
@@ -134,6 +144,12 @@ class NamesrvAddrParserTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("malformed IPv6");
         assertThatThrownBy(() -> NamesrvAddrParser.normalize("[::1-g]:9876"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("malformed IPv6");
+        assertThatThrownBy(() -> NamesrvAddrParser.normalize("[1:2:3]:9876"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("malformed IPv6");
+        assertThatThrownBy(() -> NamesrvAddrParser.normalize("[1::2::3]:9876"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("malformed IPv6");
     }


### PR DESCRIPTION
## Summary

- retain trailing empty fields while parsing comma/semicolon-separated NameServer addresses
- replace the character-only IPv6 check with strict literal validation
- cover trailing separators and structurally malformed IPv6 inputs

## Testing

- `mvn -Dtest=NamesrvAddrParserTest test` (15 tests)
- Maven Checkstyle validation

Closes #2741