### PR TITLE
fix(studio): open AI history from home

### DIFF
--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -269,6 +269,56 @@ describe('AiPage tool runner', () => {
     expect(chatStream).not.toHaveBeenCalled();
   });
 
+  it('opens the history drawer once when the route carries history intent', async () => {
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: {
+          conversations: [
+            {
+              id: 'previous',
+              messages: [{ id: 'previous-message', role: 'user', text: 'Previous conversation' }],
+              updatedAt: Date.now() - 60_000,
+            },
+          ],
+          activeConversationId: null,
+        },
+      },
+    });
+
+    renderPage({ historyIntent: 'open' });
+
+    const historyDrawer = await screen.findByRole('dialog', { name: 'AI 对话历史' });
+    expect(
+      within(historyDrawer).getByRole('button', { name: /^Previous conversation/ }),
+    ).toBeInTheDocument();
+    expect(chatStream).not.toHaveBeenCalled();
+  });
+
+  it('does not reopen history when the route has no history intent', async () => {
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: {
+          conversations: [
+            {
+              id: 'previous',
+              messages: [{ id: 'previous-message', role: 'user', text: 'Previous conversation' }],
+              updatedAt: Date.now() - 60_000,
+            },
+          ],
+          activeConversationId: null,
+        },
+      },
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(getLlmModels).toHaveBeenCalled());
+    expect(screen.queryByRole('dialog', { name: 'AI 对话历史' })).not.toBeInTheDocument();
+    expect(chatStream).not.toHaveBeenCalled();
+  });
+
   it('stops an in-flight response before switching conversations', async () => {
     useAiChatHistoryStore.setState({
       histories: {

--- a/web/src/pages/ai/chatDraft.test.ts
+++ b/web/src/pages/ai/chatDraft.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { getChatDraft } from './chatDraft';
+import { getChatDraft, shouldOpenChatHistory } from './chatDraft';
 
 describe('AI chat draft navigation state', () => {
   it('normalizes a prompt and preserves a selected model', () => {
@@ -46,5 +46,12 @@ describe('AI chat draft navigation state', () => {
     expect(getChatDraft({ prompt: '检查集群状态', model: '   ' })).toEqual({
       prompt: '检查集群状态',
     });
+  });
+
+  it('only opens history for the explicit history route intent', () => {
+    expect(shouldOpenChatHistory({ historyIntent: 'open' })).toBe(true);
+    expect(shouldOpenChatHistory({ historyIntent: 'closed' })).toBe(false);
+    expect(shouldOpenChatHistory({ prompt: '检查集群状态' })).toBe(false);
+    expect(shouldOpenChatHistory(null)).toBe(false);
   });
 });

--- a/web/src/pages/ai/chatDraft.ts
+++ b/web/src/pages/ai/chatDraft.ts
@@ -52,3 +52,8 @@ export function getChatDraft(state: unknown): ChatDraft | null {
     ...(conversationId ? { conversationId } : {}),
   };
 }
+
+export function shouldOpenChatHistory(state: unknown): boolean {
+  if (typeof state !== 'object' || state === null) return false;
+  return (state as Record<string, unknown>).historyIntent === 'open';
+}

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -64,7 +64,7 @@ import {
   type AiChatDataMode,
   useAiChatHistoryStore,
 } from '../../stores/aiChatHistoryStore';
-import { getChatDraft, type ChatMode } from './chatDraft';
+import { getChatDraft, shouldOpenChatHistory, type ChatMode } from './chatDraft';
 
 const { Text } = Typography;
 
@@ -542,10 +542,16 @@ const AiPage = () => {
 
   useEffect(() => {
     const draft = getChatDraft(location.state);
-    if (!draft || consumedDraftRef.current) return;
+    const openHistory = shouldOpenChatHistory(location.state);
+    if ((!draft && !openHistory) || consumedDraftRef.current) return;
     consumedDraftRef.current = true;
 
     void Promise.resolve().then(() => {
+      if (openHistory) setHistoryOpen(true);
+      if (!draft) {
+        navigate('/ai', { replace: true, state: null });
+        return;
+      }
       if (draft.newConversation) {
         const nextConversationId = newConversationId();
         startConversation(chatMode, nextConversationId);

--- a/web/src/pages/home/__tests__/HomePage.test.tsx
+++ b/web/src/pages/home/__tests__/HomePage.test.tsx
@@ -122,6 +122,35 @@ describe('HomePage LLM models', () => {
 
     expect(navigateMock).not.toHaveBeenCalled();
   });
+
+  it('opens the AI page with history intent from the accessible history action', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await screen.findByText('qwen3.8-max');
+
+    const historyButton = screen.getByRole('button', { name: 'AI 对话历史' });
+    expect(historyButton).toHaveAttribute('type', 'button');
+    expect(historyButton).toHaveAttribute('title', 'AI 对话历史');
+
+    await user.click(historyButton);
+
+    expect(navigateMock).toHaveBeenCalledWith('/ai', {
+      state: { historyIntent: 'open' },
+    });
+  });
+
+  it('supports keyboard activation for the history action', async () => {
+    const user = userEvent.setup();
+    renderHome();
+    await screen.findByText('qwen3.8-max');
+
+    screen.getByRole('button', { name: 'AI 对话历史' }).focus();
+    await user.keyboard('{Enter}');
+
+    expect(navigateMock).toHaveBeenCalledWith('/ai', {
+      state: { historyIntent: 'open' },
+    });
+  });
 });
 
 describe('HomePage footer', () => {

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -215,6 +215,10 @@ const HomePage = () => {
     });
   };
 
+  const handleHistoryOpen = () => {
+    navigate('/ai', { state: { historyIntent: 'open' } });
+  };
+
   return (
     <ConfigProvider theme={{ algorithm: theme.defaultAlgorithm }}>
       <div
@@ -470,7 +474,13 @@ const HomePage = () => {
                     />
                   </div>
                   <div className="flex shrink-0 items-center gap-1">
-                    <button className="p-1 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-50 transition-colors">
+                    <button
+                      type="button"
+                      className="p-1 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-50 transition-colors"
+                      aria-label={t('ai.history.title')}
+                      title={t('ai.history.title')}
+                      onClick={handleHistoryOpen}
+                    >
                       <ClockCounterClockwise size={20} />
                     </button>
                   </div>


### PR DESCRIPTION
## Summary

- make the Home AI history icon an accessible button with localized label and tooltip
- navigate to the AI workspace with an explicit history intent instead of duplicating the drawer on Home
- consume the route intent once on the AI page and open the existing history drawer

Closes #2749

## Verification

- npm test -- src/pages/home/__tests__/HomePage.test.tsx src/pages/ai/__tests__/AiPage.test.tsx src/pages/ai/chatDraft.test.ts src/stores/aiChatHistoryStore.test.ts
- npm exec eslint -- src/pages/home/index.tsx src/pages/home/__tests__/HomePage.test.tsx src/pages/ai/index.tsx src/pages/ai/chatDraft.ts src/pages/ai/chatDraft.test.ts src/pages/ai/__tests__/AiPage.test.tsx
- npm run build