### PR TITLE
[ISSUE #2651] fix(export): stop system alert export when the result set shrinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build frontend Docker image (cached)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./web
           push: false

--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -19,6 +19,7 @@ import {
   retryAlertDelivery,
   listAlertSilences,
   listSystemAlertsPage,
+  listAllSystemAlerts,
 } from '../../../services/opsService';
 import SystemAlertsPage from '../systemAlerts';
 
@@ -26,6 +27,7 @@ vi.mock('../../../services/opsService', () => ({
   acknowledgeAlert: vi.fn(),
   clearAcknowledgedAlerts: vi.fn(),
   listSystemAlertsPage: vi.fn(),
+  listAllSystemAlerts: vi.fn(),
   getCollectorStatus: vi.fn().mockResolvedValue({ collectionInterval: 'PT30S' }),
   listAlertDeliveries: vi.fn().mockResolvedValue([]),
   listRelatedSystemAlerts: vi.fn().mockResolvedValue([]),
@@ -229,6 +231,75 @@ describe('SystemAlertsPage', () => {
         }),
       );
     });
+  });
+
+  it('exports all matching system alerts through the paginated collector', async () => {
+    const createObjectURL = vi.fn().mockReturnValue('blob:alerts');
+    const revokeObjectURL = vi.fn();
+    const originalCreate = URL.createObjectURL;
+    const originalRevoke = URL.revokeObjectURL;
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+    try {
+      vi.mocked(listAllSystemAlerts).mockResolvedValue([
+        {
+          id: 1,
+          level: 'error',
+          title: 'Broker unavailable',
+          description: 'broker a',
+          time: '2026-08-10 01:00',
+          acknowledged: false,
+        },
+        {
+          id: 2,
+          level: 'warning',
+          title: 'Consumer lag',
+          description: 'consumer b',
+          time: '2026-08-10 01:01',
+          acknowledged: false,
+        },
+      ]);
+      const user = userEvent.setup();
+      renderPage();
+      await screen.findByText('Broker unavailable');
+
+      await user.click(screen.getByRole('button', { name: '导出 CSV' }));
+
+      await waitFor(() => expect(listAllSystemAlerts).toHaveBeenCalledTimes(1));
+      expect(listAllSystemAlerts).toHaveBeenCalledWith({
+        level: undefined,
+        domain: undefined,
+        transition: undefined,
+        notificationSuppressed: undefined,
+        instanceId: undefined,
+        labelKey: undefined,
+        labelValue: undefined,
+        from: undefined,
+        to: undefined,
+      });
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      const blob = createObjectURL.mock.calls[0][0] as Blob;
+      await expect(blob.text()).resolves.toContain('Broker unavailable');
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:alerts');
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: originalCreate,
+      });
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        value: originalRevoke,
+      });
+      clickSpy.mockRestore();
+    }
   });
 
   it('does not offer acknowledgement for resolved alert history', async () => {

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -43,6 +43,7 @@ import {
   listRelatedSystemAlerts,
   retryAlertDelivery,
   listSystemAlertsPage,
+  listAllSystemAlerts,
   createAlertSilence,
   deleteAlertSilence,
   listAlertSilences,
@@ -255,13 +256,7 @@ const SystemAlertsPage = () => {
   const exportAlerts = async () => {
     setExporting(true);
     try {
-      const query = currentQuery();
-      const first = await listSystemAlertsPage({ ...query, page: 1, pageSize: 100 });
-      const rows = [...first.items];
-      for (let currentPage = 2; rows.length < first.total; currentPage += 1) {
-        const result = await listSystemAlertsPage({ ...query, page: currentPage, pageSize: 100 });
-        rows.push(...result.items);
-      }
+      const rows = await listAllSystemAlerts(currentQuery());
       downloadCsv(
         `rocketmq-system-alerts-${new Date().toISOString().slice(0, 10)}.csv`,
         buildCsv(ALERT_EXPORT_COLUMNS, rows),

--- a/web/src/services/opsService.test.ts
+++ b/web/src/services/opsService.test.ts
@@ -24,6 +24,7 @@ import {
   getAuditFilterOptions,
   listAlertRules,
   listAlertRulesPage,
+  listAllSystemAlerts,
   listAuditRecords,
   listSystemAlerts,
   listSystemAlertsPage,
@@ -31,10 +32,18 @@ import {
   updateAlertRule,
 } from './opsService';
 
-vi.mock('./dataMode', () => ({ isMockMode: () => true }));
+const { mode, opsApi } = vi.hoisted(() => ({
+  mode: { mock: true },
+  opsApi: {
+    listSystemAlertsPage: vi.fn(),
+  },
+}));
+
+vi.mock('./dataMode', () => ({ isMockMode: () => mode.mock }));
 vi.mock('../config', () => ({
   API_BASE_URL: '/api',
 }));
+vi.mock('../api/ops', () => opsApi);
 
 describe('ops service mock data', () => {
   const auditRecords = mockAuditRecords as unknown as AuditRecord[];
@@ -232,5 +241,110 @@ describe('ops service mock data', () => {
       '"2026-08-01 10:00:00","\'=admin","DELETE","TOPIC","csv-export-target",' +
         '"prod-cn","removed ""topic"", safely","SUCCESS","\'=denied"',
     );
+  });
+});
+
+describe('ops service system alert export pagination', () => {
+  const alert = (id: number, title: string) => ({
+    id,
+    level: 'error',
+    title,
+    description: '',
+    time: '2026-08-10 01:00',
+    acknowledged: false,
+  });
+
+  afterEach(() => {
+    mode.mock = true;
+    opsApi.listSystemAlertsPage.mockReset();
+  });
+
+  it('collects every API system alert page until the reported total is reached', async () => {
+    mode.mock = false;
+    opsApi.listSystemAlertsPage
+      .mockResolvedValueOnce({
+        items: [alert(1, 'first alert')],
+        total: 2,
+        page: 1,
+        size: 100,
+      })
+      .mockResolvedValueOnce({
+        items: [alert(2, 'second alert')],
+        total: 2,
+        page: 2,
+        size: 100,
+      });
+
+    const alerts = await listAllSystemAlerts({ level: 'error' });
+
+    expect(opsApi.listSystemAlertsPage).toHaveBeenNthCalledWith(1, {
+      level: 'error',
+      page: 1,
+      pageSize: 100,
+    });
+    expect(opsApi.listSystemAlertsPage).toHaveBeenNthCalledWith(2, {
+      level: 'error',
+      page: 2,
+      pageSize: 100,
+    });
+    expect(alerts.map((item) => item.id)).toEqual([1, 2]);
+  });
+
+  it('stops exporting when the result set shrinks and a page comes back empty', async () => {
+    mode.mock = false;
+    opsApi.listSystemAlertsPage
+      .mockResolvedValueOnce({
+        items: [alert(1, 'first alert')],
+        total: 3,
+        page: 1,
+        size: 100,
+      })
+      .mockResolvedValueOnce({
+        items: [],
+        total: 1,
+        page: 2,
+        size: 100,
+      });
+
+    const alerts = await listAllSystemAlerts();
+
+    expect(opsApi.listSystemAlertsPage).toHaveBeenCalledTimes(2);
+    expect(alerts.map((item) => item.id)).toEqual([1]);
+  });
+
+  it('honors a lower total reported by a later page', async () => {
+    mode.mock = false;
+    opsApi.listSystemAlertsPage
+      .mockResolvedValueOnce({
+        items: [alert(1, 'first alert'), alert(2, 'second alert')],
+        total: 5,
+        page: 1,
+        size: 100,
+      })
+      .mockResolvedValueOnce({
+        items: [alert(3, 'third alert')],
+        total: 3,
+        page: 2,
+        size: 100,
+      });
+
+    const alerts = await listAllSystemAlerts();
+
+    expect(opsApi.listSystemAlertsPage).toHaveBeenCalledTimes(2);
+    expect(alerts.map((item) => item.id)).toEqual([1, 2, 3]);
+  });
+
+  it('stops API system alert export when pagination exceeds the safety limit', async () => {
+    mode.mock = false;
+    opsApi.listSystemAlertsPage.mockResolvedValue({
+      items: [alert(1, 'first alert')],
+      total: Number.MAX_SAFE_INTEGER,
+      page: 1,
+      size: 100,
+    });
+
+    await expect(listAllSystemAlerts()).rejects.toThrow('System alert export exceeded 100 pages');
+    expect(opsApi.listSystemAlertsPage).toHaveBeenCalledTimes(100);
+    expect(opsApi.listSystemAlertsPage).toHaveBeenLastCalledWith({ page: 100, pageSize: 100 });
   });
 });

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -28,6 +28,9 @@ import { mockAlertRules } from '../mock/alerts';
 import { mockAuditRecords } from '../mock/audit';
 import { systemAlerts as mockSystemAlerts } from '../mock/dashboard';
 
+const EXPORT_PAGE_SIZE = 100;
+const MAX_EXPORT_PAGES = 100;
+
 let auditRecordsState = mockAuditRecords as unknown as AuditRecord[];
 const alertRulesState = mockAlertRules as unknown as AlertRule[];
 let alertSilencesState: AlertSilence[] = [];
@@ -369,6 +372,25 @@ export async function listSystemAlertsPage(
     size: pageSize,
   };
 }
+
+export const listAllSystemAlerts = async (query: SystemAlertQuery = {}): Promise<SystemAlert[]> => {
+  const alerts: SystemAlert[] = [];
+  let page = 1;
+
+  while (page <= MAX_EXPORT_PAGES) {
+    const result = await listSystemAlertsPage({
+      ...query,
+      page,
+      pageSize: EXPORT_PAGE_SIZE,
+    });
+    alerts.push(...result.items);
+    const total = result.total ?? alerts.length;
+    if (result.items.length === 0 || alerts.length >= total) return alerts;
+    page += 1;
+  }
+
+  throw new Error(`System alert export exceeded ${MAX_EXPORT_PAGES} pages`);
+};
 
 export async function listRelatedSystemAlerts(id: number): Promise<SystemAlert[]> {
   if (isMockMode()) return [];


### PR DESCRIPTION
## Summary

- collect system alert export rows through a shared paginated service helper
- stop when a page comes back empty or a later response reports a lower total
- keep a finite 100-page safety bound and reuse the collector from the alerts page

## Testing

- `npx vitest run src/services/opsService.test.ts src/pages/ops/__tests__/SystemAlertsPage.test.tsx` (27 tests)
- full Vitest suite: 742 tests passed
- `npm run build` passed (tsc + Vite)
- `git diff --check`

Fixes #2651



## Note

- `.github/workflows/ci.yml` carries the same policy-approved Docker action revisions as #2550 (repo-wide startup fix) so this PR can run CI; the diff disappears once #2550 lands.
