### PR TITLE
[ISSUE #2634] fix(consumer): ignore stale settings responses in the group modal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build frontend Docker image (cached)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./web
           push: false

--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -108,6 +108,14 @@ const renderWithProviders = (ui: React.ReactElement, initialEntry = '/instance/c
     </App>,
   );
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
 describe('Consumer page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -910,6 +918,71 @@ describe('Consumer page', () => {
       });
     });
     expect(await screen.findByText('消费组配置已保存')).toBeInTheDocument();
+  });
+
+  it('ignores a stale settings response that resolves after another group opened', async () => {
+    type GroupSettings = {
+      groupName: string;
+      retryQueueNums: number;
+      retryMaxTimes: number;
+    };
+    const staleRequest = deferred<GroupSettings>();
+    const freshRequest = deferred<GroupSettings>();
+    vi.mocked(consumerService.listConsumerGroupPage).mockResolvedValue(
+      groupPage([
+        { ...group, name: 'stale-cg' },
+        { ...group, name: 'fresh-cg' },
+      ]),
+    );
+    vi.mocked(consumerService.getConsumerGroupSettings).mockImplementation((name: string) =>
+      name === 'stale-cg' ? staleRequest.promise : freshRequest.promise,
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ConsumerPage />);
+
+    const staleRow = await screen.findByRole('row', { name: /stale-cg/ });
+    await user.click(within(staleRow).getByRole('button', { name: /详\s*情/ }));
+    const staleDialog = await screen.findByRole('dialog', { name: /stale-cg/ });
+    await user.click(within(staleDialog).getByRole('tab', { name: /配\s*置/ }));
+    await waitFor(() =>
+      expect(consumerService.getConsumerGroupSettings).toHaveBeenCalledWith(
+        'stale-cg',
+        'instance-1',
+      ),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    // jsdom never finishes the zoom-leave transition, so wait for the leave
+    // state instead of the dialog being removed from the DOM
+    await waitFor(() => expect(staleDialog).toHaveClass('ant-zoom-leave'));
+
+    const freshRow = await screen.findByRole('row', { name: /fresh-cg/ });
+    await user.click(within(freshRow).getByRole('button', { name: /详\s*情/ }));
+    const freshDialog = await screen.findByRole('dialog', { name: /fresh-cg/ });
+    await user.click(within(freshDialog).getByRole('tab', { name: /概\s*览/ }));
+    await user.click(within(freshDialog).getByRole('tab', { name: /配\s*置/ }));
+    await waitFor(() =>
+      expect(consumerService.getConsumerGroupSettings).toHaveBeenCalledWith(
+        'fresh-cg',
+        'instance-1',
+      ),
+    );
+
+    act(() => {
+      freshRequest.resolve({ groupName: 'fresh-cg', retryQueueNums: 2, retryMaxTimes: 8 });
+    });
+    await waitFor(() =>
+      expect(within(freshDialog).getByLabelText('最大重试次数')).toHaveValue('8'),
+    );
+
+    // stale-cg resolves after fresh-cg was already applied; it must not overwrite the form
+    act(() => {
+      staleRequest.resolve({ groupName: 'stale-cg', retryQueueNums: 7, retryMaxTimes: 7 });
+    });
+
+    expect(within(freshDialog).getByLabelText('重试队列数')).toHaveValue('2');
+    expect(within(freshDialog).getByLabelText('最大重试次数')).toHaveValue('8');
   });
 
   it('renders an unknown (-1) lag as unavailable in the table and the lag detail', async () => {

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -273,6 +273,7 @@ const ConsumerPageContent = ({
 
   const groupRequestIdRef = useRef(0);
   const stackRequestIdRef = useRef(0);
+  const settingsRequestIdRef = useRef(0);
 
   const [autoRefresh, setAutoRefresh] = useState(false);
   const silentRefreshRef = useRef(false);
@@ -433,15 +434,22 @@ const ConsumerPageContent = ({
 
   const loadGroupSettings = async (group: ConsumerGroup) => {
     if (!selectedInstanceId) return;
+    const requestId = ++settingsRequestIdRef.current;
     setSettingsGroup(group);
     setSettingsLoading(true);
     try {
       const settings = await getConsumerGroupSettings(group.name, selectedInstanceId);
-      settingsForm.setFieldsValue(settings);
+      if (requestId === settingsRequestIdRef.current) {
+        settingsForm.setFieldsValue(settings);
+      }
     } catch {
-      message.error('加载消费组配置失败，请稍后重试');
+      if (requestId === settingsRequestIdRef.current) {
+        message.error('加载消费组配置失败，请稍后重试');
+      }
     } finally {
-      setSettingsLoading(false);
+      if (requestId === settingsRequestIdRef.current) {
+        setSettingsLoading(false);
+      }
     }
   };
 
@@ -1263,6 +1271,7 @@ const ConsumerPageContent = ({
         }
         open={modalOpen}
         onCancel={() => {
+          settingsRequestIdRef.current += 1;
           setModalOpen(false);
           setSelectedGroup(null);
           setShowOnlyInconsistent(false);


### PR DESCRIPTION
## Summary

- sequence consumer settings requests with a request-id ref
- ignore stale success, error, and completion callbacks after the modal closes or another group loads
- add a regression test covering out-of-order settings responses across two group modals

## Testing

- `npx vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` (22 tests)
- full Vitest suite: 742 tests passed
- `npm run build` passed (tsc + Vite)
- `git diff --check`

Fixes #2634



## Note

- `.github/workflows/ci.yml` carries the same policy-approved Docker action revisions as #2550 (repo-wide startup fix) so this PR can run CI; the diff disappears once #2550 lands.
