### PR TITLE
fix(web): scope instance requests by data mode

### DIFF
--- a/web/src/services/instanceService.test.ts
+++ b/web/src/services/instanceService.test.ts
@@ -165,4 +165,25 @@ describe('instanceService list request dedupe', () => {
     await listInstances({});
     expect(instanceApiMock.listInstances).toHaveBeenCalledTimes(2);
   });
+
+  it('does not share inflight requests across data modes', async () => {
+    dataModeMock.isMockMode.mockReturnValue(false);
+    let resolveRealList!: (value: Instance[]) => void;
+    instanceApiMock.listInstances.mockImplementationOnce(
+      () =>
+        new Promise<Instance[]>((resolve) => {
+          resolveRealList = resolve;
+        }),
+    );
+
+    const realRequest = listInstances({});
+    dataModeMock.isMockMode.mockReturnValue(true);
+    const mockResult = await listInstances({});
+
+    expect(mockResult.length).toBeGreaterThan(0);
+    expect(instanceApiMock.listInstances).toHaveBeenCalledTimes(1);
+
+    resolveRealList([]);
+    await expect(realRequest).resolves.toEqual([]);
+  });
 });

--- a/web/src/services/instanceService.ts
+++ b/web/src/services/instanceService.ts
@@ -41,18 +41,19 @@ const CLOUD_CAPABILITIES: InstanceCapabilities['capabilities'] = [
 const inflightListRequests = new Map<string, Promise<Instance[]>>();
 
 export function listInstances(query: InstanceQuery = {}): Promise<Instance[]> {
-  const key = JSON.stringify([query.type ?? null, query.search?.trim() || null]);
+  const mockMode = isMockMode();
+  const key = JSON.stringify([mockMode, query.type ?? null, query.search?.trim() || null]);
   const inflight = inflightListRequests.get(key);
   if (inflight) {
     return inflight.then((items) => items.map(copyInstance));
   }
-  const request = fetchInstances(query).finally(() => inflightListRequests.delete(key));
+  const request = fetchInstances(query, mockMode).finally(() => inflightListRequests.delete(key));
   inflightListRequests.set(key, request);
   return request.then((items) => items.map(copyInstance));
 }
 
-async function fetchInstances(query: InstanceQuery): Promise<Instance[]> {
-  if (isMockMode()) {
+async function fetchInstances(query: InstanceQuery, mockMode: boolean): Promise<Instance[]> {
+  if (mockMode) {
     const search = query.search?.trim().toLowerCase();
     return mockInstances
       .filter((instance) => matchesType(instance, query.type))


### PR DESCRIPTION
## Summary

- include the captured Mock/Real data mode in the instance-list in-flight request key
- use the same captured mode for the underlying fetch
- cover a mode switch while an identical real request is still pending

## Tests

- `npm test -- src/services/instanceService.test.ts` (7 passed)
- `npm exec eslint -- src/services/instanceService.ts src/services/instanceService.test.ts`

Closes #2755