### PR TITLE
[ISSUE #2759] fix(metrics): sanitize mini bar metric samples

### DIFF
--- a/web/src/components/MiniBar.tsx
+++ b/web/src/components/MiniBar.tsx
@@ -32,13 +32,16 @@ const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: M
     );
   }
 
-  const max = Math.max(...data, 1);
+  // Metric backends can temporarily emit non-finite or negative samples. Keep
+  // those values from leaking into CSS lengths and collapsing the sparkline.
+  const safeData = data.map((value) => (Number.isFinite(value) && value > 0 ? value : 0));
+  const max = Math.max(...safeData, 1);
   const barWidth = Math.max(2, (width - (data.length - 1) * 2) / data.length);
 
   return (
     <div
       role="img"
-      aria-label={label || `趋势数据：${data.join('、')}`}
+      aria-label={label || `趋势数据：${safeData.join('、')}`}
       style={{
         display: 'inline-flex',
         alignItems: 'flex-end',
@@ -47,7 +50,7 @@ const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: M
         width,
       }}
     >
-      {data.map((value, i) => (
+      {safeData.map((value, i) => (
         <div
           key={i}
           style={{

--- a/web/src/components/__tests__/MiniBar.test.tsx
+++ b/web/src/components/__tests__/MiniBar.test.tsx
@@ -23,6 +23,16 @@ const getBarHeights = () =>
   Array.from(screen.getByRole('img').children, (bar) => (bar as HTMLElement).style.height);
 
 describe('MiniBar', () => {
+  it('renders finite non-negative heights for malformed metric samples', () => {
+    const { container } = render(<MiniBar data={[Number.NaN, Number.POSITIVE_INFINITY, -5, 10]} />);
+
+    const heights = [...container.querySelectorAll('[role="img"] > div')].map(
+      (bar) => (bar as HTMLElement).style.height,
+    );
+    expect(heights).toEqual(['0px', '0px', '0px', '32px']);
+    expect(container.innerHTML).not.toMatch(/NaN|Infinity|-\d+px/);
+  });
+
   it('renders zero values without a visible bar', () => {
     render(<MiniBar data={[0, 0, 0]} height={20} label="Throughput trend" />);
 


### PR DESCRIPTION
## Summary

- normalize non-finite and negative MiniBar samples before calculating dimensions
- keep generated CSS heights and the default accessible label finite
- cover malformed and valid metric samples with a focused component test

## Verification

- MiniBar.test.tsx: 3 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 19 changed lines

Fixes #2759
