### PR TITLE
[ISSUE #2761] fix(metrics): sanitize mini line metric samples

### DIFF
--- a/web/src/components/MiniLine.tsx
+++ b/web/src/components/MiniLine.tsx
@@ -47,8 +47,9 @@ const MiniLine = ({
   animated = true,
   responsive = false,
 }: MiniLineProps) => {
-  const max = Math.max(...data, 1);
-  const min = Math.min(...data, 0);
+  const safeData = data.map((value) => (Number.isFinite(value) ? value : 0));
+  const max = Math.max(...safeData, 1);
+  const min = Math.min(...safeData, 0);
   const range = max - min || 1;
 
   const pad = 4;
@@ -61,8 +62,8 @@ const MiniLine = ({
   if (data.length < 2) return null;
 
   // Build smooth Catmull-Rom → Bezier control points
-  const points = data.map((v, i) => ({
-    x: pad + (i / (data.length - 1)) * innerW,
+  const points = safeData.map((v, i) => ({
+    x: pad + (i / (safeData.length - 1)) * innerW,
     y: pad + innerH - ((v - min) / range) * innerH,
   }));
 

--- a/web/src/components/__tests__/MiniLine.test.tsx
+++ b/web/src/components/__tests__/MiniLine.test.tsx
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import MiniLine from '../MiniLine';
+
+describe('MiniLine', () => {
+  it('keeps malformed metric samples out of SVG coordinates', () => {
+    const { container } = render(
+      <MiniLine data={[1, Number.NaN, Number.POSITIVE_INFINITY, 4]} animated={false} />,
+    );
+
+    expect(container.querySelector('svg')).not.toBeNull();
+    expect(container.innerHTML).not.toMatch(/NaN|Infinity/);
+  });
+});


### PR DESCRIPTION
## Summary

- normalize non-finite MiniLine samples before calculating ranges and points
- prevent malformed values from reaching SVG path coordinates
- add a focused regression test for mixed valid and invalid samples

## Verification

- MiniLine.test.tsx: 1 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 24 changed lines

Fixes #2761
