### PR TITLE
[ISSUE #2764] fix(navigation): preserve modified search shortcuts

### DIFF
--- a/web/src/layouts/navigationSearch.test.ts
+++ b/web/src/layouts/navigationSearch.test.ts
@@ -71,6 +71,15 @@ describe('navigation search helpers', () => {
 
   it('recognizes Control/Command-K but rejects alternative shortcuts', () => {
     expect(
+      isNavigationSearchShortcut({
+        key: 'k',
+        ctrlKey: true,
+        metaKey: false,
+        altKey: false,
+        shiftKey: true,
+      }),
+    ).toBe(false);
+    expect(
       isNavigationSearchShortcut({ key: 'k', ctrlKey: true, metaKey: false, altKey: false }),
     ).toBe(true);
     expect(

--- a/web/src/layouts/navigationSearch.ts
+++ b/web/src/layouts/navigationSearch.ts
@@ -69,6 +69,7 @@ export function isNavigationSearchShortcut(event: {
   metaKey: boolean;
   ctrlKey: boolean;
   altKey: boolean;
+  shiftKey?: boolean;
   target?: EventTarget | null;
 }): boolean {
   const isEditableTarget =
@@ -81,6 +82,7 @@ export function isNavigationSearchShortcut(event: {
     event.key.toLowerCase() === 'k' &&
     (event.metaKey || event.ctrlKey) &&
     !event.altKey &&
+    !event.shiftKey &&
     !isEditableTarget
   );
 }


### PR DESCRIPTION
## Summary

- exclude shifted Ctrl/Cmd-K events from the navigation search shortcut
- preserve existing Alt-key and editable-target guards
- cover Ctrl-Shift-K in the navigation helper tests

## Verification

- navigationSearch.test.ts: 7 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 11 changed lines

Fixes #2764
