### PR TITLE
[ISSUE #2760] fix(tables): reject invalid column widths

### DIFF
--- a/web/src/utils/table.test.ts
+++ b/web/src/utils/table.test.ts
@@ -20,6 +20,14 @@ import { describe, expect, it } from 'vitest';
 import { tableScrollX } from './table';
 
 describe('tableScrollX', () => {
+  it('falls back for non-positive and non-finite widths without reducing scroll space', () => {
+    expect(
+      tableScrollX([{ width: -40 }, { width: Number.NaN }, { width: '0px' }, { width: '80px' }], {
+        extra: Number.NEGATIVE_INFINITY,
+      }),
+    ).toBe(440);
+  });
+
   it('sums the declared column widths', () => {
     expect(tableScrollX([{ width: 220 }, { width: 200 }, { width: 100 }])).toBe(520);
   });

--- a/web/src/utils/table.ts
+++ b/web/src/utils/table.ts
@@ -61,11 +61,13 @@ function columnWidth(column: ColumnLike): number {
     return column.children.reduce((total, child) => total + columnWidth(child), 0);
   }
   if (typeof column.width === 'number') {
-    return column.width;
+    return Number.isFinite(column.width) && column.width > 0 ? column.width : UNSIZED_COLUMN_WIDTH;
   }
   if (typeof column.width === 'string') {
     const parsed = Number.parseFloat(column.width);
-    return Number.isFinite(parsed) && column.width.endsWith('px') ? parsed : UNSIZED_COLUMN_WIDTH;
+    return Number.isFinite(parsed) && parsed > 0 && column.width.endsWith('px')
+      ? parsed
+      : UNSIZED_COLUMN_WIDTH;
   }
   return UNSIZED_COLUMN_WIDTH;
 }
@@ -80,6 +82,6 @@ export function tableScrollX(
     declared +
     (options.selection ? SELECTION_COLUMN_WIDTH : 0) +
     (options.expandable ? EXPAND_COLUMN_WIDTH : 0) +
-    (options.extra ?? 0)
+    (Number.isFinite(options.extra) && (options.extra ?? 0) > 0 ? options.extra! : 0)
   );
 }


### PR DESCRIPTION
## Summary

- fall back to the unsized-column width for invalid numeric and pixel widths
- ignore invalid extra scroll space instead of returning a non-finite result
- cover mixed negative, zero, NaN, infinite, and valid widths

## Verification

- table.test.ts: 6 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 16 changed lines

Fixes #2760
