### PR TITLE
[ISSUE #2762] fix(ai): normalize chat conversation identifiers

### DIFF
--- a/web/src/pages/ai/chatDraft.test.ts
+++ b/web/src/pages/ai/chatDraft.test.ts
@@ -19,6 +19,13 @@ import { describe, expect, it } from 'vitest';
 import { getChatDraft } from './chatDraft';
 
 describe('AI chat draft navigation state', () => {
+  it('normalizes conversation identifiers before history lookup', () => {
+    expect(getChatDraft({ conversationId: ' conversation-1 ' })).toEqual({
+      prompt: '',
+      conversationId: 'conversation-1',
+    });
+  });
+
   it('normalizes a prompt and preserves a selected model', () => {
     expect(getChatDraft({ prompt: '  检查集群状态  ', model: '  qwen3.7-max  ' })).toEqual({
       prompt: '检查集群状态',

--- a/web/src/pages/ai/chatDraft.ts
+++ b/web/src/pages/ai/chatDraft.ts
@@ -34,7 +34,7 @@ export function getChatDraft(state: unknown): ChatDraft | null {
   const prompt = typeof candidate.prompt === 'string' ? candidate.prompt.trim() : '';
   const conversationId =
     typeof candidate.conversationId === 'string' && candidate.conversationId.trim()
-      ? candidate.conversationId
+      ? candidate.conversationId.trim()
       : undefined;
   if (!prompt && !conversationId) return null;
   const model = typeof candidate.model === 'string' ? candidate.model.trim() : '';


### PR DESCRIPTION
## Summary

- return normalized AI chat conversation identifiers from navigation state
- keep prompt, model, mode, and flag handling unchanged
- cover a padded conversation-only draft

## Verification

- chatDraft.test.ts: 5 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 9 changed lines

Fixes #2762
