### PR TITLE
[ISSUE #2763] fix(alerts): normalize padded UTC timestamps

### DIFF
--- a/web/src/utils/format.test.ts
+++ b/web/src/utils/format.test.ts
@@ -54,6 +54,7 @@ describe('formatBytes', () => {
   });
 
   it('treats timezone-less alert timestamps as UTC', () => {
+    expect(formatUtcDateTime(' 2026-08-23T10:35:38 ', 'UTC')).toBe('2026-08-23 10:35:38 UTC');
     expect(formatUtcDateTime('2026-08-23T10:35:38.590731', 'America/Los_Angeles')).toBe(
       '2026-08-23 03:35:38 PDT',
     );

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -42,10 +42,11 @@ export function formatUtcDateTime(
   timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone,
 ): string {
   if (date === null || date === undefined || (typeof date === 'string' && !date.trim())) return '-';
+  const normalizedDate = typeof date === 'string' ? date.trim() : date;
   const utcDate =
-    typeof date === 'string' && !/(?:Z|[+-]\d{2}:?\d{2})$/i.test(date.trim())
-      ? new Date(`${date}Z`)
-      : new Date(date);
+    typeof normalizedDate === 'string' && !/(?:Z|[+-]\d{2}:?\d{2})$/i.test(normalizedDate)
+      ? new Date(`${normalizedDate}Z`)
+      : new Date(normalizedDate);
   if (Number.isNaN(utcDate.getTime())) return '-';
 
   const parts = new Intl.DateTimeFormat('en-US', {


### PR DESCRIPTION
## Summary

- trim UTC timestamp strings once before offset detection and parsing
- preserve the existing UTC treatment for offset-less alert timestamps
- cover padded offset-less input in the formatter tests

## Verification

- format.test.ts: 8 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 8 changed lines

Fixes #2763
