### PR TITLE
[ISSUE #2765] fix(ai): preserve custom models in provider fallbacks

### DIFF
--- a/web/src/pages/studio/__tests__/LlmSettings.test.ts
+++ b/web/src/pages/studio/__tests__/LlmSettings.test.ts
@@ -61,4 +61,11 @@ describe('LlmSettingsPage', () => {
       { value: 'custom-model', label: 'custom-model' },
     ]);
   });
+
+  it('keeps a saved custom model visible for a known provider', () => {
+    expect(fallbackModelOptions('openai', ' custom-deployment ')).toContainEqual({
+      value: 'custom-deployment',
+      label: 'custom-deployment',
+    });
+  });
 });

--- a/web/src/pages/studio/llmModelOptions.ts
+++ b/web/src/pages/studio/llmModelOptions.ts
@@ -49,6 +49,8 @@ export const FALLBACK_MODELS: Record<string, string[]> = {
 };
 
 export function fallbackModelOptions(provider: string, model?: string) {
-  const fallback = FALLBACK_MODELS[provider] || [model || ''].filter(Boolean);
-  return fallback.map((item) => ({ value: item, label: item }));
+  const currentModel = model?.trim();
+  const fallback = FALLBACK_MODELS[provider] || [];
+  const models = [...new Set([...fallback, ...(currentModel ? [currentModel] : [])])];
+  return models.map((item) => ({ value: item, label: item }));
 }


### PR DESCRIPTION
## Summary

- append the normalized saved model to known-provider fallback choices
- deduplicate models already present in provider defaults
- cover a custom saved model for a known provider

## Verification

- LlmSettings.test.ts: 5 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 13 changed lines

Fixes #2765
