### PR TITLE
[ISSUE #2766] fix(instances): normalize instance selector searches

### DIFF
--- a/web/src/components/InstanceSelect.test.ts
+++ b/web/src/components/InstanceSelect.test.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { matchesInstanceOption } from './InstanceSelect';
+
+describe('InstanceSelect filtering', () => {
+  it('normalizes padded and compatibility-form search input', () => {
+    expect(matchesInstanceOption('  PROD  ', 'RocketMQ prod cluster')).toBe(true);
+    expect(matchesInstanceOption('ＲＭＱ', 'rmq-instance')).toBe(true);
+  });
+});

--- a/web/src/components/InstanceSelect.tsx
+++ b/web/src/components/InstanceSelect.tsx
@@ -31,6 +31,12 @@ interface InstanceSelectProps {
   placeholder?: string;
 }
 
+const normalizeFilterText = (value: string): string => value.normalize('NFKC').trim().toLowerCase();
+
+export function matchesInstanceOption(input: string, label: unknown): boolean {
+  return normalizeFilterText(String(label ?? '')).includes(normalizeFilterText(input));
+}
+
 /**
  * 实例维度页面统一的实例选择器：支持输入并按实例 ID 筛选（showSearch），
  * 选中后由页面通过 onChange 切换路由实例。
@@ -60,11 +66,7 @@ export function InstanceSelect({
       }}
       options={options}
       optionFilterProp="label"
-      filterOption={(input, option) =>
-        String(option?.label ?? '')
-          .toLowerCase()
-          .includes(input.toLowerCase())
-      }
+      filterOption={(input, option) => matchesInstanceOption(input, option?.label)}
       notFoundContent="暂无匹配实例"
       style={style ?? { width: 220 }}
     />


### PR DESCRIPTION
## Summary

- normalize instance queries and labels with NFKC, trimming, and case folding
- use the shared matcher in the Ant Design selector filter
- cover padded and full-width search input

## Verification

- InstanceSelect.test.ts: 1 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 22 changed lines

Fixes #2766
