### PR TITLE
[ISSUE #2767] fix(producers): normalize selector suggestions

### DIFF
--- a/web/src/api/producer.test.ts
+++ b/web/src/api/producer.test.ts
@@ -70,6 +70,14 @@ describe('Producer API', () => {
     expect(result).toEqual([]);
   });
 
+  it('normalizes duplicate and blank topic suggestions', async () => {
+    mock.onGet('/topics').reply(200, {
+      topicList: [' orders ', '', 'payments', 'orders'],
+    });
+
+    await expect(fetchTopicList('instance-1')).resolves.toEqual(['orders', 'payments']);
+  });
+
   it('fetches active producer group suggestions', async () => {
     mock.onGet('/producer/groups').reply((config) => {
       expect(config.params.instanceId).toBe('instance-1');
@@ -88,6 +96,15 @@ describe('Producer API', () => {
     await expect(
       fetchProducerGroups('instance-1', { topic: 'order-events', query: 'pg', limit: 20 }),
     ).resolves.toEqual(['pg-order', 'pg-payment']);
+  });
+
+  it('normalizes producer group suggestions while preserving backend order', async () => {
+    mock.onGet('/producer/groups').reply(200, {
+      code: 200,
+      data: [' pg-orders ', '', 'pg-payments', 'pg-orders'],
+    });
+
+    await expect(fetchProducerGroups('instance-1')).resolves.toEqual(['pg-orders', 'pg-payments']);
   });
 
   it('queries producer connections by topic and group', async () => {

--- a/web/src/api/producer.ts
+++ b/web/src/api/producer.ts
@@ -69,6 +69,10 @@ interface ProducerConnectionResponse {
   summary?: ProducerConnectionSummary;
 }
 
+const normalizeSuggestions = (values: string[]): string[] => [
+  ...new Set(values.map((value) => value.trim()).filter(Boolean)),
+];
+
 // ─── API ────────────────────────────────────────────────────────
 
 const hasText = (value?: string | null) => Boolean(value?.trim() && value.trim() !== 'null');
@@ -153,7 +157,7 @@ export function buildProducerConnectionSummary(
 export async function fetchTopicList(instanceId: string): Promise<string[]> {
   const res = await client.get<TopicListResponse>('/topics', { params: { instanceId } });
   const topics = res.data.data?.map((topic) => topic.name) ?? res.data.topicList ?? [];
-  return topics.sort();
+  return normalizeSuggestions(topics).sort((left, right) => left.localeCompare(right));
 }
 
 /** Fetch active producer groups for query suggestions */
@@ -173,7 +177,7 @@ export async function fetchProducerGroups(
       limit: options.limit,
     },
   });
-  return res.data.data ?? [];
+  return normalizeSuggestions(res.data.data ?? []);
 }
 
 /** Query producer connections by topic and producer group */


### PR DESCRIPTION
## Summary

- trim, remove blanks, and deduplicate topic and producer group suggestions
- retain alphabetical topic order and backend relevance order for groups
- cover padded, blank, and duplicate API values

## Verification

- producer.test.ts: 12 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 25 changed lines

Fixes #2767
