### PR TITLE
[ISSUE #2769] fix(auth): reject corrupted stored identity metadata

### DIFF
--- a/web/src/stores/authStorage.test.ts
+++ b/web/src/stores/authStorage.test.ts
@@ -60,6 +60,13 @@ describe('auth session storage', () => {
     expect(readAuthSession()).toEqual({ user: 'studio-admin', userId: null, admin: true });
   });
 
+  it('rejects corrupted identity and permission values', () => {
+    localStorage.setItem(USER_ID_STORAGE_KEY, '-1.5');
+    localStorage.setItem(USER_ADMIN_STORAGE_KEY, 'yes');
+
+    expect(readAuthSession()).toEqual({ user: null, userId: null, admin: null });
+  });
+
   it('clears every persisted session key', () => {
     localStorage.setItem('token', 'legacy-token');
     persistAuthSession('studio-admin', 7, true);

--- a/web/src/stores/authStorage.ts
+++ b/web/src/stores/authStorage.ts
@@ -30,7 +30,13 @@ function parseUserId(raw: string | null): number | null {
     return null;
   }
   const parsed = Number(raw);
-  return Number.isFinite(parsed) ? parsed : null;
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseAdmin(raw: string | null): boolean | null {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return null;
 }
 
 export function readAuthSession(): AuthSession {
@@ -39,7 +45,7 @@ export function readAuthSession(): AuthSession {
     return {
       user: localStorage.getItem(USER_STORAGE_KEY),
       userId: parseUserId(localStorage.getItem(USER_ID_STORAGE_KEY)),
-      admin: admin != null ? admin === 'true' : null,
+      admin: parseAdmin(admin),
     };
   } catch {
     return { user: null, userId: null, admin: null };


### PR DESCRIPTION
## Summary

- accept only positive safe-integer user IDs from browser storage
- treat unrecognized admin values as unknown instead of false
- cover corrupted persisted identity metadata

## Verification

- authStorage.test.ts: 6 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 17 changed lines

Fixes #2769
