### PR TITLE
[ISSUE #2768] fix(messages): stabilize invalid store time sorting

### DIFF
--- a/web/src/api/message.test.ts
+++ b/web/src/api/message.test.ts
@@ -92,6 +92,35 @@ describe('message API', () => {
     ]);
   });
 
+  it('places malformed store times last without reordering them', async () => {
+    const record = (msgId: string, storeTime: number | string) => ({
+      msgId,
+      topic: 'orders',
+      tag: '',
+      key: '',
+      body: '',
+      storeTime,
+      bornHost: '',
+      storeHost: '',
+      properties: {},
+      size: 0,
+    });
+    mock.onGet('/messages').reply(200, {
+      code: 200,
+      data: [
+        record('nan', Number.NaN),
+        record('valid', 100),
+        record('infinite', Number.POSITIVE_INFINITY),
+      ],
+    });
+
+    await expect(queryMessages({ topic: 'orders' })).resolves.toMatchObject([
+      { msgId: 'valid' },
+      { msgId: 'nan' },
+      { msgId: 'infinite' },
+    ]);
+  });
+
   it('uses the paged query contract and preserves its truncation state', async () => {
     const params = { instanceId: 'instance-1', topic: 'orders', page: 2, pageSize: 50 };
     const page = { items: [], total: 200, page: 2, size: 50, resultMayBeTruncated: true };

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -71,15 +71,21 @@ export interface DirectConsumeMessageResult {
   autoCommit: boolean;
 }
 
-const toStoreTimestamp = (storeTime: MessageRecord['storeTime']): number => {
-  if (typeof storeTime === 'number') return storeTime;
+const toStoreTimestamp = (storeTime: MessageRecord['storeTime']): number | null => {
+  if (typeof storeTime === 'number') return Number.isFinite(storeTime) ? storeTime : null;
 
   const parsed = Date.parse(storeTime);
-  return Number.isNaN(parsed) ? 0 : parsed;
+  return Number.isNaN(parsed) ? null : parsed;
 };
 
 export const sortMessagesByStoreTimeDesc = (messages: MessageRecord[]): MessageRecord[] =>
-  [...messages].sort((a, b) => toStoreTimestamp(b.storeTime) - toStoreTimestamp(a.storeTime));
+  [...messages].sort((a, b) => {
+    const left = toStoreTimestamp(a.storeTime);
+    const right = toStoreTimestamp(b.storeTime);
+    if (left === null) return right === null ? 0 : 1;
+    if (right === null) return -1;
+    return right - left;
+  });
 
 // Matches mock/dlq.ts
 export interface DLQGroup {


### PR DESCRIPTION
## Summary

- treat non-finite numeric and unparseable message timestamps as invalid
- sort valid timestamps descending and keep invalid rows stable at the end
- cover valid, NaN, and infinite store times

## Verification

- message.test.ts: 8 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 43 changed lines

Fixes #2768
