### PR TITLE
[ISSUE #2771] fix(web): normalize API base URL overrides

### DIFF
--- a/web/src/config.test.ts
+++ b/web/src/config.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { API_BASE_URL } from './config';
+import { API_BASE_URL, normalizeApiBaseUrl } from './config';
 
 describe('config API base url', () => {
   it('defaults to a relative /api path when no env override is set', () => {
@@ -29,7 +29,10 @@ describe('config API base url', () => {
     expect(API_BASE_URL.startsWith('//localhost')).toBe(false);
   });
 
-  it('strips a single trailing slash', () => {
+  it('strips trailing slashes and accidental whitespace from overrides', () => {
     expect(API_BASE_URL.endsWith('/')).toBe(false);
+    expect(normalizeApiBaseUrl('  https://studio.example/api///  ')).toBe(
+      'https://studio.example/api',
+    );
   });
 });

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -10,4 +10,6 @@
 export const USE_MOCK = false;
 
 /** API prefix for browser requests. Defaults to the reverse-proxy friendly `/api`. */
-export const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '/api').replace(/\/$/, '');
+export const normalizeApiBaseUrl = (value: string): string => value.trim().replace(/\/+$/, '');
+
+export const API_BASE_URL = normalizeApiBaseUrl(import.meta.env.VITE_API_BASE_URL || '/api');


### PR DESCRIPTION
## Summary

- trim API base URL environment overrides
- remove repeated trailing slashes through a reusable normalizer
- cover a padded override with multiple trailing slashes

## Verification

- config.test.ts: 3 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 11 changed lines

Fixes #2771
