### PR TITLE
[ISSUE #2774] fix(lite-topic): clamp session consumption progress

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicSession.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicSession.java
@@ -72,10 +72,11 @@ public class LiteTopicSession {
     }
 
     public double getConsumptionProgress() {
-        if (totalMessages == null || totalMessages == 0 || consumedMessages == null) {
+        if (totalMessages == null || totalMessages <= 0 || consumedMessages == null) {
             return 0.0;
         }
-        return (double) consumedMessages / totalMessages * 100.0;
+        double progress = (double) consumedMessages / totalMessages * 100.0;
+        return Math.min(100.0, Math.max(0.0, progress));
     }
 
     @Data

--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSessionTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSessionTest.java
@@ -38,4 +38,19 @@ class LiteTopicSessionTest {
 
         assertThat(session.getConsumptionProgress()).isEqualTo(40.0);
     }
+
+    @Test
+    void consumptionProgressShouldStayWithinPercentageBounds() {
+        LiteTopicSession session = new LiteTopicSession();
+        session.setTotalMessages(10L);
+
+        session.setConsumedMessages(-1L);
+        assertThat(session.getConsumptionProgress()).isZero();
+
+        session.setConsumedMessages(11L);
+        assertThat(session.getConsumptionProgress()).isEqualTo(100.0);
+
+        session.setTotalMessages(-10L);
+        assertThat(session.getConsumptionProgress()).isZero();
+    }
 }


### PR DESCRIPTION
## Summary

- treat non-positive total messages as empty progress
- clamp Lite Topic session progress to the 0-100 range
- cover negative, over-total, and invalid-total counters

## Verification

- mise x java@temurin-21 -- mvn -Dtest=LiteTopicSessionTest test: 3 tests passed
- Checkstyle passed
- scope check: 20 changed lines

Fixes #2774
