### PR TITLE
[ISSUE #2772] fix(clusters): tolerate null cluster summary rows

### DIFF
--- a/web/src/pages/cluster/clusterStats.test.ts
+++ b/web/src/pages/cluster/clusterStats.test.ts
@@ -107,4 +107,12 @@ describe('countClusterComponents', () => {
     ];
     expect(countClusterComponents(clusters)).toEqual({ brokers: 0, nameServers: 0, proxies: 0 });
   });
+
+  it('skips null rows from partially malformed cluster responses', () => {
+    expect(countClusterComponents([null, baseCluster, undefined])).toEqual({
+      brokers: 0,
+      nameServers: 0,
+      proxies: 0,
+    });
+  });
 });

--- a/web/src/pages/cluster/clusterStats.ts
+++ b/web/src/pages/cluster/clusterStats.ts
@@ -31,12 +31,14 @@ export interface ClusterComponentCounts {
  * `nameServers` as null. Guard every field so the summary never crashes on
  * such payloads.
  */
-export function countClusterComponents(clusters: ClusterInfo[]): ClusterComponentCounts {
+export function countClusterComponents(
+  clusters: readonly (ClusterInfo | null | undefined)[],
+): ClusterComponentCounts {
   return clusters.reduce(
-    (acc, c) => ({
-      brokers: acc.brokers + (c.brokers ?? []).length,
-      nameServers: acc.nameServers + (c.nameServers ?? []).length,
-      proxies: acc.proxies + (c.proxies ?? []).length,
+    (acc, cluster) => ({
+      brokers: acc.brokers + (cluster?.brokers ?? []).length,
+      nameServers: acc.nameServers + (cluster?.nameServers ?? []).length,
+      proxies: acc.proxies + (cluster?.proxies ?? []).length,
     }),
     { brokers: 0, nameServers: 0, proxies: 0 },
   );


### PR DESCRIPTION
## Summary

- accept nullable rows at the cluster aggregation boundary
- skip malformed null rows while continuing to count valid clusters
- cover null and undefined entries in cluster summary tests

## Verification

- clusterStats.test.ts: 4 tests passed
- npm run build passed
- targeted ESLint and Prettier checks passed
- scope check: 20 changed lines

Fixes #2772
