### PR TITLE
[ISSUE #2770] fix(acl): reject invalid wildcard target addresses

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/IpRangeMatcher.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/IpRangeMatcher.java
@@ -53,7 +53,7 @@ public final class IpRangeMatcher {
      * Returns {@code true} when {@code ip} is within {@code cidrOrIp}.
      *
      * <ul>
-     *   <li>{@code 0.0.0.0}, {@code 0.0.0.0/0} or {@code ::/0} match any non-blank ip.</li>
+     *   <li>{@code 0.0.0.0}, {@code 0.0.0.0/0} or {@code ::/0} match any valid IP literal.</li>
      *   <li>An entry without a {@code /} matches the equivalent IPv4 or IPv6 literal.</li>
      *   <li>IPv4 and IPv6 CIDR entries are matched using their respective prefix widths.</li>
      *   <li>Any unparseable input or address-family mismatch returns {@code false}.</li>
@@ -71,7 +71,7 @@ public final class IpRangeMatcher {
         String entry = cidrOrIp.trim();
 
         if (WILDCARD_V4.equals(entry) || WILDCARD_V4_CIDR.equals(entry) || WILDCARD_V6_CIDR.equals(entry)) {
-            return true;
+            return parseAddressLiteral(target) != null;
         }
 
         int slash = entry.indexOf('/');

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/IpRangeMatcherTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/IpRangeMatcherTest.java
@@ -65,6 +65,8 @@ class IpRangeMatcherTest {
 
     @Test
     void malformedInputReturnsFalse() {
+        assertThat(IpRangeMatcher.isInRange("not-an-ip", "0.0.0.0")).isFalse();
+        assertThat(IpRangeMatcher.isInRange("not-an-ip", "::/0")).isFalse();
         assertThat(IpRangeMatcher.isInRange("not-an-ip", "192.168.1.0/24")).isFalse();
         assertThat(IpRangeMatcher.isInRange("192.168.1.10", "not-an-ip/24")).isFalse();
         assertThat(IpRangeMatcher.isInRange("192.168.1.10", "192.168.1.0/99")).isFalse();


### PR DESCRIPTION
## Summary

- parse target addresses before accepting ACL wildcard entries
- reject non-address strings without changing valid IPv4/IPv6 wildcard behavior
- cover malformed targets for IPv4 and IPv6 wildcards

## Verification

- mise x java@temurin-21 -- mvn -Dtest=IpRangeMatcherTest test: 15 tests passed
- Checkstyle passed
- scope check: 6 changed lines

Fixes #2770
