### PR TITLE
[ISSUE #2773] fix(regions): normalize unknown region identifiers

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/RegionNames.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/RegionNames.java
@@ -64,6 +64,7 @@ public class RegionNames {
         if (regionId == null || regionId.isBlank()) {
             return regionId;
         }
-        return names.getOrDefault(regionId.trim(), regionId);
+        String normalizedRegionId = regionId.trim();
+        return names.getOrDefault(normalizedRegionId, normalizedRegionId);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/RegionNamesTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/RegionNamesTest.java
@@ -50,6 +50,7 @@ class RegionNamesTest {
     @Test
     void resolveShouldFallBackToRawIdForUnknownRegionsTest() {
         assertThat(regionNames.resolve("mars-north-1")).isEqualTo("mars-north-1");
+        assertThat(regionNames.resolve(" mars-north-1 ")).isEqualTo("mars-north-1");
         assertThat(regionNames.resolve(" cn-hangzhou ")).isEqualTo("\u534e\u4e1c1\uff08\u676d\u5dde\uff09");
     }
 


### PR DESCRIPTION
## Summary

- use the trimmed region ID for both lookup and unknown-region fallback
- preserve existing null and blank pass-through behavior
- cover a padded unknown region identifier

## Verification

- mise x java@temurin-21 -- mvn -Dtest=RegionNamesTest test: 3 tests passed
- Checkstyle passed
- scope check: 4 changed lines

Fixes #2773
