### PR TITLE
[ISSUE #2775] fix(producers): canonicalize connection summaries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionSummaryVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionSummaryVO.java
@@ -71,6 +71,7 @@ public class ProducerConnectionSummaryVO {
         return (int) connections.stream()
                 .map(extractor)
                 .filter(ProducerConnectionSummaryVO::hasText)
+                .map(String::trim)
                 .distinct()
                 .count();
     }
@@ -95,6 +96,7 @@ public class ProducerConnectionSummaryVO {
         return connections.stream()
                 .map(ProducerConnectionVO::getClientId)
                 .filter(ProducerConnectionSummaryVO::hasText)
+                .map(String::trim)
                 .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
                 .entrySet()
                 .stream()

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionSummaryVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionSummaryVOTest.java
@@ -79,6 +79,18 @@ class ProducerConnectionSummaryVOTest {
                 .containsExactly("UNKNOWN");
     }
 
+    @Test
+    void fromShouldCanonicalizeClientIdsAndAddressesBeforeCounting() {
+        ProducerConnectionSummaryVO summary = ProducerConnectionSummaryVO.from(List.of(
+                connection("producer-a", "10.0.0.1:38888", "Java", "5.1.0"),
+                connection(" producer-a ", " 10.0.0.1:38888 ", "Java", "5.1.0")));
+
+        assertThat(summary.getUniqueClientCount()).isEqualTo(1);
+        assertThat(summary.getUniqueAddressCount()).isEqualTo(1);
+        assertThat(summary.getDuplicateClientIds()).containsExactly("producer-a");
+        assertThat(summary.getWarnings()).contains(ProducerConnectionSummaryVO.DUPLICATE_CLIENT_ID);
+    }
+
     private ProducerConnectionVO connection(String clientId, String address, String language, String version) {
         return ProducerConnectionVO.builder()
                 .clientId(clientId)


### PR DESCRIPTION
## Summary

- trim client IDs and addresses before backend distinct counting
- group padded client IDs under the same duplicate identifier
- cover canonical counts, duplicates, and warnings

## Verification

- mise x java@temurin-21 -- mvn -Dtest=ProducerConnectionSummaryVOTest test: 5 tests passed
- Checkstyle passed
- scope check: 14 changed lines

Fixes #2775
