### PR TITLE
[ISSUE #2777] fix(lite-topic): handle negative quota counters

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicQuota.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicQuota.java
@@ -41,14 +41,14 @@ public class LiteTopicQuota {
         if (maxTopicCount == null || maxTopicCount <= 0 || currentTopicCount == null) {
             return 0.0;
         }
-        return (double) currentTopicCount / maxTopicCount;
+        return (double) Math.max(0, currentTopicCount) / maxTopicCount;
     }
 
     public double getSessionUsageRate() {
         if (maxSessionCount == null || maxSessionCount <= 0 || currentSessionCount == null) {
             return 0.0;
         }
-        return (double) currentSessionCount / maxSessionCount;
+        return (double) Math.max(0, currentSessionCount) / maxSessionCount;
     }
 
     public boolean isNearQuotaLimit(double threshold) {
@@ -65,6 +65,7 @@ public class LiteTopicQuota {
         if (maxTopicCount == null || maxTopicCount <= 0) {
             return 0;
         }
-        return Math.max(0, maxTopicCount - (currentTopicCount == null ? 0 : currentTopicCount));
+        int current = currentTopicCount == null ? 0 : Math.max(0, currentTopicCount);
+        return Math.max(0, maxTopicCount - current);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
@@ -65,4 +65,17 @@ class LiteTopicQuotaTest {
         assertThat(quota.getSessionUsageRate()).isZero();
         assertThat(quota.getRemainingQuota()).isEqualTo(10);
     }
+
+    @Test
+    void negativeCurrentCountsShouldBehaveLikeZeroWithoutOverflow() {
+        LiteTopicQuota quota = new LiteTopicQuota();
+        quota.setMaxTopicCount(Integer.MAX_VALUE);
+        quota.setCurrentTopicCount(Integer.MIN_VALUE);
+        quota.setMaxSessionCount(10);
+        quota.setCurrentSessionCount(-1);
+
+        assertThat(quota.getUsageRate()).isZero();
+        assertThat(quota.getSessionUsageRate()).isZero();
+        assertThat(quota.getRemainingQuota()).isEqualTo(Integer.MAX_VALUE);
+    }
 }


### PR DESCRIPTION
## Summary

- normalize negative current topic and session counters to zero
- avoid remaining-quota overflow for extreme negative values
- cover Integer.MIN_VALUE and negative session counts

## Verification

- mise x java@temurin-21 -- mvn -Dtest=LiteTopicQuotaTest test: 5 tests passed
- Checkstyle passed
- scope check: 20 changed lines

Fixes #2777
