### PR TITLE
[ISSUE #2778] fix(metrics): reject non-finite metric samples

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricSample.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricSample.java
@@ -55,6 +55,9 @@ public record MetricSample(
         if (availability == MetricAvailability.AVAILABLE && value == null) {
             throw new IllegalArgumentException("Available metric samples require a value");
         }
+        if (availability == MetricAvailability.AVAILABLE && !Double.isFinite(value)) {
+            throw new IllegalArgumentException("Available metric samples require a finite value");
+        }
         if (availability == MetricAvailability.AVAILABLE && unavailableReason != null) {
             throw new IllegalArgumentException("Available metric samples cannot have an unavailable reason");
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricSampleTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricSampleTest.java
@@ -40,4 +40,16 @@ class MetricSampleTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Available metric samples require a value");
     }
+
+    @Test
+    void availableSamplesRequireAFiniteValueTest() {
+        assertThatThrownBy(() -> new MetricSample("broker.availability", AlertDomain.CLUSTER, "local", null,
+                null, Double.NaN, MetricAvailability.AVAILABLE, Instant.now()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Available metric samples require a finite value");
+        assertThatThrownBy(() -> new MetricSample("broker.availability", AlertDomain.CLUSTER, "local", null,
+                null, Double.POSITIVE_INFINITY, MetricAvailability.AVAILABLE, Instant.now()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Available metric samples require a finite value");
+    }
 }


### PR DESCRIPTION
## Summary

- reject NaN and infinite values for AVAILABLE metric samples
- keep explicit unavailable-sample semantics unchanged
- cover NaN and positive infinity at the MetricSample boundary

## Verification

- mise x java@temurin-21 -- mvn -Dtest=MetricSampleTest test: 3 tests passed
- Checkstyle passed
- scope check: 15 changed lines

Fixes #2778
