### PR TITLE
[ISSUE #2776] fix(lite-topic): handle invalid TTL summary inputs

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicSummary.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicSummary.java
@@ -52,14 +52,25 @@ public class LiteTopicSummary {
             return "UNKNOWN";
         }
 
+        if (averageTTL == null || averageTTL <= 0) {
+            return "ACTIVE";
+        }
         long now = System.currentTimeMillis();
-        long elapsed = now - lastActiveTime.getTime();
+        if (lastActiveTime.getTime() >= now) {
+            return "ACTIVE";
+        }
+        long elapsed;
+        try {
+            elapsed = Math.subtractExact(now, lastActiveTime.getTime());
+        } catch (ArithmeticException exception) {
+            return "EXPIRED";
+        }
 
         // EXPIRED must be checked first: elapsed > averageTTL implies elapsed > averageTTL * 0.8,
         // so ordering it second would make EXPIRED unreachable.
-        if (averageTTL != null && elapsed > averageTTL) {
+        if (elapsed > averageTTL) {
             return "EXPIRED";
-        } else if (averageTTL != null && elapsed > averageTTL * 0.8) {
+        } else if (elapsed > averageTTL * 0.8) {
             return "EXPIRING_SOON";
         } else {
             return "ACTIVE";
@@ -67,7 +78,7 @@ public class LiteTopicSummary {
     }
 
     public double getConsumerDensity() {
-        if (topicCount == null || topicCount == 0 || consumerCount == null) {
+        if (topicCount == null || topicCount <= 0 || consumerCount == null || consumerCount <= 0) {
             return 0.0;
         }
         return (double) consumerCount / topicCount;

--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSummaryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSummaryTest.java
@@ -52,4 +52,25 @@ class LiteTopicSummaryTest {
         assertThat(summary.getConsumerDensity()).isZero();
         assertThat(summary.isEmptyAggregation()).isTrue();
     }
+
+    @Test
+    void ttlAndDensityShouldIgnoreInvalidNegativeInputs() {
+        LiteTopicSummary summary = new LiteTopicSummary();
+        summary.setLastActiveTime(new Date(System.currentTimeMillis() - 1_000));
+        summary.setAverageTTL(-1L);
+        summary.setTopicCount(-2);
+        summary.setConsumerCount(3);
+
+        assertThat(summary.getTTLStatus()).isEqualTo("ACTIVE");
+        assertThat(summary.getConsumerDensity()).isZero();
+    }
+
+    @Test
+    void futureActivityShouldNotAppearExpired() {
+        LiteTopicSummary summary = new LiteTopicSummary();
+        summary.setLastActiveTime(new Date(System.currentTimeMillis() + 60_000));
+        summary.setAverageTTL(10_000L);
+
+        assertThat(summary.getTTLStatus()).isEqualTo("ACTIVE");
+    }
 }


### PR DESCRIPTION
## Summary

- treat non-positive TTL values and future activity timestamps as active
- guard TTL elapsed-time overflow and invalid consumer density inputs
- cover negative TTL/counts and future activity

## Verification

- mise x java@temurin-21 -- mvn -Dtest=LiteTopicSummaryTest test: 6 tests passed
- Checkstyle passed
- scope check: 40 changed lines

Fixes #2776
