### PR TITLE
fix(ai): bound Claude CLI stderr buffering

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProvider.java
@@ -52,6 +52,8 @@ public class ClaudeCodeAgentProvider extends CliAgentProvider {
     private static final String ANTHROPIC_APP_SUFFIX = "/apps/anthropic";
     private static final long STREAM_TIMEOUT_SECONDS = 300;
     private static final long OUTPUT_DRAIN_TIMEOUT_SECONDS = 10;
+    private static final int MAX_STDERR_BYTES = 64 * 1024;
+    private static final String STDERR_TRUNCATED_SUFFIX = "\n...[stderr truncated]";
 
     private final LlmProperties llmProperties;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -179,7 +181,11 @@ public class ClaudeCodeAgentProvider extends CliAgentProvider {
         CompletableFuture<String> result = new CompletableFuture<>();
         Thread.ofVirtual().start(() -> {
             try (stream) {
-                result.complete(new String(stream.readAllBytes(), StandardCharsets.UTF_8));
+                byte[] bytes = stream.readNBytes(MAX_STDERR_BYTES + 1);
+                boolean truncated = bytes.length > MAX_STDERR_BYTES;
+                int length = Math.min(bytes.length, MAX_STDERR_BYTES);
+                String output = new String(bytes, 0, length, StandardCharsets.UTF_8);
+                result.complete(truncated ? output + STDERR_TRUNCATED_SUFFIX : output);
             } catch (Exception exception) {
                 result.completeExceptionally(exception);
             }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProviderTest.java
@@ -51,6 +51,18 @@ class ClaudeCodeAgentProviderTest {
     }
 
     @Test
+    void streamShouldBoundStderrIncludedInFailuresTest() {
+        TestClaudeCodeAgentProvider provider = new TestClaudeCodeAgentProvider(
+                List.of("sh", "-c", "yes failure | head -c 131072 >&2; exit 1"), 5);
+
+        assertThatThrownBy(() -> provider.stream(
+                LlmConfigVO.builder().build(), "prompt", null, ignored -> { }))
+                .isInstanceOf(LlmGatewayException.class)
+                .hasMessageContaining("[stderr truncated]")
+                .satisfies(exception -> assertThat(exception.getMessage().length()).isLessThan(70_000));
+    }
+
+    @Test
     void streamShouldEnforceTimeoutBeforeWaitingForStdoutTest() {
         TestClaudeCodeAgentProvider provider = new TestClaudeCodeAgentProvider(
                 List.of("sh", "-c", "sleep 2"), 1);


### PR DESCRIPTION
## Summary
- cap buffered Claude CLI stderr at 64 KiB
- mark truncated diagnostics while continuing to drain the process pipe safely
- cover oversized failure output with a regression test

## Why
The Claude subprocess previously used `readAllBytes()` for stderr. A noisy or malfunctioning CLI could therefore retain an unbounded byte array for every request before Studio surfaced the failure.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn -q -Dtest=ClaudeCodeAgentProviderTest test`