### PR TITLE
fix(message): preserve epoch queue timestamps

### DIFF
--- a/web/src/components/QueueBrowser.tsx
+++ b/web/src/components/QueueBrowser.tsx
@@ -42,9 +42,9 @@ export interface TopicOption {
   value: string;
 }
 
-const formatTimeMs = (value: number | string) => {
-  const ts = typeof value === 'string' ? new Date(value).getTime() : value;
-  if (!ts || Number.isNaN(ts)) return '-';
+export const formatTimeMs = (value: number | string) => {
+  const ts = typeof value === 'string' ? Date.parse(value) : value;
+  if (!Number.isFinite(ts)) return '-';
   return new Date(ts).toLocaleString('zh-CN', { hour12: false });
 };
 

--- a/web/src/components/__tests__/QueueBrowser.test.tsx
+++ b/web/src/components/__tests__/QueueBrowser.test.tsx
@@ -20,7 +20,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MessageRecord, QueueOffset } from '../../api/message';
 import { getQueueOffsets, pullMessageAtOffset } from '../../api/message';
-import { useQueueBrowser } from '../QueueBrowser';
+import { formatTimeMs, useQueueBrowser } from '../QueueBrowser';
 
 vi.mock('../../api/message', () => ({
   getQueueOffsets: vi.fn(),
@@ -88,6 +88,19 @@ function QueueBrowserProbe({ instanceId = 'instance-a' }: { instanceId?: string 
     </div>
   );
 }
+
+describe('formatTimeMs', () => {
+  it('preserves the Unix epoch timestamp', () => {
+    expect(formatTimeMs(0)).not.toBe('-');
+  });
+
+  it.each(['not-a-date', Number.NaN, Number.POSITIVE_INFINITY])(
+    'returns a placeholder for invalid timestamp %s',
+    (value) => {
+      expect(formatTimeMs(value)).toBe('-');
+    },
+  );
+});
 
 describe('QueueBrowser request ownership', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- keep valid Unix epoch (`0`) queue message timestamps instead of rendering them as missing
- reject non-finite numeric timestamps before constructing a `Date`
- add regression coverage for epoch and malformed timestamp values

## Why
The formatter used a falsy check, which conflated the valid epoch timestamp with unavailable data. It also allowed infinities to reach date formatting.

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/components/__tests__/QueueBrowser.test.tsx`