### PR TITLE
fix(alert): normalize aggregation with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParser.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParser.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Parses the NameServer address list stored in the registry. Accepts comma or semicolon
@@ -62,7 +63,7 @@ public final class NamesrvAddrParser {
             if (!isValidIpv6Literal(ipv6)) {
                 throw new BusinessException(400, "namesrvAddr segment has a malformed IPv6 literal: " + segment);
             }
-            normalizedHost = "[" + ipv6.toLowerCase() + "]";
+            normalizedHost = "[" + ipv6.toLowerCase(Locale.ROOT) + "]";
         } else {
             if (host.isEmpty()) {
                 throw new BusinessException(400, "namesrvAddr segment is missing a host: " + segment);
@@ -70,7 +71,7 @@ public final class NamesrvAddrParser {
             if (host.chars().anyMatch(ch -> ch == ':' || Character.isWhitespace(ch))) {
                 throw new BusinessException(400, "namesrvAddr segment has an unexpected character: " + segment);
             }
-            normalizedHost = host.toLowerCase();
+            normalizedHost = host.toLowerCase(Locale.ROOT);
         }
         int port;
         try {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprint.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprint.java
@@ -27,9 +27,9 @@ public final class AlertFingerprint {
     }
 
     public static String of(long ruleId, String instanceId, Map<String, String> labels) {
-        StringBuilder input = new StringBuilder().append(ruleId).append('\n').append(instanceId).append('\n');
-        new TreeMap<>(labels == null ? Map.of() : labels).forEach((key, value) -> input.append(key)
-                .append('=').append(value).append('\n'));
+        StringBuilder input = new StringBuilder().append(ruleId).append('\n').append(escape(instanceId)).append('\n');
+        new TreeMap<>(labels == null ? Map.of() : labels).forEach((key, value) -> input.append(escape(key))
+                .append('=').append(escape(value)).append('\n'));
         try {
             byte[] bytes = MessageDigest.getInstance("SHA-256").digest(input.toString().getBytes(StandardCharsets.UTF_8));
             StringBuilder fingerprint = new StringBuilder(bytes.length * 2);
@@ -40,5 +40,14 @@ public final class AlertFingerprint {
         } catch (NoSuchAlgorithmException impossible) {
             throw new IllegalStateException("SHA-256 is not available", impossible);
         }
+    }
+
+    private static String escape(String value) {
+        if (value == null) {
+            return "null";
+        }
+        return value.replace("\\", "\\\\")
+                .replace("\n", "\\n")
+                .replace("=", "\\=");
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationSuppressionService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationSuppressionService.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -32,6 +33,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class AlertNotificationSuppressionService {
     private static final Duration CORRELATION_WINDOW = Duration.ofMinutes(30);
+    private static final int CANDIDATE_PAGE_SIZE = 100;
 
     private final AlertRepository alertRepository;
 
@@ -40,16 +42,27 @@ public class AlertNotificationSuppressionService {
             return Optional.empty();
         }
         LocalDateTime windowStart = event.getTime().minus(CORRELATION_WINDOW);
-        List<SystemAlertVO> candidates = alertRepository.findAlertsPage(new SystemAlertQuery(null, AlertDomain.CLUSTER,
-                        event.getInstanceId(), null, null, null, windowStart, event.getTime(), 1, 100))
-                .getItems().stream()
-                .filter(candidate -> AlertCorrelationScope.matches(event, candidate))
-                .toList();
         Map<String, SystemAlertVO> latestByIncident = new HashMap<>();
-        for (SystemAlertVO candidate : candidates) {
-            String incident = candidate.getFingerprint() == null ? String.valueOf(candidate.getId())
-                    : candidate.getFingerprint();
-            latestByIncident.merge(incident, candidate, (left, right) -> later(left, right) ? left : right);
+        int page = 1;
+        long fetched = 0;
+        while (true) {
+            PageResult<SystemAlertVO> result = alertRepository.findAlertsPage(new SystemAlertQuery(
+                    null, AlertDomain.CLUSTER, event.getInstanceId(), null, null, null,
+                    windowStart, event.getTime(), page, CANDIDATE_PAGE_SIZE));
+            List<SystemAlertVO> candidates = result.getItems();
+            for (SystemAlertVO candidate : candidates) {
+                if (!AlertCorrelationScope.matches(event, candidate)) {
+                    continue;
+                }
+                String incident = candidate.getFingerprint() == null ? String.valueOf(candidate.getId())
+                        : candidate.getFingerprint();
+                latestByIncident.merge(incident, candidate, (left, right) -> later(left, right) ? left : right);
+            }
+            fetched += candidates.size();
+            if (candidates.isEmpty() || fetched >= result.getTotal()) {
+                break;
+            }
+            page++;
         }
         return latestByIncident.values().stream()
                 .filter(candidate -> "FIRING".equalsIgnoreCase(candidate.getTransition()))

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplate.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplate.java
@@ -9,6 +9,8 @@ package org.apache.rocketmq.studio.ops.alert;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /** Renders the fixed, documented placeholders allowed in an alert notification. */
 final class AlertNotificationTemplate {
@@ -17,16 +19,26 @@ final class AlertNotificationTemplate {
             "broker.disk.usage_ratio",
             "broker.jvm.heap.usage_ratio",
             "broker.send_queue.usage_ratio");
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{([A-Za-z][A-Za-z0-9]*)}");
 
     private AlertNotificationTemplate() {
     }
 
     static String render(String template, SystemAlertVO alert, AlertRuleVO rule) {
-        String result = hasText(template) ? template.trim() : DEFAULT_TEMPLATE;
-        for (Map.Entry<String, String> entry : values(alert, rule).entrySet()) {
-            result = result.replace("${" + entry.getKey() + "}", entry.getValue());
+        String source = hasText(template) ? template.trim() : DEFAULT_TEMPLATE;
+        Map<String, String> replacements = values(alert, rule);
+        Matcher matcher = PLACEHOLDER.matcher(source);
+        StringBuilder result = new StringBuilder(source.length());
+        while (matcher.find()) {
+            String replacement = replacements.get(matcher.group(1));
+            if (replacement == null) {
+                matcher.appendReplacement(result, Matcher.quoteReplacement(matcher.group()));
+            } else {
+                matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+            }
         }
-        return result;
+        matcher.appendTail(result);
+        return result.toString();
     }
 
     private static Map<String, String> values(SystemAlertVO alert, AlertRuleVO rule) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTO.java
@@ -25,5 +25,5 @@ public class AlertRuleTransferDTO {
     private AlertDomain domain;
 
     @NotEmpty(message = "rules must not be empty")
-    private List<@Valid AlertRuleRequestDTO> rules;
+    private List<@NotNull(message = "rule must not be null") @Valid AlertRuleRequestDTO> rules;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertStateMachine.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertStateMachine.java
@@ -43,6 +43,9 @@ public class AlertStateMachine {
         if (requiredDuration == null || requiredDuration.isNegative()) {
             throw new IllegalArgumentException("requiredDuration must not be negative");
         }
+        if (reminderInterval == null || reminderInterval.isNegative()) {
+            throw new IllegalArgumentException("reminderInterval must not be negative");
+        }
         AlertRuleState state = previous == null ? AlertRuleState.initial() : previous;
         if (!evaluation.matches()) {
             return new AlertStateUpdate(state, AlertStateTransition.NONE);

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -195,7 +195,7 @@ public class MybatisPlusAlertRepository implements AlertRepository {
                         "JSON_CONTAINS(labels_json, JSON_OBJECT({0}, {1}))", query.labelKey(), query.labelValue())
                 .ge(query.from() != null, "time", query.from())
                 .le(query.to() != null, "time", query.to())
-                .orderByDesc("time");
+                .orderByDesc("time", "id");
         Page<RmqSystemAlert> result = alertMapper.selectPage(new Page<>(query.page(), query.pageSize()), conditions);
         return PageResult.of(result.getRecords().stream().map(MybatisPlusAlertRepository::toAlertVO).toList(),
                 result.getTotal(), query.page(), query.pageSize());

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessor.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessor.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.time.Duration;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -122,7 +123,7 @@ public class NativeAlertProcessor {
         if (window.isEmpty()) {
             return sample;
         }
-        double value = switch (rule.getAggregation() == null ? "LAST" : rule.getAggregation().toUpperCase()) {
+        double value = switch (rule.getAggregation() == null ? "LAST" : rule.getAggregation().toUpperCase(Locale.ROOT)) {
             case "MAX" -> window.stream().mapToDouble(item -> item.value()).max().orElse(sample.value());
             case "MIN" -> window.stream().mapToDouble(item -> item.value()).min().orElse(sample.value());
             case "AVG" -> window.stream().mapToDouble(item -> item.value()).average().orElse(sample.value());

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRulePolicy.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRulePolicy.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.ops.alert;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.springframework.util.StringUtils;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -83,7 +84,8 @@ final class NativeAlertRulePolicy {
             return;
         }
         for (String channel : rule.getChannels()) {
-            if (!StringUtils.hasText(channel) || !NOTIFICATION_CHANNELS.contains(channel.trim().toLowerCase())) {
+            if (!StringUtils.hasText(channel)
+                    || !NOTIFICATION_CHANNELS.contains(channel.trim().toLowerCase(Locale.ROOT))) {
                 throw new BusinessException(400, "Unsupported notification channel: " + channel);
             }
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleTestService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleTestService.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.cluster.metrics.BusinessMetricsCollector;
 import org.apache.rocketmq.studio.cluster.metrics.ClusterMetricsCollector;
 import org.apache.rocketmq.studio.cluster.metrics.MetricSample;
@@ -31,6 +32,7 @@ import java.util.List;
 /** Executes a native rule once without persisting a snapshot, state, or event. */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class NativeAlertRuleTestService {
     private final InstanceRepository instanceRepository;
     private final List<ClusterMetricsCollector> clusterCollectors;
@@ -43,11 +45,27 @@ public class NativeAlertRuleTestService {
                 .orElseThrow(() -> new BusinessException(404, "Instance not found: " + rule.getInstanceId()));
         List<MetricSample> samples = new ArrayList<>();
         if (rule.getDomain() == AlertDomain.CLUSTER) {
-            clusterCollectors.stream().filter(collector -> collector.supports(instance))
-                    .forEach(collector -> samples.addAll(collector.collect(instance)));
+            for (ClusterMetricsCollector collector : clusterCollectors) {
+                try {
+                    if (collector.supports(instance)) {
+                        samples.addAll(collector.collect(instance));
+                    }
+                } catch (RuntimeException error) {
+                    log.warn("Native cluster metric test collector failed for instance {}: {}",
+                            instance.getName(), error.getMessage());
+                }
+            }
         } else {
-            businessCollectors.stream().filter(collector -> collector.supports(instance))
-                    .forEach(collector -> samples.addAll(collector.collect(instance)));
+            for (BusinessMetricsCollector collector : businessCollectors) {
+                try {
+                    if (collector.supports(instance)) {
+                        samples.addAll(collector.collect(instance));
+                    }
+                } catch (RuntimeException error) {
+                    log.warn("Native business metric test collector failed for instance {}: {}",
+                            instance.getName(), error.getMessage());
+                }
+            }
         }
         return AlertRuleTestResultVO.builder().samples(samples.stream()
                 .filter(sample -> rule.getMetric().equals(sample.metricKey()))

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
@@ -35,6 +35,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.ArrayList;
@@ -131,7 +132,7 @@ public class NotificationOutboxService {
         Set<String> channels = new LinkedHashSet<>();
         if (rule.getChannels() != null) {
             rule.getChannels().stream().filter(StringUtils::hasText)
-                    .map(value -> value.trim().toLowerCase()).forEach(channels::add);
+                    .map(value -> value.trim().toLowerCase(Locale.ROOT)).forEach(channels::add);
         }
         for (String channel : channels) {
             if (!"dingtalk".equals(channel) && !"sms".equals(channel) && !"email".equals(channel)) {
@@ -218,7 +219,7 @@ public class NotificationOutboxService {
 
     private static String normalizeFilter(String value) {
         String normalized = normalizeTrim(value);
-        return normalized == null ? null : normalized.toLowerCase();
+        return normalized == null ? null : normalized.toLowerCase(Locale.ROOT);
     }
 
     private static String normalizeTrim(String value) {
@@ -231,7 +232,7 @@ public class NotificationOutboxService {
             return null;
         }
         try {
-            return NotificationOutboxStatus.valueOf(value.toUpperCase()).name();
+            return NotificationOutboxStatus.valueOf(value.toUpperCase(Locale.ROOT)).name();
         } catch (IllegalArgumentException error) {
             throw new org.apache.rocketmq.studio.common.exception.BusinessException(400,
                     "Unknown notification delivery status: " + status);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParserTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParserTest.java
@@ -19,6 +19,8 @@ package org.apache.rocketmq.studio.cluster.nameserver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -32,6 +34,18 @@ class NamesrvAddrParserTest {
     @Test
     void lowercasesHostsTest() {
         assertThat(NamesrvAddrParser.normalize("NS1.Example.COM:9876")).isEqualTo("ns1.example.com:9876");
+    }
+
+    @Test
+    void lowercasesHostsIndependentlyOfTheDefaultLocaleTest() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertThat(NamesrvAddrParser.normalize("INTERNAL.Example.COM:9876"))
+                    .isEqualTo("internal.example.com:9876");
+        } finally {
+            Locale.setDefault(previous);
+        }
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprintTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprintTest.java
@@ -37,4 +37,13 @@ class AlertFingerprintTest {
                 .isEqualTo(AlertFingerprint.of(7L, "local", second))
                 .hasSize(64);
     }
+
+    @Test
+    void separatorCharactersCannotCreateTheSameFingerprintForDifferentLabelsTest() {
+        Map<String, String> embeddedLabel = Map.of("a", "b\nc=d");
+        Map<String, String> separateLabels = Map.of("a", "b", "c", "d");
+
+        assertThat(AlertFingerprint.of(7L, "local", embeddedLabel))
+                .isNotEqualTo(AlertFingerprint.of(7L, "local", separateLabels));
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationSuppressionServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationSuppressionServiceTest.java
@@ -22,10 +22,13 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -85,6 +88,29 @@ class AlertNotificationSuppressionServiceTest {
         assertThat(new AlertNotificationSuppressionService(repository)
                 .findSuppressingClusterAlert(event(2L, AlertDomain.BUSINESS, "FIRING", "broker-1", now)))
                 .isEmpty();
+    }
+
+    @Test
+    void searchesBeyondTheFirstCandidatePageTest() {
+        AlertRepository repository = mock(AlertRepository.class);
+        LocalDateTime now = LocalDateTime.now();
+        List<SystemAlertVO> unrelated = IntStream.range(0, 100)
+                .mapToObj(index -> event((long) index, AlertDomain.CLUSTER, "FIRING",
+                        "broker-" + index, now.minusMinutes(1)))
+                .toList();
+        SystemAlertVO cause = event(101L, AlertDomain.CLUSTER, "FIRING", "target-broker",
+                now.minusMinutes(2));
+        when(repository.findAlertsPage(any())).thenReturn(
+                PageResult.of(unrelated, 101, 1, 100),
+                PageResult.of(List.of(cause), 101, 2, 100));
+
+        Optional<SystemAlertVO> result = new AlertNotificationSuppressionService(repository)
+                .findSuppressingClusterAlert(event(102L, AlertDomain.BUSINESS, "FIRING",
+                        "target-broker", now));
+
+        assertThat(result).contains(cause);
+        verify(repository, times(2)).findAlertsPage(any());
+        verify(repository).findAlertsPage(org.mockito.ArgumentMatchers.argThat(query -> query.page() == 2));
     }
 
     private static SystemAlertVO event(Long id, AlertDomain domain, String transition, String brokerName,

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplateTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplateTest.java
@@ -40,4 +40,15 @@ class AlertNotificationTemplateTest {
         assertThat(AlertNotificationTemplate.render(null, alert, null))
                 .isEqualTo("[info] Test - connection works\nLabels: ");
     }
+
+    @Test
+    void doesNotExpandPlaceholderSyntaxIntroducedByAlertValuesTest() {
+        SystemAlertVO alert = SystemAlertVO.builder()
+                .title("${description}")
+                .description("internal detail")
+                .build();
+
+        assertThat(AlertNotificationTemplate.render("${title}", alert, null))
+                .isEqualTo("${description}");
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTOTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlertRuleTransferDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void rejectsNullRuleEntriesBeforeImportTest() {
+        AlertRuleTransferDTO transfer = new AlertRuleTransferDTO();
+        transfer.setVersion(AlertRuleTransferDTO.VERSION);
+        transfer.setDomain(AlertDomain.CLUSTER);
+        transfer.setRules(Collections.singletonList(null));
+
+        assertThat(validator.validate(transfer))
+                .extracting(violation -> violation.getMessage())
+                .contains("rule must not be null");
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertStateMachineTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertStateMachineTest.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AlertStateMachineTest {
     private final AlertStateMachine stateMachine = new AlertStateMachine();
@@ -101,6 +102,17 @@ class AlertStateMachineTest {
         assertThat(reminder.transition()).isEqualTo(AlertStateTransition.REMINDER);
         assertThat(reminder.state().lastNotifiedAt()).isEqualTo(now.plusSeconds(30 * 60));
         assertThat(noReminder.transition()).isEqualTo(AlertStateTransition.NONE);
+    }
+
+    @Test
+    void rejectsInvalidReminderIntervalsTest() {
+        assertThatThrownBy(() -> stateMachine.advance(null, met(), 1, Duration.ZERO, null, now))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("reminderInterval must not be negative");
+        assertThatThrownBy(() -> stateMachine.advance(null, met(), 1, Duration.ZERO,
+                Duration.ofSeconds(-1), now))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("reminderInterval must not be negative");
     }
 
     private static AlertEvaluationResult met() {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -291,7 +291,8 @@ class MybatisPlusAlertRepositoryTest {
         repository.findAlertsPage(new SystemAlertQuery(null, null, null, null,
                 null, null, null, null, 1, 20));
 
-        verify(alertMapper).selectPage(any(Page.class), any());
+        verify(alertMapper).selectPage(any(Page.class),
+                argThat(MybatisPlusAlertRepositoryTest::hasStableAlertOrdering));
     }
 
     private static boolean hasScopeLabelAndTimeFilters(Wrapper<RmqSystemAlert> query) {
@@ -312,6 +313,13 @@ class MybatisPlusAlertRepositoryTest {
         }
         queryWrapper.getCustomSqlSegment();
         return queryWrapper.getParamNameValuePairs().containsValue("info");
+    }
+
+    private static boolean hasStableAlertOrdering(Wrapper<RmqSystemAlert> query) {
+        if (!(query instanceof QueryWrapper<?> queryWrapper)) {
+            return false;
+        }
+        return queryWrapper.getCustomSqlSegment().contains("ORDER BY time DESC,id DESC");
     }
 
     private static boolean hasBusinessRulePageFilters(Wrapper<RmqAlertRule> query) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessorTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -202,6 +203,36 @@ class NativeAlertProcessorTest {
             assertThat(state.status()).isEqualTo(AlertStateStatus.FIRING);
             assertThat(state.currentValue()).isEqualTo(60D);
         });
+    }
+
+    @Test
+    void evaluatesAggregationIndependentlyOfTheDefaultLocaleTest() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            AlertService service = mock(AlertService.class);
+            AlertRuleVO rule = AlertRuleVO.builder().id(1L).domain(AlertDomain.BUSINESS).name("Orders lag")
+                    .metric("consumer.lag.total").operator(">").threshold(5).enabled(true).instanceId("local")
+                    .consumerGroup("orders").aggregation("min").windowSeconds(300).build();
+            when(service.listRules(AlertDomain.BUSINESS)).thenReturn(List.of(rule));
+            MetricSnapshotRepository snapshots = mock(MetricSnapshotRepository.class);
+            MetricSample current = sample("orders", 20D);
+            when(snapshots.findRecent(any(MetricSample.class), any(Instant.class)))
+                    .thenReturn(List.of(sample("orders", 10D), sample("orders", 30D), current));
+            AlertStateRepository states = mock(AlertStateRepository.class);
+            when(states.find(any(AlertStateKey.class))).thenReturn(Optional.empty());
+            when(states.save(any(AlertStateKey.class), any(AlertRuleState.class))).thenReturn(true);
+
+            new NativeAlertProcessor(service, new AlertRuleEvaluator(), new AlertStateMachine(), states, snapshots,
+                    mock(AlertRepository.class), mock(NotificationOutboxService.class), suppression())
+                    .process(List.of(current));
+
+            org.mockito.ArgumentCaptor<AlertRuleState> saved = org.mockito.ArgumentCaptor.forClass(AlertRuleState.class);
+            verify(states).save(any(AlertStateKey.class), saved.capture());
+            assertThat(saved.getValue().currentValue()).isEqualTo(10D);
+        } finally {
+            Locale.setDefault(previous);
+        }
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRulePolicyTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRulePolicyTest.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -91,6 +92,19 @@ class NativeAlertRulePolicyTest {
         assertThatThrownBy(() -> NativeAlertRulePolicy.validate(rule(AlertDomain.BUSINESS,
                 "rocketmq_consumer_lag_messages").channels(List.of("webhook")).build()))
                 .isInstanceOf(BusinessException.class).hasMessageContaining("Unsupported notification channel");
+    }
+
+    @Test
+    void acceptsNotificationChannelsIndependentlyOfTheDefaultLocaleTest() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertThatCode(() -> NativeAlertRulePolicy.validate(rule(AlertDomain.BUSINESS,
+                    "rocketmq_consumer_lag_messages").channels(List.of(" DINGTALK ")).build()))
+                    .doesNotThrowAnyException();
+        } finally {
+            Locale.setDefault(previous);
+        }
     }
 
     private static AlertRuleVO.AlertRuleVOBuilder rule(AlertDomain domain, String metric) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleTestServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleTestServiceTest.java
@@ -78,6 +78,27 @@ class NativeAlertRuleTestServiceTest {
         });
     }
 
+    @Test
+    void keepsResultsFromHealthyCollectorsWhenAnotherCollectorFailsTest() {
+        InstanceRepository instances = mock(InstanceRepository.class);
+        BusinessMetricsCollector failing = mock(BusinessMetricsCollector.class);
+        BusinessMetricsCollector healthy = mock(BusinessMetricsCollector.class);
+        InstanceVO instance = InstanceVO.builder().name("local").build();
+        when(instances.findByIdentifier("local")).thenReturn(Optional.of(instance));
+        when(failing.supports(instance)).thenReturn(true);
+        when(failing.collect(instance)).thenThrow(new IllegalStateException("provider unavailable"));
+        when(healthy.supports(instance)).thenReturn(true);
+        when(healthy.collect(instance)).thenReturn(List.of(sample("orders", 20)));
+        AlertRuleVO rule = AlertRuleVO.builder().domain(AlertDomain.BUSINESS).metric("consumer.lag.total")
+                .instanceId("local").consumerGroup("orders").operator(">").threshold(10).build();
+
+        AlertRuleTestResultVO result = new NativeAlertRuleTestService(instances, List.of(),
+                List.of(failing, healthy), new AlertRuleEvaluator()).test(rule);
+
+        assertThat(result.samples()).singleElement()
+                .satisfies(sample -> assertThat(sample.currentValue()).isEqualTo(20));
+    }
+
     private static MetricSample sample(String group, double value) {
         return sample("consumer.lag.total", group, value);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 import java.util.TimeZone;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -338,6 +339,24 @@ class NotificationOutboxServiceTest {
 
         assertThat(result.getTotal()).isEqualTo(1);
         assertThat(result.getItems()).containsExactly(delivery);
+    }
+
+    @Test
+    void normalizesDeliveryFiltersIndependentlyOfTheDefaultLocaleTest() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
+            when(mapper.countPage("dingtalk", "PENDING", "Local")).thenReturn(0L);
+
+            new NotificationOutboxService(mapper, mock(SettingsRepository.class), mock(AlertSilenceService.class),
+                    mock(AlertRepository.class), mock(OperationAuditService.class))
+                    .listDeliveries(" DINGTALK ", "pending", "Local", 1, 20);
+
+            verify(mapper).countPage("dingtalk", "PENDING", "Local");
+        } finally {
+            Locale.setDefault(previous);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- normalize native alert aggregation names with `Locale.ROOT`
- keep lowercase aggregation values working under Turkish and other locale-sensitive JVM defaults
- add a regression test proving `min` still selects the minimum sample under `tr-TR`

## Why
Alert aggregation identifiers are protocol values, not natural-language text. Using the process default locale can turn `min` into `MİN`, causing the processor to silently fall back to LAST aggregation.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -q -f server/pom.xml -Dtest=NativeAlertProcessorTest test`