### PR TITLE
fix(alert): normalize delivery filters with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
@@ -35,6 +35,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.ArrayList;
@@ -131,7 +132,7 @@ public class NotificationOutboxService {
         Set<String> channels = new LinkedHashSet<>();
         if (rule.getChannels() != null) {
             rule.getChannels().stream().filter(StringUtils::hasText)
-                    .map(value -> value.trim().toLowerCase()).forEach(channels::add);
+                    .map(value -> value.trim().toLowerCase(Locale.ROOT)).forEach(channels::add);
         }
         for (String channel : channels) {
             if (!"dingtalk".equals(channel) && !"sms".equals(channel) && !"email".equals(channel)) {
@@ -218,7 +219,7 @@ public class NotificationOutboxService {
 
     private static String normalizeFilter(String value) {
         String normalized = normalizeTrim(value);
-        return normalized == null ? null : normalized.toLowerCase();
+        return normalized == null ? null : normalized.toLowerCase(Locale.ROOT);
     }
 
     private static String normalizeTrim(String value) {
@@ -231,7 +232,7 @@ public class NotificationOutboxService {
             return null;
         }
         try {
-            return NotificationOutboxStatus.valueOf(value.toUpperCase()).name();
+            return NotificationOutboxStatus.valueOf(value.toUpperCase(Locale.ROOT)).name();
         } catch (IllegalArgumentException error) {
             throw new org.apache.rocketmq.studio.common.exception.BusinessException(400,
                     "Unknown notification delivery status: " + status);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 import java.util.TimeZone;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -338,6 +339,24 @@ class NotificationOutboxServiceTest {
 
         assertThat(result.getTotal()).isEqualTo(1);
         assertThat(result.getItems()).containsExactly(delivery);
+    }
+
+    @Test
+    void normalizesDeliveryFiltersIndependentlyOfTheDefaultLocaleTest() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
+            when(mapper.countPage("dingtalk", "PENDING", "Local")).thenReturn(0L);
+
+            new NotificationOutboxService(mapper, mock(SettingsRepository.class), mock(AlertSilenceService.class),
+                    mock(AlertRepository.class), mock(OperationAuditService.class))
+                    .listDeliveries(" DINGTALK ", "pending", "Local", 1, 20);
+
+            verify(mapper).countPage("dingtalk", "PENDING", "Local");
+        } finally {
+            Locale.setDefault(previous);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- normalize notification channels and delivery filters with `Locale.ROOT`
- parse delivery status identifiers without depending on the JVM language
- cover channel/status filtering under a Turkish default locale

## Why
Channel and status values are stable identifiers. Locale-sensitive casing can turn `DINGTALK` into `dıngtalk` and `pending` into `PENDİNG`, skipping notifications or rejecting valid filters.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -q -f server/pom.xml -Dtest=NotificationOutboxServiceTest test`