### PR TITLE
fix(alert): validate channels with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRulePolicy.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRulePolicy.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.ops.alert;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.springframework.util.StringUtils;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -83,7 +84,8 @@ final class NativeAlertRulePolicy {
             return;
         }
         for (String channel : rule.getChannels()) {
-            if (!StringUtils.hasText(channel) || !NOTIFICATION_CHANNELS.contains(channel.trim().toLowerCase())) {
+            if (!StringUtils.hasText(channel)
+                    || !NOTIFICATION_CHANNELS.contains(channel.trim().toLowerCase(Locale.ROOT))) {
                 throw new BusinessException(400, "Unsupported notification channel: " + channel);
             }
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRulePolicyTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRulePolicyTest.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -91,6 +92,19 @@ class NativeAlertRulePolicyTest {
         assertThatThrownBy(() -> NativeAlertRulePolicy.validate(rule(AlertDomain.BUSINESS,
                 "rocketmq_consumer_lag_messages").channels(List.of("webhook")).build()))
                 .isInstanceOf(BusinessException.class).hasMessageContaining("Unsupported notification channel");
+    }
+
+    @Test
+    void acceptsNotificationChannelsIndependentlyOfTheDefaultLocaleTest() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertThatCode(() -> NativeAlertRulePolicy.validate(rule(AlertDomain.BUSINESS,
+                    "rocketmq_consumer_lag_messages").channels(List.of(" DINGTALK ")).build()))
+                    .doesNotThrowAnyException();
+        } finally {
+            Locale.setDefault(previous);
+        }
     }
 
     private static AlertRuleVO.AlertRuleVOBuilder rule(AlertDomain domain, String metric) {


### PR DESCRIPTION
## Summary
- normalize alert notification channel identifiers with `Locale.ROOT`
- preserve case-insensitive validation under locale-sensitive JVM defaults
- add Turkish-locale regression coverage for `DINGTALK`

## Why
Notification channel names are identifiers. Locale-sensitive lowercase conversion changes uppercase `I` to a dotless character under Turkish, rejecting an otherwise supported channel.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -q -f server/pom.xml -Dtest=NativeAlertRulePolicyTest test`