### PR TITLE
fix(nameserver): normalize hosts with root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParser.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParser.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Parses the NameServer address list stored in the registry. Accepts comma or semicolon
@@ -62,7 +63,7 @@ public final class NamesrvAddrParser {
             if (!isValidIpv6Literal(ipv6)) {
                 throw new BusinessException(400, "namesrvAddr segment has a malformed IPv6 literal: " + segment);
             }
-            normalizedHost = "[" + ipv6.toLowerCase() + "]";
+            normalizedHost = "[" + ipv6.toLowerCase(Locale.ROOT) + "]";
         } else {
             if (host.isEmpty()) {
                 throw new BusinessException(400, "namesrvAddr segment is missing a host: " + segment);
@@ -70,7 +71,7 @@ public final class NamesrvAddrParser {
             if (host.chars().anyMatch(ch -> ch == ':' || Character.isWhitespace(ch))) {
                 throw new BusinessException(400, "namesrvAddr segment has an unexpected character: " + segment);
             }
-            normalizedHost = host.toLowerCase();
+            normalizedHost = host.toLowerCase(Locale.ROOT);
         }
         int port;
         try {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParserTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParserTest.java
@@ -19,6 +19,8 @@ package org.apache.rocketmq.studio.cluster.nameserver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -32,6 +34,18 @@ class NamesrvAddrParserTest {
     @Test
     void lowercasesHostsTest() {
         assertThat(NamesrvAddrParser.normalize("NS1.Example.COM:9876")).isEqualTo("ns1.example.com:9876");
+    }
+
+    @Test
+    void lowercasesHostsIndependentlyOfTheDefaultLocaleTest() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertThat(NamesrvAddrParser.normalize("INTERNAL.Example.COM:9876"))
+                    .isEqualTo("internal.example.com:9876");
+        } finally {
+            Locale.setDefault(previous);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- lowercase NameServer hostnames and IPv6 literals with `Locale.ROOT`
- keep normalized DNS names ASCII-stable under locale-sensitive JVM defaults
- add Turkish-locale regression coverage for a hostname containing uppercase `I`

## Why
DNS names and IP literals are protocol identifiers. Locale-sensitive casing can turn `INTERNAL` into `ınternal`, producing a different and generally unresolvable hostname.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -q -f server/pom.xml -Dtest=NamesrvAddrParserTest test`