### PR TITLE
fix(proxy): reject malformed bracketed IPv6 addresses

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.studio.cluster.proxy;
 
+import org.apache.commons.validator.routines.InetAddressValidator;
 import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.NoRedirectClientHttpRequestFactory;
@@ -53,6 +54,7 @@ public class ProxyAddressService {
 
     private static final Pattern PROXY_ADDR_PATTERN =
             Pattern.compile("^(\\[[0-9a-fA-F:.]+]|[A-Za-z0-9._-]+):(\\d{1,5})$");
+    private static final InetAddressValidator INET_ADDRESS_VALIDATOR = InetAddressValidator.getInstance();
     private static final int MIN_PORT = 1;
     private static final int MAX_PORT = 65535;
 
@@ -310,6 +312,11 @@ public class ProxyAddressService {
         Matcher matcher = PROXY_ADDR_PATTERN.matcher(normalized);
         if (!matcher.matches()) {
             throw new BusinessException(400, fieldName + " must be in host:port or [ipv6]:port format");
+        }
+        String host = matcher.group(1);
+        if (host.startsWith("[")
+                && !INET_ADDRESS_VALIDATOR.isValidInet6Address(host.substring(1, host.length() - 1))) {
+            throw new BusinessException(400, fieldName + " contains a malformed IPv6 address");
         }
         int port = Integer.parseInt(matcher.group(2));
         if (port < MIN_PORT || port > MAX_PORT) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
@@ -104,7 +104,10 @@ class ProxyAddressServiceTest {
                 "10.0.0.1:0",
                 "10.0.0.1:65536",
                 "http://10.0.0.1:8081",
-                "10.0.0.1:8081/path"
+                "10.0.0.1:8081/path",
+                "[:::]:8081",
+                "[2001:db8::1::2]:8081",
+                "[127.0.0.1]:8081"
         );
 
         for (String invalidProxyAddr : invalidProxyAddrs) {


### PR DESCRIPTION
## Summary
- validate bracketed proxy hosts as real IPv6 literals after the structural address match
- reject malformed or bracketed IPv4 values before storing or probing them
- extend proxy address regression coverage with invalid IPv6 forms

## Why
The existing regular expression only restricted the character set, so values such as `[:::]:8081` passed validation and were persisted as unreachable proxy nodes.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -q -f server/pom.xml -Dtest=ProxyAddressServiceTest test`