### PR TITLE
fix(proxy): retry discovery after transient failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/CollectorScheduler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/CollectorScheduler.java
@@ -84,12 +84,19 @@ public class CollectorScheduler {
                 .filter(java.util.Objects::nonNull)
                 .toList();
         Duration timeout = parsePositiveDuration(properties.getCollectionTimeout(), Duration.ofSeconds(15));
+        long passStartedAt = System.nanoTime();
+        long timeoutNanos = timeout.toNanos();
         for (Future<?> job : jobs) {
             try {
-                job.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+                long remainingNanos = timeoutNanos - (System.nanoTime() - passStartedAt);
+                if (remainingNanos <= 0) {
+                    job.cancel(true);
+                    continue;
+                }
+                job.get(remainingNanos, TimeUnit.NANOSECONDS);
             } catch (java.util.concurrent.TimeoutException error) {
                 job.cancel(true);
-                log.warn("Native metric collection exceeded {} for one instance and was cancelled", timeout);
+                log.warn("Native metric collection pass exceeded {} and unfinished work was cancelled", timeout);
             } catch (InterruptedException error) {
                 Thread.currentThread().interrupt();
                 return;

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepository.java
@@ -60,6 +60,7 @@ public class MybatisPlusMetricSnapshotRepository implements MetricSnapshotReposi
         return mapper.selectList(new QueryWrapper<RmqMetricSnapshot>()
                         .eq("instance_id", scope.instanceId()).eq("metric_key", scope.metricKey())
                         .eq("domain", scope.domain().name()).eq("labels_hash", sha256(labelsJson))
+                        .isNull(scope.clusterId() == null, "cluster_id")
                         .eq(scope.clusterId() != null, "cluster_id", scope.clusterId())
                         .eq("availability", MetricAvailability.AVAILABLE.name())
                         .ge("collected_at", LocalDateTime.ofInstant(since, ZoneOffset.UTC))

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameserverRegistryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameserverRegistryService.java
@@ -57,7 +57,11 @@ public class NameserverRegistryService {
             // The unique index is the final guard against concurrent duplicate creates.
             throw duplicateName(name);
         }
-        return toVO(nameserverMapper.selectById(entity.getId()));
+        RmqNameserver stored = nameserverMapper.selectById(entity.getId());
+        if (stored == null) {
+            throw concurrentlyDeleted(entity.getId());
+        }
+        return toVO(stored);
     }
 
     public NameserverRegistryVO update(UpdateNameserverRegistryDTO command) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.studio.cluster.proxy;
 
+import org.apache.commons.validator.routines.InetAddressValidator;
 import org.apache.rocketmq.studio.cluster.broker.ClusterService;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.NoRedirectClientHttpRequestFactory;
@@ -53,6 +54,7 @@ public class ProxyAddressService {
 
     private static final Pattern PROXY_ADDR_PATTERN =
             Pattern.compile("^(\\[[0-9a-fA-F:.]+]|[A-Za-z0-9._-]+):(\\d{1,5})$");
+    private static final InetAddressValidator INET_ADDRESS_VALIDATOR = InetAddressValidator.getInstance();
     private static final int MIN_PORT = 1;
     private static final int MAX_PORT = 65535;
 
@@ -310,6 +312,11 @@ public class ProxyAddressService {
         Matcher matcher = PROXY_ADDR_PATTERN.matcher(normalized);
         if (!matcher.matches()) {
             throw new BusinessException(400, fieldName + " must be in host:port or [ipv6]:port format");
+        }
+        String host = matcher.group(1);
+        if (host.startsWith("[")
+                && !INET_ADDRESS_VALIDATOR.isValidInet6Address(host.substring(1, host.length() - 1))) {
+            throw new BusinessException(400, fieldName + " contains a malformed IPv6 address");
         }
         int port = Integer.parseInt(matcher.group(2));
         if (port < MIN_PORT || port > MAX_PORT) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ProxyConsumerResolver.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ProxyConsumerResolver.java
@@ -173,6 +173,8 @@ public class ProxyConsumerResolver {
         } catch (Exception e) {
             log.debug("Proxy discovery via heartbeat syncer failed for instance {}: {}",
                     instanceId, e.getMessage());
+            // A failed lookup is transient and must not suppress discovery for the full cache TTL.
+            return List.of();
         }
         List<String> addresses = ips.stream()
                 .map(ip -> ip + ":" + PROXY_REMOTING_PORT)

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/CollectorSchedulerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/CollectorSchedulerTest.java
@@ -84,6 +84,40 @@ class CollectorSchedulerTest {
     }
 
     @Test
+    void appliesCollectionTimeoutToTheWholePassInsteadOfEachInstanceTest() {
+        AlertingProperties properties = new AlertingProperties();
+        properties.setCollectionTimeout("PT0.25S");
+        InstanceRepository instances = mock(InstanceRepository.class);
+        when(instances.findAll()).thenReturn(List.of(
+                InstanceVO.builder().name("slow-a").build(),
+                InstanceVO.builder().name("slow-b").build(),
+                InstanceVO.builder().name("slow-c").build()));
+        ClusterMetricsCollector collector = mock(ClusterMetricsCollector.class);
+        when(collector.supports(any(InstanceVO.class))).thenReturn(true);
+        when(collector.collect(any(InstanceVO.class))).thenAnswer(invocation -> {
+            try {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            return List.of();
+        });
+        AlertCollectionLease lease = mock(AlertCollectionLease.class);
+        when(lease.tryAcquire()).thenReturn(true);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CollectorScheduler scheduler = new CollectorScheduler(properties, instances, List.of(collector), List.of(),
+                mock(MetricSnapshotRepository.class), mock(NativeAlertProcessor.class), lease, executor);
+
+        long startedAt = System.nanoTime();
+        scheduler.collect();
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+        scheduler.stopCollectionExecutor();
+
+        assertTrue(elapsedMillis < 600,
+                "the configured timeout should cap the complete pass, elapsed=" + elapsedMillis + "ms");
+    }
+
+    @Test
     void collectsAndPersistsSupportedSamplesTest() {
         AlertingProperties properties = new AlertingProperties();
         InstanceRepository instances = mock(InstanceRepository.class);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepositoryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.ops.alert.AlertDomain;
+import org.apache.rocketmq.studio.persistence.entity.RmqMetricSnapshot;
+import org.apache.rocketmq.studio.persistence.mapper.RmqMetricSnapshotMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MybatisPlusMetricSnapshotRepositoryTest {
+
+    @Mock
+    private RmqMetricSnapshotMapper mapper;
+
+    @Test
+    void nullClusterScopeShouldOnlyReadUnscopedSnapshotsTest() {
+        when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of());
+        MybatisPlusMetricSnapshotRepository repository =
+                new MybatisPlusMetricSnapshotRepository(mapper, new ObjectMapper());
+        MetricSample scope = new MetricSample("broker.availability", AlertDomain.CLUSTER,
+                "local", null, Map.of(), 1D, MetricAvailability.AVAILABLE, Instant.now());
+
+        repository.findRecent(scope, Instant.EPOCH);
+
+        ArgumentCaptor<Wrapper<RmqMetricSnapshot>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(mapper).selectList(queryCaptor.capture());
+        QueryWrapper<RmqMetricSnapshot> query = (QueryWrapper<RmqMetricSnapshot>) queryCaptor.getValue();
+        assertThat(query.getSqlSegment()).contains("cluster_id IS NULL");
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameserverRegistryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameserverRegistryServiceTest.java
@@ -201,6 +201,24 @@ class NameserverRegistryServiceTest {
     }
 
     @Test
+    void createShouldThrowWhenEntryVanishesBeforeReloadTest() {
+        when(nameserverMapper.selectCount(any())).thenReturn(0L);
+        when(nameserverMapper.insert(any(RmqNameserver.class))).thenAnswer(invocation -> {
+            RmqNameserver entity = invocation.getArgument(0);
+            entity.setId(12L);
+            return 1;
+        });
+        when(nameserverMapper.selectById(12L)).thenReturn(null);
+
+        assertThatThrownBy(() -> service.create(CreateNameserverRegistryDTO.builder()
+                .name("prod")
+                .namesrvAddr("10.0.0.1:9876")
+                .build()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("deleted concurrently");
+    }
+
+    @Test
     void updateShouldPersistAndReturnStoredEntryTest() {
         RmqNameserver existing = new RmqNameserver();
         existing.setId(1L);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
@@ -104,7 +104,10 @@ class ProxyAddressServiceTest {
                 "10.0.0.1:0",
                 "10.0.0.1:65536",
                 "http://10.0.0.1:8081",
-                "10.0.0.1:8081/path"
+                "10.0.0.1:8081/path",
+                "[:::]:8081",
+                "[2001:db8::1::2]:8081",
+                "[127.0.0.1]:8081"
         );
 
         for (String invalidProxyAddr : invalidProxyAddrs) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ProxyConsumerResolverTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ProxyConsumerResolverTest.java
@@ -95,6 +95,24 @@ class ProxyConsumerResolverTest {
     }
 
     @Test
+    void discoverProxyAddressesShouldRetryAfterATransientFailureTest() throws Exception {
+        ConsumerConnection syncer = new ConsumerConnection();
+        Connection proxy = new Connection();
+        proxy.setClientId("proxy-a");
+        proxy.setClientAddr("10.0.4.66:10911");
+        syncer.setConnectionSet(new HashSet<>(List.of(proxy)));
+        when(adminExt.examineConsumerConnectionInfo("CID_DefaultHeartBeatSyncerTopic"))
+                .thenThrow(new IllegalStateException("nameserver unavailable"))
+                .thenReturn(syncer);
+
+        assertThat(resolver.discoverProxyAddresses("instance-a")).isEmpty();
+        assertThat(resolver.discoverProxyAddresses("instance-a")).containsExactly("10.0.4.66:8080");
+
+        org.mockito.Mockito.verify(adminExt, org.mockito.Mockito.times(2))
+                .examineConsumerConnectionInfo("CID_DefaultHeartBeatSyncerTopic");
+    }
+
+    @Test
     void resolveConsumerConnectionShouldReturnNullWhenNoProxyDiscoveredTest() throws Exception {
         when(adminExt.examineConsumerConnectionInfo("CID_DefaultHeartBeatSyncerTopic"))
                 .thenThrow(new IllegalStateException("syncer group missing"));


### PR DESCRIPTION
## Summary
- return an empty result without caching when proxy discovery throws
- allow the next request to retry the heartbeat-syncer lookup immediately
- add regression coverage for failure followed by recovery

## Why
A transient NameServer/admin failure was cached as an empty proxy list for 60 seconds. During that interval proxy-connected consumers remained invisible even after the cluster recovered.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -q -f server/pom.xml -Dtest=ProxyConsumerResolverTest test`