### PR TITLE
fix(mock): normalize connection filters consistently

### DIFF
--- a/web/src/services/connectionsService.test.ts
+++ b/web/src/services/connectionsService.test.ts
@@ -77,4 +77,22 @@ describe('connectionsService mock connections', () => {
       listConnections({ namesrvAddr: '10.101.2.1:9876', clusterId: 'ns-pre' }),
     ).resolves.toEqual([]);
   });
+
+  it('normalizes optional filters like the real endpoint', async () => {
+    const padded = await listConnections({
+      namesrvAddr: '10.101.2.1:9876',
+      clusterId: ' ns-prod ',
+      type: ' Consumer ',
+    });
+    const blank = await listConnections({
+      namesrvAddr: '10.101.2.1:9876',
+      clusterId: '  ',
+      type: '  ',
+    });
+
+    expect(padded).not.toHaveLength(0);
+    expect(padded.every((connection) => connection.clusterName === 'ns-prod')).toBe(true);
+    expect(padded.every((connection) => connection.type === 'Consumer')).toBe(true);
+    expect(blank).not.toHaveLength(0);
+  });
 });

--- a/web/src/services/connectionsService.ts
+++ b/web/src/services/connectionsService.ts
@@ -16,10 +16,11 @@ export async function listConnections(params?: ClientConnectionQuery): Promise<C
     const instanceCluster = mockClientClusterByNamesrvAddr[namesrvAddr];
     if (!instanceCluster) return [];
 
+    const clusterId = params?.clusterId?.trim();
+    const type = params?.type?.trim();
     let result = mockClients.filter((connection) => connection.clusterName === instanceCluster);
-    if (params?.clusterId)
-      result = result.filter((connection) => connection.clusterName === params.clusterId);
-    if (params?.type) result = result.filter((c) => c.type === params.type);
+    if (clusterId) result = result.filter((connection) => connection.clusterName === clusterId);
+    if (type) result = result.filter((connection) => connection.type === type);
     return (result as unknown as ClientConnection[]).map(copyConnection);
   }
   return connApi.listConnections(params);


### PR DESCRIPTION
## Summary
- trim mock-mode cluster and client-type filters before matching
- treat blank optional filters as absent
- add regression coverage for padded and blank filter values

## Why
The backend normalizes optional connection filters, but mock mode compared raw strings. The same request could therefore return data in real mode and an empty list in mock mode.

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/services/connectionsService.test.ts`