### PR TITLE
fix(dlq): reject blank selected message IDs

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQResendSelectedRequestDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQResendSelectedRequestDTO.java
@@ -39,7 +39,7 @@ public class DLQResendSelectedRequestDTO {
 
     @NotEmpty(message = "At least one msgId is required")
     @Size(max = 100, message = "At most 100 msgIds are allowed per resend")
-    private List<String> msgIds;
+    private List<@NotBlank(message = "msgId must not be blank") String> msgIds;
 
     private String targetTopic;
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQControllerTest.java
@@ -427,6 +427,24 @@ class DLQControllerTest {
     }
 
     @Test
+    void resendSelectedMessagesShouldRejectBlankMsgIdsTest() throws Exception {
+        Map<String, Object> body = Map.of(
+                "instanceId", "instance-1",
+                "groupName", "test-group",
+                "msgIds", List.of("msg-1", " ")
+        );
+
+        mockMvc.perform(post("/api/dlq/resend-selected")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("msgId must not be blank"));
+
+        verifyNoInteractions(dlqService);
+    }
+
+    @Test
     void resendSelectedMessagesShouldRejectMoreThanHundredMsgIdsTest() throws Exception {
         List<String> msgIds = new java.util.ArrayList<>();
         for (int i = 0; i < 101; i++) {


### PR DESCRIPTION
## Summary
- validate every selected DLQ message ID instead of only validating the list size
- reject empty and whitespace-only IDs before invoking the provider
- add controller-level regression coverage

## Why
A syntactically non-empty selection such as `["   "]` passed request validation and reached the resend provider with an unusable message identifier.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=DLQControllerTest test`