### PR TITLE
fix(mock): validate message pagination consistently

### DIFF
--- a/web/src/services/messageService.test.ts
+++ b/web/src/services/messageService.test.ts
@@ -20,6 +20,7 @@ import {
   consumeMessageDirectly,
   getMessageTrace,
   listDLQGroups,
+  queryMessagePage,
   queryMessages,
 } from './messageService';
 
@@ -52,6 +53,15 @@ describe('message service mock data', () => {
     });
 
     expect(messages.map((message) => message.msgId)).toEqual(['AC1E0A6400002A9F0000000001A3F7C2']);
+  });
+
+  it('validates mock message pagination like the real endpoint', async () => {
+    await expect(queryMessagePage({ topic: 'order-create', page: 0 })).rejects.toThrow(
+      'page must be positive',
+    );
+    await expect(
+      queryMessagePage({ topic: 'order-create', page: 1, pageSize: 201 }),
+    ).rejects.toThrow('pageSize must be between 1 and 200');
   });
 
   it('returns copied message trace rows', async () => {

--- a/web/src/services/messageService.ts
+++ b/web/src/services/messageService.ts
@@ -61,6 +61,9 @@ export async function queryMessagePage(
     const items = await queryMessages(params);
     const page = params.page ?? 1;
     const pageSize = params.pageSize ?? 50;
+    if (page < 1 || pageSize < 1 || pageSize > 200) {
+      throw new Error('page must be positive and pageSize must be between 1 and 200');
+    }
     const from = Math.min((page - 1) * pageSize, items.length);
     return {
       items: items.slice(from, from + pageSize),


### PR DESCRIPTION
## Summary
- enforce the message endpoint page and page-size bounds in mock mode
- reject zero or negative pages and page sizes above 200 instead of applying JavaScript negative slicing
- add regression coverage for both invalid cases

## Why
Real mode rejects invalid pagination, while mock mode could return unrelated rows for page zero because `Array.slice` interprets negative offsets from the end.

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/services/messageService.test.ts`