### PR TITLE
fix(dlq): guard invalid message timestamps

### DIFF
--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -24,7 +24,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import type { DLQGroup, DLQGroupPage, DLQMessagePage, DLQResendResult } from '../../../api/message';
 import { LangProvider } from '../../../i18n/LangContext';
 import * as messageService from '../../../services/messageService';
-import DLQPage from '../dlq';
+import DLQPage, { formatDateTime } from '../dlq';
 
 vi.mock('../../../services/messageService', () => ({
   listDLQGroups: vi.fn(),
@@ -153,6 +153,12 @@ describe('DLQ page', () => {
   afterEach(() => {
     clickSpy.mockRestore();
     vi.clearAllMocks();
+  });
+
+  it('renders invalid message timestamps as unavailable without throwing', () => {
+    expect(formatDateTime(Number.NaN)).toBe('-');
+    expect(formatDateTime(Number.POSITIVE_INFINITY)).toBe('-');
+    expect(formatDateTime(0)).not.toBe('-');
   });
 
   it('loads DLQ groups through the service layer', async () => {

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -78,9 +78,9 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
   return fallback;
 };
 
-const formatDateTime = (iso?: string | null): string => {
-  if (!iso) return '-';
-  const d = new Date(iso);
+export const formatDateTime = (value?: string | number | null): string => {
+  if (value === undefined || value === null || value === '') return '-';
+  const d = new Date(value);
   if (Number.isNaN(d.getTime())) return '-';
   const pad = (n: number) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
@@ -534,9 +534,7 @@ const DLQPage = () => {
       key: 'storeTime',
       width: 160,
       render: (storeTime: number) => (
-        <Text style={{ fontFamily: 'monospace', fontSize: 14 }}>
-          {formatDateTime(new Date(storeTime).toISOString())}
-        </Text>
+        <Text style={{ fontFamily: 'monospace', fontSize: 14 }}>{formatDateTime(storeTime)}</Text>
       ),
     },
     {
@@ -555,7 +553,7 @@ const DLQPage = () => {
       ellipsis: true,
       render: (body: string | null) => (
         <Text type="secondary" style={{ fontSize: 14 }}>
-          {body && body.length > 80 ? `${body.slice(0, 80)}…` : body ?? '-'}
+          {body && body.length > 80 ? `${body.slice(0, 80)}…` : (body ?? '-')}
         </Text>
       ),
     },
@@ -791,7 +789,10 @@ const DLQPage = () => {
             >
               <Space size={24} wrap>
                 <div>
-                  <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
+                  <Text
+                    type="secondary"
+                    style={{ fontSize: 14, display: 'block', marginBottom: 4 }}
+                  >
                     DLQ Topic
                   </Text>
                   <Text copyable style={{ fontFamily: 'monospace' }}>
@@ -799,17 +800,26 @@ const DLQPage = () => {
                   </Text>
                 </div>
                 <div>
-                  <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
+                  <Text
+                    type="secondary"
+                    style={{ fontSize: 14, display: 'block', marginBottom: 4 }}
+                  >
                     死信数量
                   </Text>
-                  <Text strong style={{ color: detailGroup.messageCount > 0 ? '#fa8c16' : undefined }}>
+                  <Text
+                    strong
+                    style={{ color: detailGroup.messageCount > 0 ? '#fa8c16' : undefined }}
+                  >
                     {detailGroup.statsAvailable === false
                       ? '不可用'
                       : detailGroup.messageCount.toLocaleString()}
                   </Text>
                 </div>
                 <div>
-                  <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
+                  <Text
+                    type="secondary"
+                    style={{ fontSize: 14, display: 'block', marginBottom: 4 }}
+                  >
                     最近入队时间
                   </Text>
                   <Text style={{ fontFamily: 'monospace' }}>


### PR DESCRIPTION
## Summary
- format numeric DLQ message timestamps directly instead of calling `toISOString` first
- render malformed and non-finite provider timestamps as unavailable
- preserve valid epoch timestamps and add regression coverage

## Why
`Date#toISOString()` throws a `RangeError` for malformed timestamps, so one bad provider row could crash the DLQ detail table render.

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/pages/instance/__tests__/DLQPage.test.tsx`