### PR TITLE
fix(nameserver): handle create reload races

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameserverRegistryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameserverRegistryService.java
@@ -57,7 +57,11 @@ public class NameserverRegistryService {
             // The unique index is the final guard against concurrent duplicate creates.
             throw duplicateName(name);
         }
-        return toVO(nameserverMapper.selectById(entity.getId()));
+        RmqNameserver stored = nameserverMapper.selectById(entity.getId());
+        if (stored == null) {
+            throw concurrentlyDeleted(entity.getId());
+        }
+        return toVO(stored);
     }
 
     public NameserverRegistryVO update(UpdateNameserverRegistryDTO command) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameserverRegistryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameserverRegistryServiceTest.java
@@ -201,6 +201,24 @@ class NameserverRegistryServiceTest {
     }
 
     @Test
+    void createShouldThrowWhenEntryVanishesBeforeReloadTest() {
+        when(nameserverMapper.selectCount(any())).thenReturn(0L);
+        when(nameserverMapper.insert(any(RmqNameserver.class))).thenAnswer(invocation -> {
+            RmqNameserver entity = invocation.getArgument(0);
+            entity.setId(12L);
+            return 1;
+        });
+        when(nameserverMapper.selectById(12L)).thenReturn(null);
+
+        assertThatThrownBy(() -> service.create(CreateNameserverRegistryDTO.builder()
+                .name("prod")
+                .namesrvAddr("10.0.0.1:9876")
+                .build()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("deleted concurrently");
+    }
+
+    @Test
     void updateShouldPersistAndReturnStoredEntryTest() {
         RmqNameserver existing = new RmqNameserver();
         existing.setId(1L);


### PR DESCRIPTION
## Summary
- handle a concurrent deletion between nameserver insertion and reload
- return an explicit not-found business error instead of dereferencing a missing row
- add regression coverage for the race

## Why
The create path reloads the inserted record before mapping it. A concurrent delete could make that lookup return null and turn a normal race into an internal null-pointer error.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=NameserverRegistryServiceTest test`