### PR TITLE
fix(metrics): bound the complete collection pass

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/CollectorScheduler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/CollectorScheduler.java
@@ -84,12 +84,19 @@ public class CollectorScheduler {
                 .filter(java.util.Objects::nonNull)
                 .toList();
         Duration timeout = parsePositiveDuration(properties.getCollectionTimeout(), Duration.ofSeconds(15));
+        long passStartedAt = System.nanoTime();
+        long timeoutNanos = timeout.toNanos();
         for (Future<?> job : jobs) {
             try {
-                job.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+                long remainingNanos = timeoutNanos - (System.nanoTime() - passStartedAt);
+                if (remainingNanos <= 0) {
+                    job.cancel(true);
+                    continue;
+                }
+                job.get(remainingNanos, TimeUnit.NANOSECONDS);
             } catch (java.util.concurrent.TimeoutException error) {
                 job.cancel(true);
-                log.warn("Native metric collection exceeded {} for one instance and was cancelled", timeout);
+                log.warn("Native metric collection pass exceeded {} and unfinished work was cancelled", timeout);
             } catch (InterruptedException error) {
                 Thread.currentThread().interrupt();
                 return;

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/CollectorSchedulerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/CollectorSchedulerTest.java
@@ -84,6 +84,40 @@ class CollectorSchedulerTest {
     }
 
     @Test
+    void appliesCollectionTimeoutToTheWholePassInsteadOfEachInstanceTest() {
+        AlertingProperties properties = new AlertingProperties();
+        properties.setCollectionTimeout("PT0.25S");
+        InstanceRepository instances = mock(InstanceRepository.class);
+        when(instances.findAll()).thenReturn(List.of(
+                InstanceVO.builder().name("slow-a").build(),
+                InstanceVO.builder().name("slow-b").build(),
+                InstanceVO.builder().name("slow-c").build()));
+        ClusterMetricsCollector collector = mock(ClusterMetricsCollector.class);
+        when(collector.supports(any(InstanceVO.class))).thenReturn(true);
+        when(collector.collect(any(InstanceVO.class))).thenAnswer(invocation -> {
+            try {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            return List.of();
+        });
+        AlertCollectionLease lease = mock(AlertCollectionLease.class);
+        when(lease.tryAcquire()).thenReturn(true);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CollectorScheduler scheduler = new CollectorScheduler(properties, instances, List.of(collector), List.of(),
+                mock(MetricSnapshotRepository.class), mock(NativeAlertProcessor.class), lease, executor);
+
+        long startedAt = System.nanoTime();
+        scheduler.collect();
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+        scheduler.stopCollectionExecutor();
+
+        assertTrue(elapsedMillis < 600,
+                "the configured timeout should cap the complete pass, elapsed=" + elapsedMillis + "ms");
+    }
+
+    @Test
     void collectsAndPersistsSupportedSamplesTest() {
         AlertingProperties properties = new AlertingProperties();
         InstanceRepository instances = mock(InstanceRepository.class);


### PR DESCRIPTION
## Summary
- apply the collection timeout as one deadline for the whole scheduled pass
- stop waiting once the shared budget is exhausted and cancel unfinished jobs
- cover multiple blocked collectors with a timing regression test

## Why
Waiting for each collector with the full timeout made a pass take `collector count × timeout`, allowing slow providers to overlap later scheduling cycles.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=CollectorSchedulerTest test`