### PR TITLE
fix(alert): stabilize alert pagination order

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -195,7 +195,7 @@ public class MybatisPlusAlertRepository implements AlertRepository {
                         "JSON_CONTAINS(labels_json, JSON_OBJECT({0}, {1}))", query.labelKey(), query.labelValue())
                 .ge(query.from() != null, "time", query.from())
                 .le(query.to() != null, "time", query.to())
-                .orderByDesc("time");
+                .orderByDesc("time", "id");
         Page<RmqSystemAlert> result = alertMapper.selectPage(new Page<>(query.page(), query.pageSize()), conditions);
         return PageResult.of(result.getRecords().stream().map(MybatisPlusAlertRepository::toAlertVO).toList(),
                 result.getTotal(), query.page(), query.pageSize());

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -291,7 +291,8 @@ class MybatisPlusAlertRepositoryTest {
         repository.findAlertsPage(new SystemAlertQuery(null, null, null, null,
                 null, null, null, null, 1, 20));
 
-        verify(alertMapper).selectPage(any(Page.class), any());
+        verify(alertMapper).selectPage(any(Page.class),
+                argThat(MybatisPlusAlertRepositoryTest::hasStableAlertOrdering));
     }
 
     private static boolean hasScopeLabelAndTimeFilters(Wrapper<RmqSystemAlert> query) {
@@ -312,6 +313,13 @@ class MybatisPlusAlertRepositoryTest {
         }
         queryWrapper.getCustomSqlSegment();
         return queryWrapper.getParamNameValuePairs().containsValue("info");
+    }
+
+    private static boolean hasStableAlertOrdering(Wrapper<RmqSystemAlert> query) {
+        if (!(query instanceof QueryWrapper<?> queryWrapper)) {
+            return false;
+        }
+        return queryWrapper.getCustomSqlSegment().contains("ORDER BY time DESC,id DESC");
     }
 
     private static boolean hasBusinessRulePageFilters(Wrapper<RmqAlertRule> query) {


### PR DESCRIPTION
## Summary
- add alert ID as a deterministic tie-breaker after event time
- keep page boundaries stable when multiple alerts share a timestamp
- add repository regression coverage

## Why
Ordering only by event time left equal-timestamp rows nondeterministic, so alerts could move between pages or appear twice across consecutive requests.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=MybatisPlusAlertRepositoryTest test`