### PR TITLE
fix(alert): make fingerprint input unambiguous

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprint.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprint.java
@@ -27,9 +27,9 @@ public final class AlertFingerprint {
     }
 
     public static String of(long ruleId, String instanceId, Map<String, String> labels) {
-        StringBuilder input = new StringBuilder().append(ruleId).append('\n').append(instanceId).append('\n');
-        new TreeMap<>(labels == null ? Map.of() : labels).forEach((key, value) -> input.append(key)
-                .append('=').append(value).append('\n'));
+        StringBuilder input = new StringBuilder().append(ruleId).append('\n').append(escape(instanceId)).append('\n');
+        new TreeMap<>(labels == null ? Map.of() : labels).forEach((key, value) -> input.append(escape(key))
+                .append('=').append(escape(value)).append('\n'));
         try {
             byte[] bytes = MessageDigest.getInstance("SHA-256").digest(input.toString().getBytes(StandardCharsets.UTF_8));
             StringBuilder fingerprint = new StringBuilder(bytes.length * 2);
@@ -40,5 +40,14 @@ public final class AlertFingerprint {
         } catch (NoSuchAlgorithmException impossible) {
             throw new IllegalStateException("SHA-256 is not available", impossible);
         }
+    }
+
+    private static String escape(String value) {
+        if (value == null) {
+            return "null";
+        }
+        return value.replace("\\", "\\\\")
+                .replace("\n", "\\n")
+                .replace("=", "\\=");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprintTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprintTest.java
@@ -37,4 +37,13 @@ class AlertFingerprintTest {
                 .isEqualTo(AlertFingerprint.of(7L, "local", second))
                 .hasSize(64);
     }
+
+    @Test
+    void separatorCharactersCannotCreateTheSameFingerprintForDifferentLabelsTest() {
+        Map<String, String> embeddedLabel = Map.of("a", "b\nc=d");
+        Map<String, String> separateLabels = Map.of("a", "b", "c", "d");
+
+        assertThat(AlertFingerprint.of(7L, "local", embeddedLabel))
+                .isNotEqualTo(AlertFingerprint.of(7L, "local", separateLabels));
+    }
 }


### PR DESCRIPTION
## Summary
- escape structural delimiters in alert instance and label values before hashing
- prevent distinct label maps from serializing to the same fingerprint input
- preserve fingerprints for ordinary values and add collision coverage

## Why
Newlines and equals signs inside label values could mimic the fingerprint serialization delimiters, allowing structurally different alerts to share a fingerprint.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=AlertFingerprintTest test`