### PR TITLE
fix(alert): reject overflowing rule durations

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleDuration.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleDuration.java
@@ -37,7 +37,11 @@ final class AlertRuleDuration {
             } catch (NumberFormatException error) {
                 throw invalid(value);
             }
-            result = result.plus(toDuration(amount, matcher.group(2), value));
+            try {
+                result = result.plus(toDuration(amount, matcher.group(2), value));
+            } catch (ArithmeticException error) {
+                throw invalid(value);
+            }
             end = matcher.end();
         }
         if (end != value.trim().length()) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleDurationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleDurationTest.java
@@ -11,11 +11,22 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AlertRuleDurationTest {
     @Test
     void parsesTheRuleDurationSyntaxTest() {
         assertThat(AlertRuleDuration.parse("1h30m")).isEqualTo(Duration.ofMinutes(90));
         assertThat(AlertRuleDuration.parse(null)).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    void rejectsDurationsThatOverflowInsteadOfLeakingArithmeticErrorsTest() {
+        assertThatThrownBy(() -> AlertRuleDuration.parse(Long.MAX_VALUE + "y"))
+                .isInstanceOf(org.apache.rocketmq.studio.common.exception.BusinessException.class)
+                .hasMessage("Invalid alert duration: " + Long.MAX_VALUE + "y");
+        assertThatThrownBy(() -> AlertRuleDuration.parse(Long.MAX_VALUE + "s1s"))
+                .isInstanceOf(org.apache.rocketmq.studio.common.exception.BusinessException.class)
+                .hasMessage("Invalid alert duration: " + Long.MAX_VALUE + "s1s");
     }
 }


### PR DESCRIPTION
## Summary
- translate duration arithmetic overflow into a 400 business error
- cover overflowing units and compound duration addition

## Why
Syntactically valid but extremely large duration values could escape request validation and fail with an uncaught arithmetic exception during parsing.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=AlertRuleDurationTest test`