### PR TITLE
fix(alert): isolate rule test collector failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleTestService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleTestService.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.cluster.metrics.BusinessMetricsCollector;
 import org.apache.rocketmq.studio.cluster.metrics.ClusterMetricsCollector;
 import org.apache.rocketmq.studio.cluster.metrics.MetricSample;
@@ -31,6 +32,7 @@ import java.util.List;
 /** Executes a native rule once without persisting a snapshot, state, or event. */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class NativeAlertRuleTestService {
     private final InstanceRepository instanceRepository;
     private final List<ClusterMetricsCollector> clusterCollectors;
@@ -43,11 +45,27 @@ public class NativeAlertRuleTestService {
                 .orElseThrow(() -> new BusinessException(404, "Instance not found: " + rule.getInstanceId()));
         List<MetricSample> samples = new ArrayList<>();
         if (rule.getDomain() == AlertDomain.CLUSTER) {
-            clusterCollectors.stream().filter(collector -> collector.supports(instance))
-                    .forEach(collector -> samples.addAll(collector.collect(instance)));
+            for (ClusterMetricsCollector collector : clusterCollectors) {
+                try {
+                    if (collector.supports(instance)) {
+                        samples.addAll(collector.collect(instance));
+                    }
+                } catch (RuntimeException error) {
+                    log.warn("Native cluster metric test collector failed for instance {}: {}",
+                            instance.getName(), error.getMessage());
+                }
+            }
         } else {
-            businessCollectors.stream().filter(collector -> collector.supports(instance))
-                    .forEach(collector -> samples.addAll(collector.collect(instance)));
+            for (BusinessMetricsCollector collector : businessCollectors) {
+                try {
+                    if (collector.supports(instance)) {
+                        samples.addAll(collector.collect(instance));
+                    }
+                } catch (RuntimeException error) {
+                    log.warn("Native business metric test collector failed for instance {}: {}",
+                            instance.getName(), error.getMessage());
+                }
+            }
         }
         return AlertRuleTestResultVO.builder().samples(samples.stream()
                 .filter(sample -> rule.getMetric().equals(sample.metricKey()))

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleTestServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleTestServiceTest.java
@@ -78,6 +78,27 @@ class NativeAlertRuleTestServiceTest {
         });
     }
 
+    @Test
+    void keepsResultsFromHealthyCollectorsWhenAnotherCollectorFailsTest() {
+        InstanceRepository instances = mock(InstanceRepository.class);
+        BusinessMetricsCollector failing = mock(BusinessMetricsCollector.class);
+        BusinessMetricsCollector healthy = mock(BusinessMetricsCollector.class);
+        InstanceVO instance = InstanceVO.builder().name("local").build();
+        when(instances.findByIdentifier("local")).thenReturn(Optional.of(instance));
+        when(failing.supports(instance)).thenReturn(true);
+        when(failing.collect(instance)).thenThrow(new IllegalStateException("provider unavailable"));
+        when(healthy.supports(instance)).thenReturn(true);
+        when(healthy.collect(instance)).thenReturn(List.of(sample("orders", 20)));
+        AlertRuleVO rule = AlertRuleVO.builder().domain(AlertDomain.BUSINESS).metric("consumer.lag.total")
+                .instanceId("local").consumerGroup("orders").operator(">").threshold(10).build();
+
+        AlertRuleTestResultVO result = new NativeAlertRuleTestService(instances, List.of(),
+                List.of(failing, healthy), new AlertRuleEvaluator()).test(rule);
+
+        assertThat(result.samples()).singleElement()
+                .satisfies(sample -> assertThat(sample.currentValue()).isEqualTo(20));
+    }
+
     private static MetricSample sample(String group, double value) {
         return sample("consumer.lag.total", group, value);
     }


### PR DESCRIPTION
## Summary
- isolate failures from individual metric collectors during rule tests
- retain samples from healthy collectors when another provider fails
- add mixed success/failure regression coverage

## Why
One collector exception previously aborted the whole rule-test request and hid valid results from every other collector.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=NativeAlertRuleTestServiceTest test`