### PR TITLE
fix(alert): render notification templates in one pass

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplate.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplate.java
@@ -9,6 +9,8 @@ package org.apache.rocketmq.studio.ops.alert;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /** Renders the fixed, documented placeholders allowed in an alert notification. */
 final class AlertNotificationTemplate {
@@ -17,16 +19,26 @@ final class AlertNotificationTemplate {
             "broker.disk.usage_ratio",
             "broker.jvm.heap.usage_ratio",
             "broker.send_queue.usage_ratio");
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{([A-Za-z][A-Za-z0-9]*)}");
 
     private AlertNotificationTemplate() {
     }
 
     static String render(String template, SystemAlertVO alert, AlertRuleVO rule) {
-        String result = hasText(template) ? template.trim() : DEFAULT_TEMPLATE;
-        for (Map.Entry<String, String> entry : values(alert, rule).entrySet()) {
-            result = result.replace("${" + entry.getKey() + "}", entry.getValue());
+        String source = hasText(template) ? template.trim() : DEFAULT_TEMPLATE;
+        Map<String, String> replacements = values(alert, rule);
+        Matcher matcher = PLACEHOLDER.matcher(source);
+        StringBuilder result = new StringBuilder(source.length());
+        while (matcher.find()) {
+            String replacement = replacements.get(matcher.group(1));
+            if (replacement == null) {
+                matcher.appendReplacement(result, Matcher.quoteReplacement(matcher.group()));
+            } else {
+                matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+            }
         }
-        return result;
+        matcher.appendTail(result);
+        return result.toString();
     }
 
     private static Map<String, String> values(SystemAlertVO alert, AlertRuleVO rule) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplateTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplateTest.java
@@ -40,4 +40,15 @@ class AlertNotificationTemplateTest {
         assertThat(AlertNotificationTemplate.render(null, alert, null))
                 .isEqualTo("[info] Test - connection works\nLabels: ");
     }
+
+    @Test
+    void doesNotExpandPlaceholderSyntaxIntroducedByAlertValuesTest() {
+        SystemAlertVO alert = SystemAlertVO.builder()
+                .title("${description}")
+                .description("internal detail")
+                .build();
+
+        assertThat(AlertNotificationTemplate.render("${title}", alert, null))
+                .isEqualTo("${description}");
+    }
 }


### PR DESCRIPTION
## Summary
- replace alert template placeholders in a single regex pass
- quote replacement values so dollar signs and backslashes remain literal
- prevent placeholder-looking alert content from being expanded recursively

## Why
Sequential string replacement treated placeholder syntax inside user-controlled alert values as a second template directive, changing the notification content.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=AlertNotificationTemplateTest test`