### PR TITLE
fix(alert): reject null rules in imports

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTO.java
@@ -25,5 +25,5 @@ public class AlertRuleTransferDTO {
     private AlertDomain domain;
 
     @NotEmpty(message = "rules must not be empty")
-    private List<@Valid AlertRuleRequestDTO> rules;
+    private List<@NotNull(message = "rule must not be null") @Valid AlertRuleRequestDTO> rules;
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTOTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlertRuleTransferDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void rejectsNullRuleEntriesBeforeImportTest() {
+        AlertRuleTransferDTO transfer = new AlertRuleTransferDTO();
+        transfer.setVersion(AlertRuleTransferDTO.VERSION);
+        transfer.setDomain(AlertDomain.CLUSTER);
+        transfer.setRules(Collections.singletonList(null));
+
+        assertThat(validator.validate(transfer))
+                .extracting(violation -> violation.getMessage())
+                .contains("rule must not be null");
+    }
+}


### PR DESCRIPTION
## Summary
- require every element in an imported alert rule list to be non-null
- preserve nested bean validation for valid rule objects
- add DTO validation regression coverage

## Why
A list containing null satisfied the container constraints and could fail later while processing an otherwise accepted import request.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=AlertRuleTransferDTOTest test`