### PR TITLE
fix(mock): validate ACL user pagination

### DIFF
--- a/web/src/services/aclService.test.ts
+++ b/web/src/services/aclService.test.ts
@@ -23,6 +23,7 @@ import {
   examineBrokerClusterAclConfig,
   listAclRules,
   listAclUsers,
+  pageAclUsers,
   updateAclRule,
   updateAclUser,
 } from './aclService';
@@ -79,6 +80,13 @@ describe('ACL service mock data', () => {
     expect(second[0].username).toBe('user-admin');
     expect(second[0].clusters).not.toContain('mutated-cluster');
     expect(second[0]).not.toBe(first[0]);
+  });
+
+  it('validates ACL user pagination like the backend', async () => {
+    await expect(pageAclUsers({ page: 0, pageSize: 20 })).rejects.toThrow('page must be >= 1');
+    await expect(pageAclUsers({ page: 1, pageSize: 101 })).rejects.toThrow(
+      'pageSize must be between 1 and 100',
+    );
   });
 
   it('copies ACL user arrays on create and update', async () => {

--- a/web/src/services/aclService.ts
+++ b/web/src/services/aclService.ts
@@ -96,6 +96,9 @@ export async function pageAclUsers(params: {
   pageSize: number;
 }): Promise<AclUserPage> {
   if (isMockMode()) {
+    if (params.page < 1 || params.pageSize < 1 || params.pageSize > 100) {
+      throw new Error('page must be >= 1 and pageSize must be between 1 and 100');
+    }
     const users = await listAclUsers(params);
     const from = (params.page - 1) * params.pageSize;
     return {


### PR DESCRIPTION
## Summary
- enforce the backend page and page-size bounds in ACL mock mode
- reject page zero and page sizes above 100 before array slicing
- add mock-service regression coverage

## Why
Mock mode accepted invalid pagination that the real ACL endpoint rejects, and negative JavaScript slice offsets could return unrelated users.

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/services/aclService.test.ts`