### PR TITLE
fix(metrics): isolate unscoped snapshot history

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepository.java
@@ -60,6 +60,7 @@ public class MybatisPlusMetricSnapshotRepository implements MetricSnapshotReposi
         return mapper.selectList(new QueryWrapper<RmqMetricSnapshot>()
                         .eq("instance_id", scope.instanceId()).eq("metric_key", scope.metricKey())
                         .eq("domain", scope.domain().name()).eq("labels_hash", sha256(labelsJson))
+                        .isNull(scope.clusterId() == null, "cluster_id")
                         .eq(scope.clusterId() != null, "cluster_id", scope.clusterId())
                         .eq("availability", MetricAvailability.AVAILABLE.name())
                         .ge("collected_at", LocalDateTime.ofInstant(since, ZoneOffset.UTC))

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepositoryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.ops.alert.AlertDomain;
+import org.apache.rocketmq.studio.persistence.entity.RmqMetricSnapshot;
+import org.apache.rocketmq.studio.persistence.mapper.RmqMetricSnapshotMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MybatisPlusMetricSnapshotRepositoryTest {
+
+    @Mock
+    private RmqMetricSnapshotMapper mapper;
+
+    @Test
+    void nullClusterScopeShouldOnlyReadUnscopedSnapshotsTest() {
+        when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of());
+        MybatisPlusMetricSnapshotRepository repository =
+                new MybatisPlusMetricSnapshotRepository(mapper, new ObjectMapper());
+        MetricSample scope = new MetricSample("broker.availability", AlertDomain.CLUSTER,
+                "local", null, Map.of(), 1D, MetricAvailability.AVAILABLE, Instant.now());
+
+        repository.findRecent(scope, Instant.EPOCH);
+
+        ArgumentCaptor<Wrapper<RmqMetricSnapshot>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(mapper).selectList(queryCaptor.capture());
+        QueryWrapper<RmqMetricSnapshot> query = (QueryWrapper<RmqMetricSnapshot>) queryCaptor.getValue();
+        assertThat(query.getSqlSegment()).contains("cluster_id IS NULL");
+    }
+}


### PR DESCRIPTION
## Summary
- constrain null-cluster metric history queries to rows whose cluster ID is also null
- keep cluster-scoped snapshots out of unscoped alert aggregation
- add query-wrapper regression coverage

## Why
Omitting the cluster predicate for a null scope matched every cluster sharing the same instance, metric, domain, and labels, contaminating unscoped alert windows.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=MybatisPlusMetricSnapshotRepositoryTest test`