### PR TITLE
fix(mock): isolate Grafana dashboard state

### DIFF
--- a/web/src/services/grafanaService.test.ts
+++ b/web/src/services/grafanaService.test.ts
@@ -35,6 +35,18 @@ describe('grafanaService', () => {
     expect(model.uid).toBe('rocketmq-overview');
   });
 
+  it('does not expose mutable mock dashboard state', async () => {
+    const dashboards = await listGrafanaDashboards();
+    dashboards[0].tags.push('mutated');
+    const model = await getGrafanaDashboard('rocketmq-overview');
+    (model.panels as Array<Record<string, unknown>>)[0].title = 'mutated';
+
+    const freshDashboards = await listGrafanaDashboards();
+    const freshModel = await getGrafanaDashboard('rocketmq-overview');
+    expect(freshDashboards[0].tags).not.toContain('mutated');
+    expect((freshModel.panels as Array<Record<string, unknown>>)[0].title).toBe('Messages In TPS');
+  });
+
   it('throws for an unknown dashboard uid in mock mode', async () => {
     await expect(getGrafanaDashboard('nope')).rejects.toThrow();
   });

--- a/web/src/services/grafanaService.ts
+++ b/web/src/services/grafanaService.ts
@@ -12,7 +12,7 @@ export async function listGrafanaDashboards(): Promise<GrafanaDashboardInfo[]> {
       uid,
       title,
       description,
-      tags,
+      tags: [...tags],
     }));
   }
   return metricsApi.listGrafanaDashboards();
@@ -24,7 +24,7 @@ export async function getGrafanaDashboard(uid: string): Promise<Record<string, u
     if (!found) {
       throw new Error(`Grafana dashboard not found: ${uid}`);
     }
-    return found.model;
+    return structuredClone(found.model);
   }
   return metricsApi.getGrafanaDashboard(uid);
 }


### PR DESCRIPTION
## Summary
- copy dashboard tags returned by the mock list API
- deep-clone mock dashboard models before exposing them to callers
- add mutation regression coverage

## Why
Mock callers received references to module-level fixtures, so editing a returned tag or nested panel permanently changed later reads and exports in the same session.

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/services/grafanaService.test.ts`