### PR TITLE
fix(ai): enforce history limit in UTF-8 bytes

### DIFF
--- a/web/src/stores/aiChatHistoryStore.test.ts
+++ b/web/src/stores/aiChatHistoryStore.test.ts
@@ -160,6 +160,25 @@ describe('aiChatHistoryStore', () => {
     );
   });
 
+  it('measures the persisted history limit in UTF-8 bytes', async () => {
+    const { MAX_AI_CHAT_HISTORY_BYTES } = await import('./aiChatHistoryStore');
+    const store = await loadStore();
+    for (let index = 0; index < 20; index += 1) {
+      store
+        .getState()
+        .setMessages('real', `conversation-${index}`, [
+          { id: `message-${index}`, role: 'user', text: '界'.repeat(16 * 1024) },
+        ]);
+    }
+
+    const serialized = JSON.stringify({
+      conversations: store.getState().histories.real.conversations,
+    });
+    expect(new TextEncoder().encode(serialized).byteLength).toBeLessThanOrEqual(
+      MAX_AI_CHAT_HISTORY_BYTES,
+    );
+  });
+
   it('clears pending throttled persistence when histories are cleared', async () => {
     vi.useFakeTimers();
     const store = await loadStore();

--- a/web/src/stores/aiChatHistoryStore.ts
+++ b/web/src/stores/aiChatHistoryStore.ts
@@ -83,6 +83,8 @@ const boundMessageFields = (messages: AiChatMessage[]): AiChatMessage[] =>
     thinking: truncateMessageField(message.thinking),
   }));
 
+const utf8ByteLength = (value: string): number => new TextEncoder().encode(value).byteLength;
+
 const restoreMessages = (messages: unknown): AiChatMessage[] =>
   (Array.isArray(messages) ? messages : [])
     .filter(isRecord)
@@ -110,7 +112,7 @@ const limitHistorySize = (history: AiChatHistory): AiChatHistory => {
   }));
   while (
     conversations.length > 0 &&
-    JSON.stringify({ conversations }).length > MAX_AI_CHAT_HISTORY_BYTES
+    utf8ByteLength(JSON.stringify({ conversations })) > MAX_AI_CHAT_HISTORY_BYTES
   ) {
     const oldestIndex = conversations.length - 1;
     const oldest = conversations[oldestIndex];


### PR DESCRIPTION
## Summary
- measure serialized AI chat history using its actual UTF-8 byte length
- retain the existing bounded eviction behavior for oversized histories
- add multibyte conversation regression coverage

## Why
The storage budget was compared with JavaScript UTF-16 code units, allowing non-ASCII histories to exceed the documented 512 KiB limit and fail session storage persistence.

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/stores/aiChatHistoryStore.test.ts`