### PR TITLE
fix(lite-topic): guard invalid activity timestamps

### DIFF
--- a/web/src/pages/studio/LiteTopic.tsx
+++ b/web/src/pages/studio/LiteTopic.tsx
@@ -69,9 +69,10 @@ const formatDuration = (ms: number | undefined | null): string => {
   return `${(ms / 3600000).toFixed(1)}h`;
 };
 
-const formatTime = (timestamp: number | undefined | null): string => {
-  if (!timestamp) return '-';
-  return new Date(timestamp).toLocaleString();
+export const formatTime = (timestamp: number | undefined | null): string => {
+  if (timestamp == null || !Number.isFinite(timestamp)) return '-';
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString();
 };
 
 const getProgressStatus = (percent: number): 'exception' | 'active' | 'normal' => {

--- a/web/src/pages/studio/__tests__/LiteTopic.test.tsx
+++ b/web/src/pages/studio/__tests__/LiteTopic.test.tsx
@@ -22,7 +22,7 @@ import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
 import type { LiteTopicItem, LiteTopicQuota } from '../../../api/liteTopic';
 import { downloadCsv } from '../../../utils/download';
-import LiteTopic from '../LiteTopic';
+import LiteTopic, { formatTime } from '../LiteTopic';
 
 const apiMocks = vi.hoisted(() => ({
   queryLiteTopicCapability: vi.fn(),
@@ -77,6 +77,14 @@ const createDeferred = <T,>() => {
   });
   return { promise, resolve, reject };
 };
+
+describe('LiteTopic time formatting', () => {
+  it('preserves epoch timestamps and rejects invalid provider values', () => {
+    expect(formatTime(0)).toBe(new Date(0).toLocaleString());
+    expect(formatTime(Number.POSITIVE_INFINITY)).toBe('-');
+    expect(formatTime(Number.MAX_VALUE)).toBe('-');
+  });
+});
 
 const createQuota = (currentTopicCount: number): LiteTopicQuota => ({
   currentTopicCount,


### PR DESCRIPTION
## Summary
- preserve valid epoch timestamps in Lite Topic activity views and CSV exports
- render non-finite and out-of-range provider timestamps as unavailable
- add formatter regression coverage

## Why
The truthiness check discarded epoch zero, while malformed finite or infinite values could leak `Invalid Date` into the UI and exported data.

## Testing
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- src/pages/studio/__tests__/LiteTopic.test.tsx`