### PR TITLE
fix(alert): scan all suppression candidates

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationSuppressionService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationSuppressionService.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -32,6 +33,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class AlertNotificationSuppressionService {
     private static final Duration CORRELATION_WINDOW = Duration.ofMinutes(30);
+    private static final int CANDIDATE_PAGE_SIZE = 100;
 
     private final AlertRepository alertRepository;
 
@@ -40,16 +42,27 @@ public class AlertNotificationSuppressionService {
             return Optional.empty();
         }
         LocalDateTime windowStart = event.getTime().minus(CORRELATION_WINDOW);
-        List<SystemAlertVO> candidates = alertRepository.findAlertsPage(new SystemAlertQuery(null, AlertDomain.CLUSTER,
-                        event.getInstanceId(), null, null, null, windowStart, event.getTime(), 1, 100))
-                .getItems().stream()
-                .filter(candidate -> AlertCorrelationScope.matches(event, candidate))
-                .toList();
         Map<String, SystemAlertVO> latestByIncident = new HashMap<>();
-        for (SystemAlertVO candidate : candidates) {
-            String incident = candidate.getFingerprint() == null ? String.valueOf(candidate.getId())
-                    : candidate.getFingerprint();
-            latestByIncident.merge(incident, candidate, (left, right) -> later(left, right) ? left : right);
+        int page = 1;
+        long fetched = 0;
+        while (true) {
+            PageResult<SystemAlertVO> result = alertRepository.findAlertsPage(new SystemAlertQuery(
+                    null, AlertDomain.CLUSTER, event.getInstanceId(), null, null, null,
+                    windowStart, event.getTime(), page, CANDIDATE_PAGE_SIZE));
+            List<SystemAlertVO> candidates = result.getItems();
+            for (SystemAlertVO candidate : candidates) {
+                if (!AlertCorrelationScope.matches(event, candidate)) {
+                    continue;
+                }
+                String incident = candidate.getFingerprint() == null ? String.valueOf(candidate.getId())
+                        : candidate.getFingerprint();
+                latestByIncident.merge(incident, candidate, (left, right) -> later(left, right) ? left : right);
+            }
+            fetched += candidates.size();
+            if (candidates.isEmpty() || fetched >= result.getTotal()) {
+                break;
+            }
+            page++;
         }
         return latestByIncident.values().stream()
                 .filter(candidate -> "FIRING".equalsIgnoreCase(candidate.getTransition()))

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationSuppressionServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationSuppressionServiceTest.java
@@ -22,10 +22,13 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -85,6 +88,29 @@ class AlertNotificationSuppressionServiceTest {
         assertThat(new AlertNotificationSuppressionService(repository)
                 .findSuppressingClusterAlert(event(2L, AlertDomain.BUSINESS, "FIRING", "broker-1", now)))
                 .isEmpty();
+    }
+
+    @Test
+    void searchesBeyondTheFirstCandidatePageTest() {
+        AlertRepository repository = mock(AlertRepository.class);
+        LocalDateTime now = LocalDateTime.now();
+        List<SystemAlertVO> unrelated = IntStream.range(0, 100)
+                .mapToObj(index -> event((long) index, AlertDomain.CLUSTER, "FIRING",
+                        "broker-" + index, now.minusMinutes(1)))
+                .toList();
+        SystemAlertVO cause = event(101L, AlertDomain.CLUSTER, "FIRING", "target-broker",
+                now.minusMinutes(2));
+        when(repository.findAlertsPage(any())).thenReturn(
+                PageResult.of(unrelated, 101, 1, 100),
+                PageResult.of(List.of(cause), 101, 2, 100));
+
+        Optional<SystemAlertVO> result = new AlertNotificationSuppressionService(repository)
+                .findSuppressingClusterAlert(event(102L, AlertDomain.BUSINESS, "FIRING",
+                        "target-broker", now));
+
+        assertThat(result).contains(cause);
+        verify(repository, times(2)).findAlertsPage(any());
+        verify(repository).findAlertsPage(org.mockito.ArgumentMatchers.argThat(query -> query.page() == 2));
     }
 
     private static SystemAlertVO event(Long id, AlertDomain domain, String transition, String brokerName,


### PR DESCRIPTION
## Summary
- page through the full 30-minute cluster-alert correlation window
- aggregate matching incident state across every returned page
- add coverage for a suppressing incident beyond the first 100 events

## Why
The previous single-page query silently missed active cluster incidents whenever 100 newer unrelated cluster events existed in the correlation window, causing redundant business notifications.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=AlertNotificationSuppressionServiceTest test`