### PR TITLE
fix(ai): normalize provider engine registration

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistry.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistry.java
@@ -18,11 +18,10 @@ package org.apache.rocketmq.studio.ops.ai;
 
 import org.springframework.stereotype.Component;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Selects the CLI agent provider (claude code / qoder) for the configured engine.
@@ -33,17 +32,30 @@ public class AgentProviderRegistry {
     private final Map<String, AgentProvider> providers;
 
     public AgentProviderRegistry(List<AgentProvider> providerList) {
-        this.providers = providerList.stream()
-                .collect(Collectors.toMap(AgentProvider::engine, Function.identity()));
+        Map<String, AgentProvider> registered = new LinkedHashMap<>();
+        for (AgentProvider provider : providerList) {
+            String engine = normalizeEngine(provider.engine());
+            if (engine.isEmpty()) {
+                throw new IllegalStateException("Agent provider engine is required");
+            }
+            if (registered.putIfAbsent(engine, provider) != null) {
+                throw new IllegalStateException("Duplicate agent provider engine: " + engine);
+            }
+        }
+        this.providers = Map.copyOf(registered);
     }
 
     public AgentProvider forEngine(String engine) {
-        AgentProvider provider = providers.get(engine == null ? "" : engine.trim().toLowerCase(Locale.ROOT));
+        AgentProvider provider = providers.get(normalizeEngine(engine));
         if (provider == null) {
             throw new LlmGatewayException(400, "llm.config.unsupported_engine",
                     "Agent engine is not supported: " + engine,
                     "Use one of: claude-code, qoder.");
         }
         return provider;
+    }
+
+    private static String normalizeEngine(String engine) {
+        return engine == null ? "" : engine.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistryTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,5 +41,27 @@ class AgentProviderRegistryTest {
         } finally {
             Locale.setDefault(original);
         }
+    }
+
+    @Test
+    void shouldNormalizeProviderEngineDuringRegistration() {
+        AgentProvider provider = mock(AgentProvider.class);
+        when(provider.engine()).thenReturn(" CLI ");
+
+        AgentProviderRegistry registry = new AgentProviderRegistry(List.of(provider));
+
+        assertThat(registry.forEngine("cli")).isSameAs(provider);
+    }
+
+    @Test
+    void shouldRejectDuplicateNormalizedProviderEngines() {
+        AgentProvider first = mock(AgentProvider.class);
+        AgentProvider second = mock(AgentProvider.class);
+        when(first.engine()).thenReturn("CLI");
+        when(second.engine()).thenReturn(" cli ");
+
+        assertThatThrownBy(() -> new AgentProviderRegistry(List.of(first, second)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Duplicate agent provider engine: cli");
     }
 }


### PR DESCRIPTION
## Summary
- normalize provider engine identifiers during registration as well as lookup
- reject blank and duplicate normalized engine registrations explicitly
- add mixed-case and duplicate regression coverage

## Why
Lookup is case-insensitive and trimmed, but registration previously stored the raw provider identifier, making otherwise valid providers unreachable and hiding normalized collisions until runtime.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=AgentProviderRegistryTest test`