### PR TITLE
fix(credentials): trim paged search terms

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
@@ -49,10 +49,18 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
                 .map(MybatisPlusCloudCredentialRepository::toVO)
                 .collect(Collectors.toList());
     }
-    @Override public PageResult<CloudCredentialVO> findPage(InstanceVendor vendor, String search, int page, int pageSize) {
-        QueryWrapper<RmqCloudCredential> q = new QueryWrapper<RmqCloudCredential>().eq(vendor != null, "vendor", vendor == null ? null : vendor.name()).like(search != null && !search.isBlank(), "name", search).orderByDesc("gmt_modified", "id");
+    @Override
+    public PageResult<CloudCredentialVO> findPage(InstanceVendor vendor, String search, int page, int pageSize) {
+        String normalizedSearch = search == null || search.isBlank() ? null : search.trim();
+        QueryWrapper<RmqCloudCredential> q = new QueryWrapper<RmqCloudCredential>()
+                .eq(vendor != null, "vendor", vendor == null ? null : vendor.name())
+                .like(normalizedSearch != null, "name", normalizedSearch)
+                .orderByDesc("gmt_modified", "id");
         Page<RmqCloudCredential> result = credentialMapper.selectPage(new Page<>(page, pageSize), q);
-        return PageResult.of(result.getRecords().stream().map(MybatisPlusCloudCredentialRepository::toVO).toList(), result.getTotal(), page, pageSize);
+        return PageResult.of(result.getRecords().stream()
+                        .map(MybatisPlusCloudCredentialRepository::toVO)
+                        .toList(),
+                result.getTotal(), page, pageSize);
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
@@ -17,12 +17,17 @@
 
 package org.apache.rocketmq.studio.provider.credential;
 
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.persistence.entity.RmqCloudCredential;
 import org.apache.rocketmq.studio.persistence.mapper.RmqCloudCredentialMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -32,6 +37,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,6 +81,20 @@ class MybatisPlusCloudCredentialRepositoryTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Invalid persisted cloud credential vendor")
                 .hasMessageContaining("3");
+    }
+
+    @Test
+    void findPageShouldTrimTheSearchTerm() {
+        when(credentialMapper.selectPage(any(IPage.class), any(Wrapper.class)))
+                .thenReturn(new Page<RmqCloudCredential>(1, 20));
+
+        repository.findPage(null, "  credential  ", 1, 20);
+
+        ArgumentCaptor<Wrapper<RmqCloudCredential>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(credentialMapper).selectPage(any(IPage.class), queryCaptor.capture());
+        QueryWrapper<RmqCloudCredential> query = (QueryWrapper<RmqCloudCredential>) queryCaptor.getValue();
+        query.getCustomSqlSegment();
+        assertThat(query.getParamNameValuePairs()).containsValue("%credential%");
     }
 
     private RmqCloudCredential entity(Long id, String name, String vendor) {


### PR DESCRIPTION
## Summary
- normalize surrounding whitespace before applying credential name filters
- keep blank searches unfiltered
- add repository query regression coverage

## Why
The paged credential endpoint passed user-entered whitespace into the SQL `LIKE` value, so pasted or padded search terms returned no matches even when the normalized name existed.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn -f server/pom.xml -Dtest=MybatisPlusCloudCredentialRepositoryTest test`