### PR TITLE
fix(common): isolate page result items

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/domain/PageResult.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/domain/PageResult.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.common.domain;
 
 import lombok.Getter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,7 +32,9 @@ public class PageResult<T> {
 
     public static <T> PageResult<T> of(List<T> items, long total, int page, int size) {
         PageResult<T> result = new PageResult<>();
-        result.items = items == null ? Collections.emptyList() : items;
+        result.items = items == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(items));
         result.total = total;
         result.page = page;
         result.size = size;

--- a/server/src/test/java/org/apache/rocketmq/studio/common/domain/PageResultTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/domain/PageResultTest.java
@@ -18,7 +18,11 @@ package org.apache.rocketmq.studio.common.domain;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PageResultTest {
 
@@ -27,5 +31,17 @@ class PageResultTest {
         PageResult<String> result = PageResult.of(null, 0, 1, 20);
 
         assertThat(result.getItems()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void ofShouldIsolateItemsFromTheSourceList() {
+        List<String> source = new ArrayList<>(List.of("first"));
+
+        PageResult<String> result = PageResult.of(source, 1, 1, 20);
+        source.add("later");
+
+        assertThat(result.getItems()).containsExactly("first");
+        assertThatThrownBy(() -> result.getItems().add("mutated"))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 }


### PR DESCRIPTION
## Summary
- copy page items when constructing a `PageResult`
- expose an unmodifiable page list without changing null-element behavior
- add regression coverage for source-list and caller mutation

## Why
`PageResult` retained the caller's mutable list (including `subList` views), so later source mutations could change an already returned page and callers could mutate shared backing state.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn -f server/pom.xml -Dtest=PageResultTest test`
