### PR TITLE
fix(alert): reject invalid reminder intervals

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertStateMachine.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertStateMachine.java
@@ -43,6 +43,9 @@ public class AlertStateMachine {
         if (requiredDuration == null || requiredDuration.isNegative()) {
             throw new IllegalArgumentException("requiredDuration must not be negative");
         }
+        if (reminderInterval == null || reminderInterval.isNegative()) {
+            throw new IllegalArgumentException("reminderInterval must not be negative");
+        }
         AlertRuleState state = previous == null ? AlertRuleState.initial() : previous;
         if (!evaluation.matches()) {
             return new AlertStateUpdate(state, AlertStateTransition.NONE);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertStateMachineTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertStateMachineTest.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AlertStateMachineTest {
     private final AlertStateMachine stateMachine = new AlertStateMachine();
@@ -101,6 +102,17 @@ class AlertStateMachineTest {
         assertThat(reminder.transition()).isEqualTo(AlertStateTransition.REMINDER);
         assertThat(reminder.state().lastNotifiedAt()).isEqualTo(now.plusSeconds(30 * 60));
         assertThat(noReminder.transition()).isEqualTo(AlertStateTransition.NONE);
+    }
+
+    @Test
+    void rejectsInvalidReminderIntervalsTest() {
+        assertThatThrownBy(() -> stateMachine.advance(null, met(), 1, Duration.ZERO, null, now))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("reminderInterval must not be negative");
+        assertThatThrownBy(() -> stateMachine.advance(null, met(), 1, Duration.ZERO,
+                Duration.ofSeconds(-1), now))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("reminderInterval must not be negative");
     }
 
     private static AlertEvaluationResult met() {


### PR DESCRIPTION
## Summary
- reject null reminder intervals before alert state transitions
- reject negative reminder intervals instead of treating them as immediately due
- add regression coverage for both invalid values

## Why
The alert state machine validated the firing duration but not the reminder interval. A null interval failed later with an unrelated exception, while a negative interval caused every subsequent firing sample to emit a reminder.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn -f server/pom.xml -Dtest=AlertStateMachineTest test`
