### PR TITLE
fix(message): enforce broker topology guard on the primary msgId lookup path

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -142,7 +142,9 @@ public class RocketMQMessageProvider implements MessageProvider {
         MessageExt messageExt = null;
         if (StringUtils.hasText(topic)) {
             try {
-                messageExt = adminExt.viewMessage(topic, msgId);
+                if (isWithinKnownBrokerTopology(adminExt, msgId)) {
+                    messageExt = adminExt.viewMessage(topic, msgId);
+                }
             } catch (Exception e) {
                 log.warn("viewMessage(topic={}, msgId={}) failed: {}", topic, msgId, e.getMessage());
             }
@@ -188,6 +190,29 @@ public class RocketMQMessageProvider implements MessageProvider {
         log.warn("Rejecting decoded broker address {} for msgId={} because it is not a known broker endpoint"
                 + " for the selected instance", brokerAddr, msgId);
         return null;
+    }
+
+    /**
+     * Offset-style message ids embed a broker address that {@code MQAdminImpl#viewMessage} connects
+     * to directly, so ids whose embedded address is outside the selected instance topology must be
+     * rejected before that call. Ids that do not decode as offset ids take MQAdminImpl's unique-key
+     * lookup, which resolves brokers from the topic route and needs no guard. When the topology
+     * itself cannot be verified, reject too — mirroring the fallback path's behavior — instead of
+     * handing an unverified address to remoting.
+     */
+    private boolean isWithinKnownBrokerTopology(DefaultMQAdminExt adminExt, String msgId) {
+        MessageId messageId;
+        try {
+            messageId = MessageDecoder.decodeMessageId(msgId);
+        } catch (Exception e) {
+            return true;
+        }
+        try {
+            return validatedBrokerAddr(adminExt, msgId, messageId) != null;
+        } catch (Exception e) {
+            log.warn("Could not verify broker topology for msgId={}: {}", msgId, e.getMessage());
+            return false;
+        }
     }
 
     private String decodedBrokerAddr(MessageId messageId) {
@@ -566,7 +591,10 @@ public class RocketMQMessageProvider implements MessageProvider {
     private long resolveMessageStoreTimestamp(DefaultMQAdminExt adminExt, String msgId, String topic) {
         if (StringUtils.hasText(topic)) {
             try {
-                MessageExt messageExt = adminExt.viewMessage(topic, msgId);
+                MessageExt messageExt = null;
+                if (isWithinKnownBrokerTopology(adminExt, msgId)) {
+                    messageExt = adminExt.viewMessage(topic, msgId);
+                }
                 if (messageExt != null) {
                     return messageExt.getStoreTimestamp();
                 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -250,14 +250,68 @@ class RocketMQMessageProviderTest {
     void queryByMsgIdRejectsDecodedBrokerOutsideKnownTopology() throws Exception {
         String msgId = MessageDecoder.createMessageId(new InetSocketAddress("10.2.3.4", 10911), 12345L);
         when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithBrokerAddresses("172.30.10.100:10911"));
-        when(adminExt.viewMessage("TopicA", msgId))
-                .thenThrow(new IllegalStateException("primary lookup failed"));
 
         List<MessageRecordVO> result = provider.queryMessages(
                 "instance-a", "TopicA", msgId, null, null, 100L, 200L);
 
         assertThat(result).isEmpty();
+        verify(adminExt, never()).viewMessage(anyString(), anyString());
         verify(adminExt, never()).getDefaultMQAdminExtImpl();
+    }
+
+    @Test
+    void queryByMsgIdRejectsOffsetIdWhenTopologyCannotBeVerified() throws Exception {
+        String msgId = MessageDecoder.createMessageId(new InetSocketAddress("172.30.10.100", 10911), 12345L);
+        when(adminExt.examineBrokerClusterInfo()).thenThrow(new IllegalStateException("nameserver unreachable"));
+
+        List<MessageRecordVO> result = provider.queryMessages(
+                "instance-a", "TopicA", msgId, null, null, 100L, 200L);
+
+        assertThat(result).isEmpty();
+        verify(adminExt, never()).viewMessage(anyString(), anyString());
+        verify(adminExt, never()).getDefaultMQAdminExtImpl();
+    }
+
+    @Test
+    void queryByMsgIdRejectsOffsetIdWhenTopologyIsEmpty() throws Exception {
+        String msgId = MessageDecoder.createMessageId(new InetSocketAddress("172.30.10.100", 10911), 12345L);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithBrokerAddresses());
+
+        List<MessageRecordVO> result = provider.queryMessages(
+                "instance-a", "TopicA", msgId, null, null, 100L, 200L);
+
+        assertThat(result).isEmpty();
+        verify(adminExt, never()).viewMessage(anyString(), anyString());
+    }
+
+    @Test
+    void queryByMsgIdPassesNonOffsetIdsThroughToViewMessage() throws Exception {
+        when(adminExt.viewMessage("TopicA", "uniq-key-1"))
+                .thenThrow(new IllegalStateException("unique key lookup handled by MQAdminImpl"));
+
+        List<MessageRecordVO> result = provider.queryMessages(
+                "instance-a", "TopicA", "uniq-key-1", null, null, 100L, 200L);
+
+        assertThat(result).isEmpty();
+        verify(adminExt).viewMessage("TopicA", "uniq-key-1");
+        verify(adminExt, never()).examineBrokerClusterInfo();
+    }
+
+    @Test
+    void queryByMsgIdStillViewsMessagesInsideKnownTopology() throws Exception {
+        String msgId = MessageDecoder.createMessageId(
+                new InetSocketAddress("172.30.10.100", 10911), 12345L);
+        MessageExt message = new MessageExt();
+        message.setMsgId(msgId);
+        message.setTopic("TopicA");
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithBrokerAddresses("172.30.10.100:10911"));
+        when(adminExt.viewMessage("TopicA", msgId)).thenReturn(message);
+
+        List<MessageRecordVO> result = provider.queryMessages(
+                "instance-a", "TopicA", msgId, null, null, 100L, 200L);
+
+        assertThat(result).singleElement().extracting(MessageRecordVO::getMsgId).isEqualTo(msgId);
+        verify(adminExt).viewMessage("TopicA", msgId);
     }
 
     @Test
@@ -661,13 +715,12 @@ class RocketMQMessageProviderTest {
     void getMessageTraceDoesNotUseDecodedBrokerOutsideKnownTopology() throws Exception {
         String msgId = MessageDecoder.createMessageId(new InetSocketAddress("10.2.3.4", 10911), 12345L);
         when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithBrokerAddresses("172.30.10.100:10911"));
-        when(adminExt.viewMessage("TopicA", msgId))
-                .thenThrow(new IllegalStateException("topic lookup failed"));
         when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
                 .thenReturn(new QueryResult(0L, List.of()));
 
         provider.getMessageTrace("instance-a", msgId, "TopicA");
 
+        verify(adminExt, never()).viewMessage(anyString(), anyString());
         verify(adminExt, never()).getDefaultMQAdminExtImpl();
         ArgumentCaptor<Long> beginCaptor = ArgumentCaptor.forClass(Long.class);
         ArgumentCaptor<Long> endCaptor = ArgumentCaptor.forClass(Long.class);


### PR DESCRIPTION
## What is the purpose of the change

Fixes #2832.

PR #2339 added a broker-topology guard (`validatedBrokerAddr`) for offset message ids, but it only covered the fallback path (`viewMessageByOffsetId`). The primary lookup path — `adminExt.viewMessage(topic, msgId)` in `queryByMsgId` and `resolveMessageStoreTimestamp` — runs **before** the fallback with no validation. Since `MQAdminImpl.viewMessage` decodes the broker address embedded in a 32-char offset id and opens a RocketMQ remoting connection to it, a forged msgId made Studio connect to an attacker-chosen `ip:port` (reader-accessible via `GET /api/messages` and `GET /api/messages/{msgId}/trace`), which is the exact primitive `ToolAccessPolicy` deny-lists for readers.

## Brief changelog

- Add `isWithinKnownBrokerTopology`: decode the msgId and validate the embedded broker address against the instance topology with the existing `validatedBrokerAddr` helper before invoking `adminExt.viewMessage(topic, msgId)`; apply it in both `queryByMsgId` and `resolveMessageStoreTimestamp`.
- Semantics mirror the merged fallback guard: ids that do not decode as offset ids pass through (MQAdminImpl's unique-key lookup resolves brokers from the topic route and is not steerable by the id); decodable ids outside the topology are rejected; when the topology itself cannot be verified (cluster-info RPC fails), reject too instead of handing an unverified address to remoting.
- Message ids surfaced by the API are offset ids built from `storeHost` + commit-log offset (`MessageDecoder.decode` sets `msgId` via `createMessageId`), so the copy-id-and-search flow decodes to an in-topology address and is unaffected.
- Tests: strengthen the two guard tests to verify `adminExt.viewMessage` is never invoked for out-of-topology ids (previously they stubbed `viewMessage` to throw, which masked the primary-path connection), add a positive-path test (in-topology id still resolves through `viewMessage`), and add edge cases: topology RPC failure rejected, empty topology rejected, non-offset id passed through without any topology RPC.

## Verifying this change

- `mvn -f server/pom.xml -Dtest=RocketMQMessageProviderTest test` — 35 tests pass.
- Red/green: on the unmodified branch, all four reject-path guard tests fail (`queryByMsgIdRejectsDecodedBrokerOutsideKnownTopology`, `queryByMsgIdRejectsOffsetIdWhenTopologyCannotBeVerified`, `queryByMsgIdRejectsOffsetIdWhenTopologyIsEmpty`, `getMessageTraceDoesNotUseDecodedBrokerOutsideKnownTopology`) because the primary path does invoke `viewMessage` for out-of-topology addresses; with the fix they pass. `queryByMsgIdStillViewsMessagesInsideKnownTopology` and `queryByMsgIdPassesNonOffsetIdsThroughToViewMessage` pin the behavior-preservation side of the guard.
- Real-client primitive check (no mocks): with a plain `ServerSocket` as the embedded address and an unreachable NameServer, `DefaultMQAdminExt.viewMessage("TopicA", MessageDecoder.createMessageId(new InetSocketAddress("127.0.0.1", trapPort), 42L))` accepted a connection on the trap socket and sent a 64-byte remoting request — confirming the pre-fix primary path connects to attacker-controlled addresses. The guarded code path rejects such ids before remoting (covered by the `never()` interaction tests).
- `mvn -B -ntp clean package -DskipTests` (CI backend-build step) passes. Across full `mvn -B test` runs the only observed failure is a pre-existing intra-test race in `OpenAiCompatibleLlmGatewayTest.successfulAndFailedStreamsEmitOneTerminalSequence` (it reuses a single-slot executor for two sequential chats; the second chat can be rejected with `llm.gateway.overloaded` if the worker thread has not exited after the first stream's terminal event). The race is load-sensitive and uncorrelated with this PR: across five full-suite runs it fired on both variants (3/3 runs with this fix, 1/2 control runs on the unmodified branch), and by surefire class order the AI test executes before the message-provider classes are even loaded, so no code touched by this PR participates in that path. The class passes in isolation.



