### PR TITLE
fix(dlq): validate the resend target topic before dispatching messages

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.topic.TopicValidator;
 import org.apache.rocketmq.remoting.protocol.admin.TopicOffset;
 import org.apache.rocketmq.remoting.protocol.admin.TopicStatsTable;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
@@ -34,6 +35,7 @@ import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.util.Pagination;
+import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
 import org.apache.rocketmq.studio.instance.dlq.DLQExcelExportResultVO;
 import org.apache.rocketmq.studio.instance.dlq.DLQExportResultVO;
 import org.apache.rocketmq.studio.instance.dlq.DLQGroupVO;
@@ -178,6 +180,9 @@ public class RocketMQDLQProvider implements DLQProvider {
         if (begin >= end) {
             throw new BusinessException(400, "DLQ resend start time must be before end time");
         }
+        if (StringUtils.hasText(targetTopic)) {
+            validateResendTargetTopic(instanceId, targetTopic);
+        }
 
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + groupName;
 
@@ -250,6 +255,9 @@ public class RocketMQDLQProvider implements DLQProvider {
         }
         if (selected.isEmpty()) {
             throw new BusinessException(400, "At least one valid msgId is required for selected DLQ resend");
+        }
+        if (StringUtils.hasText(targetTopic)) {
+            validateResendTargetTopic(instanceId, targetTopic);
         }
 
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + groupName;
@@ -545,6 +553,42 @@ public class RocketMQDLQProvider implements DLQProvider {
             log.warn("Failed to resend dead letter msgId={} to topic={}: {}",
                     deadLetter.getMsgId(), destination, e.getMessage());
             return false;
+        }
+    }
+
+    /**
+     * An explicit resend target is a powerful override: without validation it can feed dead
+     * letters back into their own DLQ or retry topic, poison broker system topics, or silently
+     * create new topics on clusters with autoCreateTopicEnable. Restrict it to valid, existing,
+     * non-system topics on the selected instance.
+     */
+    private void validateResendTargetTopic(String instanceId, String targetTopic) {
+        TopicValidator.ValidateResult validity = TopicValidator.validateTopic(targetTopic);
+        if (!validity.isValid()) {
+            throw new BusinessException(400, "targetTopic is not a valid RocketMQ topic name: "
+                    + targetTopic);
+        }
+        if (SystemTopicFilter.isSystem(targetTopic)) {
+            throw new BusinessException(400,
+                    "targetTopic must not be a RocketMQ system, retry or DLQ topic: " + targetTopic);
+        }
+        boolean exists;
+        try {
+            exists = Boolean.TRUE.equals(runtimeAdminClientResolver.execute(instanceId, admin -> {
+                TopicList topics = admin.fetchAllTopicList();
+                return topics != null && topics.getTopicList() != null
+                        && topics.getTopicList().contains(targetTopic);
+            }));
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(502, "Failed to verify targetTopic on the selected instance: "
+                    + e.getMessage());
+        }
+        if (!exists) {
+            throw new BusinessException(400,
+                    "targetTopic does not exist on the selected instance; create the topic before resending: "
+                            + targetTopic);
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -237,9 +237,86 @@ class RocketMQDLQProviderTest {
     }
 
     @Test
+    void resendMessagesRejectsRetryAndDlqTopicsAsTarget() throws Exception {
+        assertThatThrownBy(() -> provider.resendMessages(
+                "instance-a", "group-a", 100L, 200L, "%DLQ%group-a"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("must not be a RocketMQ system, retry or DLQ topic")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+
+        verify(runtimeAdminClientResolver, never()).executeProducer(anyString(), any());
+        verify(adminExt, never()).fetchAllTopicList();
+    }
+
+    @Test
+    void resendMessagesRejectsSystemTopicsAsTarget() {
+        assertThatThrownBy(() -> provider.resendMessages(
+                "instance-a", "group-a", 100L, 200L, "RMQ_SYS_TRACE_TOPIC"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("must not be a RocketMQ system, retry or DLQ topic");
+
+        verify(runtimeAdminClientResolver, never()).executeProducer(anyString(), any());
+    }
+
+    @Test
+    void resendMessagesRejectsInvalidTargetTopicName() throws Exception {
+        assertThatThrownBy(() -> provider.resendMessages(
+                "instance-a", "group-a", 100L, 200L, "not a valid topic"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("not a valid RocketMQ topic name");
+
+        verify(runtimeAdminClientResolver, never()).executeProducer(anyString(), any());
+        verify(adminExt, never()).fetchAllTopicList();
+    }
+
+    @Test
+    void resendMessagesRejectsTargetTopicMissingFromInstance() throws Exception {
+        TopicList otherTopics = new TopicList();
+        otherTopics.setTopicList(Set.of("unrelated-topic"));
+        when(adminExt.fetchAllTopicList()).thenReturn(otherTopics);
+
+        assertThatThrownBy(() -> provider.resendMessages(
+                "instance-a", "group-a", 100L, 200L, "target-topic"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("targetTopic does not exist on the selected instance");
+
+        verify(runtimeAdminClientResolver, never()).executeProducer(anyString(), any());
+        verify(pullConsumer, never()).pull(any(MessageQueue.class), anyString(), anyLong(), anyInt());
+    }
+
+    @Test
+    void resendSelectedMessagesRejectsSystemTopicAsTarget() throws Exception {
+        assertThatThrownBy(() -> provider.resendMessages(
+                "instance-a", "group-a", List.of("msg-1"), "%DLQ%group-a"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("must not be a RocketMQ system, retry or DLQ topic");
+
+        verify(runtimeAdminClientResolver, never()).executeProducer(anyString(), any());
+        verify(adminExt, never()).fetchAllTopicList();
+        verify(pullConsumer, never()).pull(any(MessageQueue.class), anyString(), anyLong(), anyInt());
+    }
+
+    @Test
+    void resendMessagesFailsGracefullyWhenTopicListCannotBeRead() throws Exception {
+        when(adminExt.fetchAllTopicList()).thenThrow(new IllegalStateException("nameserver unreachable"));
+
+        assertThatThrownBy(() -> provider.resendMessages(
+                "instance-a", "group-a", 100L, 200L, "target-topic"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Failed to verify targetTopic on the selected instance")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+
+        verify(runtimeAdminClientResolver, never()).executeProducer(anyString(), any());
+        verify(pullConsumer, never()).pull(any(MessageQueue.class), anyString(), anyLong(), anyInt());
+    }
+
+    @Test
     void resendMessagesShouldNormalizeGroupNameBeforeBuildingDlqTopicAndAuditing() throws Exception {
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
         when(pullConsumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(null);
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of("target-topic"));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
         provider.resendMessages("instance-a", " group-a ", 100L, 200L, "target-topic");
 
         verify(runtimeAdminClientResolver).executePullConsumer(eq("instance-a"), any());
@@ -253,6 +330,9 @@ class RocketMQDLQProviderTest {
     void resendMessagesDoesNotPullWhenDlqQueueSetIsNull() throws Exception {
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
         when(pullConsumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(null);
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of("target-topic"));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
         provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic");
 
         verify(runtimeAdminClientResolver).executePullConsumer(eq("instance-a"), any());
@@ -285,6 +365,9 @@ class RocketMQDLQProviderTest {
         when(pullConsumer.searchOffset(queue, 200L)).thenReturn(0L);
         when(pullConsumer.pull(queue, "*", 0L, 32)).thenReturn(pullResult);
         when(dlqProducer.send(any(Message.class))).thenReturn(sendResult);
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of("target-topic"));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
         provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic");
 
         verify(runtimeAdminClientResolver).executePullConsumer(eq("instance-a"), any());
@@ -296,6 +379,9 @@ class RocketMQDLQProviderTest {
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
         when(pullConsumer.fetchSubscribeMessageQueues(dlqTopic))
                 .thenThrow(new IllegalStateException("broker unavailable"));
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of("target-topic"));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
         assertThatThrownBy(() -> provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Failed to scan DLQ topic " + dlqTopic)
@@ -322,6 +408,9 @@ class RocketMQDLQProviderTest {
                 .thenThrow(new IllegalStateException("broker unavailable"));
         when(pullConsumer.searchOffset(eq(emptyQueue), anyLong())).thenReturn(0L);
         when(pullConsumer.pull(eq(emptyQueue), eq("*"), eq(0L), eq(32))).thenReturn(emptyResult);
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of("target-topic"));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
         assertThat(provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic"))
                 .extracting("matched", "resent", "failed", "outcome", "scanIncomplete", "failedQueueCount")
                 .containsExactly(0, 0, 0, "PARTIAL", true, 1);
@@ -345,6 +434,9 @@ class RocketMQDLQProviderTest {
         when(pullConsumer.fetchSubscribeMessageQueues(dlqTopic)).thenReturn(Set.of(queue));
         when(pullConsumer.searchOffset(eq(queue), anyLong())).thenReturn(10L);
         when(pullConsumer.pull(eq(queue), eq("*"), eq(10L), eq(32))).thenReturn(stalledResult);
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of("target-topic"));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
         provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic");
 
         verify(pullConsumer, times(1)).pull(queue, "*", 10L, 32);
@@ -373,6 +465,9 @@ class RocketMQDLQProviderTest {
         when(pullConsumer.pull(queue, "*", 20L, 32)).thenReturn(foundAfterCorrection);
         when(pullConsumer.pull(queue, "*", 40L, 32)).thenReturn(endOfQueue);
         when(dlqProducer.send(any(Message.class))).thenReturn(sendResult);
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of("orders"));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
         assertThat(provider.resendMessages("instance-a", "group-a", 100L, 200L, "orders"))
                 .extracting("matched", "resent", "failed", "outcome")
                 .containsExactly(1, 1, 0, "SUCCESS");
@@ -409,6 +504,9 @@ class RocketMQDLQProviderTest {
         when(pullConsumer.searchOffset(queue, 200L)).thenReturn(0L);
         when(pullConsumer.pull(queue, "*", 0L, 32)).thenReturn(pullResult);
         when(dlqProducer.send(any(Message.class))).thenReturn(sendResult);
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of("target-topic"));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
         assertThat(provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic"))
                 .extracting("matched", "resent", "failed", "outcome")
                 .containsExactly(1, 0, 1, "FAILED");
@@ -446,6 +544,9 @@ class RocketMQDLQProviderTest {
         when(pullConsumer.searchOffset(queue, 200L)).thenReturn(0L);
         when(pullConsumer.pull(queue, "*", 0L, 32)).thenReturn(pullResult);
         when(dlqProducer.send(any(Message.class))).thenReturn(sendResult);
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of("target-topic"));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
         assertThat(provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic"))
                 .extracting("matched", "resent", "failed", "outcome")
                 .containsExactly(1, 1, 0, "SUCCESS");
@@ -474,6 +575,9 @@ class RocketMQDLQProviderTest {
 
         when(adminExt.viewMessage(dlqTopic, "old-msg")).thenReturn(oldDeadLetter);
         when(dlqProducer.send(any(Message.class))).thenReturn(sendResult);
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of("target-topic"));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
 
         assertThat(provider.resendMessages(
                 "instance-a", "group-a", List.of("old-msg"), "target-topic"))
@@ -498,6 +602,9 @@ class RocketMQDLQProviderTest {
                 .thenThrow(new IllegalStateException("message not found"));
         when(adminExt.viewMessage(dlqTopic, "found-msg")).thenReturn(found);
         when(dlqProducer.send(any(Message.class))).thenReturn(sendResult);
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of("target-topic"));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
 
         assertThat(provider.resendMessages(
                 "instance-a", "group-a", List.of("missing-msg", "found-msg"), "target-topic"))
@@ -531,6 +638,9 @@ class RocketMQDLQProviderTest {
         when(pullConsumer.searchOffset(queue, 200L)).thenReturn(5001L);
         when(pullConsumer.pull(queue, "*", 0L, 32)).thenReturn(pullResult);
         when(dlqProducer.send(any(Message.class))).thenReturn(sendResult);
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of("target-topic"));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
         assertThat(provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic"))
                 .extracting("matched", "resent", "failed", "outcome", "scanIncomplete", "failedQueueCount")
                 .containsExactly(5000, 5000, 0, "PARTIAL", true, 0);


### PR DESCRIPTION
## What is the purpose of the change

Fixes #2834.

`POST /api/dlq/resend` and `/api/dlq/resend-selected` accept a user-controlled `targetTopic` that `RocketMQDLQProvider.resolveTargetTopic` returns verbatim and `resendOne` passes to `producer.send()`. A `targetTopic` of `%DLQ%<sameGroup>` feeds dead letters back into the DLQ being drained (unbounded growth on repetition), system topics such as `RMQ_SYS_TRACE_TOPIC` or `SCHEDULE_TOPIC_XXXX` get poisoned, and on clusters with `autoCreateTopicEnable=true` any non-existent name silently creates a new topic outside the audited topic-creation flow.

## Brief changelog

- Add `validateResendTargetTopic`, called once per resend request before scanning/dispatching when an explicit `targetTopic` is present:
  - `TopicValidator.validateTopic` rejects invalid topic names;
  - `SystemTopicFilter.isSystem` rejects RocketMQ system, `%RETRY%` and `%DLQ%` topics;
  - the target must exist in the instance's `fetchAllTopicList` so resend cannot act as an implicit topic-creation primitive.
- Legitimate cross-topic resend to an existing business topic is unchanged.
- Tests: six new red/green-verified cases — retry/DLQ target, system topic and invalid name rejected before any RPC; missing target rejected; the selected-resend entry point (`resendSelectedMessages`) enforces the same validation; a topology RPC failure while verifying the target is graded to 502 instead of leaking a raw remoting exception. Existing resend tests stub the topic list for their valid targets.

## Verifying this change

- `mvn -f server/pom.xml -Dtest=RocketMQDLQProviderTest test` — 26 tests pass.
- Red/green: with the production change stashed, the four new validation tests all fail (the forged targets reach the send path); with the fix they pass.
- Full `mvn -B test` run in progress on this branch (link to follow in a comment).

