### PR TITLE
fix: ACL 并发创建重复 accessKey 返回 500 而非 409

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.studio.persistence.entity.RmqAclRule;
 import org.apache.rocketmq.studio.persistence.entity.RmqAclUser;
 import org.apache.rocketmq.studio.persistence.mapper.RmqAclRuleMapper;
 import org.apache.rocketmq.studio.persistence.mapper.RmqAclUserMapper;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -237,7 +238,15 @@ public class MybatisPlusAclRepository implements AclRepository {
                         .set("white_remote_address", null));
             }
         } else {
-            userMapper.insert(entity);
+            try {
+                userMapper.insert(entity);
+            } catch (DuplicateKeyException exception) {
+                // A concurrent create of the same accessKey can win the check-then-insert
+                // race and hit the unique key instead; surface it as a conflict like the
+                // other duplicate-key paths (e.g. CloudCredentialService).
+                throw new BusinessException(409,
+                        "Plain access account already exists for accessKey: " + config.getAccessKey());
+            }
         }
 
         upsertPlainAccessRules(config);

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
@@ -285,6 +285,26 @@ class MybatisPlusAclRepositoryTest {
     }
 
     @Test
+    void createShouldTranslateConcurrentDuplicateAccessKeyToConflict() {
+        when(userMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of());
+        when(userMapper.insert(any(RmqAclUser.class)))
+                .thenThrow(new org.springframework.dao.DuplicateKeyException("duplicate accessKey"));
+
+        PlainAccessConfigVO config = PlainAccessConfigVO.builder()
+                .accessKey("svc-x")
+                .secretKey("secret-x")
+                .build();
+
+        assertThatThrownBy(() -> repository.createAndUpdatePlainAccessConfig(config))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Plain access account already exists for accessKey: svc-x")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(409));
+
+        // The conflict aborts before any permission rules are touched.
+        verifyNoInteractions(ruleMapper);
+    }
+
+    @Test
     void updateWithBlankSecretShouldKeepStoredSecret() {
         RmqAclUser existing = userEntity(1L, "svc-x",
                 CredentialUtils.encodeBase64("kept-secret-value"));


### PR DESCRIPTION

## What is the purpose of the change

MybatisPlusAclRepository 的创建逻辑是典型的 check-then-act:先 selectList 查 accessKey 是否存在,再 insert。数据库有 uk_access_key 唯一索引兜底。
•问题:并发创建相同 accessKey 时,后插入者抛 DuplicateKeyException,但该 repository 没有捕获(对照 AuthService、CloudCredentialService、NameserverRegistryService 均有 catch (DuplicateKeyExce
ption) 翻译成 409),GlobalExceptionHandler 也无专门处理器,会落到通用 Exception 处理器 → HTTP 500 "Internal Server Error",而不是干净的 409。

•触发条件:两个请求同时创建同一 accessKey(或重试/双击提交),竞态窗口真实存在。

•修复建议:参照 CloudCredentialService.createShouldTranslateConcurrentDuplicateKeyToConflict 的既有模式,在创建分支捕获 DuplicateKeyException 转为 409。]

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
