### PR TITLE
fix(ops): format audit timestamps and preserve remote deploy/.env on redeploy

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -53,8 +53,10 @@ check_prereqs() {
 
 package_source() {
   info "📦 本地打包源码..."
+  # deploy/.env 是环境专属配置（如 STUDIO_METRICS_PROMETHEUS_BASE_URL），不随源码覆盖远端
   tar czf "$SRC_TAR" -C "$PROJECT_DIR" \
     --exclude='web/node_modules' --exclude='web/dist' --exclude='server/target' \
+    --exclude='deploy/.env' \
     server web deploy
   log "打包完成 ($(du -h "$SRC_TAR" | cut -f1))"
 }
@@ -63,7 +65,10 @@ upload_source() {
   info "📤 传输源码到 $REMOTE:$REMOTE_PATH ..."
   run_remote "mkdir -p $REMOTE_PATH"
   scp -q "$SRC_TAR" "$REMOTE:$REMOTE_PATH/"
-  run_remote "cd $REMOTE_PATH && rm -rf server web deploy && tar xzf $(basename "$SRC_TAR") && rm $(basename "$SRC_TAR")"
+  # 保留远端环境专属配置（tar 已排除，这里防 rm -rf 误删）
+  run_remote "cd $REMOTE_PATH && [ -f deploy/.env ] && cp deploy/.env /tmp/deploy-env-backup; \
+    rm -rf server web deploy && tar xzf $(basename "$SRC_TAR") && rm $(basename "$SRC_TAR"); \
+    [ -f /tmp/deploy-env-backup ] && mv /tmp/deploy-env-backup deploy/.env || true"
   run_remote 'docker network inspect rocketmq_net >/dev/null 2>&1 || docker network create rocketmq_net'
   log "源码就位，rocketmq_net 网络就绪"
 }

--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -46,6 +46,7 @@ import {
   listAuditRecords,
 } from '../../services/opsService';
 import { downloadBlob } from '../../utils/download';
+import { formatDateTime } from '../../utils/format';
 import { tableScrollX } from '../../utils/table';
 
 const emptyFilterOptions: AuditFilterOptions = {
@@ -233,17 +234,20 @@ const AuditPage: React.FC = () => {
       width: 180,
       sorter: (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
       defaultSortOrder: 'descend',
+      render: (timestamp: string) => formatDateTime(timestamp),
     },
     {
       title: t('audit.operator'),
       dataIndex: 'operator',
       width: 130,
+      align: 'center',
       sorter: (a, b) => (a.operator ?? '').localeCompare(b.operator ?? ''),
     },
     {
       title: t('audit.opType'),
       dataIndex: 'operationType',
       width: 190,
+      align: 'center',
       sorter: (a, b) => (a.operationType ?? '').localeCompare(b.operationType ?? ''),
       render: (type: string) => <Tag>{formatFilterLabel(type)}</Tag>,
     },
@@ -252,6 +256,7 @@ const AuditPage: React.FC = () => {
       dataIndex: 'resourceType',
       width: 120,
       ellipsis: true,
+      align: 'right',
       sorter: (a, b) => (a.resourceType ?? '').localeCompare(b.resourceType ?? ''),
     },
     {
@@ -266,6 +271,7 @@ const AuditPage: React.FC = () => {
       dataIndex: 'target',
       width: 200,
       ellipsis: true,
+      align: 'center',
     },
     {
       title: t('audit.detail'),
@@ -276,6 +282,7 @@ const AuditPage: React.FC = () => {
       title: t('audit.result'),
       dataIndex: 'result',
       width: 80,
+      align: 'center',
       sorter: (a, b) => (a.result ?? '').localeCompare(b.result ?? ''),
       render: (result: string) => (
         <Tag color={resultColor(result)}>{formatFilterLabel(result)}</Tag>


### PR DESCRIPTION
## Problem

- The audit log page rendered the raw `LocalDateTime` value (`2026-08-27T17:41:57`, ISO format with `T`) in the time column.
- `deploy/deploy.sh` packaged the local `deploy/.env` and removed the remote `deploy/` directory before upload, overwriting environment-specific configuration on the target host (e.g. the Prometheus base URL was lost this way, causing metrics 503).

## Changes

- Audit page time column now uses the shared `formatDateTime` util (`YYYY-MM-DD HH:mm:ss`), consistent with alert/client/instance pages. Column alignment adjusted per design (operator/type/object/result centered, resource type right-aligned).
- `deploy.sh` excludes `deploy/.env` from the source package and backs up / restores the remote `deploy/.env` around upload.

## Tests

- `AuditPage.test.tsx` + `format.test.ts` (14) green; `npm run build` passes; verified on a live deployment.
