### PR TITLE
fix(web): clamp out-of-range pages to the last valid page after deletes

### DIFF
--- a/web/src/pages/instance/__tests__/AclPage.test.tsx
+++ b/web/src/pages/instance/__tests__/AclPage.test.tsx
@@ -158,6 +158,49 @@ describe('ACL page', () => {
     expect(within(accessKeyCell).queryByRole('button')).not.toBeInTheDocument();
   });
 
+  it('clamps rules back to a valid page when the current page becomes empty', async () => {
+    const user = userEvent.setup();
+    const ruleItems = (count: number) =>
+      Array.from({ length: count }, (_, index) => ({
+        id: index + 1,
+        principal: 'remote-user',
+        resource: `acl-topic-${String(index + 1).padStart(2, '0')}`,
+        resourceType: 'Topic',
+        resourcePattern: 'LITERAL',
+        actions: ['PUB'],
+        decision: 'ALLOW',
+        scope: 'cluster',
+        aclVersion: 2,
+        gmtCreate: '2026-07-23T00:00:00Z',
+      }));
+    let call = 0;
+    vi.mocked(aclService.listAclRules).mockImplementation(async (params) => {
+      call += 1;
+      if (params?.page === 2) {
+        // Page 2 went out of range (its rules were deleted server-side).
+        return { items: [], total: 15, page: 2, size: 20 };
+      }
+      // First load reports 45 rules (3 pages); the clamp re-fetch reports the shrunk 15.
+      return call === 1
+        ? { items: ruleItems(20), total: 45, page: 1, size: 20 }
+        : { items: ruleItems(15), total: 15, page: 1, size: 20 };
+    });
+    renderWithProviders(<AclPage />);
+
+    expect(await screen.findByText('acl-topic-01')).toBeInTheDocument();
+
+    const secondPage = document.querySelector('.ant-pagination-item-2');
+    expect(secondPage).not.toBeNull();
+    await user.click(secondPage as HTMLElement);
+
+    // The empty out-of-range page is corrected: the rules reload page 1.
+    await waitFor(() =>
+      expect(aclService.listAclRules).toHaveBeenLastCalledWith(
+        expect.objectContaining({ page: 1, pageSize: 20 }),
+      ),
+    );
+  });
+
   it('closes an ACL rule dialog when switching to another instance', async () => {
     const user = userEvent.setup();
     vi.mocked(instanceService.listInstances).mockResolvedValue([

--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -91,6 +91,12 @@ const group: ConsumerGroup = {
   instances: [],
 };
 
+const buildGroups = (count: number): ConsumerGroup[] =>
+  Array.from({ length: count }, (_, index) => ({
+    ...group,
+    name: `remote-cg-${String(index + 1).padStart(2, '0')}`,
+  }));
+
 const groupPage = (
   items: ConsumerGroup[],
   overrides: Partial<{ total: number; page: number; size: number }> = {},
@@ -292,6 +298,36 @@ describe('Consumer page', () => {
     cleanup();
     Modal.destroyAll();
     message.destroy();
+  });
+
+  it('clamps back to a valid page when the current page becomes empty after a delete', async () => {
+    const user = userEvent.setup();
+    let call = 0;
+    vi.mocked(consumerService.listConsumerGroupPage).mockImplementation(async (params) => {
+      call += 1;
+      if (params?.page === 2) {
+        // Page 2 went out of range (its rows were deleted server-side).
+        return groupPage([], { total: 15, page: 2 });
+      }
+      // First load reports 45 rows (3 pages); the clamp re-fetch reports the shrunk 15.
+      return call === 1
+        ? groupPage(buildGroups(20), { total: 45, size: 20 })
+        : groupPage(buildGroups(15), { total: 15, size: 20 });
+    });
+    renderWithProviders(<ConsumerPage />);
+
+    expect(await screen.findByText('remote-cg-01')).toBeInTheDocument();
+
+    const secondPage = document.querySelector('.ant-pagination-item-2');
+    expect(secondPage).not.toBeNull();
+    await user.click(secondPage as HTMLElement);
+
+    // The empty out-of-range page is corrected: the list reloads page 1.
+    await waitFor(() =>
+      expect(consumerService.listConsumerGroupPage).toHaveBeenLastCalledWith(
+        expect.objectContaining({ page: 1, pageSize: 20 }),
+      ),
+    );
   });
 
   it('submits the canonical global delivery order type', async () => {

--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -324,6 +324,63 @@ describe('TopicPage', () => {
     expect(within(getTableBody()).queryByText('topic-01')).not.toBeInTheDocument();
   });
 
+  it('clamps back to a valid page when the current page becomes empty after a delete', async () => {
+    const user = userEvent.setup();
+    instanceServiceMocks.listInstances.mockResolvedValue([
+      {
+        id: 6,
+        name: 'instance-a',
+        type: 'DIRECT',
+        endpoint: '127.0.0.1:9876',
+        remark: '',
+        topicCount: 45,
+        consumerGroupCount: 0,
+        gmtCreate: '2026-01-01T00:00:00Z',
+        gmtModified: '2026-01-01T00:00:00Z',
+      },
+    ]);
+    const requestedPages: number[] = [];
+    topicServiceMocks.listTopicsPage.mockImplementation(async (params) => {
+      requestedPages.push(params?.page ?? 0);
+      if (params?.page === 2) {
+        // Page 2 went out of range (its rows were deleted server-side):
+        // report no items and the shrunk total.
+        return { items: [], total: 15, page: 2, size: 20 };
+      }
+      // The first load reports 45 rows (3 pages); the clamp re-fetch
+      // reports the shrunk 15 rows that fit on a single page.
+      return requestedPages.length === 1
+        ? {
+            items: buildTopics(20).map((t) => ({ ...t, instanceId: 'instance-a' })),
+            total: 45,
+            page: 1,
+            size: 20,
+          }
+        : {
+            items: buildTopics(15).map((t) => ({ ...t, instanceId: 'instance-a' })),
+            total: 15,
+            page: 1,
+            size: 20,
+          };
+    });
+    renderWithProviders('/instance/instance-a/topic');
+
+    expect(await screen.findByText('topic-01')).toBeInTheDocument();
+
+    const secondPage = document.querySelector('.ant-pagination-item-2');
+    expect(secondPage).not.toBeNull();
+    await user.click(secondPage as HTMLElement);
+
+    // The empty out-of-range page is corrected: the table reloads the last valid page.
+    await waitFor(() =>
+      expect(topicServiceMocks.listTopicsPage).toHaveBeenLastCalledWith(
+        expect.objectContaining({ page: 1, pageSize: 20 }),
+      ),
+    );
+    expect(requestedPages).toEqual([1, 2, 1]);
+    expect(within(getTableBody()).getByText('topic-15')).toBeInTheDocument();
+  });
+
   it('keeps the selected instance when rebuilding a topic without a broker route', async () => {
     const user = userEvent.setup();
     const topic = { ...buildTopics(1)[0], instanceId: 'instance-a' };

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -197,6 +197,9 @@ const AclPageContent = ({
         if (!mounted) return;
         setRules(nextRules.items.map(normalizeRule));
         setRuleTotal(nextRules.total);
+        if (nextRules.items.length === 0 && nextRules.total > 0 && rulePage > 1) {
+          setRulePage(Math.max(1, Math.ceil(nextRules.total / rulePageSize)));
+        }
       })
       .catch(() => {
         if (mounted) message.error(t('common.fetchDataFailed'));
@@ -215,6 +218,9 @@ const AclPageContent = ({
         if (mounted) {
           setUsers(result.items.map(normalizeUser));
           setUserTotal(result.total);
+          if (result.items.length === 0 && result.total > 0 && userPage > 1) {
+            setUserPage(Math.max(1, Math.ceil(result.total / userPageSize)));
+          }
         }
       })
       .catch(() => {

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -331,6 +331,9 @@ const ConsumerPageContent = ({
           if (requestId === groupRequestIdRef.current) {
             setGroups(result.items);
             setTotalGroups(result.total);
+            if (result.items.length === 0 && result.total > 0 && page > 1) {
+              setPage(Math.max(1, Math.ceil(result.total / pageSize)));
+            }
           }
         })
         .catch(() => {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -382,6 +382,9 @@ const TopicPage = () => {
           if (requestId === topicRequestIdRef.current) {
             setTopics(result.items);
             setTotalTopics(result.total);
+            if (result.items.length === 0 && result.total > 0 && tablePage > 1) {
+              setTablePage(Math.max(1, Math.ceil(result.total / tablePageSize)));
+            }
           }
         })
         .catch(() => {


### PR DESCRIPTION
## What is the purpose of the change

consumer/topic/acl pages did not recover when the current page drained
past the shrunk total (e.g. deleting the last row on the final page
left an empty table on an invalid page). Apply the same clamp as
#2592: when the list comes back empty but total > 0, jump to
ceil(total / pageSize) and reload.

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
