### PR TITLE
fix(message): render unavailable message timestamps as placeholders

### DIFF
--- a/web/src/pages/instance/__tests__/MessageTimeFormat.test.ts
+++ b/web/src/pages/instance/__tests__/MessageTimeFormat.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatTimeMs, storeTimeSortValue } from '../message';
+
+describe('formatTimeMs', () => {
+  it('renders a valid millisecond timestamp with the full precision suffix', () => {
+    expect(formatTimeMs('2026-08-31T12:00:00.250Z')).toMatch(
+      /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$/,
+    );
+  });
+
+  it('renders numeric epoch milliseconds', () => {
+    expect(formatTimeMs(1756627200250)).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$/);
+  });
+
+  it('renders unavailable values as the placeholder instead of NaN fields', () => {
+    expect(formatTimeMs('')).toBe('-');
+    expect(formatTimeMs(0)).toBe('-');
+    expect(formatTimeMs('not-a-timestamp')).toBe('-');
+  });
+});
+
+describe('storeTimeSortValue', () => {
+  it('orders valid timestamps numerically', () => {
+    const earlier = storeTimeSortValue('2026-08-31T11:00:00.000Z');
+    const later = storeTimeSortValue('2026-08-31T12:00:00.000Z');
+    expect(later - earlier).toBeGreaterThan(0);
+  });
+
+  it('passes numeric values through and pins non-finite numbers', () => {
+    expect(storeTimeSortValue(1756627200250)).toBe(1756627200250);
+    expect(storeTimeSortValue(Number.NaN)).toBe(0);
+  });
+
+  it('pins invalid and empty strings to the epoch so they do not break sorting', () => {
+    expect(storeTimeSortValue('')).toBe(0);
+    expect(storeTimeSortValue('garbage')).toBe(0);
+    expect(
+      storeTimeSortValue('garbage') - storeTimeSortValue('2026-08-31T12:00:00.000Z'),
+    ).toBeLessThan(0);
+  });
+});

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -121,11 +121,18 @@ const formatSize = (bytes: number): string => {
   return `${bytes} B`;
 };
 
-const formatTimeMs = (value: number | string): string => {
+export const formatTimeMs = (value: number | string): string => {
   if (!value) return '-';
   const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '-';
   const pad = (n: number, len = 2) => String(n).padStart(len, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`;
+};
+
+export const storeTimeSortValue = (value: number | string): number => {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
 };
 
 const formatBody = (body: string): string => {
@@ -583,7 +590,7 @@ const MessagePageContent = ({
       dataIndex: 'storeTime',
       key: 'storeTime',
       width: 185,
-      sorter: (a, b) => new Date(a.storeTime).valueOf() - new Date(b.storeTime).valueOf(),
+      sorter: (a, b) => storeTimeSortValue(a.storeTime) - storeTimeSortValue(b.storeTime),
       render: (time: string) => (
         <span style={{ fontFamily: 'monospace', fontSize: 14, whiteSpace: 'nowrap' }}>
           {formatTimeMs(time)}


### PR DESCRIPTION
## Summary
- guard `formatTimeMs` against unparseable store-time values so the table renders the standard `-` placeholder instead of `NaN-NaN-NaN` fields
- route the store-time column sorter through a `storeTimeSortValue` helper that pins non-finite values to the epoch, mirroring `toStoreTimestamp` in `api/message.ts`
- export both helpers and add regression coverage

## Why
The message record `storeTime` is typed as `number | string`, and provider responses can carry empty or malformed timestamps. `new Date()` on such values yields an invalid date, so the cell rendered `NaN-NaN-NaN NaN:NaN:NaN.NaN`, and the column sorter compared `NaN` against real timestamps, producing unstable ordering.

## Testing
- `cd web && ./node_modules/.bin/vitest run src/pages/instance/__tests__/MessageTimeFormat.test.ts` — 6 passed
- `cd web && ./node_modules/.bin/tsc --noEmit` — clean
- `cd web && ./node_modules/.bin/eslint src/pages/instance/message.tsx src/pages/instance/__tests__/MessageTimeFormat.test.ts` — 0 errors
