### PR TITLE
fix(studio): render invalid user timestamps as placeholders

### DIFF
--- a/web/src/pages/studio/UserManagement.tsx
+++ b/web/src/pages/studio/UserManagement.tsx
@@ -57,7 +57,11 @@ interface PasswordFormValues {
   newPassword: string;
 }
 
-const dateTime = (value?: string) => (value ? new Date(value).toLocaleString() : '-');
+export const dateTime = (value?: string): string => {
+  if (!value) return '-';
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? '-' : parsed.toLocaleString();
+};
 const PAGE_SIZE_OPTIONS = [20, 50, 100];
 
 type RoleFilter = 'admin' | 'reader';

--- a/web/src/pages/studio/__tests__/UserManagement.test.tsx
+++ b/web/src/pages/studio/__tests__/UserManagement.test.tsx
@@ -27,7 +27,7 @@ import {
   type StudioUser,
 } from '../../../api/studioUsers';
 import { downloadCsv } from '../../../utils/download';
-import UserManagementPage from '../UserManagement';
+import UserManagementPage, { dateTime } from '../UserManagement';
 
 type MockAuthState = { admin: boolean; userId: number; logout: () => void };
 vi.mock('../../../api/studioUsers', () => ({
@@ -67,6 +67,21 @@ const studioUserPage = {
   page: 1,
   size: 20,
 };
+
+describe('dateTime', () => {
+  it('renders a placeholder for missing values', () => {
+    expect(dateTime(undefined)).toBe('-');
+    expect(dateTime('')).toBe('-');
+  });
+
+  it('renders a placeholder for unparseable values', () => {
+    expect(dateTime('not-a-timestamp')).toBe('-');
+  });
+
+  it('renders parseable values localized', () => {
+    expect(dateTime('2026-08-22T08:00:00')).toBe(new Date('2026-08-22T08:00:00').toLocaleString());
+  });
+});
 
 const renderPage = () =>
   render(


### PR DESCRIPTION
## Summary
- Guard `dateTime()` in the studio user management page: unparseable values now render as the standard `'-'` placeholder instead of `Invalid Date`
- Export the helper for unit testing (same precedent as `formatTime` in `LiteTopic.tsx`)
- Add regression tests covering missing, unparseable, and parseable values

## Why
Backend timestamps (`passwordChangedAt`, `gmtCreate`, `gmtModified`) can arrive unparseable (e.g. empty-after-trim variants or malformed strings from legacy rows). `new Date(value).toLocaleString()` then rendered the literal text `Invalid Date` in the user table and in the CSV export, leaking a raw locale artifact into the UI.

## Testing
- `./node_modules/.bin/vitest run src/pages/studio/__tests__/UserManagement.test.tsx` → 7 passed
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/pages/studio/UserManagement.tsx src/pages/studio/__tests__/UserManagement.test.tsx` → 0 errors
