### PR TITLE
fix(ops): normalize fixed tokens with a stable case mapping

### DIFF
--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -62,6 +62,7 @@ import {
   updateAlertRule,
 } from '../../services/opsService';
 import { tableScrollX } from '../../utils/table';
+import { toToken } from '../../utils/localeToken';
 import { formatDateTime } from '../../utils/format';
 import { listInstances } from '../../services/instanceService';
 import type { Instance } from '../../api/instance';
@@ -280,7 +281,7 @@ const AlertsPage = ({ domain = 'CLUSTER' }: AlertsPageProps) => {
       const transfer = await exportAlertRulesTransfer(domain);
       downloadBlob(
         new Blob([JSON.stringify(transfer, null, 2)], { type: 'application/json;charset=utf-8' }),
-        `rocketmq-studio-${domain.toLowerCase()}-alert-rules.json`,
+        `rocketmq-studio-${toToken(domain)}-alert-rules.json`,
       );
       message.success(t('alerts.exportSuccess'));
     } catch {

--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -46,6 +46,7 @@ import {
   listAuditRecords,
 } from '../../services/opsService';
 import { downloadBlob } from '../../utils/download';
+import { toToken } from '../../utils/localeToken';
 import { formatDateTime } from '../../utils/format';
 import { tableScrollX } from '../../utils/table';
 
@@ -59,9 +60,9 @@ const emptyFilterOptions: AuditFilterOptions = {
 const formatFilterLabel = (value: string) => value.trim().replace(/_/g, ' ');
 
 const resultColor = (result: string) => {
-  const normalized = result.toUpperCase();
-  if (normalized === 'SUCCESS') return 'green';
-  if (normalized === 'PARTIAL') return 'orange';
+  const normalized = toToken(result);
+  if (normalized === 'success') return 'green';
+  if (normalized === 'partial') return 'orange';
   return 'red';
 };
 

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -56,6 +56,7 @@ import type {
   SystemAlert,
 } from '../../api/ops';
 import { formatUtcDateTime, formatNumber } from '../../utils/format';
+import { toToken } from '../../utils/localeToken';
 import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 
 const { Text } = Typography;
@@ -63,7 +64,7 @@ const { Text } = Typography;
 const ALERT_EXPORT_PAGE_SIZE = 100;
 const ALERT_EXPORT_MAX_PAGES = 10_000;
 
-const normalizeAlertLevel = (level?: string | null) => (level ?? '').toLowerCase();
+const normalizeAlertLevel = (level?: string | null) => toToken(level);
 const formatAlertTransition = (
   transition: SystemAlert['transition'] | undefined,
   firingLabel: string,

--- a/web/src/utils/localeToken.test.ts
+++ b/web/src/utils/localeToken.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { toToken } from './localeToken';
+
+describe('toToken', () => {
+  it('lowercases fixed tokens with the root locale', () => {
+    expect(toToken('CRITICAL')).toBe('critical');
+    expect(toToken('SUCCESS')).toBe('success');
+    expect(toToken('PARTIAL')).toBe('partial');
+    expect(toToken('global')).toBe('global');
+  });
+
+  it('treats null and undefined as the empty token', () => {
+    expect(toToken(null)).toBe('');
+    expect(toToken(undefined)).toBe('');
+    expect(toToken('')).toBe('');
+  });
+
+  it('does not mutate the input contract for mixed-case values', () => {
+    expect(toToken('MixedCase')).toBe('mixedcase');
+  });
+});

--- a/web/src/utils/localeToken.ts
+++ b/web/src/utils/localeToken.ts
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+
+/**
+ * Locale-stable lowercasing for comparison against fixed tokens.
+ *
+ * Plain toLowerCase() applies the host browser's locale rules, so a fixed
+ * token such as "CRITICAL" becomes "cRıTıCAL" under the Turkish locale and
+ * silently fails an equality check against "critical". The 'en' locale maps
+ * ASCII letters identically to the root locale; 'root' itself is rejected by
+ * some V8/ICU builds with "Incorrect locale information provided".
+ */
+export const toToken = (value: string | null | undefined): string =>
+  (value ?? '').toLocaleLowerCase('en');


### PR DESCRIPTION
## Summary
- add `toToken` in `utils/localeToken.ts`, a locale-stable lowercasing helper for comparing against fixed tokens
- use it for the system-alert level normalization, the audit result color mapping, and the alert-rules export file name
- add regression coverage for the helper

## Why
Plain `toLowerCase()`/`toUpperCase()` apply the host browser's locale rules. Under the Turkish locale, fixed tokens containing `I`/`i` break: `CRITICAL` normalizes to `cRıTıCAL`, so the level filter tabs and counts silently stop matching, and `partial`.toUpperCase() yields `PARTİAL`, so the audit result badge falls through to the error color. The export file name had the same latent mismatch for non-ASCII domain values.

## Testing
- `cd web && ./node_modules/.bin/vitest run src/pages/ops/ src/utils/localeToken.test.ts` — 6 files, 45 tests passed
- `cd web && ./node_modules/.bin/tsc --noEmit` — clean
- `cd web && ./node_modules/.bin/eslint src/utils/localeToken.ts src/utils/localeToken.test.ts src/pages/ops/systemAlerts.tsx src/pages/ops/audit.tsx src/pages/ops/alerts.tsx` — 0 errors
