### PR TITLE
fix(ai): bound tool catalog major version parsing

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalog.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalog.java
@@ -147,7 +147,13 @@ public class ToolCatalog {
     }
 
     private static int majorVersion(String version) {
-        return Integer.parseInt(version.substring(0, version.indexOf('.')));
+        String major = version.substring(0, version.indexOf('.'));
+        try {
+            return Integer.parseInt(major);
+        } catch (NumberFormatException error) {
+            throw new IllegalStateException(
+                    "Tool catalog major version is out of range: " + version, error);
+        }
     }
 
     private static String sha256(byte[] bytes) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/ToolCatalogTest.java
@@ -86,6 +86,20 @@ class ToolCatalogTest {
     }
 
     @Test
+    void rejectsMajorVersionThatOverflowsIntegerRange() {
+        Resource oversized = utf8Resource("""
+                version: 99999999999.0.0
+                minimumClientVersion: 99999999999.0.0
+                tools:
+                %s
+                """.formatted(tool("rmq.cluster.list", false)));
+
+        assertThatThrownBy(() -> ToolCatalog.load(oversized, canonicalSchema()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("major version is out of range");
+    }
+
+    @Test
     void rejectsIncompatibleMinimumClientMajorVersion() {
         Resource incompatible = utf8Resource("""
                 version: 2.0.0


### PR DESCRIPTION
## Summary
- Bound `majorVersion` parsing in `ToolCatalog` so an out-of-integer-range catalog
  major version fails fast with an actionable startup error instead of a raw
  `NumberFormatException`.
- Added regression test `rejectsMajorVersionThatOverflowsIntegerRange`.

## Why
The tool catalog schema accepts `^[0-9]+\.[0-9]+\.[0-9]+...` for `version`, where the
major component is an unbounded digit string. A schema-valid catalog such as
`99999999999.0.0` made `Integer.parseInt` overflow at Spring bean initialization,
surfacing as an obscure `NumberFormatException` (wrapped in `BeanCreationException`)
instead of a clear message pointing at the catalog version. The bounded parse now
reports the offending version explicitly.

## Testing
- `cd server && mvn -Dtest=ToolCatalogTest test` — Tests run: 7, Failures: 0, Errors: 0
