### PR TITLE
fix(ops): guard unparseable system alert time filters

### DIFF
--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -22,7 +22,7 @@ import {
   listAlertSilences,
   listSystemAlertsPage,
 } from '../../../services/opsService';
-import SystemAlertsPage from '../systemAlerts';
+import SystemAlertsPage, { isLocalDateTimeValue } from '../systemAlerts';
 
 vi.mock('../../../services/opsService', () => ({
   acknowledgeAlert: vi.fn(),
@@ -485,4 +485,34 @@ describe('SystemAlertsPage', () => {
       );
     });
   });
+
+  it('ignores unparseable time filter values instead of crashing the query', async () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, 'en');
+    renderPage();
+
+    const startFilter = await screen.findByLabelText('Filter by start time');
+    fireEvent.change(startFilter, { target: { value: '2026-08-10T01:00' } });
+    await waitFor(() => {
+      expect(listSystemAlertsPage).toHaveBeenLastCalledWith(
+        expect.objectContaining({ from: expect.any(String) }),
+      );
+    });
+
+    fireEvent.change(startFilter, { target: { value: 'not-a-date' } });
+    await waitFor(() => {
+      expect(listSystemAlertsPage).toHaveBeenLastCalledWith(
+        expect.objectContaining({ from: undefined, to: undefined }),
+      );
+    });
+    expect(screen.getByText('Broker unavailable')).toBeInTheDocument();
+  });
+
+  it('validates local datetime filter values', () => {
+    expect(isLocalDateTimeValue('2026-08-10T01:00')).toBe(true);
+    expect(isLocalDateTimeValue('not-a-date')).toBe(false);
+    expect(isLocalDateTimeValue('')).toBe(false);
+    expect(isLocalDateTimeValue('2026-1-2T03:04')).toBe(false);
+    expect(isLocalDateTimeValue('2026-13-01T10:00')).toBe(false);
+  });
+
 });

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -90,6 +90,9 @@ const parseSilenceLabels = (
   return labels;
 };
 
+export const isLocalDateTimeValue = (value: string): boolean =>
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value) &&
+  !Number.isNaN(new Date(`${value}:00`).getTime());
 const localDateTimeToUtc = (value: string) => new Date(`${value}:00`).toISOString();
 const localDateTimeToUtcDatabaseValue = (value: string) =>
   new Date(`${value}:00`).toISOString().replace('Z', '');
@@ -175,8 +178,14 @@ const SystemAlertsPage = () => {
       instanceId: instanceFilter.trim() || undefined,
       labelKey: labelKey && labelValue ? labelKey : undefined,
       labelValue: labelKey && labelValue ? labelValue : undefined,
-      from: fromFilter ? localDateTimeToUtcDatabaseValue(fromFilter) : undefined,
-      to: toFilter ? localDateTimeToUtcDatabaseValue(toFilter) : undefined,
+      from:
+        fromFilter && isLocalDateTimeValue(fromFilter)
+          ? localDateTimeToUtcDatabaseValue(fromFilter)
+          : undefined,
+      to:
+        toFilter && isLocalDateTimeValue(toFilter)
+          ? localDateTimeToUtcDatabaseValue(toFilter)
+          : undefined,
     };
   };
 


### PR DESCRIPTION
## Summary
- Clamp the page-size contribution of every in-memory `subList` page slice to
  `>= 0` in the shared provider paging defaults and the vendor/DLQ overrides
  (InstanceProvider, MetadataProvider, ApacheInstanceProvider path,
  TencentInstanceProvider, AliyunInstanceProvider, RocketMQMetadataProvider,
  RocketMQDLQProvider).
- Rewrite the two DLQ slice computations from `min(offset + pageSize, size)` to the
  clamp-then-add form, which also removes a `long` overflow when
  `Pagination.pageOffset` caps the offset at `Long.MAX_VALUE`.
- Added regression tests: negative `pageSize` yields an empty page on all three
  `InstanceProvider` default page methods, and the DLQ group listing now survives
  both a negative `pageSize` and a `page` value that overflows `offset + pageSize`.

## Why
Controllers pass `page`/`pageSize` through as raw `@RequestParam int` values
(`TopicController` has no `@Validated`, and `DLQController.listDLQGroups` declares
no bounds). With `pageSize = -1` the slice end was computed as `to < from`, so
`List.subList(from, to)` threw `IndexOutOfBoundsException` — HTTP 500 instead of
an empty page. In the DLQ paths the `offset + pageSize` addition additionally
overflowed `long` for very large page numbers (the offset is intentionally capped
at `Long.MAX_VALUE` by `Pagination.pageOffset`), producing the same 500 even with
a positive, controller-validated `pageSize`.

## Testing
- `cd server && mvn -Dtest=InstanceProviderTest,RocketMQDLQProviderTest test`
  — Tests run: 26, Failures: 0, Errors: 0
- `cd server && mvn -Dtest=RocketMQMetadataProviderTest test`
  — Tests run: 34, Failures: 0, Errors: 0
