### PR TITLE
fix(ai): compare LLM API base schemes with the root locale

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClient.java
@@ -375,7 +375,7 @@ public class OpenAiCompatibleLlmClient {
     private boolean isValidApiBase(String apiBase) {
         try {
             URI uri = new URI(normalizeApiBase(apiBase));
-            String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase();
+            String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
             return ("http".equals(scheme) || "https".equals(scheme)) && StringUtils.hasText(uri.getHost());
         } catch (IllegalArgumentException | URISyntaxException exception) {
             return false;

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/OpenAiCompatibleLlmClientTest.java
@@ -130,6 +130,25 @@ class OpenAiCompatibleLlmClientTest {
     }
 
     @Test
+    void completeShouldAcceptUppercaseSchemeApiBaseRegardlessOfHostLocale() {
+        AtomicReference<String> requestPath = new AtomicReference<>();
+        server.createContext("/v1/chat/completions", exchange -> {
+            requestPath.set(exchange.getRequestURI().getPath());
+            respond(exchange, 200, """
+                    {"choices":[{"message":{"content":"upper scheme ok"}}]}
+                    """, "application/json");
+        });
+        LlmConfigVO config = config("openai", "sk-test");
+        String host = "127.0.0.1:" + server.getAddress().getPort();
+        config.setApiBase("HTTP://" + host + "/v1");
+
+        String result = client.complete(config, "hello", null);
+
+        assertThat(result).isEqualTo("upper scheme ok");
+        assertThat(requestPath.get()).isEqualTo("/v1/chat/completions");
+    }
+
+    @Test
     void streamShouldParseOpenAiCompatibleSseDeltas() {
         AtomicReference<JsonNode> requestBody = new AtomicReference<>();
         server.createContext("/v1/chat/completions", exchange -> {


### PR DESCRIPTION
## Summary
- compare the LLM API base URI scheme with `Locale.ROOT` instead of the host default locale

## Why
`uri.getScheme().toLowerCase()` applies the JVM's default locale. Under a Turkish-locale JVM, a scheme containing `I` (e.g. a user-typed `HTTPS` variant or any future scheme letter) lowercases to the dotless `ı`, so the `http`/`https` equality check silently rejects a valid base URL with "LLM API base URL is invalid". The same class already normalizes provider names with `Locale.ROOT` in `normalize(...)`, so this aligns the scheme check with the established convention.

## Testing
- `mvn -q -f server/pom.xml -Dtest=OpenAiCompatibleLlmClientTest test` — Tests run: 23, Failures: 0, Errors: 0 (includes new `completeShouldAcceptUppercaseSchemeApiBaseRegardlessOfHostLocale`)
