### PR TITLE
fix(provider): bound in-memory page slices for negative page sizes

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
@@ -59,7 +59,7 @@ public interface InstanceProvider {
         int total = topics.size();
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
+        int to = from + (int) Math.min(Math.max(pageSize, 0), total - from);
         return PageResult.of(topics.subList(from, to), total, page, pageSize);
     }
 
@@ -76,7 +76,7 @@ public interface InstanceProvider {
         int total = consumers.size();
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
+        int to = from + (int) Math.min(Math.max(pageSize, 0), total - from);
         return TopicConsumerPageVO.builder()
                 .items(consumers.subList(from, to))
                 .total(total)
@@ -93,7 +93,7 @@ public interface InstanceProvider {
         int total = groups.size();
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
+        int to = from + (int) Math.min(Math.max(pageSize, 0), total - from);
         return PageResult.of(groups.subList(from, to), total, page, pageSize);
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
@@ -221,7 +221,7 @@ public class AliyunInstanceProvider implements InstanceProvider {
         int total = topics.size();
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
+        int to = from + (int) Math.min(Math.max(pageSize, 0), total - from);
         return PageResult.of(topics.subList(from, to), total, page, pageSize);
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/MetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/MetadataProvider.java
@@ -41,7 +41,7 @@ public interface MetadataProvider {
         int total = topics.size();
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
+        int to = from + (int) Math.min(Math.max(pageSize, 0), total - from);
         return PageResult.of(topics.subList(from, to), total, page, pageSize);
     }
 
@@ -62,7 +62,7 @@ public interface MetadataProvider {
         int total = groups.size();
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
+        int to = from + (int) Math.min(Math.max(pageSize, 0), total - from);
         return PageResult.of(groups.subList(from, to), total, page, pageSize);
     }
 
@@ -79,7 +79,7 @@ public interface MetadataProvider {
         int total = consumers.size();
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
+        int to = from + (int) Math.min(Math.max(pageSize, 0), total - from);
         return TopicConsumerPageVO.builder()
                 .items(consumers.subList(from, to))
                 .total(total)

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -118,7 +118,7 @@ public class RocketMQDLQProvider implements DLQProvider {
         dlqTopics.sort(Comparator.naturalOrder());
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, dlqTopics.size());
-        int to = (int) Math.min(offset + pageSize, dlqTopics.size());
+        int to = from + (int) Math.min(Math.max(pageSize, 0), dlqTopics.size() - from);
         List<DLQGroupVO> groups = dlqTopics.subList(from, to).stream()
                 .map(topic -> buildDLQGroup(adminExt,
                         topic.substring(MixAll.DLQ_GROUP_TOPIC_PREFIX.length()), topic))
@@ -318,7 +318,7 @@ public class RocketMQDLQProvider implements DLQProvider {
                 .toList();
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, all.size());
-        int to = (int) Math.min(offset + pageSize, all.size());
+        int to = from + (int) Math.min(Math.max(pageSize, 0), all.size() - from);
         return PageResult.of(all.subList(from, to), all.size(), page, pageSize);
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -477,7 +477,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
             int total = sortedGroups.size();
             long offset = Pagination.pageOffset(page, pageSize);
             int from = (int) Math.min(offset, total);
-            int to = from + (int) Math.min(pageSize, total - from);
+            int to = from + (int) Math.min(Math.max(pageSize, 0), total - from);
             List<TopicConsumerVO> consumers = new ArrayList<>();
             for (String group : sortedGroups.subList(from, to)) {
                 try {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -280,7 +280,7 @@ public class TencentInstanceProvider implements InstanceProvider {
         int total = topics.size();
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
+        int to = from + (int) Math.min(Math.max(pageSize, 0), total - from);
         return PageResult.of(topics.subList(from, to), total, page, pageSize);
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/InstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/InstanceProviderTest.java
@@ -17,8 +17,11 @@
 package org.apache.rocketmq.studio.provider;
 
 import java.util.Arrays;
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerPageVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
+import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,5 +46,49 @@ public class InstanceProviderTest {
         assertThat(result.getTotal()).isEqualTo(2);
         assertThat(result.getPage()).isEqualTo(Integer.MAX_VALUE);
         assertThat(result.getPageSize()).isEqualTo(100);
+    }
+
+    @Test
+    public void listTopicsPageShouldReturnEmptyPageForNegativePageSizeTest() {
+        InstanceProvider provider = mock(InstanceProvider.class);
+        TopicVO topic = new TopicVO();
+        topic.setName("orders");
+        when(provider.listTopics("instance-a", null, null)).thenReturn(Arrays.asList(topic));
+        when(provider.listTopicsPage("instance-a", null, null, 1, -1))
+                .thenCallRealMethod();
+
+        PageResult<TopicVO> result = provider.listTopicsPage("instance-a", null, null, 1, -1);
+
+        assertThat(result.getItems()).isEmpty();
+        assertThat(result.getTotal()).isEqualTo(1);
+    }
+
+    @Test
+    public void getTopicConsumersPageShouldReturnEmptyPageForNegativePageSizeTest() {
+        InstanceProvider provider = mock(InstanceProvider.class);
+        when(provider.getTopicConsumers("instance-a", "orders")).thenReturn(Arrays.asList(
+                TopicConsumerVO.builder().group("group-a").build()));
+        when(provider.getTopicConsumersPage("instance-a", "orders", 1, -1))
+                .thenCallRealMethod();
+
+        TopicConsumerPageVO result = provider.getTopicConsumersPage("instance-a", "orders", 1, -1);
+
+        assertThat(result.getItems()).isEmpty();
+        assertThat(result.getTotal()).isEqualTo(1);
+    }
+
+    @Test
+    public void listConsumerGroupsPageShouldReturnEmptyPageForNegativePageSizeTest() {
+        InstanceProvider provider = mock(InstanceProvider.class);
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName("group-a");
+        when(provider.listConsumerGroups("instance-a", null)).thenReturn(Arrays.asList(group));
+        when(provider.listConsumerGroupsPage("instance-a", null, 1, -1))
+                .thenCallRealMethod();
+
+        PageResult<ConsumerGroupVO> result = provider.listConsumerGroupsPage("instance-a", null, 1, -1);
+
+        assertThat(result.getItems()).isEmpty();
+        assertThat(result.getTotal()).isEqualTo(1);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -176,6 +176,33 @@ class RocketMQDLQProviderTest {
     }
 
     @Test
+    void listDLQGroupsShouldReturnEmptyPageForNegativePageSizeTest() throws Exception {
+        TopicList topicList = new TopicList();
+        topicList.setTopicList(Set.of(MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a"));
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList);
+        lenient().when(adminExt.examineTopicStats(anyString())).thenReturn(new TopicStatsTable());
+
+        PageResult<DLQGroupVO> page = provider.listDLQGroups("instance-a", null, 1, -1);
+
+        assertThat(page.getItems()).isEmpty();
+        assertThat(page.getTotal()).isEqualTo(1);
+    }
+
+    @Test
+    void listDLQGroupsShouldReturnEmptyPageForOversizedPageNumberTest() throws Exception {
+        TopicList topicList = new TopicList();
+        topicList.setTopicList(Set.of(MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a"));
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList);
+        lenient().when(adminExt.examineTopicStats(anyString())).thenReturn(new TopicStatsTable());
+
+        PageResult<DLQGroupVO> page =
+                provider.listDLQGroups("instance-a", null, Integer.MAX_VALUE, 20);
+
+        assertThat(page.getItems()).isEmpty();
+        assertThat(page.getTotal()).isEqualTo(1);
+    }
+
+    @Test
     void listDLQGroupsShouldFilterCaseInsensitivelyTest() throws Exception {
         TopicList topicList = new TopicList();
         topicList.setTopicList(Set.of(


### PR DESCRIPTION
## Summary
- Clamp the page-size contribution of every in-memory `subList` page slice to
  `>= 0` in the shared provider paging defaults and the vendor/DLQ overrides
  (InstanceProvider, MetadataProvider, ApacheInstanceProvider path,
  TencentInstanceProvider, AliyunInstanceProvider, RocketMQMetadataProvider,
  RocketMQDLQProvider).
- Rewrite the two DLQ slice computations from `min(offset + pageSize, size)` to the
  clamp-then-add form, which also removes a `long` overflow when
  `Pagination.pageOffset` caps the offset at `Long.MAX_VALUE`.
- Added regression tests: negative `pageSize` yields an empty page on all three
  `InstanceProvider` default page methods, and the DLQ group listing now survives
  both a negative `pageSize` and a `page` value that overflows `offset + pageSize`.

## Why
Controllers pass `page`/`pageSize` through as raw `@RequestParam int` values
(`TopicController` has no `@Validated`, and `DLQController.listDLQGroups` declares
no bounds). With `pageSize = -1` the slice end was computed as `to < from`, so
`List.subList(from, to)` threw `IndexOutOfBoundsException` — HTTP 500 instead of
an empty page. In the DLQ paths the `offset + pageSize` addition additionally
overflowed `long` for very large page numbers (the offset is intentionally capped
at `Long.MAX_VALUE` by `Pagination.pageOffset`), producing the same 500 even with
a positive, controller-validated `pageSize`.

## Testing
- `cd server && mvn -Dtest=InstanceProviderTest,RocketMQDLQProviderTest test`
  — Tests run: 26, Failures: 0, Errors: 0
- `cd server && mvn -Dtest=RocketMQMetadataProviderTest test`
  — Tests run: 34, Failures: 0, Errors: 0
