### PR TITLE
[ISSUE #2698][ISSUE #2699] fix(server): consolidate boundary correctness

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthCookie.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthCookie.java
@@ -36,6 +36,10 @@ final class AuthCookie {
     }
 
     static String authorization(HttpServletRequest request, AuthProperties properties) {
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (hasBearerToken(authorization)) {
+            return authorization;
+        }
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
@@ -46,7 +50,13 @@ final class AuthCookie {
             }
         }
         // API clients that explicitly requested a bearer token at login authenticate with this header.
-        return request.getHeader(HttpHeaders.AUTHORIZATION);
+        return authorization;
+    }
+
+    private static boolean hasBearerToken(String authorization) {
+        return authorization != null
+                && authorization.regionMatches(true, 0, TOKEN_PREFIX, 0, TOKEN_PREFIX.length())
+                && !authorization.substring(TOKEN_PREFIX.length()).isBlank();
     }
 
     static boolean requestsBearerToken(HttpServletRequest request) {

--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthService.java
@@ -213,6 +213,9 @@ public class AuthService {
     public RmqStudioUser setUserEnabled(Long userId, boolean enabled) {
         requireDatabaseBacked();
         RmqStudioUser user = getUser(userId);
+        if (Boolean.valueOf(enabled).equals(user.getEnabled())) {
+            return user;
+        }
         if (!enabled && Boolean.TRUE.equals(user.getAdmin())) {
             // Lock the enabled administrator rows so concurrent disables serialize. A plain
             // count would let two requests both observe a count of 2 and disable everyone.

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MetricsService.java
@@ -138,13 +138,16 @@ public class MetricsService {
     }
 
     private void validateQueryWindow(MetricQueryDTO query) {
-        long rangeSeconds = query.getEnd() - query.getStart();
-        if (rangeSeconds <= 0) {
+        long start = query.getStart();
+        long end = query.getEnd();
+        if (end <= start) {
             throw badRequest("Metric query end must be later than start");
         }
-        if (rangeSeconds > MAX_RANGE_SECONDS) {
+        if (start <= Long.MAX_VALUE - MAX_RANGE_SECONDS
+                && end > start + MAX_RANGE_SECONDS) {
             throw badRequest("Metric query range must not exceed 31 days");
         }
+        long rangeSeconds = end - start;
         BigDecimal stepMillis = parseStepMillis(query.getStep());
         if (stepMillis.signum() <= 0) {
             throw badRequest("Metric query step must be positive");

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffService.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Stream;
@@ -192,12 +193,26 @@ public class NameServerConfigDiffService {
                         .filter(node -> node != null)
                         .map(NameServerVO::getAddr);
         Stream<String> endpointAddresses = splitEndpoint(cluster.getEndpoint()).stream();
-        return Stream.concat(declared, endpointAddresses)
+        Map<String, String> uniqueAddresses = new LinkedHashMap<>();
+        Stream.concat(declared, endpointAddresses)
                 .filter(address -> address != null && !address.isBlank())
                 .map(String::trim)
-                .distinct()
+                .forEach(address -> uniqueAddresses.putIfAbsent(canonicalAddressKey(address), address));
+        return uniqueAddresses.values().stream()
                 .sorted()
                 .toList();
+    }
+
+    private String canonicalAddressKey(String address) {
+        int separator = address.lastIndexOf(':');
+        if (separator <= 0 || address.indexOf(':') != separator) {
+            return address;
+        }
+        String host = address.substring(0, separator);
+        if (host.indexOf('%') >= 0) {
+            return address;
+        }
+        return host.toLowerCase(Locale.ROOT) + address.substring(separator);
     }
 
     private String connectionEndpoint(ClusterVO cluster, List<String> addresses) {

--- a/server/src/main/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandler.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.studio.ops.ai.LlmGatewayException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -144,5 +145,17 @@ public class GlobalExceptionHandler {
             HttpMediaTypeNotSupportedException ex) {
         log.warn("Unsupported media type: {}", ex.getMessage());
         return Result.error(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value(), ex.getMessage());
+    }
+
+    /**
+     * Requests that cannot accept any available response representation must be
+     * reported as 406, not 500.
+     */
+    @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
+    @ResponseStatus(HttpStatus.NOT_ACCEPTABLE)
+    public Result<?> handleHttpMediaTypeNotAcceptableException(
+            HttpMediaTypeNotAcceptableException ex) {
+        log.warn("No acceptable response media type: {}", ex.getMessage());
+        return Result.error(HttpStatus.NOT_ACCEPTABLE.value(), ex.getMessage());
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQService.java
@@ -56,51 +56,65 @@ public class DLQService {
     public DLQResendResultVO resendMessages(String instanceId, String groupName, Long startTime, Long endTime,
                                              String targetTopic) {
         requireApacheInstance(instanceId);
-        validateResendRequest(groupName, startTime, endTime);
-        log.info("Resending DLQ messages: group={}, targetTopic={}", groupName, targetTopic);
-        return dlqProvider.resendMessages(instanceId, groupName, startTime, endTime, targetTopic);
+        String normalizedGroupName = requireGroupName(groupName);
+        validateTimeRange(startTime, endTime);
+        String normalizedTargetTopic = normalizeOptional(targetTopic);
+        log.info("Resending DLQ messages: group={}, targetTopic={}",
+                normalizedGroupName, normalizedTargetTopic);
+        return dlqProvider.resendMessages(
+                instanceId, normalizedGroupName, startTime, endTime, normalizedTargetTopic);
     }
 
     public DLQExportResultVO exportMessages(String instanceId, String groupName, Long startTime, Long endTime,
                                             Integer maxCount) {
         requireApacheInstance(instanceId);
-        validateResendRequest(groupName, startTime, endTime);
-        log.info("Exporting DLQ messages: group={}, maxCount={}", groupName, maxCount);
-        return dlqProvider.exportMessages(instanceId, groupName, startTime, endTime, maxCount);
+        String normalizedGroupName = requireGroupName(groupName);
+        validateTimeRange(startTime, endTime);
+        log.info("Exporting DLQ messages: group={}, maxCount={}", normalizedGroupName, maxCount);
+        return dlqProvider.exportMessages(instanceId, normalizedGroupName, startTime, endTime, maxCount);
     }
 
     public PageResult<DLQMessageVO> listMessages(String instanceId, String groupName, Long startTime, Long endTime,
                                                  int page, int pageSize) {
         requireApacheInstance(instanceId);
-        validateResendRequest(groupName, startTime, endTime);
-        log.info("Listing DLQ messages: group={}, page={}, pageSize={}", groupName, page, pageSize);
-        return dlqProvider.listMessages(instanceId, groupName, startTime, endTime, page, pageSize);
+        String normalizedGroupName = requireGroupName(groupName);
+        validateTimeRange(startTime, endTime);
+        log.info("Listing DLQ messages: group={}, page={}, pageSize={}", normalizedGroupName, page, pageSize);
+        return dlqProvider.listMessages(
+                instanceId, normalizedGroupName, startTime, endTime, page, pageSize);
     }
 
     public DLQResendResultVO resendSelectedMessages(String instanceId, String groupName, List<String> msgIds,
                                                     String targetTopic) {
         requireApacheInstance(instanceId);
+        String normalizedGroupName = requireGroupName(groupName);
         if (msgIds == null || msgIds.isEmpty()) {
             throw new BusinessException(400, "At least one msgId is required");
         }
         if (msgIds.size() > MAX_SELECTED_MESSAGES) {
             throw new BusinessException(400, "At most 100 msgIds are allowed per resend");
         }
+        List<String> normalizedMsgIds = normalizeMsgIds(msgIds);
+        String normalizedTargetTopic = normalizeOptional(targetTopic);
         log.info("Resending selected DLQ messages: group={}, count={}, targetTopic={}",
-                groupName, msgIds.size(), targetTopic);
-        return dlqProvider.resendMessages(instanceId, groupName, msgIds, targetTopic);
+                normalizedGroupName, normalizedMsgIds.size(), normalizedTargetTopic);
+        return dlqProvider.resendMessages(
+                instanceId, normalizedGroupName, normalizedMsgIds, normalizedTargetTopic);
     }
 
     public DLQExcelExportResultVO exportExcel(String instanceId, String groupName, Long startTime, Long endTime,
                                               List<String> msgIds) {
         requireApacheInstance(instanceId);
-        validateResendRequest(groupName, startTime, endTime);
+        String normalizedGroupName = requireGroupName(groupName);
+        validateTimeRange(startTime, endTime);
         if (msgIds != null && msgIds.size() > MAX_SELECTED_MESSAGES) {
             throw new BusinessException(400, "At most 100 msgIds are allowed per export");
         }
-        log.info("Exporting DLQ messages as Excel: group={}, selected={}", groupName,
-                msgIds == null ? 0 : msgIds.size());
-        return dlqProvider.exportExcel(instanceId, groupName, startTime, endTime, msgIds);
+        List<String> normalizedMsgIds = msgIds == null ? null : normalizeMsgIds(msgIds);
+        log.info("Exporting DLQ messages as Excel: group={}, selected={}", normalizedGroupName,
+                normalizedMsgIds == null ? 0 : normalizedMsgIds.size());
+        return dlqProvider.exportExcel(
+                instanceId, normalizedGroupName, startTime, endTime, normalizedMsgIds);
     }
 
     private void requireApacheInstance(String instanceId) {
@@ -111,10 +125,29 @@ public class DLQService {
         });
     }
 
-    private void validateResendRequest(String groupName, Long startTime, Long endTime) {
+    private String requireGroupName(String groupName) {
         if (!StringUtils.hasText(groupName)) {
             throw new BusinessException(400, "groupName is required");
         }
+        return groupName.trim();
+    }
+
+    private String normalizeOptional(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    private List<String> normalizeMsgIds(List<String> msgIds) {
+        return msgIds.stream()
+                .map(msgId -> {
+                    if (!StringUtils.hasText(msgId)) {
+                        throw new BusinessException(400, "msgId must not be blank");
+                    }
+                    return msgId.trim();
+                })
+                .toList();
+    }
+
+    private void validateTimeRange(Long startTime, Long endTime) {
         if ((startTime == null) != (endTime == null)) {
             throw new BusinessException(400, "startTime and endTime must be provided together");
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogService.java
@@ -83,14 +83,16 @@ public class AliyunCatalogService implements CloudCatalogProvider {
     public List<CloudInstanceOptionVO> listCloudInstances(Long credentialId, String regionId, String search) {
         requireId(credentialId, "credentialId");
         requireNonBlank(regionId, "regionId");
-        List<ListInstancesResponseBody.List> all = fetchAllInstances(credentialId, regionId);
+        String normalizedRegionId = regionId.strip();
+        String normalizedSearch = search == null ? null : search.strip();
+        List<ListInstancesResponseBody.List> all = fetchAllInstances(credentialId, normalizedRegionId);
         List<CloudInstanceOptionVO> options = new ArrayList<>();
         for (ListInstancesResponseBody.List item : all) {
             if (item == null) {
                 continue;
             }
             CloudInstanceOptionVO vo = AliyunConverters.toInstanceOptionVO(item);
-            if (matchesSearch(search, vo)) {
+            if (matchesSearch(normalizedSearch, vo)) {
                 options.add(vo);
             }
         }
@@ -102,13 +104,15 @@ public class AliyunCatalogService implements CloudCatalogProvider {
         requireId(credentialId, "credentialId");
         requireNonBlank(regionId, "regionId");
         requireNonBlank(cloudInstanceId, "cloudInstanceId");
-        GetInstanceRequest request = GetInstanceRequest.builder().instanceId(cloudInstanceId).build();
-        GetInstanceResponse response = clientFactory.call(credentialId, regionId,
+        String normalizedRegionId = regionId.strip();
+        String normalizedCloudInstanceId = cloudInstanceId.strip();
+        GetInstanceRequest request = GetInstanceRequest.builder().instanceId(normalizedCloudInstanceId).build();
+        GetInstanceResponse response = clientFactory.call(credentialId, normalizedRegionId,
                 client -> client.getInstance(request));
         GetInstanceResponseBody body = response == null ? null : response.getBody();
         GetInstanceResponseBody.Data data = body == null ? null : body.getData();
         if (data == null) {
-            throw new BusinessException(404, "Aliyun instance not found: " + cloudInstanceId);
+            throw new BusinessException(404, "Aliyun instance not found: " + normalizedCloudInstanceId);
         }
         return AliyunConverters.toInstanceDetailVO(data);
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigService.java
@@ -116,7 +116,7 @@ public class RocketMQBrokerConfigService {
 
     private FlushDiskType parseFlushDiskType(String value) {
         try {
-            return FlushDiskType.valueOf(value);
+            return FlushDiskType.valueOf(value.trim());
         } catch (IllegalArgumentException e) {
             return FlushDiskType.ASYNC_FLUSH;
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -115,28 +115,27 @@ public class RocketMQMessageProvider implements MessageProvider {
                                                  String topic, String msgId, String tag, String key,
                                                  Long startTime, Long endTime) {
 
+        if (StringUtils.hasText(msgId)) {
+            return queryByMsgId(adminExt, topic, msgId);
+        }
+
         long end = endTime != null ? endTime : System.currentTimeMillis();
         long begin = startTime != null ? startTime : end - ONE_HOUR_MILLIS;
         if (begin >= end) {
             throw new BusinessException(400, "Message query start time must be before end time");
         }
-
-        List<MessageRecordVO> result;
-        if (StringUtils.hasText(msgId)) {
-            result = queryByMsgId(adminExt, topic, msgId);
-        } else if (StringUtils.hasText(topic) && StringUtils.hasText(key)) {
-            result = queryByKey(adminExt, topic, key, tag, begin, end);
-        } else if (StringUtils.hasText(topic)) {
+        if (StringUtils.hasText(topic) && StringUtils.hasText(key)) {
+            return queryByKey(adminExt, topic, key, tag, begin, end);
+        }
+        if (StringUtils.hasText(topic)) {
             if (begin >= 0 && end >= 0 && end - begin > MAX_TOPIC_QUERY_WINDOW_MILLIS) {
                 throw new BusinessException(400, "Topic message query time range must not exceed 7 days");
             }
-            result = queryByTopic(instanceId, topic, tag, begin, end, DEFAULT_TOPIC_LIMIT);
-        } else {
-            log.warn("queryMessages requires at least one of msgId/topic, returning empty list");
-            return Collections.emptyList();
+            return queryByTopic(instanceId, topic, tag, begin, end, DEFAULT_TOPIC_LIMIT);
         }
 
-        return result;
+        log.warn("queryMessages requires at least one of msgId/topic, returning empty list");
+        return Collections.emptyList();
     }
 
     private List<MessageRecordVO> queryByMsgId(DefaultMQAdminExt adminExt, String topic, String msgId) {

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCookieTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCookieTest.java
@@ -28,19 +28,42 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AuthCookieTest {
 
     @Test
-    void usesHttpOnlySecureCookieAndPrefersItOverAuthorizationHeader() {
+    void usesHttpOnlySecureCookie() {
         AuthProperties properties = new AuthProperties();
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setCookies(new Cookie("rmq_studio_session", "cookie-token"));
-        request.addHeader("Authorization", "Bearer header-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         AuthCookie.write(response, properties, "cookie-token", Duration.ofMinutes(30));
 
-        assertThat(AuthCookie.authorization(request, properties)).isEqualTo("Bearer cookie-token");
         assertThat(response.getHeader("Set-Cookie"))
                 .contains("HttpOnly")
                 .contains("Secure")
                 .contains("SameSite=Strict");
+    }
+
+    @Test
+    void prefersExplicitBearerTokenOverStaleCookie() {
+        AuthProperties properties = new AuthProperties();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("rmq_studio_session", "stale-cookie-token"));
+        request.addHeader("Authorization", "bearer current-header-token");
+
+        assertThat(AuthCookie.authorization(request, properties))
+                .isEqualTo("bearer current-header-token");
+    }
+
+    @Test
+    void fallsBackToCookieForEmptyOrNonBearerAuthorization() {
+        AuthProperties properties = new AuthProperties();
+        MockHttpServletRequest emptyHeaderRequest = new MockHttpServletRequest();
+        emptyHeaderRequest.setCookies(new Cookie("rmq_studio_session", "cookie-token"));
+        emptyHeaderRequest.addHeader("Authorization", "Bearer   ");
+        MockHttpServletRequest nonBearerRequest = new MockHttpServletRequest();
+        nonBearerRequest.setCookies(new Cookie("rmq_studio_session", "cookie-token"));
+        nonBearerRequest.addHeader("Authorization", "Basic credentials");
+
+        assertThat(AuthCookie.authorization(emptyHeaderRequest, properties))
+                .isEqualTo("Bearer cookie-token");
+        assertThat(AuthCookie.authorization(nonBearerRequest, properties))
+                .isEqualTo("Bearer cookie-token");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceDatabaseTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthServiceDatabaseTest.java
@@ -184,6 +184,21 @@ class AuthServiceDatabaseTest {
     }
 
     @Test
+    void settingTheCurrentEnabledStateShouldBeIdempotentTest() {
+        RmqStudioUser disabledAdmin = user(1L, "retired-admin", true, false, "password-1");
+        RmqStudioUser enabledOperator = user(2L, "operator", false, true, "password-1");
+        when(userMapper.selectById(1L)).thenReturn(disabledAdmin);
+        when(userMapper.selectById(2L)).thenReturn(enabledOperator);
+
+        assertThat(authService.setUserEnabled(1L, false)).isSameAs(disabledAdmin);
+        assertThat(authService.setUserEnabled(2L, true)).isSameAs(enabledOperator);
+
+        verify(userMapper, never()).selectList(any(Wrapper.class));
+        verify(userMapper, never()).updateById(any(RmqStudioUser.class));
+        verify(sessionMapper, never()).update(isNull(), any(Wrapper.class));
+    }
+
+    @Test
     void databaseAuthenticationThrottlesLastSeenWrites() {
         RmqStudioUser user = user(1L, "operator", false, true, "password-1");
         RmqStudioSession session = activeSession(10L, 1L,

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsServiceTest.java
@@ -245,6 +245,47 @@ class MetricsServiceTest {
     }
 
     @Test
+    void queryShouldRejectReversedWindowWhenTimestampSubtractionWouldOverflow() {
+        MetricQueryDTO query = MetricQueryDTO.builder()
+                .metric("rocketmq_messages_in_total")
+                .start(Long.MAX_VALUE)
+                .end(Long.MIN_VALUE)
+                .step("1m")
+                .build();
+
+        assertBadRequest(query, "Metric query end must be later than start");
+        verifyNoInteractions(metricsSource);
+    }
+
+    @Test
+    void queryShouldRejectOversizedWindowWhenTimestampSubtractionWouldOverflow() {
+        MetricQueryDTO query = MetricQueryDTO.builder()
+                .metric("rocketmq_messages_in_total")
+                .start(Long.MIN_VALUE)
+                .end(Long.MAX_VALUE)
+                .step("1h")
+                .build();
+
+        assertBadRequest(query, "Metric query range must not exceed 31 days");
+        verifyNoInteractions(metricsSource);
+    }
+
+    @Test
+    void queryShouldAcceptMaximumWindowNearTimestampUpperBound() {
+        MetricQueryDTO query = MetricQueryDTO.builder()
+                .metric("rocketmq_messages_in_total")
+                .start(Long.MAX_VALUE - 31L * 24 * 60 * 60)
+                .end(Long.MAX_VALUE)
+                .step("1h")
+                .build();
+        when(metricsSource.query(query)).thenReturn(emptyMetricData());
+
+        metricsService.query(query);
+
+        verify(metricsSource).query(query);
+    }
+
+    @Test
     void queryShouldRejectOversizedWindow() {
         MetricQueryDTO query = MetricQueryDTO.builder()
                 .metric("rocketmq_messages_in_total")

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerConfigDiffServiceTest.java
@@ -218,6 +218,40 @@ class NameServerConfigDiffServiceTest {
     }
 
     @Test
+    void compareShouldDeduplicateDnsHostnamesIgnoringCase() throws Exception {
+        stubAdminFactory();
+        when(clusterService.getCluster("cluster-a")).thenReturn(cluster(
+                "ns.example.com:9876", List.of(nameServer("NS.EXAMPLE.COM:9876"))));
+        when(admin.getNameServerConfig(List.of("NS.EXAMPLE.COM:9876")))
+                .thenReturn(Map.of("NS.EXAMPLE.COM:9876", properties("listenPort", "9876")));
+
+        NameServerConfigDiffVO result = service.compare("cluster-a");
+
+        assertThat(result.getNodeCount()).isEqualTo(1);
+        assertThat(result.getReachableNodeCount()).isEqualTo(1);
+        verify(admin).getNameServerConfig(List.of("NS.EXAMPLE.COM:9876"));
+    }
+
+    @Test
+    void compareShouldPreserveIpv6ZoneCase() throws Exception {
+        stubAdminFactory();
+        String lowerZone = "[fe80::1%en0]:9876";
+        String upperZone = "[fe80::1%EN0]:9876";
+        when(clusterService.getCluster("cluster-a")).thenReturn(cluster(
+                upperZone, List.of(nameServer(lowerZone))));
+        when(admin.getNameServerConfig(List.of(lowerZone)))
+                .thenReturn(Map.of(lowerZone, properties("listenPort", "9876")));
+        when(admin.getNameServerConfig(List.of(upperZone)))
+                .thenReturn(Map.of(upperZone, properties("listenPort", "9876")));
+
+        NameServerConfigDiffVO result = service.compare("cluster-a");
+
+        assertThat(result.getNodeCount()).isEqualTo(2);
+        verify(admin).getNameServerConfig(List.of(lowerZone));
+        verify(admin).getNameServerConfig(List.of(upperZone));
+    }
+
+    @Test
     void compareShouldMarkTheCheckIncompleteWhenEveryNodeIsUnavailable() throws Exception {
         stubAdminFactory();
         when(clusterService.getCluster("cluster-a")).thenReturn(cluster(

--- a/server/src/test/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandlerTest.java
@@ -20,11 +20,15 @@ import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.ops.ai.LlmGatewayException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -88,6 +92,13 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.code").value(405));
     }
 
+    @Test
+    void unacceptableResponseMediaTypeReturns406WithEnvelopeInsteadOf500() throws Exception {
+        mockMvc.perform(get("/test/not-acceptable"))
+                .andExpect(status().isNotAcceptable())
+                .andExpect(jsonPath("$.code").value(406));
+    }
+
     @RestController
     static class FailingController {
 
@@ -100,6 +111,11 @@ class GlobalExceptionHandlerTest {
         Result<Void> failLlm() {
             throw new LlmGatewayException(504, "llm.provider.timeout",
                     "LLM provider request timed out", "Retry later.");
+        }
+
+        @GetMapping("/test/not-acceptable")
+        Result<Void> failNotAcceptable() throws HttpMediaTypeNotAcceptableException {
+            throw new HttpMediaTypeNotAcceptableException(List.of(MediaType.APPLICATION_JSON));
         }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQServiceTest.java
@@ -90,6 +90,47 @@ class DLQServiceTest {
     }
 
     @Test
+    void actionsShouldNormalizeIdentifiersBeforeDelegatingTest() {
+        List<String> msgIds = List.of(" msg-1 ", " msg-2 ");
+
+        dlqService.resendMessages("instance-1", " group-1 ", 1000L, 2000L, " target-topic ");
+        dlqService.exportMessages("instance-1", " group-1 ", 1000L, 2000L, 100);
+        dlqService.listMessages("instance-1", " group-1 ", 1000L, 2000L, 1, 20);
+        dlqService.resendSelectedMessages("instance-1", " group-1 ", msgIds, " target-topic ");
+        dlqService.exportExcel("instance-1", " group-1 ", 1000L, 2000L, msgIds);
+
+        verify(dlqProvider).resendMessages(
+                "instance-1", "group-1", 1000L, 2000L, "target-topic");
+        verify(dlqProvider).exportMessages("instance-1", "group-1", 1000L, 2000L, 100);
+        verify(dlqProvider).listMessages("instance-1", "group-1", 1000L, 2000L, 1, 20);
+        verify(dlqProvider).resendMessages(
+                "instance-1", "group-1", List.of("msg-1", "msg-2"), "target-topic");
+        verify(dlqProvider).exportExcel(
+                "instance-1", "group-1", 1000L, 2000L, List.of("msg-1", "msg-2"));
+    }
+
+    @Test
+    void resendMessagesShouldTreatBlankTargetTopicAsAbsentTest() {
+        dlqService.resendMessages("instance-1", "group-1", 1000L, 2000L, "   ");
+
+        verify(dlqProvider).resendMessages("instance-1", "group-1", 1000L, 2000L, null);
+    }
+
+    @Test
+    void selectedActionsShouldRejectBlankMsgIdsTest() {
+        assertThatThrownBy(() -> dlqService.resendSelectedMessages(
+                "instance-1", "group-1", List.of("msg-1", " "), null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("msgId must not be blank");
+        assertThatThrownBy(() -> dlqService.exportExcel(
+                "instance-1", "group-1", null, null, List.of("msg-1", " ")))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("msgId must not be blank");
+
+        verifyNoInteractions(dlqProvider);
+    }
+
+    @Test
     void resendMessagesShouldAcceptNullTimeRange() {
         dlqService.resendMessages("instance-1", "group-1", null, null, "target-topic");
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogServiceTest.java
@@ -167,6 +167,19 @@ class AliyunCatalogServiceTest {
     }
 
     @Test
+    void listCloudInstancesShouldNormalizeRegionAndSearchTest() {
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any()))
+                .thenReturn(instancesResponse(List.of(instanceRow("rmq-prod-001", "Production"))));
+
+        List<CloudInstanceOptionVO> result = service.listCloudInstances(
+                CREDENTIAL_ID, "  cn-hangzhou  ", "  production  ");
+
+        assertThat(result).extracting(CloudInstanceOptionVO::getInstanceName)
+                .containsExactly("Production");
+        verify(clientFactory).call(eq(CREDENTIAL_ID), eq(REGION), any());
+    }
+
+    @Test
     void listCloudInstancesShouldRequireRegionTest() {
         assertThatThrownBy(() -> service.listCloudInstances(CREDENTIAL_ID, " ", null))
                 .isInstanceOf(BusinessException.class)
@@ -210,6 +223,17 @@ class AliyunCatalogServiceTest {
         assertThat(detail.getEndpoints().get(0).getEndpointType()).isEqualTo("TCP_INTERNET");
         assertThat(detail.getEndpoints().get(1).getEndpointUrl())
                 .isEqualTo("rmq-cn-001-vpc.rmq.aliyuncs.com:8080");
+    }
+
+    @Test
+    void getCloudInstanceShouldNormalizeLookupIdentifiersTest() {
+        when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any())).thenReturn(null);
+
+        assertThatThrownBy(() -> service.getCloudInstance(
+                CREDENTIAL_ID, "  cn-hangzhou  ", "  rmq-missing  "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Aliyun instance not found: rmq-missing");
+        verify(clientFactory).call(eq(CREDENTIAL_ID), eq(REGION), any());
     }
 
     private static List<ListInstancesResponseBody.List> instanceRows(int count, int idOffset) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigServiceTest.java
@@ -8,6 +8,7 @@ package org.apache.rocketmq.studio.provider.apache;
 
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
+import org.apache.rocketmq.studio.common.domain.enums.FlushDiskType;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.ops.audit.AuditService;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
@@ -19,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Properties;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -26,6 +28,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RocketMQBrokerConfigServiceTest {
@@ -86,5 +89,22 @@ class RocketMQBrokerConfigServiceTest {
         verify(auditService).record(
                 "UPDATE_BROKER_CONFIG", "BROKER", "CLUSTER:cluster-a", "cluster-a",
                 "brokerAddr=broker-a:10911, config={}", "SUCCESS");
+    }
+
+    @Test
+    void trimsFlushDiskTypeWithoutChangingUnknownValueFallback() throws Exception {
+        Properties padded = new Properties();
+        padded.setProperty("flushDiskType", " SYNC_FLUSH ");
+        when(adminExt.getBrokerConfig("broker-a:10911")).thenReturn(padded);
+
+        assertThat(brokerConfigService.getBrokerConfig("broker-a:10911").getFlushDiskType())
+                .isEqualTo(FlushDiskType.SYNC_FLUSH);
+
+        Properties unknown = new Properties();
+        unknown.setProperty("flushDiskType", "future-mode");
+        when(adminExt.getBrokerConfig("broker-b:10911")).thenReturn(unknown);
+
+        assertThat(brokerConfigService.getBrokerConfig("broker-b:10911").getFlushDiskType())
+                .isEqualTo(FlushDiskType.ASYNC_FLUSH);
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -230,6 +230,23 @@ class RocketMQMessageProviderTest {
     }
 
     @Test
+    void queryByMsgIdIgnoresUnrelatedTimeBounds() throws Exception {
+        MessageExt message = new MessageExt();
+        message.setMsgId("msg-1");
+        message.setTopic("TopicA");
+        when(adminExt.viewMessage("TopicA", "msg-1")).thenReturn(message);
+
+        assertThat(provider.queryMessages(
+                "instance-a", "TopicA", "msg-1", null, null, 200L, 100L))
+                .singleElement().extracting(MessageRecordVO::getMsgId).isEqualTo("msg-1");
+        assertThat(provider.queryMessages(
+                "instance-a", "TopicA", "msg-1", null, null, 100L, 100L))
+                .singleElement().extracting(MessageRecordVO::getMsgId).isEqualTo("msg-1");
+
+        verify(adminExt, times(2)).viewMessage("TopicA", "msg-1");
+    }
+
+    @Test
     void queryByMsgIdRejectsDecodedBrokerOutsideKnownTopology() throws Exception {
         String msgId = MessageDecoder.createMessageId(new InetSocketAddress("10.2.3.4", 10911), 12345L);
         when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithBrokerAddresses("172.30.10.100:10911"));


### PR DESCRIPTION
## What is the purpose of the change

Consolidate the reviewed server-side boundary fixes from #2693, #2694, #2703, #2704, #2705, #2715, and #2716 into one backend-focused pull request, as requested in the maintainer note on #2724.

The defects are reproducible at request and provider boundaries:

- repeating an already-applied user enabled-state update still performs guard/write/session side effects;
- padded Aliyun, DLQ, and broker configuration values pass validation but are delegated unnormalized;
- DNS NameServer hostnames differing only by case are probed twice;
- extreme signed timestamps can overflow duration subtraction;
- message-ID lookup rejects unused equal or reversed time bounds;
- an explicit Bearer credential loses to a stale session cookie;
- unacceptable response media types fall through without the expected HTTP 406 envelope.

Issues #2463, #2464, #2465, and #2470 were closed only by the stale workflow; their original reports and confirmation comments remain the reproduction evidence.

## Brief changelog

- normalize identifiers once before service/provider delegation;
- make no-op user state updates idempotent;
- compare metric windows without overflow;
- keep message-ID lookup independent from unused time bounds;
- prefer explicit non-empty Bearer credentials and map media-type negotiation failures to 406;
- retain focused regression coverage beside every changed boundary.

## Verifying this change

- Java 21 targeted Maven test matrix: 121 tests passed, 0 failures/errors/skips;
- Java 21 `mvn -q -f server/pom.xml -DskipTests package` passed;
- Checkstyle passed as part of both Maven commands;
- `git diff --check` passed;
- scope: 18 files, 356 insertions, 45 deletions, 7 reviewed commits.

Addresses #2463

Addresses #2464

Addresses #2465

Addresses #2470

Fixes #2698

Fixes #2699

Fixes #2700

Fixes #2709

Fixes #2710
