### PR TITLE
[ISSUE #2708][ISSUE #2712] fix(ai): harden CLI provider lifecycle

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/CliAgentProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/CliAgentProvider.java
@@ -61,18 +61,29 @@ public abstract class CliAgentProvider implements AgentProvider {
 
     @Override
     public boolean available() {
+        Process process = null;
         try {
             ProcessBuilder builder = new ProcessBuilder("sh", "-c", "command -v " + binaryName());
             processEnvironment.apply(builder, Map.of());
-            Process process = builder.redirectErrorStream(true).start();
+            process = startAvailabilityProcess(builder.redirectErrorStream(true));
             boolean finished = process.waitFor(5, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+            }
             return finished && process.exitValue() == 0;
         } catch (IOException | InterruptedException exception) {
+            if (process != null) {
+                process.destroyForcibly();
+            }
             if (exception instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
             return false;
         }
+    }
+
+    protected Process startAvailabilityProcess(ProcessBuilder builder) throws IOException {
+        return builder.start();
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/QoderAgentProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/QoderAgentProvider.java
@@ -50,9 +50,12 @@ public class QoderAgentProvider extends CliAgentProvider {
     @Override
     protected List<String> buildCommand(LlmConfigVO config, String prompt, String modelOverride) {
         List<String> command = new ArrayList<>(List.of("qodercli", "-p", prompt == null ? "" : prompt));
-        if (StringUtils.hasText(modelOverride)) {
+        String model = StringUtils.hasText(modelOverride)
+                ? modelOverride.trim()
+                : config == null ? null : config.getModel();
+        if (StringUtils.hasText(model)) {
             command.add("-m");
-            command.add(modelOverride.trim());
+            command.add(model.trim());
         }
         return command;
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/CliAgentProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/CliAgentProviderTest.java
@@ -18,10 +18,15 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class CliAgentProviderTest {
 
-    private static final class FakeCli extends CliAgentProvider {
+    private static class FakeCli extends CliAgentProvider {
         private final String script;
         private final int outputLimitBytes;
         private final Map<String, String> environment;
@@ -89,6 +94,20 @@ class CliAgentProviderTest {
         }
     }
 
+    private static final class AvailabilityCli extends FakeCli {
+        private final Process process;
+
+        AvailabilityCli(Process process) {
+            super("echo unused");
+            this.process = process;
+        }
+
+        @Override
+        protected Process startAvailabilityProcess(ProcessBuilder builder) {
+            return process;
+        }
+    }
+
     @Test
     void completeSurvivesLargeStderrOutput() {
         // Write well over the 64 KiB pipe buffer to stderr, then print the completion on stdout.
@@ -152,5 +171,30 @@ class CliAgentProviderTest {
                 assertThat(environment).doesNotContainKey("SERVER_SECRET"));
         assertThat(processEnvironment.childEnvironments.get(1))
                 .containsEntry("PROVIDER_TOKEN", "request-token");
+    }
+
+    @Test
+    void availabilityDestroysProbeWhenItTimesOut() throws Exception {
+        Process process = mock(Process.class);
+        when(process.waitFor(anyLong(), eq(java.util.concurrent.TimeUnit.SECONDS))).thenReturn(false);
+
+        assertThat(new AvailabilityCli(process).available()).isFalse();
+
+        verify(process).destroyForcibly();
+    }
+
+    @Test
+    void availabilityDestroysProbeAndPreservesInterrupt() throws Exception {
+        Process process = mock(Process.class);
+        when(process.waitFor(anyLong(), eq(java.util.concurrent.TimeUnit.SECONDS)))
+                .thenThrow(new InterruptedException("test interrupt"));
+
+        try {
+            assertThat(new AvailabilityCli(process).available()).isFalse();
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            verify(process).destroyForcibly();
+        } finally {
+            Thread.interrupted();
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/QoderAgentProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/QoderAgentProviderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QoderAgentProviderTest {
+
+    private final QoderAgentProvider provider = new QoderAgentProvider(new CliProcessEnvironment(List.of()));
+
+    @Test
+    void buildCommandUsesConfiguredModelWhenRequestDoesNotOverrideIt() {
+        LlmConfigVO config = LlmConfigVO.builder().model(" qoder-configured ").build();
+
+        assertThat(provider.buildCommand(config, "prompt", null))
+                .containsExactly("qodercli", "-p", "prompt", "-m", "qoder-configured");
+    }
+
+    @Test
+    void buildCommandPrefersRequestModelOverride() {
+        LlmConfigVO config = LlmConfigVO.builder().model("qoder-configured").build();
+
+        assertThat(provider.buildCommand(config, "prompt", " qoder-request "))
+                .containsExactly("qodercli", "-p", "prompt", "-m", "qoder-request");
+    }
+
+    @Test
+    void buildCommandOmitsBlankModel() {
+        LlmConfigVO config = LlmConfigVO.builder().model(" ").build();
+
+        assertThat(provider.buildCommand(config, null, null))
+                .containsExactly("qodercli", "-p", "");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Consolidate the two reviewed CLI-based AI provider fixes from #2713 and #2717 into one AI Provider lifecycle pull request, following the maintainer guidance on #2724.

Two concrete failures are covered:

- a CLI availability probe that exceeds `waitFor(timeout)` remains alive because the process is never terminated;
- Qoder command construction ignores the saved provider model when the request does not supply an override.

## Brief changelog

- forcibly terminate timed-out CLI probes and preserve the caller interrupt state when interrupted;
- use the configured Qoder model as the fallback while preserving request-model precedence;
- cover timeout, interruption, configured, overridden, and blank model paths with process-isolated tests.

## Verifying this change

- Java 21 targeted Maven tests: 10 passed, 0 failures/errors/skips;
- Java 21 `mvn -q -f server/pom.xml -DskipTests package` passed;
- Checkstyle passed as part of both Maven commands;
- `git diff --check` passed;
- scope: 4 files, 114 insertions, 4 deletions, 2 reviewed commits.

Fixes #2708

Fixes #2712
