### PR TITLE
fix(tencent): clamp oversized cloud queue counts

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -1096,7 +1096,7 @@ public class TencentInstanceProvider implements InstanceProvider {
     }
 
     private static int toInteger(Long value) {
-        return value == null ? 0 : Math.toIntExact(value);
+        return value == null ? 0 : value > Integer.MAX_VALUE ? Integer.MAX_VALUE : value.intValue();
     }
 
     private static void requireTopicName(String topicName) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -208,6 +208,21 @@ class TencentInstanceProviderTest {
     }
 
     @Test
+    void listTopicsShouldClampOversizedQueueCountsTest() throws Exception {
+        TopicItem oversized = topicItem("orders-oversized", "NORMAL", (long) Integer.MAX_VALUE + 1L);
+        DescribeTopicListResponse response = new DescribeTopicListResponse();
+        response.setData(new TopicItem[]{oversized});
+        when(client.DescribeTopicList(any())).thenReturn(response);
+        when(client.DescribeTopic(any())).thenReturn(new DescribeTopicResponse());
+
+        List<TopicVO> topics = provider.listTopics(STUDIO_INSTANCE_ID, null, null);
+
+        assertThat(topics).hasSize(1);
+        assertThat(topics.get(0).getWriteQueues()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(topics.get(0).getReadQueues()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
     void listTopicsPageShouldUseTencentNativePaginationAndFiltersTest() throws Exception {
         TopicItem item = topicItem("orders-fifo-10000", "FIFO", 8L);
         DescribeTopicListResponse response = new DescribeTopicListResponse();


### PR DESCRIPTION
## Summary
- Clamp `TencentInstanceProvider.toInteger` (used for topic `writeQueues`/`readQueues`
  mapping) to `Integer.MAX_VALUE` for oversized cloud values, replacing the unguarded
  `Math.toIntExact`.
- Added regression test `listTopicsShouldClampOversizedQueueCounts`.

## Why
`TopicItem.getQueueNum()` is a `Long` returned by the Tencent Cloud OpenAPI. A value
above `Integer.MAX_VALUE` made `Math.toIntExact` throw `ArithmeticException` during
topic listing — HTTP 500 instead of a degraded view. This was the only unguarded
long→int conversion in the file: the sibling helpers for total counts and retry
counts already saturate at `Integer.MAX_VALUE`, so this brings queue-count mapping
in line with the established pattern.

## Testing
- `cd server && mvn -Dtest=TencentInstanceProviderTest test`
  — Tests run: 37, Failures: 0, Errors: 0
