### PR TITLE
fix(message): treat negative trace time values as unavailable

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -846,7 +846,11 @@ public class RocketMQMessageProvider implements MessageProvider {
 
     private static long parseLong(String value) {
         try {
-            return Long.parseLong(value.trim());
+            long parsed = Long.parseLong(value.trim());
+            // Negative trace times/costs cannot occur in well-formed broker trace
+            // payloads; treat them as unavailable (0) so the console renders a
+            // placeholder instead of a 1969/1970 timestamp.
+            return parsed < 0 ? 0L : parsed;
         } catch (Exception e) {
             return 0L;
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -456,6 +456,30 @@ class RocketMQMessageProviderTest {
     }
 
     @Test
+    void getMessageTraceShouldTreatNegativeTimeValuesAsUnavailable() throws Exception {
+        String pub = traceContext("Pub", "-1000", "cn", "prod-group", "TopicA", "msg-123",
+                "tag1", "key1", "broker:10911", "15", "-50", "0", "offset-1", "true");
+        String subAfter = traceContext("SubAfter", "req-1", "msg-123", "-20", "true", "key1",
+                "3", "-3000", "cons-group");
+        MessageExt traceMessage = new MessageExt();
+        traceMessage.setBody(traceBody(pub, subAfter).getBytes(StandardCharsets.UTF_8));
+        QueryResult queryResult = new QueryResult(0L, List.of(traceMessage));
+        when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
+                .thenReturn(queryResult);
+
+        TraceRecordVO record = provider.getMessageTrace("instance-a", "msg-123", "orders");
+
+        TraceNodeVO produce = record.getNodes().get(0);
+        assertThat(produce.getTimestamp()).isEqualTo(0);
+        assertThat(produce.getCostTime()).isEqualTo(0);
+        TraceNodeVO consume = record.getNodes().get(1);
+        assertThat(consume.getTimestamp()).isEqualTo(0);
+        assertThat(consume.getCostTime()).isEqualTo(0);
+        assertThat(record.getConsumerStatus()).hasSize(1);
+        assertThat(record.getConsumerStatus().get(0).getConsumeTime()).isEqualTo(0);
+    }
+
+    @Test
     void getMessageTraceParsesEndTransactionState() throws Exception {
         String body = traceBody(traceContext("EndTransaction", "2000", "cn", "tx-group", "TopicA",
                 "msg-tx", "tag2", "key2", "broker:10911", "0", "tx-1", "COMMIT_MESSAGE", "false"));


### PR DESCRIPTION
## Summary
- Treat negative time values from broker trace payloads as unavailable (`0`) in
  `RocketMQMessageProvider.parseLong`, which feeds trace node `timestamp`,
  `costTime` and consumer `consumeTime`.
- Added regression test `getMessageTraceShouldTreatNegativeTimeValuesAsUnavailable`.

## Why
The parser already degrades unparseable fields to `0`, but a *parseable* negative
value passed straight through. The web console's timestamp guard
(`if (!value) return '-'`) only treats `0` as unavailable, so a negative
`timestamp` rendered as a 1969/1970 date and a negative `costTime` as a negative
duration — visible garbage instead of the placeholder that unparseable fields get.
Well-formed RocketMQ trace payloads never carry negative epoch-millisecond times
or costs, so clamping them to `0` (the established "unavailable" sentinel) restores
graceful degradation.

## Testing
- `cd server && mvn -Dtest=RocketMQMessageProviderTest test`
  — Tests run: 32, Failures: 0, Errors: 0
