### PR TITLE
fix(proxy): evict expired proxy address cache entries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ProxyConsumerResolver.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/ProxyConsumerResolver.java
@@ -35,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,8 @@ public class ProxyConsumerResolver {
     // Capturing a jstack on the client takes far longer than reading the proxy's own client
     // manager, so the running info query gets its own, more generous budget.
     private static final long PROXY_RUNNING_INFO_TIMEOUT_MILLIS = 10_000L;
-    private static final long PROXY_ADDRESS_CACHE_TTL_MILLIS = 60_000L;
+    static final long PROXY_ADDRESS_CACHE_TTL_MILLIS = 60_000L;
+    static final int MAX_PROXY_ADDRESS_CACHE_ENTRIES = 128;
     private static final String DEFAULT_INSTANCE_KEY = "__default__";
 
     private final MqAdminExtFactory adminFactory;
@@ -73,6 +75,8 @@ public class ProxyConsumerResolver {
     private final Map<String, CachedProxyAddresses> proxyAddressCache = new ConcurrentHashMap<>();
     private final AtomicBoolean clientStarted = new AtomicBoolean(false);
     private volatile NettyRemotingClient remotingClient;
+    private long proxyAddressCacheTtlMillis = PROXY_ADDRESS_CACHE_TTL_MILLIS;
+    private int maxProxyAddressCacheEntries = MAX_PROXY_ADDRESS_CACHE_ENTRIES;
 
     /**
      * Queries the proxies of the given instance for the consumer connection info of the group.
@@ -180,8 +184,34 @@ public class ProxyConsumerResolver {
                 .map(ip -> ip + ":" + PROXY_REMOTING_PORT)
                 .toList();
         proxyAddressCache.put(cacheKey,
-                new CachedProxyAddresses(addresses, System.currentTimeMillis() + PROXY_ADDRESS_CACHE_TTL_MILLIS));
+                new CachedProxyAddresses(addresses, System.currentTimeMillis() + proxyAddressCacheTtlMillis));
+        evictStaleProxyAddresses();
         return addresses;
+    }
+
+    /**
+     * Removes expired cache entries and, when the cache exceeds its bound, the entries with the
+     * earliest expiry. The cache is keyed by the caller-supplied instance id and entries are only
+     * revalidated lazily on read, so without active eviction every instance id ever queried would
+     * leave a permanently stale entry behind.
+     */
+    private void evictStaleProxyAddresses() {
+        long now = System.currentTimeMillis();
+        proxyAddressCache.entrySet().removeIf(entry -> entry.getValue().expiresAtMillis() <= now);
+        while (proxyAddressCache.size() > maxProxyAddressCacheEntries) {
+            proxyAddressCache.entrySet().stream()
+                    .min(Comparator.comparingLong(entry -> entry.getValue().expiresAtMillis()))
+                    .ifPresent(oldest -> proxyAddressCache.remove(oldest.getKey(), oldest.getValue()));
+        }
+    }
+
+    int proxyAddressCacheSize() {
+        return proxyAddressCache.size();
+    }
+
+    void setCacheLimitsForTest(long ttlMillis, int maxEntries) {
+        this.proxyAddressCacheTtlMillis = ttlMillis;
+        this.maxProxyAddressCacheEntries = maxEntries;
     }
 
     private <T> T executeAdmin(String instanceId, MqAdminExtFactory.AdminAction<T> action) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ProxyConsumerResolverTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ProxyConsumerResolverTest.java
@@ -134,4 +134,44 @@ class ProxyConsumerResolverTest {
         // 192.0.2.1 (TEST-NET) is unreachable, so the remoting query must degrade to null
         assertThat(resolver.resolveConsumerConnection("instance-a", "cg-orders")).isNull();
     }
+    @Test
+    void discoverProxyAddressesShouldEvictExpiredEntriesTest() throws Exception {
+        resolver.setCacheLimitsForTest(50, 128);
+        when(adminExt.examineConsumerConnectionInfo("CID_DefaultHeartBeatSyncerTopic"))
+                .thenReturn(emptySyncer());
+
+        resolver.discoverProxyAddresses("instance-a");
+        resolver.discoverProxyAddresses("instance-b");
+        assertThat(resolver.proxyAddressCacheSize()).isEqualTo(2);
+
+        Thread.sleep(150);
+        resolver.discoverProxyAddresses("instance-c");
+
+        // Entries a and b are expired and must be gone; only the fresh entry survives.
+        assertThat(resolver.proxyAddressCacheSize()).isEqualTo(1);
+    }
+
+    @Test
+    void discoverProxyAddressesShouldBoundCacheSizeTest() throws Exception {
+        resolver.setCacheLimitsForTest(60_000, 2);
+        when(adminExt.examineConsumerConnectionInfo("CID_DefaultHeartBeatSyncerTopic"))
+                .thenReturn(emptySyncer());
+
+        resolver.discoverProxyAddresses("instance-a");
+        resolver.discoverProxyAddresses("instance-b");
+        resolver.discoverProxyAddresses("instance-c");
+
+        // All entries are fresh, so the cache must drop the earliest-expiring entry.
+        assertThat(resolver.proxyAddressCacheSize()).isEqualTo(2);
+        assertThat(resolver.discoverProxyAddresses("instance-c")).containsExactly("10.0.0.1:8080");
+    }
+
+    private ConsumerConnection emptySyncer() {
+        Connection proxy = new Connection();
+        proxy.setClientId("proxy-a");
+        proxy.setClientAddr("10.0.0.1:10911");
+        ConsumerConnection syncer = new ConsumerConnection();
+        syncer.setConnectionSet(new HashSet<>(List.of(proxy)));
+        return syncer;
+    }
 }


### PR DESCRIPTION
## Summary
- Evict expired entries from `ProxyConsumerResolver.proxyAddressCache` on every discovery write
- Bound the cache to 128 entries, dropping the earliest-expiring entry when the bound is exceeded
- Add regression tests for expired-entry eviction and the size bound

## Why
The cache is keyed by the caller-supplied instance id, and each entry carries a 60s TTL that is only *checked* on read — expired entries were never removed from the map. On a long-running Studio instance serving many instances (or with instance ids that churn), every distinct id ever queried left a permanently stale entry behind, so the map grew without bound while holding dead proxy address lists.

## Testing
- `mvn -Dtest=ProxyConsumerResolverTest test` → Tests run: 7, Failures: 0, Errors: 0 (5 existing + 2 new regression tests)
