### PR TITLE
fix(ops): ignore unparseable audit timestamps in sorting and cleanup

### DIFF
--- a/web/src/pages/ops/__tests__/AuditPage.test.tsx
+++ b/web/src/pages/ops/__tests__/AuditPage.test.tsx
@@ -22,7 +22,7 @@ import type React from 'react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LangProvider } from '../../../i18n/LangContext';
 import * as opsService from '../../../services/opsService';
-import AuditPage from '../audit';
+import AuditPage, { auditTimestamp } from '../audit';
 
 vi.mock('../../../services/opsService', () => ({
   cleanupAuditLogs: vi.fn(),
@@ -45,6 +45,17 @@ const deferred = <T,>() => {
   });
   return { promise, resolve };
 };
+
+describe('auditTimestamp', () => {
+  it('maps parseable timestamps to epoch milliseconds', () => {
+    expect(auditTimestamp('2026-07-03 09:45:12')).toBe(new Date('2026-07-03 09:45:12').getTime());
+  });
+
+  it('maps unparseable timestamps to zero so the column sorter stays deterministic', () => {
+    expect(auditTimestamp('not-a-timestamp')).toBe(0);
+    expect(auditTimestamp('')).toBe(0);
+  });
+});
 
 describe('Audit page', () => {
   let createObjectURL: ReturnType<typeof vi.fn>;

--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -58,6 +58,11 @@ const emptyFilterOptions: AuditFilterOptions = {
 
 const formatFilterLabel = (value: string) => value.trim().replace(/_/g, ' ');
 
+export const auditTimestamp = (value: string): number => {
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
 const resultColor = (result: string) => {
   const normalized = result.toUpperCase();
   if (normalized === 'SUCCESS') return 'green';
@@ -232,7 +237,7 @@ const AuditPage: React.FC = () => {
       title: t('audit.time'),
       dataIndex: 'timestamp',
       width: 180,
-      sorter: (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+      sorter: (a, b) => auditTimestamp(a.timestamp) - auditTimestamp(b.timestamp),
       defaultSortOrder: 'descend',
       render: (timestamp: string) => formatDateTime(timestamp),
     },

--- a/web/src/services/opsService.test.ts
+++ b/web/src/services/opsService.test.ts
@@ -19,6 +19,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AuditRecord } from '../api/ops';
 import { mockAuditRecords } from '../mock/audit';
 import {
+  cleanupAuditLogs,
   createAlertRule,
   exportAuditLogs,
   getAuditFilterOptions,
@@ -233,4 +234,35 @@ describe('ops service mock data', () => {
         '"prod-cn","removed ""topic"", safely","SUCCESS","\'=denied"',
     );
   });
+
+  it('keeps audit records with unparseable timestamps when cleaning up', async () => {
+    const oldRecord = {
+      id: 90010,
+      timestamp: '2000-01-01 00:00:00',
+      operator: 'admin',
+      operationType: 'CREATE_TOPIC',
+      resourceType: 'TOPIC',
+      target: 'cleanup-old-topic',
+      clusterId: 'prod-cn',
+      detail: 'ancient record',
+      result: 'SUCCESS',
+    } as AuditRecord;
+    const unknownRecord = {
+      ...oldRecord,
+      id: 90011,
+      timestamp: 'not-a-timestamp',
+      target: 'cleanup-unknown-topic',
+    } as AuditRecord;
+    insertedRecords.push(oldRecord, unknownRecord);
+    auditRecords.push(oldRecord, unknownRecord);
+
+    const deleted = await cleanupAuditLogs(7);
+
+    expect(deleted).toBeGreaterThan(0);
+    const after = await listAuditRecords({ page: 1, pageSize: 500 });
+    const ids = after.items.map((item) => item.id);
+    expect(ids).not.toContain(90010);
+    expect(ids).toContain(90011);
+  });
+
 });

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -477,7 +477,10 @@ export async function exportAuditLogs(params: AuditFilter = {}): Promise<string>
 export async function cleanupAuditLogs(beforeDays: number): Promise<number> {
   if (isMockMode()) {
     const cutoff = new Date(Date.now() - beforeDays * 24 * 60 * 60 * 1000);
-    const remaining = auditRecordsState.filter((record) => new Date(record.timestamp) >= cutoff);
+    const remaining = auditRecordsState.filter((record) => {
+      const recordedAt = new Date(record.timestamp);
+      return Number.isNaN(recordedAt.getTime()) || recordedAt >= cutoff;
+    });
     const deleted = auditRecordsState.length - remaining.length;
     auditRecordsState = remaining;
     return deleted;


### PR DESCRIPTION
## Summary
- Extract an exported `auditTimestamp()` helper that maps unparseable audit timestamps to `0` (same convention as `toStoreTimestamp` in `api/message.ts`)
- Use it in the audit log time column sorter so `NaN` no longer leaks into the comparison
- In `cleanupAuditLogs` (mock mode), keep records whose timestamp cannot be parsed instead of deleting them
- Add regression tests for the helper and the cleanup behavior

## Why
When a `timestamp` value is unparseable, `new Date(...).getTime()` yields `NaN`. In the column sorter, `NaN` compared against real numbers makes every comparison `false`, so table sorting becomes nondeterministic for rows with bad timestamps. In `cleanupAuditLogs`, `NaN >= cutoff` is always `false`, so undated rows were silently deleted together with genuinely old rows — an audit record disappears without ever being dated.

## Testing
- `./node_modules/.bin/vitest run src/pages/ops/__tests__/AuditPage.test.tsx src/services/opsService.test.ts` → 20 passed
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/pages/ops/audit.tsx src/services/opsService.ts src/pages/ops/__tests__/AuditPage.test.tsx src/services/opsService.test.ts` → 0 errors
