### PR TITLE
fix(credential): serialize Tencent client lookup with invalidation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentClientFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentClientFactory.java
@@ -48,13 +48,20 @@ public class TencentClientFactory {
 
     public TrocketClient client(Long credentialId, String region) {
         String key = cacheKey(credentialId, region);
-        TrocketClient cached = clients.get(key);
-        if (cached != null) {
-            return cached;
-        }
+        // The fast-path read must share the invalidation monitor: outside it, a thread suspended
+        // between the read and the return could hand out a client that a concurrent credential
+        // rotation just evicted, still carrying the replaced secret.
         synchronized (this) {
+            TrocketClient cached = cachedClient(key);
+            if (cached != null) {
+                return cached;
+            }
             return clients.computeIfAbsent(key, ignored -> createClient(credentialId, region));
         }
+    }
+
+    TrocketClient cachedClient(String key) {
+        return clients.get(key);
     }
 
     public synchronized void invalidateCredential(Long credentialId) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentClientFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentClientFactoryTest.java
@@ -20,10 +20,12 @@ import com.tencentcloudapi.trocket.v20230308.TrocketClient;
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialRepository;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -79,6 +81,36 @@ class TencentClientFactoryTest {
         assertThat(factory.creationCount).hasValue(2);
     }
 
+    @Test
+    void clientShouldNotReturnClientEvictedByConcurrentInvalidationTest() throws Exception {
+        long credentialId = 1L;
+        String region = "ap-shanghai";
+        StaleReadFactory factory = new StaleReadFactory();
+        TrocketClient cached = factory.client(credentialId, region);
+
+        Thread lookupThread = new Thread(() ->
+                factory.observed.set(factory.client(credentialId, region)),
+                "tencent-client-stale-read-test");
+        lookupThread.start();
+        assertThat(factory.readCompleted.await(5, TimeUnit.SECONDS)).isTrue();
+
+        Thread invalidationThread = new Thread(() -> {
+            factory.invalidateCredential(credentialId);
+            factory.invalidationCompleted.set(Instant.now());
+        }, "tencent-client-invalidation-test");
+        invalidationThread.start();
+        awaitBlockedOrTerminated(invalidationThread);
+
+        factory.allowReturn.countDown();
+        lookupThread.join(TimeUnit.SECONDS.toMillis(5));
+        invalidationThread.join(TimeUnit.SECONDS.toMillis(5));
+
+        // The lookup may return the cached client, but only if the invalidation that evicted it
+        // had not finished before the lookup returned.
+        assertThat(factory.observed.get()).isSameAs(cached);
+        assertThat(factory.lookupCompleted.get()).isBefore(factory.invalidationCompleted.get());
+    }
+
     private static void awaitBlockedOrTerminated(Thread thread) {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
         while (thread.getState() != Thread.State.BLOCKED && thread.isAlive()
@@ -86,6 +118,43 @@ class TencentClientFactoryTest {
             Thread.onSpinWait();
         }
         assertThat(thread.getState() == Thread.State.BLOCKED || !thread.isAlive()).isTrue();
+    }
+
+    private static final class StaleReadFactory extends TencentClientFactory {
+        final CountDownLatch readCompleted = new CountDownLatch(1);
+        final CountDownLatch allowReturn = new CountDownLatch(1);
+        final AtomicReference<TrocketClient> observed = new AtomicReference<>();
+        final AtomicReference<Instant> lookupCompleted = new AtomicReference<>();
+        final AtomicReference<Instant> invalidationCompleted = new AtomicReference<>();
+
+        private StaleReadFactory() {
+            super(mock(CloudCredentialRepository.class));
+        }
+
+        @Override
+        protected TrocketClient createClient(Long credentialId, String region) {
+            return mock(TrocketClient.class);
+        }
+
+        @Override
+        TrocketClient cachedClient(String key) {
+            TrocketClient cached = super.cachedClient(key);
+            if (cached == null) {
+                return cached;
+            }
+            // Simulate a thread suspended between the cache read and the return, while a
+            // concurrent credential rotation runs. The completion timestamp is stamped while
+            // still inside client(), so the ordering against the invalidation is exact.
+            readCompleted.countDown();
+            try {
+                assertThat(allowReturn.await(5, TimeUnit.SECONDS)).isTrue();
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Stale read interrupted", exception);
+            }
+            lookupCompleted.set(Instant.now());
+            return cached;
+        }
     }
 
     private static final class BlockingClientFactory extends TencentClientFactory {


### PR DESCRIPTION
## Summary
- Move the `TencentClientFactory.client()` fast-path cache read inside the same monitor that `invalidateCredential()` holds
- Add a package-private `cachedClient` seam and a regression test that suspends a lookup between the cache read and the return while a concurrent credential rotation runs

## Why
The cached-client read ran outside the invalidation lock: a thread suspended between the map read and the return could hand out a client that a concurrent credential rotation (triggered on credential update/delete by `CloudCredentialService`) had just evicted. That client still carries the replaced secret, so a request signed seconds after a rotation fails with a confusing "credential is invalid" even though the new credential is configured.

## Testing
- `mvn -Dtest=TencentClientFactoryTest test` → Tests run: 5, Failures: 0, Errors: 0 (4 existing + 1 new regression test)
