### PR TITLE
fix(broker): require stable identity for credentialed admin clients

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
@@ -58,16 +58,21 @@ public class MqAdminExtFactory {
      * Runs an action against a started admin client bound to the given NameServer address.
      *
      * @param namesrvAddr NameServer address list, e.g. {@code host1:9876;host2:9876}
-     * @param rpcHook     optional RPC hook for authentication, may be {@code null}
+     * @param rpcHook     RPC hook for authentication; must be {@code null} — a caller holding a
+     *                    hook must use the identity-qualified overload, because a hook instance's
+     *                    identity hash is not a stable credential identity
      * @param action      the admin interaction to execute
      * @param <T>         result type
      * @return the action result
      * @throws BusinessException if the connection cannot be established or the action fails
      */
     public <T> T execute(String namesrvAddr, RPCHook rpcHook, AdminAction<T> action) {
-        String authenticationIdentity = rpcHook == null ? "anonymous"
-                : "custom-hook-" + Integer.toUnsignedString(System.identityHashCode(rpcHook));
-        return execute(namesrvAddr, rpcHook, authenticationIdentity, action);
+        if (rpcHook != null) {
+            throw new BusinessException(400,
+                    "An RPCHook requires the identity-qualified overload: a hook instance is not "
+                            + "a stable credential identity");
+        }
+        return execute(namesrvAddr, null, "anonymous", action);
     }
 
     /**

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -138,14 +139,16 @@ class MqAdminExtFactoryTest {
     }
 
     @Test
-    void executeShouldNotShareClientsAcrossLegacyHookInstances() throws Exception {
+    void executeShouldRejectHookWithoutStableIdentity() throws Exception {
         DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
         RecordingFactory factory = new RecordingFactory(admin);
 
-        factory.execute("10.0.0.1:9876", mock(RPCHook.class), ignored -> null);
-        factory.execute("10.0.0.1:9876", mock(RPCHook.class), ignored -> null);
+        assertThatThrownBy(() -> factory.execute("10.0.0.1:9876", mock(RPCHook.class), ignored -> null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("identity-qualified");
 
-        assertThat(factory.created.get()).isEqualTo(2);
+        assertThat(factory.created.get()).isZero();
+        verify(admin, never()).start();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Make `MqAdminExtFactory.execute(namesrvAddr, rpcHook, action)` reject a non-null `RPCHook` instead of silently deriving the cache identity from `System.identityHashCode(rpcHook)`
- Callers holding a hook must use the identity-qualified overload with a stable, non-secret credential identity
- Update the pinned legacy-hook test to assert the new contract

## Why
The hook-instance identity hash is stable per object but not per credential: any caller that builds a fresh hook per request (the natural pattern — `RuntimeAdminClientResolver.resolveCredential` already constructs a new `AclClientRPCHook` per call) mints a distinct cache identity per request, so the factory creates one admin client per request and `release()` can never evict them (it only knows endpoint and credential-ref keys). All current production callers pass a `null` hook, so the trap is latent — this PR turns it into a loud 400 before it becomes unbounded growth.

## Testing
- `mvn -Dtest=MqAdminExtFactoryTest test` → Tests run: 13, Failures: 0, Errors: 0 (12 existing, 1 updated to the new contract)
