### PR TITLE
fix(broker): close pooled clients created during pool shutdown

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqClientPool.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqClientPool.java
@@ -53,6 +53,9 @@ public class MqClientPool {
     private final Map<ClientKey, Object> cache = new ConcurrentHashMap<>();
     private final AtomicInteger instanceCounter = new AtomicInteger();
     private volatile boolean closed = false;
+    // Serializes client creation/insertion with release/shutdown so a client started while the
+    // pool is shutting down cannot be inserted after the shutdown scan and leak un-shut-down.
+    private final Object lifecycleLock = new Object();
 
     @FunctionalInterface
     public interface ClientAction<C, T> {
@@ -79,15 +82,23 @@ public class MqClientPool {
         if (closed) {
             throw new BusinessException(503, "RocketMQ client pool is shutting down");
         }
-        @SuppressWarnings("unchecked")
-        C client = (C) cache.computeIfAbsent(cacheKey, key -> {
-            // Re-check under the cache lock so a request that passed the initial closed check
-            // cannot create a fresh connection while the pool is shutting down.
+        C client;
+        synchronized (lifecycleLock) {
+            // Re-check under the lifecycle lock so a request that passed the initial closed check
+            // cannot create a fresh connection while the pool is shutting down, and a just-created
+            // client cannot be inserted after the shutdown scan has already run.
             if (closed) {
                 throw new BusinessException(503, "RocketMQ client pool is shutting down");
             }
-            return creator.create(key.namesrvAddr(), rpcHook);
-        });
+            @SuppressWarnings("unchecked")
+            C cached = (C) cache.get(cacheKey);
+            if (cached != null) {
+                client = cached;
+            } else {
+                client = creator.create(cacheKey.namesrvAddr(), rpcHook);
+                cache.put(cacheKey, client);
+            }
+        }
         try {
             return action.apply(client);
         } catch (BusinessException ex) {
@@ -104,13 +115,15 @@ public class MqClientPool {
         if (normalized.isEmpty()) {
             return;
         }
-        cache.entrySet().removeIf(entry -> {
-            if (!entry.getKey().namesrvAddr().equals(normalized)) {
-                return false;
-            }
-            safeShutdown(entry.getValue());
-            return true;
-        });
+        synchronized (lifecycleLock) {
+            cache.entrySet().removeIf(entry -> {
+                if (!entry.getKey().namesrvAddr().equals(normalized)) {
+                    return false;
+                }
+                safeShutdown(entry.getValue());
+                return true;
+            });
+        }
         log.info("Released pooled RocketMQ clients for namesrv {}", normalized);
     }
 
@@ -120,11 +133,13 @@ public class MqClientPool {
         if (normalized.isEmpty()) {
             return;
         }
-        for (Kind kind : Kind.values()) {
-            ClientKey key = new ClientKey(normalized, identity(authenticationIdentity), kind);
-            Object client = cache.remove(key);
-            if (client != null) {
-                safeShutdown(client);
+        synchronized (lifecycleLock) {
+            for (Kind kind : Kind.values()) {
+                ClientKey key = new ClientKey(normalized, identity(authenticationIdentity), kind);
+                Object client = cache.remove(key);
+                if (client != null) {
+                    safeShutdown(client);
+                }
             }
         }
         log.info("Released pooled RocketMQ clients for namesrv {} and identity {}", normalized,
@@ -136,7 +151,7 @@ public class MqClientPool {
         C create(String namesrvAddr, RPCHook rpcHook);
     }
 
-    private DefaultMQPullConsumer createPullConsumer(String namesrvAddr, RPCHook rpcHook) {
+    protected DefaultMQPullConsumer createPullConsumer(String namesrvAddr, RPCHook rpcHook) {
         DefaultMQPullConsumer consumer = new DefaultMQPullConsumer(PULL_CONSUMER_GROUP, rpcHook);
         consumer.setNamesrvAddr(namesrvAddr);
         consumer.setInstanceName(buildInstanceName(namesrvAddr));
@@ -151,7 +166,7 @@ public class MqClientPool {
         }
     }
 
-    private DefaultMQProducer createProducer(String namesrvAddr, RPCHook rpcHook) {
+    protected DefaultMQProducer createProducer(String namesrvAddr, RPCHook rpcHook) {
         DefaultMQProducer producer = new DefaultMQProducer(PRODUCER_GROUP, rpcHook);
         producer.setNamesrvAddr(namesrvAddr);
         producer.setInstanceName(buildInstanceName(namesrvAddr));
@@ -211,9 +226,11 @@ public class MqClientPool {
 
     @PreDestroy
     public void shutdown() {
-        closed = true;
-        cache.values().forEach(this::safeShutdown);
-        cache.clear();
+        synchronized (lifecycleLock) {
+            closed = true;
+            cache.values().forEach(this::safeShutdown);
+            cache.clear();
+        }
         log.info("Shut down all pooled RocketMQ clients");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqClientPoolTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqClientPoolTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class MqClientPoolTest {
+
+    @Test
+    void withPullConsumerShouldReusePooledClient() throws Exception {
+        RecordingPool pool = new RecordingPool();
+
+        DefaultMQPullConsumer first =
+                pool.withPullConsumer("10.0.0.1:9876", null, "credential-a", consumer -> consumer);
+        DefaultMQPullConsumer second =
+                pool.withPullConsumer("10.0.0.1:9876", null, "credential-a", consumer -> consumer);
+
+        assertThat(second).isSameAs(first);
+        assertThat(pool.created).hasSize(1);
+    }
+
+    @Test
+    void withPullConsumerShouldNotShareClientsAcrossIdentities() throws Exception {
+        RecordingPool pool = new RecordingPool();
+
+        DefaultMQPullConsumer first =
+                pool.withPullConsumer("10.0.0.1:9876", null, "credential-a", consumer -> consumer);
+        DefaultMQPullConsumer second =
+                pool.withPullConsumer("10.0.0.1:9876", null, "credential-b", consumer -> consumer);
+
+        assertThat(second).isNotSameAs(first);
+        assertThat(pool.created).hasSize(2);
+    }
+
+    @Test
+    void releaseShouldShutdownAndEvictClient() throws Exception {
+        RecordingPool pool = new RecordingPool();
+
+        DefaultMQPullConsumer first =
+                pool.withPullConsumer("10.0.0.1:9876", null, "credential-a", consumer -> consumer);
+        pool.release("10.0.0.1:9876", "credential-a");
+        DefaultMQPullConsumer second =
+                pool.withPullConsumer("10.0.0.1:9876", null, "credential-a", consumer -> consumer);
+
+        verify(first).shutdown();
+        assertThat(second).isNotSameAs(first);
+        assertThat(pool.created).hasSize(2);
+    }
+
+    @Test
+    void shutdownShouldCloseConcurrentlyCreatedClient() throws Exception {
+        BlockingPool pool = new BlockingPool();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> caller = executor.submit(
+                    () -> pool.withPullConsumer("10.0.0.1:9876", null, "credential-a", consumer -> consumer));
+            assertThat(pool.creationStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+            // The in-flight creation holds the lifecycle lock, so shutdown must wait for it and
+            // close the client it produces instead of scanning an empty pool and leaking it.
+            Future<?> shutdownTask = executor.submit(pool::shutdown);
+
+            pool.allowCreation.countDown();
+            caller.get(5, TimeUnit.SECONDS);
+            shutdownTask.get(5, TimeUnit.SECONDS);
+
+            assertThat(pool.created).hasSize(1);
+            verify(pool.created.get(0), times(1)).shutdown();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void withPullConsumerShouldRejectCallsAfterShutdown() {
+        RecordingPool pool = new RecordingPool();
+        pool.shutdown();
+
+        assertThatThrownBy(
+                () -> pool.withPullConsumer("10.0.0.1:9876", null, null, consumer -> consumer))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("shutting down");
+        assertThat(pool.created).isEmpty();
+    }
+
+    private static class RecordingPool extends MqClientPool {
+        final List<DefaultMQPullConsumer> created = new CopyOnWriteArrayList<>();
+
+        @Override
+        protected DefaultMQPullConsumer createPullConsumer(String namesrvAddr, RPCHook rpcHook) {
+            DefaultMQPullConsumer consumer = mock(DefaultMQPullConsumer.class);
+            created.add(consumer);
+            return consumer;
+        }
+    }
+
+    private static final class BlockingPool extends RecordingPool {
+        private final CountDownLatch creationStarted = new CountDownLatch(1);
+        private final CountDownLatch allowCreation = new CountDownLatch(1);
+
+        @Override
+        protected DefaultMQPullConsumer createPullConsumer(String namesrvAddr, RPCHook rpcHook) {
+            DefaultMQPullConsumer consumer = super.createPullConsumer(namesrvAddr, rpcHook);
+            creationStarted.countDown();
+            try {
+                assertThat(allowCreation.await(5, TimeUnit.SECONDS)).isTrue();
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Client creation interrupted", exception);
+            }
+            return consumer;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Serialize `MqClientPool` client creation/insertion with `release()`/`shutdown()` via a `lifecycleLock`
- Re-check `closed` under the lifecycle lock instead of inside the `computeIfAbsent` lambda
- Make `createPullConsumer`/`createProducer` protected (test seam, mirroring `MqAdminExtFactory.newAdmin`) and add `MqClientPoolTest` with a regression test for the race

## Why
`shutdown()` sets `closed`, scans `cache.values()`, and clears — but a concurrent request whose client was still being created (network I/O) passed the `closed` re-check *before* the slow creation and then inserted the started client *after* the scan/clear. That client was never shut down: its Netty threads and NameServer connections stayed alive past context destruction (started clients hold non-daemon threads, which can even hang JVM exit). `release()` had the same window.

## Testing
- `mvn -Dtest=MqClientPoolTest test` → Tests run: 5, Failures: 0, Errors: 0 (new test class)
- `mvn -Dtest='RuntimeAdminClientResolverTest,RocketMQAdminClientImplTest' test` → 9/9 and 39/39 pass (direct consumers of the pool)
