### PR TITLE
fix(web): harden client connection search normalization and field guards

### DIFF
--- a/web/src/pages/cluster/__tests__/clientsSearch.test.ts
+++ b/web/src/pages/cluster/__tests__/clientsSearch.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { matchesClientSearch } from '../clients';
+
+describe('matchesClientSearch', () => {
+  it('matches client id case-insensitively', () => {
+    const connection = { clientId: 'PID_10.0.0.5_1', address: '10.0.0.5:8080' };
+    expect(matchesClientSearch(connection, 'pid_10.0.0.5')).toBe(true);
+    expect(matchesClientSearch(connection, 'PID_10.0.0.5_1')).toBe(true);
+    expect(matchesClientSearch(connection, 'nope')).toBe(false);
+  });
+
+  it('matches address case-insensitively', () => {
+    const connection = { clientId: 'PID_1', address: '10.0.0.5:8080' };
+    expect(matchesClientSearch(connection, '10.0.0.5:8080')).toBe(true);
+  });
+
+  it('trims whitespace from the search input', () => {
+    const connection = { clientId: 'PID_1', address: '10.0.0.5:8080' };
+    expect(matchesClientSearch(connection, '  pid_1  ')).toBe(true);
+    expect(matchesClientSearch(connection, '  nope  ')).toBe(false);
+  });
+
+  it('treats empty and whitespace-only search as a full match', () => {
+    const connection = { clientId: 'PID_1', address: '10.0.0.5:8080' };
+    expect(matchesClientSearch(connection, '')).toBe(true);
+    expect(matchesClientSearch(connection, '   ')).toBe(true);
+    expect(matchesClientSearch(connection, undefined)).toBe(true);
+  });
+
+  it('does not throw when clientId or address is missing', () => {
+    expect(matchesClientSearch({}, 'pid')).toBe(false);
+    expect(matchesClientSearch({ clientId: null, address: undefined }, '  ')).toBe(true);
+    expect(matchesClientSearch({ address: '10.0.0.9:8080' }, '10.0.0.9')).toBe(true);
+    expect(matchesClientSearch({ clientId: 'PID_9' }, 'pid_9')).toBe(true);
+  });
+});

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -97,6 +97,31 @@ const countBy = (values: string[]) =>
     .map(([label, count]) => ({ label, count }))
     .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
 
+/**
+ * Connection fields matched by the client search box. Typed as nullable to
+ * mirror what the backend may actually return for legacy payloads.
+ */
+export type ClientSearchFields = {
+  clientId?: string | null;
+  address?: string | null;
+};
+
+/**
+ * Case- and whitespace-insensitive client search match that tolerates
+ * missing clientId/address fields and whitespace-only search input.
+ */
+export const matchesClientSearch = (
+  connection: ClientSearchFields,
+  rawSearch: string | null | undefined,
+) => {
+  const normalizedSearch = (rawSearch ?? '').trim().toLowerCase();
+  if (!normalizedSearch) return true;
+  return (
+    (connection.clientId ?? '').toLowerCase().includes(normalizedSearch) ||
+    (connection.address ?? '').toLowerCase().includes(normalizedSearch)
+  );
+};
+
 type ApiErrorLike = {
   message?: unknown;
   response?: {
@@ -266,14 +291,10 @@ const ClientsPage = () => {
   }, [clusterConnections]);
 
   /* ─── Filtered data (search + cluster only, table handles column filters) ─── */
-  const filtered = useMemo(() => {
-    const normalizedSearch = search.toLowerCase();
-    return clusterConnections.filter(
-      (connection) =>
-        connection.clientId.toLowerCase().includes(normalizedSearch) ||
-        connection.address?.toLowerCase().includes(normalizedSearch),
-    );
-  }, [clusterConnections, search]);
+  const filtered = useMemo(
+    () => clusterConnections.filter((connection) => matchesClientSearch(connection, search)),
+    [clusterConnections, search],
+  );
 
   const exportConnections = useMemo(() => {
     const matches = (key: string, value: string) => {


### PR DESCRIPTION
## Summary

- Extract the client connection search matching in `pages/cluster/clients.tsx` into an exported, unit-testable `matchesClientSearch` helper.
- Normalize the search input with `trim()` + `toLowerCase()` so whitespace-only input no longer empties the table (previously an untrimmed `""`/`"  "` search behaved inconsistently, and `toLowerCase()` alone left padding intact).
- Guard `connection.clientId` (and `address`) against `null`/`undefined` payloads from the backend, which previously could throw `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` and blank out the whole page.
- Treat an empty / whitespace-only search as a full match, matching the behavior already used by the certs page search.

## Why

The clients page search box fed raw user input directly into `toLowerCase()` and called `.toLowerCase()` unconditionally on backend-provided connection fields. In the same file `connection.address?.` is already defensively option-chained, showing the payload shape is not guaranteed to match the TS interface, yet `clientId` was not protected the same way.

## Testing

- `cd web && ./node_modules/.bin/vitest run src/pages/cluster/__tests__/clientsSearch.test.ts src/pages/cluster/__tests__/ClientsPage.test.tsx` — 2 files, 20 tests passed (5 new helper regression tests: case-insensitive id/address match, whitespace trimming, empty/undefined search, missing clientId/address fields).
- `cd web && ./node_modules/.bin/tsc --noEmit` — clean.
- `cd web && ./node_modules/.bin/eslint src/pages/cluster/clients.tsx src/pages/cluster/__tests__/clientsSearch.test.ts` — 0 errors (1 pre-existing-style react-refresh warning for the exported helper, same precedent as `message.tsx`/`LiteTopic.tsx` page-level helper exports).
