### PR TITLE
fix(settings): preserve unmanaged settings fields on partial saves

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/settings/SettingsService.java
@@ -147,6 +147,28 @@ public class SettingsService {
             if (!StringUtils.hasText(settings.getAwsRegion())) {
                 settings.setAwsRegion(currentSettings.getAwsRegion());
             }
+            // The settings blob has two partial writers: the general-settings save does not
+            // manage the LLM tuning values, and the LLM-config save does not manage the
+            // notification fields. An absent (null) value therefore inherits the stored one,
+            // while an explicit empty string still clears a text field.
+            if (settings.getDingtalkWebhook() == null) {
+                settings.setDingtalkWebhook(currentSettings.getDingtalkWebhook());
+            }
+            if (settings.getSmsWebhook() == null) {
+                settings.setSmsWebhook(currentSettings.getSmsWebhook());
+            }
+            if (settings.getEmailRecipients() == null) {
+                settings.setEmailRecipients(currentSettings.getEmailRecipients());
+            }
+            if (settings.getLlmEngine() == null) {
+                settings.setLlmEngine(currentSettings.getLlmEngine());
+            }
+            if (settings.getMaxTokens() == null) {
+                settings.setMaxTokens(currentSettings.getMaxTokens());
+            }
+            if (settings.getTemperature() == null) {
+                settings.setTemperature(currentSettings.getTemperature());
+            }
         }
         settings.setClearApiKey(false);
         settings.setClearDingtalkSigningSecret(false);

--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsServiceTest.java
@@ -179,6 +179,67 @@ class SettingsServiceTest {
     }
 
     @Test
+    void saveGeneralSettingsShouldPreserveLlmTuningWhenGeneralSaveOmitsItTest() {
+        GeneralSettingsVO existing = GeneralSettingsVO.builder()
+                .maxTokens(4096)
+                .temperature(0.7)
+                .build();
+        GeneralSettingsVO update = GeneralSettingsVO.builder()
+                .theme("light")
+                .build();
+        when(settingsRepository.loadGeneralSettings()).thenReturn(existing);
+
+        settingsService.saveGeneralSettings(update);
+
+        assertThat(update.getMaxTokens()).isEqualTo(4096);
+        assertThat(update.getTemperature()).isEqualTo(0.7);
+    }
+
+    @Test
+    void saveGeneralSettingsShouldPreserveNotificationFieldsWhenLlmSaveOmitsThemTest() {
+        GeneralSettingsVO existing = GeneralSettingsVO.builder()
+                .dingtalkWebhook("https://oapi.dingtalk.com/robot/send?access-token=tok")
+                .smsWebhook("https://sms.example.com/hook")
+                .emailRecipients("ops@example.com")
+                .llmEngine("http")
+                .build();
+        GeneralSettingsVO update = GeneralSettingsVO.builder()
+                .theme("light")
+                .llmProvider("tongyi")
+                .maxTokens(2048)
+                .temperature(0.5)
+                .build();
+        when(settingsRepository.loadGeneralSettings()).thenReturn(existing);
+
+        settingsService.saveGeneralSettings(update);
+
+        assertThat(update.getDingtalkWebhook())
+                .isEqualTo("https://oapi.dingtalk.com/robot/send?access-token=tok");
+        assertThat(update.getSmsWebhook()).isEqualTo("https://sms.example.com/hook");
+        assertThat(update.getEmailRecipients()).isEqualTo("ops@example.com");
+        assertThat(update.getLlmEngine()).isEqualTo("http");
+    }
+
+    @Test
+    void saveGeneralSettingsShouldStillClearNotificationFieldsWhenExplicitlyEmptiedTest() {
+        GeneralSettingsVO existing = GeneralSettingsVO.builder()
+                .dingtalkWebhook("https://oapi.dingtalk.com/robot/send?access-token=tok")
+                .smsWebhook("https://sms.example.com/hook")
+                .build();
+        GeneralSettingsVO update = GeneralSettingsVO.builder()
+                .theme("light")
+                .dingtalkWebhook("")
+                .smsWebhook("")
+                .build();
+        when(settingsRepository.loadGeneralSettings()).thenReturn(existing);
+
+        settingsService.saveGeneralSettings(update);
+
+        assertThat(update.getDingtalkWebhook()).isEmpty();
+        assertThat(update.getSmsWebhook()).isEmpty();
+    }
+
+    @Test
     void saveGeneralSettingsShouldRejectMetadataLlmBaseUrlBeforePersistingTest() {
         GeneralSettingsVO update = GeneralSettingsVO.builder()
                 .baseUrl("http://169.254.169.254/latest/meta-data")


### PR DESCRIPTION
## Summary
- In `SettingsService.saveGeneralSettings`, inherit the stored value for fields that a
  partial writer does not manage: `dingtalkWebhook`, `smsWebhook`, `emailRecipients`,
  `llmEngine`, `maxTokens`, `temperature`.
- An absent (`null`) value now inherits the stored one; an explicit empty string still
  clears a text field, so the existing clear-by-empty-string behaviour is unchanged.
- Added regression tests for both partial-writer directions and the explicit-clear case.

## Why
The persisted settings blob has two writers that each manage only part of the fields:
- the general-settings save (`/api/settings/general/save`, `GeneralSettingsUpdateDTO`)
  has no `maxTokens`/`temperature` properties, so every general save nulled the LLM
  tuning and the next LLM config load silently fell back to the defaults;
- the LLM config save (`LlmConfigService.saveConfig`) builds the VO without
  `dingtalkWebhook`/`smsWebhook`/`emailRecipients`/`llmEngine`, so saving the LLM
  config wiped the notification channels and engine override.

Both were data-loss-on-save bugs in the opposite direction of each other.

## Testing
- `cd server && mvn -Dtest=SettingsServiceTest test` — Tests run: 46, Failures: 0, Errors: 0
- `cd server && mvn -Dtest=LlmConfigServiceTest test` — Tests run: 28, Failures: 0, Errors: 0
