### PR TITLE
fix(ai): tolerate malformed tool parameter schemas

### DIFF
--- a/web/src/pages/ai/__tests__/toolInputTemplate.test.ts
+++ b/web/src/pages/ai/__tests__/toolInputTemplate.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildToolInputTemplate } from '../index';
+import type { McpTool } from '../../../api/ai';
+
+const tool = (overrides: Partial<McpTool>): McpTool => ({
+  name: 'rmq.tool',
+  description: 'test tool',
+  parameters: {},
+  ...overrides,
+});
+
+describe('buildToolInputTemplate', () => {
+  it('fills required fields from schema defaults, enums, and type fallbacks', () => {
+    const template = buildToolInputTemplate(
+      tool({
+        parameters: {
+          type: 'object',
+          required: ['cluster', 'level', 'retries', 'enabled', 'extra'],
+          properties: {
+            cluster: { type: 'string' },
+            level: { type: 'string', enum: ['P1', 'P2'] },
+            retries: { type: 'integer', default: 3 },
+            enabled: { type: 'boolean' },
+            extra: { type: 'string' },
+          },
+        },
+      }),
+      'cluster-a',
+    );
+
+    expect(JSON.parse(template)).toEqual({
+      cluster: 'cluster-a',
+      level: 'P1',
+      retries: 3,
+      enabled: false,
+      extra: '',
+    });
+  });
+
+  it('does not crash when the tool omits its parameter schema', () => {
+    expect(buildToolInputTemplate(tool({ parameters: undefined as unknown as Record<string, unknown> }))).toBe('{}');
+    expect(
+      buildToolInputTemplate(tool({ parameters: 'broken' as unknown as Record<string, unknown> })),
+    ).toBe('{}');
+  });
+
+  it('ignores required fields that are missing from the properties map', () => {
+    const template = buildToolInputTemplate(
+      tool({
+        parameters: {
+          type: 'object',
+          required: ['cluster', 'orphan'],
+          properties: { cluster: { type: 'string' } },
+        },
+      }),
+    );
+
+    expect(JSON.parse(template)).toEqual({ cluster: '', orphan: '' });
+  });
+});

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -150,11 +150,12 @@ const defaultSchemaValue = (schema: unknown): unknown => {
   }
 };
 
-const buildToolInputTemplate = (tool: McpTool, cluster?: string): string => {
-  const required = Array.isArray(tool.parameters.required)
-    ? tool.parameters.required.filter((field): field is string => typeof field === 'string')
+export const buildToolInputTemplate = (tool: McpTool, cluster?: string): string => {
+  const parameters = isRecord(tool.parameters) ? tool.parameters : {};
+  const required = Array.isArray(parameters.required)
+    ? parameters.required.filter((field): field is string => typeof field === 'string')
     : [];
-  const properties = isRecord(tool.parameters.properties) ? tool.parameters.properties : {};
+  const properties = isRecord(parameters.properties) ? parameters.properties : {};
   const input = Object.fromEntries(
     required.map((field) => [
       field,


### PR DESCRIPTION
## Summary
- Guard `buildToolInputTemplate()` against tools whose `parameters` object is missing or not an object (defensive read via the existing `isRecord` helper)
- Export `buildToolInputTemplate()` for unit testing (same precedent as the `AiMessage` export in this page)
- Add unit tests covering schema defaults/enums/type fallbacks, missing/broken `parameters`, and required fields absent from `properties`

## Why
Tool metadata comes from the MCP catalog over the wire, so the `McpTool.parameters` shape is not guaranteed. `buildToolInputTemplate()` dereferenced `tool.parameters.required` without a type check: a tool entry with a missing or malformed `parameters` field threw a `TypeError` inside `loadTools()`, failing the whole catalog load (and the automatic first-tool selection) even though every other tool was fine.

## Testing
- `./node_modules/.bin/vitest run src/pages/ai/__tests__/` → 17 passed (3 new)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/pages/ai/index.tsx src/pages/ai/__tests__/toolInputTemplate.test.ts` → 0 errors
