### PR TITLE
fix(config): skip fabricated snapshot persistence without base config

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -242,6 +242,7 @@ public class ClusterService {
         requireMatchingDefaultQueueNums(command);
         ClusterVO cluster = resolveCluster(command.getId(), command.getInstanceId());
 
+        boolean hasStoredConfig = cluster.getConfig() != null;
         ClusterConfigVO config = copyConfig(cluster.getConfig());
         applyConfig(command, config);
 
@@ -279,7 +280,15 @@ public class ClusterService {
 
         ClusterConfigUpdateResultVO.Status status = updateStatus(successfulBrokers, failedBrokers);
         if (failedBrokers.isEmpty()) {
-            clusterRepository.updateConfig(command.getId(), config);
+            if (hasStoredConfig) {
+                // Without a stored base the applied config is padded with zero defaults
+                // (live read failed and nothing was persisted yet); persisting it would
+                // store a fabricated snapshot that later fallback reads would show as
+                // real values such as a 0-message-size limit or permission 0. Persist
+                // before mutating the in-memory cluster so a persistence failure leaves
+                // the previous snapshot untouched.
+                clusterRepository.updateConfig(command.getId(), config);
+            }
             cluster.setConfig(config);
         }
         recordConfigUpdateAudit(command.getId(), status, successfulBrokers, failedBrokers);

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -51,6 +51,7 @@ import org.assertj.core.api.ThrowableAssert;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -426,6 +427,44 @@ class ClusterServiceTest {
     }
 
     @Test
+    void updateConfigShouldSkipSnapshotPersistenceWhenNoStoredConfigExists() {
+        ClusterVO configLessCluster = ClusterVO.builder()
+                .name("test-cluster")
+                .brokers(List.of(BrokerVO.builder()
+                        .name("broker-0")
+                        .addr("10.0.0.1:10911")
+                        .build()))
+                .build();
+        configLessCluster.setId("cluster-1");
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(configLessCluster));
+
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .fileReservedTime(48)
+                .build();
+
+        ClusterConfigUpdateResultVO result = clusterService.updateClusterConfig(command);
+
+        assertThat(result.getStatus()).isEqualTo(ClusterConfigUpdateResultVO.Status.SUCCESS);
+        assertThat(result.getCluster().getConfig().getFileReservedTime()).isEqualTo(48);
+        verify(clusterRepository, never()).updateConfig(eq("cluster-1"), any());
+    }
+
+    @Test
+    void updateConfigShouldPersistSnapshotWhenStoredConfigExists() {
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .fileReservedTime(48)
+                .build();
+
+        clusterService.updateClusterConfig(command);
+
+        verify(clusterRepository).updateConfig(eq("cluster-1"), any(ClusterConfigVO.class));
+    }
+
+    @Test
     void updateConfigShouldReportPartialFailureAfterOneBrokerSucceeds() {
         sampleCluster.setBrokers(List.of(
                 BrokerVO.builder().name("broker-0").addr("10.0.0.1:10911").build(),
@@ -569,7 +608,7 @@ class ClusterServiceTest {
     }
 
     @Test
-    void updateConfigShouldLeaveNullStoredConfigWhenRepositoryUpdateFails() {
+    void updateConfigShouldSkipPersistenceWhenStoredConfigIsNull() {
         ClusterVO clusterWithNullConfig = ClusterVO.builder()
                 .name("null-config-cluster")
                 .status(ClusterStatus.healthy)
@@ -577,19 +616,21 @@ class ClusterServiceTest {
                 .config(null)
                 .build();
         clusterWithNullConfig.setId("cluster-nc");
-        RuntimeException persistenceFailure = new RuntimeException("persistence failed");
         when(clusterRepository.findById("cluster-nc")).thenReturn(Optional.of(clusterWithNullConfig));
-        doThrow(persistenceFailure).when(clusterRepository)
-                .updateConfig(eq("cluster-nc"), any(ClusterConfigVO.class));
 
         UpdateConfigDTO command = UpdateConfigDTO.builder()
                 .id("cluster-nc")
                 .flushDiskType("ASYNC_FLUSH")
                 .build();
 
-        assertThatThrownBy(() -> clusterService.updateClusterConfig(command))
-                .isSameAs(persistenceFailure);
-        assertThat(clusterWithNullConfig.getConfig()).isNull();
+        ClusterConfigUpdateResultVO result = clusterService.updateClusterConfig(command);
+
+        // The applied config is padded with zero defaults, so it must not be persisted as
+        // a fabricated snapshot; the in-memory cluster still reflects the applied values.
+        assertThat(result.getStatus()).isEqualTo(ClusterConfigUpdateResultVO.Status.SUCCESS);
+        assertThat(result.getCluster().getConfig().getFlushDiskType())
+                .isEqualTo(FlushDiskType.ASYNC_FLUSH);
+        verify(clusterRepository, never()).updateConfig(eq("cluster-nc"), any(ClusterConfigVO.class));
     }
 
     @Test
@@ -790,6 +831,8 @@ class ClusterServiceTest {
     @Test
     void updateClusterConfigShouldUseLiveClusterWhenItIsNotPersisted() {
         when(clusterProvider.refreshClusterDetail("cluster-1")).thenReturn(sampleCluster);
+        when(brokerConfigService.getBrokerConfig(eq("10.0.0.1:10911"), isNull()))
+                .thenReturn(sampleCluster.getConfig());
         UpdateConfigDTO command = UpdateConfigDTO.builder()
                 .id("cluster-1")
                 .maxMessageSize(8_388_608)


### PR DESCRIPTION
## Summary
- `ClusterService.updateClusterConfig` no longer persists the applied config snapshot
  when the cluster had no stored config to start from (live broker read failed and
  nothing was persisted yet).
- Persistence now happens before the in-memory cluster is mutated, so a persistence
  failure leaves the previous snapshot untouched (previously pinned behaviour, kept).
- Updated the null-config regression test to the new semantics and added
  `updateConfigShouldSkipSnapshotPersistenceWhenNoStoredConfigExists` /
  `updateConfigShouldPersistSnapshotWhenStoredConfigExists`.

## Why
`copyConfig(null)` yields a VO padded with zero defaults. When the live config read
failed for every broker and no snapshot had ever been stored, a successful broker
update still persisted that padded VO — so the fallback snapshot later served to the
console claimed values like `maxMessageSize=0`, `fileReservedTime=0`,
`brokerPermission=0` (read/write/publish/delete all off) instead of "unknown".
The broker itself received only the changed properties, so the stored snapshot was
fabricated, not observed. Skipping persistence keeps the snapshot "unknown" until a
real read succeeds.

## Testing
- `cd server && mvn -Dtest=ClusterServiceTest test` — Tests run: 41, Failures: 0, Errors: 0
- `cd server && mvn -Dtest=ClusterControllerTest test` — Tests run: 34, Failures: 0, Errors: 0
