### PR TITLE
fix(proxy): bound DNS resolution in the socket health probe

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/SocketProxyHealthProbe.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/SocketProxyHealthProbe.java
@@ -22,11 +22,18 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Default {@link ProxyHealthProbe} backed by a plain TCP connect. A connect succeeds as
  * soon as the remote end accepts the handshake, so this also works for proxies that only
  * listen on gRPC without exposing an HTTP health endpoint.
+ *
+ * <p>The whole probe (name resolution + connect) is bounded by {@code timeoutMillis}. For IP
+ * literals the resolution is instant; for hostnames it may block on DNS, which the socket
+ * connect timeout does not cover, so a slow DNS degrades the probe to unreachable instead of
+ * holding a probe thread past its share of the topology budget.
  */
 @Slf4j
 @Component
@@ -35,12 +42,82 @@ public class SocketProxyHealthProbe implements ProxyHealthProbe {
     @Override
     public ProbeResult probe(String host, int port, int timeoutMillis) {
         long start = System.nanoTime();
-        try (Socket socket = new Socket()) {
-            socket.connect(new InetSocketAddress(host, port), timeoutMillis);
-            long latencyMs = (System.nanoTime() - start) / 1_000_000L;
-            return ProbeResult.reachable(latencyMs);
+        Socket socket = null;
+        try {
+            socket = new Socket();
+            InetSocketAddress address = resolveAddress(host, port, start, timeoutMillis);
+            if (address == null) {
+                // Name resolution did not finish within the probe budget.
+                return ProbeResult.unreachable();
+            }
+            long elapsedMillis = millisSince(start);
+            int remainingMillis = Math.max(1, timeoutMillis - (int) Math.min(elapsedMillis, Integer.MAX_VALUE));
+            socket.connect(address, remainingMillis);
+            return ProbeResult.reachable(millisSince(start));
         } catch (IOException exception) {
             return ProbeResult.unreachable();
+        } finally {
+            closeQuietly(socket);
+        }
+    }
+
+    /**
+     * Resolves {@code host:port} to a socket address within the remaining probe budget.
+     *
+     * @return the resolved address, or {@code null} when a hostname's DNS lookup does not finish
+     *         within the remaining budget
+     */
+    InetSocketAddress resolveAddress(String host, int port, long startNanos, int timeoutMillis) {
+        if (isIpLiteral(host)) {
+            return new InetSocketAddress(host, port);
+        }
+        CompletableFuture<InetSocketAddress> resolution =
+                CompletableFuture.supplyAsync(() -> doResolve(host, port));
+        try {
+            long remainingMillis = timeoutMillis - millisSince(startNanos);
+            return resolution.get(Math.max(1, remainingMillis), TimeUnit.MILLISECONDS);
+        } catch (Exception exception) {
+            resolution.cancel(true);
+            return null;
+        }
+    }
+
+    /** Package-private seam so tests can simulate slow or failing name resolution. */
+    InetSocketAddress doResolve(String host, int port) {
+        return new InetSocketAddress(host, port);
+    }
+
+    private static long millisSince(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000L;
+    }
+
+    private static boolean isIpLiteral(String host) {
+        if (host == null || host.isEmpty()) {
+            return false;
+        }
+        if (host.startsWith("[") && host.endsWith("]")) {
+            return true; // bracketed IPv6 literal
+        }
+        int dots = 0;
+        for (int i = 0; i < host.length(); i++) {
+            char c = host.charAt(i);
+            if (c == '.') {
+                dots++;
+            } else if (c < '0' || c > '9') {
+                return false;
+            }
+        }
+        return dots == 3;
+    }
+
+    private static void closeQuietly(Socket socket) {
+        if (socket == null) {
+            return;
+        }
+        try {
+            socket.close();
+        } catch (IOException ignored) {
+            // already closed
         }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/SocketProxyHealthProbeTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/SocketProxyHealthProbeTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.proxy;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SocketProxyHealthProbeTest {
+
+    @Test
+    void probeShouldReportReachableForListeningAddress() throws Exception {
+        try (ServerSocket server = new ServerSocket(0)) {
+            SocketProxyHealthProbe probe = new SocketProxyHealthProbe();
+
+            ProxyHealthProbe.ProbeResult result =
+                    probe.probe("127.0.0.1", server.getLocalPort(), 2_000);
+
+            assertThat(result.reachable()).isTrue();
+            assertThat(result.latencyMs()).isGreaterThanOrEqualTo(0);
+        }
+    }
+
+    @Test
+    void probeShouldReportUnreachableForClosedPort() throws Exception {
+        int closedPort;
+        try (ServerSocket server = new ServerSocket(0)) {
+            closedPort = server.getLocalPort();
+        }
+
+        SocketProxyHealthProbe probe = new SocketProxyHealthProbe();
+
+        ProxyHealthProbe.ProbeResult result = probe.probe("127.0.0.1", closedPort, 2_000);
+
+        assertThat(result.reachable()).isFalse();
+    }
+
+    @Test
+    void resolveAddressShouldReturnAddressForFastResolution() {
+        FastResolveProbe probe = new FastResolveProbe();
+
+        InetSocketAddress address =
+                probe.resolveAddress("fast-proxy", 8081, System.nanoTime(), 500);
+
+        assertThat(address).isNotNull();
+        assertThat(address.getPort()).isEqualTo(8081);
+    }
+
+    @Test
+    void resolveAddressShouldBoundSlowNameResolution() {
+        SlowResolveProbe probe = new SlowResolveProbe();
+        long start = System.nanoTime();
+
+        InetSocketAddress address =
+                probe.resolveAddress("slow-proxy", 8081, System.nanoTime(), 30);
+
+        long elapsedMillis = (System.nanoTime() - start) / 1_000_000L;
+        assertThat(address).isNull();
+        // The slow resolution (300 ms) must not be awaited; the probe budget (30 ms) bounds it.
+        assertThat(elapsedMillis).isLessThan(250);
+    }
+
+    @Test
+    void probeShouldDegradeToUnreachableWhenNameResolutionExceedsBudget() {
+        SlowResolveProbe probe = new SlowResolveProbe();
+        long start = System.nanoTime();
+
+        ProxyHealthProbe.ProbeResult result = probe.probe("slow-proxy", 8081, 30);
+
+        long elapsedMillis = (System.nanoTime() - start) / 1_000_000L;
+        assertThat(result.reachable()).isFalse();
+        assertThat(elapsedMillis).isLessThan(250);
+    }
+
+    private static final class FastResolveProbe extends SocketProxyHealthProbe {
+        @Override
+        InetSocketAddress doResolve(String host, int port) {
+            return new InetSocketAddress("127.0.0.1", port);
+        }
+    }
+
+    private static final class SlowResolveProbe extends SocketProxyHealthProbe {
+        @Override
+        InetSocketAddress doResolve(String host, int port) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(300);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+            }
+            return new InetSocketAddress("127.0.0.1", port);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Bound name resolution in `SocketProxyHealthProbe` to the probe's `timeoutMillis` budget
- IP literals (IPv4 / bracketed IPv6) still resolve inline; hostnames are resolved on a background thread and joined within the remaining budget
- Add a new `SocketProxyHealthProbeTest` with regression tests for reachable/closed ports, fast resolution, and slow-DNS degradation

## Why
`new InetSocketAddress(host, port)` performs a blocking DNS lookup for hostname-based proxy addresses, and the socket `connect` timeout only covers the TCP handshake — not the resolution. A slow or unresponsive DNS server could therefore hold a probe thread far past the 2s per-probe budget and the 10s overall topology budget; with only 8 probe threads, a few such lookups stall the whole proxy topology build even for healthy nodes.

## Testing
- `mvn -Dtest='SocketProxyHealthProbeTest,ProxyAddressServiceTest' test` → SocketProxyHealthProbeTest 5/5 (new class), ProxyAddressServiceTest 17/17 (main consumer of the probe)
