### PR TITLE
fix(nameserver): normalize optional k8s identifiers in registry entries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameserverRegistryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NameserverRegistryService.java
@@ -48,8 +48,8 @@ public class NameserverRegistryService {
         RmqNameserver entity = new RmqNameserver();
         entity.setName(name);
         entity.setNamesrvAddr(NamesrvAddrParser.normalize(command.getNamesrvAddr()));
-        entity.setK8sNamespace(command.getK8sNamespace());
-        entity.setK8sId(command.getK8sId());
+        entity.setK8sNamespace(normalizeOptionalIdentifier(command.getK8sNamespace()));
+        entity.setK8sId(normalizeOptionalIdentifier(command.getK8sId()));
         entity.setDescription(command.getDescription());
         try {
             nameserverMapper.insert(entity);
@@ -78,8 +78,8 @@ public class NameserverRegistryService {
         }
         entity.setName(name);
         entity.setNamesrvAddr(NamesrvAddrParser.normalize(command.getNamesrvAddr()));
-        entity.setK8sNamespace(command.getK8sNamespace());
-        entity.setK8sId(command.getK8sId());
+        entity.setK8sNamespace(normalizeOptionalIdentifier(command.getK8sNamespace()));
+        entity.setK8sId(normalizeOptionalIdentifier(command.getK8sId()));
         entity.setDescription(command.getDescription());
         try {
             int updated = nameserverMapper.updateById(entity);
@@ -108,6 +108,18 @@ public class NameserverRegistryService {
             throw new BusinessException(400, "name must not be blank");
         }
         return name;
+    }
+
+    /**
+     * The k8s identifiers locate cluster resources, so surrounding whitespace must not
+     * create near-miss lookups ("prod" vs "prod ") and a blank value means "unset".
+     */
+    private static String normalizeOptionalIdentifier(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        String trimmed = raw.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private static BusinessException duplicateName(String name) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameserverRegistryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameserverRegistryServiceTest.java
@@ -105,6 +105,88 @@ class NameserverRegistryServiceTest {
     }
 
     @Test
+    void createShouldTrimKubernetesIdentifiersTest() {
+        when(nameserverMapper.selectCount(any())).thenReturn(0L);
+        when(nameserverMapper.insert(any(RmqNameserver.class))).thenAnswer(invocation -> {
+            RmqNameserver entity = invocation.getArgument(0);
+            entity.setId(10L);
+            return 1;
+        });
+        RmqNameserver stored = new RmqNameserver();
+        stored.setId(10L);
+        stored.setName("rocketmq4");
+        stored.setNamesrvAddr("rocketmq4-nameserver:9876");
+        stored.setK8sNamespace("prod");
+        stored.setK8sId("ids-42");
+        when(nameserverMapper.selectById(10L)).thenReturn(stored);
+
+        service.create(CreateNameserverRegistryDTO.builder()
+                .name("rocketmq4")
+                .namesrvAddr("rocketmq4-nameserver:9876")
+                .k8sNamespace("  prod  ")
+                .k8sId("  ids-42  ")
+                .build());
+
+        ArgumentCaptor<RmqNameserver> captor = ArgumentCaptor.forClass(RmqNameserver.class);
+        verify(nameserverMapper).insert(captor.capture());
+        assertThat(captor.getValue().getK8sNamespace()).isEqualTo("prod");
+        assertThat(captor.getValue().getK8sId()).isEqualTo("ids-42");
+    }
+
+    @Test
+    void createShouldTreatBlankKubernetesIdentifiersAsUnsetTest() {
+        when(nameserverMapper.selectCount(any())).thenReturn(0L);
+        when(nameserverMapper.insert(any(RmqNameserver.class))).thenAnswer(invocation -> {
+            RmqNameserver entity = invocation.getArgument(0);
+            entity.setId(11L);
+            return 1;
+        });
+        RmqNameserver stored = new RmqNameserver();
+        stored.setId(11L);
+        stored.setName("rocketmq5");
+        stored.setNamesrvAddr("rocketmq5-nameserver:9876");
+        when(nameserverMapper.selectById(11L)).thenReturn(stored);
+
+        service.create(CreateNameserverRegistryDTO.builder()
+                .name("rocketmq5")
+                .namesrvAddr("rocketmq5-nameserver:9876")
+                .k8sNamespace("   ")
+                .k8sId("")
+                .build());
+
+        ArgumentCaptor<RmqNameserver> captor = ArgumentCaptor.forClass(RmqNameserver.class);
+        verify(nameserverMapper).insert(captor.capture());
+        assertThat(captor.getValue().getK8sNamespace()).isNull();
+        assertThat(captor.getValue().getK8sId()).isNull();
+    }
+
+    @Test
+    void updateShouldNormalizeKubernetesIdentifiersTest() {
+        RmqNameserver entity = new RmqNameserver();
+        entity.setId(20L);
+        entity.setName("rocketmq6");
+        entity.setNamesrvAddr("rocketmq6-nameserver:9876");
+        when(nameserverMapper.selectById(20L)).thenReturn(entity);
+        when(nameserverMapper.selectCount(any())).thenReturn(0L);
+        when(nameserverMapper.updateById(any(RmqNameserver.class))).thenReturn(1);
+        entity.setK8sNamespace("prod");
+        entity.setK8sId(null);
+
+        service.update(UpdateNameserverRegistryDTO.builder()
+                .id(20L)
+                .name("rocketmq6")
+                .namesrvAddr("rocketmq6-nameserver:9876")
+                .k8sNamespace("  prod  ")
+                .k8sId("   ")
+                .build());
+
+        ArgumentCaptor<RmqNameserver> captor = ArgumentCaptor.forClass(RmqNameserver.class);
+        verify(nameserverMapper).updateById(captor.capture());
+        assertThat(captor.getValue().getK8sNamespace()).isEqualTo("prod");
+        assertThat(captor.getValue().getK8sId()).isNull();
+    }
+
+    @Test
     void createShouldRejectDuplicateNameTest() {
         when(nameserverMapper.selectCount(any())).thenReturn(1L);
 


### PR DESCRIPTION
## Summary
- Normalize the optional `k8sNamespace`/`k8sId` identifiers in
  `NameserverRegistryService.create`/`update`: surrounding whitespace is trimmed and a
  blank value is stored as `null` ("unset"), mirroring the already-documented
  normalization of the registry `name`.
- Added regression tests for trim-on-create, blank-means-unset-on-create and
  normalization-on-update.

## Why
Registry names are compared and displayed as-is, so `create` already trims them with an
explicit rationale against near-duplicate entries. The k8s identifiers — which locate
cluster resources and are compared for lookups — were stored verbatim, so `"prod "` and
`"prod"` (or `"  "`) were accepted as distinct, non-null values. The k8s certificate
service applies the same trim-and-null treatment to its identifiers
(`normalizeOptionalIdentity`); this brings the nameserver registry in line with it.

## Testing
- `cd server && mvn -Dtest=NameserverRegistryServiceTest test`
  — Tests run: 23, Failures: 0, Errors: 0
