### PR TITLE
fix(ai): discard stale tool execution results

### DIFF
--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -453,4 +453,43 @@ describe('AiPage tool runner', () => {
     expect(await screen.findByText('工具参数必须是有效的 JSON 对象')).toBeInTheDocument();
     expect(executeTool).not.toHaveBeenCalled();
   });
+
+  it('discards a tool execution result after the selected tool changes', async () => {
+    const user = userEvent.setup();
+    vi.mocked(listTools).mockResolvedValue([
+      { name: 'rmq.first', description: 'first', parameters: {} },
+      { name: 'rmq.second', description: 'second', parameters: {} },
+    ]);
+    let resolveFirst!: (value: unknown) => void;
+    vi.mocked(executeTool).mockImplementation((name) =>
+      name === 'rmq.first'
+        ? new Promise((resolve) => {
+            resolveFirst = resolve;
+          })
+        : Promise.resolve({ tool: name }),
+    );
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: '工具' }));
+    const dialog = await screen.findByRole('dialog', { name: 'AI 工具' });
+    await waitFor(() => expect(listTools).toHaveBeenCalledWith('cluster-a'));
+
+    await user.click(within(dialog).getByRole('button', { name: /执\s*行/ }));
+    await waitFor(() => expect(executeTool).toHaveBeenCalledWith('rmq.first', {}));
+
+    const toolSelect = within(dialog).getByRole('combobox', { name: '选择工具' });
+    await user.click(toolSelect);
+    await user.click(
+      await screen.findByText('rmq.second', { selector: '.ant-select-item-option-content' }),
+    );
+
+    await act(async () => resolveFirst({ tool: 'rmq.first', stale: true }));
+    await act(async () => {});
+    expect(within(dialog).queryByTestId('tool-result')).not.toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole('button', { name: /执\s*行/ }));
+    const result = await within(dialog).findByTestId('tool-result');
+    expect(result).toHaveTextContent('"tool": "rmq.second"');
+    expect(result).not.toHaveTextContent('stale');
+  });
 });

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -473,6 +473,7 @@ const AiPage = () => {
   const conversationIdRef = useRef<string | null>(history.activeConversationId);
   const chatInFlightRef = useRef(false);
   const toolLoadRequestRef = useRef(0);
+  const toolExecuteRequestRef = useRef(0);
   const consumedDraftRef = useRef(false);
   const pendingAutoSendRef = useRef<{
     prompt: string;
@@ -745,18 +746,22 @@ const AiPage = () => {
   const selectTool = useCallback(
     (name: string, availableTools: McpTool[] = tools, clusterId: string = selectedClusterId) => {
       const tool = availableTools.find((item) => item.name === name);
+      toolExecuteRequestRef.current += 1;
       setSelectedToolName(name);
       setToolInput(tool ? buildToolInputTemplate(tool, clusterId) : '{}');
       setToolResult(undefined);
+      setToolExecuting(false);
     },
-    [selectedClusterId, setSelectedToolName, setToolInput, setToolResult, tools],
+    [selectedClusterId, setSelectedToolName, setToolInput, setToolResult, setToolExecuting, tools],
   );
 
   const loadTools = useCallback(
     async (clusterId: string) => {
       const requestId = ++toolLoadRequestRef.current;
+      toolExecuteRequestRef.current += 1;
       setSelectedToolName('');
       setToolResult(undefined);
+      setToolExecuting(false);
       setToolsLoading(true);
       try {
         const availableTools = await listTools(clusterId || undefined);
@@ -838,15 +843,19 @@ const AiPage = () => {
       return;
     }
 
+    const executionId = ++toolExecuteRequestRef.current;
     setToolExecuting(true);
     setToolResult(undefined);
     try {
-      setToolResult(await executeTool(selectedToolName, parsedInput));
+      const result = await executeTool(selectedToolName, parsedInput);
+      if (executionId !== toolExecuteRequestRef.current) return;
+      setToolResult(result);
       message.success('工具执行成功');
     } catch (error) {
+      if (executionId !== toolExecuteRequestRef.current) return;
       message.error(error instanceof Error ? error.message : '工具执行失败');
     } finally {
-      setToolExecuting(false);
+      if (executionId === toolExecuteRequestRef.current) setToolExecuting(false);
     }
   }, [selectedToolName, toolExecuting, toolInput]);
 


### PR DESCRIPTION
## Summary
- Add a `toolExecuteRequestRef` execution-generation counter to the AI tool runner
- `selectTool()` and `loadTools()` now invalidate any in-flight execution (and reset its spinner), and `handleExecuteTool()` only applies a result/message if its generation is still current
- Add a page regression test: start a tool execution, switch the selected tool while it is in flight, and verify the stale result is discarded

## Why
Tool execution is async but the modal only guarded against *double submits* (the `toolExecuting` state flag), not against the tool changing while a request was in flight. Switching tools (or the cluster, which reloads the catalog) called `setToolResult(undefined)` for the new tool, and the in-flight request then resolved into that slot — the user saw tool A's result rendered under tool B, and the spinner state could also desynchronize (stuck on or cleared early).

## Testing
- `./node_modules/.bin/vitest run src/pages/ai/__tests__/AiPage.test.tsx` → 14 passed (1 new)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/pages/ai/index.tsx src/pages/ai/__tests__/AiPage.test.tsx` → 0 errors
