### PR TITLE
fix(nameserver): reject structurally invalid IPv6 address literals

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParser.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParser.java
@@ -18,6 +18,9 @@ package org.apache.rocketmq.studio.cluster.nameserver;
 
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -89,6 +92,8 @@ public final class NamesrvAddrParser {
         if (ipv6.isEmpty() || ipv6.chars().filter(ch -> ch == ':').count() < 2) {
             return false;
         }
+        // Character-set pre-filter: only literal characters are accepted, so getByName
+        // below parses the value as an address literal and cannot issue a DNS lookup.
         for (char ch : ipv6.toCharArray()) {
             boolean valid = ch == ':'
                     || Character.isDigit(ch)
@@ -98,6 +103,12 @@ public final class NamesrvAddrParser {
                 return false;
             }
         }
-        return true;
+        // The charset check alone accepts values with too few groups ("1:2:3"); the
+        // literal parse is the full structural validation.
+        try {
+            return InetAddress.getByName(ipv6) instanceof Inet6Address;
+        } catch (UnknownHostException exception) {
+            return false;
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParserTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NamesrvAddrParserTest.java
@@ -126,6 +126,22 @@ class NamesrvAddrParserTest {
     }
 
     @Test
+    void rejectsIpv6LiteralsWithTooFewGroupsTest() {
+        assertThatThrownBy(() -> NamesrvAddrParser.normalize("[1:2:3]:9876"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("malformed IPv6 literal");
+        assertThatThrownBy(() -> NamesrvAddrParser.normalize("[ffff:0]:9876"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("malformed IPv6 literal");
+    }
+
+    @Test
+    void acceptsFullFormIpv6LiteralsTest() {
+        assertThat(NamesrvAddrParser.normalize("[2001:0DB8:0000:0000:0000:0000:0000:0001]:9876"))
+                .isEqualTo("[2001:0db8:0000:0000:0000:0000:0000:0001]:9876");
+    }
+
+    @Test
     void rejectsMalformedIpv6LiteralsTest() {
         assertThatThrownBy(() -> NamesrvAddrParser.normalize("[abc]:9876"))
                 .isInstanceOf(BusinessException.class)


### PR DESCRIPTION
## Summary
- `NamesrvAddrParser.isValidIpv6Literal` now performs a full address-literal parse
  (`InetAddress.getByName`, after the existing character-set pre-filter that prevents
  any DNS lookup) in addition to the character/colon checks.
- Added regression tests: literals with too few groups (`[1:2:3]`, `[ffff:0]`) are
  rejected, and full-form literals are accepted and lowercased.

## Why
The old check only validated the character set and required at least two colons, so
`[1:2:3]` — three groups, not a valid IPv6 address — was accepted into the registry
and only failed much later when the probe connected through the RocketMQ client. The
pre-filtered character set guarantees `getByName` treats the value as a literal (no
hostname, no DNS), so the parse adds full structural validation without the
unbounded-resolution risk the parser was designed to avoid.

## Testing
- `cd server && mvn -Dtest=NamesrvAddrParserTest test` — Tests run: 17, Failures: 0, Errors: 0
- `cd server && mvn -Dtest=NameserverRegistryServiceTest,NameServerControllerTest test`
  — Tests run: 36, Failures: 0, Errors: 0
