### PR TITLE
fix(alert): trim paged alert level filters

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepository.java
@@ -178,8 +178,7 @@ public class MybatisPlusAlertRepository implements AlertRepository {
 
     private QueryWrapper<RmqSystemAlert> alertQuery(String level) {
         return new QueryWrapper<RmqSystemAlert>()
-                .eq(StringUtils.hasText(level), "level",
-                        level == null ? null : level.toLowerCase(Locale.ROOT))
+                .eq(StringUtils.hasText(level), "level", normalizeLevel(level))
                 .orderByDesc("time", "id");
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertRepositoryTest.java
@@ -251,6 +251,15 @@ class MybatisPlusAlertRepositoryTest {
     }
 
     @Test
+    void findAlertsShouldTrimLevelFilterWhitespaceTest() {
+        when(alertMapper.selectList(any())).thenReturn(List.of());
+
+        repository.findAlerts(" ERROR ");
+
+        verify(alertMapper).selectList(argThat(MybatisPlusAlertRepositoryTest::hasTrimmedLevelParameter));
+    }
+
+    @Test
     void saveAlertShouldPersistCanonicalScopeLabelsTest() {
         SystemAlertVO alert = SystemAlertVO.builder().level(org.apache.rocketmq.studio.common.domain.enums.AlertLevel.warning)
                 .labels(Map.of("topic", "orders", "brokerName", "broker-a")).build();
@@ -305,6 +314,14 @@ class MybatisPlusAlertRepositoryTest {
                 && queryWrapper.getParamNameValuePairs().containsValue("broker-a")
                 && queryWrapper.getParamNameValuePairs().containsValue(LocalDateTime.of(2026, 8, 1, 0, 0))
                 && queryWrapper.getParamNameValuePairs().containsValue(LocalDateTime.of(2026, 8, 2, 0, 0));
+    }
+
+    private static boolean hasTrimmedLevelParameter(Wrapper<RmqSystemAlert> query) {
+        if (!(query instanceof QueryWrapper<?> queryWrapper)) {
+            return false;
+        }
+        queryWrapper.getCustomSqlSegment();
+        return queryWrapper.getParamNameValuePairs().containsValue("error");
     }
 
     private static boolean hasInfoLevelParameter(Wrapper<RmqSystemAlert> query) {


### PR DESCRIPTION
## Summary
- route the paged alert query's level filter through the existing `normalizeLevel` helper so whitespace is trimmed and the value lowercased with the root locale, matching the unfiltered listing path

## Why
`alertQuery` lowercased the level but did not trim it, while the sibling listing query already used `normalizeLevel`. A caller sending `" ERROR "` (for example from a URL-encoded form or an over-eager client) produced a query for the literal padded value, so the page silently came back empty instead of matching the stored `error` rows.

## Testing
- `mvn -q -f server/pom.xml -Dtest=MybatisPlusAlertRepositoryTest test` — Tests run: 17, Failures: 0, Errors: 0 (includes new `findAlertsShouldTrimLevelFilterWhitespaceTest`)
