### PR TITLE
fix(web): trim whitespace in cluster overview search normalization

### DIFF
--- a/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
@@ -441,6 +441,24 @@ describe('Cluster page', () => {
     expect(screen.getByPlaceholderText('搜索 Proxy 地址')).toHaveValue('not-found');
   });
 
+  it('keeps all broker rows visible when the broker search is whitespace-only', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<ClusterPage />);
+    expect(await screen.findByText('rocketmq-prod-0')).toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText('搜索集群名称、Broker 名称或地址');
+    await user.type(input, '   ');
+    const searchBox = input.closest('.ant-input-search');
+    expect(searchBox).not.toBeNull();
+    const searchButton = (searchBox as HTMLElement).querySelector('.ant-input-search-button');
+    expect(searchButton).not.toBeNull();
+    await user.click(searchButton as HTMLElement);
+
+    expect(await screen.findByText('rocketmq-prod-0')).toBeInTheDocument();
+    expect(screen.getByText('rocketmq-prod-1')).toBeInTheDocument();
+  });
+
   it('creates and deletes nameserver registry entries', async () => {
     const user = userEvent.setup();
     renderWithProviders(<ClusterPage />);

--- a/web/src/pages/cluster/clusterSearchText.test.ts
+++ b/web/src/pages/cluster/clusterSearchText.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { searchText } from './index';
+
+describe('searchText', () => {
+  it('lowercases and trims search-box input', () => {
+    expect(searchText('  RocketMQ-Prod ')).toBe('rocketmq-prod');
+  });
+
+  it('normalizes empty and whitespace-only input to an empty string', () => {
+    expect(searchText('')).toBe('');
+    expect(searchText('   ')).toBe('');
+  });
+
+  it('treats null and undefined input as an empty string', () => {
+    expect(searchText(null)).toBe('');
+    expect(searchText(undefined)).toBe('');
+  });
+});

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -99,7 +99,14 @@ type NameServerConfigDiffNode = NameServerConfigDiffResult['nodes'][number];
 type BrokerConfigDiffBroker = BrokerConfigDiffResult['brokers'][number];
 
 const safeText = (value: string | null | undefined) => value ?? '';
-const searchText = (value: string | null | undefined) => safeText(value).toLowerCase();
+/**
+ * Normalize a search-box input: null-safe, trimmed and lower-cased.
+ * Trimming matters because the broker/nameserver/proxy panels use
+ * `Input.Search onSearch`, where a whitespace-only submission would
+ * otherwise hide every row.
+ */
+export const searchText = (value: string | null | undefined) =>
+  safeText(value).trim().toLowerCase();
 const compareText = (left: string | null | undefined, right: string | null | undefined) =>
   safeText(left).localeCompare(safeText(right));
 


### PR DESCRIPTION
## Summary

- Make the cluster overview page's shared `searchText` normalizer trim user input in addition to being null-safe and lower-casing it (`pages/cluster/index.tsx`).
- Export `searchText` for unit coverage and add regression tests:
  - new unit suite `pages/cluster/clusterSearchText.test.ts` (trim / empty / whitespace-only / null / undefined input);
  - new page-level test in `ClusterPage.test.tsx`: submitting a whitespace-only broker search keeps all broker rows visible.

## Why

The broker / NameServer / Proxy panels all use `Input.Search` with `onSearch`, so a submission of only spaces previously produced a non-empty normalized keyword. Since `"".includes(" ")` is `false` for every row, a whitespace-only search silently hid the entire table until the user cleared the box. The certs and clients pages already trim their search input; the overview page was the remaining outlier in the cluster domain.

## Testing

- `cd web && ./node_modules/.bin/vitest run src/pages/cluster/clusterSearchText.test.ts src/pages/cluster/__tests__/ClusterPage.test.tsx` — 2 files, 24 tests passed (3 new unit tests, 1 new page-level regression test; all pre-existing tests still pass).
- `cd web && ./node_modules/.bin/tsc --noEmit` — clean.
- `cd web && ./node_modules/.bin/eslint src/pages/cluster/index.tsx src/pages/cluster/clusterSearchText.test.ts src/pages/cluster/__tests__/ClusterPage.test.tsx` — 0 errors (1 react-refresh warning for the exported helper, same precedent as other page-level helper exports).
