### PR TITLE
fix(web): harden producer group AutoComplete option filtering

### DIFF
--- a/web/src/pages/studio/Producer.tsx
+++ b/web/src/pages/studio/Producer.tsx
@@ -72,6 +72,21 @@ const PRODUCER_CONNECTION_EXPORT_COLUMNS: CsvColumn<ProducerConnectionExportRow>
 
 const PRODUCER_GROUP_SELECTOR_LIMIT = 20;
 
+/**
+ * Case-insensitive AutoComplete filter for producer-group suggestions.
+ *
+ * Both sides are coerced with String() and null-guaranteed so that a
+ * non-string option value (e.g. a `null` group returned by the API) or a
+ * missing search string cannot throw and blank out the dropdown.
+ */
+export const matchesProducerGroupOption = (
+  inputValue: string | null | undefined,
+  option?: { value?: unknown } | null,
+) =>
+  String(option?.value ?? '')
+    .toLowerCase()
+    .includes(String(inputValue ?? '').toLowerCase());
+
 const ProducerPage = () => {
   const [form] = Form.useForm();
   const [topicList, setTopicList] = useState<string[]>([]);
@@ -350,7 +365,7 @@ const ProducerPage = () => {
                 void loadProducerGroups(value);
               }}
               filterOption={(inputValue, option) =>
-                option?.value.toLowerCase().includes(inputValue.toLowerCase()) ?? false
+                matchesProducerGroupOption(inputValue, option)
               }
             />
           </Form.Item>

--- a/web/src/pages/studio/__tests__/producerGroupFilter.test.ts
+++ b/web/src/pages/studio/__tests__/producerGroupFilter.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { matchesProducerGroupOption } from '../Producer';
+
+describe('matchesProducerGroupOption', () => {
+  it('matches group values case-insensitively', () => {
+    const option = { value: 'order-events-producer' };
+    expect(matchesProducerGroupOption('ORDER-EVENTS', option)).toBe(true);
+    expect(matchesProducerGroupOption('producer', option)).toBe(true);
+    expect(matchesProducerGroupOption('missing-group', option)).toBe(false);
+  });
+
+  it('matches every option for an empty search string', () => {
+    expect(matchesProducerGroupOption('', { value: 'any-group' })).toBe(true);
+  });
+
+  it('does not throw when the option value is null or undefined', () => {
+    expect(matchesProducerGroupOption('group', { value: null })).toBe(false);
+    expect(matchesProducerGroupOption('group', {})).toBe(false);
+    expect(matchesProducerGroupOption('group', undefined)).toBe(false);
+    expect(matchesProducerGroupOption('', { value: null })).toBe(true);
+  });
+
+  it('does not throw when the input value is undefined', () => {
+    expect(matchesProducerGroupOption(undefined, { value: 'any-group' })).toBe(true);
+  });
+
+  it('coerces non-string option values before comparing', () => {
+    expect(matchesProducerGroupOption('1234', { value: 12345 })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the fragile inline AutoComplete `filterOption` in the studio Producer page (`pages/studio/Producer.tsx`) with an exported `matchesProducerGroupOption` helper.
- The old expression was `option?.value.toLowerCase().includes(inputValue.toLowerCase()) ?? false`. The `?? false` only protects the case where `option` itself is nullish (the optional chain short-circuits); it does NOT protect the cases that actually throw:
  - `option.value` is `null`/`undefined` (e.g. a `null` group in the API response) → `TypeError: Cannot read properties of null (reading 'toLowerCase')` inside the dropdown render;
  - a non-string `option.value` (number, etc.) → same `TypeError`.
- The new helper coerces both sides with `String(...) ?? ''` so any option value or search string is compared safely, case-insensitively.

## Why

The producer-group selector builds its options from live API data (`fetchProducerGroups`), unlike the static topic/instance selectors. A single malformed payload entry therefore used to throw inside antd's filter path and break the whole suggestion dropdown. The same defensive `String(option?.label ?? '')` pattern is already used in `components/InstanceSelect.tsx`; this brings the Producer selector in line with it.

## Testing

- `cd web && ./node_modules/.bin/vitest run src/pages/studio/__tests__/producerGroupFilter.test.ts` — 5 new regression tests passed (case-insensitive match, empty input, null/undefined/non-string option values, undefined input).
- `cd web && ./node_modules/.bin/vitest run src/pages/studio/__tests__/Producer.test.tsx` — 13 pre-existing tests still pass.
- `cd web && ./node_modules/.bin/tsc --noEmit` — clean.
- `cd web && ./node_modules/.bin/eslint src/pages/studio/Producer.tsx src/pages/studio/__tests__/producerGroupFilter.test.ts` — 0 errors (1 react-refresh warning for the exported helper, same precedent as other page-level helper exports).
