### PR TITLE
fix(client): cap consumer connection group scan at a defensive limit

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -65,6 +65,14 @@ public class RocketMQClientProvider implements ClientProvider {
 
     private static final long SUBSCRIPTION_GROUP_TIMEOUT_MILLIS = 5000L;
 
+    /**
+     * Defensive cap on the number of consumer groups whose connections are queried per scan.
+     * Each group costs one sequential admin RPC, so an unbounded cluster group table could hold
+     * the request thread for minutes; the cap bounds the worst case at the cost of a partial
+     * listing, which is logged.
+     */
+    static final int MAX_CONSUMER_GROUPS_SCANNED = 200;
+
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
     private final MqAdminExtFactory adminFactory;
 
@@ -308,6 +316,11 @@ public class RocketMQClientProvider implements ClientProvider {
             String group = groupEntry.getKey();
             if (isSystemGroup(group)) {
                 continue;
+            }
+            if (attemptedGroupQueries >= MAX_CONSUMER_GROUPS_SCANNED) {
+                log.warn("Consumer connection scan reached its {}-group cap; remaining groups "
+                        + "were not queried", MAX_CONSUMER_GROUPS_SCANNED);
+                break;
             }
             attemptedGroupQueries++;
             try {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
@@ -504,6 +504,28 @@ class RocketMQClientProviderTest {
         });
     }
 
+    @Test
+    void consumerScanCapsGroupQueriesAtDefensiveLimit() throws Exception {
+        SubscriptionGroupWrapper wrapper = new SubscriptionGroupWrapper();
+        ConcurrentHashMap<String, SubscriptionGroupConfig> groups = new ConcurrentHashMap<>();
+        for (int i = 0; i < 300; i++) {
+            groups.put("group-" + i, new SubscriptionGroupConfig());
+        }
+        wrapper.setSubscriptionGroupTable(groups);
+        ConsumerConnection emptyConsumerConnection = new ConsumerConnection();
+        emptyConsumerConnection.setConnectionSet(new HashSet<>());
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo("127.0.0.1:10911"));
+        when(adminExt.getAllSubscriptionGroup("127.0.0.1:10911", 5000L)).thenReturn(wrapper);
+        when(adminExt.examineConsumerConnectionInfo(anyString())).thenReturn(emptyConsumerConnection);
+
+        List<ClientConnectionVO> connections =
+                provider.findConnections("instance-a", "cluster-a", "Consumer");
+
+        assertThat(connections).isEmpty();
+        verify(adminExt, times(RocketMQClientProvider.MAX_CONSUMER_GROUPS_SCANNED))
+                .examineConsumerConnectionInfo(anyString());
+    }
+
     private static SubscriptionGroupWrapper subscriptionGroups(String... names) {
         SubscriptionGroupWrapper wrapper = new SubscriptionGroupWrapper();
         ConcurrentHashMap<String, SubscriptionGroupConfig> groups = new ConcurrentHashMap<>();


### PR DESCRIPTION
## Summary
- Cap `RocketMQClientProvider.findConsumerConnections` at 200 consumer-group connection queries per scan (`MAX_CONSUMER_GROUPS_SCANNED`)
- Log a warning when the cap is hit so partial listings are visible in the server log
- Add a regression test with a 300-group cluster asserting exactly the cap is queried

## Why
The consumer connection page scans every subscription group in the cluster and issues one sequential `examineConsumerConnectionInfo` admin RPC per group, with no cap. On a long-running cluster whose group table has grown to thousands of entries, a single page load issues thousands of sequential broker round-trips and can hold the request thread for minutes — far past the frontend's request timeout. The cap bounds the worst case at the cost of a logged partial listing (system groups still don't count against it).

## Testing
- `mvn -Dtest='RocketMQClientProviderTest,ProducerConnectionServiceTest,ClientServiceTest' test` → RocketMQClientProviderTest 25/25 (incl. new cap regression), ProducerConnectionServiceTest 7/7, ClientServiceTest 5/5
