### PR TITLE
fix(web): normalize dropdown option-filter input and option values

### DIFF
--- a/web/src/components/InstanceSelect.tsx
+++ b/web/src/components/InstanceSelect.tsx
@@ -32,6 +32,15 @@ interface InstanceSelectProps {
 }
 
 /**
+ * 下拉筛选：大小写不敏感，且对搜索串与 label 两侧做 String() 归一化，
+ * 避免非字符串 label 或缺失的搜索值在 Select 过滤路径中抛错。
+ */
+export const matchesInstanceOption = (
+  input: string | null | undefined,
+  option?: { label?: unknown } | null,
+) => String(option?.label ?? '').toLowerCase().includes(String(input ?? '').toLowerCase());
+
+/**
  * 实例维度页面统一的实例选择器：支持输入并按实例 ID 筛选（showSearch），
  * 选中后由页面通过 onChange 切换路由实例。
  */
@@ -60,11 +69,7 @@ export function InstanceSelect({
       }}
       options={options}
       optionFilterProp="label"
-      filterOption={(input, option) =>
-        String(option?.label ?? '')
-          .toLowerCase()
-          .includes(input.toLowerCase())
-      }
+      filterOption={(input, option) => matchesInstanceOption(input, option)}
       notFoundContent="暂无匹配实例"
       style={style ?? { width: 220 }}
     />

--- a/web/src/components/__tests__/instanceSelectFilter.test.ts
+++ b/web/src/components/__tests__/instanceSelectFilter.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { matchesInstanceOption } from '../InstanceSelect';
+
+describe('matchesInstanceOption', () => {
+  it('matches option labels case-insensitively', () => {
+    const option = { label: 'instance-a' };
+    expect(matchesInstanceOption('INSTANCE-A', option)).toBe(true);
+    expect(matchesInstanceOption('instance', option)).toBe(true);
+    expect(matchesInstanceOption('instance-b', option)).toBe(false);
+  });
+
+  it('matches every option for an empty search string', () => {
+    expect(matchesInstanceOption('', { label: 'any' })).toBe(true);
+  });
+
+  it('does not throw for nullish or non-string labels and input', () => {
+    expect(matchesInstanceOption('x', { label: null })).toBe(false);
+    expect(matchesInstanceOption('x', {})).toBe(false);
+    expect(matchesInstanceOption('x', undefined)).toBe(false);
+    expect(matchesInstanceOption(undefined, { label: 'any' })).toBe(true);
+    expect(matchesInstanceOption('1', { label: 21 })).toBe(true);
+  });
+});

--- a/web/src/pages/settings/AiAssistantTab.tsx
+++ b/web/src/pages/settings/AiAssistantTab.tsx
@@ -98,6 +98,22 @@ const baseUrlPresets = (
   ollama: [{ value: 'http://localhost:11434/v1', label: t('settings.ollamaLocal') }],
 });
 
+/**
+ * Case-insensitive AutoComplete filter for model / API-base suggestions.
+ * Both the search string and the option value/label are coerced with
+ * String() and null-guaranteed so a non-string preset entry or a missing
+ * search value cannot throw inside the dropdown filter.
+ */
+export const matchesAiOption = (
+  input: string | null | undefined,
+  option?: { value?: unknown; label?: unknown } | null,
+) => {
+  const keyword = String(input ?? '').toLowerCase();
+  return [option?.value, option?.label].some(
+    (part) => String(part ?? '').toLowerCase().includes(keyword),
+  );
+};
+
 interface TestState {
   success: boolean;
   msg: string;
@@ -364,11 +380,7 @@ export const AiAssistantTab = () => {
               <AutoComplete
                 options={modelOptions}
                 placeholder={t('settings.selectOrEnterModel')}
-                filterOption={(input, option) =>
-                  String(option?.value ?? '')
-                    .toLowerCase()
-                    .includes(input.toLowerCase())
-                }
+                filterOption={(input, option) => matchesAiOption(input, option)}
                 allowClear
               />
             </Form.Item>
@@ -431,10 +443,7 @@ export const AiAssistantTab = () => {
                 options={baseUrlPresets(t)[selectedProvider ?? 'tongyi'] ?? []}
                 placeholder="https://dashscope.aliyuncs.com/compatible-mode/v1"
                 suffixIcon={<CaretDownOutlined style={{ color: '#9CA3AF' }} />}
-                filterOption={(input, option) =>
-                  (option?.value ?? '').toLowerCase().includes(input.toLowerCase()) ||
-                  (option?.label ?? '').toString().toLowerCase().includes(input.toLowerCase())
-                }
+                filterOption={(input, option) => matchesAiOption(input, option)}
               />
             </Form.Item>
 

--- a/web/src/pages/settings/__tests__/aiAssistantOptionFilter.test.ts
+++ b/web/src/pages/settings/__tests__/aiAssistantOptionFilter.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { matchesAiOption } from '../AiAssistantTab';
+
+describe('matchesAiOption', () => {
+  it('matches the option value case-insensitively', () => {
+    const option = { value: 'qwen-plus', label: 'Qwen Plus' };
+    expect(matchesAiOption('QWEN-PLUS', option)).toBe(true);
+    expect(matchesAiOption('qwen', option)).toBe(true);
+    expect(matchesAiOption('gpt-4', option)).toBe(false);
+  });
+
+  it('matches the option label when the value does not match', () => {
+    const option = { value: 'https://example.com/v1', label: 'Azure endpoint' };
+    expect(matchesAiOption('azure', option)).toBe(true);
+  });
+
+  it('matches every option for an empty search string', () => {
+    expect(matchesAiOption('', { value: 'qwen-plus' })).toBe(true);
+  });
+
+  it('does not throw for nullish or non-string values and input', () => {
+    expect(matchesAiOption('x', { value: null, label: undefined })).toBe(false);
+    expect(matchesAiOption('x', undefined)).toBe(false);
+    expect(matchesAiOption(undefined, { value: 'qwen-plus' })).toBe(true);
+    expect(matchesAiOption('123', { value: 456 })).toBe(false);
+    expect(matchesAiOption('45', { value: 456 })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- `components/InstanceSelect.tsx`: extract the instance-selector `filterOption` into an exported `matchesInstanceOption` helper that coerces **both** the search string and the option label with `String(...) ?? ''` before lower-casing.
- `pages/settings/AiAssistantTab.tsx`: extract the two AutoComplete `filterOption`s (model selector + API-base preset selector) into one exported `matchesAiOption` helper with the same double-sided coercion; the old API-base filter additionally called `.toLowerCase()` on `option.value` without any `String()` guard, and all three old expressions called `input.toLowerCase()` unguarded.
- Add regression suites for both helpers (case-insensitive match, empty input, nullish/non-string options and input).

## Why

These dropdown filters compared user input against option fields without normalizing either side: a missing search string (`input.toLowerCase()` on `undefined`) or a non-string option value (`(option?.value ?? '').toLowerCase()` on a number/null payload) would throw inside antd's filter path and break the whole dropdown. This is the same class of gap already fixed for the studio producer-group selector (`matchesProducerGroupOption`) and the component already used the one-sided `String(option?.label ?? '')` pattern while leaving `input` unguarded.

## Testing

- `cd web && ./node_modules/.bin/vitest run src/pages/settings/__tests__/aiAssistantOptionFilter.test.ts src/components/__tests__/instanceSelectFilter.test.ts` — 2 files, 10 new tests passed.
- `cd web && ./node_modules/.bin/vitest run src/pages/settings/__tests__/AiAssistantTab.test.tsx` — 5 pre-existing tests still pass.
- `cd web && ./node_modules/.bin/vitest run src/components` — 8 files, 58 tests passed (no regressions in the shared component domain).
- `cd web && ./node_modules/.bin/tsc --noEmit` — clean.
- `cd web && ./node_modules/.bin/eslint src/pages/settings/AiAssistantTab.tsx src/components/InstanceSelect.tsx src/pages/settings/__tests__/aiAssistantOptionFilter.test.ts src/components/__tests__/instanceSelectFilter.test.ts` — 0 errors (2 react-refresh warnings for the exported helpers, same precedent as other helper exports).
