### PR TITLE
fix(home): guard and stabilize dashboard number rendering

### DIFF
--- a/web/src/pages/home/__tests__/DashboardPage.test.tsx
+++ b/web/src/pages/home/__tests__/DashboardPage.test.tsx
@@ -15,7 +15,7 @@ import type { DashboardData } from '../../../api/metrics';
 import { LangProvider } from '../../../i18n/LangContext';
 import * as dashboardService from '../../../services/dashboardService';
 import * as instanceService from '../../../services/instanceService';
-import DashboardPage from '../dashboard';
+import DashboardPage, { renderCount } from '../dashboard';
 
 vi.mock('../../../services/dashboardService', () => ({ getDashboard: vi.fn() }));
 vi.mock('../../../services/instanceService', () => ({ listInstances: vi.fn() }));
@@ -259,5 +259,33 @@ describe('DashboardPage', () => {
     expect(
       screen.queryByText('cloud-instance', { selector: '.ant-select-item-option-content' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('renders clusters with missing throughput or TPS numbers without crashing', async () => {
+    const data: DashboardData = dashboard('broken-cluster');
+    data.clusters = [
+      {
+        ...data.clusters[0],
+        tpsIn: null as unknown as number,
+        tpsOut: null as unknown as number,
+        throughput: undefined as unknown as number[],
+      },
+    ];
+    vi.mocked(dashboardService.getDashboard).mockResolvedValue(data);
+    renderWithProviders(<DashboardPage />);
+
+    await screen.findByText('broken-cluster');
+    const row = screen.getByText('broken-cluster').closest('tr');
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getAllByText('N/A').length).toBeGreaterThanOrEqual(2);
+    expect(within(row as HTMLElement).getByText('—')).toBeInTheDocument();
+  });
+
+  it('formats dashboard counts with a stable locale and N/A placeholders', () => {
+    expect(renderCount(1234567)).toBe('1,234,567');
+    expect(renderCount(0)).toBe('0');
+    expect(renderCount(null)).toBe('N/A');
+    expect(renderCount(undefined)).toBe('N/A');
+    expect(renderCount(Number.NaN)).toBe('N/A');
   });
 });

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -29,8 +29,8 @@ import { useLang } from '../../i18n/LangContext';
 
 const { Text } = Typography;
 
-const renderTopologyCount = (value: number | null) =>
-  value === null ? 'N/A' : value.toLocaleString();
+export const renderCount = (value: number | null | undefined): string =>
+  value == null || Number.isNaN(value) ? 'N/A' : value.toLocaleString('en-US');
 
 const DashboardPage = () => {
   const navigate = useNavigate();
@@ -147,7 +147,7 @@ const DashboardPage = () => {
       icon: <ClusterOutlined style={{ fontSize: 22, color: '#52c41a' }} />,
       color: '#52c41a',
       suffix: '',
-      detail: `${stats.totalBrokers} Brokers · ${renderTopologyCount(stats.totalProxies)} Proxy`,
+      detail: `${stats.totalBrokers} Brokers · ${renderCount(stats.totalProxies)} Proxy`,
     },
     {
       title: t('dashboard.topics'),
@@ -163,7 +163,7 @@ const DashboardPage = () => {
       icon: <ArrowDown size={22} weight="duotone" color="#fa8c16" />,
       color: '#fa8c16',
       suffix: '/s',
-      detail: `${t('dashboard.tpsOut')}: ${stats.tpsOut.toLocaleString()}/s`,
+      detail: `${t('dashboard.tpsOut')}: ${renderCount(stats.tpsOut)}/s`,
     },
     {
       title: t('dashboard.todayMessages'),
@@ -172,7 +172,9 @@ const DashboardPage = () => {
       color: '#722ed1',
       suffix: '',
       detail: t('dashboard.millionMessages', {
-        n: (stats.totalMessagesToday / 1_000_000).toFixed(1),
+        n: Number.isFinite(stats.totalMessagesToday)
+          ? (stats.totalMessagesToday / 1_000_000).toFixed(1)
+          : '0',
       }),
     },
   ];
@@ -212,7 +214,7 @@ const DashboardPage = () => {
       key: 'brokers',
       width: 80,
       align: 'center' as const,
-      render: renderTopologyCount,
+      render: renderCount,
     },
     {
       title: t('dashboard.proxy'),
@@ -220,7 +222,7 @@ const DashboardPage = () => {
       key: 'proxies',
       width: 80,
       align: 'center' as const,
-      render: renderTopologyCount,
+      render: renderCount,
     },
     {
       title: t('dashboard.topic'),
@@ -242,7 +244,7 @@ const DashboardPage = () => {
       key: 'tpsIn',
       width: 90,
       align: 'right' as const,
-      render: (v: number) => v.toLocaleString(),
+      render: renderCount,
     },
     {
       title: t('dashboard.tpsOut'),
@@ -250,7 +252,7 @@ const DashboardPage = () => {
       key: 'tpsOut',
       width: 90,
       align: 'right' as const,
-      render: (v: number) => v.toLocaleString(),
+      render: renderCount,
     },
     {
       title: t('dashboard.trend'),
@@ -259,7 +261,7 @@ const DashboardPage = () => {
       width: 110,
       render: (data: number[], record: DashboardData['clusters'][0]) => (
         <MiniBar
-          data={data}
+          data={Array.isArray(data) ? data : []}
           color={
             record.status === 'healthy'
               ? '#52c41a'


### PR DESCRIPTION
## Summary
- Consolidate dashboard number rendering into an exported `renderCount()` helper: null/undefined/NaN become the existing `N/A` placeholder, and formatting uses a stable `en-US` locale (same convention as `formatNumber` in `utils/format.ts`)
- Apply it to the broker/proxy/TPS-in/TPS-out table columns and the TPS-out stat card detail
- Guard the "million messages" stat detail against a non-finite `totalMessagesToday` (renders `0` instead of `NaN`)
- Pass a guaranteed array to `MiniBar` when a cluster row omits `throughput`
- Add regression tests: a cluster with null TPS values and a missing throughput series renders without crashing, plus unit tests for `renderCount`

## Why
Dashboard data comes from the backend over JSON, so field shapes are not guaranteed even when the TypeScript type says otherwise. Two crash/leak paths: `v.toLocaleString()` on the TPS columns throws for a `null` value taken from the wire, and `MiniBar` reads `data.length`, so a cluster row missing `throughput` crashed the whole dashboard page (no error boundary). The unqualified `toLocaleString()` calls additionally produced locale-dependent separators that varied with the viewer's browser locale, inconsistent with the rest of the app's stable formatting.

## Testing
- `./node_modules/.bin/vitest run src/pages/home/` → 12 passed (2 new)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/pages/home/dashboard.tsx src/pages/home/__tests__/DashboardPage.test.tsx` → 0 errors
