### PR TITLE
fix(login): trim usernames and tolerate missing login payloads

### DIFF
--- a/web/src/pages/login/index.test.tsx
+++ b/web/src/pages/login/index.test.tsx
@@ -92,4 +92,51 @@ describe('LoginPage', () => {
     expect(screen.getByText('login.passwordRequired')).toBeTruthy();
     expect(loginApiMock).not.toHaveBeenCalled();
   });
+
+  it('trims surrounding whitespace from the submitted username', async () => {
+    loginApiMock.mockResolvedValue({
+      user: { username: 'alice', userId: 42, admin: false },
+    });
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('login.usernamePlaceholder'), {
+      target: { value: '  alice  ' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('login.passwordPlaceholder'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'login.title' }));
+
+    await waitFor(() => expect(loginApiMock).toHaveBeenCalledWith('alice', 'secret'));
+    expect(loginStoreMock).toHaveBeenCalledWith('alice', 42, false);
+  });
+
+  it('rejects a whitespace-only username without calling the API', async () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('login.usernamePlaceholder'), {
+      target: { value: '   ' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('login.passwordPlaceholder'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'login.title' }));
+
+    await waitFor(() => expect(screen.getByText('login.usernameRequired')).toBeTruthy());
+    expect(loginApiMock).not.toHaveBeenCalled();
+  });
+
+  it('shows a friendly error when the login payload has no user', async () => {
+    loginApiMock.mockResolvedValue(null);
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText('login.usernamePlaceholder'), {
+      target: { value: 'alice' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('login.passwordPlaceholder'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'login.title' }));
+
+    await waitFor(() => expect(screen.getByText('login.failed')).toBeTruthy());
+    expect(loginStoreMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/pages/login/index.tsx
+++ b/web/src/pages/login/index.tsx
@@ -50,8 +50,12 @@ const LoginPage = () => {
   const onFinish = async (values: LoginFormValues) => {
     setLoading(true);
     try {
-      const data = await loginApi(values.username, values.password);
-      authLogin(data.user.username, data.user.userId, data.user.admin);
+      const data = await loginApi(values.username.trim(), values.password);
+      const user = data?.user;
+      if (!user?.username) {
+        throw new Error(t('login.failed'));
+      }
+      authLogin(user.username, user.userId, user.admin);
       message.success(t('login.success'));
       navigate('/', { replace: true });
     } catch (err: unknown) {
@@ -116,7 +120,7 @@ const LoginPage = () => {
             <Form.Item
               label={t('login.username')}
               name="username"
-              rules={[{ required: true, message: t('login.usernameRequired') }]}
+              rules={[{ required: true, whitespace: true, message: t('login.usernameRequired') }]}
             >
               <Input
                 prefix={<UserOutlined />}


### PR DESCRIPTION
## Summary
- Trim surrounding whitespace from the username before calling the login API (password is left untouched on purpose)
- Reject whitespace-only usernames with the existing required-field validation (`whitespace: true`)
- Tolerate a missing `user` object in the login payload: instead of a raw `TypeError` from `data.user.username`, the user sees the standard "login failed" message
- Add regression tests for trimming, whitespace-only input, and a payload without a user

## Why
Users commonly copy usernames from docs or spreadsheets, which drags along leading/trailing spaces; those were sent verbatim and failed with a cryptic backend 401 even though the account exists. Separately, `login()` returns `res.data.data`, which is `null` whenever the backend wraps the response in an unexpected envelope — `data.user.username` then threw `Cannot read properties of null`, and that raw TypeError leaked into the error toast.

## Testing
- `./node_modules/.bin/vitest run src/pages/login/index.test.tsx` → 6 passed (3 new)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/pages/login/index.tsx src/pages/login/index.test.tsx` → 0 errors
