### PR TITLE
fix(group): normalize reset topic before apply

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
@@ -329,11 +329,12 @@ public class MetadataService {
     public void resetOffset(String instanceId, String name, long timestamp, String topic) {
         instanceId = normalizeInstanceId(instanceId);
         String groupName = requireName(name, "consumer group name");
+        String topicName = requireName(topic, "topic name");
         InstanceProvider provider = resolve(instanceId);
         String normalizedInstanceId = instanceId;
         executeWithAudit(provider, Operation.RESET_OFFSET, ResourceType.GROUP, groupName, instanceId,
-                "topic=" + optionalDetail(topic) + ", timestamp=" + timestamp,
-                () -> provider.resetOffset(normalizedInstanceId, groupName, timestamp, topic));
+                "topic=" + topicName + ", timestamp=" + timestamp,
+                () -> provider.resetOffset(normalizedInstanceId, groupName, timestamp, topicName));
     }
 
 

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/MetadataServiceTest.java
@@ -520,7 +520,7 @@ class MetadataServiceTest {
 
         metadataService.createConsumerGroup(group);
         metadataService.deleteConsumerGroup("cloud-instance", " cg-orders ");
-        metadataService.resetOffset("cloud-instance", " cg-orders ", 1784246400000L, "orders");
+        metadataService.resetOffset("cloud-instance", " cg-orders ", 1784246400000L, " orders ");
 
         verify(operationAuditService).record("CREATE_GROUP", "GROUP", "cg-orders",
                 "cloud-instance", "consumeType=-, subscriptionMode=-, retryMaxTimes=16", "SUCCESS", null);
@@ -528,6 +528,18 @@ class MetadataServiceTest {
                 "cloud-instance", null, "SUCCESS", null);
         verify(operationAuditService).record("RESET_OFFSET", "GROUP", "cg-orders",
                 "cloud-instance", "topic=orders, timestamp=1784246400000", "SUCCESS", null);
+        verify(cloudProvider).resetOffset("cloud-instance", "cg-orders", 1784246400000L, "orders");
+    }
+
+    @Test
+    void resetOffsetShouldRejectBlankTopicBeforeProviderResolution() {
+        assertThatThrownBy(() -> metadataService.resetOffset("instance-a", "cg-orders",
+                1784246400000L, " "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topic name is required")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+
+        verifyNoInteractions(apacheProvider);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- validate and trim the reset Topic at the MetadataService boundary
- pass the same normalized Topic to the provider and audit record
- reject blank Topics before provider resolution

## Tests

- `mvn -Dmaven.repo.local=D:\Dev\m2-cache -Dtest=MetadataServiceTest test` (36 passed, Checkstyle passed)
- `git diff --check`

Closes #2877