### PR TITLE
fix(message): normalize incomplete message query and DLQ responses

### DIFF
--- a/web/src/api/message.test.ts
+++ b/web/src/api/message.test.ts
@@ -21,6 +21,7 @@ import client from './client';
 import {
   consumeMessageDirectly,
   getMessageTrace,
+  listDLQGroups,
   queryMessagePage,
   queryMessages,
 } from './message';
@@ -206,5 +207,46 @@ describe('message API', () => {
     mock.onPost('/messages/direct-consume', request).reply(200, { code: 200, data: result });
 
     await expect(consumeMessageDirectly(request)).resolves.toEqual(result);
+  });
+
+  it('treats a missing message list as an empty result', async () => {
+    mock.onGet('/messages').reply(200, { code: 200, data: null });
+
+    await expect(queryMessages({ topic: 'orders' })).resolves.toEqual([]);
+  });
+
+  it('normalizes a paged message query with a missing item list', async () => {
+    mock.onGet('/messages/page').reply(200, { code: 200, data: null });
+
+    const page = await queryMessagePage({ topic: 'orders', page: 1, pageSize: 50 });
+    expect(page.items).toEqual([]);
+  });
+
+  it('normalizes a paged message query with a null item list', async () => {
+    mock.onGet('/messages/page').reply(200, {
+      code: 200,
+      data: { items: null, total: 3, page: 1, size: 50, resultMayBeTruncated: false },
+    });
+
+    const page = await queryMessagePage({ topic: 'orders', page: 1, pageSize: 50 });
+    expect(page.items).toEqual([]);
+    expect(page.total).toBe(3);
+  });
+
+  it('normalizes a missing trace record into an empty node list', async () => {
+    mock.onGet('/messages/msg-3/trace', { params: { instanceId: 'instance-1' } }).reply(
+      200,
+      { code: 200, data: null },
+    );
+
+    const trace = await getMessageTrace('msg-3', 'instance-1');
+    expect(trace.nodes).toEqual([]);
+  });
+
+  it('treats a missing DLQ group page item list as empty', async () => {
+    mock.onGet('/dlq').reply(200, { code: 200, data: { total: 0, page: 1, size: 20 } });
+
+    const page = await listDLQGroups('instance-1');
+    expect(page.items).toEqual([]);
   });
 });

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -129,14 +129,18 @@ export interface DLQMessagePage {
 // ─── Messages ───────────────────────────────────────────────────
 export async function queryMessages(params: MessageQuery) {
   const res = await client.get<{ data: MessageRecord[] }>('/messages', { params });
-  return sortMessagesByStoreTimeDesc(res.data.data);
+  return sortMessagesByStoreTimeDesc(Array.isArray(res.data.data) ? res.data.data : []);
 }
 
 export async function queryMessagePage(
   params: MessageQuery & { page?: number; pageSize?: number },
 ) {
   const res = await client.get<{ data: MessageQueryPage }>('/messages/page', { params });
-  return { ...res.data.data, items: sortMessagesByStoreTimeDesc(res.data.data.items) };
+  const page = res.data.data;
+  return {
+    ...page,
+    items: sortMessagesByStoreTimeDesc(Array.isArray(page?.items) ? page.items : []),
+  };
 }
 
 // The backend reports business statuses ("finish" | "failed") on trace nodes,
@@ -168,7 +172,7 @@ export async function getMessageTrace(
   const trace = res.data.data;
   return {
     ...trace,
-    nodes: (trace.nodes ?? []).map((node) => ({
+    nodes: (trace?.nodes ?? []).map((node) => ({
       ...node,
       status: mapTraceNodeStatus(node.status),
     })),
@@ -202,7 +206,8 @@ export async function listDLQGroups(instanceId: string, search?: string, page = 
   const res = await client.get<{ data: DLQGroupPage }>('/dlq', {
     params: { instanceId, search, page, pageSize },
   });
-  return res.data.data;
+  const dlqPage = res.data.data;
+  return { ...dlqPage, items: Array.isArray(dlqPage?.items) ? dlqPage.items : [] };
 }
 
 export async function resendDLQ(data: {
@@ -251,7 +256,7 @@ export interface QueueOffset {
 
 export async function getQueueOffsets(params: { instanceId: string; topic: string }) {
   const res = await client.get<{ data: QueueOffset[] }>('/messages/queues', { params });
-  return res.data.data;
+  return Array.isArray(res.data.data) ? res.data.data : [];
 }
 
 export async function pullMessageAtOffset(params: {
@@ -279,7 +284,8 @@ export async function listDLQMessages(params: {
     `/dlq/${encodeURIComponent(params.groupName)}/messages`,
     { params },
   );
-  return res.data.data;
+  const dlqPage = res.data.data;
+  return { ...dlqPage, items: Array.isArray(dlqPage?.items) ? dlqPage.items : [] };
 }
 
 export async function resendDLQSelected(data: {


### PR DESCRIPTION
## Summary
- Guard `queryMessages` and `queryMessagePage` against a missing or null `data` payload, so the store-time sort no longer throws on `[...null]` and the paged contract always returns an `items` array
- Guard `getMessageTrace` so a missing trace record normalizes to an empty node list instead of throwing on `trace.nodes`
- Normalize `listDLQGroups` and `listDLQMessages` to always return an `items` array even when the backend omits it
- Guard `getQueueOffsets` so a null payload resolves to an empty queue list

## Why
The shared client only rejects non-success business codes; a success envelope with `data: null` (empty results on some backends, partially populated pages after a broker timeout) still flows through. The message/DLQ endpoints dereference `res.data.data.items` or spread the payload directly, so a single missing field turns an empty result page into an uncaught `TypeError` in the UI instead of an empty table.

## Testing
- `cd web && ./node_modules/.bin/vitest run src/api/message.test.ts` → 12 passed (5 new regression tests: null message list, missing/null paged items, missing trace record, missing DLQ page items)
- `./node_modules/.bin/vitest run src/services/messageService.test.ts` → 7 passed
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/api/message.ts src/api/message.test.ts` → clean
