### PR TITLE
fix(alert): guard unknown notification outbox statuses

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
@@ -156,7 +156,7 @@ public class NotificationOutboxService {
         return mapper.selectList(new QueryWrapper<RmqAlertNotificationOutbox>().eq("alert_id", alertId)
                         .orderByAsc("id"))
                 .stream().map(row -> NotificationDeliveryVO.builder().id(row.getId()).channel(row.getChannel())
-                        .status(NotificationOutboxStatus.valueOf(row.getStatus()))
+                        .status(parseStoredStatus(row.getStatus()))
                         .attemptCount(row.getAttemptCount() == null ? 0 : row.getAttemptCount())
                         .nextAttemptAt(row.getNextAttemptAt()).lastError(row.getLastError())
                         .deliveredAt(row.getDeliveredAt()).build()).toList();
@@ -224,6 +224,21 @@ public class NotificationOutboxService {
 
     private static String normalizeTrim(String value) {
         return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    /**
+     * Maps a stored status to the known outbox lifecycle. Legacy or partially written rows must
+     * not break the delivery listing, so unknown values surface as FAILED for manual attention.
+     */
+    private static NotificationOutboxStatus parseStoredStatus(String status) {
+        if (!StringUtils.hasText(status)) {
+            return NotificationOutboxStatus.FAILED;
+        }
+        try {
+            return NotificationOutboxStatus.valueOf(status.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException unknown) {
+            return NotificationOutboxStatus.FAILED;
+        }
     }
 
     private static String normalizeStatus(String status) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
@@ -360,6 +360,29 @@ class NotificationOutboxServiceTest {
     }
 
     @Test
+    void mapsUnknownStoredOutboxStatusesToFailedWhenListingTest() {
+        RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
+        RmqAlertNotificationOutbox unknown = new RmqAlertNotificationOutbox();
+        unknown.setId(8L);
+        unknown.setAlertId(9L);
+        unknown.setChannel("dingtalk");
+        unknown.setStatus("BOUNCED");
+        RmqAlertNotificationOutbox lowerCase = new RmqAlertNotificationOutbox();
+        lowerCase.setId(9L);
+        lowerCase.setAlertId(9L);
+        lowerCase.setChannel("email");
+        lowerCase.setStatus(" pending ");
+        when(mapper.selectList(any())).thenReturn(List.of(unknown, lowerCase));
+
+        List<NotificationDeliveryVO> result = new NotificationOutboxService(mapper,
+                mock(SettingsRepository.class), mock(AlertSilenceService.class), mock(AlertRepository.class),
+                mock(OperationAuditService.class)).listDeliveries(9L);
+
+        assertThat(result).extracting(NotificationDeliveryVO::getStatus)
+                .containsExactly(NotificationOutboxStatus.FAILED, NotificationOutboxStatus.PENDING);
+    }
+
+    @Test
     void retriesOnlyFailedDeliveryAndResetsItsDispatchStateTest() {
         RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
         OperationAuditService audit = mock(OperationAuditService.class);


### PR DESCRIPTION
## Summary
- parse stored outbox statuses through a guarded helper in `NotificationOutboxService.listDeliveries(alertId)`
- trim and root-locale uppercase the stored value; unknown or blank statuses surface as `FAILED`

## Why
`listDeliveries` called `NotificationOutboxStatus.valueOf(row.getStatus())` directly. A legacy or partially written row with an unrecognized status (or whitespace/case drift) made `valueOf` throw `IllegalArgumentException`, turning the whole per-alert delivery listing into a 500. Unknown values now map to `FAILED` so they are visible and need manual attention, matching how the retry endpoint already treats non-`FAILED` rows as untouched.

## Testing
- `cd server && mvn -q -Dtest=NotificationOutboxServiceTest test` — all tests pass, including the new `mapsUnknownStoredOutboxStatusesToFailedWhenListingTest` which lists a row storing `BOUNCED` (→ `FAILED`) and one storing ` pending ` (→ `PENDING`)
