### PR TITLE
fix(ai): keep chat message ids unique across same-millisecond sends

### DIFF
--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -453,4 +453,47 @@ describe('AiPage tool runner', () => {
     expect(await screen.findByText('工具参数必须是有效的 JSON 对象')).toBeInTheDocument();
     expect(executeTool).not.toHaveBeenCalled();
   });
+
+  it('keeps stream chunks out of a previous stopped response created in the same tick', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1000);
+    vi.mocked(chatStream).mockImplementation((data, onChunk, signal) => {
+      if (data.message === 'first-question') {
+        return new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError')),
+          );
+        });
+      }
+      return new Promise<void>((resolve) => {
+        onChunk('world');
+        resolve();
+      });
+    });
+    renderPage();
+    const input = await screen.findByPlaceholderText(
+      '输入你的问题或指令，例如：查看集群状态、创建 Topic、诊断消费延迟...',
+    );
+    await waitFor(() => expect(getLlmModels).toHaveBeenCalled());
+
+    fireEvent.change(input, { target: { value: 'first-question' } });
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    await screen.findByText('first-question');
+    expect(screen.getByText('正在思考…')).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /停\s*止/ }));
+    await screen.findByText('回答已停止。');
+
+    fireEvent.change(input, { target: { value: 'second-question' } });
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    await screen.findByText('second-question');
+
+    expect(screen.getAllByText('回答已停止。')).toHaveLength(1);
+    expect(screen.getAllByText('world')).toHaveLength(1);
+    nowSpy.mockRestore();
+  });
 });

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -125,8 +125,14 @@ const quickActions = [
 
 const GLOBAL_TOOL_SCOPE = '__global__';
 
-const newConversationId = (): string =>
-  `conversation-${typeof crypto?.randomUUID === 'function' ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`}`;
+const uniqueSuffix = (): string =>
+  typeof crypto?.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random()}`;
+
+const newConversationId = (): string => `conversation-${uniqueSuffix()}`;
+
+export const newMessageId = (prefix: string): string => `${prefix}-${uniqueSuffix()}`;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -619,13 +625,13 @@ const AiPage = () => {
       const requestId = ++streamRequestIdRef.current;
       const createdAt = Date.now();
       const userMsg: Message = {
-        id: `user-${createdAt}`,
+        id: newMessageId('user'),
         role: 'user',
         text,
         createdAt,
       };
 
-      const responseId = `ai-${Date.now()}`;
+      const responseId = newMessageId('ai');
       updateMessages(chatMode, conversationId, (prev) => [
         ...prev,
         userMsg,


### PR DESCRIPTION
## Summary
- Add a `newMessageId()` helper (exported for testing) that builds message ids from a `crypto.randomUUID()`-based unique suffix, refactored out of the existing `newConversationId()` pattern
- Use it for chat user/AI message ids instead of `user-${Date.now()}` / `ai-${Date.now()}`
- Add a regression test: stop a first response, immediately send a second one with the clock frozen on the same millisecond, and verify the second stream's chunks do not leak into the stopped first response

## Why
Chat message ids were derived from `Date.now()`, so two sends landing in the same millisecond produced identical `ai-…` response ids. The stream chunk handler and the `finally`-block `pending` update both locate messages by that id with `prev.map(...)`, so an in-flight second response appended its chunks to the first (already stopped) response as well — the stopped message visibly grew with the new answer's text, and the early `pending: false` write from the first request's `finally` could also clear the second response's "thinking" spinner prematurely.

## Testing
- `./node_modules/.bin/vitest run src/pages/ai/__tests__/` → 15 passed (1 new; verified the new test fails with the pre-fix `Date.now()`-based ids)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/pages/ai/index.tsx src/pages/ai/__tests__/AiPage.test.tsx` → 0 errors
