### PR TITLE
fix(alert): tolerate unknown alert state statuses

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepository.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -95,7 +96,7 @@ public class MybatisPlusAlertStateRepository implements AlertStateRepository {
         LocalDateTime next = entity.getLastNotifiedAt() == null || rule == null ? null
                 : entity.getLastNotifiedAt().plus(AlertRuleDuration.parse(rule.getReminderInterval()));
         return AlertRuleRuntimeVO.builder().ruleId(entity.getRuleId()).fingerprint(entity.getFingerprint())
-                .status(AlertStateStatus.valueOf(entity.getStatus())).consecutiveHits(entity.getConsecutiveHits() == null ? 0 : entity.getConsecutiveHits())
+                .status(parseStatus(entity.getStatus())).consecutiveHits(entity.getConsecutiveHits() == null ? 0 : entity.getConsecutiveHits())
                 .currentValue(entity.getCurrentValue()).lastNotifiedAt(entity.getLastNotifiedAt()).nextReminderAt(next).build();
     }
 
@@ -111,10 +112,25 @@ public class MybatisPlusAlertStateRepository implements AlertStateRepository {
     }
 
     private static AlertRuleState toState(RmqAlertState entity) {
-        return new AlertRuleState(AlertStateStatus.valueOf(entity.getStatus()),
+        return new AlertRuleState(parseStatus(entity.getStatus()),
                 entity.getConsecutiveHits() == null ? 0 : entity.getConsecutiveHits(), entity.getCurrentValue(),
                 toInstant(entity.getFirstPendingAt()), toInstant(entity.getFiredAt()),
                 toInstant(entity.getLastNotifiedAt()), toInstant(entity.getResolvedAt()));
+    }
+
+    /**
+     * A legacy or partially written status must not abort the collection cycle, so unknown values
+     * fall back to the idle state and the next sample re-advances the machine from there.
+     */
+    private static AlertStateStatus parseStatus(String status) {
+        if (status == null || status.isBlank()) {
+            return AlertStateStatus.OK;
+        }
+        try {
+            return AlertStateStatus.valueOf(status.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException unknown) {
+            return AlertStateStatus.OK;
+        }
     }
 
     private static LocalDateTime toLocal(Instant instant) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepositoryTest.java
@@ -13,7 +13,9 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -49,5 +51,52 @@ class MybatisPlusAlertStateRepositoryTest {
 
         verify(mapper).acknowledgeFiring(eq(4L), eq("fingerprint"),
                 eq(LocalDateTime.ofInstant(firedAt, ZoneOffset.UTC)), any());
+    }
+
+    @Test
+    void findToleratesUnknownStoredStatusValuesTest() {
+        RmqAlertStateMapper mapper = mock(RmqAlertStateMapper.class);
+        RmqAlertState row = new RmqAlertState();
+        row.setId(1L);
+        row.setRuleId(4L);
+        row.setFingerprint("fingerprint");
+        row.setStatus("FIRED");
+        row.setConsecutiveHits(2);
+        when(mapper.selectOne(any())).thenReturn(row);
+        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper);
+
+        assertThat(repository.find(new AlertStateKey(4L, "fingerprint")))
+                .hasValueSatisfying(state -> {
+                    assertThat(state.status()).isEqualTo(AlertStateStatus.OK);
+                    assertThat(state.consecutiveHits()).isEqualTo(2);
+                });
+    }
+
+    @Test
+    void runtimeListingToleratesUnknownStoredStatusValuesTest() {
+        RmqAlertStateMapper mapper = mock(RmqAlertStateMapper.class);
+        RmqAlertState unknown = new RmqAlertState();
+        unknown.setId(1L);
+        unknown.setRuleId(4L);
+        unknown.setFingerprint("unknown");
+        unknown.setStatus("FIRED");
+        unknown.setConsecutiveHits(2);
+        RmqAlertState lowerCase = new RmqAlertState();
+        lowerCase.setId(2L);
+        lowerCase.setRuleId(4L);
+        lowerCase.setFingerprint("lowercase");
+        lowerCase.setStatus(" firing ");
+        lowerCase.setConsecutiveHits(1);
+        when(mapper.selectList(any())).thenReturn(List.of(unknown, lowerCase));
+        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper);
+        AlertRuleVO rule = AlertRuleVO.builder().id(4L).name("Lag").reminderInterval("30m").build();
+
+        List<AlertRuleRuntimeVO> runtime = repository.findRuntimeByRuleIds(List.of(rule));
+
+        assertThat(runtime)
+                .extracting(AlertRuleRuntimeVO::getFingerprint, AlertRuleRuntimeVO::getStatus)
+                .containsExactlyInAnyOrder(
+                        org.assertj.core.groups.Tuple.tuple("unknown", AlertStateStatus.OK),
+                        org.assertj.core.groups.Tuple.tuple("lowercase", AlertStateStatus.FIRING));
     }
 }


### PR DESCRIPTION
## Summary
- parse stored alert-state statuses through a guarded helper in `MybatisPlusAlertStateRepository`
- trim and root-locale uppercase the value; unknown or blank statuses fall back to `OK` in both `find` and the runtime listing

## Why
`toState` is on the hot path of `NativeAlertProcessor.process`: every sample, for every rule, loads the persisted state and calls `AlertStateStatus.valueOf(entity.getStatus())`. One legacy or corrupted status value in `rmq_alert_state` threw `IllegalArgumentException` inside the collection transaction, aborting the whole alert evaluation cycle for every rule and fingerprint. The runtime listing (`/api/alert-rules/runtime`) had the same unguarded parse. Unknown values now fall back to the idle `OK` state so the next sample re-advances the state machine from a safe baseline.

## Testing
- `cd server && mvn -q -Dtest=MybatisPlusAlertStateRepositoryTest test` — all tests pass, including the new `findToleratesUnknownStoredStatusValuesTest` (stored `FIRED` → `OK`) and `runtimeListingToleratesUnknownStoredStatusValuesTest` (stored `FIRED` → `OK`, stored ` firing ` → `FIRING`)
