### PR TITLE
fix(alert): tolerate malformed silence domain values

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepository.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.studio.persistence.mapper.RmqAlertSilenceMapper;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -69,11 +70,26 @@ public class MybatisPlusAlertSilenceRepository implements AlertSilenceRepository
 
     private AlertSilenceVO toVo(RmqAlertSilence entity) {
         return AlertSilenceVO.builder().id(entity.getId())
-                .domain(entity.getDomain() == null ? null : AlertDomain.valueOf(entity.getDomain()))
+                .domain(parseDomain(entity.getDomain()))
                 .ruleId(entity.getRuleId()).instanceId(entity.getInstanceId())
                 .labels(readLabels(entity.getLabelsJson()))
                 .startsAt(entity.getStartsAt()).endsAt(entity.getEndsAt())
                 .reason(entity.getReason()).createdBy(entity.getCreatedBy()).build();
+    }
+
+    /**
+     * A legacy or manually edited domain must not break silence matching, so unknown values fall
+     * back to the business domain like {@code rmq_alert_rule} rows without a recognized domain.
+     */
+    private static AlertDomain parseDomain(String domain) {
+        if (domain == null || domain.isBlank()) {
+            return null;
+        }
+        try {
+            return AlertDomain.valueOf(domain.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException unknown) {
+            return AlertDomain.BUSINESS;
+        }
     }
 
     private String writeLabels(Map<String, String> labels) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.persistence.entity.RmqAlertSilence;
+import org.apache.rocketmq.studio.persistence.mapper.RmqAlertSilenceMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MybatisPlusAlertSilenceRepositoryTest {
+    @Test
+    void findAllToleratesMalformedStoredDomainValuesTest() {
+        RmqAlertSilenceMapper mapper = mock(RmqAlertSilenceMapper.class);
+        when(mapper.selectList(any())).thenReturn(List.of(
+                silence(1L, " business "),
+                silence(2L, "LEGACY"),
+                silence(3L, "CLUSTER")));
+        MybatisPlusAlertSilenceRepository repository =
+                new MybatisPlusAlertSilenceRepository(mapper, new ObjectMapper());
+
+        List<AlertSilenceVO> result = repository.findAll();
+
+        assertThat(result).extracting(AlertSilenceVO::getDomain)
+                .containsExactly(AlertDomain.BUSINESS, AlertDomain.BUSINESS, AlertDomain.CLUSTER);
+    }
+
+    @Test
+    void findAllKeepsUnscopedSilencesDomainlessTest() {
+        RmqAlertSilenceMapper mapper = mock(RmqAlertSilenceMapper.class);
+        when(mapper.selectList(any())).thenReturn(List.of(silence(1L, null)));
+        MybatisPlusAlertSilenceRepository repository =
+                new MybatisPlusAlertSilenceRepository(mapper, new ObjectMapper());
+
+        List<AlertSilenceVO> result = repository.findAll();
+
+        assertThat(result).singleElement()
+                .satisfies(vo -> assertThat(vo.getDomain()).isNull());
+    }
+
+    private static RmqAlertSilence silence(Long id, String domain) {
+        RmqAlertSilence entity = new RmqAlertSilence();
+        entity.setId(id);
+        entity.setDomain(domain);
+        entity.setStartsAt(LocalDateTime.of(2026, 8, 22, 9, 0));
+        entity.setEndsAt(LocalDateTime.of(2026, 8, 22, 10, 0));
+        entity.setCreatedBy("admin");
+        return entity;
+    }
+}


### PR DESCRIPTION
## Summary
- parse stored silence domains through a guarded helper in `MybatisPlusAlertSilenceRepository.toVo`
- trim and root-locale uppercase the value; blank domains stay unscoped, unknown values fall back to `BUSINESS`

## Why
`toVo` called `AlertDomain.valueOf(entity.getDomain())` directly on the raw database value. The write path always stores the canonical enum name, but a legacy row (for example a lowercase `business`) or a manually edited value made `valueOf` throw `IllegalArgumentException` inside `findAll()`. That single row broke both the silence listing endpoint and `AlertSilenceService.activeUntil`, which reads every silence on every notification enqueue and dispatch — so one bad row silently disabled silence matching for all alerts. The fallback follows the existing convention in `MybatisPlusAlertRepository.parseDomain`, which maps unrecognized rule domains to `BUSINESS`.

## Testing
- `cd server && mvn -q -Dtest=MybatisPlusAlertSilenceRepositoryTest,AlertSilenceServiceTest test` — all tests pass, including the new `MybatisPlusAlertSilenceRepositoryTest` covering stored ` business ` → `BUSINESS`, `LEGACY` → `BUSINESS`, `CLUSTER` → `CLUSTER`, and `null` → unscoped
