### PR TITLE
fix(ai): treat non-array tool catalogs as empty

### DIFF
--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -21,7 +21,7 @@ import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { MemoryRouter } from 'react-router-dom';
 import { LangProvider } from '../../../i18n/LangContext';
-import { chatStream, executeTool, listTools } from '../../../api/ai';
+import { chatStream, executeTool, listTools, type McpTool } from '../../../api/ai';
 import { listClusters, type ClusterInfo } from '../../../api/cluster';
 import { getLlmConfig, getLlmModels } from '../../../api/llm';
 import { useAiChatHistoryStore } from '../../../stores/aiChatHistoryStore';
@@ -452,5 +452,18 @@ describe('AiPage tool runner', () => {
 
     expect(await screen.findByText('工具参数必须是有效的 JSON 对象')).toBeInTheDocument();
     expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it('treats a non-array tool catalog payload as an empty catalog', async () => {
+    const user = userEvent.setup();
+    vi.mocked(listTools).mockResolvedValue(null as unknown as McpTool[]);
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: '工具' }));
+    const dialog = await screen.findByRole('dialog', { name: 'AI 工具' });
+    await waitFor(() => expect(listTools).toHaveBeenCalledWith('cluster-a'));
+
+    expect(dialog).toBeInTheDocument();
+    expect(screen.queryByText('AI 工具目录加载失败')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -759,8 +759,9 @@ const AiPage = () => {
       setToolResult(undefined);
       setToolsLoading(true);
       try {
-        const availableTools = await listTools(clusterId || undefined);
+        const catalog = await listTools(clusterId || undefined);
         if (requestId !== toolLoadRequestRef.current) return;
+        const availableTools = Array.isArray(catalog) ? catalog : [];
         setTools(availableTools);
         const firstTool = availableTools.find((tool) => !tool.deprecated);
         if (firstTool) selectTool(firstTool.name, availableTools, clusterId);


### PR DESCRIPTION
## Summary
- In the AI tool runner's `loadTools()`, treat a non-array tool catalog payload as an empty catalog (`Array.isArray` guard) before setting state and auto-selecting the first tool
- Add a regression test: a `null` catalog payload leaves the tool modal open with an empty catalog instead of surfacing the "failed to load" error path

## Why
`listTools()` returns `res.data.data`, so the wire can deliver anything (e.g. `null` or an object) even though the TypeScript type says `McpTool[]`. The page dereferenced the payload with `availableTools.find(...)`: a `null` catalog threw a `TypeError` that fell into the `catch` branch, showing "AI 工具目录加载失败" (catalog load failed) even though the request succeeded, and the tool modal was left in the error state for no recoverable reason.

## Testing
- `./node_modules/.bin/vitest run src/pages/ai/__tests__/AiPage.test.tsx` → 14 passed (1 new; verified it fails with the pre-fix payload handling)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/pages/ai/index.tsx src/pages/ai/__tests__/AiPage.test.tsx` → 0 errors
