### PR TITLE
[ISSUE #2890] Serialize Proxy address mutations

### DIFF
--- a/web/src/pages/studio/Proxy.tsx
+++ b/web/src/pages/studio/Proxy.tsx
@@ -78,6 +78,7 @@ const ProxyPage: React.FC = () => {
   const [newProxyAddress, setNewProxyAddress] = useState('');
   const [nodeFilter, setNodeFilter] = useState('');
   const [addressMutationLoading, setAddressMutationLoading] = useState(false);
+  const addressMutationInFlight = useRef(false);
   const [removingProxyAddress, setRemovingProxyAddress] = useState<string | null>(null);
   const [clusterId, setClusterId] = useState<string>(
     readLocalStorage('clusterId') || 'DefaultCluster',
@@ -176,6 +177,7 @@ const ProxyPage: React.FC = () => {
   };
 
   const handleRefresh = async () => {
+    if (addressMutationInFlight.current) return;
     if (await loadProxyNodes()) {
       message.success(t('common.refreshSuccess'));
     }
@@ -189,11 +191,13 @@ const ProxyPage: React.FC = () => {
   };
 
   const handleAddProxyAddress = async () => {
+    if (addressMutationInFlight.current) return;
     const addr = newProxyAddress.trim();
     if (!addr) {
       message.warning(t('proxy.addressRequired'));
       return;
     }
+    addressMutationInFlight.current = true;
     const requestId = ++loadRequestId.current;
     setAddressMutationLoading(true);
     setLoading(true);
@@ -208,6 +212,7 @@ const ProxyPage: React.FC = () => {
         message.error(t('proxy.addAddressFailed'));
       }
     } finally {
+      addressMutationInFlight.current = false;
       if (requestId === loadRequestId.current) {
         setAddressMutationLoading(false);
         setLoading(false);
@@ -216,6 +221,8 @@ const ProxyPage: React.FC = () => {
   };
 
   const handleRemoveProxyAddress = async (addr: string) => {
+    if (addressMutationInFlight.current) return;
+    addressMutationInFlight.current = true;
     const requestId = ++loadRequestId.current;
     setRemovingProxyAddress(addr);
     setLoading(true);
@@ -233,6 +240,7 @@ const ProxyPage: React.FC = () => {
         message.error(t('proxy.removeAddressFailed'));
       }
     } finally {
+      addressMutationInFlight.current = false;
       if (requestId === loadRequestId.current) {
         setRemovingProxyAddress(null);
         setLoading(false);

--- a/web/src/pages/studio/__tests__/Proxy.test.tsx
+++ b/web/src/pages/studio/__tests__/Proxy.test.tsx
@@ -208,6 +208,24 @@ describe('ProxyPage', () => {
     expect(await screen.findByText('请输入 Proxy 地址')).toBeInTheDocument();
   });
 
+  it('submits one address mutation when add is clicked twice before rendering', async () => {
+    const mutation = createDeferred<typeof proxyHome>();
+    vi.mocked(addProxyAddress).mockImplementation(() => mutation.promise);
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText('127.0.0.1:8081');
+
+    await user.type(screen.getByLabelText('Proxy 地址'), '10.0.0.10:8081');
+    const addButton = screen.getByRole('button', { name: '新增' });
+    act(() => {
+      addButton.click();
+      addButton.click();
+    });
+
+    expect(addProxyAddress).toHaveBeenCalledTimes(1);
+    mutation.resolve(proxyHome);
+  });
+
   it('removes a Proxy address and applies the updated address list', async () => {
     const user = userEvent.setup();
     vi.mocked(queryProxyHomePage).mockResolvedValueOnce({


### PR DESCRIPTION
## What changed\n\n- add a synchronous in-flight guard shared by Proxy address add/remove actions\n- skip manual refresh while an address mutation is pending\n- add a deferred-promise regression for two add events in the same render\n\n## Why\n\nReact loading state is committed asynchronously. Two events received before that commit issued two backend writes; request IDs only hid stale UI responses and did not prevent the duplicate mutation.\n\n## Verification\n\n- npm test -- --run src/pages/studio/__tests__/Proxy.test.tsx\n- Prettier and ESLint on the two changed files\n- scope check: 2 files, 26 changed lines\n\nFixes #2890