### PR TITLE
[ISSUE #2892] Fix duplicate authentication session resolution

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
@@ -68,20 +68,18 @@ public class AuthInterceptor implements HandlerInterceptor {
             return true;
         }
         String authorization = AuthCookie.authorization(request, authProperties);
-        if (!authService.isAuthenticated(authorization)) {
+        var authenticatedUser = authService.getAuthenticatedUser(authorization).orElse(null);
+        if (authenticatedUser == null) {
             writeError(response, HttpStatus.UNAUTHORIZED, "Unauthorized");
             return false;
         }
 
-        var authenticatedUser = authService.getAuthenticatedUser(authorization).orElse(null);
-        if (authenticatedUser != null) {
-            AuthenticatedUserContext.setUser(
-                    authenticatedUser.getUserId(),
-                    authenticatedUser.getUsername(),
-                    authenticatedUser.isAdmin());
-        }
+        AuthenticatedUserContext.setUser(
+                authenticatedUser.getUserId(),
+                authenticatedUser.getUsername(),
+                authenticatedUser.isAdmin());
         if (requiresAdmin(request, requestPath(request))
-                && (authenticatedUser == null || !authenticatedUser.isAdmin())) {
+                && !authenticatedUser.isAdmin()) {
             writeError(response, HttpStatus.FORBIDDEN, "Admin permission required");
             return false;
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -33,10 +33,39 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class AuthInterceptorTest {
+
+    @Test
+    void shouldResolveAuthenticatedUserOnlyOncePerRequest() throws Exception {
+        AuthProperties properties = new AuthProperties();
+        properties.setLoginRequired(true);
+        AuthProperties.User configuredUser = new AuthProperties.User();
+        configuredUser.setUsername("reader");
+        configuredUser.setPassword("secret");
+        properties.setUsers(List.of(configuredUser));
+        AuthService authService = spy(authService(properties));
+        LoginDTO login = new LoginDTO();
+        login.setUsername("reader");
+        login.setPassword("secret");
+        String token = authService.login(login).getToken();
+        clearInvocations(authService);
+        AuthInterceptor interceptor = interceptor(properties, authService, settingsRepository());
+        MockHttpServletRequest request = authenticatedRequest("GET", "/api/clusters", token);
+
+        boolean allowed = interceptor.preHandle(
+                request, new MockHttpServletResponse(), new Object());
+
+        assertThat(allowed).isTrue();
+        verify(authService).getAuthenticatedUser("Bearer " + token);
+        verify(authService, never()).isAuthenticated("Bearer " + token);
+    }
 
     @AfterEach
     void clearAuthenticatedUser() {


### PR DESCRIPTION
## What changed\n\n- resolve the authenticated user exactly once in AuthInterceptor\n- reject an empty user snapshot before populating request context\n- reuse the same user snapshot for reader/admin authorization\n- add a regression that verifies one session resolution per request\n\n## Why\n\nAuthService.isAuthenticated delegates to getAuthenticatedUser. Calling both methods caused two database-backed session resolutions for every protected request and left a revocation race between authentication and context population.\n\n## Verification\n\n- mise exec java@temurin-21 -- mvn -q -Dtest=AuthInterceptorTest test\n- scope check: 2 files, 45 changed lines\n\nFixes #2892