### PR TITLE
[ISSUE #2889] Deduplicate LiteTopic TTL extensions

### DIFF
--- a/web/src/pages/studio/LiteTopic.tsx
+++ b/web/src/pages/studio/LiteTopic.tsx
@@ -154,6 +154,7 @@ const LiteTopicPage: React.FC = () => {
   const bootstrapRequestId = useRef(0);
   const displayRequestId = useRef(0);
   const sessionRequestId = useRef(0);
+  const extendTTLInFlight = useRef(false);
 
   useEffect(() => {
     messageRef.current = message;
@@ -307,7 +308,9 @@ const LiteTopicPage: React.FC = () => {
   };
 
   const handleExtendTTL = async () => {
+    if (extendTTLInFlight.current) return;
     if (!extendTTLForm.topicPattern || extendTTLForm.newTTL == null) return;
+    extendTTLInFlight.current = true;
     setExtendTTLLoading(true);
     try {
       await extendLiteTopicTTL(extendTTLForm.topicPattern, extendTTLForm.newTTL);
@@ -317,6 +320,7 @@ const LiteTopicPage: React.FC = () => {
     } catch {
       message.error(t('liteTopic.extendTtlFailed'));
     } finally {
+      extendTTLInFlight.current = false;
       setExtendTTLLoading(false);
     }
   };

--- a/web/src/pages/studio/__tests__/LiteTopic.test.tsx
+++ b/web/src/pages/studio/__tests__/LiteTopic.test.tsx
@@ -145,6 +145,25 @@ describe('LiteTopic Page', () => {
     expect(await screen.findByText('active-00*')).toBeInTheDocument();
   });
 
+  it('submits one TTL extension when confirm is clicked twice before rendering', async () => {
+    const extension = createDeferred<void>();
+    apiMocks.extendLiteTopicTTL.mockImplementation(() => extension.promise);
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('order-*');
+    await user.click(screen.getByRole('button', { name: '延长 TTL' }));
+    await user.type(screen.getByRole('spinbutton'), '60000');
+    const confirm = screen.getByRole('button', { name: /确\s*认/ });
+    act(() => {
+      confirm.click();
+      confirm.click();
+    });
+
+    expect(apiMocks.extendLiteTopicTTL).toHaveBeenCalledTimes(1);
+    extension.resolve();
+  });
+
   it('displays the session POP progress returned by the API as a percentage', async () => {
     const user = userEvent.setup();
     renderPage();


### PR DESCRIPTION
## What changed\n\n- acquire a synchronous in-flight guard before extending a LiteTopic TTL\n- release the guard on success or failure\n- add a deferred-promise regression for two confirmations in the same render\n\n## Why\n\nThe modal loading state alone did not prevent duplicate write requests before React committed the disabled state.\n\n## Verification\n\n- npm test -- --run src/pages/studio/__tests__/LiteTopic.test.tsx\n- Prettier and ESLint on the two changed files (existing Fast Refresh warning only)\n- scope check: 2 files, 23 changed lines\n\nFixes #2889