### PR TITLE
[ISSUE #2888] Deduplicate DLQ resend actions

### DIFF
--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -396,6 +396,31 @@ describe('DLQ page', () => {
     expect(await screen.findByText('DLQ provider is not configured')).toBeInTheDocument();
   });
 
+  it('submits one resend when confirm is clicked twice before rendering', async () => {
+    let resolveResend!: (result: DLQResendResult) => void;
+    vi.mocked(messageService.resendDLQ).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveResend = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<DLQPage />);
+
+    const row = (await screen.findByText('cg-order')).closest('tr');
+    if (!row) throw new Error('DLQ group row not found');
+    await user.click(within(row).getByRole('button', { name: '重投消息' }));
+    await user.type(screen.getByPlaceholderText('输入目标 Topic 名称'), 'orders-retry');
+    const confirm = screen.getByRole('button', { name: '确认重投' });
+    act(() => {
+      confirm.click();
+      confirm.click();
+    });
+
+    expect(messageService.resendDLQ).toHaveBeenCalledTimes(1);
+    await act(async () => resolveResend({ matched: 7, resent: 7, failed: 0, outcome: 'SUCCESS' }));
+  });
+
   it('warns when DLQ resend scans only part of the available queues', async () => {
     vi.mocked(messageService.resendDLQ).mockResolvedValue({
       matched: 3,

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -143,6 +143,7 @@ const DLQPage = () => {
   const detailRequestIdRef = useRef(0);
   const retryRequestIdRef = useRef(0);
   const groupRequestIdRef = useRef(0);
+  const resendInFlightRef = useRef(false);
 
   useEffect(
     () => () => {
@@ -245,7 +246,9 @@ const DLQPage = () => {
       return;
     }
     if (!retryGroup || !selectedInstanceId) return;
+    if (resendInFlightRef.current) return;
 
+    resendInFlightRef.current = true;
     const requestId = retryRequestIdRef.current + 1;
     retryRequestIdRef.current = requestId;
     const groupName = retryGroup.groupName;
@@ -279,6 +282,7 @@ const DLQPage = () => {
         setRetryError(getErrorMessage(error, DEFAULT_RETRY_ERROR));
       }
     } finally {
+      resendInFlightRef.current = false;
       if (retryRequestIdRef.current === requestId) {
         setRetrySubmitting(false);
       }
@@ -353,6 +357,8 @@ const DLQPage = () => {
 
   const resendSelectedMessages = async (msgIds: string[]) => {
     if (!selectedInstanceId || !detailGroup || msgIds.length === 0) return;
+    if (resendInFlightRef.current) return;
+    resendInFlightRef.current = true;
     setDetailResending(true);
     setDetailError(null);
     try {
@@ -373,6 +379,7 @@ const DLQPage = () => {
     } catch (error) {
       setDetailError(getErrorMessage(error, '重发死信消息失败，请稍后重试'));
     } finally {
+      resendInFlightRef.current = false;
       setDetailResending(false);
     }
   };


### PR DESCRIPTION
## What changed\n\n- share a synchronous resend guard between group and selected-message resends\n- prevent duplicate confirmation events from issuing repeated writes\n- add a deferred-promise regression for two confirmations in the same render\n\n## Why\n\nThe page loading states were asynchronous and allowed duplicate delivery side effects before the next render.\n\n## Verification\n\n- npm test -- --run src/pages/instance/__tests__/DLQPage.test.tsx\n- Prettier and ESLint on the two changed files (existing Fast Refresh warning only)\n- scope check: 2 files, 32 changed lines\n\nFixes #2888