### PR TITLE
[ISSUE #2899] Clear stale broker topology after load failure

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -217,6 +217,7 @@ const BrokerClusterPage = () => {
       setProxyData(mapped.proxies);
     } catch {
       if (!mountedRef.current || requestId !== loadRequestId.current) return;
+      clearData();
       message.error(t('common.refreshFailed'));
     } finally {
       if (mountedRef.current && requestId === loadRequestId.current) {

--- a/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
+++ b/web/src/pages/studio/__tests__/BrokerCluster.test.tsx
@@ -265,6 +265,48 @@ describe('BrokerCluster Page', () => {
     expect(screen.queryByText('proxy-a')).not.toBeInTheDocument();
   });
 
+  it('clears topology from the previous instance when the next instance fails to load', async () => {
+    vi.mocked(listInstances).mockResolvedValue([
+      {
+        id: 1,
+        name: 'instance-1',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '10.0.1.20:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        gmtCreate: '',
+        gmtModified: '',
+      },
+      {
+        id: 2,
+        name: 'instance-2',
+        remark: '',
+        type: 'DIRECT',
+        endpoint: '10.0.2.20:9876',
+        topicCount: 0,
+        consumerGroupCount: 0,
+        gmtCreate: '',
+        gmtModified: '',
+      },
+    ]);
+    vi.mocked(listClusters)
+      .mockResolvedValueOnce(clusterFixture)
+      .mockRejectedValueOnce(new Error('instance-2 unavailable'));
+    const user = userEvent.setup();
+    renderWithProviders(<BrokerCluster />);
+    await screen.findByText('broker-api-a');
+
+    await user.click(screen.getByRole('combobox', { name: '选择实例' }));
+    await user.click(
+      await screen.findByText('instance-2', { selector: '.ant-select-item-option-content' }),
+    );
+
+    await waitFor(() => expect(listClusters).toHaveBeenLastCalledWith('instance-2'));
+    await waitFor(() => expect(screen.queryByText('broker-api-a')).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: '导出' })).toBeDisabled();
+  });
+
   it('polls only while live refresh is enabled and the document is visible', async () => {
     const visibilityState = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
     renderWithProviders(<BrokerCluster />);


### PR DESCRIPTION
## Summary\n- clear broker, NameServer, and proxy datasets when the active instance topology request fails\n- preserve request ownership so stale failures cannot clear a newer successful result\n- disable export naturally once the failed instance has no current data\n\n## Verification\n- Regression test failed before the fix because instance A rows remained after instance B failed\n- npm test -- --run src/pages/studio/__tests__/BrokerCluster.test.tsx (15 passed)\n- Prettier check passed\n- ESLint passed\n- Scope: 2 files, 43 changed lines\n\nFixes #2899