### PR TITLE
[ISSUE #2900] Deduplicate Queue Browser requests

### DIFF
--- a/web/src/components/QueueBrowser.tsx
+++ b/web/src/components/QueueBrowser.tsx
@@ -59,9 +59,11 @@ export const useQueueBrowser = (instanceId?: string) => {
   const [queues, setQueues] = useState<QueueOffset[]>([]);
   const [loading, setLoading] = useState(false);
   const [offsets, setOffsets] = useState<Record<string, number>>({});
-  const [pulling, setPulling] = useState<string | null>(null);
+  const [pulling, setPulling] = useState<Set<string>>(() => new Set());
   const [entries, setEntries] = useState<PulledEntry[]>([]);
   const requestSeqRef = useRef(0);
+  const loadingRef = useRef(false);
+  const pullingRef = useRef(new Set<string>());
 
   useEffect(() => {
     const requestId = ++requestSeqRef.current;
@@ -70,13 +72,16 @@ export const useQueueBrowser = (instanceId?: string) => {
       setQueues([]);
       setOffsets({});
       setEntries([]);
+      loadingRef.current = false;
       setLoading(false);
-      setPulling(null);
+      pullingRef.current.clear();
+      setPulling(new Set());
     });
   }, [instanceId, topic]);
 
   const loadQueues = useCallback(async () => {
-    if (!instanceId || !topic) return;
+    if (!instanceId || !topic || loadingRef.current) return;
+    loadingRef.current = true;
     const requestId = ++requestSeqRef.current;
     setLoading(true);
     setQueues([]);
@@ -97,7 +102,10 @@ export const useQueueBrowser = (instanceId?: string) => {
         message.error(err instanceof Error ? err.message : '加载队列信息失败');
       }
     } finally {
-      if (requestId === requestSeqRef.current) setLoading(false);
+      if (requestId === requestSeqRef.current) {
+        loadingRef.current = false;
+        setLoading(false);
+      }
     }
   }, [instanceId, topic]);
 
@@ -105,8 +113,10 @@ export const useQueueBrowser = (instanceId?: string) => {
     if (!instanceId || !topic) return;
     const requestId = requestSeqRef.current;
     const key = `${queue.brokerName}-${queue.queueId}`;
+    if (pullingRef.current.has(key)) return;
     const offset = offsets[key] ?? queue.minOffset;
-    setPulling(key);
+    pullingRef.current.add(key);
+    setPulling(new Set(pullingRef.current));
     try {
       const msg = await pullMessageAtOffset({
         instanceId,
@@ -125,7 +135,8 @@ export const useQueueBrowser = (instanceId?: string) => {
         message.error(err instanceof Error ? err.message : '拉取消息失败');
       }
     } finally {
-      if (requestId === requestSeqRef.current) setPulling(null);
+      pullingRef.current.delete(key);
+      if (requestId === requestSeqRef.current) setPulling(new Set(pullingRef.current));
     }
   };
 
@@ -272,7 +283,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                     <Button
                       size="small"
                       type="primary"
-                      loading={state.pulling === key}
+                      loading={state.pulling.has(key)}
                       onClick={() => void state.handlePull(record)}
                     >
                       查看

--- a/web/src/components/__tests__/QueueBrowser.test.tsx
+++ b/web/src/components/__tests__/QueueBrowser.test.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MessageRecord, QueueOffset } from '../../api/message';
@@ -85,6 +85,7 @@ function QueueBrowserProbe({ instanceId = 'instance-a' }: { instanceId?: string 
         {state.entries.map((entry) => entry.message?.msgId ?? 'empty').join(',')}
       </output>
       <output aria-label="loading">{String(state.loading)}</output>
+      <output aria-label="pulling">{state.pulling.size > 0 ? 'true' : 'false'}</output>
     </div>
   );
 }
@@ -179,5 +180,39 @@ describe('QueueBrowser request ownership', () => {
     });
     expect(screen.getByLabelText('entries')).toHaveTextContent('');
     expect(screen.queryByText('stale-message')).not.toBeInTheDocument();
+  });
+
+  it('deduplicates pulls for the same queue before loading state renders', async () => {
+    const pull = createDeferred<MessageRecord | null>();
+    vi.mocked(getQueueOffsets).mockResolvedValue([queue('broker-a')]);
+    vi.mocked(pullMessageAtOffset).mockReturnValue(pull.promise);
+    const user = userEvent.setup();
+    render(<QueueBrowserProbe />);
+
+    await user.click(screen.getByRole('button', { name: 'topic-a' }));
+    await user.click(screen.getByRole('button', { name: 'load' }));
+    await waitFor(() => expect(screen.getByLabelText('queues')).toHaveTextContent('broker-a'));
+
+    const pullButton = screen.getByRole('button', { name: 'pull' });
+    fireEvent.click(pullButton);
+    fireEvent.click(pullButton);
+
+    expect(pullMessageAtOffset).toHaveBeenCalledTimes(1);
+    await act(async () => pull.resolve(messageRecord('message-a')));
+  });
+
+  it('deduplicates queue loads before loading state renders', async () => {
+    const queues = createDeferred<QueueOffset[]>();
+    vi.mocked(getQueueOffsets).mockReturnValue(queues.promise);
+    const user = userEvent.setup();
+    render(<QueueBrowserProbe />);
+
+    await user.click(screen.getByRole('button', { name: 'topic-a' }));
+    const loadButton = screen.getByRole('button', { name: 'load' });
+    fireEvent.click(loadButton);
+    fireEvent.click(loadButton);
+
+    expect(getQueueOffsets).toHaveBeenCalledTimes(1);
+    await act(async () => queues.resolve([queue('broker-a')]));
   });
 });


### PR DESCRIPTION
## Summary\n- synchronously admit only one queue-list request for the active topic\n- track pull operations by queue key so the same queue cannot be pulled twice while different queues remain independent\n- keep request-generation checks when instance or topic changes\n\n## Verification\n- Both same-render duplicate-load and duplicate-pull tests failed before the fix\n- npm test -- --run src/components/__tests__/QueueBrowser.test.tsx (8 passed)\n- Prettier check passed\n- ESLint passed with 2 pre-existing Fast Refresh warnings and no errors\n- Scope: 2 files, 62 changed lines\n\nFixes #2900