### PR TITLE
[ISSUE #2901] Preserve polling request ownership across rerenders

### DIFF
--- a/web/src/hooks/useVisiblePolling.test.tsx
+++ b/web/src/hooks/useVisiblePolling.test.tsx
@@ -128,4 +128,38 @@ describe('useVisiblePolling', () => {
     });
     expect(poll).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps the in-flight guard when the poll callback changes', async () => {
+    const first = deferred();
+    const oldPoll = vi.fn().mockReturnValue(first.promise);
+    const newPoll = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = renderHook(({ poll }) => useVisiblePolling(true, 1_000, poll), {
+      initialProps: { poll: oldPoll },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+    });
+    rerender({ poll: newPoll });
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+    });
+    expect(newPoll).not.toHaveBeenCalled();
+
+    await act(async () => {
+      first.resolve();
+      await first.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+    });
+    expect(newPoll).toHaveBeenCalledTimes(1);
+  });
 });

--- a/web/src/hooks/useVisiblePolling.ts
+++ b/web/src/hooks/useVisiblePolling.ts
@@ -15,27 +15,30 @@
  * limitations under the License.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export function useVisiblePolling(
   enabled: boolean,
   intervalMs: number,
   poll: () => void | Promise<void>,
 ): void {
+  const pollInFlightRef = useRef<Promise<void> | null>(null);
+
   useEffect(() => {
     if (!enabled) return;
 
-    let pollInFlight = false;
     const pollWhenVisible = () => {
-      if (document.visibilityState !== 'visible' || pollInFlight) return;
+      if (document.visibilityState !== 'visible' || pollInFlightRef.current) return;
 
-      pollInFlight = true;
-      void Promise.resolve()
+      const inFlight = Promise.resolve()
         .then(poll)
         .catch(() => undefined)
         .finally(() => {
-          pollInFlight = false;
+          if (pollInFlightRef.current === inFlight) {
+            pollInFlightRef.current = null;
+          }
         });
+      pollInFlightRef.current = inFlight;
     };
     const intervalId = window.setInterval(pollWhenVisible, intervalMs);
     document.addEventListener('visibilitychange', pollWhenVisible);


### PR DESCRIPTION
## Summary\n- store the active polling promise in a hook-level ref instead of an effect-local boolean\n- retain the no-overlap guarantee when the callback or interval recreates the effect\n- clear the guard only from the promise that currently owns it\n\n## Verification\n- Rerender regression test failed before the fix because the replacement callback overlapped the pending request\n- npm test -- --run src/hooks/useVisiblePolling.test.tsx (5 passed)\n- Prettier check passed\n- ESLint passed\n- Scope: 2 files, 49 changed lines\n\nFixes #2901