### PR TITLE
[ISSUE #2903] Stabilize broker address fallback

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProvider.java
@@ -176,9 +176,10 @@ public class RealClusterProvider implements ClusterProvider {
         if (data.getBrokerAddrs() != null) {
             addr = data.getBrokerAddrs().get(MixAll.MASTER_ID);
             if (addr == null) {
-                addr = data.getBrokerAddrs().values().stream()
-                        .filter(Objects::nonNull)
-                        .findFirst()
+                addr = data.getBrokerAddrs().entrySet().stream()
+                        .filter(entry -> entry.getKey() != null && entry.getValue() != null)
+                        .min(Map.Entry.comparingByKey())
+                        .map(Map.Entry::getValue)
                         .orElse(null);
             }
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -210,9 +210,10 @@ public class RocketMQClusterProvider implements ClusterProvider {
             // Use master address (brokerId = 0) preferentially
             String masterAddr = brokerData.getBrokerAddrs().get(0L);
             if (!StringUtils.hasText(masterAddr)) {
-                masterAddr = brokerData.getBrokerAddrs().values().stream()
-                        .filter(StringUtils::hasText)
-                        .findFirst()
+                masterAddr = brokerData.getBrokerAddrs().entrySet().stream()
+                        .filter(entry -> StringUtils.hasText(entry.getValue()))
+                        .min(Map.Entry.comparingByKey())
+                        .map(Map.Entry::getValue)
                         .orElse(null);
             }
             if (!StringUtils.hasText(masterAddr)) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RealClusterProviderTest.java
@@ -110,6 +110,27 @@ class RealClusterProviderTest {
     }
 
     @Test
+    void describeClusterShouldChooseTheLowestAvailableBrokerIdWhenMasterIsMissing() throws Exception {
+        ClusterInfo info = new ClusterInfo();
+        HashMap<Long, String> slaveAddrs = new HashMap<>();
+        slaveAddrs.put(32L, "10.0.0.32:10911");
+        slaveAddrs.put(1L, "10.0.0.1:10911");
+        HashMap<String, BrokerData> brokers = new HashMap<>();
+        brokers.put("broker-a", new BrokerData("DefaultCluster", "broker-a", slaveAddrs));
+        info.setBrokerAddrTable(brokers);
+        HashMap<String, Set<String>> clusters = new HashMap<>();
+        clusters.put("DefaultCluster", Set.of("broker-a"));
+        info.setClusterAddrTable(clusters);
+        stubClusterInfo("10.0.0.1:9876", info);
+
+        ClusterVO cluster = provider.describeCluster("10.0.0.1:9876");
+
+        assertThat(cluster.getBrokers()).singleElement()
+                .extracting(BrokerVO::getAddr)
+                .isEqualTo("10.0.0.1:10911");
+    }
+
+    @Test
     void describeClusterShouldDefaultAbsentRuntimeCollectionsToEmpty() throws Exception {
         stubClusterInfo("10.0.0.1:9876", sampleClusterInfo());
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
@@ -211,6 +211,25 @@ class RocketMQClusterProviderTest {
     }
 
     @Test
+    void discoverClustersShouldUseLowestBrokerIdWhenMasterIsMissing() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RocketMQClusterProvider provider = newProvider(adminExt);
+        ClusterInfo info = clusterInfo();
+        HashMap<Long, String> addrs = new HashMap<>();
+        addrs.put(32L, "10.0.0.32:10911");
+        addrs.put(1L, "10.0.0.1:10911");
+        info.getBrokerAddrTable().put(
+                "broker-a", new BrokerData("DefaultCluster", "broker-a", addrs));
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(info);
+
+        ClusterVO cluster = provider.discoverClusters().get(0);
+
+        assertThat(cluster.getBrokers()).singleElement()
+                .extracting(broker -> broker.getAddr())
+                .isEqualTo("10.0.0.1:10911");
+    }
+
+    @Test
     void discoverClustersShouldDiscoverProxiesViaHeartbeatSyncerTest() throws Exception {
         DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
         RocketMQClusterProvider provider = newProvider(adminExt);


### PR DESCRIPTION
## Summary
- continue preferring broker ID 0 when the master is available
- use the lowest broker ID with a nonblank address when the master is absent
- apply the same deterministic policy to both Apache cluster mapping implementations

## Verification
- both focused regressions failed before the fix by selecting broker ID 32 ahead of broker ID 1
- mvn -Dtest=RocketMQClusterProviderTest,RealClusterProviderTest test passed on Temurin 21
- 25 tests passed with zero failures; Checkstyle reported zero violations
- Scope: 4 files, 54 changed lines

Fixes #2903