### PR TITLE
fix(ai): project empty message trace timelines

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandler.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -51,13 +52,24 @@ public class MessageTraceToolHandler implements ToolHandler {
         return project(msgId, trace);
     }
 
+    /**
+     * Providers may report a missing trace as {@code null} or as a record whose node and
+     * consumer-status lists are absent; the output schema only requires the arrays to be
+     * present, so project empty timelines instead of turning the tool call into an NPE 500.
+     */
     private static Map<String, Object> project(String msgId, TraceRecordVO trace) {
+        List<TraceNodeVO> nodes = trace == null || trace.getNodes() == null
+                ? List.of()
+                : trace.getNodes();
+        List<ConsumerStatusVO> consumerStatus = trace == null || trace.getConsumerStatus() == null
+                ? List.of()
+                : trace.getConsumerStatus();
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("msgId", msgId);
-        result.put("nodes", trace.getNodes().stream()
+        result.put("nodes", nodes.stream()
                 .map(MessageTraceToolHandler::projectNode)
                 .toList());
-        result.put("consumerStatus", trace.getConsumerStatus().stream()
+        result.put("consumerStatus", consumerStatus.stream()
                 .map(MessageTraceToolHandler::projectConsumerStatus)
                 .toList());
         return result;

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandlerTest.java
@@ -83,4 +83,32 @@ class MessageTraceToolHandlerTest {
 
         verify(messageService).getMessageTrace("instance-a", "msg-1", "TopicA");
     }
+
+    @Test
+    void executeShouldProjectEmptyTimelineWhenTraceIsNull() {
+        when(messageService.getMessageTrace(eq("instance-a"), eq("msg-2"), eq("TopicA")))
+                .thenReturn(null);
+
+        Object result = handler.execute(Map.of(
+                "cluster", "instance-a", "msgId", "msg-2", "topic", "TopicA"));
+
+        Map<?, ?> row = (Map<?, ?>) result;
+        assertThat(row.get("msgId")).isEqualTo("msg-2");
+        assertThat((List<?>) row.get("nodes")).isEmpty();
+        assertThat((List<?>) row.get("consumerStatus")).isEmpty();
+    }
+
+    @Test
+    void executeShouldProjectEmptyTimelineWhenTraceListsAreNull() {
+        when(messageService.getMessageTrace(eq("instance-a"), eq("msg-3"), eq("TopicA")))
+                .thenReturn(TraceRecordVO.builder().build());
+
+        Object result = handler.execute(Map.of(
+                "cluster", "instance-a", "msgId", "msg-3", "topic", "TopicA"));
+
+        Map<?, ?> row = (Map<?, ?>) result;
+        assertThat(row.get("msgId")).isEqualTo("msg-3");
+        assertThat((List<?>) row.get("nodes")).isEmpty();
+        assertThat((List<?>) row.get("consumerStatus")).isEmpty();
+    }
 }


### PR DESCRIPTION
## Summary

`MessageTraceToolHandler` projects the trace timeline into the tool output, but assumed `MessageService.getMessageTrace` always returns a record with populated `nodes` / `consumerStatus` lists. Providers may report a missing trace as `null` (the service's own `recordTraceQuery` already guards for exactly that case) or as a record whose lists are absent, and the handler turned both shapes into an NPE 500 for AI/MCP/CLI callers.

The projection now treats a missing trace or missing lists as an empty timeline. The tool output schema only requires the arrays to be present, so empty arrays stay schema-valid.

## Why

The same trace lookup is also served to the web UI, where a missing trace renders as an empty timeline. MCP/CLI callers of `rmq.message.trace` should get the same "no trace found" answer instead of an internal error.

## Testing

Extended `MessageTraceToolHandlerTest` with two regression cases: null trace record, and record with null node/consumer-status lists.

```
mvn -q -Dtest=MessageTraceToolHandlerTest test
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```
