### PR TITLE
[ISSUE #2911] Fix Aliyun lag aggregation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
@@ -192,7 +192,10 @@ final class AliyunConverters {
             }
         }
         GetConsumerGroupLagResponseBody.TotalLag totalLag = data.getTotalLag();
-        if (totalLag != null && totalLag.getReadyCount() != null) {
+        // The aggregate repeats the per-topic counts. Keep it only as a fallback when
+        // the API does not expose the topic breakdown, otherwise callers that sum rows
+        // report the same lag twice.
+        if (rows.isEmpty() && totalLag != null && totalLag.getReadyCount() != null) {
             rows.add(QueueProgressVO.builder()
                     .broker("total")
                     .queueId(0)

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersLagTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersLagTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.alibaba;
+
+import com.aliyun.sdk.service.rocketmq20220801.models.DataTopicLagMapValue;
+import com.aliyun.sdk.service.rocketmq20220801.models.GetConsumerGroupLagResponseBody;
+import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AliyunConvertersLagTest {
+
+    @Test
+    void topicBreakdownShouldNotBeCountedAgainAsAnAggregateRow() {
+        GetConsumerGroupLagResponseBody.Data data = GetConsumerGroupLagResponseBody.Data.builder()
+                .topicLagMap(Map.of(
+                        "orders", DataTopicLagMapValue.builder().readyCount(40L).build(),
+                        "payments", DataTopicLagMapValue.builder().readyCount(60L).build()))
+                .totalLag(GetConsumerGroupLagResponseBody.TotalLag.builder().readyCount(100L).build())
+                .build();
+
+        List<QueueProgressVO> rows = AliyunConverters.toQueueProgressRows(data);
+
+        assertThat(rows).extracting(QueueProgressVO::getTopic)
+                .containsExactlyInAnyOrder("orders", "payments");
+        assertThat(rows).noneMatch(row -> "total".equals(row.getBroker()));
+        assertThat(rows.stream().mapToLong(QueueProgressVO::getDiffTotal).sum()).isEqualTo(100L);
+    }
+
+    @Test
+    void aggregateShouldRemainAvailableWhenTopicBreakdownIsMissing() {
+        GetConsumerGroupLagResponseBody.Data data = GetConsumerGroupLagResponseBody.Data.builder()
+                .totalLag(GetConsumerGroupLagResponseBody.TotalLag.builder().readyCount(100L).build())
+                .build();
+
+        assertThat(AliyunConverters.toQueueProgressRows(data)).singleElement()
+                .satisfies(row -> {
+                    assertThat(row.getBroker()).isEqualTo("total");
+                    assertThat(row.getDiffTotal()).isEqualTo(100L);
+                });
+    }
+}


### PR DESCRIPTION
Closes #2911

Summary:
- avoid emitting the aggregate lag row when per-topic lag rows are available
- retain totalLag as a fallback for responses without a topic breakdown
- add focused converter regression coverage

Verification:
- mise exec java@temurin-21 -- mvn -Dtest=AliyunConvertersLagTest test
- 2 tests, 0 failures; Checkstyle 0 violations