### PR TITLE
[ISSUE #2912] Align system group filtering

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/SystemGroupFilter.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/SystemGroupFilter.java
@@ -16,6 +16,8 @@
  */
 package org.apache.rocketmq.studio.common.util;
 
+import org.apache.rocketmq.common.MixAll;
+
 /**
  * Shared utility for identifying RocketMQ system consumer groups.
  *
@@ -39,15 +41,12 @@ public final class SystemGroupFilter {
         if (group == null || group.isEmpty()) {
             return true;
         }
-        return group.startsWith("CID_RMQ_SYS_")
+        return MixAll.isSysConsumerGroupPullMessage(group)
                 || group.startsWith("CID_ONSAPI_")
                 || group.startsWith("CID_SYS_")
                 || group.startsWith("CID_HOUSEKEEPING")
                 || group.startsWith("rmq_sys_")
                 || group.startsWith("%RETRY%")
-                || group.startsWith("%DLQ%")
-                || group.startsWith("TOOLS_CONSUMER")
-                || group.startsWith("FILTERSRV_CONSUMER")
-                || group.startsWith("SELF_TEST_");
+                || group.startsWith("%DLQ%");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemGroupFilterTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemGroupFilterTest.java
@@ -33,10 +33,16 @@ class SystemGroupFilterTest {
         assertThat(SystemGroupFilter.isSystem("rmq_sys_TRACE_DATA")).isTrue();
         assertThat(SystemGroupFilter.isSystem("%RETRY%consumer-a")).isTrue();
         assertThat(SystemGroupFilter.isSystem("%DLQ%consumer-a")).isTrue();
-        assertThat(SystemGroupFilter.isSystem("TOOLS_CONSUMER_monitor")).isTrue();
-        assertThat(SystemGroupFilter.isSystem("FILTERSRV_CONSUMER_filter")).isTrue();
-        assertThat(SystemGroupFilter.isSystem("SELF_TEST_GROUP")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("DEFAULT_CONSUMER")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("TOOLS_CONSUMER")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("SCHEDULE_CONSUMER")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("FILTERSRV_CONSUMER")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("__MONITOR_CONSUMER")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("SELF_TEST_C_GROUP")).isTrue();
 
         assertThat(SystemGroupFilter.isSystem("order-service-consumer")).isFalse();
+        assertThat(SystemGroupFilter.isSystem("TOOLS_CONSUMER_monitor")).isFalse();
+        assertThat(SystemGroupFilter.isSystem("FILTERSRV_CONSUMER_filter")).isFalse();
+        assertThat(SystemGroupFilter.isSystem("SELF_TEST_GROUP")).isFalse();
     }
 }


### PR DESCRIPTION
Closes #2912

Summary:
- delegate canonical RocketMQ system consumer groups to MixAll
- retain Studio-specific reserved prefixes
- stop hiding legal groups that only begin with reserved exact names

Verification:
- mise exec java@temurin-21 -- mvn -Dtest=SystemGroupFilterTest test
- 1 test, 0 failures; Checkstyle 0 violations