### PR TITLE
[ISSUE #2913] Make metric snapshot batches atomic

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepository.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.rocketmq.studio.persistence.entity.RmqMetricSnapshot;
 import org.apache.rocketmq.studio.persistence.mapper.RmqMetricSnapshotMapper;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -42,6 +43,7 @@ public class MybatisPlusMetricSnapshotRepository implements MetricSnapshotReposi
     private final ObjectMapper objectMapper;
 
     @Override
+    @Transactional
     public void saveAll(List<MetricSample> samples) {
         for (MetricSample sample : samples) {
             mapper.insert(toEntity(sample));

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepositoryTest.java
@@ -27,7 +27,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +44,14 @@ class MybatisPlusMetricSnapshotRepositoryTest {
 
     @Mock
     private RmqMetricSnapshotMapper mapper;
+
+    @Test
+    void saveAllShouldUseOneTransactionForTheWholeSampleBatchTest() throws Exception {
+        Method saveAll = MybatisPlusMetricSnapshotRepository.class
+                .getMethod("saveAll", List.class);
+
+        assertThat(saveAll.isAnnotationPresent(Transactional.class)).isTrue();
+    }
 
     @Test
     void nullClusterScopeShouldOnlyReadUnscopedSnapshotsTest() {


### PR DESCRIPTION
Closes #2913

Summary:
- wrap each metric snapshot batch in one Spring transaction
- prevent earlier samples from remaining committed when a later insert fails
- add regression coverage for the repository transaction contract

Verification:
- mise exec java@temurin-21 -- mvn -Dtest=MybatisPlusMetricSnapshotRepositoryTest test
- 2 tests, 0 failures; Checkstyle 0 violations