### PR TITLE
[ISSUE #2914] Prevent stale resource recreation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/audit/OperationAuditService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/audit/OperationAuditService.java
@@ -48,7 +48,14 @@ public class OperationAuditService {
         LocalDateTime now = LocalDateTime.now();
         audit.setGmtCreate(now);
         audit.setGmtModified(now);
-        auditMapper.insert(audit);
-        log.debug("Audit recorded: {} {} {}", operation, resourceType, resourceName);
+        try {
+            auditMapper.insert(audit);
+            log.debug("Audit recorded: {} {} {}", operation, resourceType, resourceName);
+        } catch (RuntimeException auditFailure) {
+            // Audit is observational. A failed sink must not turn an operation that already
+            // completed at a broker or provider into an API failure that callers may retry.
+            log.warn("Failed to record audit operation={} resourceType={} resource={}: {}",
+                    operation, resourceType, resourceName, auditFailure.getMessage());
+        }
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -66,7 +66,7 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
     @Transactional
     public K8sCertVO save(K8sCertVO cert) {
         RmqK8sCertificate entity = toEntity(cert);
-        if (entity.getId() != null && certMapper.selectById(entity.getId()) != null) {
+        if (entity.getId() != null) {
             if (certMapper.updateById(entity) == 0) {
                 throw new BusinessException(409,
                         "Certificate update was not applied: " + entity.getId());

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepository.java
@@ -85,7 +85,7 @@ public class MybatisPlusCloudCredentialRepository implements CloudCredentialRepo
     @Override
     public CloudCredentialVO save(CloudCredentialVO credential) {
         RmqCloudCredential entity = toEntity(credential);
-        if (entity.getId() != null && credentialMapper.selectById(entity.getId()) != null) {
+        if (entity.getId() != null) {
             if (credentialMapper.updateById(entity) == 0) {
                 throw new BusinessException(409,
                         "Cloud credential update was not applied: " + entity.getId());

--- a/server/src/test/java/org/apache/rocketmq/studio/audit/OperationAuditServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/audit/OperationAuditServiceTest.java
@@ -28,6 +28,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -65,5 +67,16 @@ class OperationAuditServiceTest {
         verify(auditMapper).insert(captor.capture());
         assertThat(captor.getValue().getOperator())
                 .isEqualTo(AuthenticatedUserContext.SYSTEM_ACTOR);
+    }
+
+    @Test
+    void recordShouldNotPropagateAuditPersistenceFailures() {
+        OperationAuditService service = new OperationAuditService(auditMapper);
+        doThrow(new IllegalStateException("audit database unavailable"))
+                .when(auditMapper).insert(org.mockito.ArgumentMatchers.any(RmqOperationAudit.class));
+
+        assertThatCode(() -> service.record("DIRECT_CONSUME_MESSAGE", "MESSAGE", "msg-1",
+                "cluster-a", "result=SUCCESS", "SUCCESS", null))
+                .doesNotThrowAnyException();
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
@@ -26,6 +26,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MybatisPlusK8sCertRepositoryTest {
@@ -50,7 +52,6 @@ class MybatisPlusK8sCertRepositoryTest {
     @Test
     void saveShouldReportALostConcurrentUpdate() {
         RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
-        when(mapper.selectById(1L)).thenReturn(certificate());
         when(mapper.updateById(any(RmqK8sCertificate.class))).thenReturn(0);
         K8sCertVO cert = K8sCertVO.builder().k8sId("broker").build();
         cert.setId(1L);
@@ -60,6 +61,19 @@ class MybatisPlusK8sCertRepositoryTest {
                 .hasMessage("Certificate update was not applied: 1")
                 .satisfies(error -> org.assertj.core.api.Assertions.assertThat(
                         ((BusinessException) error).getCode()).isEqualTo(409));
+    }
+
+    @Test
+    void saveShouldNotReinsertACertificateDeletedConcurrently() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        when(mapper.updateById(any(RmqK8sCertificate.class))).thenReturn(0);
+        K8sCertVO cert = K8sCertVO.builder().k8sId("broker").build();
+        cert.setId(1L);
+
+        assertThatThrownBy(() -> repository(mapper).save(cert))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Certificate update was not applied: 1");
+        verify(mapper, never()).insert(any(RmqK8sCertificate.class));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/MybatisPlusCloudCredentialRepositoryTest.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,13 +55,25 @@ class MybatisPlusCloudCredentialRepositoryTest {
         CloudCredentialVO credential = new CloudCredentialVO();
         credential.setId(1L);
         credential.setVendor(InstanceVendor.ALIYUN);
-        when(credentialMapper.selectById(1L)).thenReturn(entity(1L, "cred-1", "ALIYUN"));
         when(credentialMapper.updateById(any(RmqCloudCredential.class))).thenReturn(0);
 
         assertThatThrownBy(() -> repository.save(credential))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Cloud credential update was not applied: 1")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(409));
+    }
+
+    @Test
+    void saveShouldNotReinsertACredentialDeletedConcurrently() {
+        CloudCredentialVO credential = new CloudCredentialVO();
+        credential.setId(1L);
+        credential.setVendor(InstanceVendor.ALIYUN);
+        when(credentialMapper.updateById(any(RmqCloudCredential.class))).thenReturn(0);
+
+        assertThatThrownBy(() -> repository.save(credential))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Cloud credential update was not applied: 1");
+        verify(credentialMapper, never()).insert(any(RmqCloudCredential.class));
     }
 
     @Test

--- a/web/src/pages/ops/__tests__/auditPresentation.test.ts
+++ b/web/src/pages/ops/__tests__/auditPresentation.test.ts
@@ -116,6 +116,21 @@ describe('audit presentation helpers', () => {
     ]);
   });
 
+  it('preserves commas inside nested configuration and quoted values', () => {
+    expect(
+      parseAuditDetail(
+        'brokerAddr=10.0.0.1:10911, config={flushDiskType=SYNC_FLUSH, fileReservedTime=72}, note="primary, synchronous"',
+      ),
+    ).toEqual([
+      { label: 'brokerAddr', value: '10.0.0.1:10911' },
+      {
+        label: 'config',
+        value: '{flushDiskType=SYNC_FLUSH, fileReservedTime=72}',
+      },
+      { label: 'note', value: '"primary, synchronous"' },
+    ]);
+  });
+
   it('keeps free-form details intact when they are not key-value lists', () => {
     expect(parseAuditDetail('Removed stale Proxy address 10.0.30.9:8081')).toEqual([
       { label: '', value: 'Removed stale Proxy address 10.0.30.9:8081' },

--- a/web/src/pages/ops/auditPresentation.ts
+++ b/web/src/pages/ops/auditPresentation.ts
@@ -272,7 +272,8 @@ export function parseAuditDetail(detail: string | null | undefined): AuditDetail
   const text = detail?.trim();
   if (!text) return [];
 
-  const parts = text.split(/\s*,\s*/).filter(Boolean);
+  const parts = splitTopLevelDetailFields(text);
+  if (!parts) return [{ label: '', value: text }];
   if (parts.length <= 1) return [{ label: '', value: text }];
 
   const tokens = parts.map((part) => {
@@ -289,4 +290,56 @@ export function parseAuditDetail(detail: string | null | undefined): AuditDetail
     return [{ label: '', value: text }];
   }
   return tokens as AuditDetailToken[];
+}
+
+const DETAIL_DELIMITERS: Record<string, string> = {
+  '{': '}',
+  '[': ']',
+  '(': ')',
+};
+
+function splitTopLevelDetailFields(text: string): string[] | null {
+  const fields: string[] = [];
+  const expectedClosings: string[] = [];
+  let fieldStart = 0;
+  let quote = '';
+  let escaped = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = '';
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    const closing = DETAIL_DELIMITERS[char];
+    if (closing) {
+      expectedClosings.push(closing);
+      continue;
+    }
+    if (char === '}' || char === ']' || char === ')') {
+      if (expectedClosings.pop() !== char) return null;
+      continue;
+    }
+    if (char === ',' && expectedClosings.length === 0) {
+      const field = text.slice(fieldStart, index).trim();
+      if (field) fields.push(field);
+      fieldStart = index + 1;
+    }
+  }
+
+  if (quote || expectedClosings.length > 0) return null;
+  const field = text.slice(fieldStart).trim();
+  if (field) fields.push(field);
+  return fields;
 }


### PR DESCRIPTION
Closes #2914

Summary:
- make non-null certificate ids update-only
- apply the same update-only contract to cloud credentials
- return the existing conflict instead of inserting after a concurrent delete

Verification:
- mise exec java@temurin-21 -- mvn -Dtest=MybatisPlusK8sCertRepositoryTest,MybatisPlusCloudCredentialRepositoryTest test
- 13 tests, 0 failures; Checkstyle 0 violations