### PR TITLE
[ISSUE #2915] Preserve broker diff failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerConfigDiffService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/BrokerConfigDiffService.java
@@ -76,6 +76,7 @@ public class BrokerConfigDiffService {
                         .name(broker.name())
                         .address(broker.address())
                         .reachable(false)
+                        .message(exception.getMessage())
                         .build());
             }
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerConfigDiffServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerConfigDiffServiceTest.java
@@ -143,7 +143,7 @@ class BrokerConfigDiffServiceTest {
                         BrokerConfigDiffVO.BrokerStatusVO::getMessage)
                 .containsExactly(
                         tuple("10.0.0.1:10911", true, null),
-                        tuple("10.0.0.2:10911", false, null));
+                        tuple("10.0.0.2:10911", false, "broker unavailable"));
     }
 
     @Test


### PR DESCRIPTION
Closes #2915

Summary:
- retain each failed broker config read message in the diff response
- populate the existing message field already rendered by the cluster page
- update partial-result regression coverage

Verification:
- mise exec java@temurin-21 -- mvn -Dtest=BrokerConfigDiffServiceTest test
- 7 tests, 0 failures; Checkstyle 0 violations