### PR TITLE
fix(metrics): survive malformed snapshot retention config in cleanup

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/CollectorScheduler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/CollectorScheduler.java
@@ -120,10 +120,9 @@ public class CollectorScheduler {
 
     @Scheduled(fixedDelayString = "${studio.alerting.snapshot-cleanup-interval:PT1H}")
     public void cleanUpSnapshots() {
-        Duration retention = Duration.parse(properties.getSnapshotRetention());
-        if (retention.isNegative() || retention.isZero()) {
-            return;
-        }
+        // A malformed or non-positive retention value must not fail the scheduled cleanup; fall
+        // back to the default retention instead of leaving the snapshot table to grow unbounded.
+        Duration retention = parsePositiveDuration("snapshot retention", properties.getSnapshotRetention(), Duration.ofDays(1));
         snapshotRepository.deleteBefore(Instant.now().minus(retention));
     }
 
@@ -176,11 +175,15 @@ public class CollectorScheduler {
     }
 
     private static Duration parsePositiveDuration(String value, Duration fallback) {
+        return parsePositiveDuration("collection timeout", value, fallback);
+    }
+
+    private static Duration parsePositiveDuration(String settingName, String value, Duration fallback) {
         try {
             Duration duration = Duration.parse(value);
             return duration.isPositive() ? duration : fallback;
         } catch (RuntimeException error) {
-            log.warn("Invalid native metric collection timeout '{}'; using {}", value, fallback);
+            log.warn("Invalid native metric {} '{}'; using {}", settingName, value, fallback);
             return fallback;
         }
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/CollectorSchedulerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/CollectorSchedulerTest.java
@@ -152,6 +152,18 @@ class CollectorSchedulerTest {
     }
 
     @Test
+    void survivesMalformedSnapshotRetentionTest() {
+        AlertingProperties properties = new AlertingProperties();
+        properties.setSnapshotRetention("not-a-duration");
+        MetricSnapshotRepository snapshots = mock(MetricSnapshotRepository.class);
+
+        new CollectorScheduler(properties, mock(InstanceRepository.class), List.of(), List.of(), snapshots,
+                mock(NativeAlertProcessor.class), mock(AlertCollectionLease.class)).cleanUpSnapshots();
+
+        verify(snapshots).deleteBefore(any(Instant.class));
+    }
+
+    @Test
     void doesNotCollectWhenAnotherReplicaHoldsTheLeaseTest() {
         AlertingProperties properties = new AlertingProperties();
         InstanceRepository instances = mock(InstanceRepository.class);


### PR DESCRIPTION
## Summary
- Parse `studio.alerting.snapshot-retention` defensively in `CollectorScheduler.cleanUpSnapshots()`, reusing the existing `parsePositiveDuration` helper (now parameterized with a setting name for accurate log messages)
- A malformed or non-positive retention value falls back to the 24h default retention with a warning instead of throwing out of the scheduled task

## Why
`cleanUpSnapshots()` ran `Duration.parse(properties.getSnapshotRetention())` without any guard, while its two sibling settings (`studio.alerting.collection-timeout` and `studio.alerting.collection-lease-duration`) already use defensive parsing. A typo in the retention value (e.g. `1h` instead of `PT1H`) made the hourly cleanup task throw a `DateTimeParseException` on every run, so the short-lived `rmq_metric_snapshot` table grew unbounded until the configuration was fixed.

## Testing
- `mvn -Dtest=CollectorSchedulerTest test` → Tests run: 7, Failures: 0, Errors: 0 (1 new: a malformed retention value no longer throws and still deletes expired snapshots using the fallback)
