### PR TITLE
fix(metrics): skip unmaterializable snapshot rows in recent reads

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepository.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.studio.ops.alert.AlertDomain;
 import org.apache.rocketmq.studio.persistence.entity.RmqMetricSnapshot;
 import org.apache.rocketmq.studio.persistence.mapper.RmqMetricSnapshotMapper;
 import org.springframework.stereotype.Repository;
@@ -33,8 +35,10 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class MybatisPlusMetricSnapshotRepository implements MetricSnapshotRepository {
@@ -65,7 +69,7 @@ public class MybatisPlusMetricSnapshotRepository implements MetricSnapshotReposi
                         .eq("availability", MetricAvailability.AVAILABLE.name())
                         .ge("collected_at", LocalDateTime.ofInstant(since, ZoneOffset.UTC))
                         .orderByAsc("collected_at"))
-                .stream().map(this::toSample).toList();
+                .stream().map(this::toSample).filter(Objects::nonNull).toList();
     }
 
     private RmqMetricSnapshot toEntity(MetricSample sample) {
@@ -83,14 +87,21 @@ public class MybatisPlusMetricSnapshotRepository implements MetricSnapshotReposi
         return entity;
     }
 
+    /**
+     * Materializes a persisted snapshot row, returning null (and logging) when the row is
+     * structurally invalid - e.g. a NULL value on an available row, or an enum value left behind
+     * by an older Studio version. Skipping one bad row keeps it from breaking the recent-samples
+     * window that alert aggregation reads until the retention cleanup removes it.
+     */
     private MetricSample toSample(RmqMetricSnapshot entity) {
         try {
-            return new MetricSample(entity.getMetricKey(), org.apache.rocketmq.studio.ops.alert.AlertDomain.valueOf(entity.getDomain()),
+            return new MetricSample(entity.getMetricKey(), AlertDomain.valueOf(entity.getDomain()),
                     entity.getInstanceId(), entity.getClusterId(), objectMapper.readValue(entity.getLabelsJson(), new TypeReference<>() { }),
                     entity.getValue(), MetricAvailability.valueOf(entity.getAvailability()),
                     entity.getCollectedAt().toInstant(ZoneOffset.UTC));
-        } catch (JsonProcessingException error) {
-            throw new IllegalStateException("Unable to read metric labels", error);
+        } catch (JsonProcessingException | IllegalArgumentException | NullPointerException error) {
+            log.warn("Skipping unreadable metric snapshot row id={}: {}", entity.getId(), error.toString());
+            return null;
         }
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepositoryTest.java
@@ -29,6 +29,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 
@@ -57,5 +59,37 @@ class MybatisPlusMetricSnapshotRepositoryTest {
         verify(mapper).selectList(queryCaptor.capture());
         QueryWrapper<RmqMetricSnapshot> query = (QueryWrapper<RmqMetricSnapshot>) queryCaptor.getValue();
         assertThat(query.getSqlSegment()).contains("cluster_id IS NULL");
+    }
+    @Test
+    void skipsUnmaterializableSnapshotRowsTest() {
+        RmqMetricSnapshot good = snapshot(1L, "AVAILABLE", 42.0);
+        RmqMetricSnapshot nullValue = snapshot(2L, "AVAILABLE", null);
+        RmqMetricSnapshot unknownDomain = snapshot(3L, "AVAILABLE", 1.0);
+        unknownDomain.setDomain("LEGACY");
+        when(mapper.selectList(any(Wrapper.class)))
+                .thenReturn(List.of(good, nullValue, unknownDomain));
+        MybatisPlusMetricSnapshotRepository repository =
+                new MybatisPlusMetricSnapshotRepository(mapper, new ObjectMapper());
+        MetricSample scope = new MetricSample("broker.availability", AlertDomain.CLUSTER,
+                "local", null, Map.of(), 1D, MetricAvailability.AVAILABLE, Instant.now());
+
+        List<MetricSample> recent = repository.findRecent(scope, Instant.EPOCH);
+
+        assertThat(recent).hasSize(1);
+        assertThat(recent.get(0).value()).isEqualTo(42.0);
+    }
+
+    private static RmqMetricSnapshot snapshot(long id, String availability, Double value) {
+        RmqMetricSnapshot entity = new RmqMetricSnapshot();
+        entity.setId(id);
+        entity.setInstanceId("local");
+        entity.setMetricKey("broker.availability");
+        entity.setDomain("CLUSTER");
+        entity.setLabelsHash("hash");
+        entity.setLabelsJson("{}");
+        entity.setValue(value);
+        entity.setAvailability(availability);
+        entity.setCollectedAt(LocalDateTime.now(ZoneOffset.UTC));
+        return entity;
     }
 }


### PR DESCRIPTION
## Summary
- `MybatisPlusMetricSnapshotRepository.toSample()` now returns null (with a warning log) when a persisted snapshot row cannot be materialized: unknown `domain`/`availability` enum values, a NULL value on an available row, or a missing collected timestamp
- `findRecent()` filters out those rows instead of letting the `MetricSample` constructor throw
- Adds a regression test with a valid row mixed with a NULL-value row and an unknown-domain row

## Why
`rmq_metric_snapshot` allows `value` to be NULL, and its `domain`/`availability` columns are plain strings. A structurally invalid row (a legacy enum value from an older Studio version, a NULL value on an AVAILABLE row, or a direct DB edit) made `toSample()` throw an `IllegalArgumentException`/`NullPointerException` that was not caught (only JSON errors were), so one bad record broke the entire recent-samples window read by alert aggregation for that scope — every alert evaluation in the scope failed until the 24h retention cleanup removed the row.

## Testing
- `mvn -Dtest=MybatisPlusMetricSnapshotRepositoryTest test` → Tests run: 2, Failures: 0, Errors: 0 (1 new; verified it errors with the pre-fix materialization)
