### PR TITLE
fix(proxy): strip IPv6 brackets when probing proxy topology

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
@@ -175,7 +175,7 @@ public class ProxyAddressService {
                 log.warn("Skipping malformed proxy address in topology: {}", addr);
                 continue;
             }
-            String host = matcher.group(1);
+            String host = stripIpv6Brackets(matcher.group(1));
             int grpcPort = Integer.parseInt(matcher.group(2));
             Integer remotingPort = deriveRemotingPort(grpcPort);
             tasks.add(new ProbeTask(addr, grpcPort, remotingPort,
@@ -247,6 +247,16 @@ public class ProxyAddressService {
         }
         future.cancel(true);
         return ProxyHealthProbe.ProbeResult.unreachable();
+    }
+
+    /**
+     * {@code InetSocketAddress} treats a bracketed IPv6 literal as a hostname, so probing
+     * would always fail with an unknown-host error and report healthy IPv6 proxies as DOWN.
+     */
+    private static String stripIpv6Brackets(String host) {
+        return host.startsWith("[") && host.endsWith("]")
+                ? host.substring(1, host.length() - 1)
+                : host;
     }
 
     /** In-flight probe pair for one registered proxy address. */

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
@@ -346,4 +346,29 @@ class ProxyAddressServiceTest {
         assertThat(down.isGrpcReachable()).isFalse();
         assertThat(down.isRemotingReachable()).isFalse();
     }
+
+    @Test
+    void buildTopologyShouldStripBracketsWhenProbingBracketedIpv6Host() {
+        // InetSocketAddress treats a bracketed IPv6 literal as a hostname, so the probe must
+        // receive the bare literal or a healthy IPv6 proxy is always reported DOWN.
+        java.util.concurrent.atomic.AtomicReference<String> probedHost =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        ProxyHealthProbe capturingProbe = (host, port, timeoutMillis) -> {
+            probedHost.set(host);
+            return ProxyHealthProbe.ProbeResult.reachable(1L);
+        };
+        java.util.concurrent.ExecutorService executor =
+                java.util.concurrent.Executors.newSingleThreadExecutor();
+        ProxyAddressService service =
+                new ProxyAddressService(clusterService, capturingProbe, executor, 500L);
+        service.addProxyAddr("[::1]:9001");
+
+        List<ProxyTopologyVO> topology = service.buildTopology();
+        executor.shutdownNow();
+
+        ProxyTopologyVO node = topology.get(1);
+        assertThat(node.getProxyAddr()).isEqualTo("[::1]:9001");
+        assertThat(node.getStatus()).isEqualTo("UP");
+        assertThat(probedHost.get()).isEqualTo("::1");
+    }
 }


### PR DESCRIPTION
## Summary

Proxy addresses are stored bracketed for IPv6 (`[::1]:8081`) — that format is validated on add and shown to users — but `buildTopology()` passed the bracketed host straight to the health probe. `InetSocketAddress` treats a bracketed IPv6 literal as a *hostname*, so the lookup always failed with an unknown-host error and every registered IPv6 proxy was reported as DOWN even while healthy.

The topology build now strips the brackets before probing, so IPv6 proxies get the same TCP treatment as IPv4 and hostname entries.

## Why

`addProxyAddr` explicitly accepts and validates bracketed IPv6 addresses, but the topology view could never show one as UP — a live IPv6 proxy looked dead in the console.

## Testing

Extended `ProxyAddressServiceTest`: a new case registers `[::1]:9001` with a capturing probe and asserts the probe receives the bare literal `::1` and the node reports UP.

```
mvn -q -Dtest=ProxyAddressServiceTest test
Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
```
