### PR TITLE
fix(proxy): skip stale proxy probes queued past the topology budget

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressService.java
@@ -207,12 +207,25 @@ public class ProxyAddressService {
     }
 
     private CompletableFuture<ProxyHealthProbe.ProbeResult> probeAsync(String host, int port) {
+        CompletableFuture<ProxyHealthProbe.ProbeResult> future = new CompletableFuture<>();
         try {
-            return CompletableFuture.supplyAsync(
-                    () -> healthProbe.probe(host, port, HEALTH_PROBE_TIMEOUT_MILLIS), probeExecutor);
+            probeExecutor.execute(() -> {
+                // The topology budget may have elapsed while this task waited in the queue;
+                // its future was already cancelled, so skip the socket work instead of
+                // pinning a pool thread with a probe the caller no longer waits for.
+                if (future.isDone()) {
+                    return;
+                }
+                try {
+                    future.complete(healthProbe.probe(host, port, HEALTH_PROBE_TIMEOUT_MILLIS));
+                } catch (RuntimeException probeFailure) {
+                    future.complete(ProxyHealthProbe.ProbeResult.unreachable());
+                }
+            });
         } catch (RejectedExecutionException ex) {
-            return CompletableFuture.completedFuture(ProxyHealthProbe.ProbeResult.unreachable());
+            future.complete(ProxyHealthProbe.ProbeResult.unreachable());
         }
+        return future;
     }
 
     private void awaitProbes(List<ProbeTask> tasks) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressServiceTest.java
@@ -346,4 +346,51 @@ class ProxyAddressServiceTest {
         assertThat(down.isGrpcReachable()).isFalse();
         assertThat(down.isRemotingReachable()).isFalse();
     }
+
+    @Test
+    void buildTopologyShouldSkipQueuedProbeAfterBudgetCancelsItsFuture() throws Exception {
+        // Single probe thread: 10.9.0.1's probe runs first and blocks on the gate, so
+        // 10.9.0.2's probe task sits in the queue past the 300 ms budget. When the gate
+        // opens, the queued task must see its cancelled future and skip the socket work
+        // instead of pinning a pool thread with a probe nobody waits for.
+        java.util.concurrent.CountDownLatch gate = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.atomic.AtomicInteger queuedHostProbes =
+                new java.util.concurrent.atomic.AtomicInteger();
+        ProxyHealthProbe gatedProbe = (host, port, timeoutMillis) -> {
+            if ("10.9.0.1".equals(host)) {
+                try {
+                    gate.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            } else if ("10.9.0.2".equals(host)) {
+                queuedHostProbes.incrementAndGet();
+            }
+            return ProxyHealthProbe.ProbeResult.reachable(1L);
+        };
+        java.util.concurrent.ExecutorService executor =
+                java.util.concurrent.Executors.newSingleThreadExecutor();
+        ProxyAddressService service =
+                new ProxyAddressService(clusterService, gatedProbe, executor, 300L);
+        service.addProxyAddr("10.9.0.1:9001");
+        service.addProxyAddr("10.9.0.2:9001");
+
+        List<ProxyTopologyVO> topology = service.buildTopology();
+
+        // Budget elapsed with 10.9.0.1 gated and 10.9.0.2 still queued, so both are DOWN.
+        assertThat(topology.get(1).getProxyAddr()).isEqualTo("10.9.0.1:9001");
+        assertThat(topology.get(1).getStatus()).isEqualTo("DOWN");
+        assertThat(topology.get(2).getProxyAddr()).isEqualTo("10.9.0.2:9001");
+        assertThat(topology.get(2).getStatus()).isEqualTo("DOWN");
+
+        // Release the gate: 10.9.0.1's task finishes and the queued 10.9.0.2 task runs.
+        gate.countDown();
+        java.util.concurrent.CountDownLatch drained = new java.util.concurrent.CountDownLatch(1);
+        executor.execute(drained::countDown);
+        assertThat(drained.await(5, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+        executor.shutdownNow();
+
+        // The queued probe's future was cancelled by the budget, so its socket work was skipped.
+        assertThat(queuedHostProbes).hasValue(0);
+    }
 }


### PR DESCRIPTION
## Summary

`buildTopology()` submits every probe with `CompletableFuture.supplyAsync(...)`. When the overall budget elapses, `awaitProbe()` cancels the unfinished futures — but cancelling a `supplyAsync` future does **not** unqueue its task. Probes that were still waiting in the bounded 8-thread probe pool therefore ran their socket work later, after the topology had already been returned, pinning pool threads with results nobody reads (up to 2 s each, times every queued probe, on every overloaded request).

`probeAsync()` now completes the future from the task itself and skips the probe when the future is already done (cancelled or rejected), so queued-but-unstarted probes become no-ops. Probes that already started behave exactly as before.

## Why

With many unreachable proxies the probe queue grows; after each budget-exceeded topology call the pool kept doing stale work, and under repeated requests the stale tasks can outlive the pool's usefulness — a classic cancelled-future leak.

## Testing

Extended `ProxyAddressServiceTest`: a single-thread executor with a 300 ms budget, where the first probe blocks on a latch and the second probe's task sits in the queue. After the budget cancels both futures, the gate opens; the queued task must run without invoking the probe.

```
mvn -q -Dtest=ProxyAddressServiceTest test
Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
```
