### PR TITLE
fix(metrics): tolerate dashboard resources without descriptions

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardService.java
@@ -166,7 +166,10 @@ public class GrafanaDashboardService {
         Map<String, Resource> resourcesByUid = new LinkedHashMap<>();
         Arrays.stream(resolveResources())
                 .filter(resource -> uidOf(resource) != null)
-                .sorted(Comparator.comparing(Resource::getDescription))
+                // Resources without a description are ordered last: the description is only a
+                // deterministic tie-breaker for deduplication, not a load-bearing field.
+                .sorted(Comparator.comparing(Resource::getDescription,
+                        Comparator.nullsLast(Comparator.naturalOrder())))
                 .forEach(resource -> resourcesByUid.putIfAbsent(uidOf(resource), resource));
         return new ArrayList<>(resourcesByUid.values());
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardServiceTest.java
@@ -179,6 +179,17 @@ class GrafanaDashboardServiceTest {
         }
     }
 
+    @Test
+    void listDashboardsShouldTolerateResourcesWithoutDescriptions() {
+        Resource described = resource("b.json", "file [b.json]", "{\"title\": \"B\"}");
+        Resource undescribed = resource("a.json", null, "{\"title\": \"A\"}");
+        GrafanaDashboardService service = serviceWithResources(described, undescribed);
+
+        List<GrafanaDashboardInfo> dashboards = service.listDashboards();
+
+        assertEquals(List.of("a", "b"), dashboards.stream().map(GrafanaDashboardInfo::uid).toList());
+    }
+
     private static GrafanaDashboardService serviceWithResources(Resource... resources) {
         return new GrafanaDashboardService(new ObjectMapper()) {
             @Override


### PR DESCRIPTION
## Summary
- Order dashboard resources by description with `Comparator.nullsLast(...)` in `GrafanaDashboardService.resolveUniqueResources()` so a resource without a description is tolerated instead of throwing
- Adds a regression test listing dashboards from resources where one description is null

## Why
The duplicate-uid deduplication sorts resolved resources by `Resource.getDescription()` to pick a deterministic winner, but the plain `Comparator.comparing(Resource::getDescription)` NPEs when a resource's description is null (the default `PathMatchingResourcePatternResolver` always sets one, but the resolver is injected and the test seam already overrides it). One such resource made `listDashboards()`, `getDashboard()` and the archive export all fail with a 500.

## Testing
- `mvn -Dtest=GrafanaDashboardServiceTest test` → Tests run: 13, Failures: 0, Errors: 0 (1 new; verified it errors with the pre-fix comparator)
