### PR TITLE
fix(client): tolerate null connection lists from client providers

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ClientService.java
@@ -33,7 +33,8 @@ public class ClientService {
 
     public List<ClientConnectionVO> listConnections(String instanceId, String clusterId, String type) {
         log.info("Listing client connections, instanceId={}, clusterId={}, type={}", instanceId, clusterId, type);
-        return clientProvider.findConnections(requireInstanceId(instanceId), normalizeFilter(clusterId), normalizeFilter(type));
+        return nullToEmpty(clientProvider.findConnections(
+                requireInstanceId(instanceId), normalizeFilter(clusterId), normalizeFilter(type)));
     }
 
     public List<ClientConnectionVO> listConnectionsAt(String namesrvAddr, String clusterId, String type) {
@@ -41,7 +42,13 @@ public class ClientService {
         if (!StringUtils.hasText(namesrvAddr)) {
             throw new BusinessException(400, "namesrvAddr is required");
         }
-        return clientProvider.findConnectionsAt(namesrvAddr.trim(), normalizeFilter(clusterId), normalizeFilter(type));
+        return nullToEmpty(clientProvider.findConnectionsAt(
+                namesrvAddr.trim(), normalizeFilter(clusterId), normalizeFilter(type)));
+    }
+
+    /** Providers may report an unavailable lookup as {@code null}; the API contract is a list. */
+    private static List<ClientConnectionVO> nullToEmpty(List<ClientConnectionVO> connections) {
+        return connections == null ? List.of() : connections;
     }
 
     private String requireInstanceId(String instanceId) {

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionService.java
@@ -39,7 +39,9 @@ public class ProducerConnectionService {
         String normalizedInstanceId = requireFilter(instanceId, "instanceId");
         String normalizedTopic = requireFilter(topic, "topic");
         String normalizedProducerGroup = normalizeOptionalFilter(producerGroup);
-        return clientProvider.findProducerConnections(normalizedInstanceId, normalizedTopic, normalizedProducerGroup)
+        List<ClientConnectionVO> connections = clientProvider.findProducerConnections(
+                normalizedInstanceId, normalizedTopic, normalizedProducerGroup);
+        return (connections == null ? List.of() : connections)
                 .stream()
                 .map(this::toProducerConnection)
                 .toList();
@@ -47,11 +49,13 @@ public class ProducerConnectionService {
 
     public List<String> listProducerGroups(String instanceId, String topic, String query, Integer limit) {
         String normalizedInstanceId = requireFilter(instanceId, "instanceId");
-        return clientProvider.findProducerGroups(
+        List<String> groups = clientProvider.findProducerGroups(
                 normalizedInstanceId,
                 normalizeOptionalFilter(topic),
                 normalizeOptionalFilter(query),
                 normalizeSelectorLimit(limit));
+        // Providers may report an unavailable lookup as null; the API contract is a list.
+        return groups == null ? List.of() : groups;
     }
 
     private ProducerConnectionVO toProducerConnection(ClientConnectionVO connection) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientServiceTest.java
@@ -93,4 +93,22 @@ class ClientServiceTest {
 
         verifyNoInteractions(clientProvider);
     }
+
+    @Test
+    void listConnectionsShouldTreatNullProviderResultAsEmpty() {
+        when(clientProvider.findConnections("instance-1", "cluster-a", null)).thenReturn(null);
+
+        List<ClientConnectionVO> result = clientService.listConnections("instance-1", "cluster-a", null);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void listConnectionsAtShouldTreatNullProviderResultAsEmpty() {
+        when(clientProvider.findConnectionsAt("10.0.1.31:9876", null, null)).thenReturn(null);
+
+        List<ClientConnectionVO> result = clientService.listConnectionsAt("10.0.1.31:9876", null, null);
+
+        assertThat(result).isEmpty();
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerConnectionServiceTest.java
@@ -129,4 +129,26 @@ class ProducerConnectionServiceTest {
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
         verifyNoInteractions(clientProvider);
     }
+
+    @Test
+    void listConnectionsShouldTreatNullProviderResultAsEmpty() {
+        when(clientProvider.findProducerConnections("instance-1", "order-topic", "pg-order"))
+                .thenReturn(null);
+
+        List<ProducerConnectionVO> result = producerConnectionService.listConnections(
+                "instance-1", "order-topic", "pg-order");
+
+        assertThat(result).isEmpty();
+        verify(clientProvider).findProducerConnections("instance-1", "order-topic", "pg-order");
+    }
+
+    @Test
+    void listProducerGroupsShouldTreatNullProviderResultAsEmpty() {
+        when(clientProvider.findProducerGroups("instance-1", null, null, 20)).thenReturn(null);
+
+        List<String> result = producerConnectionService.listProducerGroups("instance-1", null, null, null);
+
+        assertThat(result).isEmpty();
+        verify(clientProvider).findProducerGroups("instance-1", null, null, 20);
+    }
 }


### PR DESCRIPTION
## Summary

The client connection endpoints trust the provider layer to return non-null lists, but the `ClientProvider` contract only declares `List<...>` return types:

- `ProducerConnectionService.listConnections()` called `.stream()` directly on the provider result, so a provider reporting an unavailable lookup as `null` surfaced as a raw NPE 500.
- `ClientService` and `listProducerGroups()` passed a `null` straight through the API as `data: null`, breaking the list contract the frontend maps over.

The service layer now normalizes a `null` provider result to an empty list, matching how the provider implementations already report "nothing found" (`List.of()`).

## Why

The provider interface is the boundary between Studio and the RocketMQ runtime; implementations can report unavailable lookups as `null` without violating anything, and the endpoints should degrade to "no connections" instead of a 500 or a null payload.

## Testing

Extended `ClientServiceTest` (+2) and `ProducerConnectionServiceTest` (+2) with null-provider-result cases for all four endpoints.

```
mvn -q -Dtest="ClientServiceTest,ProducerConnectionServiceTest" test
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
```
