### PR TITLE
fix(acl): align ACL 2.0 binding type validation with the policy service

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/Acl2PolicyContext.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/Acl2PolicyContext.java
@@ -57,7 +57,7 @@ public class Acl2PolicyContext {
     /** Policy name (unique identifier for ACL 2.0 policies) */
     private String policyName;
 
-    /** Binding type: USER / GROUP / SERVICE_ACCOUNT */
+    /** Binding type: TOPIC / GROUP / * / USER / SERVICE_ACCOUNT (case-insensitive) */
     private String boundType;
 
     /** Bound entity ID (e.g., username, group name) */
@@ -163,14 +163,29 @@ public class Acl2PolicyContext {
                 }
             }
         }
-        if (boundType != null && !isValidBoundType(boundType)) {
+        if (boundType == null || boundType.trim().isEmpty() || !isValidBoundType(boundType)) {
             throw new IllegalArgumentException(
-                String.format("boundType must be USER, GROUP, or SERVICE_ACCOUNT, got: %s", boundType));
+                String.format("boundType must be one of TOPIC, GROUP, *, USER, SERVICE_ACCOUNT (got: %s)",
+                    boundType));
         }
     }
 
+    /**
+     * Mirrors the operational binding-type vocabulary of {@code AclService#validateAcl2Policy} so
+     * the model validator and the service agree on the accepted types and on case-insensitive
+     * input.
+     */
     private boolean isValidBoundType(String type) {
-        return "USER".equals(type) || "GROUP".equals(type) || "SERVICE_ACCOUNT".equals(type);
+        switch (type.trim().toUpperCase(java.util.Locale.ROOT)) {
+            case "TOPIC":
+            case "GROUP":
+            case "*":
+            case "USER":
+            case "SERVICE_ACCOUNT":
+                return true;
+            default:
+                return false;
+        }
     }
     public boolean isIsAdmin() {
         return isAdmin;

--- a/server/src/test/java/org/apache/rocketmq/studio/model/Acl2PolicyContextTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/Acl2PolicyContextTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class Acl2PolicyContextTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"USER", "user", " Group ", "topic", "SERVICE_ACCOUNT", "service_account", "*"})
+    void validateShouldAcceptTheServiceBoundTypeVocabularyCaseInsensitively(String boundType) {
+        Acl2PolicyContext policy = validPolicy();
+        policy.setBoundType(boundType);
+
+        assertThatCode(policy::validate).doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"TOPICS", "ACCOUNT", " ", ""})
+    void validateShouldRejectBoundTypesOutsideTheServiceVocabulary(String boundType) {
+        Acl2PolicyContext policy = validPolicy();
+        policy.setBoundType(boundType);
+
+        assertThatThrownBy(policy::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("boundType must be one of TOPIC, GROUP, *, USER, SERVICE_ACCOUNT");
+    }
+
+    @Test
+    void validateShouldRequireABoundTypeLikeThePolicyService() {
+        Acl2PolicyContext policy = validPolicy();
+        policy.setBoundType(null);
+
+        assertThatThrownBy(policy::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("boundType must be one of TOPIC, GROUP, *, USER, SERVICE_ACCOUNT");
+    }
+
+    private static Acl2PolicyContext validPolicy() {
+        Acl2PolicyContext policy = new Acl2PolicyContext();
+        policy.setAccessKey("svc-a");
+        policy.setPolicyName("orders-policy");
+        policy.setBoundType("USER");
+        Acl2PolicyContext.AuthorizationRule rule =
+                Acl2PolicyContext.AuthorizationRule.defaultAllowRule("orders-*");
+        policy.setRules(List.of(rule));
+        return policy;
+    }
+}


### PR DESCRIPTION
## Summary
- align `Acl2PolicyContext.validate()` with the operational `AclService#validateAcl2Policy` binding-type vocabulary
- require a non-blank `boundType` and accept `TOPIC`, `GROUP`, `*`, `USER`, `SERVICE_ACCOUNT` case-insensitively
- add regression coverage for the model validator's accepted and rejected binding types

## Why
Two validators for the same ACL 2.0 policy concept disagreed: the model validator only accepted exactly-cased `USER`/`GROUP`/`SERVICE_ACCOUNT` and silently let a null `boundType` through, while the service validator (covered by `AclServiceTest`) requires a non-blank type and accepts the wider `TOPIC`/`GROUP`/`*`/`USER`/`SERVICE_ACCOUNT` set case-insensitively. A policy the service accepts (`"topic"`, `"user"`) failed the model's `validate()` with a misleading exception, and a null binding type passed the model but failed the service.

## Testing
- `cd server && mvn -q -Dtest=Acl2PolicyContextTest test` — 11 tests pass (new class)
- `cd server && mvn -q -Dtest=AclServiceTest test` — all tests pass (regression for the aligned vocabulary)
