### PR TITLE
fix(acl): carry the ACL user whitelist through user upserts

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -443,6 +443,9 @@ public class MybatisPlusAclRepository implements AclRepository {
         entity.setSecretKey(CredentialUtils.encodeBase64(user.getSecretKey()));
         entity.setAdmin(user.isAdmin());
         entity.setClusters(joinNormalizedCsv(user.getClusters()));
+        // The generic upsert path must carry the whitelist through like toUserVO does; the
+        // plain-access endpoint keeps its explicit clear-when-null semantics on its own path.
+        entity.setWhiteRemoteAddress(user.getWhiteRemoteAddress());
         entity.setGmtCreate(user.getGmtCreate());
         entity.setGmtModified(LocalDateTime.now());
         return entity;

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
@@ -459,6 +459,34 @@ class MybatisPlusAclRepositoryTest {
         assertThat(captor.getValue().getClusters()).isEqualTo("cluster-a,cluster-b");
     }
 
+    @Test
+    void saveUserShouldPersistTheWhiteRemoteAddress() {
+        when(userMapper.insert(any(RmqAclUser.class))).thenReturn(1);
+        AclUserVO user = AclUserVO.builder().username("svc-a").accessKey("svc-a")
+                .secretKey("secret").whiteRemoteAddress("10.0.0.0/8").build();
+
+        repository.saveUser(user);
+
+        ArgumentCaptor<RmqAclUser> captor = ArgumentCaptor.forClass(RmqAclUser.class);
+        verify(userMapper).insert(captor.capture());
+        assertThat(captor.getValue().getWhiteRemoteAddress()).isEqualTo("10.0.0.0/8");
+    }
+
+    @Test
+    void replaceUserShouldCarryTheWhiteRemoteAddressIntoTheUpdate() {
+        RmqAclUser existing = userEntity(3L, "svc-a", "c2VjcmV0");
+        when(userMapper.selectById(3L)).thenReturn(existing);
+        when(userMapper.updateById(any(RmqAclUser.class))).thenReturn(1);
+        AclUserVO replacement = AclUserVO.builder().id(3L).username("svc-a").accessKey("svc-a")
+                .secretKey("secret").whiteRemoteAddress("192.168.0.0/16").build();
+
+        repository.replaceUser(replacement);
+
+        ArgumentCaptor<RmqAclUser> captor = ArgumentCaptor.forClass(RmqAclUser.class);
+        verify(userMapper).updateById(captor.capture());
+        assertThat(captor.getValue().getWhiteRemoteAddress()).isEqualTo("192.168.0.0/16");
+    }
+
     private static RmqAclUser userEntity(Long id, String accessKey, String encodedSecret) {
         RmqAclUser entity = new RmqAclUser();
         entity.setId(id);


### PR DESCRIPTION
## Summary
- map `whiteRemoteAddress` in `MybatisPlusAclRepository.toUserEntity` so the generic user upsert path persists the whitelist
- add capture-based regression tests for `saveUser` and `replaceUser`

## Why
`toUserVO` reads `white_remote_address` from the row, but `toUserEntity` never wrote it back: every upsert through the generic `saveUser`/`replaceUser` path silently dropped the whitelist carried on the VO. The plain-access endpoint worked around this by building its entity manually, but any caller of the generic upsert with a set whitelist lost it without an error. Existing `updateUser` behavior is unchanged because the merged VO carries a null whitelist and MyBatis-Plus omits null fields from `updateById`.

## Testing
- `cd server && mvn -q -Dtest=MybatisPlusAclRepositoryTest test` — all tests pass, including the new `saveUserShouldPersistTheWhiteRemoteAddress` and `replaceUserShouldCarryTheWhiteRemoteAddressIntoTheUpdate`
- `cd server && mvn -q -Dtest=AclServiceTest test` — all tests pass (regression for the update flow)
