### PR TITLE
fix(components): make MiniBar and MiniLine tolerate malformed series data

### DIFF
--- a/web/src/components/MiniBar.tsx
+++ b/web/src/components/MiniBar.tsx
@@ -24,7 +24,10 @@ interface MiniBarProps {
 }
 
 const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: MiniBarProps) => {
-  if (!data.length) {
+  // Non-array data (e.g. a malformed wire payload) renders the empty state, and non-finite
+  // elements (NaN/Infinity) are dropped so they cannot poison the scale or the bar heights.
+  const values = (Array.isArray(data) ? data : []).filter((value) => Number.isFinite(value));
+  if (values.length === 0) {
     return (
       <span aria-label={label || '暂无趋势数据'} style={{ color: '#8c8c8c' }}>
         —
@@ -32,13 +35,16 @@ const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: M
     );
   }
 
-  const max = Math.max(...data, 1);
-  const barWidth = Math.max(2, (width - (data.length - 1) * 2) / data.length);
+  let max = 1;
+  for (const value of values) {
+    if (value > max) max = value;
+  }
+  const barWidth = Math.max(2, (width - (values.length - 1) * 2) / values.length);
 
   return (
     <div
       role="img"
-      aria-label={label || `趋势数据：${data.join('、')}`}
+      aria-label={label || `趋势数据：${values.join('、')}`}
       style={{
         display: 'inline-flex',
         alignItems: 'flex-end',
@@ -47,7 +53,7 @@ const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: M
         width,
       }}
     >
-      {data.map((value, i) => (
+      {values.map((value, i) => (
         <div
           key={i}
           style={{
@@ -55,7 +61,7 @@ const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: M
             height: `${value === 0 ? 0 : Math.max(4, (value / max) * height)}px`,
             backgroundColor: color,
             borderRadius: 2,
-            opacity: 0.3 + (i / data.length) * 0.7,
+            opacity: 0.3 + (i / values.length) * 0.7,
             transition: 'height 0.3s ease',
           }}
         />

--- a/web/src/components/MiniLine.tsx
+++ b/web/src/components/MiniLine.tsx
@@ -47,8 +47,15 @@ const MiniLine = ({
   animated = true,
   responsive = false,
 }: MiniLineProps) => {
-  const max = Math.max(...data, 1);
-  const min = Math.min(...data, 0);
+  // Non-array data (e.g. a malformed wire payload) renders nothing, and non-finite elements
+  // (NaN/Infinity) are dropped so they cannot produce a NaN path.
+  const values = (Array.isArray(data) ? data : []).filter((value) => Number.isFinite(value));
+  let max = 1;
+  let min = 0;
+  for (const value of values) {
+    if (value > max) max = value;
+    if (value < min) min = value;
+  }
   const range = max - min || 1;
 
   const pad = 4;
@@ -58,11 +65,11 @@ const MiniLine = ({
   const gradientId = useMemo(() => `ml-grad-${++_lineId}`, []);
   const glowId = useMemo(() => `ml-glow-${++_lineId}`, []);
 
-  if (data.length < 2) return null;
+  if (values.length < 2) return null;
 
   // Build smooth Catmull-Rom → Bezier control points
-  const points = data.map((v, i) => ({
-    x: pad + (i / (data.length - 1)) * innerW,
+  const points = values.map((v, i) => ({
+    x: pad + (i / (values.length - 1)) * innerW,
     y: pad + innerH - ((v - min) / range) * innerH,
   }));
 

--- a/web/src/components/__tests__/MiniBar.test.tsx
+++ b/web/src/components/__tests__/MiniBar.test.tsx
@@ -34,4 +34,16 @@ describe('MiniBar', () => {
 
     expect(getBarHeights()).toEqual(['0px', '4px', '20px']);
   });
+
+  it('renders the empty state when data is not an array', () => {
+    render(<MiniBar data={null as unknown as number[]} label="Throughput trend" />);
+
+    expect(screen.getByLabelText('Throughput trend')).toHaveTextContent('—');
+  });
+
+  it('ignores non-finite values when scaling bars', () => {
+    render(<MiniBar data={[Number.NaN, 0, 10]} height={20} label="Throughput trend" />);
+
+    expect(getBarHeights()).toEqual(['0px', '20px']);
+  });
 });

--- a/web/src/components/__tests__/MiniLine.test.tsx
+++ b/web/src/components/__tests__/MiniLine.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import MiniLine from '../MiniLine';
+
+describe('MiniLine', () => {
+  it('renders nothing when data is not an array', () => {
+    const { container } = render(<MiniLine data={undefined as unknown as number[]} />);
+
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('renders nothing when fewer than two finite values remain', () => {
+    const { container } = render(<MiniLine data={[Number.NaN, 5]} />);
+
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('excludes non-finite values from the rendered path', () => {
+    const { container } = render(<MiniLine data={[0, Number.NaN, 5, 1]} />);
+
+    const path = container.querySelector('path');
+    expect(path).not.toBeNull();
+    expect(path?.getAttribute('d')).not.toContain('NaN');
+  });
+
+  it('renders a path for finite data', () => {
+    const { container } = render(<MiniLine data={[0, 5, 1, 8]} />);
+
+    const path = container.querySelector('path');
+    expect(path).not.toBeNull();
+    expect(path?.getAttribute('d')).toContain('C');
+  });
+});


### PR DESCRIPTION
## Summary
- `MiniBar` and `MiniLine` now tolerate non-array `data` props (rendered as empty / nothing) and drop non-finite elements (`NaN`/`Infinity`) before scaling
- Replaced `Math.max(...data, 1)` / `Math.min(...data, 0)` spreads with loops so a very large series cannot hit the call-argument limit
- Adds regression tests: `MiniBar.test.tsx` (non-array data, NaN elements) and a new `MiniLine.test.tsx` (non-array data, <2 finite values, NaN excluded from the path)

## Why
Both shared mini-chart components read `data.length` and spread `data` into `Math.max`/`Math.min` without validating the array. A non-array payload (e.g. `null`/`undefined` from a malformed wire response) crashed the whole component tree at `data.length`, and a single `NaN` element poisoned `max`/`min`, producing `NaNpx` bar heights / `NaN` SVG path coordinates that silently broke the chart. The dashboard trend column passes the raw `throughput` array from the API straight in, so the component itself must be defensive even where a call site adds its own guard.

## Testing
- `./node_modules/.bin/vitest run src/components/__tests__/MiniBar.test.tsx src/components/__tests__/MiniLine.test.tsx src/pages/home/__tests__/DashboardPage.test.tsx` → 13 passed (5 new; verified all 5 fail with the pre-fix components)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/components/MiniBar.tsx src/components/MiniLine.tsx src/components/__tests__/MiniBar.test.tsx src/components/__tests__/MiniLine.test.tsx` → 0 errors
