### PR TITLE
fix(litetopic): clamp unbounded consumption progress and quota usage rates

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicQuota.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicQuota.java
@@ -41,14 +41,22 @@ public class LiteTopicQuota {
         if (maxTopicCount == null || maxTopicCount <= 0 || currentTopicCount == null) {
             return 0.0;
         }
-        return (double) currentTopicCount / maxTopicCount;
+        return clampUnitInterval((double) currentTopicCount / maxTopicCount);
     }
 
     public double getSessionUsageRate() {
         if (maxSessionCount == null || maxSessionCount <= 0 || currentSessionCount == null) {
             return 0.0;
         }
-        return (double) currentSessionCount / maxSessionCount;
+        return clampUnitInterval((double) currentSessionCount / maxSessionCount);
+    }
+
+    /**
+     * Current counts drift from the configured maximum between quota polls; clamp the reported
+     * rate to the unit interval instead of exposing negative or over-100% gauges.
+     */
+    private static double clampUnitInterval(double rate) {
+        return Math.min(1.0, Math.max(0.0, rate));
     }
 
     public boolean isNearQuotaLimit(double threshold) {

--- a/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicSession.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/LiteTopicSession.java
@@ -75,7 +75,10 @@ public class LiteTopicSession {
         if (totalMessages == null || totalMessages == 0 || consumedMessages == null) {
             return 0.0;
         }
-        return (double) consumedMessages / totalMessages * 100.0;
+        // The provider's total and consumed counters drift independently, so a transient
+        // mismatch must not leak negative or over-100 percentages into the UI.
+        double progress = (double) consumedMessages / totalMessages * 100.0;
+        return Math.min(100.0, Math.max(0.0, progress));
     }
 
     @Data

--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
@@ -65,4 +65,18 @@ class LiteTopicQuotaTest {
         assertThat(quota.getSessionUsageRate()).isZero();
         assertThat(quota.getRemainingQuota()).isEqualTo(10);
     }
+
+    @Test
+    void usageRatesShouldClampCountDriftIntoTheUnitInterval() {
+        LiteTopicQuota quota = new LiteTopicQuota();
+        quota.setMaxTopicCount(10);
+        quota.setMaxSessionCount(10);
+        quota.setCurrentTopicCount(15);
+        assertThat(quota.getUsageRate()).isEqualTo(1.0);
+        assertThat(quota.isNearQuotaLimit(0.9)).isTrue();
+        quota.setCurrentTopicCount(-1);
+        assertThat(quota.getUsageRate()).isZero();
+        quota.setCurrentSessionCount(-3);
+        assertThat(quota.getSessionUsageRate()).isZero();
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSessionTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSessionTest.java
@@ -38,4 +38,14 @@ class LiteTopicSessionTest {
 
         assertThat(session.getConsumptionProgress()).isEqualTo(40.0);
     }
+
+    @Test
+    void consumptionProgressShouldClampCounterDriftIntoTheValidRange() {
+        LiteTopicSession session = new LiteTopicSession();
+        session.setTotalMessages(10L);
+        session.setConsumedMessages(12L);
+        assertThat(session.getConsumptionProgress()).isEqualTo(100.0);
+        session.setConsumedMessages(-2L);
+        assertThat(session.getConsumptionProgress()).isZero();
+    }
 }


### PR DESCRIPTION
## Summary
- clamp `LiteTopicSession.getConsumptionProgress()` to the valid 0–100 percentage range
- clamp `LiteTopicQuota.getUsageRate()` and `getSessionUsageRate()` to the unit interval
- add regression coverage for counter drift above and below the valid range

## Why
The provider's total/consumed counters and the current/max quota counters drift independently between polls. A transient mismatch (consumed ahead of total, or a current count above the configured maximum) leaked negative or over-100% ratios straight into the view objects, where gauges render them. The sibling quota helpers already defend against this (`isQuotaExceeded` requires a positive maximum, `getRemainingQuota` clamps at zero); this brings the ratio getters in line with that behavior.

## Testing
- `cd server && mvn -q -Dtest=LiteTopicSessionTest,LiteTopicQuotaTest test` — all tests pass, including the new `consumptionProgressShouldClampCounterDriftIntoTheValidRange` and `usageRatesShouldClampCountDriftIntoTheUnitInterval`
