### PR TITLE
fix(components): stabilize useVisiblePolling scheduling against callback churn

### DIFF
--- a/web/src/hooks/useVisiblePolling.test.tsx
+++ b/web/src/hooks/useVisiblePolling.test.tsx
@@ -110,6 +110,53 @@ describe('useVisiblePolling', () => {
     expect(poll).not.toHaveBeenCalled();
   });
 
+  it('does not schedule polls for a non-finite or non-positive interval', async () => {
+    const poll = vi.fn().mockResolvedValue(undefined);
+
+    const first = renderHook(() => useVisiblePolling(true, Number.NaN, poll));
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+    expect(poll).not.toHaveBeenCalled();
+    first.unmount();
+
+    renderHook(() => useVisiblePolling(true, 0, poll));
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+    expect(poll).not.toHaveBeenCalled();
+  });
+
+  it('keeps polling when the callback identity changes on re-render', async () => {
+    let calls = 0;
+    const { rerender } = renderHook(
+      ({ onPoll }: { onPoll: () => void }) => useVisiblePolling(true, 1_000, onPoll),
+      { initialProps: { onPoll: () => { calls += 1; } } },
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    // A re-render replaces the inline callback's identity (e.g. a parent re-rendering
+    // while loading data). If the subscription depends on the callback, the interval is
+    // re-created here and the next tick is delayed past t=1000.
+    rerender({ onPoll: () => { calls += 1; } });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(calls).toBe(1);
+  });
+
   it('waits for a hidden page to become visible', async () => {
     visibilityState = 'hidden';
     const poll = vi.fn().mockResolvedValue(undefined);

--- a/web/src/hooks/useVisiblePolling.ts
+++ b/web/src/hooks/useVisiblePolling.ts
@@ -15,15 +15,26 @@
  * limitations under the License.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export function useVisiblePolling(
   enabled: boolean,
   intervalMs: number,
   poll: () => void | Promise<void>,
 ): void {
+  // Track the latest callback in a ref so a caller passing an inline (non-memoized) callback
+  // does not re-subscribe the interval on every render — re-subscribing resets the timer and
+  // polling can effectively never fire under frequent re-renders.
+  const pollRef = useRef(poll);
+  useEffect(() => {
+    pollRef.current = poll;
+  });
+
   useEffect(() => {
     if (!enabled) return;
+    // A non-finite or non-positive interval would make setInterval fire as fast as the
+    // event loop allows, hammering the poll callback.
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) return;
 
     let pollInFlight = false;
     const pollWhenVisible = () => {
@@ -31,7 +42,7 @@ export function useVisiblePolling(
 
       pollInFlight = true;
       void Promise.resolve()
-        .then(poll)
+        .then(() => pollRef.current())
         .catch(() => undefined)
         .finally(() => {
           pollInFlight = false;
@@ -44,5 +55,5 @@ export function useVisiblePolling(
       window.clearInterval(intervalId);
       document.removeEventListener('visibilitychange', pollWhenVisible);
     };
-  }, [enabled, intervalMs, poll]);
+  }, [enabled, intervalMs]);
 }


### PR DESCRIPTION
## Summary
- `useVisiblePolling` now skips scheduling when `intervalMs` is not finite or not positive (a `NaN`/`0`/negative interval would make `setInterval` fire as fast as the event loop allows)
- The poll callback is tracked in a ref and the subscription now depends only on `[enabled, intervalMs]`, so callers passing an inline (non-memoized) callback no longer reset the interval on every render
- Adds regression tests: a non-finite/non-positive interval schedules nothing, and the polling cadence survives re-renders that replace the callback identity

## Why
The effect's dependency array included the `poll` callback, so a parent that re-renders (e.g. while loading data) with a fresh inline callback cleared and re-created the interval on every render — the timer was perpetually reset and the tick could never elapse, silently disabling auto-refresh. Separately, nothing validated `intervalMs`, so a malformed interval value would turn the interval into a millisecond-resolution loop hammering the poll callback.

## Testing
- `./node_modules/.bin/vitest run src/hooks/useVisiblePolling.test.tsx` → 6 passed (2 new; verified both fail with the pre-fix hook)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/hooks/useVisiblePolling.ts src/hooks/useVisiblePolling.test.tsx` → 0 errors, 0 warnings
