### PR TITLE
fix(instance): bound batch instance deletes to 100 ids

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/BatchDeleteInstancesDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/BatchDeleteInstancesDTO.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.studio.instance;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.List;
 @Data
 public class BatchDeleteInstancesDTO {
 
-    @NotEmpty
+    @NotEmpty(message = "ids is required")
+    @Size(max = 100, message = "at most 100 instance ids are allowed")
     private List<String> ids;
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/BatchDeleteInstancesDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/BatchDeleteInstancesDTOTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BatchDeleteInstancesDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void idsShouldRequireAtLeastOneIdentifierTest() {
+        BatchDeleteInstancesDTO request = new BatchDeleteInstancesDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactly("ids is required");
+    }
+
+    @Test
+    void idsShouldBoundTheBatchAtOneHundredTest() {
+        BatchDeleteInstancesDTO request = new BatchDeleteInstancesDTO();
+        request.setIds(IntStream.rangeClosed(1, 101).mapToObj(index -> "inst-" + index).toList());
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactly("at most 100 instance ids are allowed");
+    }
+
+    @Test
+    void idsShouldAcceptAFullBatchTest() {
+        BatchDeleteInstancesDTO request = new BatchDeleteInstancesDTO();
+        request.setIds(IntStream.rangeClosed(1, 100).mapToObj(index -> "inst-" + index).toList());
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- bound `BatchDeleteInstancesDTO.ids` with `@Size(max = 100)`, matching the batch limits used by every other bulk endpoint
- add an explicit `@NotEmpty` message and bean-validation regression tests

## Why
The batch instance delete accepted an unbounded identifier list: only `@NotEmpty` was present, while the bulk rule toggle/delete, the DLQ selected resend, and the topic/group import endpoints all cap their selection at 100. Since `InstanceService.deleteInstances` fans out one provider call per identifier, an oversized batch could run away unbounded. The 100-id bound matches the established convention in this codebase.

## Testing
- `cd server && mvn -q -Dtest=BatchDeleteInstancesDTOTest test` — 3 tests pass (new class)
- `cd server && mvn -q -Dtest=InstanceServiceTest test` — all tests pass (regression for the delete flow)
