### PR TITLE
fix(components): keep each queue pull spinner independent in QueueBrowser

### DIFF
--- a/web/src/components/QueueBrowser.tsx
+++ b/web/src/components/QueueBrowser.tsx
@@ -59,7 +59,7 @@ export const useQueueBrowser = (instanceId?: string) => {
   const [queues, setQueues] = useState<QueueOffset[]>([]);
   const [loading, setLoading] = useState(false);
   const [offsets, setOffsets] = useState<Record<string, number>>({});
-  const [pulling, setPulling] = useState<string | null>(null);
+  const [pulling, setPulling] = useState<ReadonlySet<string>>(() => new Set());
   const [entries, setEntries] = useState<PulledEntry[]>([]);
   const requestSeqRef = useRef(0);
 
@@ -71,7 +71,7 @@ export const useQueueBrowser = (instanceId?: string) => {
       setOffsets({});
       setEntries([]);
       setLoading(false);
-      setPulling(null);
+      setPulling(new Set());
     });
   }, [instanceId, topic]);
 
@@ -106,7 +106,9 @@ export const useQueueBrowser = (instanceId?: string) => {
     const requestId = requestSeqRef.current;
     const key = `${queue.brokerName}-${queue.queueId}`;
     const offset = offsets[key] ?? queue.minOffset;
-    setPulling(key);
+    // A Set so concurrent pulls each keep their own indicator; clearing one must not
+    // clear the spinner of another pull that is still in flight.
+    setPulling((current) => new Set(current).add(key));
     try {
       const msg = await pullMessageAtOffset({
         instanceId,
@@ -125,7 +127,14 @@ export const useQueueBrowser = (instanceId?: string) => {
         message.error(err instanceof Error ? err.message : '拉取消息失败');
       }
     } finally {
-      if (requestId === requestSeqRef.current) setPulling(null);
+      if (requestId === requestSeqRef.current) {
+        setPulling((current) => {
+          if (!current.has(key)) return current;
+          const next = new Set(current);
+          next.delete(key);
+          return next;
+        });
+      }
     }
   };
 
@@ -272,7 +281,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                     <Button
                       size="small"
                       type="primary"
-                      loading={state.pulling === key}
+                      loading={state.pulling.has(key)}
                       onClick={() => void state.handlePull(record)}
                     >
                       查看

--- a/web/src/components/__tests__/QueueBrowser.test.tsx
+++ b/web/src/components/__tests__/QueueBrowser.test.tsx
@@ -79,12 +79,20 @@ function QueueBrowserProbe({ instanceId = 'instance-a' }: { instanceId?: string 
       >
         pull
       </button>
+      <button
+        type="button"
+        disabled={state.queues.length < 2}
+        onClick={() => state.queues[1] && void state.handlePull(state.queues[1])}
+      >
+        pull-2
+      </button>
       <output aria-label="topic">{state.topic ?? ''}</output>
       <output aria-label="queues">{state.queues.map((item) => item.brokerName).join(',')}</output>
       <output aria-label="entries">
         {state.entries.map((entry) => entry.message?.msgId ?? 'empty').join(',')}
       </output>
       <output aria-label="loading">{String(state.loading)}</output>
+      <output aria-label="pulling">{Array.from(state.pulling).join(',')}</output>
     </div>
   );
 }
@@ -101,6 +109,40 @@ describe('formatTimeMs', () => {
     },
   );
 });
+
+  it('keeps the second pull indicator while an older pull finishes first', async () => {
+    const first = createDeferred<MessageRecord | null>();
+    const second = createDeferred<MessageRecord | null>();
+    vi.mocked(pullMessageAtOffset)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    vi.mocked(getQueueOffsets).mockResolvedValue([queue('broker-a'), queue('broker-b')]);
+    const user = userEvent.setup();
+    render(<QueueBrowserProbe />);
+
+    await user.click(screen.getByRole('button', { name: 'topic-a' }));
+    await waitFor(() => expect(screen.getByLabelText('topic')).toHaveTextContent('topic-a'));
+    await user.click(screen.getByRole('button', { name: 'load' }));
+    await waitFor(() => expect(screen.getByLabelText('queues')).toHaveTextContent('broker-a,broker-b'));
+
+    await user.click(screen.getByRole('button', { name: 'pull' }));
+    await waitFor(() => expect(screen.getByLabelText('pulling')).toHaveTextContent('broker-a-0'));
+    await user.click(screen.getByRole('button', { name: 'pull-2' }));
+    await waitFor(() => expect(screen.getByLabelText('pulling')).toHaveTextContent('broker-b-0'));
+
+    await act(async () => {
+      first.resolve(messageRecord('msg-1'));
+    });
+
+    // The first pull finished; the second is still in flight and keeps its indicator.
+    expect(screen.getByLabelText('pulling')).not.toHaveTextContent('broker-a-0');
+    expect(screen.getByLabelText('pulling')).toHaveTextContent('broker-b-0');
+
+    await act(async () => {
+      second.resolve(messageRecord('msg-2'));
+    });
+    await waitFor(() => expect(screen.getByLabelText('pulling')).toHaveTextContent(''));
+  });
 
 describe('QueueBrowser request ownership', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- `useQueueBrowser` now tracks in-flight pulls with a `Set` of queue keys instead of a single key, so concurrent pulls each keep their own spinner
- Clearing a pull's indicator only removes its own key, so one pull finishing no longer clears the indicator of another pull still in flight
- Adds a regression test: start two pulls on different queues, let the first finish first, and verify the second keeps its indicator until it completes

## Why
`pulling` was a single `string | null`. Starting a second pull overwrote the first key (hiding its spinner while it was still in flight), and when the first pull's `finally` ran it called `setPulling(null)`, clearing the second pull's spinner even though the second request had not resolved — the "查看" button lost its loading state while the pull was still running.

## Testing
- `./node_modules/.bin/vitest run src/components/__tests__/QueueBrowser.test.tsx` → 7 passed (1 new; fails without the fix)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/components/QueueBrowser.tsx src/components/__tests__/QueueBrowser.test.tsx` → 0 errors (2 pre-existing react-refresh warnings for the exported hook, same precedent as other page files)
