### PR TITLE
fix(components): tolerate non-string tags and severities in asset lists

### DIFF
--- a/web/src/components/AlertRuleAssetList.tsx
+++ b/web/src/components/AlertRuleAssetList.tsx
@@ -55,6 +55,9 @@ export const AlertRuleAssetList: React.FC = () => {
   const severityOptions = useMemo(
     () =>
       Array.from(new Set(assets.flatMap((asset) => asset.severities || [])))
+        // A malformed wire payload may carry non-string severities; keep only real strings
+        // so the sort and the filter options cannot throw.
+        .filter((severity): severity is string => typeof severity === 'string' && severity.length > 0)
         .sort((a, b) => a.localeCompare(b))
         .map((severity) => ({ label: severity.toUpperCase(), value: severity })),
     [assets],
@@ -66,7 +69,7 @@ export const AlertRuleAssetList: React.FC = () => {
       const matchesSearch =
         !normalizedSearch ||
         [asset.name, asset.group]
-          .filter(Boolean)
+          .filter((value): value is string => typeof value === 'string')
           .some((value) => value.toLowerCase().includes(normalizedSearch));
       const matchesSeverity =
         selectedSeverities.length === 0 ||
@@ -176,11 +179,13 @@ export const AlertRuleAssetList: React.FC = () => {
       width: 180,
       render: (severities: string[]) => (
         <Space size={[0, 4]} wrap>
-          {(severities || []).map((severity) => (
-            <Tag key={severity} color={SEVERITY_COLORS[severity] || 'default'}>
-              {severity.toUpperCase()}
-            </Tag>
-          ))}
+          {(severities || [])
+            .filter((severity): severity is string => typeof severity === 'string')
+            .map((severity) => (
+              <Tag key={severity} color={SEVERITY_COLORS[severity] || 'default'}>
+                {severity.toUpperCase()}
+              </Tag>
+            ))}
         </Space>
       ),
     },

--- a/web/src/components/GrafanaDashboardList.tsx
+++ b/web/src/components/GrafanaDashboardList.tsx
@@ -51,6 +51,9 @@ export const GrafanaDashboardList: React.FC = () => {
   const tagOptions = useMemo(
     () =>
       Array.from(new Set(dashboards.flatMap((dashboard) => dashboard.tags || [])))
+        // A malformed wire payload may carry non-string tags; keep only real strings so
+        // the sort and the filter options cannot throw.
+        .filter((tag): tag is string => typeof tag === 'string' && tag.length > 0)
         .sort((a, b) => a.localeCompare(b))
         .map((tag) => ({ label: tag, value: tag })),
     [dashboards],
@@ -62,7 +65,7 @@ export const GrafanaDashboardList: React.FC = () => {
       const matchesSearch =
         !normalizedSearch ||
         [dashboard.uid, dashboard.title, dashboard.description, ...(dashboard.tags || [])]
-          .filter(Boolean)
+          .filter((value): value is string => typeof value === 'string')
           .some((value) => value.toLowerCase().includes(normalizedSearch));
       const matchesTags =
         selectedTags.length === 0 ||
@@ -179,11 +182,13 @@ export const GrafanaDashboardList: React.FC = () => {
       width: 140,
       render: (tags: string[]) => (
         <Space size={[0, 4]} wrap>
-          {(tags || []).map((tag) => (
-            <Tag key={tag} color="blue">
-              {tag}
-            </Tag>
-          ))}
+          {(tags || [])
+            .filter((tag): tag is string => typeof tag === 'string')
+            .map((tag) => (
+              <Tag key={tag} color="blue">
+                {tag}
+              </Tag>
+            ))}
         </Space>
       ),
     },

--- a/web/src/components/__tests__/AlertRuleAssetList.test.tsx
+++ b/web/src/components/__tests__/AlertRuleAssetList.test.tsx
@@ -186,6 +186,16 @@ describe('AlertRuleAssetList', () => {
     });
   });
 
+  it('tolerates assets with malformed severity entries', async () => {
+    vi.mocked(alertRuleAssetService.listAlertRuleAssets).mockResolvedValue([
+      { name: 'asset-a', group: 'asset-a.rules', ruleCount: 1, severities: ['critical', null] },
+    ]);
+    renderWithProviders(<AlertRuleAssetList />);
+
+    await waitFor(() => expect(screen.getByText('asset-a')).toBeInTheDocument());
+    expect(screen.getByText('CRITICAL')).toBeInTheDocument();
+  });
+
   it('downloads the yaml when Export is clicked', async () => {
     const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:url');
     const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});

--- a/web/src/components/__tests__/GrafanaDashboardList.test.tsx
+++ b/web/src/components/__tests__/GrafanaDashboardList.test.tsx
@@ -292,6 +292,16 @@ describe('GrafanaDashboardList', () => {
     clickSpy.mockRestore();
   });
 
+  it('tolerates dashboards with malformed tag entries', async () => {
+    vi.mocked(listGrafanaDashboards).mockResolvedValue([
+      { uid: 'dash-a', title: 'Dash A', description: '', tags: ['rocketmq', 42, null] },
+    ]);
+    renderDashboardList();
+
+    await waitFor(() => expect(screen.getByText('Dash A')).toBeInTheDocument());
+    expect(screen.getByText('rocketmq')).toBeInTheDocument();
+  });
+
   it('uses the JSON filename returned by mock bulk export', async () => {
     vi.mocked(exportGrafanaDashboards).mockResolvedValue({
       blob: new Blob(['json-content'], { type: 'application/json' }),


### PR DESCRIPTION
## Summary
- `GrafanaDashboardList` and `AlertRuleAssetList` now keep only real strings when building tag/severity filter options, searching rows, and rendering tag cells
- Adds a regression test per component: a list entry with a non-string tag/severity value (e.g. `42`/`null` from a malformed wire payload) no longer crashes the list

## Why
Both components flatten `tags`/`severities` from the API and immediately call string methods on the values: `localeCompare` in the options sort and `toUpperCase()` in the tag cell. A single non-string entry (a number or `null` in the wire payload) threw a `TypeError` during render, crashing the whole list view. The search filters had the same exposure via `value.toLowerCase()`.

## Testing
- `./node_modules/.bin/vitest run src/components/__tests__/GrafanaDashboardList.test.tsx src/components/__tests__/AlertRuleAssetList.test.tsx` → 18 passed (2 new; verified both fail with the pre-fix components)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint` on the 4 changed files → 0 errors
