### PR TITLE
fix(k8s): report concurrent cert removal instead of resurrecting it

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -66,7 +66,13 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
     @Transactional
     public K8sCertVO save(K8sCertVO cert) {
         RmqK8sCertificate entity = toEntity(cert);
-        if (entity.getId() != null && certMapper.selectById(entity.getId()) != null) {
+        if (entity.getId() != null) {
+            // An id that no longer resolves to a row was removed between the service's read
+            // and this save; re-inserting it would resurrect the deleted certificate.
+            if (certMapper.selectById(entity.getId()) == null) {
+                throw new BusinessException(404,
+                        "Certificate not found, removed concurrently: " + entity.getId());
+            }
             if (certMapper.updateById(entity) == 0) {
                 throw new BusinessException(409,
                         "Certificate update was not applied: " + entity.getId());

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
@@ -24,8 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 class MybatisPlusK8sCertRepositoryTest {
@@ -60,6 +62,21 @@ class MybatisPlusK8sCertRepositoryTest {
                 .hasMessage("Certificate update was not applied: 1")
                 .satisfies(error -> org.assertj.core.api.Assertions.assertThat(
                         ((BusinessException) error).getCode()).isEqualTo(409));
+    }
+
+    @Test
+    void saveShouldReportConcurrentRemovalInsteadOfResurrecting() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        when(mapper.selectById(1L)).thenReturn(null);
+        K8sCertVO cert = K8sCertVO.builder().k8sId("broker").build();
+        cert.setId(1L);
+
+        assertThatThrownBy(() -> repository(mapper).save(cert))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Certificate not found, removed concurrently: 1")
+                .satisfies(error -> org.assertj.core.api.Assertions.assertThat(
+                        ((BusinessException) error).getCode()).isEqualTo(404));
+        verify(mapper, never()).insert(any(RmqK8sCertificate.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
`MybatisPlusK8sCertRepository.save()` decided insert-vs-update with
`id != null && selectById(id) != null`. When the id was set but the row had
disappeared in the meantime (a concurrent `deleteCert` between the service's
`findById` and the save), the expression fell through to the insert branch and
re-inserted the deleted certificate under its old id, resurrecting it.

The update path now splits the two cases: an id that no longer resolves to a
row is reported as a 404 concurrent removal, so a renew/update racing a delete
fails closed instead of reviving the row. The existing 409 for a lost
`updateById` is unchanged.

## Why
`renewCert`/`updateCert` read the cert, mutate a copy, and save it. Without the
guard, a delete that lands in that window silently recreates the certificate
with its old primary key, leaving a "deleted" cert visible in `listCerts` and
the audit trail pointing at a row that was supposed to be gone.

## Testing
```
cd server && mvn -Dtest="MybatisPlusK8sCertRepositoryTest" test
```
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
New regression test `saveShouldReportConcurrentRemovalInsteadOfResurrecting`
asserts the 404 and that `insert` is never called when the id is missing.
