### PR TITLE
fix(trace): return message trace timeline in chronological order

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -24,6 +24,8 @@ import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -83,6 +85,7 @@ public class MessageService {
         TraceRecordVO result = providerRegistry.byInstanceId(instanceId)
                 .map(provider -> provider.getMessageTrace(instanceId, msgId, topic))
                 .orElseGet(() -> messageProvider.getMessageTrace(instanceId, msgId, topic));
+        result = normalizeTrace(result);
         recordTraceQuery(instanceId, msgId, topic, result);
         return result;
     }
@@ -135,6 +138,7 @@ public class MessageService {
         TraceRecordVO result = providerRegistry.byInstanceId(instanceId)
                 .map(provider -> provider.getMessageTrace(instanceId, msgId, topic, traceTopic))
                 .orElseGet(() -> messageProvider.getMessageTrace(instanceId, msgId, topic, traceTopic));
+        result = normalizeTrace(result);
         recordTraceQuery(instanceId, msgId, topic, result);
         return result;
     }
@@ -146,9 +150,36 @@ public class MessageService {
         log.info("Getting message trace by key: key={}, topic={}, traceTopic={}", key, topic, traceTopic);
         // Trace query history is keyed by message id; key-based lookups are intentionally
         // not recorded so the key is not misreported as a message id.
-        return providerRegistry.byInstanceId(instanceId)
+        TraceRecordVO result = providerRegistry.byInstanceId(instanceId)
                 .map(provider -> provider.getMessageTraceByKey(instanceId, key, topic, traceTopic))
                 .orElseGet(() -> messageProvider.getMessageTraceByKey(instanceId, key, topic, traceTopic));
+        return normalizeTrace(result);
+    }
+
+    /**
+     * Providers emit trace nodes in broker result order, which is not chronological across
+     * trace types and queues, and the UI renders the timeline as-is. Order the nodes here
+     * (stable, so provider order is kept for equal timestamps) and normalize missing lists
+     * to empty so the UI never sees null.
+     */
+    private static TraceRecordVO normalizeTrace(TraceRecordVO result) {
+        if (result == null) {
+            return TraceRecordVO.builder().nodes(List.of()).consumerStatus(List.of()).build();
+        }
+        List<TraceNodeVO> nodes = result.getNodes();
+        if (nodes == null) {
+            nodes = List.of();
+        } else if (nodes.size() > 1) {
+            nodes = new ArrayList<>(nodes);
+            nodes.sort(Comparator.comparingLong(TraceNodeVO::getTimestamp));
+        }
+        if (nodes == result.getNodes() && result.getConsumerStatus() != null) {
+            return result;
+        }
+        return TraceRecordVO.builder()
+                .nodes(nodes)
+                .consumerStatus(result.getConsumerStatus() == null ? List.of() : result.getConsumerStatus())
+                .build();
     }
     private void recordMessageQuery(String instanceId, String topic, String msgId, String tag,
                                     String key, Long startTime, Long endTime, List<MessageRecordVO> result) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -245,4 +245,67 @@ class MessageServiceTest {
                 org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyInt(),
                 org.mockito.ArgumentMatchers.anyInt());
     }
+
+    @Test
+    void traceTimelineShouldBeReturnedInChronologicalOrder() {
+        MessageProvider fallback = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        QueryHistoryService history = mock(QueryHistoryService.class);
+        MessageService service = new MessageService(fallback, registry, history, mock(OperationAuditService.class));
+        when(registry.byInstanceId("instance-a")).thenReturn(Optional.empty());
+        when(fallback.getMessageTrace("instance-a", "msg-001", "orders")).thenReturn(TraceRecordVO.builder()
+                .nodes(List.of(
+                        traceNode("consume", 300L),
+                        traceNode("produce", 100L),
+                        traceNode("endTransaction", 200L)))
+                .consumerStatus(List.of())
+                .build());
+
+        TraceRecordVO result = service.getMessageTrace("instance-a", "msg-001", "orders");
+
+        assertThat(result.getNodes()).extracting(TraceNodeVO::getTitle)
+                .containsExactly("produce", "endTransaction", "consume");
+        verify(history).recordTraceQuery("instance-a", "msg-001", "orders", 3, 0);
+    }
+
+    @Test
+    void traceTimelineShouldKeepProviderOrderForEqualTimestamps() {
+        MessageProvider fallback = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(fallback, registry, mock(QueryHistoryService.class),
+                mock(OperationAuditService.class));
+        when(registry.byInstanceId("instance-a")).thenReturn(Optional.empty());
+        when(fallback.getMessageTrace("instance-a", "msg-001", "orders")).thenReturn(TraceRecordVO.builder()
+                .nodes(List.of(
+                        traceNode("consume-a", 100L),
+                        traceNode("consume-b", 100L),
+                        traceNode("produce", 50L)))
+                .consumerStatus(List.of())
+                .build());
+
+        TraceRecordVO result = service.getMessageTrace("instance-a", "msg-001", "orders");
+
+        assertThat(result.getNodes()).extracting(TraceNodeVO::getTitle)
+                .containsExactly("produce", "consume-a", "consume-b");
+    }
+
+    @Test
+    void traceTimelineShouldNormalizeMissingNodeLists() {
+        MessageProvider fallback = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(fallback, registry, mock(QueryHistoryService.class),
+                mock(OperationAuditService.class));
+        when(registry.byInstanceId("instance-a")).thenReturn(Optional.empty());
+        when(fallback.getMessageTrace("instance-a", "msg-001", "orders"))
+                .thenReturn(TraceRecordVO.builder().build());
+
+        TraceRecordVO result = service.getMessageTrace("instance-a", "msg-001", "orders");
+
+        assertThat(result.getNodes()).isEmpty();
+        assertThat(result.getConsumerStatus()).isEmpty();
+    }
+
+    private static TraceNodeVO traceNode(String title, long timestamp) {
+        return TraceNodeVO.builder().title(title).timestamp(timestamp).build();
+    }
 }


### PR DESCRIPTION
## Summary
- order message trace timeline nodes chronologically in `MessageService` before returning them (stable sort, applied to the three-arg trace, four-arg trace, and key-based trace lookups)
- normalize missing node/consumer-status lists to empty lists so the UI never sees null
- add regression coverage for ordering, equal-timestamp stability, and null lists

## Why
Providers emit trace nodes in broker result order, which is not chronological across trace types and queues: the trace topic has multiple queues and `Pub`/`SubAfter`/`EndTransaction` contexts arrive interleaved. Neither the provider layer nor the web client sorts the timeline, so the UI could render produce after consume. Sorting defensively in the service layer covers every provider (Apache, Aliyun, Tencent) at once, and the stable sort keeps provider order for equal timestamps.

## Testing
- `cd server && mvn -q -Dtest=MessageServiceTest test` — all tests pass, including the new `traceTimelineShouldBeReturnedInChronologicalOrder`, `traceTimelineShouldKeepProviderOrderForEqualTimestamps`, and `traceTimelineShouldNormalizeMissingNodeLists`
- `cd server && mvn -q -Dtest=MessageControllerTest test` — all tests pass (regression for the trace endpoints)
