### PR TITLE
fix(message): reject unknown message history query types

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
@@ -159,6 +159,7 @@ public class QueryHistoryService {
 
     public PageResult<MessageQueryHistoryVO> listMessageQueries(String clusterId, String queryType,
                                                                  String search, int page, int pageSize) {
+        validateQueryType(queryType);
         String pattern = escapeLike(search);
         String queriedBy = AuthenticatedUserContext.currentUsernameOrSystem();
         QueryWrapper<RmqMessageQuery> query = new QueryWrapper<RmqMessageQuery>()
@@ -291,5 +292,20 @@ public class QueryHistoryService {
             return search;
         }
         return search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+    }
+
+    /**
+     * The query types written by {@code MessageService#recordMessageQuery}. The controller
+     * passes the raw user-supplied filter through, so an unknown value would silently return
+     * an empty page instead of surfacing a 400.
+     */
+    private static void validateQueryType(String queryType) {
+        if (!StringUtils.hasText(queryType)) {
+            return;
+        }
+        if (!"MSG_ID".equals(queryType) && !"KEY".equals(queryType) && !"TOPIC".equals(queryType)) {
+            throw new org.apache.rocketmq.studio.common.exception.BusinessException(
+                    400, "queryType must be one of MSG_ID, KEY, TOPIC");
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
@@ -20,6 +20,7 @@ import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.auth.AuthenticatedUserContext;
 import org.apache.rocketmq.studio.persistence.entity.RmqMessageQuery;
 import org.apache.rocketmq.studio.persistence.entity.RmqTraceQuery;
@@ -35,6 +36,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -138,6 +140,38 @@ class QueryHistoryServiceTest {
         ArgumentCaptor<Wrapper<RmqMessageQuery>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
         verify(messageQueryMapper).selectPage(any(Page.class), queryCaptor.capture());
         assertThat(queryCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
+    }
+
+    @Test
+    void rejectsUnknownMessageHistoryQueryTypeBeforeQuerying() {
+        assertThatThrownBy(() -> service.listMessageQueries("cluster-a", "msg_id", null, 1, 20))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("queryType must be one of MSG_ID, KEY, TOPIC");
+        assertThatThrownBy(() -> service.listMessageQueries("cluster-a", "GARBAGE", null, 1, 20))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("queryType must be one of MSG_ID, KEY, TOPIC");
+        assertThatThrownBy(() -> service.listMessageQueries("cluster-a", " TOPIC ", null, 1, 20))
+                .isInstanceOf(BusinessException.class);
+
+        verify(messageQueryMapper, never()).selectPage(any(Page.class), any(Wrapper.class));
+    }
+
+    @Test
+    void acceptsEveryRecordedMessageHistoryQueryType() {
+        when(messageQueryMapper.selectPage(any(Page.class), any(Wrapper.class)))
+                .thenAnswer(invocation -> {
+                    Page<RmqMessageQuery> result = invocation.getArgument(0);
+                    result.setRecords(java.util.List.of());
+                    result.setTotal(0);
+                    return result;
+                });
+
+        service.listMessageQueries("cluster-a", "MSG_ID", null, 1, 20);
+        service.listMessageQueries("cluster-a", "KEY", null, 1, 20);
+        service.listMessageQueries("cluster-a", "TOPIC", null, 1, 20);
+        service.listMessageQueries("cluster-a", null, null, 1, 20);
+
+        verify(messageQueryMapper, org.mockito.Mockito.times(4)).selectPage(any(Page.class), any(Wrapper.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `QueryHistoryService.listMessageQueries` rejects unknown `queryType` filters with a 400 before querying
- accept only the recorded vocabulary `MSG_ID`/`KEY`/`TOPIC` (or an absent filter)
- add regression coverage for accepted and rejected query types

## Why
The controller passes the raw user-supplied filter straight into `.eq("query_type", ...)`, but only the values written by `MessageService#recordMessageQuery` (`MSG_ID`, `KEY`, `TOPIC`) can ever match a row. A filter such as `msg_id` or `TOPIC ` therefore returned a silent empty page instead of surfacing a validation error, which read like "no history" to the user.

## Testing
- `cd server && mvn -q -Dtest=QueryHistoryServiceTest test` — all tests pass, including the new `rejectsUnknownMessageHistoryQueryTypeBeforeQuerying` and `acceptsEveryRecordedMessageHistoryQueryType`
- `cd server && mvn -q -Dtest=QueryHistoryControllerTest test` — all tests pass (regression for the history endpoints)
