### PR TITLE
fix(services): tolerate paged results without items in export walks

### DIFF
--- a/web/src/api/settings.test.ts
+++ b/web/src/api/settings.test.ts
@@ -112,4 +112,23 @@ describe('data sources API', () => {
       testDataSource({ type: source.type, url: source.url, auth: source.auth }),
     ).resolves.toEqual({ success: true, message: 'Connection successful' });
   });
+
+  it('treats a null page payload as an empty page during the export walk', async () => {
+    mock.onGet('/settings/datasources/page').reply(200, { code: 0, data: null });
+
+    const all = await listAllDataSources();
+
+    expect(all).toEqual([]);
+  });
+
+  it('treats a page payload without items as an empty page during the export walk', async () => {
+    mock.onGet('/settings/datasources/page').reply(200, {
+      code: 0,
+      data: { total: 2, page: 1, size: 100 },
+    });
+
+    const all = await listAllDataSources();
+
+    expect(all).toEqual([]);
+  });
 });

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -129,9 +129,15 @@ export async function listAllDataSources(params: { search?: string; type?: strin
       page,
       pageSize: DATA_SOURCE_EXPORT_PAGE_SIZE,
     });
-    allDataSources.push(...result.items);
-    const total = result.total ?? allDataSources.length;
-    if (result.items.length === 0 || allDataSources.length >= total) {
+    // A success envelope may still carry a null or item-less payload; treat it as an
+    // empty page instead of crashing the whole export walk.
+    const items = Array.isArray(result?.items) ? result.items : [];
+    allDataSources.push(...items);
+    const total =
+      result && typeof result.total === 'number' && Number.isFinite(result.total)
+        ? result.total
+        : allDataSources.length;
+    if (items.length === 0 || allDataSources.length >= total) {
       return allDataSources;
     }
     page += 1;

--- a/web/src/api/studioUsers.test.ts
+++ b/web/src/api/studioUsers.test.ts
@@ -89,4 +89,30 @@ describe('studio users API', () => {
       exportRequestParams[1],
     ]);
   });
+
+  it('treats a null page payload as an empty page during the export walk', async () => {
+    mock.onGet('/studio-users').reply(200, { code: 0, data: null });
+
+    const all = await loadStudioUsersForExport();
+
+    expect(all).toEqual([]);
+  });
+
+  it('collects every page and stops at the reported total', async () => {
+    mock.onGet('/studio-users').reply((config) => {
+      const page = Number(config.params?.page ?? 1);
+      const items =
+        page === 1
+          ? [
+              { id: 1, username: 'operator-one', admin: false, enabled: true },
+              { id: 2, username: 'operator-two', admin: true, enabled: true },
+            ]
+          : [{ id: 3, username: 'operator-three', admin: false, enabled: false }];
+      return [200, { code: 0, data: { items, total: 3, page, size: 100 } }];
+    });
+
+    const all = await loadStudioUsersForExport();
+
+    expect(all.map((user) => user.id)).toEqual([1, 2, 3]);
+  });
 });

--- a/web/src/api/studioUsers.ts
+++ b/web/src/api/studioUsers.ts
@@ -63,9 +63,15 @@ export const listAllStudioUsers = async (
       page,
       pageSize: STUDIO_USER_EXPORT_PAGE_SIZE,
     });
-    allUsers.push(...result.items);
-    const total = result.total ?? allUsers.length;
-    if (result.items.length === 0 || allUsers.length >= total) return allUsers;
+    // A success envelope may still carry a null or item-less payload; treat it as an
+    // empty page instead of crashing the whole export walk.
+    const items = Array.isArray(result?.items) ? result.items : [];
+    allUsers.push(...items);
+    const total =
+      result && typeof result.total === 'number' && Number.isFinite(result.total)
+        ? result.total
+        : allUsers.length;
+    if (items.length === 0 || allUsers.length >= total) return allUsers;
     page += 1;
   }
   throw new Error(`Studio user export exceeded ${STUDIO_USER_MAX_EXPORT_PAGES} pages`);

--- a/web/src/services/consumerService.test.ts
+++ b/web/src/services/consumerService.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createConsumerGroup,
   getConsumerGroup,
@@ -44,7 +44,48 @@ vi.mock('../config', () => ({
 }));
 vi.mock('../api/metadata', () => metadataApi);
 
+describe('consumer group export pagination tolerance', () => {
+  beforeEach(() => {
+    metadataApi.listConsumerGroupPage.mockReset();
+  });
+  afterEach(() => {
+    mode.mock = true;
+    vi.clearAllMocks();
+  });
+
+  it('treats a null or item-less page payload as an empty page', async () => {
+    mode.mock = false;
+    vi.mocked(metadataApi.listConsumerGroupPage)
+      .mockResolvedValueOnce(null as never)
+      .mockResolvedValueOnce({ total: 2, page: 2, size: 100 } as never);
+
+    const groups = await listAllConsumerGroups();
+
+    expect(groups).toEqual([]);
+  });
+
+  it('collects every page and stops at the reported total', async () => {
+    mode.mock = false;
+    const group = (name: string) =>
+      ({ name, subscribedTopics: [], instances: [] } as never);
+    vi.mocked(metadataApi.listConsumerGroupPage)
+      .mockResolvedValueOnce({
+        items: [group('cg-a'), group('cg-b')],
+        total: 3,
+        page: 1,
+        size: 100,
+      })
+      .mockResolvedValueOnce({ items: [group('cg-c')], total: 3, page: 2, size: 100 });
+
+    const groups = await listAllConsumerGroups();
+
+    expect(groups.map((item) => item.name)).toEqual(['cg-a', 'cg-b', 'cg-c']);
+  });
+
+});
+
 describe('consumer service mock data', () => {
+
   it('returns copied consumer group rows', async () => {
     const first = await listConsumerGroups({ search: 'cg-order-notify' });
     expect(first[0].name).toBe('cg-order-notify');

--- a/web/src/services/consumerService.ts
+++ b/web/src/services/consumerService.ts
@@ -138,9 +138,15 @@ export async function listAllConsumerGroups(
       page,
       pageSize: EXPORT_PAGE_SIZE,
     });
-    groups.push(...result.items);
-    const total = result.total ?? groups.length;
-    if (result.items.length === 0 || groups.length >= total) {
+    // A success envelope may still carry a null or item-less payload; treat it as an
+    // empty page instead of crashing the whole export walk.
+    const items = Array.isArray(result?.items) ? result.items : [];
+    groups.push(...items);
+    const total =
+      result && typeof result.total === 'number' && Number.isFinite(result.total)
+        ? result.total
+        : groups.length;
+    if (items.length === 0 || groups.length >= total) {
       return groups.map(normalizeConsumerGroup);
     }
     page += 1;

--- a/web/src/services/topicService.export.test.ts
+++ b/web/src/services/topicService.export.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { listTopicsPage } from '../api/metadata';
+import { listAllTopics } from './topicService';
+
+vi.mock('./dataMode', () => ({ isMockMode: () => false }));
+vi.mock('../config', () => ({
+  API_BASE_URL: '/api',
+}));
+vi.mock('../api/metadata', () => ({
+  listTopicsPage: vi.fn(),
+}));
+
+describe('topic export pagination tolerance', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('treats a null page payload as an empty page', async () => {
+    vi.mocked(listTopicsPage).mockResolvedValueOnce(null as never);
+
+    const topics = await listAllTopics();
+
+    expect(topics).toEqual([]);
+    expect(listTopicsPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a page payload without items as an empty page', async () => {
+    vi.mocked(listTopicsPage).mockResolvedValueOnce({
+      total: 3,
+      page: 1,
+      size: 100,
+    } as never);
+
+    const topics = await listAllTopics();
+
+    expect(topics).toEqual([]);
+  });
+
+  it('collects every page and stops at the reported total', async () => {
+    const pageOne = Array.from({ length: 100 }, (_, index) => ({ name: `topic-${index}` }));
+    const pageTwo = Array.from(
+      { length: 40 },
+      (_, index) => ({ name: `topic-100-${index}` }),
+    );
+    vi.mocked(listTopicsPage)
+      .mockResolvedValueOnce({ items: pageOne, total: 140, page: 1, size: 100 })
+      .mockResolvedValueOnce({ items: pageTwo, total: 140, page: 2, size: 100 });
+
+    const topics = await listAllTopics();
+
+    expect(topics).toHaveLength(140);
+    expect(listTopicsPage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/services/topicService.ts
+++ b/web/src/services/topicService.ts
@@ -95,9 +95,15 @@ export const listAllTopics = async (params: TopicQuery = {}): Promise<Topic[]> =
 
   while (page <= MAX_EXPORT_PAGES) {
     const result = await listTopicsPage({ ...params, page, pageSize: EXPORT_PAGE_SIZE });
-    topics.push(...result.items);
-    const total = result.total ?? topics.length;
-    if (result.items.length === 0 || topics.length >= total) return topics;
+    // A success envelope may still carry a null or item-less payload; treat it as an
+    // empty page instead of crashing the whole export walk.
+    const items = Array.isArray(result?.items) ? result.items : [];
+    topics.push(...items);
+    const total =
+      result && typeof result.total === 'number' && Number.isFinite(result.total)
+        ? result.total
+        : topics.length;
+    if (items.length === 0 || topics.length >= total) return topics;
     page += 1;
   }
 


### PR DESCRIPTION
## Summary
- `topicService.listAllTopics`, `consumerService.listAllConsumerGroups`, `settings.listAllDataSources`, and `studioUsers.listAllStudioUsers` now treat a success envelope whose `data` is `null` or lacks `items` as an empty page instead of crashing
- `total` is only trusted when it is a finite number
- Adds regression tests for every export walk (null payload, item-less payload, and the multi-page happy path)

## Why
All four export flows walk the list in pages with `page <= MAX` and spread `result.items` into an accumulator. The client interceptor validates the business `code`, but a `code: 0` envelope can still carry `data: null` or a page object without `items` — in that case `items` is `undefined`, `push(...undefined)` throws a `TypeError`, and the entire export (topics/groups CSV, data-source export, studio-user export) dies on a single malformed page.

## Testing
- `./node_modules/.bin/vitest run src/services/topicService.export.test.ts src/services/consumerService.test.ts src/api/settings.test.ts src/api/studioUsers.test.ts src/services/topicService.test.ts` → 37 passed (8 new; the 6 tolerance tests fail with the pre-fix code, the 2 happy-path tests pass both before and after)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint` on the 8 changed files → 0 errors
