### PR TITLE
fix(ops): tolerate malformed alert rule transfer imports

### DIFF
--- a/web/src/services/opsService.test.ts
+++ b/web/src/services/opsService.test.ts
@@ -20,6 +20,7 @@ import type { AuditRecord } from '../api/ops';
 import { mockAuditRecords } from '../mock/audit';
 import {
   createAlertRule,
+  importAlertRulesTransfer,
   exportAuditLogs,
   getAuditFilterOptions,
   listAlertRules,
@@ -232,5 +233,28 @@ describe('ops service mock data', () => {
       '"2026-08-01 10:00:00","\'=admin","DELETE","TOPIC","csv-export-target",' +
         '"prod-cn","removed ""topic"", safely","SUCCESS","\'=denied"',
     );
+  });
+
+  it('tolerates a transfer import with missing or malformed rules', async () => {
+    const rules = await importAlertRulesTransfer({
+      version: 1,
+      domain: 'CLUSTER',
+      rules: [
+        { name: 'imported-a', metric: 'metric-a', operator: '>', threshold: 1 },
+        { name: 'imported-b' },
+      ] as never,
+    });
+
+    expect(rules).toHaveLength(2);
+    expect(rules[0].channels).toEqual([]);
+    expect(rules[1].metric).toBe('');
+    expect(rules[1].operator).toBe('>');
+    expect(rules[1].enabled).toBe(true);
+  });
+
+  it('treats a transfer import without a rules array as an empty import', async () => {
+    const rules = await importAlertRulesTransfer({ version: 1, domain: 'CLUSTER' } as never);
+
+    expect(rules).toEqual([]);
   });
 });

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -159,9 +159,23 @@ export async function importAlertRulesTransfer(
 ): Promise<AlertRule[]> {
   if (!isMockMode()) return opsApi.importAlertRulesTransfer(data, domain);
   const startId = Date.now();
-  const imported = data.rules.map((rule, index) => ({
-    ...copyAlertRule(rule as AlertRule),
+  // The transfer file is user-supplied JSON; tolerate a missing rules array and
+  // rules with missing fields using the same defaults as createAlertRule instead
+  // of crashing the whole import.
+  const rules = Array.isArray(data?.rules) ? data.rules : [];
+  const imported = rules.map((rule, index) => ({
     id: startId + index,
+    name: '',
+    metric: '',
+    operator: '>',
+    threshold: 0,
+    thresholdUnit: '',
+    duration: '',
+    enabled: true,
+    lastTriggered: null,
+    description: '',
+    ...rule,
+    channels: [...(rule.channels ?? [])],
   }));
   alertRulesState.push(...imported);
   return imported.map(copyAlertRule);


### PR DESCRIPTION
## Summary
- `opsService.importAlertRulesTransfer` (mock mode) now tolerates a transfer file without a `rules` array and rules with missing fields, applying the same defaults as `createAlertRule`
- Adds regression tests: a rule missing `channels` and other fields, and a transfer object without `rules` at all

## Why
The transfer file is user-supplied JSON (downloaded earlier or hand-edited). The import mapped `data.rules` directly and copied each rule with `[...rule.channels]` — a missing `rules` array or a rule without `channels` threw a `TypeError` and aborted the whole import, even though every rule carries independent defaults in `createAlertRule`.

## Testing
- `./node_modules/.bin/vitest run src/services/opsService.test.ts` → 13 passed (2 new; verified both fail with the pre-fix service)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint src/services/opsService.ts src/services/opsService.test.ts` → 0 errors
