### PR TITLE
fix(services): clamp mock pagination like listTopicsPage

### DIFF
--- a/web/src/services/consumerService.test.ts
+++ b/web/src/services/consumerService.test.ts
@@ -44,7 +44,29 @@ vi.mock('../config', () => ({
 }));
 vi.mock('../api/metadata', () => metadataApi);
 
-describe('consumer service mock data', () => {
+describe('consumer service mock data', () => {  it('clamps zero or negative pagination to the first page in mock mode', () => {
+    const first = listConsumerGroupPage({ page: 0, pageSize: 0 }) as Promise<{
+      page: number;
+      size: number;
+      items: unknown[];
+    }>;
+    const second = listConsumerGroupPage({ page: -3, pageSize: 500 }) as Promise<{
+      page: number;
+      size: number;
+      items: unknown[];
+    }>;
+
+    return Promise.all([first, second]).then(([a, b]) => {
+      expect(a.page).toBe(1);
+      expect(a.size).toBe(1);
+      expect(a.items).toHaveLength(1);
+      expect(b.page).toBe(1);
+      expect(b.size).toBe(100);
+      expect((b.items[0] as { name: string }).name).toBe((a.items[0] as { name: string }).name);
+    });
+  });
+
+
   it('returns copied consumer group rows', async () => {
     const first = await listConsumerGroups({ search: 'cg-order-notify' });
     expect(first[0].name).toBe('cg-order-notify');

--- a/web/src/services/consumerService.ts
+++ b/web/src/services/consumerService.ts
@@ -112,8 +112,10 @@ export async function listConsumerGroupPage(
   params: ConsumerGroupPageQuery = {},
 ): Promise<PageResult<ConsumerGroup>> {
   if (isMockMode()) {
-    const page = params.page ?? 1;
-    const pageSize = params.pageSize ?? 20;
+    // Clamp like listTopicsPage so a zero or negative page/pageSize cannot make the
+    // one-based offset negative and slice from the end of the list.
+    const page = Math.max(params.page ?? 1, 1);
+    const pageSize = Math.min(Math.max(params.pageSize ?? 20, 1), 100);
     const groups = filterConsumerGroups(params);
     const from = Math.min((page - 1) * pageSize, groups.length);
     return {

--- a/web/src/services/messageService.test.ts
+++ b/web/src/services/messageService.test.ts
@@ -117,4 +117,16 @@ describe('message service mock data', () => {
     expect(all.items).toHaveLength(1);
     expect(all.total).toBeGreaterThanOrEqual(1);
   });
+
+  it('clamps zero or negative pagination to the first page for DLQ groups', () => {
+    const first = listDLQGroups('instance-a', undefined, 0, 0);
+    const second = listDLQGroups('instance-a', undefined, -3, 500);
+
+    return Promise.all([first, second]).then(([a, b]) => {
+      expect(a.page).toBe(1);
+      expect(a.size).toBe(1);
+      expect(b.page).toBe(1);
+      expect(b.size).toBe(100);
+    });
+  });
 });

--- a/web/src/services/messageService.ts
+++ b/web/src/services/messageService.ts
@@ -126,12 +126,16 @@ export async function listDLQGroups(
     const groups = (mockDLQGroups as unknown as DLQGroup[]).filter(
       (group) => !search || group.groupName.includes(search) || group.dlqTopic.includes(search),
     );
-    const from = Math.min((page - 1) * pageSize, groups.length);
+    // Clamp like listTopicsPage so a zero or negative page/pageSize cannot make the
+    // one-based offset negative and slice from the end of the list.
+    const safePage = Math.max(page, 1);
+    const safePageSize = Math.min(Math.max(pageSize, 1), 100);
+    const from = Math.min((safePage - 1) * safePageSize, groups.length);
     return {
-      items: groups.slice(from, from + pageSize).map(cloneDLQGroup),
+      items: groups.slice(from, from + safePageSize).map(cloneDLQGroup),
       total: groups.length,
-      page,
-      size: pageSize,
+      page: safePage,
+      size: safePageSize,
     };
   }
   return messageApi.listDLQGroups(instanceId, search, page, pageSize);

--- a/web/src/services/topicService.test.ts
+++ b/web/src/services/topicService.test.ts
@@ -119,4 +119,17 @@ describe('topic service mock data', () => {
     const after = await listTopics({ clusterId: existing.clusterId });
     expect(after).toEqual(before);
   });
+
+  it('clamps zero or negative pagination to the first page for topic consumers', () => {
+    const first = getTopicConsumerPage('order-create', undefined, 0, 0);
+    const second = getTopicConsumerPage('order-create', undefined, -3, 500);
+
+    return Promise.all([first, second]).then(([a, b]) => {
+      expect(a.page).toBe(1);
+      expect(a.pageSize).toBe(1);
+      expect(b.page).toBe(1);
+      expect(b.pageSize).toBe(100);
+      expect((b.items[0] as { group: string }).group).toBe((a.items[0] as { group: string }).group);
+    });
+  });
 });

--- a/web/src/services/topicService.ts
+++ b/web/src/services/topicService.ts
@@ -221,12 +221,16 @@ export async function getTopicConsumerPage(
     const consumers = cloneConsumers(
       (topicConsumers[name] as unknown as ConsumerGroupInfo[]) ?? [],
     );
-    const from = Math.min((page - 1) * pageSize, consumers.length);
+    // Clamp like listTopicsPage so a zero or negative page/pageSize cannot make the
+    // one-based offset negative and slice from the end of the list.
+    const safePage = Math.max(page, 1);
+    const safePageSize = Math.min(Math.max(pageSize, 1), 100);
+    const from = Math.min((safePage - 1) * safePageSize, consumers.length);
     return {
-      items: consumers.slice(from, from + pageSize),
+      items: consumers.slice(from, from + safePageSize),
       total: consumers.length,
-      page,
-      pageSize,
+      page: safePage,
+      pageSize: safePageSize,
     };
   }
   return metadataApi.getTopicConsumerPage(name, instanceId, page, pageSize);


### PR DESCRIPTION
## Summary
- `consumerService.listConsumerGroupPage`, `topicService.getTopicConsumerPage`, and `messageService.listDLQGroups` (mock mode) now clamp `page` to >= 1 and `pageSize` to 1..100, matching the existing `listTopicsPage` behavior
- Adds a regression test per service: zero/negative page and zero/oversized pageSize resolve to the first page instead of a negative slice

## Why
These mock pagination paths computed `from = (page - 1) * pageSize` without clamping, while `listTopicsPage`, `aclService.pageAclUsers`, `messageService.queryMessagePage`, and `opsService.listAlertRulesPage` already validate or clamp the same inputs. A zero or negative `pageSize` made `from` negative, and `Array.prototype.slice` interprets negative indices from the end of the array — so `pageSize: 0` returned an empty page and `page: 0` returned a shifted, wrong window of rows.

## Testing
- `./node_modules/.bin/vitest run src/services/consumerService.test.ts src/services/topicService.test.ts src/services/messageService.test.ts` → 33 passed (3 new; verified all 3 fail with the pre-fix services)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint` on the 6 changed files → 0 errors
