### PR TITLE
fix(services): normalize import and cleanup results from partial envelopes

### DIFF
--- a/web/src/api/metadata.test.ts
+++ b/web/src/api/metadata.test.ts
@@ -265,4 +265,50 @@ describe('topic metadata API', () => {
       }),
     ).resolves.toMatchObject({ imported: 1, failed: 0 });
   });
+
+describe('import result normalization', () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  it('normalizes a null topic import result', async () => {
+    mock.onPost('/topics/import').reply(200, { code: 0, data: null });
+
+    const result = await importTopics({ instanceId: 'instance-a', topics: [] });
+
+    expect(result).toEqual({ imported: 0, failed: 0, topics: [], failures: [] });
+  });
+
+  it('normalizes a topic import result without a topics array', async () => {
+    mock.onPost('/topics/import').reply(200, { code: 0, data: { imported: 1, failed: 0 } });
+
+    const result = await importTopics({ instanceId: 'instance-a', topics: [] });
+
+    expect(result).toEqual({ imported: 1, failed: 0, topics: [], failures: [] });
+  });
+
+  it('normalizes a null consumer group import result', async () => {
+    mock.onPost('/groups/import').reply(200, { code: 0, data: null });
+
+    const result = await importConsumerGroups({ instanceId: 'instance-a', groups: [] });
+
+    expect(result).toEqual({ imported: 0, failed: 0, groups: [], failures: [] });
+  });
+
+  it('normalizes a consumer group import result without a groups array', async () => {
+    mock.onPost('/groups/import').reply(200, {
+      code: 0,
+      data: { imported: 2, failed: 1, failures: [{ index: 1, message: 'boom' }] },
+    });
+
+    const result = await importConsumerGroups({ instanceId: 'instance-a', groups: [] });
+
+    expect(result).toEqual({
+      imported: 2,
+      failed: 1,
+      groups: [],
+      failures: [{ index: 1, message: 'boom' }],
+    });
+  });
+});
 });

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -225,7 +225,15 @@ export async function exportTopics(params?: TopicExportQuery) {
 
 export async function importTopics(data: ImportTopicsRequest) {
   const res = await client.post<{ data: ImportTopicsResult }>('/topics/import', data);
-  return res.data.data;
+  const result = res.data.data;
+  // A success envelope may still carry a null or partial result; normalize it so the
+  // import UI can always iterate the reported groups and failures.
+  return {
+    imported: result?.imported ?? 0,
+    failed: result?.failed ?? 0,
+    topics: result?.topics ?? [],
+    failures: result?.failures ?? [],
+  };
 }
 
 export async function createTopic(data: Partial<Topic>) {
@@ -421,7 +429,15 @@ export async function resetConsumerOffset(data: ResetConsumerOffsetRequest) {
 
 export async function importConsumerGroups(data: ImportConsumerGroupsRequest) {
   const res = await client.post<{ data: ImportConsumerGroupsResult }>('/groups/import', data);
-  return res.data.data;
+  const result = res.data.data;
+  // A success envelope may still carry a null or partial result; normalize it so the
+  // import UI can always iterate the reported groups and failures.
+  return {
+    imported: result?.imported ?? 0,
+    failed: result?.failed ?? 0,
+    groups: result?.groups ?? [],
+    failures: result?.failures ?? [],
+  };
 }
 
 export async function exportConsumerGroups(params?: ConsumerGroupExportQuery) {

--- a/web/src/api/producer.test.ts
+++ b/web/src/api/producer.test.ts
@@ -232,4 +232,29 @@ describe('Producer API', () => {
     expect(result.duplicateClientIds).toEqual(['producer-a']);
     expect(result.warnings).toContain('DUPLICATE_CLIENT_ID');
   });
+
+describe('producer topic list tolerance', () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  it('treats a non-array topic list payload as empty', async () => {
+    mock.onGet('/topics').reply(200, { code: 0, data: null, topicList: 'a,b' });
+
+    const topics = await fetchTopicList('instance-a');
+
+    expect(topics).toEqual([]);
+  });
+
+  it('drops non-string entries from a topic payload', async () => {
+    mock.onGet('/topics').reply(200, {
+      code: 0,
+      data: [{ name: 'topic-b' }, null, { name: 'topic-a' }],
+    });
+
+    const topics = await fetchTopicList('instance-a');
+
+    expect(topics).toEqual(['topic-a', 'topic-b']);
+  });
+});
 });

--- a/web/src/api/producer.ts
+++ b/web/src/api/producer.ts
@@ -152,7 +152,12 @@ export function buildProducerConnectionSummary(
 /** Fetch topic names for a managed instance. */
 export async function fetchTopicList(instanceId: string): Promise<string[]> {
   const res = await client.get<TopicListResponse>('/topics', { params: { instanceId } });
-  const topics = res.data.data?.map((topic) => topic.name) ?? res.data.topicList ?? [];
+  const rawTopics = res.data.data?.map((topic) => topic?.name) ?? res.data.topicList ?? [];
+  // The topic list may arrive as a non-array payload or with non-string entries;
+  // keep only usable names so the sort below cannot throw.
+  const topics = Array.isArray(rawTopics)
+    ? rawTopics.filter((name): name is string => typeof name === 'string' && name.length > 0)
+    : [];
   return topics.sort();
 }
 

--- a/web/src/services/opsService.cleanup.test.ts
+++ b/web/src/services/opsService.cleanup.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { cleanupAuditLogs as apiCleanupAuditLogs } from '../api/ops';
+import { cleanupAuditLogs } from './opsService';
+
+vi.mock('./dataMode', () => ({ isMockMode: () => false }));
+vi.mock('../config', () => ({
+  API_BASE_URL: '/api',
+}));
+vi.mock('../api/ops', () => ({
+  cleanupAuditLogs: vi.fn(),
+}));
+
+describe('audit cleanup API tolerance', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('treats a null cleanup result as zero deleted records', async () => {
+    vi.mocked(apiCleanupAuditLogs).mockResolvedValueOnce(null as never);
+
+    await expect(cleanupAuditLogs(7)).resolves.toBe(0);
+  });
+
+  it('forwards a finite deleted count', async () => {
+    vi.mocked(apiCleanupAuditLogs).mockResolvedValueOnce({ deleted: 5 });
+
+    await expect(cleanupAuditLogs(7)).resolves.toBe(5);
+  });
+});

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -483,5 +483,5 @@ export async function cleanupAuditLogs(beforeDays: number): Promise<number> {
     return deleted;
   }
   const result = await opsApi.cleanupAuditLogs(beforeDays);
-  return result.deleted;
+  return result?.deleted ?? 0;
 }


### PR DESCRIPTION
## Summary
- `api/metadata.importTopics` and `api/metadata.importConsumerGroups` normalize their result: a success envelope with `data: null` or a partial result now resolves to zeroed counters and empty `topics`/`groups`/`failures` arrays
- `api/producer.fetchTopicList` tolerates a non-array topic-list payload and drops non-string entries before sorting
- `opsService.cleanupAuditLogs` treats a null API result as zero deleted records
- Adds regression tests for every case (null payloads, missing arrays, non-array topic lists, plus happy paths)

## Why
The client interceptor validates the business `code`, but a `code: 0` envelope can still carry `data: null` or a result object with missing fields. The import endpoints returned `res.data.data` verbatim, so the import UI's `result.topics.map(...)` / `result.groups.map(...)` crashed on a null or partial payload. `fetchTopicList` fell back to `topicList` and called `.sort()` unconditionally — a string payload threw `topics.sort is not a function`. `cleanupAuditLogs` read `result.deleted` off an unguarded response.

## Testing
- `./node_modules/.bin/vitest run src/api/metadata.test.ts src/api/producer.test.ts src/services/opsService.cleanup.test.ts` → 24 passed (8 new; verified 7 fail with the pre-fix code, the remaining one is the happy-path check that passes both before and after)
- `./node_modules/.bin/tsc --noEmit` → clean
- `./node_modules/.bin/eslint` on the 6 changed files → 0 errors
