### PR TITLE
fix(k8s): derive PEM validity window in the service clock zone

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
@@ -30,7 +30,6 @@ import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -82,8 +81,11 @@ public class K8sCertService {
         List<String> san = command.getSan();
         if (command.getCertPem() != null && !command.getCertPem().isBlank()) {
             X509Certificate parsed = parseCertificate(command.getCertPem());
-            notBefore = LocalDateTime.ofInstant(parsed.getNotBefore().toInstant(), ZoneId.systemDefault());
-            notAfter = LocalDateTime.ofInstant(parsed.getNotAfter().toInstant(), ZoneId.systemDefault());
+            // Certificate validity instants are absolute; render them in the service clock's
+            // zone so they stay comparable with the LocalDateTime.now(clock) values used by
+            // refreshExpirationState, even when the JVM default zone differs from the clock.
+            notBefore = LocalDateTime.ofInstant(parsed.getNotBefore().toInstant(), clock.getZone());
+            notAfter = LocalDateTime.ofInstant(parsed.getNotAfter().toInstant(), clock.getZone());
             issuer = parsed.getIssuerX500Principal().getName();
             san = extractSubjectAlternativeNames(parsed);
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
@@ -524,4 +525,56 @@ class K8sCertServiceTest {
         cert.setGmtModified(sampleCert.getGmtModified());
         return cert;
     }
+    private static final String FIXED_PEM =
+                "-----BEGIN CERTIFICATE-----\n" +
+                "MIIC6jCCAdKgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwDTELMAkGA1UEAwwCY2Ew\n" +
+                "HhcNMjUwMTAxMDAwMDAwWhcNMjYwMTAxMDAwMDAwWjAUMRIwEAYDVQQDDAl6b25l\n" +
+                "LXRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDefm2k8W00HEFq\n" +
+                "tSjmSMD+bZ4bz8acwnKPYsNdUgPp/Nl7SlBmtV1ztUtqHtKYGvjT/pzgjXE2iU8X\n" +
+                "yzgZ9aIvUIkxdcoHoK2rDKX8FySMAWtTjLS9FEst+O8+rBvDkPU0tD8RP8Yr8R8d\n" +
+                "sC8L8bMOnLSRQE45wvWmy72QE/HZe4SqNvHMu7ub6CUTDVArHlT+ioLIGlGJWU3U\n" +
+                "/hZUe5f5FzBvoVnLD6qSkzn1X+6MIH6g5V6P8pdllhydSnhjY+0eA2RR0MOGb+g2\n" +
+                "VclMTKR07RgwQ/okIJFLDbrOwb5unduDKPNjNKF9ZvyV5lcTTJUcd+n9U/v3+500\n" +
+                "gCHRuGEzAgMBAAGjTTBLMAkGA1UdEwQCMAAwHQYDVR0OBBYEFB+S1UkHBWBGhEa3\n" +
+                "m4+TrH5IVdcrMB8GA1UdIwQYMBaAFAHvq5UN1IDLM7OMWn929EWM21FKMA0GCSqG\n" +
+                "SIb3DQEBCwUAA4IBAQB1Nf2+zs7DDHMYXxdd8fjRTK9BVjYeDlxt0Ig14OZSTdSp\n" +
+                "hVdsC6jeTGgJbSAdM9Prc9TNvgzLARJ+I2Uxsf/2bKk7xdQO4utQrK0qIMqZQz6d\n" +
+                "t7cVJrca30ZmeaLR18KrwjxLCCOqqxzBh9AGP6yyTZYaAcnSzjcgnzEQPj0VD8pl\n" +
+                "mmIeKDUqx68OBolQS/ls8oUF6LfUbqtb8r64DV9WnsWE+by6P/eEwB7soA/pjUk8\n" +
+                "iXVijklQHUfVAYvNje75NyCR76+LPgWWjfq0uBGtr2lFYB0N2ao5Q+7WQvz/H4o4\n" +
+                "qayioHxN97q6MOUJiqH6tbubc2/NEIUu2mhvvD5D\n" +
+                "-----END CERTIFICATE-----\n" ;
+    @Test
+    void createCertShouldDerivePemValidityInTheClockZone() {
+        // A PEM's validity window is an absolute instant. Converting it in the JVM default
+        // zone while expiry checks use LocalDateTime.now(clock) drifts when the zones differ.
+        ZoneId clockZone = ZoneId.systemDefault().equals(ZoneOffset.UTC)
+                ? ZoneId.of("Pacific/Kiritimati")
+                : ZoneOffset.UTC;
+        Clock zoneClock = Clock.fixed(Instant.parse("2025-07-01T12:00:00Z"), clockZone);
+        K8sCertService zoneService = new K8sCertService(k8sCertRepository, operationAuditService, zoneClock);
+
+        CreateCertDTO command = CreateCertDTO.builder()
+                .k8sId("zone-test")
+                .cluster("test-cluster")
+                .type("TLS")
+                .certPem(FIXED_PEM)
+                .build();
+
+        ArgumentCaptor<K8sCertVO> captor = ArgumentCaptor.forClass(K8sCertVO.class);
+        when(k8sCertRepository.save(captor.capture())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        zoneService.createCert(command);
+
+        K8sCertVO saved = captor.getValue();
+        // The embedded certificate is valid 2025-01-01T00:00:00Z .. 2026-01-01T00:00:00Z.
+        assertThat(saved.getNotBefore())
+                .isEqualTo(LocalDateTime.ofInstant(Instant.parse("2025-01-01T00:00:00Z"), clockZone));
+        assertThat(saved.getNotAfter())
+                .isEqualTo(LocalDateTime.ofInstant(Instant.parse("2026-01-01T00:00:00Z"), clockZone));
+        // Proves the conversion used the clock zone, not the JVM default zone.
+        assertThat(saved.getNotAfter())
+                .isNotEqualTo(LocalDateTime.ofInstant(Instant.parse("2026-01-01T00:00:00Z"), ZoneId.systemDefault()));
+    }
+
 }


### PR DESCRIPTION
## Summary
`K8sCertService.createCert` converted the parsed PEM's `notBefore`/`notAfter`
instants with `ZoneId.systemDefault()`, while every other time computation in
the service (`refreshExpirationState`, `listCerts`, renewal) works against
`LocalDateTime.now(clock)` in the clock's zone. The conversion now uses
`clock.getZone()`, so stored validity windows stay comparable with the
expiry checks even when the JVM default zone differs from the service clock.

## Why
The certificate validity instants are absolute, but `LocalDateTime` is zone-
relative. Mixing `ZoneId.systemDefault()` at write time with the clock zone at
read time shifts the stored dates by the zone offset whenever they differ, so
a cert can appear expired (or not) on the wrong day after a timezone change or
when the service clock is pinned to a specific zone.

## Testing
```
cd server && mvn -Dtest="K8sCertServiceTest" test
```
Tests run: 22, Failures: 0, Errors: 0, Skipped: 0
New regression test `createCertShouldDerivePemValidityInTheClockZone` pins the
clock to a zone that always differs from the JVM default and asserts the stored
`notBefore`/`notAfter` match the certificate's absolute instants rendered in
the clock zone.
