### PR TITLE
fix(dashboard): treat type-less instance rows as proxy clusters

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -440,7 +440,11 @@ public class RocketMQDashboardProvider implements DashboardProvider {
     }
 
     private ClusterType clusterTypeFor(InstanceVO instance) {
-        return switch (instance.getType()) {
+        // Rows persisted before the type column was introduced may carry a null type;
+        // render them as a generic proxy-backed cluster instead of failing the whole
+        // dashboard on a null-enum NPE in the switch.
+        InstanceType type = instance.getType() == null ? InstanceType.PROXY_CLUSTER : instance.getType();
+        return switch (type) {
             case DIRECT -> ClusterType.V4_DIRECT;
             case PROXY_LOCAL -> ClusterType.V5_PROXY_LOCAL;
             case CLOUD, PROXY_CLUSTER -> ClusterType.V5_PROXY_CLUSTER;

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -746,4 +746,54 @@ class RocketMQDashboardProviderTest {
         kvTable.setTable(table);
         return kvTable;
     }
+    @Test
+    void dashboardShouldTreatTypelessInstanceAsProxyCluster() throws Exception {
+        // A row persisted before the type column existed has a null type; the dashboard
+        // must not fail the aggregation on a null-enum NPE.
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        InstanceVO legacy = InstanceVO.builder()
+                .name("legacy")
+                .endpoint("10.0.0.9:9876")
+                .build();
+        legacy.setId(9L);
+        when(resolver.resolveInstance("legacy")).thenReturn(legacy);
+        when(resolver.execute(eq(legacy), any())).thenAnswer(invocation ->
+                invocation.<MqAdminExtFactory.AdminAction<DashboardDataVO>>getArgument(1).apply(adminExt));
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+        when(adminExt.getAllTopicConfig("10.0.0.11:10911", 5000)).thenReturn(topicConfig("order-topic"));
+        when(adminExt.getAllSubscriptionGroup("10.0.0.11:10911", 5000)).thenReturn(subscriptionGroups());
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtimeStats());
+
+        DashboardDataVO dashboard = newProvider(adminExt, resolver, List.of(legacy)).getDashboardData();
+
+        assertThat(dashboard.getClusters()).singleElement().satisfies(cluster -> {
+            assertThat(cluster.getType()).isEqualTo(ClusterType.V5_PROXY_CLUSTER);
+            assertThat(cluster.getStatus()).isEqualTo(ClusterStatus.healthy);
+        });
+    }
+
+    @Test
+    void dashboardShouldKeepAggregationAliveWhenTypelessInstanceFails() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        InstanceVO legacy = InstanceVO.builder()
+                .name("legacy")
+                .endpoint("10.0.0.9:9876")
+                .build();
+        legacy.setId(9L);
+        when(resolver.resolveInstance("legacy")).thenReturn(legacy);
+        when(resolver.execute(eq(legacy), any())).thenThrow(new IllegalStateException("connection refused"));
+
+        DashboardDataVO dashboard = newProvider(adminExt, resolver, List.of(legacy)).getDashboardData();
+
+        // Before the fix the null type NPE'd inside the catch path and 500ed the whole page.
+        assertThat(dashboard.getStats().getTotalClusters()).isEqualTo(1);
+        assertThat(dashboard.getClusters()).singleElement().satisfies(cluster -> {
+            assertThat(cluster.getType()).isEqualTo(ClusterType.V5_PROXY_CLUSTER);
+            assertThat(cluster.getStatus()).isEqualTo(ClusterStatus.warning);
+        });
+    }
+
 }


### PR DESCRIPTION
## Summary
`RocketMQDashboardProvider.clusterTypeFor` switched directly on
`instance.getType()`. Instance rows persisted before the `type` column was
introduced carry a null type (the repository explicitly maps a null type to
null), and a null enum in a switch throws NPE. The null now normalizes to
`PROXY_CLUSTER`, the same generic bucket the rest of the code path already
assigns to non-DIRECT instances (`configuredNameServers` stays null, proxies
render as "not discoverable" instead of "zero").

## Why
A single legacy type-less instance row 500ed the entire dashboard: in the
aggregate path the NPE was raised inside the catch block that is supposed to
degrade that instance to a warning row, so no per-instance isolation was left
in place. The direct `?instanceId=` path had the same NPE.

## Testing
```
cd server && mvn -Dtest="RocketMQDashboardProviderTest" test
```
Tests run: 31, Failures: 0, Errors: 0, Skipped: 0
New regression tests `dashboardShouldTreatTypelessInstanceAsProxyCluster`
(type-less instance renders a healthy V5_PROXY_CLUSTER row) and
`dashboardShouldKeepAggregationAliveWhenTypelessInstanceFails` (type-less
instance whose admin call fails degrades to a warning row instead of NPE-ing
the whole page).
