### PR TITLE
fix(broker): normalize flush disk type input before applying cluster config

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -401,7 +401,8 @@ public class ClusterService {
     private Map<String, String> buildBrokerPropertyMap(UpdateConfigDTO command) {
         Map<String, String> props = new LinkedHashMap<>();
         if (command.getFlushDiskType() != null) {
-            props.put("flushDiskType", command.getFlushDiskType());
+            // Send the canonical enum name so the broker's own FlushDiskType.valueOf accepts it.
+            props.put("flushDiskType", parseFlushDiskType(command.getFlushDiskType()).name());
         }
         if (command.getAutoCreateTopicEnable() != null) {
             props.put("autoCreateTopicEnable", command.getAutoCreateTopicEnable().toString());
@@ -493,11 +494,15 @@ public class ClusterService {
     }
 
     private FlushDiskType parseFlushDiskType(String value) {
-        try {
-            return FlushDiskType.valueOf(value);
-        } catch (IllegalArgumentException ex) {
-            throw new BusinessException(400, "Invalid flushDiskType: " + value);
+        // Tolerate surrounding whitespace and case variants (e.g. " async_flush ") so clients
+        // do not have to reproduce the exact enum spelling to update the cluster config.
+        String normalized = value == null ? "" : value.trim();
+        for (FlushDiskType type : FlushDiskType.values()) {
+            if (type.name().equalsIgnoreCase(normalized)) {
+                return type;
+            }
         }
+        throw new BusinessException(400, "Invalid flushDiskType: " + value);
     }
 
     public boolean restartBroker(String clusterId, String brokerName) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -38,6 +38,7 @@ import org.apache.rocketmq.studio.provider.apache.RocketMQBrokerConfigService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -46,6 +47,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import org.assertj.core.api.ThrowableAssert;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -522,6 +524,38 @@ class ClusterServiceTest {
                 .hasMessageContaining("Invalid flushDiskType: INVALID_FLUSH")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
         verify(clusterRepository, never()).updateConfig(eq("cluster-1"), any(ClusterConfigVO.class));
+    }
+
+    @Test
+    void updateConfigShouldAcceptCaseAndWhitespaceInsensitiveFlushDiskType() {
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+
+        UpdateConfigDTO command = UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .flushDiskType(" async_flush ")
+                .build();
+
+        ClusterConfigUpdateResultVO result = clusterService.updateClusterConfig(command);
+
+        assertThat(result.getStatus()).isEqualTo(ClusterConfigUpdateResultVO.Status.SUCCESS);
+        assertThat(result.getCluster().getConfig().getFlushDiskType()).isEqualTo(FlushDiskType.ASYNC_FLUSH);
+        ArgumentCaptor<Properties> sent = ArgumentCaptor.forClass(Properties.class);
+        verify(brokerConfigService).updateBrokerConfig(eq("10.0.0.1:10911"), eq("cluster-1"), sent.capture());
+        assertThat(sent.getValue().getProperty("flushDiskType")).isEqualTo("ASYNC_FLUSH");
+    }
+
+    @Test
+    void previewConfigShouldNormalizeFlushDiskTypeForBrokerProperty() {
+        when(clusterRepository.findById("cluster-1")).thenReturn(Optional.of(sampleCluster));
+
+        ClusterConfigPreviewVO preview = clusterService.previewClusterConfig(UpdateConfigDTO.builder()
+                .id("cluster-1")
+                .flushDiskType("sync_flush")
+                .build());
+
+        assertThat(preview.getProposedConfig().getFlushDiskType()).isEqualTo(FlushDiskType.SYNC_FLUSH);
+        assertThat(preview.getBrokerProperties()).containsEntry("flushDiskType", "SYNC_FLUSH");
+        assertThat(preview.isChanged()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `ClusterService.parseFlushDiskType` matched the `FlushDiskType` enum with a case-sensitive,
  whitespace-sensitive `valueOf`, so valid values like `" async_flush "` or `"Sync_Flush"` were
  rejected with a 400 before any broker was touched.
- It now trims and compares case-insensitively against the enum names.
- `buildBrokerPropertyMap` now sends the canonical enum name (e.g. `ASYNC_FLUSH`) to the broker,
  so the broker-side `FlushDiskType.valueOf` accepts the property even when the client sent a
  case variant.
- Genuinely invalid values still fail fast with the same 400 `Invalid flushDiskType: ...` message.

## Why
The config update/preview endpoints take the flush disk type as a free-form string. A strict
`valueOf` makes the API brittle to casing and padding that is otherwise irrelevant, and without
canonicalizing the property value a lenient parse would forward a value the broker itself
rejects, leaving preview and update inconsistent with what the broker applies.

## Testing
- `mvn -Dtest=ClusterServiceTest test`: Tests run: 41, Failures: 0, Errors: 0, Skipped: 0.
- New tests `updateConfigShouldAcceptCaseAndWhitespaceInsensitiveFlushDiskType` and
  `previewConfigShouldNormalizeFlushDiskTypeForBrokerProperty` verified to fail on the unfixed
  code with `BusinessException: Invalid flushDiskType:  async_flush ` (Tests run: 2, Errors: 2).
