### PR TITLE
fix(audit): reject result filters outside the recorded vocabulary

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditService.java
@@ -134,6 +134,7 @@ public class AuditService {
                                                String resourceType, String clusterId,
                                                String startDate, String endDate,
                                                String result, int page, int pageSize) {
+        validateResultFilter(result);
         LocalDateTime start = parseDate(startDate, true, "startDate");
         LocalDateTime end = parseDate(endDate, false, "endDate");
         if (start != null && end != null && start.isAfter(end)) {
@@ -141,6 +142,20 @@ public class AuditService {
         }
         return auditRepository.findPage(search, operationType, resourceType, clusterId,
                 start, end, result, page, pageSize);
+    }
+
+    /**
+     * Every {@code record} call site writes {@code SUCCESS} or {@code FAILED} to the result
+     * column, so a filter outside that vocabulary can never match a row: surface a 400 instead
+     * of a silent empty page.
+     */
+    private static void validateResultFilter(String result) {
+        if (result == null || result.isEmpty()) {
+            return;
+        }
+        if (!"SUCCESS".equals(result) && !"FAILED".equals(result)) {
+            throw new BusinessException(400, "result must be SUCCESS or FAILED");
+        }
     }
 
     private LocalDateTime parseDate(String dateStr, boolean startOfDay, String parameterName) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
@@ -35,7 +35,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -136,6 +138,32 @@ class AuditServiceTest {
                 "2026-08-02", "2026-08-01", null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("startDate must not be after endDate");
+    }
+
+    @Test
+    void queryLogsRejectsResultFiltersOutsideTheRecordedVocabulary() {
+        assertThatThrownBy(() -> auditService.queryLogs(1, 10, null, null, null, null,
+                null, null, "success"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("result must be SUCCESS or FAILED");
+        assertThatThrownBy(() -> auditService.queryLogs(1, 10, null, null, null, null,
+                null, null, "PARTIAL"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("result must be SUCCESS or FAILED");
+
+        verifyNoInteractions(auditRepository);
+    }
+
+    @Test
+    void queryLogsAcceptsEveryRecordedResultValue() {
+        when(auditRepository.findPage(isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), any(), eq(1), eq(10))).thenReturn(PageResult.empty(1, 10));
+
+        auditService.queryLogs(1, 10, null, null, null, null, null, null, "SUCCESS");
+        auditService.queryLogs(1, 10, null, null, null, null, null, null, "FAILED");
+
+        verify(auditRepository, times(2)).findPage(isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), any(), eq(1), eq(10));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `AuditService` rejects `result` filter values outside the recorded vocabulary with a 400 before querying
- accept only `SUCCESS`/`FAILED` (or an absent filter) on both the paged query and the CSV export
- add regression coverage for accepted and rejected result filters

## Why
Every `record` call site in the codebase writes either `SUCCESS` or `FAILED` to the audit result column, but the query layer passed the user-supplied `result` filter straight into `.eq("result", ...)`. A filter such as `success` or `PARTIAL` therefore returned a silent empty page instead of surfacing a validation error, which reads like "no audit history" to the user. The display layer was already normalized in the web fix for audit timestamps; this closes the same gap on the Java query side.

## Testing
- `cd server && mvn -q -Dtest=AuditServiceTest test` — all tests pass, including the new `queryLogsRejectsResultFiltersOutsideTheRecordedVocabulary` and `queryLogsAcceptsEveryRecordedResultValue`
- `cd server && mvn -q -Dtest=AuditControllerTest,MybatisPlusAuditRepositoryTest test` — all tests pass (regression for the audit endpoints)
