### PR TITLE
fix(broker): bound root-cause traversal to survive cyclic exception chains

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactory.java
@@ -26,7 +26,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -203,7 +206,10 @@ public class MqAdminExtFactory {
 
     private String rootMessage(Throwable ex) {
         Throwable cause = ex;
-        while (cause.getCause() != null && cause.getCause() != cause) {
+        // An identity set bounds the walk: a direct self-cycle is the only case the old
+        // cause.getCause() != cause check caught, a two-exception cycle still loops forever.
+        Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        while (seen.add(cause) && cause.getCause() != null) {
             cause = cause.getCause();
         }
         String message = cause.getMessage();

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqClientPool.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/MqClientPool.java
@@ -25,7 +25,10 @@ import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -137,7 +140,7 @@ public class MqClientPool {
     }
 
     private DefaultMQPullConsumer createPullConsumer(String namesrvAddr, RPCHook rpcHook) {
-        DefaultMQPullConsumer consumer = new DefaultMQPullConsumer(PULL_CONSUMER_GROUP, rpcHook);
+        DefaultMQPullConsumer consumer = newPullConsumer(rpcHook);
         consumer.setNamesrvAddr(namesrvAddr);
         consumer.setInstanceName(buildInstanceName(namesrvAddr));
         try {
@@ -152,7 +155,7 @@ public class MqClientPool {
     }
 
     private DefaultMQProducer createProducer(String namesrvAddr, RPCHook rpcHook) {
-        DefaultMQProducer producer = new DefaultMQProducer(PRODUCER_GROUP, rpcHook);
+        DefaultMQProducer producer = newProducer(rpcHook);
         producer.setNamesrvAddr(namesrvAddr);
         producer.setInstanceName(buildInstanceName(namesrvAddr));
         producer.setSendMsgTimeout((int) PRODUCER_SEND_TIMEOUT_MILLIS);
@@ -174,6 +177,16 @@ public class MqClientPool {
     private String buildInstanceName(String namesrvAddr) {
         return "rmq-studio-pool-" + Integer.toHexString(namesrvAddr.hashCode())
                 + "-" + instanceCounter.incrementAndGet();
+    }
+
+    /** Creates a new (not-yet-started) pull consumer; extractable so tests can inject a stub. */
+    protected DefaultMQPullConsumer newPullConsumer(RPCHook rpcHook) {
+        return new DefaultMQPullConsumer(PULL_CONSUMER_GROUP, rpcHook);
+    }
+
+    /** Creates a new (not-yet-started) producer; extractable so tests can inject a stub. */
+    protected DefaultMQProducer newProducer(RPCHook rpcHook) {
+        return new DefaultMQProducer(PRODUCER_GROUP, rpcHook);
     }
 
     private static String normalize(String namesrvAddr) {
@@ -202,7 +215,10 @@ public class MqClientPool {
 
     private String rootMessage(Throwable ex) {
         Throwable cause = ex;
-        while (cause.getCause() != null && cause.getCause() != cause) {
+        // An identity set bounds the walk: a direct self-cycle is the only case the old
+        // cause.getCause() != cause check caught, a two-exception cycle still loops forever.
+        Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        while (seen.add(cause) && cause.getCause() != null) {
             cause = cause.getCause();
         }
         String message = cause.getMessage();

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RegistryProbeRunner.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/RegistryProbeRunner.java
@@ -19,7 +19,10 @@ package org.apache.rocketmq.studio.cluster.broker;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.cluster.nameserver.NameserverRegistryVO;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -130,7 +133,10 @@ class RegistryProbeRunner implements AutoCloseable {
 
     private static String rootMessage(Throwable error) {
         Throwable current = error;
-        while (current.getCause() != null) {
+        // Walk the cause chain with an identity set so a cyclic cause chain (exception A caused
+        // by B and B caused by A) cannot loop forever and pin the probe's caller thread.
+        Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        while (seen.add(current) && current.getCause() != null) {
             current = current.getCause();
         }
         String message = current.getMessage();

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceRegistryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceRegistryTest.java
@@ -27,12 +27,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -164,6 +166,26 @@ class ClusterServiceRegistryTest {
             assertThat(runner.poolSize()).isLessThanOrEqualTo(1);
         } finally {
             block.countDown();
+        }
+    }
+
+    @Test
+    void probeAllShouldSurviveCyclicCauseChainWithoutHangingTest() {
+        // first <-> second form a two-exception cause cycle: walking getCause() from either
+        // one loops forever unless the traversal is bounded.
+        RuntimeException first = new RuntimeException("first");
+        RuntimeException second = new RuntimeException("second", first);
+        first.initCause(second);
+
+        try (RegistryProbeRunner runner = new RegistryProbeRunner(2, 8, 500)) {
+            List<ClusterVO> result = assertTimeoutPreemptively(Duration.ofSeconds(10),
+                    () -> runner.probeAll(List.of(NameserverRegistryVO.builder()
+                                    .id(1L).name("ns-1").namesrvAddr("ns-1:9876").build()),
+                            entry -> {
+                                throw second;
+                            }));
+
+            assertThat(result).isEmpty();
         }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqAdminExtFactoryTest.java
@@ -21,11 +21,13 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -205,5 +207,25 @@ class MqAdminExtFactoryTest {
                 .hasMessageContaining("shutting down");
         // No fresh admin connection may be established while the factory is shut down.
         assertThat(factory.created.get()).isZero();
+    }
+
+    @Test
+    void executeShouldSurviveCyclicCauseChainWithoutHanging() {
+        DefaultMQAdminExt admin = mock(DefaultMQAdminExt.class);
+        RecordingFactory factory = new RecordingFactory(admin);
+
+        // first <-> second form a two-exception cause cycle: the old
+        // cause.getCause() != cause guard only caught a direct self-cycle.
+        RuntimeException first = new RuntimeException("first");
+        RuntimeException second = new RuntimeException("second", first);
+        first.initCause(second);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(10), () -> assertThatThrownBy(
+                        () -> factory.execute("10.0.0.1:9876", null, a -> {
+                            throw second;
+                        }))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("admin call failed: second")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(502)));
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqClientPoolTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqClientPoolTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class MqClientPoolTest {
+
+    private static final class StubPool extends MqClientPool {
+        private final DefaultMQPullConsumer pullConsumer = mock(DefaultMQPullConsumer.class);
+        private final DefaultMQProducer producer = mock(DefaultMQProducer.class);
+
+        @Override
+        protected DefaultMQPullConsumer newPullConsumer(RPCHook rpcHook) {
+            return pullConsumer;
+        }
+
+        @Override
+        protected DefaultMQProducer newProducer(RPCHook rpcHook) {
+            return producer;
+        }
+    }
+
+    @Test
+    void withProducerShouldSurviveCyclicCauseChainWithoutHanging() throws Exception {
+        StubPool pool = new StubPool();
+
+        // first <-> second form a two-exception cause cycle: the old
+        // cause.getCause() != cause guard only caught a direct self-cycle.
+        RuntimeException first = new RuntimeException("first");
+        RuntimeException second = new RuntimeException("second", first);
+        first.initCause(second);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(10), () -> assertThatThrownBy(
+                        () -> pool.withProducer("10.0.0.1:9876", null, "anon", client -> {
+                            throw second;
+                        }))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("client call failed: second")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(502)));
+        verify(pool.producer, times(1)).start();
+    }
+}


### PR DESCRIPTION
## Summary
- Bounds the `rootMessage` cause-chain walk in `RegistryProbeRunner` (which had **no** cycle
  guard), `MqAdminExtFactory` and `MqClientPool` (whose `cause.getCause() != cause` guard only
  catches a *direct* self-cycle) with an `IdentityHashMap`-backed visited set.
- A two-exception cycle (A caused by B, B caused by A) previously looped forever, pinning the
  request/worker thread on every admin call or registry probe whose underlying exception chain
  is cyclic.
- Extracts `protected newPullConsumer`/`newProducer` seams in `MqClientPool` (mirroring the
  existing `MqAdminExtFactory.newAdmin` seam) so the pool can be unit-tested with stub clients.

## Why
`rootMessage` walks `Throwable.getCause()` to build user-facing 502 messages. Nothing in the
RocketMQ client or remoting stack guarantees cause chains are acyclic (custom wrappers,
`initCause`, serialization frameworks can create cycles), so an unbounded walk is a latent
infinite loop on the hot path of every live admin call and every concurrent registry probe.
`RegistryProbeRunner.rootMessage` runs inside the probe executor; a hang there also stalls the
`listRegistryClusters` request thread that joins on the probe result.

## Testing
- `mvn -Dtest=ClusterServiceRegistryTest,MqAdminExtFactoryTest,MqClientPoolTest test`:
  Tests run: 21, Failures: 0, Errors: 0, Skipped: 0 (6 + 14 + 1).
- New tests verified to fail on the unfixed code:
  `probeAllShouldSurviveCyclicCauseChainWithoutHangingTest` and
  `executeShouldSurviveCyclicCauseChainWithoutHanging` each hang until the 10s
  `assertTimeoutPreemptively` deadline (Tests run: 20, Failures: 2, Errors: 0).
- The `MqClientPoolTest` case requires the new `newProducer` seam, so its unfixed counterpart
  is the identical unguarded `rootMessage` in `MqClientPool`.

## Verification on Linux

Ubuntu 22.04, OpenJDK 21.0.12, Maven 3.6.3, rebased onto `rocketmq-studio` `6c24d2ed`, run from
`server/`:

```
$ mvn -B -ntp test
Tests run: 2154, Failures: 2, Errors: 0, Skipped: 0
```

Both failures are `AuthCorsIntegrationTest`, which fails on the branch head *without* this
change too (the test still stubs the pre-#2895 `isAuthenticated` call). #4217 repairs it.
Every other test, including the ones added here, passes.