### PR TITLE
fix(common): normalize business exception status codes into the error bands

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/exception/BusinessException.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/exception/BusinessException.java
@@ -24,6 +24,9 @@ public class BusinessException extends RuntimeException {
 
     public BusinessException(int code, String message) {
         super(message);
-        this.code = code;
+        // The global exception handler maps the code directly onto the HTTP status line, so it
+        // must stay in the 4xx/5xx band: a 2xx/3xx code would answer the error with a success
+        // or redirect status, and a code outside the band makes HttpStatus.valueOf throw.
+        this.code = code >= 400 && code <= 599 ? code : 400;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/exception/BusinessExceptionTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/exception/BusinessExceptionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BusinessExceptionTest {
+
+    @Test
+    void codesWithinTheErrorBandsShouldPassThrough() {
+        assertThat(new BusinessException(400, "bad").getCode()).isEqualTo(400);
+        assertThat(new BusinessException(401, "auth").getCode()).isEqualTo(401);
+        assertThat(new BusinessException(404, "missing").getCode()).isEqualTo(404);
+        assertThat(new BusinessException(422, "unprocessable").getCode()).isEqualTo(422);
+        assertThat(new BusinessException(502, "upstream").getCode()).isEqualTo(502);
+        assertThat(new BusinessException(599, "upper bound").getCode()).isEqualTo(599);
+    }
+
+    @Test
+    void codesOutsideTheErrorBandsShouldFallBackToBadRequest() {
+        assertThat(new BusinessException(0, "zero").getCode()).isEqualTo(400);
+        assertThat(new BusinessException(200, "success-looking").getCode()).isEqualTo(400);
+        assertThat(new BusinessException(301, "redirect-looking").getCode()).isEqualTo(400);
+        assertThat(new BusinessException(600, "future").getCode()).isEqualTo(400);
+        assertThat(new BusinessException(-7, "negative").getCode()).isEqualTo(400);
+    }
+
+    @Test
+    void messageShouldPassThroughUnchanged() {
+        BusinessException exception = new BusinessException(404, "row not found");
+
+        assertThat(exception.getMessage()).isEqualTo("row not found");
+    }
+}


### PR DESCRIPTION
## Summary
- normalize the `BusinessException` status code in the constructor: keep codes in the 4xx/5xx band, fall back to 400 for anything else
- add a regression test covering pass-through codes, out-of-band codes, and message passthrough

## Why
`GlobalExceptionHandler` maps the exception code directly onto the HTTP status line via `ResponseEntity.status(code)`, which internally calls `HttpStatus.valueOf(code)`. A business exception constructed with a code outside the 100–599 band (e.g. 0 or 600) would make the handler itself throw, converting the business error into an opaque 500; a 2xx/3xx code would answer the error with a success or redirect status while the body still says "error" — a status/message inconsistency. All current call sites already use 401–504, so this only changes behavior for future misuse.

## Testing
- `cd server && mvn -q -Dtest=BusinessExceptionTest test` — 3 tests pass (new class)
- `cd server && mvn -q -Dtest=GlobalExceptionHandlerTest test` — all tests pass (regression for the exception envelope)

## Verification on Linux

Ubuntu 22.04, OpenJDK 21.0.12, Maven 3.6.3, rebased onto `rocketmq-studio` `6c24d2ed`, run from
`server/`:

```
$ mvn -B -ntp test
Tests run: 2154, Failures: 2, Errors: 0, Skipped: 0
```

Both failures are `AuthCorsIntegrationTest`, which fails on the branch head *without* this
change too (the test still stubs the pre-#2895 `isAuthenticated` call). #4217 repairs it.
Every other test, including the ones added here, passes.