### PR TITLE
fix(cloud): consolidate inventory pagination

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProvider.java
@@ -301,7 +301,7 @@ public class AliyunInstanceProvider implements InstanceProvider {
     public List<ConsumerGroupVO> listConsumerGroups(String instanceId, String search) {
         Context ctx = resolve(instanceId);
         List<ListConsumerGroupsResponseBody.List> all = new ArrayList<>();
-        for (int page = 1; page <= AliyunConverters.MAX_PAGES; page++) {
+        for (int page = 1; ; page++) {
             ListConsumerGroupsRequest.Builder builder = ListConsumerGroupsRequest.builder()
                     .instanceId(ctx.cloudInstanceId())
                     .pageNumber(page)
@@ -319,7 +319,8 @@ public class AliyunInstanceProvider implements InstanceProvider {
                 break;
             }
             all.addAll(list);
-            if (list.size() < AliyunConverters.PAGE_SIZE) {
+            if (hasFetchedAll(page, AliyunConverters.PAGE_SIZE, data.getTotalCount())
+                    || list.size() < AliyunConverters.PAGE_SIZE) {
                 break;
             }
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentAclService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentAclService.java
@@ -53,7 +53,6 @@ import java.util.List;
 public class TencentAclService {
 
     static final int PAGE_SIZE = 100;
-    static final int MAX_PAGES = 100;
     static final String ACL_VERSION = "1.0";
     static final String RESOURCE_TYPE = "Cluster";
     static final String RESOURCE = "*";
@@ -67,23 +66,20 @@ public class TencentAclService {
     public List<AclUserVO> listUsers(String instanceId) {
         Context context = resolve(instanceId);
         List<AclUserVO> users = new ArrayList<>();
-        for (int page = 0; page < MAX_PAGES; page++) {
-            DescribeRoleListRequest request = new DescribeRoleListRequest();
-            request.setInstanceId(context.cloudInstanceId());
-            request.setOffset((long) page * PAGE_SIZE);
-            request.setLimit((long) PAGE_SIZE);
-            DescribeRoleListResponse response = clientFactory.call(context.credentialId(),
-                    context.regionId(), client -> client.DescribeRoleList(request));
+        long fetched = 0L;
+        for (long offset = 0L; ; offset += PAGE_SIZE) {
+            DescribeRoleListResponse response = describeRoles(context, offset);
             RoleItem[] data = response == null ? null : response.getData();
             if (data == null || data.length == 0) {
                 break;
             }
+            fetched += data.length;
             for (RoleItem role : data) {
                 if (role != null && StringUtils.hasText(role.getRoleName())) {
                     users.add(toUser(role, context.cloudInstanceId()));
                 }
             }
-            if (data.length < PAGE_SIZE) {
+            if (isLastRolePage(data.length, fetched, response.getTotalCount())) {
                 break;
             }
         }
@@ -94,17 +90,14 @@ public class TencentAclService {
         Context context = resolve(instanceId);
         String requestedPrincipal = StringUtils.hasText(principal) ? principal.trim() : null;
         List<AclRuleVO> rules = new ArrayList<>();
-        for (int page = 0; page < MAX_PAGES; page++) {
-            DescribeRoleListRequest request = new DescribeRoleListRequest();
-            request.setInstanceId(context.cloudInstanceId());
-            request.setOffset((long) page * PAGE_SIZE);
-            request.setLimit((long) PAGE_SIZE);
-            DescribeRoleListResponse response = clientFactory.call(context.credentialId(),
-                    context.regionId(), client -> client.DescribeRoleList(request));
+        long fetched = 0L;
+        for (long offset = 0L; ; offset += PAGE_SIZE) {
+            DescribeRoleListResponse response = describeRoles(context, offset);
             RoleItem[] data = response == null ? null : response.getData();
             if (data == null || data.length == 0) {
                 break;
             }
+            fetched += data.length;
             for (RoleItem role : data) {
                 if (role == null || !StringUtils.hasText(role.getRoleName())) {
                     continue;
@@ -115,7 +108,7 @@ public class TencentAclService {
                 }
                 rules.add(toRule(role));
             }
-            if (data.length < PAGE_SIZE) {
+            if (isLastRolePage(data.length, fetched, response.getTotalCount())) {
                 break;
             }
         }
@@ -178,27 +171,37 @@ public class TencentAclService {
     }
 
     private RoleItem findRole(Context context, String roleName) {
-        for (int page = 0; page < MAX_PAGES; page++) {
-            DescribeRoleListRequest request = new DescribeRoleListRequest();
-            request.setInstanceId(context.cloudInstanceId());
-            request.setOffset((long) page * PAGE_SIZE);
-            request.setLimit((long) PAGE_SIZE);
-            DescribeRoleListResponse response = clientFactory.call(context.credentialId(),
-                    context.regionId(), client -> client.DescribeRoleList(request));
+        long fetched = 0L;
+        for (long offset = 0L; ; offset += PAGE_SIZE) {
+            DescribeRoleListResponse response = describeRoles(context, offset);
             RoleItem[] data = response == null ? null : response.getData();
             if (data == null || data.length == 0) {
                 break;
             }
+            fetched += data.length;
             for (RoleItem role : data) {
                 if (role != null && roleName.equals(role.getRoleName())) {
                     return role;
                 }
             }
-            if (data.length < PAGE_SIZE) {
+            if (isLastRolePage(data.length, fetched, response.getTotalCount())) {
                 break;
             }
         }
         throw new BusinessException(404, "ACL user not found: " + roleName);
+    }
+
+    private DescribeRoleListResponse describeRoles(Context context, long offset) {
+        DescribeRoleListRequest request = new DescribeRoleListRequest();
+        request.setInstanceId(context.cloudInstanceId());
+        request.setOffset(offset);
+        request.setLimit((long) PAGE_SIZE);
+        return clientFactory.call(context.credentialId(),
+                context.regionId(), client -> client.DescribeRoleList(request));
+    }
+
+    private static boolean isLastRolePage(int returned, long fetched, Long totalCount) {
+        return returned < PAGE_SIZE || totalCount != null && totalCount >= 0L && fetched >= totalCount;
     }
 
     public void deleteUser(String instanceId, String username) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogService.java
@@ -43,7 +43,6 @@ import java.util.Locale;
 public class TencentCatalogService implements CloudCatalogProvider {
 
     static final int PAGE_SIZE = 100;
-    static final int MAX_PAGES = 100;
     static final List<CloudRegionVO> SUPPORTED_REGIONS = List.of(
             region("ap-guangzhou", "Guangzhou"),
             region("ap-shenzhen-fsi", "Shenzhen Finance"),
@@ -83,9 +82,9 @@ public class TencentCatalogService implements CloudCatalogProvider {
         requireId(credentialId, "credentialId");
         requireNonBlank(regionId, "regionId");
         List<CloudInstanceOptionVO> instances = new ArrayList<>();
-        for (int page = 0; page < MAX_PAGES; page++) {
+        for (long offset = 0L; ; offset += PAGE_SIZE) {
             DescribeInstanceListRequest request = new DescribeInstanceListRequest();
-            request.setOffset((long) page * PAGE_SIZE);
+            request.setOffset(offset);
             request.setLimit((long) PAGE_SIZE);
             DescribeInstanceListResponse response = clientFactory.call(credentialId, regionId,
                     client -> client.DescribeInstanceList(request));
@@ -102,11 +101,15 @@ public class TencentCatalogService implements CloudCatalogProvider {
                     instances.add(option);
                 }
             }
-            if (data.length < PAGE_SIZE) {
+            if (data.length < PAGE_SIZE || hasFetchedAll(offset, response.getTotalCount())) {
                 break;
             }
         }
         return instances;
+    }
+
+    private static boolean hasFetchedAll(long offset, Long totalCount) {
+        return totalCount != null && totalCount >= 0L && offset + PAGE_SIZE >= totalCount;
     }
 
     @Override

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -409,10 +409,10 @@ public class TencentInstanceProvider implements InstanceProvider {
     private List<ConsumerGroupVO> listConsumerGroups(String instanceId, String search, boolean enrichTimes) {
         Context context = resolve(instanceId);
         List<ConsumerGroupVO> groups = new ArrayList<>();
-        for (int page = 0; page < MAX_PAGES; page++) {
+        for (long offset = 0L; ; offset += PAGE_SIZE) {
             DescribeConsumerGroupListRequest request = new DescribeConsumerGroupListRequest();
             request.setInstanceId(context.cloudInstanceId());
-            request.setOffset((long) page * PAGE_SIZE);
+            request.setOffset(offset);
             request.setLimit((long) PAGE_SIZE);
             DescribeConsumerGroupListResponse response = clientFactory.call(context.credentialId(), context.regionId(),
                     client -> client.DescribeConsumerGroupList(request));
@@ -432,7 +432,7 @@ public class TencentInstanceProvider implements InstanceProvider {
                     groups.add(group);
                 }
             }
-            if (data.length < PAGE_SIZE) {
+            if (data.length < PAGE_SIZE || hasFetchedAll(offset, PAGE_SIZE, response.getTotalCount())) {
                 break;
             }
         }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -276,6 +276,10 @@ public class TencentInstanceProvider implements InstanceProvider {
         return totalCount != null && totalCount >= 0L && offset + pageSize >= totalCount;
     }
 
+    private static boolean hasFetchedAll(long fetched, Long totalCount) {
+        return totalCount != null && totalCount >= 0L && fetched >= totalCount;
+    }
+
     private static PageResult<TopicVO> paginate(List<TopicVO> topics, int page, int pageSize) {
         int total = topics.size();
         long offset = Pagination.pageOffset(page, pageSize);
@@ -935,11 +939,12 @@ public class TencentInstanceProvider implements InstanceProvider {
 
     private List<SubscriptionData> listTopicSubscriptionsByGroup(Context context, String groupName) {
         List<SubscriptionData> all = new ArrayList<>();
-        for (int page = 0; page < MAX_PAGES; page++) {
+        long fetched = 0L;
+        for (long offset = 0L; ; offset += PAGE_SIZE) {
             DescribeTopicListByGroupRequest request = new DescribeTopicListByGroupRequest();
             request.setInstanceId(context.cloudInstanceId());
             request.setConsumerGroup(groupName);
-            request.setOffset((long) page * PAGE_SIZE);
+            request.setOffset(offset);
             request.setLimit((long) PAGE_SIZE);
             DescribeTopicListByGroupResponse response = clientFactory.call(context.credentialId(), context.regionId(),
                     client -> client.DescribeTopicListByGroup(request));
@@ -947,8 +952,9 @@ public class TencentInstanceProvider implements InstanceProvider {
             if (data == null || data.length == 0) {
                 break;
             }
+            fetched += data.length;
             all.addAll(Arrays.asList(data));
-            if (data.length < PAGE_SIZE) {
+            if (data.length < PAGE_SIZE || hasFetchedAll(fetched, response.getTotalCount())) {
                 break;
             }
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunInstanceProviderTest.java
@@ -225,6 +225,73 @@ class AliyunInstanceProviderTest {
     }
 
     @Test
+    void listConsumerGroupsShouldFetchExactlyFiveFullPagesTest() {
+        stubInstance();
+        stubCallThrough();
+        when(asyncClient.listConsumerGroups(any(ListConsumerGroupsRequest.class))).thenAnswer(invocation -> {
+            ListConsumerGroupsRequest request = invocation.getArgument(0);
+            return CompletableFuture.completedFuture(groupsResponse(500L,
+                    groupIdsForPage(request.getPageNumber(), AliyunConverters.PAGE_SIZE)));
+        });
+
+        List<ConsumerGroupVO> groups = provider.listConsumerGroups(STUDIO_INSTANCE_ID, null);
+
+        assertThat(groups).hasSize(500);
+        ArgumentCaptor<ListConsumerGroupsRequest> captor =
+                ArgumentCaptor.forClass(ListConsumerGroupsRequest.class);
+        verify(asyncClient, times(5)).listConsumerGroups(captor.capture());
+        assertThat(captor.getAllValues()).extracting(ListConsumerGroupsRequest::getPageNumber)
+                .containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    void listConsumerGroupsShouldTraversePastLegacyFivePageCapTest() {
+        stubInstance();
+        stubCallThrough();
+        when(asyncClient.listConsumerGroups(any(ListConsumerGroupsRequest.class))).thenAnswer(invocation -> {
+            ListConsumerGroupsRequest request = invocation.getArgument(0);
+            int pageNumber = request.getPageNumber();
+            if (pageNumber <= 5) {
+                return CompletableFuture.completedFuture(groupsResponse(501L,
+                        groupIdsForPage(pageNumber, AliyunConverters.PAGE_SIZE)));
+            }
+            return CompletableFuture.completedFuture(groupsResponse(501L, "GID_500"));
+        });
+
+        List<ConsumerGroupVO> groups = provider.listConsumerGroups(STUDIO_INSTANCE_ID, null);
+
+        assertThat(groups).hasSize(501);
+        ArgumentCaptor<ListConsumerGroupsRequest> captor =
+                ArgumentCaptor.forClass(ListConsumerGroupsRequest.class);
+        verify(asyncClient, times(6)).listConsumerGroups(captor.capture());
+        assertThat(captor.getAllValues()).extracting(ListConsumerGroupsRequest::getPageNumber)
+                .containsExactly(1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    void listConsumerGroupsShouldStopOnShortPageWhenTotalCountIsMissingTest() {
+        stubInstance();
+        stubCallThrough();
+        when(asyncClient.listConsumerGroups(any(ListConsumerGroupsRequest.class))).thenAnswer(invocation -> {
+            ListConsumerGroupsRequest request = invocation.getArgument(0);
+            if (request.getPageNumber() == 1) {
+                return CompletableFuture.completedFuture(groupsResponse(null,
+                        groupIdsForPage(1, AliyunConverters.PAGE_SIZE)));
+            }
+            return CompletableFuture.completedFuture(groupsResponse(null, "GID_100"));
+        });
+
+        List<ConsumerGroupVO> groups = provider.listConsumerGroups(STUDIO_INSTANCE_ID, null);
+
+        assertThat(groups).hasSize(101);
+        ArgumentCaptor<ListConsumerGroupsRequest> captor =
+                ArgumentCaptor.forClass(ListConsumerGroupsRequest.class);
+        verify(asyncClient, times(2)).listConsumerGroups(captor.capture());
+        assertThat(captor.getAllValues()).extracting(ListConsumerGroupsRequest::getPageNumber)
+                .containsExactly(1, 2);
+    }
+
+    @Test
     void getGroupProgressShouldMapLagRowsTest() {
         stubInstance();
         stubCallThrough();
@@ -734,6 +801,12 @@ class AliyunInstanceProviderTest {
                                 .build())
                         .build())
                 .build();
+    }
+
+    private static String[] groupIdsForPage(int pageNumber, int pageSize) {
+        return IntStream.range(0, pageSize)
+                .mapToObj(index -> "GID_" + ((pageNumber - 1) * pageSize + index))
+                .toArray(String[]::new);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentAclServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentAclServiceTest.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.provider.tencent;
 
 import com.tencentcloudapi.trocket.v20230308.TrocketClient;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeRoleListRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeRoleListResponse;
 import com.tencentcloudapi.trocket.v20230308.models.ModifyRoleRequest;
 import com.tencentcloudapi.trocket.v20230308.models.RoleItem;
@@ -34,6 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -41,6 +43,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -108,6 +111,66 @@ class TencentAclServiceTest {
                 .containsExactly("reader-role");
         assertThat(service.getUserCredentials(INSTANCE_ID, "  reader-role  ").getUsername())
                 .isEqualTo("reader-role");
+    }
+
+    @Test
+    void listUsersShouldFetchExactlyTenThousandTencentRolesTest() throws Exception {
+        when(client.DescribeRoleList(any())).thenAnswer(invocation -> {
+            DescribeRoleListRequest request = invocation.getArgument(0);
+            DescribeRoleListResponse response = new DescribeRoleListResponse();
+            response.setTotalCount(10000L);
+            response.setData(rolePage(request.getOffset(), request.getLimit(), 10000));
+            return response;
+        });
+
+        assertThat(service.listUsers(INSTANCE_ID)).hasSize(10000);
+        verify(client, times(100)).DescribeRoleList(any());
+    }
+
+    @Test
+    void listRulesShouldFetchPastLegacyTenThousandTencentRoleCapTest() throws Exception {
+        when(client.DescribeRoleList(any())).thenAnswer(invocation -> {
+            DescribeRoleListRequest request = invocation.getArgument(0);
+            DescribeRoleListResponse response = new DescribeRoleListResponse();
+            response.setTotalCount(10001L);
+            response.setData(rolePage(request.getOffset(), request.getLimit(), 10001));
+            return response;
+        });
+
+        assertThat(service.listRules(INSTANCE_ID, null)).hasSize(10001);
+        verify(client, times(101)).DescribeRoleList(any());
+    }
+
+    @Test
+    void updateUserShouldFindRolePastLegacyTenThousandTencentRoleCapTest() throws Exception {
+        when(client.DescribeRoleList(any())).thenAnswer(invocation -> {
+            DescribeRoleListRequest request = invocation.getArgument(0);
+            DescribeRoleListResponse response = new DescribeRoleListResponse();
+            response.setTotalCount(10001L);
+            response.setData(rolePage(request.getOffset(), request.getLimit(), 10001));
+            return response;
+        });
+
+        AclUserVO updated = service.updateUser(INSTANCE_ID, AclUserVO.builder()
+                .username("role-10000")
+                .build());
+
+        assertThat(updated.getUsername()).isEqualTo("role-10000");
+        verify(client, times(101)).DescribeRoleList(any());
+        verify(client).ModifyRole(any());
+    }
+
+    @Test
+    void listUsersShouldStopOnShortPageWhenTencentTotalCountIsMissingTest() throws Exception {
+        when(client.DescribeRoleList(any())).thenAnswer(invocation -> {
+            DescribeRoleListRequest request = invocation.getArgument(0);
+            DescribeRoleListResponse response = new DescribeRoleListResponse();
+            response.setData(rolePage(request.getOffset(), request.getLimit(), 150));
+            return response;
+        });
+
+        assertThat(service.listUsers(INSTANCE_ID)).hasSize(150);
+        verify(client, times(2)).DescribeRoleList(any());
     }
 
     @Test
@@ -210,5 +273,22 @@ class TencentAclServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Tencent Cloud roles only support ALLOW ACL rules")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+    }
+
+    private static RoleItem[] rolePage(Long offset, Long limit, int total) {
+        int start = offset == null ? 0 : offset.intValue();
+        int size = Math.min(limit == null ? TencentAclService.PAGE_SIZE : limit.intValue(),
+                Math.max(total - start, 0));
+        return IntStream.range(0, size)
+                .mapToObj(index -> role("role-" + (start + index)))
+                .toArray(RoleItem[]::new);
+    }
+
+    private static RoleItem role(String name) {
+        RoleItem role = new RoleItem();
+        role.setRoleName(name);
+        role.setPermRead(true);
+        role.setPermWrite(false);
+        return role;
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentCatalogServiceTest.java
@@ -17,9 +17,11 @@
 package org.apache.rocketmq.studio.provider.tencent;
 
 import com.tencentcloudapi.trocket.v20230308.models.DescribeInstanceListResponse;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeInstanceListRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeInstanceResponse;
 import com.tencentcloudapi.trocket.v20230308.models.Endpoint;
 import com.tencentcloudapi.trocket.v20230308.models.InstanceItem;
+import com.tencentcloudapi.trocket.v20230308.TrocketClient;
 import org.apache.rocketmq.studio.provider.CloudInstanceDetailVO;
 import org.apache.rocketmq.studio.provider.CloudInstanceOptionVO;
 import org.apache.rocketmq.studio.provider.CloudRegionVO;
@@ -34,6 +36,9 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,11 +50,18 @@ class TencentCatalogServiceTest {
     @Mock
     private TencentClientFactory clientFactory;
 
+    @Mock
+    private TrocketClient client;
+
     private TencentCatalogService service;
 
     @BeforeEach
     void setUp() {
         service = new TencentCatalogService(clientFactory);
+        lenient().when(clientFactory.call(eq(CREDENTIAL_ID), eq(REGION), any())).thenAnswer(invocation -> {
+            TencentClientFactory.TencentCall<Object> action = invocation.getArgument(2);
+            return action.execute(client);
+        });
     }
 
     @Test
@@ -119,6 +131,48 @@ class TencentCatalogServiceTest {
         assertThat(instances).singleElement()
                 .extracting(CloudInstanceOptionVO::getInstanceId)
                 .isEqualTo("rmq-valid");
+    }
+
+    @Test
+    void listCloudInstancesShouldContinuePastTenThousandRecordsWhenTotalCountRequiresItTest() throws Exception {
+        InstanceItem item = new InstanceItem();
+        item.setInstanceId("rmq-page");
+        item.setInstanceName("page");
+        when(client.DescribeInstanceList(any())).thenAnswer(invocation -> {
+            DescribeInstanceListRequest request = invocation.getArgument(0);
+            DescribeInstanceListResponse response = new DescribeInstanceListResponse();
+            response.setTotalCount(10_001L);
+            response.setData(request.getOffset() < 10_000L
+                    ? java.util.stream.IntStream.range(0, 100).mapToObj(index -> item).toArray(InstanceItem[]::new)
+                    : new InstanceItem[]{item});
+            return response;
+        });
+
+        List<CloudInstanceOptionVO> instances = service.listCloudInstances(CREDENTIAL_ID, REGION, null);
+
+        assertThat(instances).hasSize(10_001);
+        org.mockito.ArgumentCaptor<DescribeInstanceListRequest> captor =
+                org.mockito.ArgumentCaptor.forClass(DescribeInstanceListRequest.class);
+        verify(client, times(101)).DescribeInstanceList(captor.capture());
+        assertThat(captor.getAllValues().get(100).getOffset()).isEqualTo(10_000L);
+    }
+
+    @Test
+    void listCloudInstancesShouldStopAtExactlyTenThousandRecordsWhenTotalCountIsReachedTest() throws Exception {
+        InstanceItem item = new InstanceItem();
+        item.setInstanceId("rmq-page");
+        item.setInstanceName("page");
+        when(client.DescribeInstanceList(any())).thenAnswer(invocation -> {
+            DescribeInstanceListResponse response = new DescribeInstanceListResponse();
+            response.setTotalCount(10_000L);
+            response.setData(java.util.stream.IntStream.range(0, 100)
+                    .mapToObj(index -> item)
+                    .toArray(InstanceItem[]::new));
+            return response;
+        });
+
+        assertThat(service.listCloudInstances(CREDENTIAL_ID, REGION, null)).hasSize(10_000);
+        verify(client, times(100)).DescribeInstanceList(any());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -30,6 +30,7 @@ import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageTraceRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeMessageTraceResponse;
 import com.tencentcloudapi.trocket.v20230308.models.MessageItem;
 import com.tencentcloudapi.trocket.v20230308.models.MessageTraceItem;
+import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListByGroupResponse;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeConsumerGroupListRequest;
 import com.tencentcloudapi.trocket.v20230308.models.DescribeTopicListRequest;
@@ -637,6 +638,47 @@ class TencentInstanceProviderTest {
     }
 
     @Test
+    void getGroupSubscriptionsShouldFetchExactlyTenThousandTencentSubscriptionsTest() throws Exception {
+        when(client.DescribeTopicListByGroup(any())).thenAnswer(invocation -> {
+            DescribeTopicListByGroupRequest request = invocation.getArgument(0);
+            DescribeTopicListByGroupResponse response = new DescribeTopicListByGroupResponse();
+            response.setTotalCount(10000L);
+            response.setData(subscriptionPage(request.getOffset(), request.getLimit(), 10000));
+            return response;
+        });
+
+        assertThat(provider.getGroupSubscriptions(STUDIO_INSTANCE_ID, "GID_test")).hasSize(10000);
+        verify(client, times(100)).DescribeTopicListByGroup(any());
+    }
+
+    @Test
+    void getGroupProgressShouldFetchPastLegacyTenThousandTencentSubscriptionCapTest() throws Exception {
+        when(client.DescribeTopicListByGroup(any())).thenAnswer(invocation -> {
+            DescribeTopicListByGroupRequest request = invocation.getArgument(0);
+            DescribeTopicListByGroupResponse response = new DescribeTopicListByGroupResponse();
+            response.setTotalCount(10001L);
+            response.setData(subscriptionPage(request.getOffset(), request.getLimit(), 10001));
+            return response;
+        });
+
+        assertThat(provider.getGroupProgress(STUDIO_INSTANCE_ID, "GID_test")).hasSize(10001);
+        verify(client, times(101)).DescribeTopicListByGroup(any());
+    }
+
+    @Test
+    void getGroupSubscriptionsShouldStopOnShortPageWhenTencentTotalCountIsMissingTest() throws Exception {
+        when(client.DescribeTopicListByGroup(any())).thenAnswer(invocation -> {
+            DescribeTopicListByGroupRequest request = invocation.getArgument(0);
+            DescribeTopicListByGroupResponse response = new DescribeTopicListByGroupResponse();
+            response.setData(subscriptionPage(request.getOffset(), request.getLimit(), 150));
+            return response;
+        });
+
+        assertThat(provider.getGroupSubscriptions(STUDIO_INSTANCE_ID, "GID_test")).hasSize(150);
+        verify(client, times(2)).DescribeTopicListByGroup(any());
+    }
+
+    @Test
     void resetOffsetShouldCallTencentOpenApiTest() throws Exception {
         when(client.ResetConsumerGroupOffset(any())).thenReturn(null);
 
@@ -665,6 +707,22 @@ class TencentInstanceProviderTest {
         subscription.setConsumeType("CLUSTERING");
         subscription.setMessageModel("CLUSTERING");
         return subscription;
+    }
+
+    private static SubscriptionData[] subscriptionPage(Long offset, Long limit, int total) {
+        int start = offset == null ? 0 : offset.intValue();
+        int size = Math.min(limit == null ? TencentInstanceProvider.PAGE_SIZE : limit.intValue(),
+                Math.max(total - start, 0));
+        return IntStream.range(0, size)
+                .mapToObj(index -> {
+                    SubscriptionData subscription = subscription("GID_test");
+                    subscription.setTopic("topic-" + (start + index));
+                    subscription.setSubString("*");
+                    subscription.setExpressionType("TAG");
+                    subscription.setConsumerLag((long) start + index);
+                    return subscription;
+                })
+                .toArray(SubscriptionData[]::new);
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -538,6 +538,28 @@ class TencentInstanceProviderTest {
     }
 
     @Test
+    void listConsumerGroupsShouldContinuePastTenThousandRecordsWhenTotalCountRequiresItTest() throws Exception {
+        ConsumeGroupItem item = new ConsumeGroupItem();
+        item.setConsumerGroup("GID_page");
+        when(client.DescribeConsumerGroupList(any())).thenAnswer(invocation -> {
+            DescribeConsumerGroupListRequest request = invocation.getArgument(0);
+            DescribeConsumerGroupListResponse response = new DescribeConsumerGroupListResponse();
+            response.setTotalCount(10_001L);
+            response.setData(request.getOffset() < 10_000L
+                    ? IntStream.range(0, 100).mapToObj(index -> item).toArray(ConsumeGroupItem[]::new)
+                    : new ConsumeGroupItem[]{item});
+            return response;
+        });
+
+        assertThat(provider.listConsumerGroups(STUDIO_INSTANCE_ID, "does-not-match")).isEmpty();
+
+        ArgumentCaptor<DescribeConsumerGroupListRequest> captor =
+                ArgumentCaptor.forClass(DescribeConsumerGroupListRequest.class);
+        verify(client, times(101)).DescribeConsumerGroupList(captor.capture());
+        assertThat(captor.getAllValues().get(100).getOffset()).isEqualTo(10_000L);
+    }
+
+    @Test
     void createConsumerGroupShouldCallTencentOpenApiTest() throws Exception {
         when(client.CreateConsumerGroup(any())).thenReturn(null);
         ConsumerGroupVO group = new ConsumerGroupVO();


### PR DESCRIPTION
## Summary
Consolidates the cloud inventory pagination fixes from #2684, #2610, and #2669 into one PR based on the current `rocketmq-studio` branch.

Replaces #2684
Replaces #2610
Replaces #2669

Closes #2678
Closes #2609
Closes #2667

## Changes
- Page Tencent cloud instance and consumer group inventory by `TotalCount` or short-page termination instead of the old fixed 10,000-record ceiling.
- Page Tencent ACL role and topic-subscription inventories by `TotalCount`, preserving short-page termination when the API omits totals.
- Page Aliyun consumer group inventory until `totalCount` is satisfied or a short page is returned.
- Add regression tests for boundary conditions at and beyond the old pagination ceilings.

## Verification
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest=AliyunInstanceProviderTest,TencentCatalogServiceTest,TencentAclServiceTest,TencentInstanceProviderTest test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -Dtest='org.apache.rocketmq.studio.provider.*.*Test' test`
- `JAVA_HOME=/Users/aias/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home mvn -q -DskipTests compile`
- `git diff --check origin/rocketmq-studio...HEAD`

Full backend `mvn -q test` was also run. It currently fails on the existing baseline `AlertSchemaMigrationTest` issue: `Table "rmq_instance_message" not found` while `AlertSchemaMigration` adds `result_snapshot`; this PR does not touch that area.
