### PR TITLE
[ISSUE #2954] Preserve nested audit detail values

### DIFF
--- a/web/src/pages/ops/__tests__/auditPresentation.test.ts
+++ b/web/src/pages/ops/__tests__/auditPresentation.test.ts
@@ -116,6 +116,21 @@ describe('audit presentation helpers', () => {
     ]);
   });
 
+  it('preserves commas inside nested configuration and quoted values', () => {
+    expect(
+      parseAuditDetail(
+        'brokerAddr=10.0.0.1:10911, config={flushDiskType=SYNC_FLUSH, fileReservedTime=72}, note="primary, synchronous"',
+      ),
+    ).toEqual([
+      { label: 'brokerAddr', value: '10.0.0.1:10911' },
+      {
+        label: 'config',
+        value: '{flushDiskType=SYNC_FLUSH, fileReservedTime=72}',
+      },
+      { label: 'note', value: '"primary, synchronous"' },
+    ]);
+  });
+
   it('keeps free-form details intact when they are not key-value lists', () => {
     expect(parseAuditDetail('Removed stale Proxy address 10.0.30.9:8081')).toEqual([
       { label: '', value: 'Removed stale Proxy address 10.0.30.9:8081' },

--- a/web/src/pages/ops/auditPresentation.ts
+++ b/web/src/pages/ops/auditPresentation.ts
@@ -272,7 +272,8 @@ export function parseAuditDetail(detail: string | null | undefined): AuditDetail
   const text = detail?.trim();
   if (!text) return [];
 
-  const parts = text.split(/\s*,\s*/).filter(Boolean);
+  const parts = splitTopLevelDetailFields(text);
+  if (!parts) return [{ label: '', value: text }];
   if (parts.length <= 1) return [{ label: '', value: text }];
 
   const tokens = parts.map((part) => {
@@ -289,4 +290,56 @@ export function parseAuditDetail(detail: string | null | undefined): AuditDetail
     return [{ label: '', value: text }];
   }
   return tokens as AuditDetailToken[];
+}
+
+const DETAIL_DELIMITERS: Record<string, string> = {
+  '{': '}',
+  '[': ']',
+  '(': ')',
+};
+
+function splitTopLevelDetailFields(text: string): string[] | null {
+  const fields: string[] = [];
+  const expectedClosings: string[] = [];
+  let fieldStart = 0;
+  let quote = '';
+  let escaped = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = '';
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    const closing = DETAIL_DELIMITERS[char];
+    if (closing) {
+      expectedClosings.push(closing);
+      continue;
+    }
+    if (char === '}' || char === ']' || char === ')') {
+      if (expectedClosings.pop() !== char) return null;
+      continue;
+    }
+    if (char === ',' && expectedClosings.length === 0) {
+      const field = text.slice(fieldStart, index).trim();
+      if (field) fields.push(field);
+      fieldStart = index + 1;
+    }
+  }
+
+  if (quote || expectedClosings.length > 0) return null;
+  const field = text.slice(fieldStart).trim();
+  if (field) fields.push(field);
+  return fields;
 }


### PR DESCRIPTION
Closes #2954

Problem

Audit details emitted by broker configuration operations can contain nested maps and quoted values with commas. Splitting every comma truncates these values and renders misleading detail tokens.

Change

Parse only top-level commas while tracking braces, brackets, parentheses, quotes, and escapes. Unbalanced or free-form details continue to render as one raw value.

Local verification

- Vitest auditPresentation test: 10 passed
- pnpm build: passed
- Scope check: 2 files, 70 changed lines