### PR TITLE
[ISSUE #2950] Report topic route skew once

### DIFF
--- a/web/src/utils/topicRouteDiagnostics.test.ts
+++ b/web/src/utils/topicRouteDiagnostics.test.ts
@@ -147,6 +147,31 @@ describe('topic route diagnostics', () => {
     );
   });
 
+  it('reports topic-level queue skew once without blaming each broker', () => {
+    const diagnostics = analyzeTopicRoutes([
+      route({ brokerName: 'broker-a', writeQueues: 12, readQueues: 12 }),
+      route({
+        brokerName: 'broker-b',
+        brokerAddr: '10.0.1.1:10911',
+        masterAddr: '10.0.1.1:10911',
+        brokerAddrs: {
+          '0': '10.0.1.1:10911',
+          '1': '10.0.1.2:10911',
+        },
+        writeQueues: 2,
+        readQueues: 2,
+      }),
+    ]);
+
+    expect(diagnostics.status).toBe('warning');
+    expect(diagnostics.issues.filter((item) => item.code === 'WRITE_QUEUE_SKEW')).toHaveLength(1);
+    expect(diagnostics.issues.filter((item) => item.code === 'READ_QUEUE_SKEW')).toHaveLength(1);
+    expect(diagnostics.distributions).toEqual([
+      expect.objectContaining({ brokerName: 'broker-a', status: 'healthy', issues: [] }),
+      expect.objectContaining({ brokerName: 'broker-b', status: 'healthy', issues: [] }),
+    ]);
+  });
+
   it('infers read and write permissions from legacy route payloads', () => {
     const diagnostics = analyzeTopicRoutes([
       route({

--- a/web/src/utils/topicRouteDiagnostics.ts
+++ b/web/src/utils/topicRouteDiagnostics.ts
@@ -208,8 +208,6 @@ const collectAddressDuplicates = (routes: BrokerRoute[]): Set<string> => {
 
 const distributionIssues = (
   route: BrokerRoute,
-  writeSkew: RouteQueueSkew,
-  readSkew: RouteQueueSkew,
   duplicateAddresses: Set<string>,
 ): RouteDiagnosticIssue[] => {
   const brokerName = route.brokerName || 'unknown';
@@ -300,30 +298,6 @@ const distributionIssues = (
         'warning',
         '读写队列不一致',
         '该 Broker 的读队列数和写队列数不同，扩缩容或迁移后需要确认配置是否符合预期。',
-        brokerName,
-      ),
-    );
-  }
-
-  if (hasSkew(writeSkew)) {
-    issues.push(
-      issue(
-        'WRITE_QUEUE_SKEW',
-        'warning',
-        '写队列分布不均',
-        '不同 Broker 的写队列数差距较大，生产流量可能无法均匀分摊。',
-        brokerName,
-      ),
-    );
-  }
-
-  if (hasSkew(readSkew)) {
-    issues.push(
-      issue(
-        'READ_QUEUE_SKEW',
-        'warning',
-        '读队列分布不均',
-        '不同 Broker 的读队列数差距较大，消费者负载可能无法均匀分摊。',
         brokerName,
       ),
     );
@@ -421,7 +395,7 @@ export const analyzeTopicRoutes = (routes: BrokerRoute[]): TopicRouteDiagnostics
 
   const distributions = routes.map<RouteDistribution>((route, index) => {
     const brokerIds = routeBrokerIds(route);
-    const routeIssues = distributionIssues(route, writeSkew, readSkew, duplicateAddresses);
+    const routeIssues = distributionIssues(route, duplicateAddresses);
 
     return {
       key: `${route.brokerName || 'broker'}-${index}`,
@@ -444,6 +418,26 @@ export const analyzeTopicRoutes = (routes: BrokerRoute[]): TopicRouteDiagnostics
   });
 
   const issues = distributions.flatMap((distribution) => distribution.issues);
+  if (hasSkew(writeSkew)) {
+    issues.push(
+      issue(
+        'WRITE_QUEUE_SKEW',
+        'warning',
+        '写队列分布不均',
+        '不同 Broker 的写队列数差距较大，生产流量可能无法均匀分摊。',
+      ),
+    );
+  }
+  if (hasSkew(readSkew)) {
+    issues.push(
+      issue(
+        'READ_QUEUE_SKEW',
+        'warning',
+        '读队列分布不均',
+        '不同 Broker 的读队列数差距较大，消费者负载可能无法均匀分摊。',
+      ),
+    );
+  }
   const writableBrokerCount = distributions.filter(
     (distribution) => distribution.writable && distribution.writeQueues > 0,
   ).length;


### PR DESCRIPTION
Closes #2950

Problem

Queue skew is calculated for the whole topic route but was attached to every broker distribution. This duplicated one incident N times and marked healthy broker rows as warning sources.

Change

Keep broker-specific issues on distributions and emit write/read skew once at topic scope.

Local verification

- Vitest topicRouteDiagnostics test: 5 passed
- pnpm build: passed
- Scope check: 2 files, 73 changed lines