### PR TITLE
[ISSUE #2952] Correlate resolved legacy alert incidents

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationSuppressionService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationSuppressionService.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -54,7 +55,8 @@ public class AlertNotificationSuppressionService {
                 if (!AlertCorrelationScope.matches(event, candidate)) {
                     continue;
                 }
-                String incident = candidate.getFingerprint() == null ? String.valueOf(candidate.getId())
+                String incident = candidate.getFingerprint() == null
+                        ? legacyIncidentKey(candidate)
                         : candidate.getFingerprint();
                 latestByIncident.merge(incident, candidate, (left, right) -> later(left, right) ? left : right);
             }
@@ -67,6 +69,18 @@ public class AlertNotificationSuppressionService {
         return latestByIncident.values().stream()
                 .filter(candidate -> "FIRING".equalsIgnoreCase(candidate.getTransition()))
                 .max(Comparator.comparing(SystemAlertVO::getTime, Comparator.nullsLast(Comparator.naturalOrder())));
+    }
+
+    private static String legacyIncidentKey(SystemAlertVO alert) {
+        Map<String, String> identityLabels = new LinkedHashMap<>();
+        if (alert.getLabels() != null) {
+            identityLabels.putAll(alert.getLabels());
+        }
+        long ruleId = alert.getRuleId() == null ? 0L : alert.getRuleId();
+        if (alert.getRuleId() == null && alert.getTitle() != null) {
+            identityLabels.put("__legacy_title", alert.getTitle());
+        }
+        return "legacy:" + AlertFingerprint.of(ruleId, alert.getInstanceId(), identityLabels);
     }
 
     private static boolean later(SystemAlertVO left, SystemAlertVO right) {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationSuppressionServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationSuppressionServiceTest.java
@@ -79,6 +79,23 @@ class AlertNotificationSuppressionServiceTest {
     }
 
     @Test
+    void doesNotSuppressAfterALegacyIncidentWithoutFingerprintsHasResolvedTest() {
+        AlertRepository repository = mock(AlertRepository.class);
+        LocalDateTime now = LocalDateTime.now();
+        SystemAlertVO firing = event(1L, AlertDomain.CLUSTER, "FIRING", "broker-1", now.minusMinutes(3));
+        firing.setTitle("Broker unavailable");
+        firing.setRuleId(7L);
+        SystemAlertVO resolved = event(2L, AlertDomain.CLUSTER, "RESOLVED", "broker-1", now.minusMinutes(1));
+        resolved.setTitle("Broker unavailable");
+        resolved.setRuleId(7L);
+        when(repository.findAlertsPage(any())).thenReturn(PageResult.of(List.of(firing, resolved), 2, 1, 100));
+
+        assertThat(new AlertNotificationSuppressionService(repository)
+                .findSuppressingClusterAlert(event(3L, AlertDomain.BUSINESS, "FIRING", "broker-1", now)))
+                .isEmpty();
+    }
+
+    @Test
     void doesNotSuppressAcrossDifferentBrokerScopesTest() {
         AlertRepository repository = mock(AlertRepository.class);
         LocalDateTime now = LocalDateTime.now();


### PR DESCRIPTION
Closes #2952

Problem

Rows created before alert fingerprints were populated use different database ids for FIRING and RESOLVED transitions. The suppression service therefore keeps the old FIRING transition active after the same legacy incident resolves.

Change

Use a stable legacy incident identity derived from rule id, instance, and resource labels when fingerprint is absent. Fingerprinted alerts keep the existing behavior.

Local verification

- Maven AlertNotificationSuppressionServiceTest: 6 passed
- Checkstyle: 0 violations
- Java 21 compile: passed
- Scope check: 2 files, 33 changed lines