### PR TITLE
[ISSUE #2953] Isolate audit persistence failures

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/audit/OperationAuditService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/audit/OperationAuditService.java
@@ -48,7 +48,14 @@ public class OperationAuditService {
         LocalDateTime now = LocalDateTime.now();
         audit.setGmtCreate(now);
         audit.setGmtModified(now);
-        auditMapper.insert(audit);
-        log.debug("Audit recorded: {} {} {}", operation, resourceType, resourceName);
+        try {
+            auditMapper.insert(audit);
+            log.debug("Audit recorded: {} {} {}", operation, resourceType, resourceName);
+        } catch (RuntimeException auditFailure) {
+            // Audit is observational. A failed sink must not turn an operation that already
+            // completed at a broker or provider into an API failure that callers may retry.
+            log.warn("Failed to record audit operation={} resourceType={} resource={}: {}",
+                    operation, resourceType, resourceName, auditFailure.getMessage());
+        }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/audit/OperationAuditServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/audit/OperationAuditServiceTest.java
@@ -28,6 +28,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -65,5 +67,16 @@ class OperationAuditServiceTest {
         verify(auditMapper).insert(captor.capture());
         assertThat(captor.getValue().getOperator())
                 .isEqualTo(AuthenticatedUserContext.SYSTEM_ACTOR);
+    }
+
+    @Test
+    void recordShouldNotPropagateAuditPersistenceFailures() {
+        OperationAuditService service = new OperationAuditService(auditMapper);
+        doThrow(new IllegalStateException("audit database unavailable"))
+                .when(auditMapper).insert(org.mockito.ArgumentMatchers.any(RmqOperationAudit.class));
+
+        assertThatCode(() -> service.record("DIRECT_CONSUME_MESSAGE", "MESSAGE", "msg-1",
+                "cluster-a", "result=SUCCESS", "SUCCESS", null))
+                .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
Closes #2953

Problem

Some completed broker and notification operations call the common audit sink directly. An audit insert failure can then change a completed business action into an API or worker failure and invite unsafe retries.

Change

Contain mapper failures in the common audit service and retain an actionable warning log. Successful audit inserts are unchanged.

Local verification

- Maven OperationAuditServiceTest: 3 passed
- Checkstyle: 0 violations
- Java 21 compile: passed
- Scope check: 2 files, 24 changed lines