### PR TITLE
fix(broker): keep valid clusters when a registry probe returns null entries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -106,11 +106,21 @@ public class ClusterService {
 
     private List<ClusterVO> probeRegistryEntry(NameserverRegistryVO entry) {
         try {
-            List<ClusterVO> clusters = clusterProvider.discoverClustersAt(entry.getNamesrvAddr());
-            for (ClusterVO cluster : clusters) {
+            List<ClusterVO> discovered = clusterProvider.discoverClustersAt(entry.getNamesrvAddr());
+            if (discovered == null) {
+                return List.of();
+            }
+            List<ClusterVO> clusters = new ArrayList<>(discovered.size());
+            for (ClusterVO cluster : discovered) {
+                // A null element would NPE the rename loop and discard every valid cluster in
+                // this probe response through the catch-all below; skip it instead.
+                if (cluster == null) {
+                    continue;
+                }
                 cluster.setNsClusterName(cluster.getName());
                 cluster.setName(entry.getName());
                 cluster.setEndpoint(entry.getNamesrvAddr());
+                clusters.add(cluster);
             }
             return clusters;
         } catch (Exception e) {

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceRegistryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceRegistryTest.java
@@ -27,6 +27,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -82,6 +83,38 @@ class ClusterServiceRegistryTest {
         assertThat(cluster.getName()).isEqualTo("rocketmq1");
         assertThat(cluster.getNsClusterName()).isEqualTo("DefaultCluster");
         assertThat(cluster.getEndpoint()).isEqualTo("rocketmq1-nameserver:9876");
+    }
+
+    @Test
+    void listRegistryClustersShouldKeepValidClustersWhenDiscoveryReturnsNullElementTest() {
+        when(registryService.list()).thenReturn(List.of(
+                NameserverRegistryVO.builder().id(1L).name("rocketmq1")
+                        .namesrvAddr("rocketmq1-nameserver:9876").build()));
+        ClusterVO valid = ClusterVO.builder().name("DefaultCluster").build();
+        List<ClusterVO> discovered = new ArrayList<>();
+        discovered.add(valid);
+        discovered.add(null);
+        when(clusterProvider.discoverClustersAt("rocketmq1-nameserver:9876"))
+                .thenReturn(discovered);
+
+        List<ClusterVO> result = clusterService.listRegistryClusters();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).isSameAs(valid);
+        assertThat(result.get(0).getName()).isEqualTo("rocketmq1");
+        assertThat(result.get(0).getNsClusterName()).isEqualTo("DefaultCluster");
+        assertThat(result.get(0).getEndpoint()).isEqualTo("rocketmq1-nameserver:9876");
+    }
+
+    @Test
+    void listRegistryClustersShouldTreatNullDiscoveryResultAsEmptyTest() {
+        when(registryService.list()).thenReturn(List.of(
+                NameserverRegistryVO.builder().id(1L).name("rocketmq1")
+                        .namesrvAddr("rocketmq1-nameserver:9876").build()));
+        when(clusterProvider.discoverClustersAt("rocketmq1-nameserver:9876"))
+                .thenReturn(null);
+
+        assertThat(clusterService.listRegistryClusters()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `ClusterService.probeRegistryEntry` renames every cluster returned by
  `ClusterProvider.discoverClustersAt` before aggregating it. A single `null` element in that
  list made the rename loop NPE, and the catch-all degraded the **entire** registry entry to
  empty — discarding every valid cluster the probe had found.
- The method now treats a `null` discovery result as empty and skips `null` elements, keeping
  all valid clusters from the response.

## Why
`ClusterProvider` is an interface; `RealClusterProvider` happens to never emit nulls, but any
other implementation (or a future edit) can return a list with a null hole. Today that one null
element silently wipes out the whole entry from the `/api/clusters/registry` listing instead of
costing a single cluster.

## Testing
- `mvn -Dtest=ClusterServiceRegistryTest,ClusterServiceTest test`: Tests run: 46,
  Failures: 0, Errors: 0, Skipped: 0 (7 + 39).
- New `listRegistryClustersShouldKeepValidClustersWhenDiscoveryReturnsNullElementTest`
  verified to fail on the unfixed code (Tests run: 7, Failures: 1) — the valid cluster is lost
  because the NPE degrades the whole entry.
- New `listRegistryClustersShouldTreatNullDiscoveryResultAsEmptyTest` pins the null-list
  behaviour (already safe via the catch-all, now explicit).
