### PR TITLE
fix(settings): escape LIKE wildcards in data source inventory queries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepository.java
@@ -138,13 +138,23 @@ public class MybatisPlusSettingsRepository implements SettingsRepository {
         String normalizedSearch = search == null || search.isBlank() ? null : search.trim();
         String normalizedType = type == null || type.isBlank() ? null : type.trim();
         QueryWrapper<RmqDataSource> query = new QueryWrapper<RmqDataSource>()
-                .like(normalizedSearch != null, "json", normalizedSearch)
+                .apply(normalizedSearch != null,
+                        "json LIKE CONCAT('%', {0}, '%') ESCAPE '\\'", escapeLikeWildcards(normalizedSearch))
                 .apply(normalizedType != null,
-                        "LOWER(json) LIKE CONCAT('%\"type\":\"', LOWER({0}), '\"%')", normalizedType)
+                        "LOWER(json) LIKE CONCAT('%\"type\":\"', LOWER({0}), '\"%') ESCAPE '\\'",
+                        escapeLikeWildcards(normalizedType))
                 .orderByDesc("gmt_modified", "id");
         Page<RmqDataSource> result = dataSourceMapper.selectPage(new Page<>(page, pageSize), query);
         return PageResult.of(result.getRecords().stream().map(this::toDataSourceVO).toList(),
                 result.getTotal(), page, pageSize);
+    }
+
+    /**
+     * Escapes LIKE wildcards in user input so a search for "a_b" does not match "axb".
+     * The backslash is MySQL's default escape character and is declared explicitly.
+     */
+    private String escapeLikeWildcards(String value) {
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/MybatisPlusSettingsRepositoryTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MybatisPlusSettingsRepositoryTest {
@@ -150,4 +151,23 @@ class MybatisPlusSettingsRepositoryTest {
         assertThat(stored.getJson()).contains("sk-roundtrip-token");
         assertThat(repository.loadGeneralSettings().getApiKey()).isEqualTo("sk-roundtrip-token");
     }
+    @Test
+    void shouldEscapeLikeWildcardsInDataSourceInventoryQueries() {
+        com.baomidou.mybatisplus.extension.plugins.pagination.Page<RmqDataSource> page =
+                new com.baomidou.mybatisplus.extension.plugins.pagination.Page<>(1, 10);
+        page.setRecords(java.util.List.of());
+        page.setTotal(0);
+        when(dataSourceMapper.selectPage(any(), any())).thenReturn(page);
+
+        repository.findDataSources("a_b 100%", "pro_%", 1, 10);
+
+        org.mockito.ArgumentCaptor<com.baomidou.mybatisplus.core.conditions.query.QueryWrapper<RmqDataSource>> wrapperCaptor =
+                org.mockito.ArgumentCaptor.forClass(com.baomidou.mybatisplus.core.conditions.query.QueryWrapper.class);
+        verify(dataSourceMapper).selectPage(any(), wrapperCaptor.capture());
+        String sql = wrapperCaptor.getValue().getSqlSegment();
+        assertThat(sql).contains("ESCAPE");
+        assertThat(wrapperCaptor.getValue().getParamNameValuePairs().values())
+                .contains("a\\_b 100\\%", "pro\\_\\%");
+    }
+
 }


### PR DESCRIPTION
## Summary
`MybatisPlusSettingsRepository.findDataSources` built its inventory filters with
raw LIKE patterns: the search term was wrapped with `%value%` and the type
filter interpolated `LOWER({0})` between the `"type":"` markers. `%` and `_`
in user input therefore acted as SQL wildcards — a search for `a_b` also
matched `axb`, and a type of `%` matched every data source. Both filters now
escape `\`, `%` and `_` in the user-supplied fragment and declare
`ESCAPE '\'` explicitly, so the fixed wildcard fragments around the pattern
keep their meaning while the user fragment stays literal.

## Why
The data source inventory is a settings-screen search box; its input is free
text, not an enum. Without escaping, wildcard characters in the query
over-match the JSON blob and the list shows unrelated rows, which looks like
broken filtering to the user.

## Testing
```
cd server && mvn -Dtest="MybatisPlusSettingsRepositoryTest" test
```
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
New regression test `shouldEscapeLikeWildcardsInDataSourceInventoryQueries`
captures the QueryWrapper built for a search of `a_b 100%` with a type of
`pro_%` and asserts both user fragments reach the statement with their
wildcards escaped and the clause declares an explicit escape character.
