### PR TITLE
fix(provider): report null vendor as missing in the provider registry

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProviderRegistry.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProviderRegistry.java
@@ -55,7 +55,8 @@ public class InstanceProviderRegistry {
     }
 
     public InstanceProvider forVendor(InstanceVendor vendor) {
-        InstanceProvider provider = providers.get(vendor);
+        // EnumMap.get(null) NPEs; report an absent vendor with the same 501 as an unknown one.
+        InstanceProvider provider = vendor == null ? null : providers.get(vendor);
         if (provider == null) {
             throw new BusinessException(501, "No instance provider registered for vendor " + vendor);
         }
@@ -77,7 +78,8 @@ public class InstanceProviderRegistry {
     }
 
     public CloudCatalogProvider catalogFor(InstanceVendor vendor) {
-        CloudCatalogProvider catalog = catalogs.get(vendor);
+        // EnumMap.get(null) NPEs; report an absent vendor with the same 501 as an unknown one.
+        CloudCatalogProvider catalog = vendor == null ? null : catalogs.get(vendor);
         if (catalog == null) {
             throw new BusinessException(501, "No cloud catalog provider registered for vendor " + vendor);
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/InstanceProviderRegistryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/InstanceProviderRegistryTest.java
@@ -130,6 +130,23 @@ class InstanceProviderRegistryTest {
         assertThat(registry.catalogFor(InstanceVendor.ALIYUN)).isSameAs(catalog);
     }
 
+    @Test
+    void forVendorShouldReportNullVendorAsMissingTest() {
+        // EnumMap.get(null) NPEs; a null vendor must surface as 501 like an unknown vendor.
+        assertThatThrownBy(() -> registry.forVendor(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("No instance provider registered for vendor null")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
+    }
+
+    @Test
+    void catalogForShouldReportNullVendorAsMissingTest() {
+        assertThatThrownBy(() -> registry.catalogFor(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("No cloud catalog provider registered for vendor null")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(501));
+    }
+
     private InstanceProvider stubProvider(InstanceVendor vendor) {
         InstanceProvider provider = mock(InstanceProvider.class);
         when(provider.vendor()).thenReturn(vendor);


### PR DESCRIPTION
## Summary
`InstanceProviderRegistry.forVendor` and `catalogFor` looked the vendor up
directly in an `EnumMap`. `EnumMap.get(null)` throws NPE, so a null vendor
crashed with a raw NullPointerException instead of the same 501
"No ... provider registered for vendor" that an unregistered vendor already
produces. Both lookups now map a null vendor onto the existing missing-entry
code path.

## Why
The registry is the single lookup SPI for vendor-scoped providers; current
call sites normalize a null `InstanceVO.vendor` to APACHE first, but the SPI
contract ("unknown vendor -> 501") should hold for null too, so a future
caller passing a raw persisted vendor cannot 500 the request with an NPE.

## Testing
```
cd server && mvn -Dtest="InstanceProviderRegistryTest" test
```
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
New regression tests `forVendorShouldReportNullVendorAsMissingTest` and
`catalogForShouldReportNullVendorAsMissingTest` assert the 501 BusinessException
(message "No ... provider registered for vendor null") instead of an NPE.
