### PR TITLE
fix(broker): tolerate null broker and proxy entries in cluster snapshots

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterService.java
@@ -155,7 +155,8 @@ public class ClusterService {
         if (cluster.getProxies() == null || cluster.getProxies().isEmpty()) {
             return List.of();
         }
-        return List.copyOf(cluster.getProxies());
+        // List.copyOf rejects null elements, so filter them instead of propagating an NPE.
+        return cluster.getProxies().stream().filter(Objects::nonNull).toList();
     }
 
     public void requireProxy(String clusterId, String addr) {
@@ -210,6 +211,7 @@ public class ClusterService {
             enrichWithLiveConfig(cluster, instanceId, attemptedAddresses);
             if (cluster.getBrokers() != null) {
                 cluster.getBrokers().stream()
+                        .filter(Objects::nonNull)
                         .map(BrokerVO::getAddr)
                         .filter(address -> address != null && !address.isEmpty())
                         .forEach(attemptedAddresses::add);
@@ -220,15 +222,17 @@ public class ClusterService {
     private void enrichWithLiveConfig(ClusterVO cluster, String instanceId, Set<String> attemptedAddresses) {
         if (cluster.getBrokers() != null) {
             for (BrokerVO broker : cluster.getBrokers()) {
-                if (broker.getAddr() != null && !broker.getAddr().isEmpty()
-                        && !attemptedAddresses.contains(broker.getAddr())) {
-                    try {
-                        cluster.setConfig(brokerConfigService.getBrokerConfig(broker.getAddr(), instanceId));
-                        return;
-                    } catch (Exception e) {
-                        log.warn("Failed to read live config from broker {}: {}",
-                                broker.getAddr(), e.getMessage());
-                    }
+                // Skip null entries reported by a provider instead of NPE-ing the whole list.
+                if (broker == null || broker.getAddr() == null || broker.getAddr().isEmpty()
+                        || attemptedAddresses.contains(broker.getAddr())) {
+                    continue;
+                }
+                try {
+                    cluster.setConfig(brokerConfigService.getBrokerConfig(broker.getAddr(), instanceId));
+                    return;
+                } catch (Exception e) {
+                    log.warn("Failed to read live config from broker {}: {}",
+                            broker.getAddr(), e.getMessage());
                 }
             }
         }
@@ -250,6 +254,9 @@ public class ClusterService {
         if (cluster.getBrokers() != null && !cluster.getBrokers().isEmpty()) {
             Properties brokerProps = buildBrokerProperties(command);
             for (BrokerVO broker : cluster.getBrokers()) {
+                if (broker == null) {
+                    continue;
+                }
                 String address = broker.getAddr();
                 if (address == null || address.isEmpty()) {
                     continue;
@@ -432,6 +439,7 @@ public class ClusterService {
             return List.of();
         }
         return cluster.getBrokers().stream()
+                .filter(Objects::nonNull)
                 .filter(broker -> broker.getAddr() != null && !broker.getAddr().isBlank())
                 .map(broker -> ClusterConfigPreviewVO.BrokerTargetVO.builder()
                         .name(broker.getName())

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterServiceTest.java
@@ -42,10 +42,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import org.assertj.core.api.ThrowableAssert;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -310,6 +312,71 @@ class ClusterServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Proxy not found: 127.0.0.1:8081")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(404));
+    }
+
+    private ClusterVO clusterWithNullEntries() {
+        List<BrokerVO> brokers = new ArrayList<>();
+        brokers.add(BrokerVO.builder().name("broker-0").addr("10.0.0.1:10911").build());
+        brokers.add(null);
+        List<ProxyVO> proxies = new ArrayList<>();
+        proxies.add(ProxyVO.builder().addr("10.0.0.10:8081").build());
+        proxies.add(null);
+        ClusterVO cluster = ClusterVO.builder()
+                .name("null-entry-cluster")
+                .brokers(brokers)
+                .proxies(proxies)
+                .build();
+        cluster.setId("cluster-ne");
+        return cluster;
+    }
+
+    @Test
+    void listClustersShouldTolerateNullBrokerEntries() {
+        when(clusterProvider.discoverClusters()).thenReturn(List.of(clusterWithNullEntries()));
+        when(brokerConfigService.getBrokerConfig("10.0.0.1:10911", null))
+                .thenReturn(new ClusterConfigVO());
+
+        List<ClusterVO> clusters = clusterService.listClusters();
+
+        assertThat(clusters).hasSize(1);
+        verify(brokerConfigService).getBrokerConfig("10.0.0.1:10911", null);
+    }
+
+    @Test
+    void updateClusterConfigShouldSkipNullBrokerEntries() {
+        when(clusterRepository.findById("cluster-ne")).thenReturn(Optional.of(clusterWithNullEntries()));
+
+        ClusterConfigUpdateResultVO result = clusterService.updateClusterConfig(UpdateConfigDTO.builder()
+                .id("cluster-ne")
+                .maxMessageSize(8388608)
+                .build());
+
+        assertThat(result.getStatus()).isEqualTo(ClusterConfigUpdateResultVO.Status.SUCCESS);
+        verify(brokerConfigService).updateBrokerConfig(
+                eq("10.0.0.1:10911"), eq("cluster-ne"), any(Properties.class));
+    }
+
+    @Test
+    void listProxiesShouldSkipNullProxyEntries() {
+        when(clusterRepository.findById("cluster-ne")).thenReturn(Optional.of(clusterWithNullEntries()));
+
+        List<ProxyVO> proxies = clusterService.listProxies("cluster-ne");
+
+        assertThat(proxies).hasSize(1);
+        assertThat(proxies.get(0).getAddr()).isEqualTo("10.0.0.10:8081");
+    }
+
+    @Test
+    void previewConfigShouldSkipNullBrokerTargets() {
+        when(clusterRepository.findById("cluster-ne")).thenReturn(Optional.of(clusterWithNullEntries()));
+
+        ClusterConfigPreviewVO preview = clusterService.previewClusterConfig(UpdateConfigDTO.builder()
+                .id("cluster-ne")
+                .maxMessageSize(8388608)
+                .build());
+
+        assertThat(preview.getTargetBrokers()).hasSize(1);
+        assertThat(preview.getTargetBrokers().get(0).getAddress()).isEqualTo("10.0.0.1:10911");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- A single `null` element in a cluster snapshot now costs one entry instead of 500-ing the
  request. `ClusterService` skips null broker entries in the live-config enrichment loop and the
  per-broker config update loop, filters them out of `targetBrokers` and the dedup address
  collection, and `listProxies` filters null proxies before building the result
  (`List.copyOf` rejects null elements).

## Why
`ClusterProvider` is an interface: `RealClusterProvider` happens to never emit nulls, but any
other implementation (k8s, mocks, future edits) can leave a null hole in `brokers`/`proxies`.
Today that one null NPEs `listClusters`, `getCluster`, `previewClusterConfig`,
`updateClusterConfig` and `listProxies` alike, because the service layer dereferences every
element.

## Testing
- `mvn -Dtest=ClusterServiceTest,ClusterServiceRegistryTest test`: Tests run: 48,
  Failures: 0, Errors: 0, Skipped: 0 (43 + 5).
- New tests verified to fail on the unfixed code with NullPointer
  (Tests run: 4, Errors: 4):
  `listClustersShouldTolerateNullBrokerEntries`, `updateClusterConfigShouldSkipNullBrokerEntries`,
  `listProxiesShouldSkipNullProxyEntries`, `previewConfigShouldSkipNullBrokerTargets`.
