### PR TITLE
fix(provider): keep default page slicing robust to null lists

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
@@ -59,10 +59,13 @@ public interface InstanceProvider {
     default PageResult<TopicVO> listTopicsPage(String instanceId, String type, String search,
             int page, int pageSize) {
         List<TopicVO> topics = listTopics(instanceId, type, search);
+        if (topics == null) {
+            topics = List.of();
+        }
         int total = topics.size();
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
+        int to = from + (int) Math.min(Math.max(pageSize, 0), total - from);
         return PageResult.of(topics.subList(from, to), total, page, pageSize);
     }
 
@@ -76,10 +79,13 @@ public interface InstanceProvider {
 
     default TopicConsumerPageVO getTopicConsumersPage(String instanceId, String topicName, int page, int pageSize) {
         List<TopicConsumerVO> consumers = getTopicConsumers(instanceId, topicName);
+        if (consumers == null) {
+            consumers = List.of();
+        }
         int total = consumers.size();
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
+        int to = from + (int) Math.min(Math.max(pageSize, 0), total - from);
         return TopicConsumerPageVO.builder()
                 .items(consumers.subList(from, to))
                 .total(total)
@@ -93,10 +99,13 @@ public interface InstanceProvider {
     default PageResult<ConsumerGroupVO> listConsumerGroupsPage(String instanceId, String search,
             int page, int pageSize) {
         List<ConsumerGroupVO> groups = listConsumerGroups(instanceId, search);
+        if (groups == null) {
+            groups = List.of();
+        }
         int total = groups.size();
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, total);
-        int to = from + (int) Math.min(pageSize, total - from);
+        int to = from + (int) Math.min(Math.max(pageSize, 0), total - from);
         return PageResult.of(groups.subList(from, to), total, page, pageSize);
     }
 

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/InstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/InstanceProviderTest.java
@@ -17,7 +17,10 @@
 package org.apache.rocketmq.studio.provider;
 
 import java.util.Arrays;
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerPageVO;
+import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.junit.jupiter.api.Test;
 
@@ -44,4 +47,41 @@ public class InstanceProviderTest {
         assertThat(result.getPage()).isEqualTo(Integer.MAX_VALUE);
         assertThat(result.getPageSize()).isEqualTo(100);
     }
+    @Test
+    public void listTopicsPageShouldTolerateNullTopicListTest() {
+        InstanceProvider provider = mock(InstanceProvider.class);
+        when(provider.listTopics("instance-a", "all", null)).thenReturn(null);
+        when(provider.listTopicsPage("instance-a", "all", null, 1, 10)).thenCallRealMethod();
+
+        PageResult<TopicVO> result = provider.listTopicsPage("instance-a", "all", null, 1, 10);
+
+        assertThat(result.getTotal()).isZero();
+        assertThat(result.getItems()).isEmpty();
+    }
+
+    @Test
+    public void listConsumerGroupsPageShouldTolerateNullGroupListTest() {
+        InstanceProvider provider = mock(InstanceProvider.class);
+        when(provider.listConsumerGroups("instance-a", null)).thenReturn(null);
+        when(provider.listConsumerGroupsPage("instance-a", null, 1, 10)).thenCallRealMethod();
+
+        PageResult<ConsumerGroupVO> result = provider.listConsumerGroupsPage("instance-a", null, 1, 10);
+
+        assertThat(result.getTotal()).isZero();
+        assertThat(result.getItems()).isEmpty();
+    }
+
+    @Test
+    public void getTopicConsumersPageShouldTolerateNonPositivePageSizeTest() {
+        InstanceProvider provider = mock(InstanceProvider.class);
+        when(provider.getTopicConsumers("instance-a", "orders")).thenReturn(Arrays.asList(
+                TopicConsumerVO.builder().group("group-a").build()));
+        when(provider.getTopicConsumersPage("instance-a", "orders", 1, -5)).thenCallRealMethod();
+
+        TopicConsumerPageVO result = provider.getTopicConsumersPage("instance-a", "orders", 1, -5);
+
+        assertThat(result.getItems()).isEmpty();
+        assertThat(result.getTotal()).isEqualTo(1);
+    }
+
 }


### PR DESCRIPTION
## Summary
The in-memory paging default methods on the `InstanceProvider` SPI
(`listTopicsPage`, `getTopicConsumersPage`, `listConsumerGroupsPage`) assumed
their backing list calls return a non-null list and a positive page size:
a null list NPE'd on `size()`, and a non-positive page size produced
`to < from` so `subList(from, to)` threw IndexOutOfBoundsException. The
defaults now null-coalesce the backing list to an empty list and clamp the
page size to zero for the slice bound, matching the clamping
`Pagination.pageOffset` already applies.

## Why
These defaults are the SPI contract every provider inherits; the current
Apache path happens to validate page/pageSize upstream, but any provider or
future caller that does not should get an empty page, not a 500.

## Testing
```
cd server && mvn -Dtest="InstanceProviderTest" test
```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
New regression tests: `listTopicsPageShouldTolerateNullTopicListTest`,
`listConsumerGroupsPageShouldTolerateNullGroupListTest` (null backing lists
yield empty pages instead of NPE) and
`getTopicConsumersPageShouldTolerateNonPositivePageSizeTest` (negative page
size yields an empty slice with the real total instead of IOWBE).
