### PR TITLE
fix(i18n): localize client connection load failure message

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -123,6 +123,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'cluster.diskUsage': { zh: '磁盘使用', en: 'Disk Usage' },
   'cluster.proxyAddr': { zh: 'Proxy 地址', en: 'Proxy Address' },
   'cluster.connections': { zh: '连接数', en: 'Connections' },
+  'cluster.clientsLoadFailed': { zh: '客户端连接加载失败，请稍后重试', en: 'Failed to load client connections, please retry later' },
   'cluster.grpcPort': { zh: 'gRPC 端口', en: 'gRPC Port' },
   'cluster.remotingPort': { zh: 'Remoting 端口', en: 'Remoting Port' },
   'cluster.config': { zh: '配置', en: 'Config' },

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -47,7 +47,7 @@ import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 import { tableScrollX } from '../../utils/table';
 
 const { Text } = Typography;
-const DEFAULT_LOAD_ERROR = '客户端连接加载失败，请稍后重试';
+// Localized fallback injected by the caller via getLoadErrorMessage(error, t('cluster.clientsLoadFailed')).
 
 /* ─── Helpers ─── */
 
@@ -106,7 +106,7 @@ type ApiErrorLike = {
   };
 };
 
-function getLoadErrorMessage(error: unknown): string {
+function getLoadErrorMessage(error: unknown, fallback: string): string {
   const apiError = error as ApiErrorLike;
   const responseMessage = apiError.response?.data?.message;
   if (typeof responseMessage === 'string' && responseMessage.trim()) {
@@ -115,7 +115,7 @@ function getLoadErrorMessage(error: unknown): string {
   if (typeof apiError.message === 'string' && apiError.message.trim()) {
     return apiError.message;
   }
-  return DEFAULT_LOAD_ERROR;
+  return fallback;
 }
 
 /* ═══════════════════════════════════════════
@@ -182,7 +182,7 @@ const ClientsPage = () => {
         setRegistryClusters([]);
         setSelectedEndpoint(undefined);
         setConnections([]);
-        setLoadError(getLoadErrorMessage(error));
+        setLoadError(getLoadErrorMessage(error, t('cluster.clientsLoadFailed')));
       })
       .finally(() => {
         if (registryRequestRef.current === requestId) setLoading(false);
@@ -210,7 +210,7 @@ const ClientsPage = () => {
           setConnections([]);
           setClusterFilter('ALL');
           setSelectedConnection(null);
-          setLoadError(getLoadErrorMessage(error));
+          setLoadError(getLoadErrorMessage(error, t('cluster.clientsLoadFailed')));
         }
       })
       .finally(() => {


### PR DESCRIPTION
## Summary

Localize the last hard-coded string on the clients page (`cluster/clients.tsx`):

- `getLoadErrorMessage` no longer returns a module-level hard-coded Chinese fallback; callers pass `t('cluster.clientsLoadFailed')` instead
- New `cluster.clientsLoadFailed` zh/en key in `translations.ts`

## Why

The clients page was already `useLang()`-wired, but the load-failure toast still fell back to hard-coded Chinese when the API returned no usable message, so the English UI showed Chinese.

## Testing

- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- The zh fallback text is unchanged, so existing page assertions (ClientsPage tests) keep passing
