### PR TITLE
fix(i18n): localize home dashboard load error alert

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -877,6 +877,8 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'RocketMQ Studio — 跨集群 · 跨架构 · 跨云的统一管控平台',
     en: 'RocketMQ Studio — unified control plane across clusters, architectures and clouds',
   },
+  'home.dashboardLoadDesc': { zh: '无法获取集群概览，请检查网络连接后重试。', en: 'Unable to fetch the cluster overview. Please check the network and retry.' },
+  'home.dashboardLoadFailed': { zh: '仪表盘加载失败', en: 'Dashboard failed to load' },
   'home.greeting.night': { zh: '夜深了', en: 'Late night' },
   'home.greeting.morning': { zh: '上午好', en: 'Good morning' },
   'home.greeting.noon': { zh: '中午好', en: 'Good afternoon' },

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -126,11 +126,11 @@ const DashboardPage = () => {
         <Alert
           type="error"
           showIcon
-          message="仪表盘加载失败"
-          description="无法获取集群概览，请检查网络连接后重试。"
+          message={t('home.dashboardLoadFailed')}
+          description={t('home.dashboardLoadDesc')}
           action={
             <Button size="small" onClick={() => void loadDashboard()} loading={loading}>
-              重试
+              {t('common.retry')}
             </Button>
           }
         />


### PR DESCRIPTION
## Summary

Localize the last hard-coded strings on the home dashboard error alert (`home/dashboard.tsx`):

- Alert `message` → `t('home.dashboardLoadFailed')`
- Alert `description` → `t('home.dashboardLoadDesc')`
- Retry button → `t('common.retry')` (key already existed)
- Two new `home.*` zh/en keys added

## Why

The page was already `useLang()`-wired (greetings, mode cards, banner), but the cluster-overview failure alert still rendered hard-coded Chinese in the English UI.

## Testing

- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh fallback text unchanged, so existing `DashboardPage`/`HomePage` tests are unaffected
