### PR TITLE
fix(i18n): localize Ops runtime configuration alert

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1607,6 +1607,8 @@ const translations: Record<string, Record<Lang, string>> = {
   'ops.value': { zh: '值', en: 'Value' },
   'ops.description': { zh: '描述', en: 'Description' },
   'ops.nameServerAddressList': { zh: 'NameServer 地址列表', en: 'NameServer Address List' },
+  'ops.runtimeUnavailable': { zh: '运行时配置不可用', en: 'Runtime configuration unavailable' },
+  'ops.runtimeUnavailableDefault': { zh: '当前集群不支持读取或更新 Ops 配置。', en: 'This cluster does not support reading or updating Ops configuration.' },
   'ops.isUseVIPChannel': { zh: '是否使用 VIP 通道', en: 'Is Use VIP Channel' },
   'ops.useTLS': { zh: '使用 TLS', en: 'Use TLS' },
   'ops.selectNamesrv': { zh: '请选择 NameServer 地址', en: 'Please select a NameServer address' },

--- a/web/src/pages/studio/Ops.tsx
+++ b/web/src/pages/studio/Ops.tsx
@@ -195,8 +195,8 @@ const OpsPage: React.FC = () => {
         <Alert
           type="info"
           showIcon
-          message="运行时配置不可用"
-          description={unavailableReason || '当前集群不支持读取或更新 Ops 配置。'}
+          message={t('ops.runtimeUnavailable')}
+          description={unavailableReason || t('ops.runtimeUnavailableDefault')}
           style={{ marginBottom: 24 }}
         />
       )}


### PR DESCRIPTION
## Summary

Localize the last hard-coded strings on the studio Ops page (`studio/Ops.tsx`):

- Alert `message` → `t('ops.runtimeUnavailable')`
- Alert `description` fallback → `t('ops.runtimeUnavailableDefault')` (keeps `unavailableReason` when the backend provides one)
- Two new `ops.*` zh/en keys added

## Why

The page was already `useLang()`-wired with an `ops.*` key set, but the runtime-configuration-unavailable alert still rendered hard-coded Chinese in the English UI.

## Testing

- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh fallback text unchanged (default render identical)
