### PR TITLE
fix(i18n): localize broker cluster instance selector

### DIFF
--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -518,10 +518,10 @@ const BrokerClusterPage = () => {
         </h2>
         <Space size="middle">
           <Select
-            aria-label="选择实例"
+            aria-label={t('common.selectInstance')}
             value={selectedInstanceId}
             onChange={setSelectedInstanceId}
-            placeholder="选择实例"
+            placeholder={t('common.selectInstance')}
             style={{ minWidth: 180 }}
             options={instances.map((instance) => ({ value: instance.name, label: instance.name }))}
           />


### PR DESCRIPTION
## Summary

Localize the instance selector on the broker cluster page (`studio/BrokerCluster.tsx`):

- `Select aria-label="选择实例"` → `t('common.selectInstance')`
- `Select placeholder="选择实例"` → `t('common.selectInstance')`
- Reuses the existing `common.selectInstance` zh/en key

## Why

The page was already `useLang()`-wired but the instance selector's accessibility label and placeholder were still hard-coded Chinese, so screen readers and the English UI saw Chinese.

## Testing

- `tsc --noEmit` → clean
- `eslint` on the changed file → 0 errors
- zh render unchanged (default)
