### PR TITLE
fix(i18n): localize DLQ page feedback messages

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1815,6 +1815,14 @@ const translations: Record<string, Record<Lang, string>> = {
   },
   'dlq.message': { zh: '死信消息', en: 'DLQ Message' },
   'dlq.consumerGroup': { zh: '消费者组', en: 'Consumer Group' },
+  'dlq.exportDone': { zh: '已导出 {name} 的死信消息（{bytes} 字节）', en: 'Exported DLQ messages for {name} ({bytes} bytes)' },
+  'dlq.exportFailed': { zh: '导出死信消息失败，请稍后重试', en: 'Failed to export DLQ messages, please retry later' },
+  'dlq.inputTargetTopic': { zh: '请输入目标 Topic', en: 'Enter the target topic first' },
+  'dlq.redeliverDone': { zh: '重发完成：成功 {resent} 条', en: 'Redelivery complete: {resent} resent' },
+  'dlq.redeliverFailed': { zh: '重发失败：成功 {resent}，失败 {failed}', en: 'Redelivery failed: {resent} resent, {failed} failed' },
+  'dlq.redeliverPartial': { zh: '重发部分完成：成功 {resent}，失败 {failed}', en: 'Redelivery partially complete: {resent} resent, {failed} failed' },
+  'dlq.resendDone': { zh: '重投完成：{group} → {topic}（{count} 条）', en: 'Resend complete: {group} → {topic} ({count} messages)' },
+  'dlq.resendPartial': { zh: '重投部分完成：成功 {resent}，失败 {failed}', en: 'Resend partially complete: {resent} succeeded, {failed} failed' },
 
   // ─── Message Trace ───
   'trace.title': { zh: '消息轨迹', en: 'Message Trace' },

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -241,7 +241,7 @@ const DLQPage = () => {
 
   const handleRetry = async () => {
     if (!retryTargetTopic) {
-      message.warning('请输入目标 Topic');
+      message.warning(t('dlq.inputTargetTopic'));
       return;
     }
     if (!retryGroup || !selectedInstanceId) return;
@@ -267,9 +267,9 @@ const DLQPage = () => {
           `重投扫描不完整：${result.failedQueueCount ?? 0} 个队列无法扫描，已重投 ${result.resent} 条`,
         );
       } else if (result.failed > 0) {
-        message.warning(`重投部分完成：成功 ${result.resent}，失败 ${result.failed}`);
+        message.warning(t('dlq.resendPartial', { resent: result.resent, failed: result.failed }));
       } else {
-        message.success(`重投完成：${groupName} → ${targetTopic}（${result.resent} 条）`);
+        message.success(t('dlq.resendDone', { group: groupName, topic: targetTopic, count: result.resent }));
       }
       setRetryModalOpen(false);
       setRetryGroup(null);
@@ -299,10 +299,10 @@ const DLQPage = () => {
           `导出可能不完整：${meta.failedQueueCount} 个队列无法扫描，导出上限 ${meta.limit} 条`,
         );
       } else {
-        message.success(`已导出 ${group.groupName} 的死信消息（${blob.size} 字节）`);
+        message.success(t('dlq.exportDone', { name: group.groupName, bytes: blob.size }));
       }
     } catch (error) {
-      message.error(getErrorMessage(error, '导出死信消息失败，请稍后重试'));
+      message.error(getErrorMessage(error, t('dlq.exportFailed')));
     }
   };
 
@@ -362,11 +362,11 @@ const DLQPage = () => {
         msgIds,
       });
       if (result.outcome === 'FAILED' && result.failed > 0) {
-        message.error(`重发失败：成功 ${result.resent}，失败 ${result.failed}`);
+        message.error(t('dlq.redeliverFailed', { resent: result.resent, failed: result.failed }));
       } else if (result.resent > 0 && result.failed > 0) {
-        message.warning(`重发部分完成：成功 ${result.resent}，失败 ${result.failed}`);
+        message.warning(t('dlq.redeliverPartial', { resent: result.resent, failed: result.failed }));
       } else {
-        message.success(`重发完成：成功 ${result.resent} 条`);
+        message.success(t('dlq.redeliverDone', { resent: result.resent }));
       }
       setDetailSelectedMsgIds([]);
       await loadDetailMessages(detailGroup, detailPage, detailPageSize);
@@ -398,7 +398,7 @@ const DLQPage = () => {
         );
       }
     } catch (error) {
-      message.error(getErrorMessage(error, '导出死信消息失败，请稍后重试'));
+      message.error(getErrorMessage(error, t('dlq.exportFailed')));
     }
   };
 


### PR DESCRIPTION
## Summary

Localize the DLQ page's feedback messages (`instance/dlq.tsx`):

- 9 hard-coded `message.success/error/warning` toasts → `t()` calls with new `dlq.*` zh/en keys (target topic validation, resend/redelivery results, export results)
- The two `getErrorMessage(error, '导出死信消息失败…')` export-failure fallbacks now pass `t('dlq.exportFailed')`

## Why

The page was already `useLang()`-wired but every operation toast still rendered hard-coded Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/DLQPage.test.tsx` → 17/17 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh fallback text unchanged
