### PR TITLE
fix(i18n): localize home chat placeholder and tool labels

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1116,6 +1116,10 @@ const translations: Record<string, Record<Lang, string>> = {
   'home.docs': { zh: '文档中心', en: 'Documentation' },
   'home.community': { zh: 'RocketMQ 社区', en: 'RocketMQ Community' },
   'home.brand': { zh: 'RocketMQ Studio 出品', en: 'Powered by RocketMQ Studio' },
+  'home.chatPlaceholder': { zh: '向 RocketMQ Bot 提问，全程加密、安全、可信', en: 'Ask RocketMQ Bot anything — end-to-end encrypted, secure and trusted' },
+  'home.currentVersion': { zh: '当前版本 {time} build({commit})', en: 'Version {time} build({commit})' },
+  'home.promptEnhance': { zh: 'Prompt 增强', en: 'Prompt Enhance' },
+  'home.tools': { zh: '工具', en: 'Tools' },
 
   // ─── AI Page (additional) ───
   'ai.recommended': { zh: '推荐', en: 'Rec.' },

--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -481,7 +481,7 @@ const HomePage = () => {
                   <textarea
                     ref={textareaRef}
                     className="chat-input"
-                    placeholder="向 RocketMQ Bot 提问，全程加密、安全、可信"
+                    placeholder={t('home.chatPlaceholder')}
                     value={inputValue}
                     onChange={(event) => setInputValue(event.target.value)}
                     onKeyDown={handleKeyDown}
@@ -505,7 +505,7 @@ const HomePage = () => {
                         <div className="flex items-center gap-2 overflow-x-auto scrollbar-hide max-w-full py-2">
                           <button className="tool-btn">
                             <SlidersHorizontal size={17} />
-                            <span>工具</span>
+                            <span>{t('home.tools')}</span>
                           </button>
                           <button
                             className="tool-btn"
@@ -526,7 +526,7 @@ const HomePage = () => {
                             }
                           >
                             <Sparkle size={17} weight={promoteOn ? 'fill' : 'regular'} />
-                            <span>Prompt 增强</span>
+                            <span>{t('home.promptEnhance')}</span>
                           </button>
                           <button
                             className="tool-btn"
@@ -591,7 +591,7 @@ const HomePage = () => {
             <span>{t('home.brand')}</span>
             <span style={{ margin: '0 4px' }}>｜</span>
             <span>
-              当前版本 {__BUILD_TIME__} build({__BUILD_COMMIT__})
+              {t('home.currentVersion', { time: __BUILD_TIME__, commit: __BUILD_COMMIT__ })}
             </span>
           </span>
         </footer>


### PR DESCRIPTION
## Summary

Localize the last hard-coded strings on the home chat page (`home/index.tsx`):

- Chat textarea `placeholder` → `t('home.chatPlaceholder')`
- "工具" toolbar button label → `t('home.tools')`
- "Prompt 增强" toolbar button label → `t('home.promptEnhance')`
- "当前版本 {time} build({commit})" footer → `t('home.currentVersion', { time, commit })`
- Four new `home.*` zh/en keys added

## Why

The page already used the `lang`/`t` hooks with a `home.*` key set, but these five UI strings were still hard-coded Chinese (the chat input placeholder, both toolbar labels and the version footer showed Chinese in the English UI).

## Testing

- `vitest run src/pages/home/__tests__/HomePage.test.tsx` → 5/5 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 problems
- zh render unchanged
