### PR TITLE
fix(i18n): localize topic table columns and row actions

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1719,6 +1719,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'topic.operationSuccess': { zh: 'Topic 操作成功', en: 'Topic operation successful' },
   'topic.filterType': { zh: '消息类型', en: 'Message Type' },
   'topic.filterAll': { zh: '全部类型', en: 'All Types' },
+  'topic.deleteContent': { zh: '确定要删除 Topic「{name}」吗？此操作不可撤销。', en: 'Are you sure to delete topic "{name}"? This cannot be undone.' },
 
   // ─── Group / Consumer (detailed) ───
   'group.subtitle': {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -555,11 +555,11 @@ const TopicPage = () => {
       setSendModalOpen(true);
     } else if (key === 'delete') {
       modal.confirm({
-        title: '确认删除',
-        content: `确定要删除 Topic「${topic.name}」吗？此操作不可撤销。`,
-        okText: '删除',
+        title: t('topic.confirmDelete'),
+        content: t('topic.deleteContent', { name: topic.name }),
+        okText: t('topic.delete'),
         okType: 'danger',
-        cancelText: '取消',
+        cancelText: t('common.cancel'),
         onOk: async () => {
           try {
             await deleteTopic(topic.name, selectedInstanceId || undefined);
@@ -594,7 +594,7 @@ const TopicPage = () => {
   // ─── Table columns ────────────────────────────────────────────
   const columns: TableColumnsType<Topic> = [
     {
-      title: 'Topic 名称',
+      title: t('topic.name'),
       dataIndex: 'name',
       key: 'name',
       width: 220,
@@ -606,7 +606,7 @@ const TopicPage = () => {
       ),
     },
     {
-      title: '备注',
+      title: t('topic.remark'),
       dataIndex: 'remark',
       key: 'remark',
       width: 200,
@@ -622,7 +622,7 @@ const TopicPage = () => {
       ),
     },
     {
-      title: '类型',
+      title: t('topic.type'),
       dataIndex: 'type',
       key: 'type',
       width: 100,
@@ -633,13 +633,13 @@ const TopicPage = () => {
       },
     },
     {
-      title: '状态',
+      title: t('topic.status'),
       key: 'status',
       width: 90,
-      render: () => <Tag color="green">服务中</Tag>,
+      render: () => <Tag color="green">{t('topic.serving')}</Tag>,
     },
     {
-      title: '创建时间',
+      title: t('topic.createdAt'),
       dataIndex: 'gmtCreate',
       key: 'gmtCreate',
       width: 170,
@@ -647,7 +647,7 @@ const TopicPage = () => {
       render: (d: string) => <Text type="secondary">{formatDateTime(d)}</Text>,
     },
     {
-      title: '修改时间',
+      title: t('topic.updatedAt'),
       dataIndex: 'gmtModified',
       key: 'gmtModified',
       width: 170,
@@ -655,7 +655,7 @@ const TopicPage = () => {
       render: (d: string) => <Text type="secondary">{formatDateTime(d)}</Text>,
     },
     {
-      title: '操作',
+      title: t('topic.action'),
       key: 'action',
       width: 200,
       render: (_: unknown, record: Topic) => (
@@ -666,7 +666,7 @@ const TopicPage = () => {
             style={{ borderColor: '#1677ff', color: '#1677ff' }}
             onClick={() => handleAction('detail', record)}
           >
-            详情
+            {t('topic.detail')}
           </Button>
           {!isCloudInstance && (
             <Button
@@ -675,7 +675,7 @@ const TopicPage = () => {
               style={{ borderColor: '#52c41a', color: '#52c41a' }}
               onClick={() => handleAction('send', record)}
             >
-              发送
+              {t('topic.send')}
             </Button>
           )}
           <Button
@@ -1158,7 +1158,7 @@ const TopicPage = () => {
     { title: '行号', dataIndex: 'lineNumber', key: 'lineNumber', width: 80 },
     { title: 'Topic 名称', dataIndex: 'name', key: 'name' },
     {
-      title: '状态',
+      title: t('topic.status'),
       dataIndex: 'status',
       key: 'status',
       width: 100,
@@ -1317,9 +1317,9 @@ const TopicPage = () => {
                 Modal.confirm({
                   title: '确认批量删除',
                   content: `确定要删除选中的 ${selectedRowKeys.length} 个 Topic 吗？此操作不可撤销。`,
-                  okText: '删除',
+                  okText: t('topic.delete'),
                   okType: 'danger',
-                  cancelText: '取消',
+                  cancelText: t('common.cancel'),
                   onOk: async () => {
                     try {
                       const names = selectedRowKeys.map(String);
@@ -1806,7 +1806,7 @@ const TopicPage = () => {
                     `${topic.writeQueues ?? '-'} / ${topic.readQueues ?? '-'}`,
                 },
                 {
-                  title: '状态',
+                  title: t('topic.status'),
                   key: 'status',
                   width: 100,
                   render: (_: unknown, topic: Topic) =>
@@ -1817,7 +1817,7 @@ const TopicPage = () => {
                     ),
                 },
                 {
-                  title: '操作',
+                  title: t('topic.action'),
                   key: 'action',
                   width: 90,
                   render: (_: unknown, topic: Topic) => (


### PR DESCRIPTION
## Summary

Localize the topic table display strings (`instance/topic.tsx`) by wiring the page to the existing `topic.*` keys:

- Delete-confirm modal (`确认删除`/content/`删除`/`取消`) → `topic.confirmDelete` / new `topic.deleteContent` / `topic.delete` / `common.cancel`
- Column titles 备注/类型/状态/创建时间/修改时间/操作/Topic 名称 → `topic.remark` / `topic.type` / `topic.status` / `topic.createdAt` / `topic.updatedAt` / `topic.action` / `topic.name` (all keys already existed)
- "服务中" status tag → `topic.serving`; row buttons 详情/发送/删除 → `topic.detail` / `topic.send` / `topic.delete` (keys already existed)
- One new key: `topic.deleteContent`

## Why

The page renders its topic table and row actions entirely in Chinese in the English UI. The `topic.*` keys were defined but never wired to this table region.

## Testing

- `vitest run src/pages/instance/__tests__/TopicPage.test.tsx` → 16/16 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 problems
- zh render unchanged
