### PR TITLE
fix(k8s): consolidate certificate lifecycle integrity

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertService.java
@@ -25,12 +25,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -43,6 +50,16 @@ import java.util.stream.Collectors;
 public class K8sCertService {
 
     private static final int EXPIRING_THRESHOLD_DAYS = 30;
+    private static final byte[] KEY_MATCH_CHALLENGE = "rocketmq-studio-k8s-cert".getBytes();
+    private static final byte[] DER_INTEGER_ZERO = new byte[] {0x02, 0x01, 0x00};
+    private static final byte[] RSA_ALGORITHM_IDENTIFIER = new byte[] {
+        0x30, 0x0d,
+        0x06, 0x09, 0x2a, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xf7, 0x0d, 0x01, 0x01, 0x01,
+        0x05, 0x00
+    };
+    private static final byte[] EC_PUBLIC_KEY_OID = new byte[] {
+        0x06, 0x07, 0x2a, (byte) 0x86, 0x48, (byte) 0xce, 0x3d, 0x02, 0x01
+    };
 
     private final K8sCertRepository k8sCertRepository;
     private final OperationAuditService operationAuditService;
@@ -80,12 +97,16 @@ public class K8sCertService {
         LocalDateTime notAfter = now.plusYears(1);
         String issuer = command.getIssuer();
         List<String> san = command.getSan();
-        if (command.getCertPem() != null && !command.getCertPem().isBlank()) {
-            X509Certificate parsed = parseCertificate(command.getCertPem());
-            notBefore = LocalDateTime.ofInstant(parsed.getNotBefore().toInstant(), ZoneId.systemDefault());
-            notAfter = LocalDateTime.ofInstant(parsed.getNotAfter().toInstant(), ZoneId.systemDefault());
-            issuer = parsed.getIssuerX500Principal().getName();
-            san = extractSubjectAlternativeNames(parsed);
+        String certPem = normalizeOptionalPem(command.getCertPem());
+        String keyPem = normalizeOptionalPem(command.getKeyPem());
+        ParsedCertificate parsed = null;
+        if (certPem != null) {
+            parsed = parseCertificate(certPem, now);
+            notBefore = parsed.notBefore();
+            notAfter = parsed.notAfter();
+            issuer = parsed.issuer();
+            san = parsed.san();
+            validateMtlsKeyIfNeeded(type, parsed.certificate(), keyPem, true);
         }
 
         K8sCertVO cert = K8sCertVO.builder()
@@ -97,8 +118,8 @@ public class K8sCertService {
                 .notAfter(notAfter)
                 .status(CertStatus.valid)
                 .san(san)
-                .certPem(command.getCertPem())
-                .keyPem(command.getKeyPem())
+                .certPem(certPem)
+                .keyPem(keyPem)
                 .build();
         cert.setGmtCreate(now);
         cert.setGmtModified(now);
@@ -136,6 +157,21 @@ public class K8sCertService {
             updated.setSan(command.getSan());
         }
         LocalDateTime now = LocalDateTime.now(clock);
+        String certPem = normalizeOptionalPem(command.getCertPem());
+        String keyPem = normalizeOptionalPem(command.getKeyPem());
+        ParsedCertificate parsed = null;
+        if (certPem != null) {
+            parsed = parseCertificate(certPem, now);
+            applyParsedCertificate(updated, parsed, certPem);
+        }
+        if (keyPem != null) {
+            updated.setKeyPem(keyPem);
+        }
+        if (updated.getType() == CertType.mTLS && (parsed != null || keyPem != null)) {
+            X509Certificate certificate = parsed == null ? parseCertificate(updated.getCertPem(), now).certificate()
+                    : parsed.certificate();
+            validateMtlsKeyIfNeeded(updated.getType(), certificate, updated.getKeyPem(), true);
+        }
         updated.setGmtModified(now);
 
         K8sCertVO saved = k8sCertRepository.save(refreshExpirationState(updated, now));
@@ -151,18 +187,24 @@ public class K8sCertService {
                 .orElseThrow(() -> new BusinessException(404, "Certificate not found: " + command.getId()));
 
         LocalDateTime now = LocalDateTime.now(clock);
-        LocalDateTime notAfter = now.plusYears(1);
+        String certPem = requirePem(command.getCertPem(), "certPem");
+        String keyPem = normalizeOptionalPem(command.getKeyPem());
+        ParsedCertificate parsed = parseCertificate(certPem, now);
+        if (existing.getType() == CertType.mTLS) {
+            validateMtlsKeyIfNeeded(existing.getType(), parsed.certificate(), keyPem, true);
+        }
 
         K8sCertVO renewed = copyOf(existing);
-        renewed.setNotBefore(now);
-        renewed.setNotAfter(notAfter);
-        renewed.setStatus(CertStatus.valid);
-        renewed.setDaysRemaining((int) ChronoUnit.DAYS.between(now, notAfter));
+        applyParsedCertificate(renewed, parsed, certPem);
+        if (keyPem != null) {
+            renewed.setKeyPem(keyPem);
+        }
         renewed.setGmtModified(now);
 
-        K8sCertVO saved = k8sCertRepository.save(renewed);
+        K8sCertVO saved = k8sCertRepository.save(refreshExpirationState(renewed, now));
         auditCertificate("RENEW_K8S_CERTIFICATE", saved);
-        log.info("K8s certificate renewed: {} (id={}), new expiry: {}", saved.getK8sId(), saved.getId(), notAfter);
+        log.info("K8s certificate renewed: {} (id={}), new expiry: {}", saved.getK8sId(), saved.getId(),
+                saved.getNotAfter());
         return saved;
     }
 
@@ -201,6 +243,22 @@ public class K8sCertService {
         String normalized = value.trim();
         if (normalized.isEmpty()) {
             throw new BusinessException(400, "Certificate " + field + " cannot be blank");
+        }
+        return normalized;
+    }
+
+    private String normalizeOptionalPem(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private String requirePem(String value, String field) {
+        String normalized = normalizeOptionalPem(value);
+        if (normalized == null) {
+            throw new BusinessException(400, field + " is required");
         }
         return normalized;
     }
@@ -249,17 +307,229 @@ public class K8sCertService {
                 "k8sId=" + certificate.getK8sId() + ", cluster=" + certificate.getCluster());
     }
 
-    private X509Certificate parseCertificate(String certPem) {
-        String base64 = certPem
-                .replace("-----BEGIN CERTIFICATE-----", "")
-                .replace("-----END CERTIFICATE-----", "")
-                .replaceAll("\\s", "");
+    private ParsedCertificate parseCertificate(String certPem, LocalDateTime now) {
         try {
             CertificateFactory factory = CertificateFactory.getInstance("X.509");
-            return (X509Certificate) factory.generateCertificate(
-                    new ByteArrayInputStream(Base64.getDecoder().decode(base64)));
+            Collection<? extends Certificate> certificates = factory.generateCertificates(
+                    new ByteArrayInputStream(certPem.getBytes(StandardCharsets.US_ASCII)));
+            X509Certificate certificate = certificates.stream()
+                    .filter(X509Certificate.class::isInstance)
+                    .map(X509Certificate.class::cast)
+                    .findFirst()
+                    .orElseThrow(() -> new BusinessException(400,
+                            "Invalid certificate content, expected a PEM encoded X.509 certificate"));
+            LocalDateTime notBefore = LocalDateTime.ofInstant(certificate.getNotBefore().toInstant(),
+                    clock.getZone());
+            LocalDateTime notAfter = LocalDateTime.ofInstant(certificate.getNotAfter().toInstant(),
+                    clock.getZone());
+            if (!notAfter.isAfter(now)) {
+                throw new BusinessException(400, "Certificate is expired");
+            }
+            return new ParsedCertificate(certificate, certificate.getIssuerX500Principal().getName(), notBefore,
+                    notAfter, extractSubjectAlternativeNames(certificate));
+        } catch (BusinessException exception) {
+            throw exception;
         } catch (Exception exception) {
             throw new BusinessException(400, "Invalid certificate content, expected a PEM encoded X.509 certificate");
+        }
+    }
+
+    private void applyParsedCertificate(K8sCertVO target, ParsedCertificate parsed, String certPem) {
+        target.setCertPem(certPem);
+        target.setIssuer(parsed.issuer());
+        target.setNotBefore(parsed.notBefore());
+        target.setNotAfter(parsed.notAfter());
+        target.setSan(parsed.san());
+    }
+
+    private void validateMtlsKeyIfNeeded(CertType type, X509Certificate certificate, String keyPem,
+                                         boolean requireKey) {
+        if (type != CertType.mTLS) {
+            return;
+        }
+        if (keyPem == null || keyPem.isBlank()) {
+            if (requireKey) {
+                throw new BusinessException(400, "keyPem is required for mTLS certificates");
+            }
+            return;
+        }
+        PrivateKey privateKey = parsePrivateKey(keyPem);
+        if (!matchesCertificatePublicKey(certificate, privateKey)) {
+            throw new BusinessException(400, "Private key does not match certificate public key");
+        }
+    }
+
+    private PrivateKey parsePrivateKey(String keyPem) {
+        String type = privateKeyType(keyPem);
+        byte[] keyDer = decodePemBlock(keyPem, type);
+        byte[] pkcs8Der = switch (type) {
+            case "PRIVATE KEY" -> keyDer;
+            case "RSA PRIVATE KEY" -> wrapPkcs1RsaPrivateKey(keyDer);
+            case "EC PRIVATE KEY" -> wrapSec1EcPrivateKey(keyDer);
+            default -> throw new BusinessException(400,
+                    "Invalid private key content, expected a PEM encoded private key");
+        };
+        PKCS8EncodedKeySpec keySpec;
+        try {
+            keySpec = new PKCS8EncodedKeySpec(pkcs8Der);
+        } catch (Exception exception) {
+            throw new BusinessException(400, "Invalid private key content, expected a PEM encoded private key");
+        }
+        for (String algorithm : List.of("RSA", "EC", "DSA")) {
+            try {
+                return KeyFactory.getInstance(algorithm).generatePrivate(keySpec);
+            } catch (GeneralSecurityException ignored) {
+                // Try the next common Kubernetes client key algorithm.
+            }
+        }
+        throw new BusinessException(400, "Invalid private key content, expected a PEM encoded private key");
+    }
+
+    private String privateKeyType(String keyPem) {
+        if (keyPem.contains("-----BEGIN PRIVATE KEY-----")) {
+            return "PRIVATE KEY";
+        }
+        if (keyPem.contains("-----BEGIN RSA PRIVATE KEY-----")) {
+            return "RSA PRIVATE KEY";
+        }
+        if (keyPem.contains("-----BEGIN EC PRIVATE KEY-----")) {
+            return "EC PRIVATE KEY";
+        }
+        throw new BusinessException(400, "Invalid private key content, expected a PEM encoded private key");
+    }
+
+    private byte[] decodePemBlock(String pem, String type) {
+        String base64 = pem
+                .replace("-----BEGIN " + type + "-----", "")
+                .replace("-----END " + type + "-----", "")
+                .replaceAll("\\s", "");
+        try {
+            return Base64.getDecoder().decode(base64);
+        } catch (Exception exception) {
+            throw new BusinessException(400, "Invalid private key content, expected a PEM encoded private key");
+        }
+    }
+
+    private byte[] wrapPkcs1RsaPrivateKey(byte[] pkcs1Key) {
+        return derSequence(DER_INTEGER_ZERO, RSA_ALGORITHM_IDENTIFIER, derOctetString(pkcs1Key));
+    }
+
+    private byte[] wrapSec1EcPrivateKey(byte[] sec1Key) {
+        byte[] namedCurveParameters = extractSec1EcParameters(sec1Key);
+        byte[] algorithmIdentifier = derSequence(EC_PUBLIC_KEY_OID, namedCurveParameters);
+        return derSequence(DER_INTEGER_ZERO, algorithmIdentifier, derOctetString(sec1Key));
+    }
+
+    private byte[] extractSec1EcParameters(byte[] sec1Key) {
+        DerValue sequence = readDerValue(sec1Key, 0);
+        if (sequence.tag() != 0x30 || sequence.nextOffset() != sec1Key.length) {
+            throw new BusinessException(400, "Invalid EC private key content");
+        }
+        int offset = sequence.contentOffset();
+        while (offset < sequence.nextOffset()) {
+            DerValue value = readDerValue(sec1Key, offset);
+            if (value.tag() == 0xa0) {
+                byte[] parameters = value.content();
+                if (parameters.length > 0 && parameters[0] == 0x06) {
+                    return parameters;
+                }
+                throw new BusinessException(400, "Invalid EC private key parameters");
+            }
+            offset = value.nextOffset();
+        }
+        throw new BusinessException(400, "EC private key must include named curve parameters");
+    }
+
+    private DerValue readDerValue(byte[] data, int offset) {
+        if (offset < 0 || offset + 2 > data.length) {
+            throw new BusinessException(400, "Invalid DER content");
+        }
+        int cursor = offset + 1;
+        int lengthByte = data[cursor++] & 0xff;
+        int length;
+        if ((lengthByte & 0x80) == 0) {
+            length = lengthByte;
+        } else {
+            int lengthBytes = lengthByte & 0x7f;
+            if (lengthBytes == 0 || lengthBytes > 4 || cursor + lengthBytes > data.length) {
+                throw new BusinessException(400, "Invalid DER length");
+            }
+            length = 0;
+            for (int i = 0; i < lengthBytes; i++) {
+                length = (length << 8) | (data[cursor++] & 0xff);
+            }
+        }
+        int valueOffset = cursor;
+        int nextOffset = valueOffset + length;
+        if (length < 0 || nextOffset > data.length) {
+            throw new BusinessException(400, "Invalid DER length");
+        }
+        return new DerValue(data[offset] & 0xff, valueOffset, nextOffset, data);
+    }
+
+    private byte[] derSequence(byte[]... values) {
+        return derTagged(0x30, concatenate(values));
+    }
+
+    private byte[] derOctetString(byte[] value) {
+        return derTagged(0x04, value);
+    }
+
+    private byte[] derTagged(int tag, byte[] value) {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        output.write(tag);
+        output.writeBytes(derLength(value.length));
+        output.writeBytes(value);
+        return output.toByteArray();
+    }
+
+    private byte[] derLength(int length) {
+        if (length < 0x80) {
+            return new byte[] {(byte) length};
+        }
+        int lengthBytes = 0;
+        int value = length;
+        while (value > 0) {
+            lengthBytes++;
+            value >>= 8;
+        }
+        byte[] encoded = new byte[lengthBytes + 1];
+        encoded[0] = (byte) (0x80 | lengthBytes);
+        for (int i = lengthBytes; i > 0; i--) {
+            encoded[i] = (byte) (length & 0xff);
+            length >>= 8;
+        }
+        return encoded;
+    }
+
+    private byte[] concatenate(byte[]... values) {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        for (byte[] value : values) {
+            output.writeBytes(value);
+        }
+        return output.toByteArray();
+    }
+
+    private boolean matchesCertificatePublicKey(X509Certificate certificate, PrivateKey privateKey) {
+        String publicKeyAlgorithm = certificate.getPublicKey().getAlgorithm();
+        String signatureAlgorithm = switch (publicKeyAlgorithm) {
+            case "RSA" -> "SHA256withRSA";
+            case "EC" -> "SHA256withECDSA";
+            case "DSA" -> "SHA256withDSA";
+            default -> throw new BusinessException(400,
+                    "Unsupported certificate public key algorithm: " + publicKeyAlgorithm);
+        };
+        try {
+            Signature signature = Signature.getInstance(signatureAlgorithm);
+            signature.initSign(privateKey);
+            signature.update(KEY_MATCH_CHALLENGE);
+            byte[] signed = signature.sign();
+
+            signature.initVerify(certificate.getPublicKey());
+            signature.update(KEY_MATCH_CHALLENGE);
+            return signature.verify(signed);
+        } catch (GeneralSecurityException exception) {
+            return false;
         }
     }
 
@@ -287,6 +557,19 @@ public class K8sCertService {
         } catch (Exception auditFailure) {
             log.warn("Failed to record audit operation={} resource={}: {}", operation, resourceName,
                     auditFailure.getMessage());
+        }
+    }
+
+    private record ParsedCertificate(X509Certificate certificate, String issuer, LocalDateTime notBefore,
+                                     LocalDateTime notAfter, List<String> san) {
+    }
+
+    private record DerValue(int tag, int contentOffset, int nextOffset, byte[] source) {
+
+        private byte[] content() {
+            byte[] value = new byte[nextOffset - contentOffset];
+            System.arraycopy(source, contentOffset, value, 0, value.length);
+            return value;
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepository.java
@@ -66,7 +66,13 @@ public class MybatisPlusK8sCertRepository implements K8sCertRepository {
     @Transactional
     public K8sCertVO save(K8sCertVO cert) {
         RmqK8sCertificate entity = toEntity(cert);
-        if (entity.getId() != null && certMapper.selectById(entity.getId()) != null) {
+        if (entity.getId() != null) {
+            // An id that no longer resolves to a row was removed between the service's read
+            // and this save; re-inserting it would resurrect the deleted certificate.
+            if (certMapper.selectById(entity.getId()) == null) {
+                throw new BusinessException(404,
+                        "Certificate not found, removed concurrently: " + entity.getId());
+            }
             if (certMapper.updateById(entity) == 0) {
                 throw new BusinessException(409,
                         "Certificate update was not applied: " + entity.getId());

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/RenewCertDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/RenewCertDTO.java
@@ -29,4 +29,6 @@ import lombok.NoArgsConstructor;
 public class RenewCertDTO {
     @NotNull(message = "id is required")
     private Long id;
+    private String certPem;
+    private String keyPem;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/UpdateCertDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/k8s/UpdateCertDTO.java
@@ -38,4 +38,6 @@ public class UpdateCertDTO {
     private String type;
     private String issuer;
     private List<String> san;
+    private String certPem;
+    private String keyPem;
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertControllerTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.domain.enums.CertStatus;
 import org.apache.rocketmq.studio.common.domain.enums.CertType;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -32,7 +33,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -240,6 +243,32 @@ class K8sCertControllerTest {
                 .andExpect(jsonPath("$.message").value("id is required"));
 
         verifyNoInteractions(k8sCertService);
+    }
+
+    @Test
+    void renewCertShouldBindReplacementCertificateMaterial() throws Exception {
+        K8sCertVO renewedCert = buildCert(1L, "rocketmq-tls", CertType.TLS, CertStatus.valid);
+        when(k8sCertService.renewCert(any(RenewCertDTO.class))).thenReturn(renewedCert);
+        ArgumentCaptor<RenewCertDTO> captor = ArgumentCaptor.forClass(RenewCertDTO.class);
+
+        mockMvc.perform(post("/api/k8s-certs/renew")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "id": 1,
+                                    "certPem": "-----BEGIN CERTIFICATE-----...",
+                                    "keyPem": "-----BEGIN PRIVATE KEY-----..."
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.id").value(1));
+
+        verify(k8sCertService).renewCert(captor.capture());
+        RenewCertDTO command = captor.getValue();
+        assertThat(command.getId()).isEqualTo(1L);
+        assertThat(command.getCertPem()).isEqualTo("-----BEGIN CERTIFICATE-----...");
+        assertThat(command.getKeyPem()).isEqualTo("-----BEGIN PRIVATE KEY-----...");
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/K8sCertServiceTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
@@ -401,36 +402,197 @@ class K8sCertServiceTest {
     }
 
     @Test
-    void renewCertShouldRenewCertValidity() {
-        sampleCert.setStatus(CertStatus.expired);
-        sampleCert.setDaysRemaining(0);
-        LocalDateTime originalNotBefore = sampleCert.getNotBefore();
-        LocalDateTime originalNotAfter = sampleCert.getNotAfter();
-
+    void renewCertShouldRequireReplacementCertificateMaterial() {
         when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
-        when(k8sCertRepository.save(any(K8sCertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         RenewCertDTO command = RenewCertDTO.builder().id(1L).build();
 
-        K8sCertVO result = k8sCertService.renewCert(command);
-        LocalDateTime now = LocalDateTime.now(CLOCK);
+        assertThatThrownBy(() -> k8sCertService.renewCert(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("certPem is required")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+        verify(k8sCertRepository, never()).save(any(K8sCertVO.class));
+    }
 
+    @Test
+    void renewCertShouldReplaceStoredMaterialWithParsedCertificate() {
+        sampleCert.setType(CertType.mTLS);
+        sampleCert.setStatus(CertStatus.expired);
+        sampleCert.setCertPem("old-cert-pem");
+        sampleCert.setKeyPem("old-key-pem");
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.save(any(K8sCertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        RenewCertDTO command = RenewCertDTO.builder()
+                .id(1L)
+                .certPem(VALID_RENEWED_CERT_PEM)
+                .keyPem(VALID_RENEWED_KEY_PEM)
+                .build();
+
+        K8sCertVO result = k8sCertService.renewCert(command);
+
+        assertThat(result.getCertPem()).isEqualTo(VALID_RENEWED_CERT_PEM.trim());
+        assertThat(result.getKeyPem()).isEqualTo(VALID_RENEWED_KEY_PEM.trim());
+        assertThat(result.getIssuer()).isEqualTo("O=RocketMQ Studio,CN=renewed.example.com");
+        assertThat(result.getSan()).containsExactly("renewed.example.com", "broker.renewed.example.com");
+        assertThat(result.getNotBefore()).isEqualTo(LocalDateTime.of(2026, 8, 28, 12, 31, 21));
+        assertThat(result.getNotAfter()).isEqualTo(LocalDateTime.of(2028, 11, 5, 12, 31, 21));
         assertThat(result.getStatus()).isEqualTo(CertStatus.valid);
-        assertThat(result.getDaysRemaining()).isEqualTo(365);
-        assertThat(result.getNotBefore()).isEqualTo(now);
-        assertThat(result.getNotAfter()).isEqualTo(now.plusYears(1));
-        assertThat(result.getGmtModified()).isEqualTo(now);
-        assertThat(result.getId()).isEqualTo(1L);
-        assertThat(result.getGmtCreate()).isEqualTo(sampleCert.getGmtCreate());
-        assertThat(result).isNotSameAs(sampleCert);
-        assertThat(sampleCert.getStatus()).isEqualTo(CertStatus.expired);
-        assertThat(sampleCert.getDaysRemaining()).isZero();
-        assertThat(sampleCert.getNotBefore()).isEqualTo(originalNotBefore);
-        assertThat(sampleCert.getNotAfter()).isEqualTo(originalNotAfter);
-        verify(k8sCertRepository).save(any(K8sCertVO.class));
-        verify(operationAuditService).record(eq("RENEW_K8S_CERTIFICATE"), eq("K8S_CERTIFICATE"),
-                eq("1"), eq(null), eq("k8sId=rocketmq-tls, cluster=prod-cluster"),
-                eq("SUCCESS"), eq(null));
+        assertThat(result.getGmtModified()).isEqualTo(LocalDateTime.now(CLOCK));
+    }
+
+    @Test
+    void renewCertShouldDerivePemValidityInTheClockZone() {
+        ZoneId clockZone = ZoneId.systemDefault().equals(ZoneOffset.UTC)
+                ? ZoneId.of("Pacific/Kiritimati")
+                : ZoneOffset.UTC;
+        Clock zoneClock = Clock.fixed(Instant.parse("2026-09-01T00:00:00Z"), clockZone);
+        K8sCertService zoneService = new K8sCertService(k8sCertRepository, operationAuditService, zoneClock);
+        sampleCert.setType(CertType.TLS);
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.save(any(K8sCertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        K8sCertVO result = zoneService.renewCert(RenewCertDTO.builder()
+                .id(1L)
+                .certPem(VALID_RENEWED_CERT_PEM)
+                .build());
+
+        assertThat(result.getNotBefore())
+                .isEqualTo(LocalDateTime.ofInstant(Instant.parse("2026-08-28T12:31:21Z"), clockZone));
+        assertThat(result.getNotAfter())
+                .isEqualTo(LocalDateTime.ofInstant(Instant.parse("2028-11-05T12:31:21Z"), clockZone));
+        assertThat(result.getNotAfter())
+                .isNotEqualTo(LocalDateTime.ofInstant(Instant.parse("2028-11-05T12:31:21Z"), ZoneId.systemDefault()));
+    }
+
+    @Test
+    void renewCertShouldPreserveCertificateChainAndUseLeafForMetadataAndKeyMatch() {
+        sampleCert.setType(CertType.mTLS);
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.save(any(K8sCertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        String certificateChain = VALID_RENEWED_CERT_PEM + "\n" + RSA_TRADITIONAL_CERT_PEM;
+
+        RenewCertDTO command = RenewCertDTO.builder()
+                .id(1L)
+                .certPem(certificateChain)
+                .keyPem(VALID_RENEWED_KEY_PEM)
+                .build();
+
+        K8sCertVO result = k8sCertService.renewCert(command);
+
+        assertThat(result.getCertPem()).isEqualTo(certificateChain.trim());
+        assertThat(result.getIssuer()).isEqualTo("O=RocketMQ Studio,CN=renewed.example.com");
+        assertThat(result.getSan()).containsExactly("renewed.example.com", "broker.renewed.example.com");
+    }
+
+    @Test
+    void renewCertShouldAcceptTraditionalRsaPrivateKeyPem() {
+        sampleCert.setType(CertType.mTLS);
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.save(any(K8sCertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        RenewCertDTO command = RenewCertDTO.builder()
+                .id(1L)
+                .certPem(RSA_TRADITIONAL_CERT_PEM)
+                .keyPem(RSA_PKCS1_PRIVATE_KEY_PEM)
+                .build();
+
+        K8sCertVO result = k8sCertService.renewCert(command);
+
+        assertThat(result.getKeyPem()).startsWith("-----BEGIN RSA PRIVATE KEY-----");
+        assertThat(result.getIssuer()).isEqualTo("O=RocketMQ Studio,CN=rsa-traditional.example.com");
+        assertThat(result.getSan()).containsExactly("rsa-traditional.example.com");
+    }
+
+    @Test
+    void renewCertShouldRejectTraditionalRsaPrivateKeyWhenItDoesNotMatch() {
+        sampleCert.setType(CertType.mTLS);
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
+
+        RenewCertDTO command = RenewCertDTO.builder()
+                .id(1L)
+                .certPem(RSA_TRADITIONAL_CERT_PEM)
+                .keyPem(EC_SEC1_PRIVATE_KEY_PEM)
+                .build();
+
+        assertThatThrownBy(() -> k8sCertService.renewCert(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Private key does not match certificate public key")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+        verify(k8sCertRepository, never()).save(any(K8sCertVO.class));
+    }
+
+    @Test
+    void renewCertShouldAcceptTraditionalEcPrivateKeyPem() {
+        sampleCert.setType(CertType.mTLS);
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
+        when(k8sCertRepository.save(any(K8sCertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        RenewCertDTO command = RenewCertDTO.builder()
+                .id(1L)
+                .certPem(EC_TRADITIONAL_CERT_PEM)
+                .keyPem(EC_SEC1_PRIVATE_KEY_PEM)
+                .build();
+
+        K8sCertVO result = k8sCertService.renewCert(command);
+
+        assertThat(result.getKeyPem()).startsWith("-----BEGIN EC PRIVATE KEY-----");
+        assertThat(result.getIssuer()).isEqualTo("O=RocketMQ Studio,CN=ec-traditional.example.com");
+        assertThat(result.getSan()).containsExactly("ec-traditional.example.com");
+    }
+
+    @Test
+    void renewCertShouldRejectTraditionalEcPrivateKeyWhenItDoesNotMatch() {
+        sampleCert.setType(CertType.mTLS);
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
+
+        RenewCertDTO command = RenewCertDTO.builder()
+                .id(1L)
+                .certPem(EC_TRADITIONAL_CERT_PEM)
+                .keyPem(RSA_PKCS1_PRIVATE_KEY_PEM)
+                .build();
+
+        assertThatThrownBy(() -> k8sCertService.renewCert(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Private key does not match certificate public key")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+        verify(k8sCertRepository, never()).save(any(K8sCertVO.class));
+    }
+
+    @Test
+    void renewCertShouldRejectMtlsCertificateWhenPrivateKeyDoesNotMatch() {
+        sampleCert.setType(CertType.mTLS);
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
+
+        RenewCertDTO command = RenewCertDTO.builder()
+                .id(1L)
+                .certPem(VALID_RENEWED_CERT_PEM)
+                .keyPem(MISMATCHED_KEY_PEM)
+                .build();
+
+        assertThatThrownBy(() -> k8sCertService.renewCert(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Private key does not match certificate public key")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+        verify(k8sCertRepository, never()).save(any(K8sCertVO.class));
+    }
+
+    @Test
+    void renewCertShouldRejectExpiredReplacementCertificate() {
+        k8sCertService = new K8sCertService(k8sCertRepository, operationAuditService,
+                Clock.fixed(Instant.parse("2029-01-01T00:00:00Z"), ZoneOffset.UTC));
+        when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
+
+        RenewCertDTO command = RenewCertDTO.builder()
+                .id(1L)
+                .certPem(VALID_RENEWED_CERT_PEM)
+                .build();
+
+        assertThatThrownBy(() -> k8sCertService.renewCert(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Certificate is expired")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(400));
+        verify(k8sCertRepository, never()).save(any(K8sCertVO.class));
     }
 
     @Test
@@ -443,7 +605,10 @@ class K8sCertServiceTest {
         when(k8sCertRepository.findById(1L)).thenReturn(Optional.of(sampleCert));
         when(k8sCertRepository.save(any(K8sCertVO.class))).thenThrow(new IllegalStateException("save failed"));
 
-        RenewCertDTO command = RenewCertDTO.builder().id(1L).build();
+        RenewCertDTO command = RenewCertDTO.builder()
+                .id(1L)
+                .certPem(VALID_RENEWED_CERT_PEM)
+                .build();
 
         assertThatThrownBy(() -> k8sCertService.renewCert(command))
                 .isInstanceOf(IllegalStateException.class)
@@ -524,4 +689,169 @@ class K8sCertServiceTest {
         cert.setGmtModified(sampleCert.getGmtModified());
         return cert;
     }
+
+    private static final String VALID_RENEWED_CERT_PEM = """
+            -----BEGIN CERTIFICATE-----
+            MIIDjzCCAnegAwIBAgIUVO46kDCJ4FzwSPrFNV+qJNHVSFkwDQYJKoZIhvcNAQEL
+            BQAwODEcMBoGA1UEAwwTcmVuZXdlZC5leGFtcGxlLmNvbTEYMBYGA1UECgwPUm9j
+            a2V0TVEgU3R1ZGlvMB4XDTI2MDgyODEyMzEyMVoXDTI4MTEwNTEyMzEyMVowODEc
+            MBoGA1UEAwwTcmVuZXdlZC5leGFtcGxlLmNvbTEYMBYGA1UECgwPUm9ja2V0TVEg
+            U3R1ZGlvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyCGzZweLcqx
+            jIZ0YEgGqJj9l/UyU9sTc84aLiZKN1nklQc00DW8J3wYafowIMwPnGsh8YJDDE4f
+            BytQDcUN/e+WHmZ+7M/Qp3ZK8+nO7X/WIPQBi5DrWAdtfrLMEuqqijZE90SH4/2Y
+            PmRO+F4g3fdmYM+myXPkYYpzGtuiPK2nwHBk+TnAj5QvVG1NSYmDahChhSdn+Nna
+            JuDpe4XbNGclFeIuBnU9iH9hcMHg3gVjoIId1iXxPxQatw2YXJzEEERW9Zde5OmQ
+            8hR+Iww/e7mWho7RNO5aYjlOJo2Lc4T0AhgcpCceoE0OMehcZIDkj4TcC1Ed0dnn
+            Sp8AhVPQowIDAQABo4GQMIGNMB0GA1UdDgQWBBQ84QhlHL9kov7YFxoy+9Jj4+vC
+            mDAfBgNVHSMEGDAWgBQ84QhlHL9kov7YFxoy+9Jj4+vCmDAPBgNVHRMBAf8EBTAD
+            AQH/MDoGA1UdEQQzMDGCE3JlbmV3ZWQuZXhhbXBsZS5jb22CGmJyb2tlci5yZW5l
+            d2VkLmV4YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQBYfVHNOLBkYo/755un
+            cLdwpbyiteMWo9AE5eqAgN1kx1jysPMkLwbP1jD/T3upUqkdYqxldxC/9SXHtgar
+            zb8rRjSG61KzkDv2eKVR9xVwfBJEj7R79d3Yu72VecQyWHLIx55boXC/yenMYCxK
+            wrYogCjLdmXuMp1L8gnuyxPp5rWAw+62xZZi7x4jrEzIYd74o0vMnRXc/ZHnnVfM
+            E2RfI3coIz+nWQEGLKcR5PV9dVfLWMogb9iHIDI51YI74k3F8PL1QSohsfL4CkxO
+            chctzYBkC9utC5R0bCp2yxlInf7geD3YdiO/nCOPpAXjZVu04tWUF6Jz09htc9AL
+            goXf
+            -----END CERTIFICATE-----
+            """;
+
+    private static final String VALID_RENEWED_KEY_PEM = """
+            -----BEGIN PRIVATE KEY-----
+            MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCnIIbNnB4tyrGM
+            hnRgSAaomP2X9TJT2xNzzhouJko3WeSVBzTQNbwnfBhp+jAgzA+cayHxgkMMTh8H
+            K1ANxQ3975YeZn7sz9Cndkrz6c7tf9Yg9AGLkOtYB21+sswS6qqKNkT3RIfj/Zg+
+            ZE74XiDd92Zgz6bJc+RhinMa26I8rafAcGT5OcCPlC9UbU1JiYNqEKGFJ2f42dom
+            4Ol7hds0ZyUV4i4GdT2If2FwweDeBWOggh3WJfE/FBq3DZhcnMQQRFb1l17k6ZDy
+            FH4jDD97uZaGjtE07lpiOU4mjYtzhPQCGBykJx6gTQ4x6FxkgOSPhNwLUR3R2edK
+            nwCFU9CjAgMBAAECggEAHsLDXQvLmDUTCeDjgacwJo8GOhZk3X9YrLt2ISFmDpsK
+            kg2CAIKrb38NRVBJ1HeKtgkX9co6igTE/D5SHT60TRVwhYbq/K5hYrlIoW1a62bY
+            pDcVI7mYP5saYbQKEL9FhWvotLRV6LZP88flqxw0I3a6Tr5ZngGpOvTPK9XaHh2y
+            Ikz8FgiidKSVj2hotphcnFwGcBM6S7Dkvfrr6cnjnRF0a0OePoYhrWLTwTg0Rq77
+            KJd+w+9Os0LuZ+fwGuzsDAPy2hF5ciYRO4NEjQ2DaT8oj/I+u3LByeHTM1J9DcaO
+            6ZtMNbmDfhRhKUZATPUmPsY3Za9Bd/F1XWpJMrQxXQKBgQDZZ/aeUqJN8u9LK7M6
+            ZNsIzaX2nQp/V6gVAwDBPPW37+BotTEc3kIbKXT+TRhoZLC3udlIMZFjzkuhAcw6
+            OwXf5ZCPD/5mCqH5u4VOUxrn85CmBl/MCH8TcmG/XMiStxOYQ1uz/5vmipyFZXPL
+            RX0KuZwwV003nhy4xEMKdsx2BwKBgQDEy6DJL70+6EKVO07dQKjZvMy+EZmYa3m6
+            NoxXC/uR1CkneVHnYH7wFV2T4GBAhb2ZsLfwBjmOkFwebqaBNGyQIDfijWY3q2Xx
+            Gb/Ws5ksLcVCkSp+95Rb4X41QbS/2nh+8Ifi3/6n59nfC3pxqh71b/y4/aJFZ0JG
+            I0xx5FnJhQKBgHssvvqGoPR+/nrdgIdGGx9KvIwT/52UgWOeNvBE5IbZPpC0j+Xm
+            Oxf+jg2CiqCi48jEYEnZ46Djgc/wH9CiHjrzasrTafRQc+L1DpsI1Ma0JbEbDW2h
+            JrZS6PSt0enmFhD/oNZDrQWaZQHjMA7sCONptAdjfxlS2L0KXV1xX3hDAoGAVJMC
+            fZPzq8ZbXxEG+pUgO7sk7oZX0SZXQQzSUVKIAgsAyMMdzOcuhnVYKwYht3kCm7tT
+            wWabc8ZcoIODMUHbajE+czG7fS8+91fOlzHGITNmdA45CinSa45EFBUx3cXBRSSP
+            8ZO8OGKuwmmHbLPk7Cv9m279PwB6ffQLlWLCp5UCgYAr+qcYU/PoO0mjoTRHDmQt
+            8fnFQ4wGHR1JaM7McaGb1m0YDzWhgZqBVp5/0Am/ihKbQXi4Q3iSQrStuYyn8Lyz
+            1tl2USkDMiI1auXq0FVXwKIQpCS1rs8nv2ynJuQt4qdSm06ecT4NFHO2Q5Tyb/Os
+            hotbBYMZlc54G0w1LZidXA==
+            -----END PRIVATE KEY-----
+            """;
+
+    private static final String MISMATCHED_KEY_PEM = """
+            -----BEGIN PRIVATE KEY-----
+            MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDFva1HBzjxHSOo
+            6YjAREaqKUeQcYCAhkl4zaUg6ZB+z/Sn4dcNB0NGaW4lJU2yvZLalM2h+Ou+qTTq
+            Rw7TbychjmrB1ecEB8tFNJz/PTWSjSgXKpYqxRqKK530U1lqIMY84TnjhZAh5qIq
+            xkTYH/lJKDwVhIUI/qz2tLjRDLJ1LxjZ3p0TM++xUMSUIOPhZvXQo7Gt4qK3oMgo
+            mZQDpGboplFf5LsWoUXwe1eGklsB/8kdK2OpqMnwzagggvj+ZeH/kEjRnibtnfq4
+            rT8Nv9rdxoYYX42kRM0P/FBSTQzR9VrieQpHw+e2a5ngVFmYGLhnhXk6FN1H6uRA
+            ZicQhqtLAgMBAAECggEAIbBinKbM2zthL252N3eKaIQ25pOH1p3KV7QFjZltXkWU
+            w6N07YnOuujMdLSpy6mDowzWCeHsXCPc2Ys4qeoWix+F7bdBMA0Z4xUHKG8nuOum
+            qGe/hNLm5iJvO0iWA8BIteeTYsGHIFd4SnxUD1RHNuENd4cH2VP2aOO6VxdoMhGC
+            xS+xYSQTuYavvbaFAjBjwFqmcPrlZx1B1Nm9ykzlUlrZm7L3bqcjg/lksXmrbTi3
+            e/UWzubCUxuagy91pRBJxOUBvouhIGej0Aa7uNAleIlfQkTJVHv2tT/9Jk8UrvmM
+            2d+wkzEUFK3ur9FhUb2IKeq354Z6Nmmy5bqvEy0GuQKBgQDvVTxKjo3mlp8L8FgE
+            vCMl5yhyG0uy8XTO/ryqUyGahYEiaWVVlsJ5wYTIsayyf9H9P9hb8F4NrZYUfx8Q
+            QUvWvO5XFhhGTAyOE2Z3z5Bziq9MriMtxtgqOkCcqbkY9bopXfvaz5LJxmcOZEWu
+            GfUshhpJWQRH6VMcLVCK/PaukwKBgQDTgvMhNz7UTJwpu7oLNTyFwg80tpzjmWbR
+            k4Yd1natoqmmRDK5F2X24kKmv5Dik1k3gaVegXA3lSawCAP+pUgEm2cQBNZfd31P
+            z2TL6FurrfUCX6dUizuob5LzMix08T05/bf5MNNe2gSsjVrSQsVTsnz+mg9ooOP8
+            gCNzeXxLaQKBgQDrMgQx8K2acWKTRPn6jTitQuEIYbKeg5Ka6NNXPqLDS3d/7btb
+            xPAQ3xAyegiQ0fP2wAtLLof/QRs/wT0xqDlzKe+/PUNVsd6UsJP+Ich/A0cKQAbq
+            MYK03NIqItB3quPrSyT5/wrtp0AXcIrZcUDzJEYo1oXSdYTrJ80DCV0SaQKBgB7t
+            g/20ZVSHy0Hy+FZRN4Nbh/uuRCynrrgweSj9xibHpUTxrfUQrdE27oYRdu8amq4a
+            IAM8rBsEjT6qPWNL6cb6rkxSWMJm54T3D4cdd+IXsr7hG8eqAFQ11GgJSyTibZCA
+            QBmJAS9ac9qDZOdf6hi9/bcA8gXbmNrAJe7psboZAoGAdof3MLPIMpNdYklL6UOM
+            Qs7MrN4EXKcpkGaEkPfJo+QX7s/gZiIakWCx/RrLAH++C7ZdGMhwf+h1YdTSmB/B
+            F+/MG/J91ui7TVL2o9s4WJQRtbL8JJ3dk+VQttaimbTrwh9JExby7wnkpsWEudHD
+            BBRh5yR/XVvk+eAJKLcslzo=
+            -----END PRIVATE KEY-----
+            """;
+
+    private static final String RSA_TRADITIONAL_CERT_PEM = """
+            -----BEGIN CERTIFICATE-----
+            MIIDiTCCAnGgAwIBAgIUEfeFLZXcRpgV9NI41trrXMxBIkIwDQYJKoZIhvcNAQEL
+            BQAwQDEkMCIGA1UEAwwbcnNhLXRyYWRpdGlvbmFsLmV4YW1wbGUuY29tMRgwFgYD
+            VQQKDA9Sb2NrZXRNUSBTdHVkaW8wHhcNMjYwODI5MDgxODUzWhcNMzYwODI2MDgx
+            ODUzWjBAMSQwIgYDVQQDDBtyc2EtdHJhZGl0aW9uYWwuZXhhbXBsZS5jb20xGDAW
+            BgNVBAoMD1JvY2tldE1RIFN0dWRpbzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+            AQoCggEBANJnixy4w6vpLp2GGCAe1do01pTNnToeRS1bG7XnoAIQ/blVnB0Zdukb
+            ++VSXbmMFRTNLVuHbOmYLhgwRoyWY4G7mirVCKTFbe2IsNPaDA6ujRanhfTCBnjg
+            ctcxHZvgR/tYwBwYqCxTpADzsW5K/1Ywo3gHJu2PFg6UKJAX/yIwDtCt3aoWhVgM
+            Z13e/v3ZElngwkMa3QKWezchfCSeGZ5xrP+ykUApJiNE7SqFZemmf4GcB9jcEjqR
+            Wx6zpwt36L8XANV9acdt8h3fa3DuDUuFYNb06jxejU3z4QOH18/lJNLRi8y2oeMu
+            b1myY3FT8Ceqpi0tboPd7M4eKlxJit0CAwEAAaN7MHkwHQYDVR0OBBYEFIC96/U7
+            BPvJRpo3azpHORS2T8H9MB8GA1UdIwQYMBaAFIC96/U7BPvJRpo3azpHORS2T8H9
+            MA8GA1UdEwEB/wQFMAMBAf8wJgYDVR0RBB8wHYIbcnNhLXRyYWRpdGlvbmFsLmV4
+            YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQAN1lELl6d39zn6e71w5Xm7NGq3
+            aZkwGrYNxJedDoU0NOfgdCTA1niP/Dqj3WL1if6t3eIlmqjeoMDfcZ8gIKoj3a86
+            cnw7JJ2WrBpMzl4bKTA/+JQLpOJDa8+pqiZmmwfjUPdkesSBKSAx5A5xjfMBt8OW
+            E1mkvsCb+w4kV7OyhUQx/WY1Fwn+bgGSK5H1l4LnlCh/tTussooOIeRZdEAk7Qvm
+            LXxxqopAdXkpx15VDXv9j/MW3kleBNIemvTiWtWcai/zpLSNtnOrFyADD9T0CZ7g
+            /L3VBPmF2wUE7mpqI/6X6KHAUiHANVSi5mm+goggVdfhVuRg25knQu+pVBGR
+            -----END CERTIFICATE-----
+            """;
+
+    private static final String RSA_PKCS1_PRIVATE_KEY_PEM = """
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIEowIBAAKCAQEA0meLHLjDq+kunYYYIB7V2jTWlM2dOh5FLVsbteegAhD9uVWc
+            HRl26Rv75VJduYwVFM0tW4ds6ZguGDBGjJZjgbuaKtUIpMVt7Yiw09oMDq6NFqeF
+            9MIGeOBy1zEdm+BH+1jAHBioLFOkAPOxbkr/VjCjeAcm7Y8WDpQokBf/IjAO0K3d
+            qhaFWAxnXd7+/dkSWeDCQxrdApZ7NyF8JJ4ZnnGs/7KRQCkmI0TtKoVl6aZ/gZwH
+            2NwSOpFbHrOnC3fovxcA1X1px23yHd9rcO4NS4Vg1vTqPF6NTfPhA4fXz+Uk0tGL
+            zLah4y5vWbJjcVPwJ6qmLS1ug93szh4qXEmK3QIDAQABAoIBAEx8d4WpZPhJfDin
+            Vn3Wt8brDlZpqI5IEr26MQifevtFUfbduDKb3y4+jgN/PbMFyWQWcjajtGP2fkss
+            wXi58tJmcFTBvLKpUpzW4/EfguKTcZaar4eaQOAQN68im7Deh0xHpw6PqBL1FNmD
+            vSxq9wdOBx7K+svBCDOkiFpZXtX+GaPAlRCNwsnLaS+Q5d+w3wW7A25viiKWNoES
+            Y1UV17zc8eiUuQY5Wl60Nl8WfbMX+vJFt2thB1cZI2aJlJdsC38LAdHTq64WwPmX
+            FTvA7q/8tDc7Rv8/ChfQlc8z8DDlFduZQVvcfBE9L2Dybk0eKhEF0abq819zONew
+            OFVPh8ECgYEA60ZKupNtDdGJ7VlfGP23HVEAEV5nMGlQS+ng/vFCvqnr4joC2PLr
+            32Oj3Uy8jkNG7MhBF4vcGP6tRtftKp99lXKdK+sFtru6uHthYyWIUOmlrWaBtXs7
+            9CxLFknEnTBjDeh9F/eTJOQsTIg6mdnNABFxojz9D3bn9PGmjfGFuqMCgYEA5PBm
+            /yS6y7BOscarVm9MF91xswbiLKlufXNTAok41P6dtAS2aGjk5jXuM++G21RNirSI
+            vTn/QbM0FafGXc7UTE1wBcb91GF3O4Wxn49qGAKA7HoVWksgx05q7Gz6bJofKJ3U
+            6jxReskYet17v/gEMh2d6HcEP03g52ktrpT5fH8CgYAyRg7p117SORgz84jymiRq
+            y0gsbfO20Ior7on5cCxG+aBB8wtwuFfWoD//pcoUzCN3rULbeTNK1ADKxpETLolz
+            Sc5z+AB8j5jSmuqwePCr+YFBkEnfMboZ7u0Mki7FN/Wynx8749c5ZthgciuzfGrl
+            vNR/SnD4wPvHx2tDoXxl6QKBgHJM1B9uZxRq4d9AISr2RjdkB/Ap76H8tX1MppUN
+            jaJJvNKzx545QI7vPg4P+HRoko49tEdFPXu/zLFDInaTXMr7noJD51axkqXVCelv
+            4Lg8B8II8cAy4hqfvCJuBllSWVwd8L9BfiyfWel9ytr9KJsczknRof05FKB0kqon
+            FqhhAoGBALH4wBw00eQu3eYEnqjG4cI4YWiO62LIxCDoCKMLJLck9vpY/N91/bjb
+            K6urba62nMqoecyGXX9YWE45SBJgiOcPUMXVDvzBc0GJBqp3l35FdhtItqif2lYT
+            TgFvMFEW74675NsSzF8QnkfjTVgRPDrMCfsd0DwaOPSr5E3CIXXd
+            -----END RSA PRIVATE KEY-----
+            """;
+
+    private static final String EC_TRADITIONAL_CERT_PEM = """
+            -----BEGIN CERTIFICATE-----
+            MIIB+jCCAaCgAwIBAgIUGwZU8YZ6oYdA9lBoAQlTKwXVpaEwCgYIKoZIzj0EAwIw
+            PzEjMCEGA1UEAwwaZWMtdHJhZGl0aW9uYWwuZXhhbXBsZS5jb20xGDAWBgNVBAoM
+            D1JvY2tldE1RIFN0dWRpbzAeFw0yNjA4MjkwODE4NTNaFw0zNjA4MjYwODE4NTNa
+            MD8xIzAhBgNVBAMMGmVjLXRyYWRpdGlvbmFsLmV4YW1wbGUuY29tMRgwFgYDVQQK
+            DA9Sb2NrZXRNUSBTdHVkaW8wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQ0RhZR
+            QBjblcTP6eEFpY8QHKU/FbHM8p9qpBzc+ULPtZhHZLU4vsTYrSTl+wn+fABpyl8g
+            Yf5nXzDlvYBVXZ4fo3oweDAdBgNVHQ4EFgQUrUqh0sGWajbgBKnKsKl+8M0yn7cw
+            HwYDVR0jBBgwFoAUrUqh0sGWajbgBKnKsKl+8M0yn7cwDwYDVR0TAQH/BAUwAwEB
+            /zAlBgNVHREEHjAcghplYy10cmFkaXRpb25hbC5leGFtcGxlLmNvbTAKBggqhkjO
+            PQQDAgNIADBFAiA9avA1agW/RaJxNvEAmsaKCncSML3I4fRsH3wUSxs5AQIhAOJ9
+            GMvIaq7Atb8kXFG8R3+IHIhC5zpRXgeT7jjPK0GY
+            -----END CERTIFICATE-----
+            """;
+
+    private static final String EC_SEC1_PRIVATE_KEY_PEM = """
+            -----BEGIN EC PRIVATE KEY-----
+            MHcCAQEEIPway8YYgYUZsKG4zIzevx72qP6FKj2xEnKY3OiBPrXooAoGCCqGSM49
+            AwEHoUQDQgAENEYWUUAY25XEz+nhBaWPEBylPxWxzPKfaqQc3PlCz7WYR2S1OL7E
+            2K0k5fsJ/nwAacpfIGH+Z18w5b2AVV2eHw==
+            -----END EC PRIVATE KEY-----
+            """;
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/MybatisPlusK8sCertRepositoryTest.java
@@ -24,8 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 class MybatisPlusK8sCertRepositoryTest {
@@ -60,6 +62,21 @@ class MybatisPlusK8sCertRepositoryTest {
                 .hasMessage("Certificate update was not applied: 1")
                 .satisfies(error -> org.assertj.core.api.Assertions.assertThat(
                         ((BusinessException) error).getCode()).isEqualTo(409));
+    }
+
+    @Test
+    void saveShouldReportConcurrentRemovalInsteadOfResurrecting() {
+        RmqK8sCertificateMapper mapper = mock(RmqK8sCertificateMapper.class);
+        when(mapper.selectById(1L)).thenReturn(null);
+        K8sCertVO cert = K8sCertVO.builder().k8sId("broker").build();
+        cert.setId(1L);
+
+        assertThatThrownBy(() -> repository(mapper).save(cert))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Certificate not found, removed concurrently: 1")
+                .satisfies(error -> org.assertj.core.api.Assertions.assertThat(
+                        ((BusinessException) error).getCode()).isEqualTo(404));
+        verify(mapper, never()).insert(any(RmqK8sCertificate.class));
     }
 
     @Test

--- a/web/src/api/cluster.test.ts
+++ b/web/src/api/cluster.test.ts
@@ -91,14 +91,24 @@ describe('K8s certificate API', () => {
     await expect(updateK8sCert({ id: cert.id, issuer: 'vault' })).resolves.toEqual(updated);
   });
 
-  it('renews a certificate using its id', async () => {
+  it('renews a certificate using replacement certificate material', async () => {
     const renewed = { ...cert, daysRemaining: 365, status: 'valid' };
     mock.onPost('/k8s-certs/renew').reply((config) => {
-      expect(JSON.parse(config.data)).toEqual({ id: cert.id });
+      expect(JSON.parse(config.data)).toEqual({
+        id: cert.id,
+        certPem: '-----BEGIN CERTIFICATE-----...',
+        keyPem: '-----BEGIN PRIVATE KEY-----...',
+      });
       return [200, { code: 200, message: 'success', data: renewed }];
     });
 
-    await expect(renewK8sCert(cert.id)).resolves.toEqual(renewed);
+    await expect(
+      renewK8sCert({
+        id: cert.id,
+        certPem: '-----BEGIN CERTIFICATE-----...',
+        keyPem: '-----BEGIN PRIVATE KEY-----...',
+      }),
+    ).resolves.toEqual(renewed);
   });
 
   it('sends the certificate id when deleting', async () => {

--- a/web/src/api/cluster.ts
+++ b/web/src/api/cluster.ts
@@ -178,6 +178,12 @@ export interface K8sCertInfo {
   keyPem?: string;
 }
 
+export interface RenewK8sCertRequest {
+  id: number;
+  certPem: string;
+  keyPem?: string;
+}
+
 export interface NameServerConfigValue {
   address: string;
   configured: boolean;
@@ -357,8 +363,8 @@ export async function updateK8sCert(data: Partial<K8sCertInfo>) {
   return res.data.data;
 }
 
-export async function renewK8sCert(id: number) {
-  const res = await client.post<{ data: K8sCertInfo }>('/k8s-certs/renew', { id });
+export async function renewK8sCert(data: RenewK8sCertRequest) {
+  const res = await client.post<{ data: K8sCertInfo }>('/k8s-certs/renew', data);
   return res.data.data;
 }
 

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1349,8 +1349,11 @@ const translations: Record<string, Record<Lang, string>> = {
   'settings.deepseekOfficial': { zh: 'DeepSeek 官方', en: 'DeepSeek official' },
 
   // ─── Certs ───
+  'cert.title': { zh: 'K8s 证书管理', en: 'K8s Certificate Management' },
   'cert.clusterName': { zh: 'K8s 集群名称', en: 'K8s Cluster Name' },
+  'cert.k8sId': { zh: 'k8s ID', en: 'k8s ID' },
   'cert.certName': { zh: '证书名称', en: 'Certificate Name' },
+  'cert.certType': { zh: '证书类型', en: 'Certificate Type' },
   'cert.issuer': { zh: '签发者', en: 'Issuer' },
   'cert.expiryTime': { zh: '到期时间', en: 'Expiry Time' },
   'cert.daysRemaining': { zh: '剩余天数', en: 'Days Remaining' },
@@ -1364,14 +1367,59 @@ const translations: Record<string, Record<Lang, string>> = {
   },
   'cert.deleted': { zh: '证书已删除: {name}', en: 'Certificate deleted: {name}' },
   'cert.addCert': { zh: '添加证书', en: 'Add Certificate' },
+  'cert.createCert': { zh: '新增证书', en: 'Create Certificate' },
+  'cert.added': { zh: '证书「{name}」已添加', en: 'Certificate "{name}" added' },
   'cert.searchPlaceholder': { zh: '搜索证书名称或集群', en: 'Search cert name or cluster' },
+  'cert.searchK8sPlaceholder': { zh: '搜索 k8s ID 或集群', en: 'Search k8s ID or cluster' },
   'cert.editCert': { zh: '编辑证书 — {name}', en: 'Edit Certificate — {name}' },
+  'cert.renewCert': { zh: '续期证书 — {name}', en: 'Renew Certificate — {name}' },
+  'cert.renew': { zh: '续期', en: 'Renew' },
   'cert.certUpdated': { zh: '证书「{name}」已更新', en: 'Certificate "{name}" updated' },
+  'cert.renewed': { zh: '证书「{name}」已续期', en: 'Certificate "{name}" renewed' },
   'cert.namespace': { zh: '命名空间', en: 'Namespace' },
   'cert.issuerPlaceholder': { zh: '例：kubernetes-ca', en: 'e.g. kubernetes-ca' },
   'cert.namespacePlaceholder': { zh: '例：kube-system', en: 'e.g. kube-system' },
   'cert.featureWip': { zh: '添加证书功能开发中', en: 'Add certificate feature is in development' },
   'cert.totalCount': { zh: '共 {count} 个证书', en: '{count} certificates total' },
+  'cert.localMetadataTitle': {
+    zh: '当前证书记录仅保存为 Studio 本地元数据',
+    en: 'Certificate records are stored as Studio-local metadata',
+  },
+  'cert.localMetadataDescription': {
+    zh: '创建、续期和删除操作会更新 Studio 保存的证书材料与有效期元数据；Kubernetes Provider 接入前，仍需在集群侧单独应用实际证书。',
+    en: 'Create, renew, and delete update certificate material and validity metadata stored in Studio. Apply the actual certificate in Kubernetes separately until the Kubernetes provider is connected.',
+  },
+  'cert.k8sIdRequired': { zh: '请输入 k8s ID', en: 'Please enter k8s ID' },
+  'cert.clusterRequired': { zh: '请输入集群名称', en: 'Please enter cluster name' },
+  'cert.k8sIdPlaceholder': { zh: '例如：kubernetes-daily', en: 'e.g. kubernetes-daily' },
+  'cert.clusterPlaceholder': {
+    zh: '例如：kubernetes（120.26.99.191:6443）',
+    en: 'e.g. kubernetes (120.26.99.191:6443)',
+  },
+  'cert.certPemLabel': { zh: '证书内容（PEM）', en: 'Certificate PEM' },
+  'cert.keyPemLabel': { zh: '私钥内容（PEM）', en: 'Private Key PEM' },
+  'cert.certPemCreateExtra': {
+    zh: '粘贴 PEM 格式证书，签发者、有效期与 SAN 将自动解析；留空时有效期按一年占位',
+    en: 'Paste a PEM certificate to parse issuer, validity, and SAN automatically. If empty, Studio uses a one-year placeholder validity.',
+  },
+  'cert.keyPemExtra': {
+    zh: '仅保存，不会在页面展示或返回',
+    en: 'Stored write-only; never displayed or returned by the page.',
+  },
+  'cert.renewCertPemLabel': { zh: '新证书内容（PEM）', en: 'New Certificate PEM' },
+  'cert.renewKeyPemLabel': { zh: '新私钥内容（PEM）', en: 'New Private Key PEM' },
+  'cert.renewCertPemRequired': {
+    zh: '请粘贴新的 PEM 证书内容',
+    en: 'Please paste the new PEM certificate.',
+  },
+  'cert.renewCertPemExtra': {
+    zh: '服务端会解析真实证书的签发者、有效期与 SAN；过期或无效证书会被拒绝。',
+    en: 'The server parses issuer, validity, and SAN from the real certificate. Expired or invalid certificates are rejected.',
+  },
+  'cert.renewKeyPemExtra': {
+    zh: 'mTLS 证书必须提供匹配私钥；私钥仅写入保存，不会在页面展示或返回。',
+    en: 'mTLS certificates require a matching private key. The key is write-only and is never displayed or returned.',
+  },
 
   // ─── Cluster ───
   'cluster.brokerCount': { zh: 'Broker 数', en: 'Broker Count' },

--- a/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/K8sCertsPage.test.tsx
@@ -20,13 +20,20 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import type { K8sCertInfo } from '../../../api/cluster';
-import { listK8sCerts, createK8sCert, deleteK8sCert } from '../../../services/clusterService';
+import {
+  listK8sCerts,
+  createK8sCert,
+  deleteK8sCert,
+  renewK8sCert,
+} from '../../../services/clusterService';
+import { LangProvider } from '../../../i18n/LangContext';
 import K8sCertsPage from '../certs';
 
 vi.mock('../../../services/clusterService', () => ({
   listK8sCerts: vi.fn(),
   createK8sCert: vi.fn(),
   deleteK8sCert: vi.fn(),
+  renewK8sCert: vi.fn(),
 }));
 
 const certs: K8sCertInfo[] = [
@@ -93,9 +100,11 @@ describe('K8sCertsPage', () => {
 
   const renderPage = () =>
     render(
-      <App>
-        <K8sCertsPage />
-      </App>,
+      <LangProvider>
+        <App>
+          <K8sCertsPage />
+        </App>
+      </LangProvider>,
     );
 
   it('displays certificate metadata without SAN or namespace columns', async () => {
@@ -164,7 +173,8 @@ describe('K8sCertsPage', () => {
       screen.getByPlaceholderText('例如：kubernetes（120.26.99.191:6443）'),
       'kubernetes',
     );
-    await user.click(screen.getByRole('button', { name: /添\s*加/ }));
+    const createButtons = screen.getAllByRole('button', { name: /新\s*增/ });
+    await user.click(createButtons[createButtons.length - 1]);
 
     await waitFor(() =>
       expect(createK8sCert).toHaveBeenCalledWith(
@@ -191,5 +201,35 @@ describe('K8sCertsPage', () => {
 
     await waitFor(() => expect(deleteK8sCert).toHaveBeenCalledWith(1));
     await waitFor(() => expect(screen.queryByText('rocketmq-prod-tls')).not.toBeInTheDocument());
+  });
+
+  it('renews a certificate with replacement PEM material without echoing secrets', async () => {
+    vi.mocked(renewK8sCert).mockResolvedValue({
+      ...certs[0],
+      issuer: 'O=RocketMQ Studio,CN=renewed.example.com',
+      daysRemaining: 730,
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText('rocketmq-prod-tls');
+    await user.click(screen.getAllByRole('button', { name: /续\s*期/ })[0]);
+
+    expect(screen.getByText('续期证书 — rocketmq-prod-tls')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue(/PRIVATE KEY/)).not.toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('新证书内容（PEM）'), '-----BEGIN CERTIFICATE-----...');
+    await user.type(screen.getByLabelText('新私钥内容（PEM）'), '-----BEGIN PRIVATE KEY-----...');
+    const renewButtons = screen.getAllByRole('button', { name: /续\s*期/ });
+    await user.click(renewButtons[renewButtons.length - 1]);
+
+    await waitFor(() =>
+      expect(renewK8sCert).toHaveBeenCalledWith({
+        id: 1,
+        certPem: '-----BEGIN CERTIFICATE-----...',
+        keyPem: '-----BEGIN PRIVATE KEY-----...',
+      }),
+    );
+    expect(await screen.findByText('O=RocketMQ Studio,CN=renewed.example.com')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/cluster/certs.tsx
+++ b/web/src/pages/cluster/certs.tsx
@@ -31,12 +31,18 @@ import {
   Popconfirm,
   message,
 } from 'antd';
-import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import { PlusOutlined, DeleteOutlined, SyncOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import PageHeader from '../../components/PageHeader';
 import InfoBanner from '../../components/InfoBanner';
 import type { K8sCertInfo } from '../../api/cluster';
-import { listK8sCerts, createK8sCert, deleteK8sCert } from '../../services/clusterService';
+import {
+  listK8sCerts,
+  createK8sCert,
+  deleteK8sCert,
+  renewK8sCert,
+} from '../../services/clusterService';
+import { useLang } from '../../i18n/LangContext';
 import { formatDateTime } from '../../utils/format';
 import { tableScrollX } from '../../utils/table';
 
@@ -53,15 +59,24 @@ interface CreateCertFormValues {
   keyPem?: string;
 }
 
+interface RenewCertFormValues {
+  certPem: string;
+  keyPem?: string;
+}
+
 const K8sCertsPage = () => {
+  const { t } = useLang();
   const [certs, setCerts] = useState<K8sCertInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [certSearch, setCertSearch] = useState('');
   const [certTypeFilter, setCertTypeFilter] = useState<string>('');
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [creating, setCreating] = useState(false);
+  const [renewing, setRenewing] = useState(false);
+  const [renewingCert, setRenewingCert] = useState<K8sCertInfo | null>(null);
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [createForm] = Form.useForm<CreateCertFormValues>();
+  const [renewForm] = Form.useForm<RenewCertFormValues>();
 
   useEffect(() => {
     let active = true;
@@ -108,7 +123,7 @@ const K8sCertsPage = () => {
         keyPem: values.keyPem?.trim() || undefined,
       });
       setCerts((previous) => [...previous, created]);
-      message.success(`证书「${created.k8sId}」已添加`);
+      message.success(t('cert.added', { name: created.k8sId }));
       setCreateModalOpen(false);
       createForm.resetFields();
     } catch (error: unknown) {
@@ -123,7 +138,7 @@ const K8sCertsPage = () => {
     try {
       await deleteK8sCert(cert.id);
       setCerts((previous) => previous.filter((item) => item.id !== cert.id));
-      message.success(`证书「${cert.k8sId}」已删除`);
+      message.success(t('cert.deleted', { name: cert.k8sId }));
     } catch (error: unknown) {
       message.error(getErrorMessage(error));
     } finally {
@@ -131,9 +146,44 @@ const K8sCertsPage = () => {
     }
   };
 
+  const openRenewModal = (cert: K8sCertInfo) => {
+    setRenewingCert(cert);
+    renewForm.resetFields();
+  };
+
+  const closeRenewModal = () => {
+    setRenewingCert(null);
+    renewForm.resetFields();
+  };
+
+  const handleRenew = async () => {
+    if (!renewingCert) return;
+    let values: RenewCertFormValues;
+    try {
+      values = await renewForm.validateFields();
+    } catch {
+      return;
+    }
+    setRenewing(true);
+    try {
+      const renewed = await renewK8sCert({
+        id: renewingCert.id,
+        certPem: values.certPem.trim(),
+        keyPem: values.keyPem?.trim() || undefined,
+      });
+      setCerts((previous) => previous.map((item) => (item.id === renewed.id ? renewed : item)));
+      message.success(t('cert.renewed', { name: renewed.k8sId }));
+      closeRenewModal();
+    } catch (error: unknown) {
+      message.error(getErrorMessage(error));
+    } finally {
+      setRenewing(false);
+    }
+  };
+
   const certColumns: ColumnsType<K8sCertInfo> = [
     {
-      title: 'K8s 集群名称',
+      title: t('cert.clusterName'),
       dataIndex: 'cluster',
       key: 'cluster',
       width: 260,
@@ -142,7 +192,7 @@ const K8sCertsPage = () => {
       render: (name: string) => <Text strong>{name}</Text>,
     },
     {
-      title: 'k8s ID',
+      title: t('cert.k8sId'),
       dataIndex: 'k8sId',
       key: 'k8sId',
       width: 240,
@@ -152,7 +202,7 @@ const K8sCertsPage = () => {
       ),
     },
     {
-      title: '类型',
+      title: t('common.type'),
       dataIndex: 'type',
       key: 'type',
       width: 110,
@@ -167,7 +217,7 @@ const K8sCertsPage = () => {
       },
     },
     {
-      title: '签发者',
+      title: t('cert.issuer'),
       dataIndex: 'issuer',
       key: 'issuer',
       width: 180,
@@ -176,7 +226,7 @@ const K8sCertsPage = () => {
       ellipsis: true,
     },
     {
-      title: '到期时间',
+      title: t('cert.expiryTime'),
       dataIndex: 'notAfter',
       key: 'notAfter',
       width: 170,
@@ -188,7 +238,7 @@ const K8sCertsPage = () => {
       ),
     },
     {
-      title: '剩余天数',
+      title: t('cert.daysRemaining'),
       dataIndex: 'daysRemaining',
       key: 'daysRemaining',
       width: 100,
@@ -205,60 +255,73 @@ const K8sCertsPage = () => {
       ),
     },
     {
-      title: '状态',
+      title: t('common.status'),
       dataIndex: 'status',
       key: 'status',
       width: 100,
       sorter: (a, b) => (a.status ?? '').localeCompare(b.status ?? ''),
       render: (status: string | null) => {
         const map: Record<string, { color: string; label: string }> = {
-          valid: { color: 'green', label: '有效' },
-          expiring: { color: 'orange', label: '即将过期' },
-          expired: { color: 'red', label: '已过期' },
+          valid: { color: 'green', label: t('cert.statusValid') },
+          expiring: { color: 'orange', label: t('cert.statusExpiring') },
+          expired: { color: 'red', label: t('cert.statusExpired') },
         };
-        const cfg = status ? map[status] ?? { color: 'default', label: status } : null;
+        const cfg = status ? (map[status] ?? { color: 'default', label: status }) : null;
         return cfg ? <Tag color={cfg.color}>{cfg.label}</Tag> : '-';
       },
     },
     {
-      title: '操作',
+      title: t('common.actions'),
       key: 'action',
-      width: 90,
+      width: 170,
       fixed: 'right',
       render: (_: unknown, cert: K8sCertInfo) => (
-        <Popconfirm
-          title={`确定要删除证书「${cert.k8sId}」吗？`}
-          onConfirm={() => void handleDelete(cert)}
-          okText="删除"
-          cancelText="取消"
-          okButtonProps={{ danger: true }}
-        >
+        <Space size={4}>
           <Button
             type="link"
             size="small"
-            danger
-            icon={<DeleteOutlined />}
-            loading={deletingId === cert.id}
+            icon={<SyncOutlined />}
+            onClick={() => openRenewModal(cert)}
           >
-            删除
+            {t('cert.renew')}
           </Button>
-        </Popconfirm>
+          <Popconfirm
+            title={t('cert.deleteConfirm', { name: cert.k8sId })}
+            onConfirm={() => void handleDelete(cert)}
+            okText={t('common.delete')}
+            cancelText={t('common.cancel')}
+            okButtonProps={{ danger: true }}
+          >
+            <Button
+              type="link"
+              size="small"
+              danger
+              icon={<DeleteOutlined />}
+              loading={deletingId === cert.id}
+            >
+              {t('common.delete')}
+            </Button>
+          </Popconfirm>
+        </Space>
       ),
     },
   ];
 
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader title="K8s 证书管理" subtitle={`共 ${filteredCerts.length} 个证书`} />
+      <PageHeader
+        title={t('cert.title')}
+        subtitle={t('cert.totalCount', { count: filteredCerts.length })}
+      />
       <InfoBanner
         data-testid="k8s-cert-local-metadata-notice"
-        title="当前证书记录仅保存为 Studio 本地元数据"
-        description="创建、续期和删除操作尚不会应用到 Kubernetes 集群或 cert-manager。请在集群侧管理实际证书，直到 Kubernetes Provider 接入完成。"
+        title={t('cert.localMetadataTitle')}
+        description={t('cert.localMetadataDescription')}
       />
       <Flex justify="space-between" style={{ marginBottom: 16 }}>
         <Space>
           <Input.Search
-            placeholder="搜索 k8s ID 或集群"
+            placeholder={t('cert.searchK8sPlaceholder')}
             allowClear
             onSearch={setCertSearch}
             onChange={(e) => !e.target.value && setCertSearch('')}
@@ -269,7 +332,7 @@ const K8sCertsPage = () => {
             onChange={setCertTypeFilter}
             style={{ width: 160 }}
             options={[
-              { value: '', label: '全部' },
+              { value: '', label: t('common.all') },
               { value: 'TLS', label: 'TLS' },
               { value: 'mTLS', label: 'mTLS' },
               { value: 'ServiceAccount', label: 'ServiceAccount' },
@@ -277,7 +340,7 @@ const K8sCertsPage = () => {
           />
         </Space>
         <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
-          新增证书
+          {t('cert.createCert')}
         </Button>
       </Flex>
       <Card styles={{ body: { padding: 0 } }}>
@@ -293,7 +356,7 @@ const K8sCertsPage = () => {
       </Card>
 
       <Modal
-        title="新增证书"
+        title={t('cert.createCert')}
         open={createModalOpen}
         onCancel={() => {
           setCreateModalOpen(false);
@@ -301,27 +364,27 @@ const K8sCertsPage = () => {
         }}
         onOk={() => void handleCreate()}
         confirmLoading={creating}
-        okText="添加"
-        cancelText="取消"
+        okText={t('common.add')}
+        cancelText={t('common.cancel')}
         width={640}
         destroyOnHidden
       >
         <Form form={createForm} layout="vertical" preserve={false}>
           <Form.Item
-            label="k8s ID"
+            label={t('cert.k8sId')}
             name="k8sId"
-            rules={[{ required: true, message: '请输入 k8s ID' }]}
+            rules={[{ required: true, message: t('cert.k8sIdRequired') }]}
           >
-            <Input placeholder="例如：kubernetes-daily" />
+            <Input placeholder={t('cert.k8sIdPlaceholder')} />
           </Form.Item>
           <Form.Item
-            label="K8s 集群名称"
+            label={t('cert.clusterName')}
             name="cluster"
-            rules={[{ required: true, message: '请输入集群名称' }]}
+            rules={[{ required: true, message: t('cert.clusterRequired') }]}
           >
-            <Input placeholder="例如：kubernetes（120.26.99.191:6443）" />
+            <Input placeholder={t('cert.clusterPlaceholder')} />
           </Form.Item>
-          <Form.Item label="类型" name="type" initialValue="TLS">
+          <Form.Item label={t('common.type')} name="type" initialValue="TLS">
             <Select
               virtual={false}
               options={[
@@ -332,9 +395,9 @@ const K8sCertsPage = () => {
             />
           </Form.Item>
           <Form.Item
-            label="证书内容（PEM）"
+            label={t('cert.certPemLabel')}
             name="certPem"
-            extra="粘贴 PEM 格式证书，签发者、有效期与 SAN 将自动解析；留空时有效期按一年占位"
+            extra={t('cert.certPemCreateExtra')}
           >
             <Input.TextArea
               rows={6}
@@ -342,7 +405,45 @@ const K8sCertsPage = () => {
               style={{ fontFamily: 'monospace' }}
             />
           </Form.Item>
-          <Form.Item label="私钥内容（PEM）" name="keyPem" extra="仅保存，不会在页面展示或返回">
+          <Form.Item label={t('cert.keyPemLabel')} name="keyPem" extra={t('cert.keyPemExtra')}>
+            <Input.TextArea
+              rows={6}
+              placeholder="-----BEGIN PRIVATE KEY-----..."
+              style={{ fontFamily: 'monospace' }}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal
+        title={t('cert.renewCert', { name: renewingCert?.k8sId ?? '' })}
+        open={Boolean(renewingCert)}
+        onCancel={closeRenewModal}
+        onOk={() => void handleRenew()}
+        confirmLoading={renewing}
+        okText={t('cert.renew')}
+        cancelText={t('common.cancel')}
+        width={640}
+        destroyOnHidden
+      >
+        <Form form={renewForm} layout="vertical" preserve={false}>
+          <Form.Item
+            label={t('cert.renewCertPemLabel')}
+            name="certPem"
+            rules={[{ required: true, message: t('cert.renewCertPemRequired') }]}
+            extra={t('cert.renewCertPemExtra')}
+          >
+            <Input.TextArea
+              rows={8}
+              placeholder="-----BEGIN CERTIFICATE-----..."
+              style={{ fontFamily: 'monospace' }}
+            />
+          </Form.Item>
+          <Form.Item
+            label={t('cert.renewKeyPemLabel')}
+            name="keyPem"
+            extra={t('cert.renewKeyPemExtra')}
+          >
             <Input.TextArea
               rows={6}
               placeholder="-----BEGIN PRIVATE KEY-----..."

--- a/web/src/services/clusterService.ts
+++ b/web/src/services/clusterService.ts
@@ -8,6 +8,7 @@ import type {
   ClusterInfo,
   ClusterProbeResult,
   K8sCertInfo,
+  RenewK8sCertRequest,
   NameServerConfigDiffResult,
   NameserverRegistryEntry,
 } from '../api/cluster';
@@ -235,14 +236,16 @@ export async function updateK8sCert(data: Partial<K8sCertInfo>): Promise<K8sCert
   return clusterApi.updateK8sCert(data);
 }
 
-export async function renewK8sCert(id: number): Promise<K8sCertInfo> {
+export async function renewK8sCert(data: RenewK8sCertRequest): Promise<K8sCertInfo> {
   if (isMockMode()) {
-    const existing = mockCertStore.find((cert) => cert.id === id);
-    if (!existing) throw new Error(`Certificate not found: ${id}`);
+    const existing = mockCertStore.find((cert) => cert.id === data.id);
+    if (!existing) throw new Error(`Certificate not found: ${data.id}`);
     const now = new Date();
     const notAfter = new Date(now);
     notAfter.setFullYear(notAfter.getFullYear() + 1);
     Object.assign(existing, {
+      certPem: data.certPem,
+      keyPem: data.keyPem ?? existing.keyPem,
       notBefore: now.toISOString(),
       notAfter: notAfter.toISOString(),
       status: 'valid',
@@ -250,7 +253,7 @@ export async function renewK8sCert(id: number): Promise<K8sCertInfo> {
     });
     return { ...existing, san: existing.san ? [...existing.san] : existing.san };
   }
-  return clusterApi.renewK8sCert(id);
+  return clusterApi.renewK8sCert(data);
 }
 
 export async function deleteK8sCert(id: number): Promise<void> {


### PR DESCRIPTION
## Summary

Consolidates the K8s certificate lifecycle fixes from #2689, #2935, and #2943.

This change makes certificate renewal replace the persisted PEM material, derive metadata from the submitted leaf certificate, validate mTLS key pairs, keep private keys write-only in the UI/API flow, prevent stale saves from resurrecting concurrently deleted certificates, and render PEM validity timestamps in the service clock zone.

Replaces #2689
Replaces #2935
Replaces #2943
Closes #2681

## Tests

- JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn -Dtest=K8sCertServiceTest,MybatisPlusK8sCertRepositoryTest,K8sCertControllerTest test
- npm test -- src/api/cluster.test.ts src/pages/cluster/__tests__/K8sCertsPage.test.tsx
- npm run lint
- npm run build
- git diff --check
