### PR TITLE
fix(i18n): localize DLQ tables and row actions

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1815,6 +1815,17 @@ const translations: Record<string, Record<Lang, string>> = {
   },
   'dlq.message': { zh: '死信消息', en: 'DLQ Message' },
   'dlq.consumerGroup': { zh: '消费者组', en: 'Consumer Group' },
+  'dlq.action': { zh: '操作', en: 'Actions' },
+  'dlq.deadCount': { zh: '死信数量', en: 'DLQ Count' },
+  'dlq.enqueueTime': { zh: '入队时间', en: 'Enqueued At' },
+  'dlq.export': { zh: '导出', en: 'Export' },
+  'dlq.groupName': { zh: 'Group 名称', en: 'Group Name' },
+  'dlq.lastEnqueueTime': { zh: '最近入队时间', en: 'Last Enqueued At' },
+  'dlq.resend': { zh: '重发', en: 'Resend' },
+  'dlq.resendMessages': { zh: '重投消息', en: 'Resend Messages' },
+  'dlq.searchPlaceholder': { zh: '搜索 Group 名称或 DLQ Topic', en: 'Search group name or DLQ topic' },
+  'dlq.unavailable': { zh: '不可用', en: 'Unavailable' },
+  'dlq.viewMessages': { zh: '消息明细', en: 'Message Details' },
 
   // ─── Message Trace ───
   'trace.title': { zh: '消息轨迹', en: 'Message Trace' },

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -405,7 +405,7 @@ const DLQPage = () => {
   /* ─── Table Columns ─── */
   const columns: ColumnsType<DLQGroup> = [
     {
-      title: 'Group 名称',
+      title: t('dlq.groupName'),
       dataIndex: 'groupName',
       key: 'groupName',
       width: 200,
@@ -426,7 +426,7 @@ const DLQPage = () => {
       ),
     },
     {
-      title: '死信数量',
+      title: t('dlq.deadCount'),
       dataIndex: 'messageCount',
       key: 'messageCount',
       width: 100,
@@ -447,12 +447,12 @@ const DLQPage = () => {
                     : undefined,
           }}
         >
-          {record.statsAvailable === false ? '不可用' : count.toLocaleString()}
+          {record.statsAvailable === false ? t('dlq.unavailable') : count.toLocaleString()}
         </Text>
       ),
     },
     {
-      title: '最近入队时间',
+      title: t('dlq.lastEnqueueTime'),
       dataIndex: 'lastEnqueueTime',
       key: 'lastEnqueueTime',
       width: 180,
@@ -464,7 +464,7 @@ const DLQPage = () => {
       ),
     },
     {
-      title: '操作',
+      title: t('dlq.action'),
       key: 'actions',
       width: 280,
       render: (_: unknown, record: DLQGroup) => (
@@ -475,7 +475,7 @@ const DLQPage = () => {
             style={{ borderColor: '#1677ff', color: '#1677ff' }}
             onClick={() => openDetailDrawer(record)}
           >
-            消息明细
+            {t('dlq.viewMessages')}
           </Button>
           <Button
             size="small"
@@ -484,7 +484,7 @@ const DLQPage = () => {
             onClick={() => openRetryModal(record)}
             disabled={record.statsAvailable === false || record.messageCount === 0}
           >
-            重投消息
+            {t('dlq.resendMessages')}
           </Button>
           <Button
             size="small"
@@ -493,7 +493,7 @@ const DLQPage = () => {
             onClick={() => handleExport(record)}
             disabled={record.statsAvailable === false || record.messageCount === 0}
           >
-            导出
+            {t('dlq.export')}
           </Button>
         </Flex>
       ),
@@ -529,7 +529,7 @@ const DLQPage = () => {
       render: (offset: number) => <Text style={{ fontFamily: 'monospace' }}>{offset}</Text>,
     },
     {
-      title: '入队时间',
+      title: t('dlq.enqueueTime'),
       dataIndex: 'storeTime',
       key: 'storeTime',
       width: 160,
@@ -558,7 +558,7 @@ const DLQPage = () => {
       ),
     },
     {
-      title: '操作',
+      title: t('dlq.action'),
       key: 'actions',
       width: 100,
       render: (_: unknown, record: DLQMessage) => (
@@ -568,7 +568,7 @@ const DLQPage = () => {
           loading={detailResending}
           onClick={() => void resendSelectedMessages([record.msgId])}
         >
-          重发
+          {t('dlq.resend')}
         </Button>
       ),
     },
@@ -579,7 +579,7 @@ const DLQPage = () => {
      ═══════════════════════════════════════════ */
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader title={t('dlq.title')} subtitle="管理消费失败进入死信队列的消息" />
+      <PageHeader title={t('dlq.title')} subtitle={t('dlq.subtitle')} />
 
       {/* ── Filter Bar ── */}
       <Flex justify="space-between" align="center" style={{ marginBottom: 16 }}>
@@ -591,7 +591,7 @@ const DLQPage = () => {
             style={{ width: 220 }}
           />
           <Input.Search
-            placeholder="搜索 Group 名称或 DLQ Topic"
+            placeholder={t('dlq.searchPlaceholder')}
             allowClear
             value={search}
             onChange={(e) => {


### PR DESCRIPTION
## Summary

Localize the DLQ page tables (`instance/dlq.tsx`):

- Group overview table: 死信数量/最近入队时间/Group 名称/操作 columns, the "不可用" stats fallback, and 消息明细/重投消息/导出 row buttons
- Detail table: 入队时间/操作 columns and the 重发 row button
- Page subtitle and the search placeholder (both previously hard-coded; `dlq.subtitle` key existed but was never wired)

New keys: `dlq.groupName/deadCount/unavailable/lastEnqueueTime/action/viewMessages/resendMessages/export/enqueueTime/resend/searchPlaceholder`; reuses the dormant `dlq.subtitle` key.

## Why

Both tables and their row actions rendered entirely in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/DLQPage.test.tsx` → 17/17 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
