### PR TITLE
fix(i18n): localize message trace table and detail drawer

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1807,6 +1807,17 @@ const translations: Record<string, Record<Lang, string>> = {
   'message.batchResend': { zh: '批量重发', en: 'Batch Resend' },
   'message.batchExport': { zh: '批量导出', en: 'Batch Export' },
   'message.noMatchResult': { zh: '没有查到符合条件的结果', en: 'No matching results' },
+  'message.consumeTime': { zh: '消费时间', en: 'Consume Time' },
+  'message.consumerGroup': { zh: '消费者组', en: 'Consumer Group' },
+  'message.deliveryStatus': { zh: '投递状态', en: 'Delivery Status' },
+  'message.download': { zh: '下载', en: 'Download' },
+  'message.messageBody': { zh: '消息体', en: 'Message Body' },
+  'message.messageContent': { zh: '消息内容', en: 'Message Content' },
+  'message.retryCount': { zh: '重试次数', en: 'Retry Count' },
+  'message.size': { zh: '大小', en: 'Size' },
+  'message.storeTime': { zh: '存储时间', en: 'Store Time' },
+  'message.trace': { zh: '轨迹', en: 'Trace' },
+  'message.verify': { zh: '验证', en: 'Verify' },
 
   // ─── DLQ (detailed) ───
   'dlq.subtitle': {

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -610,7 +610,7 @@ const MessagePageContent = ({
             style={{ borderColor: '#1677ff', color: '#1677ff' }}
             onClick={() => void openDetail(record, 'content')}
           >
-            详情
+            {t('message.detail')}
           </Button>
           <Button
             size="small"
@@ -618,7 +618,7 @@ const MessagePageContent = ({
             style={{ borderColor: '#722ed1', color: '#722ed1' }}
             onClick={() => void openDetail(record, 'trace')}
           >
-            轨迹
+            {t('message.trace')}
           </Button>
           <Button
             size="small"
@@ -626,7 +626,7 @@ const MessagePageContent = ({
             style={{ borderColor: '#52c41a', color: '#52c41a' }}
             onClick={handleVerifyConsume}
           >
-            验证
+            {t('message.verify')}
           </Button>
           <Button
             size="small"
@@ -634,7 +634,7 @@ const MessagePageContent = ({
             style={{ borderColor: '#fa8c16', color: '#fa8c16' }}
             onClick={() => handleDownload(record)}
           >
-            下载
+            {t('message.download')}
           </Button>
         </Flex>
       ),
@@ -648,13 +648,13 @@ const MessagePageContent = ({
     retryCount: number;
   }> = [
     {
-      title: '消费者组',
+      title: t('message.consumerGroup'),
       dataIndex: 'group',
       key: 'group',
       render: (g: string) => <span style={{ fontFamily: 'monospace', fontWeight: 500 }}>{g}</span>,
     },
     {
-      title: '投递状态',
+      title: t('message.deliveryStatus'),
       dataIndex: 'deliveryStatus',
       key: 'deliveryStatus',
       render: (status: string) => {
@@ -666,7 +666,7 @@ const MessagePageContent = ({
       },
     },
     {
-      title: '消费时间',
+      title: t('message.consumeTime'),
       dataIndex: 'consumeTime',
       key: 'consumeTime',
       render: (time: string) =>
@@ -677,7 +677,7 @@ const MessagePageContent = ({
         ),
     },
     {
-      title: '重试次数',
+      title: t('message.retryCount'),
       dataIndex: 'retryCount',
       key: 'retryCount',
       align: 'center',
@@ -691,7 +691,7 @@ const MessagePageContent = ({
   const modalTabs = [
     {
       key: 'content',
-      label: '消息内容',
+      label: t('message.messageContent'),
       children: selectedMsg && (
         <>
           <Descriptions column={2} size="small" style={{ marginBottom: 24 }}>
@@ -711,19 +711,19 @@ const MessagePageContent = ({
             <Descriptions.Item label="Key">
               <span style={{ fontFamily: 'monospace' }}>{selectedMsg.key}</span>
             </Descriptions.Item>
-            <Descriptions.Item label="大小">{formatSize(selectedMsg.size)}</Descriptions.Item>
+            <Descriptions.Item label={t('message.size')}>{formatSize(selectedMsg.size)}</Descriptions.Item>
             <Descriptions.Item label="Born Host">
               <span style={{ fontFamily: 'monospace' }}>{selectedMsg.bornHost}</span>
             </Descriptions.Item>
             <Descriptions.Item label="Store Host">
               <span style={{ fontFamily: 'monospace' }}>{selectedMsg.storeHost}</span>
             </Descriptions.Item>
-            <Descriptions.Item label="存储时间" span={2}>
+            <Descriptions.Item label={t('message.storeTime')} span={2}>
               <span style={{ fontFamily: 'monospace' }}>{formatTimeMs(selectedMsg.storeTime)}</span>
             </Descriptions.Item>
           </Descriptions>
           <Typography.Title level={5} style={{ marginBottom: 8 }}>
-            消息体
+            {t('message.messageBody')}
           </Typography.Title>
           <Paragraph
             copyable


### PR DESCRIPTION
## Summary

Localize the message trace table and detail drawer (`instance/message.tsx`):

- Trace row buttons 详情/轨迹/验证/下载 (reused `message.detail`)
- Trace table columns 消费者组/投递状态/消费时间/重试次数
- Detail drawer: 消息内容 tab label, 大小/存储时间 descriptions items, 消息体 heading

New keys: `message.consumeTime/consumerGroup/deliveryStatus/download/messageBody/messageContent/retryCount/size/storeTime/trace/verify`.

## Why

The trace table and the message detail drawer rendered entirely in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/MessagePage.test.tsx` → 9/9 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
