### PR TITLE
fix(i18n): localize message query modes and delivery status tags

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1807,6 +1807,27 @@ const translations: Record<string, Record<Lang, string>> = {
   'message.batchResend': { zh: '批量重发', en: 'Batch Resend' },
   'message.batchExport': { zh: '批量导出', en: 'Batch Export' },
   'message.noMatchResult': { zh: '没有查到符合条件的结果', en: 'No matching results' },
+<<<<<<< Updated upstream
+=======
+  'message.consumeTime': { zh: '消费时间', en: 'Consume Time' },
+  'message.consumerGroup': { zh: '消费者组', en: 'Consumer Group' },
+  'message.deliveryStatus': { zh: '投递状态', en: 'Delivery Status' },
+  'message.download': { zh: '下载', en: 'Download' },
+  'message.messageBody': { zh: '消息体', en: 'Message Body' },
+  'message.messageContent': { zh: '消息内容', en: 'Message Content' },
+  'message.retryCount': { zh: '重试次数', en: 'Retry Count' },
+  'message.size': { zh: '大小', en: 'Size' },
+  'message.storeTime': { zh: '存储时间', en: 'Store Time' },
+  'message.trace': { zh: '轨迹', en: 'Trace' },
+  'message.verify': { zh: '验证', en: 'Verify' },
+  'message.deliveryFailed': { zh: '失败', en: 'Failed' },
+  'message.deliveryPending': { zh: '等待中', en: 'Pending' },
+  'message.deliverySuccess': { zh: '成功', en: 'Success' },
+  'message.queryByKey': { zh: '按 Message Key', en: 'Query by Message Key' },
+  'message.queryByMsgId': { zh: '按 Message ID', en: 'Query by Message ID' },
+  'message.queryByQueue': { zh: '按队列浏览', en: 'Browse by Queue' },
+  'message.queryByTopic': { zh: '按 Topic 查询', en: 'Query by Topic' },
+>>>>>>> Stashed changes
 
   // ─── DLQ (detailed) ───
   'dlq.subtitle': {

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1807,8 +1807,6 @@ const translations: Record<string, Record<Lang, string>> = {
   'message.batchResend': { zh: '批量重发', en: 'Batch Resend' },
   'message.batchExport': { zh: '批量导出', en: 'Batch Export' },
   'message.noMatchResult': { zh: '没有查到符合条件的结果', en: 'No matching results' },
-<<<<<<< Updated upstream
-=======
   'message.consumeTime': { zh: '消费时间', en: 'Consume Time' },
   'message.consumerGroup': { zh: '消费者组', en: 'Consumer Group' },
   'message.deliveryStatus': { zh: '投递状态', en: 'Delivery Status' },
@@ -1827,7 +1825,6 @@ const translations: Record<string, Record<Lang, string>> = {
   'message.queryByMsgId': { zh: '按 Message ID', en: 'Query by Message ID' },
   'message.queryByQueue': { zh: '按队列浏览', en: 'Browse by Queue' },
   'message.queryByTopic': { zh: '按 Topic 查询', en: 'Query by Topic' },
->>>>>>> Stashed changes
 
   // ─── DLQ (detailed) ───
   'dlq.subtitle': {

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -90,16 +90,16 @@ type ApiErrorLike = {
 };
 
 const QUERY_OPTIONS = [
-  { value: 'topic' as const, label: '按 Topic 查询' },
-  { value: 'key' as const, label: '按 Message Key' },
-  { value: 'msgid' as const, label: '按 Message ID' },
-  { value: 'queue' as const, label: '按队列浏览' },
+  { value: 'topic' as const, labelKey: 'message.queryByTopic' },
+  { value: 'key' as const, labelKey: 'message.queryByKey' },
+  { value: 'msgid' as const, labelKey: 'message.queryByMsgId' },
+  { value: 'queue' as const, labelKey: 'message.queryByQueue' },
 ];
 
 const DELIVERY_STATUS_MAP: Record<string, { label: string; color: string }> = {
-  success: { label: '成功', color: 'green' },
-  failed: { label: '失败', color: 'red' },
-  pending: { label: '等待中', color: 'gold' },
+  success: { labelKey: 'message.deliverySuccess', color: 'green' },
+  failed: { labelKey: 'message.deliveryFailed', color: 'red' },
+  pending: { labelKey: 'message.deliveryPending', color: 'gold' },
 };
 
 const TOPIC_TAG_COLORS: Record<string, string> = {
@@ -659,10 +659,10 @@ const MessagePageContent = ({
       key: 'deliveryStatus',
       render: (status: string) => {
         const s = DELIVERY_STATUS_MAP[(status ?? '').toLowerCase()] || {
-          label: status,
+          labelKey: status,
           color: 'default',
         };
-        return <Tag color={s.color}>{s.label}</Tag>;
+        return <Tag color={s.color}>{t(s.labelKey)}</Tag>;
       },
     },
     {
@@ -846,7 +846,7 @@ const MessagePageContent = ({
               style={{ width: 220 }}
             />
             <Segmented
-              options={QUERY_OPTIONS}
+              options={QUERY_OPTIONS.map((option) => ({ ...option, label: t(option.labelKey) }))}
               value={queryMode}
               onChange={(v) => setQueryMode(v as QueryMode)}
             />


### PR DESCRIPTION
## Summary

Localize the message page's query-mode selector and delivery-status tags (`instance/message.tsx`):

- `QUERY_OPTIONS` (Segmented: 按 Topic 查询/按 Message Key/按 Message ID/按队列浏览) now carries `labelKey` and is mapped through `t()` at the render site
- `DELIVERY_STATUS_MAP` (成功/失败/等待中) now carries `labelKey`, and the trace table tag render falls back to the raw status when the key is unknown
- Seven new `message.*` zh/en keys added

## Why

The page header query-mode Segmented and the trace delivery-status tags were the last hard-coded Chinese at the top of the message page in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/MessagePage.test.tsx` → 9/9 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged; unknown statuses still render as their raw value
