### PR TITLE
fix(i18n): localize consumer lag and offset reset preview tables

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1564,6 +1564,13 @@ const translations: Record<string, Record<Lang, string>> = {
   'consumer.subscriptionMode': { zh: '订阅模式', en: 'Subscription Mode' },
   'consumer.subGroupType': { zh: '订阅组类型', en: 'Subscription Group Type' },
   'consumer.maxRetry': { zh: '最大重试次数', en: 'Max Retries' },
+  'consumer.lag': { zh: '堆积量', en: 'Backlog' },
+  'consumer.lagAfterReset': { zh: '重置后堆积', en: 'Backlog After Reset' },
+  'consumer.lagCurrent': { zh: '当前堆积', en: 'Current Backlog' },
+  'consumer.offsetCurrent': { zh: '当前位点', en: 'Current Offset' },
+  'consumer.offsetDelta': { zh: '变化', en: 'Delta' },
+  'consumer.offsetTarget': { zh: '目标位点', en: 'Target Offset' },
+  'consumer.risk': { zh: '风险', en: 'Risk' },
 
   // ─── User Menu ───
   'user.profile': { zh: '个人中心', en: 'Profile' },

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -1148,7 +1148,7 @@ const ConsumerPageContent = ({
       ),
     },
     {
-      title: '堆积量',
+      title: t('consumer.lag'),
       dataIndex: 'diffTotal',
       key: 'diffTotal',
       width: 120,
@@ -1193,7 +1193,7 @@ const ConsumerPageContent = ({
       render: (id: number) => <Tag color="blue">Queue {id}</Tag>,
     },
     {
-      title: '当前位点',
+      title: t('consumer.offsetCurrent'),
       dataIndex: 'consumerOffset',
       key: 'consumerOffset',
       width: 120,
@@ -1203,7 +1203,7 @@ const ConsumerPageContent = ({
       ),
     },
     {
-      title: '目标位点',
+      title: t('consumer.offsetTarget'),
       dataIndex: 'targetOffset',
       key: 'targetOffset',
       width: 120,
@@ -1215,7 +1215,7 @@ const ConsumerPageContent = ({
       ),
     },
     {
-      title: '变化',
+      title: t('consumer.offsetDelta'),
       dataIndex: 'offsetDelta',
       key: 'offsetDelta',
       width: 100,
@@ -1233,7 +1233,7 @@ const ConsumerPageContent = ({
       ),
     },
     {
-      title: '当前堆积',
+      title: t('consumer.lagCurrent'),
       dataIndex: 'currentLag',
       key: 'currentLag',
       width: 110,
@@ -1243,7 +1243,7 @@ const ConsumerPageContent = ({
       ),
     },
     {
-      title: '重置后堆积',
+      title: t('consumer.lagAfterReset'),
       dataIndex: 'projectedLag',
       key: 'projectedLag',
       width: 124,
@@ -1255,7 +1255,7 @@ const ConsumerPageContent = ({
       ),
     },
     {
-      title: '风险',
+      title: t('consumer.risk'),
       dataIndex: 'riskLevel',
       key: 'riskLevel',
       width: 86,


### PR DESCRIPTION
## Summary

Localize the consumer offset-reset preview table (`instance/consumer.tsx`):

- 堆积量 (lag overview table) → `consumer.lag`
- Reset preview columns 当前位点/目标位点/变化/当前堆积/重置后堆积/风险 → `consumer.offsetCurrent` / `consumer.offsetTarget` / `consumer.offsetDelta` / `consumer.lagCurrent` / `consumer.lagAfterReset` / `consumer.risk`

Seven new `consumer.*` zh/en keys added.

## Why

The lag and offset-reset preview tables rendered entirely in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` → 24/24 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
