### PR TITLE
fix(i18n): localize consumer toolbar and batch delete flow

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1564,6 +1564,11 @@ const translations: Record<string, Record<Lang, string>> = {
   'consumer.subscriptionMode': { zh: '订阅模式', en: 'Subscription Mode' },
   'consumer.subGroupType': { zh: '订阅组类型', en: 'Subscription Group Type' },
   'consumer.maxRetry': { zh: '最大重试次数', en: 'Max Retries' },
+  'consumer.batchDeleteContent': { zh: '确定要删除选中的 {count} 个 Group 吗？', en: 'Delete the {count} selected consumer groups?' },
+  'consumer.confirmBatchDelete': { zh: '确认批量删除', en: 'Confirm Batch Delete' },
+  'consumer.deleteOp': { zh: '删除', en: 'Delete' },
+  'consumer.deleteSelected': { zh: '删除 ({count})', en: 'Delete ({count})' },
+  'consumer.manageSubtitle': { zh: '管理消费者组订阅关系与消费进度，共 {count} 个 Group', en: 'Manage consumer group subscriptions and consumption progress — {count} groups' },
 
   // ─── User Menu ───
   'user.profile': { zh: '个人中心', en: 'Profile' },

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -1284,7 +1284,7 @@ const ConsumerPageContent = ({
       {/* ─── Header ─── */}
       <PageHeader
         title={t('group.title')}
-        subtitle={`管理消费者组订阅关系与消费进度，共 ${totalGroups} 个 Group`}
+        subtitle={t('consumer.manageSubtitle', { count: totalGroups })}
       />
 
       {/* ─── Filter Bar ─── */}
@@ -1297,7 +1297,7 @@ const ConsumerPageContent = ({
             style={{ width: 220 }}
           />
           <Input.Search
-            placeholder="搜索 Group 名称或 Topic"
+            placeholder={t('consumer.searchPlaceholder')}
             allowClear
             value={search}
             onChange={(e) => {
@@ -1316,8 +1316,8 @@ const ConsumerPageContent = ({
             onChange={setModeFilter}
             style={{ width: 140 }}
             options={[
-              { value: 'ALL', label: '全部模式' },
-              { value: 'Push', label: 'Push' },
+              { value: 'ALL', label: t('consumer.allModes') },
+              { value: 'Push', label: t('consumer.push') },
               { value: 'Pop', label: 'Pop' },
             ]}
           />
@@ -1329,11 +1329,11 @@ const ConsumerPageContent = ({
               icon={<DeleteOutlined />}
               onClick={() => {
                 Modal.confirm({
-                  title: '确认批量删除',
-                  content: `确定要删除选中的 ${selectedRowKeys.length} 个 Group 吗？`,
-                  okText: '删除',
+                  title: t('consumer.confirmBatchDelete'),
+                  content: t('consumer.batchDeleteContent', { count: selectedRowKeys.length }),
+                  okText: t('consumer.deleteOp'),
                   okButtonProps: { danger: true },
-                  cancelText: '取消',
+                  cancelText: t('common.cancel'),
                   onOk: async () => {
                     const names = selectedRowKeys.map(String);
                     const { deleted, failed } = await batchDeleteConsumerGroups(
@@ -1356,7 +1356,7 @@ const ConsumerPageContent = ({
                 });
               }}
             >
-              删除 ({selectedRowKeys.length})
+              {t('consumer.deleteSelected', { count: selectedRowKeys.length })}
             </Button>
           )}
           <input


### PR DESCRIPTION
## Summary

Localize the consumer group toolbar and batch-delete flow (`instance/consumer.tsx`):

- Page subtitle (with group count) → `consumer.manageSubtitle`
- Search placeholder → `consumer.searchPlaceholder` (reused a dormant exact-match key)
- Mode filter options 全部模式/Push → `consumer.allModes` / `consumer.push`
- Batch-delete confirm modal title/content/okText/cancelText → `consumer.confirmBatchDelete` / `consumer.batchDeleteContent` / `consumer.deleteOp` / `common.cancel`
- Batch-delete button (with selection count) → `consumer.deleteSelected`

New keys: `consumer.manageSubtitle/batchDeleteContent/confirmBatchDelete/deleteOp/deleteSelected`.

## Why

The consumer page header, mode filter and batch-delete flow rendered entirely in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` → 24/24 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
