### PR TITLE
fix(i18n): localize consumer detail modal tables

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1564,6 +1564,16 @@ const translations: Record<string, Record<Lang, string>> = {
   'consumer.subscriptionMode': { zh: '订阅模式', en: 'Subscription Mode' },
   'consumer.subGroupType': { zh: '订阅组类型', en: 'Subscription Group Type' },
   'consumer.maxRetry': { zh: '最大重试次数', en: 'Max Retries' },
+  'consumer.address': { zh: '地址', en: 'Address' },
+  'consumer.diagnostics': { zh: '诊断', en: 'Diagnostics' },
+  'consumer.lastHeartbeat': { zh: '最后心跳', en: 'Last Heartbeat' },
+  'consumer.protocol': { zh: '协议', en: 'Protocol' },
+  'consumer.subConsistency': { zh: '订阅一致性', en: 'Subscription Consistency' },
+  'consumer.subExpression': { zh: '订阅表达式', en: 'Subscription Expression' },
+  'consumer.threadStack': { zh: '线程栈', en: 'Thread Stack' },
+  'consumer.topicSubject': { zh: 'Topic 主题', en: 'Topic' },
+  'consumer.viewDist': { zh: '查看分布', en: 'View Distribution' },
+  'consumer.viewQueueDistTooltip': { zh: '查看该 Topic 的队列分布', en: 'View the queue distribution of this topic' },
 
   // ─── User Menu ───
   'user.profile': { zh: '个人中心', en: 'Profile' },

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -830,7 +830,7 @@ const ConsumerPageContent = ({
       },
     },
     {
-      title: '订阅模式',
+      title: t('consumer.subMode'),
       dataIndex: 'subscriptionMode',
       key: 'subscriptionMode',
       width: 84,
@@ -958,7 +958,7 @@ const ConsumerPageContent = ({
      ═══════════════════════════════════════════ */
   const subscriptionSubColumns = (groupName: string): ColumnsType<SubscriptionEntry> => [
     {
-      title: 'Topic 主题',
+      title: t('consumer.topicSubject'),
       dataIndex: 'topic',
       key: 'topic',
       width: 200,
@@ -969,7 +969,7 @@ const ConsumerPageContent = ({
       ),
     },
     {
-      title: '订阅一致性',
+      title: t('consumer.subConsistency'),
       dataIndex: 'consistency',
       key: 'consistency',
       width: 110,
@@ -984,7 +984,7 @@ const ConsumerPageContent = ({
       ),
     },
     {
-      title: '订阅模式',
+      title: t('consumer.subMode'),
       dataIndex: 'filterMode',
       key: 'filterMode',
       width: 120,
@@ -998,7 +998,7 @@ const ConsumerPageContent = ({
       },
     },
     {
-      title: '订阅表达式',
+      title: t('consumer.subExpression'),
       dataIndex: 'expression',
       key: 'expression',
       width: 260,
@@ -1016,14 +1016,14 @@ const ConsumerPageContent = ({
         <Button
           size="small"
           icon={<Eye size={14} />}
-          title="查看该 Topic 的队列分布"
+          title={t('consumer.viewQueueDistTooltip')}
           style={{ borderColor: '#1677ff', color: '#1677ff' }}
           onClick={() => {
             const group = groups.find((g) => g.name === groupName) ?? selectedGroup;
             if (group) openModal(group, 'progress', record.topic);
           }}
         >
-          查看分布
+          {t('consumer.viewDist')}
         </Button>
       ),
     },
@@ -1045,7 +1045,7 @@ const ConsumerPageContent = ({
       ),
     },
     {
-      title: '协议',
+      title: t('consumer.protocol'),
       dataIndex: 'protocol',
       key: 'protocol',
       width: 80,
@@ -1055,7 +1055,7 @@ const ConsumerPageContent = ({
       },
     },
     {
-      title: '地址',
+      title: t('consumer.address'),
       dataIndex: 'address',
       key: 'address',
       width: 150,
@@ -1066,7 +1066,7 @@ const ConsumerPageContent = ({
       ),
     },
     {
-      title: '最后心跳',
+      title: t('consumer.lastHeartbeat'),
       dataIndex: 'lastHeartbeat',
       key: 'lastHeartbeat',
       width: 150,
@@ -1077,7 +1077,7 @@ const ConsumerPageContent = ({
       ),
     },
     {
-      title: '诊断',
+      title: t('consumer.diagnostics'),
       key: 'diagnostics',
       width: 90,
       render: (_: unknown, record: ConsumerInstance) => (
@@ -1086,7 +1086,7 @@ const ConsumerPageContent = ({
           icon={<ListBullets size={14} />}
           onClick={() => void openStackModal(record)}
         >
-          线程栈
+          {t('consumer.threadStack')}
         </Button>
       ),
     },
@@ -1097,7 +1097,7 @@ const ConsumerPageContent = ({
      ═══════════════════════════════════════════ */
   const queueColumns: ColumnsType<QueueProgress> = [
     {
-      title: 'Topic 主题',
+      title: t('consumer.topicSubject'),
       dataIndex: 'topic',
       key: 'topic',
       width: 280,


### PR DESCRIPTION
## Summary

Localize the consumer detail modals (`instance/consumer.tsx`):

- Subscription tables: Topic 主题/订阅一致性/订阅模式/订阅表达式 column titles, the queue-distribution tooltip and 查看分布 row button
- Clients table: 协议/地址/最后心跳/诊断 column titles and the 线程栈 row button

New keys: `consumer.address/diagnostics/lastHeartbeat/protocol/subConsistency/subExpression/threadStack/topicSubject/viewDist/viewQueueDistTooltip`; reused the dormant `consumer.subMode` key (also applied to the main table's identical column, same text as the earlier table PR, so merges cleanly).

## Why

The subscription and client tables inside the consumer detail modal rendered entirely in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` → 24/24 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
