### PR TITLE
fix(i18n): localize topic create modal form

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1719,6 +1719,14 @@ const translations: Record<string, Record<Lang, string>> = {
   'topic.operationSuccess': { zh: 'Topic 操作成功', en: 'Topic operation successful' },
   'topic.filterType': { zh: '消息类型', en: 'Message Type' },
   'topic.filterAll': { zh: '全部类型', en: 'All Types' },
+  'topic.permRO': { zh: '只读', en: 'Read-Only' },
+  'topic.permRW': { zh: '读写', en: 'Read-Write' },
+  'topic.permWO': { zh: '只写', en: 'Write-Only' },
+  'topic.permission': { zh: '权限', en: 'Permission' },
+  'topic.queuesPerBroker': { zh: '每个 Broker 节点 8 个队列', en: '8 queues per broker node' },
+  'topic.readQueues': { zh: '读队列数', en: 'Read Queues' },
+  'topic.remarkPlaceholder': { zh: '可选，描述 Topic 用途', en: 'Optional: describe the topic purpose' },
+  'topic.writeQueues': { zh: '写队列数', en: 'Write Queues' },
 
   // ─── Group / Consumer (detailed) ───
   'group.subtitle': {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -1539,20 +1539,20 @@ const TopicPage = () => {
             <Row gutter={16}>
               <Col span={12}>
                 <Form.Item
-                  label="写队列数"
+                  label={t('topic.writeQueues')}
                   name="writeQueues"
                   rules={[{ required: true }]}
-                  extra="每个 Broker 节点 8 个队列"
+                  extra={t('topic.queuesPerBroker')}
                 >
                   <InputNumber min={1} max={256} style={{ width: '100%' }} />
                 </Form.Item>
               </Col>
               <Col span={12}>
                 <Form.Item
-                  label="读队列数"
+                  label={t('topic.readQueues')}
                   name="readQueues"
                   rules={[{ required: true }]}
-                  extra="每个 Broker 节点 8 个队列"
+                  extra={t('topic.queuesPerBroker')}
                 >
                   <InputNumber min={1} max={256} style={{ width: '100%' }} />
                 </Form.Item>
@@ -1561,17 +1561,17 @@ const TopicPage = () => {
           )}
 
           {!isCloudInstance && (
-            <Form.Item label="权限" name="perm" rules={[{ required: true }]}>
+            <Form.Item label={t('topic.permission')} name="perm" rules={[{ required: true }]}>
               <Radio.Group>
-                <Radio.Button value="RW">读写</Radio.Button>
-                <Radio.Button value="RO">只读</Radio.Button>
-                <Radio.Button value="WO">只写</Radio.Button>
+                <Radio.Button value="RW">{t('topic.permRW')}</Radio.Button>
+                <Radio.Button value="RO">{t('topic.permRO')}</Radio.Button>
+                <Radio.Button value="WO">{t('topic.permWO')}</Radio.Button>
               </Radio.Group>
             </Form.Item>
           )}
 
-          <Form.Item label="备注" name="remark">
-            <Input.TextArea rows={3} placeholder="可选，描述 Topic 用途" />
+          <Form.Item label={t('topic.remark')} name="remark">
+            <Input.TextArea rows={3} placeholder={t('topic.remarkPlaceholder')} />
           </Form.Item>
         </Form>
       </Modal>


### PR DESCRIPTION
## Summary

Localize the topic create modal (`instance/topic.tsx`):

- Queue-count form items: 写队列数/读队列数 labels and the shared 每个 Broker 节点 8 个队列 hint
- Permission radio group: 权限 label and 读写/只读/只写 options
- Remark label → `topic.remark` (reused dormant key) and its placeholder

Eight new `topic.*` zh/en keys added.

## Why

The topic create modal rendered its form labels and options entirely in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/TopicPage.test.tsx` → 16/16 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
