### PR TITLE
fix(i18n): localize topic import and route sync modals

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1719,6 +1719,19 @@ const translations: Record<string, Record<Lang, string>> = {
   'topic.operationSuccess': { zh: 'Topic 操作成功', en: 'Topic operation successful' },
   'topic.filterType': { zh: '消息类型', en: 'Message Type' },
   'topic.filterAll': { zh: '全部类型', en: 'All Types' },
+  'topic.csvImportFailed': { zh: 'CSV 无法导入', en: 'CSV could not be imported' },
+  'topic.importFieldsOnly': { zh: '仅导入可创建字段；CSV 中的 Namespace、Cluster ID 和运行状态列会被忽略。', en: 'Only importable fields are imported; the Namespace, Cluster ID and running-status columns in the CSV are ignored.' },
+  'topic.importInvalidSkip': { zh: '检测到 {count} 行无效，将跳过这些行', en: '{count} invalid row(s) detected; these rows will be skipped' },
+  'topic.importRetry': { zh: '重试失败项', en: 'Retry Failed Rows' },
+  'topic.importStart': { zh: '开始导入', en: 'Start Import' },
+  'topic.importWillImport': { zh: '检测到 {count} 个 Topic，将通过后端批量导入', en: '{count} topic(s) detected; they will be imported in batch through the backend' },
+  'topic.missingRouteTag': { zh: '缺失路由', en: 'Missing Route' },
+  'topic.syncAllGood': { zh: '所有 Topic 在 Broker 上均有路由，无需同步。', en: 'All topics already have routes on brokers; nothing to sync.' },
+  'topic.syncData': { zh: '同步数据', en: 'Sync Data' },
+  'topic.syncMissingDesc': { zh: '以下 {count} 个 Topic 在 Broker 上找不到路由，可同步写入对应集群的 Broker（按元数据记录的队列数重建）。', en: 'The following {count} topic(s) have no route on any broker; they can be synced into the brokers of their cluster (rebuilt with the queue counts recorded in metadata).' },
+  'topic.syncVerifying': { zh: '正在校验 Topic 路由…', en: 'Verifying topic routes…' },
+  'topic.syncedTag': { zh: '已同步', en: 'Synced' },
+  'topic.writeReadQueues': { zh: '写/读队列数', en: 'Write/Read Queues' },
 
   // ─── Group / Consumer (detailed) ───
   'group.subtitle': {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -1584,8 +1584,8 @@ const TopicPage = () => {
           if (!importing) setImportModalOpen(false);
         }}
         onOk={() => void handleImportTopics()}
-        okText={importRows.some((row) => row.status === 'failed') ? '重试失败项' : '开始导入'}
-        cancelText="关闭"
+        okText={importRows.some((row) => row.status === 'failed') ? t('topic.importRetry') : t('topic.importStart')}
+        cancelText={t('common.close')}
         confirmLoading={importing}
         okButtonProps={{
           disabled:
@@ -1601,24 +1601,22 @@ const TopicPage = () => {
             <Alert
               type="error"
               showIcon
-              message="CSV 无法导入"
+              message={t('topic.csvImportFailed')}
               description={importErrors.join('；')}
             />
           ) : importRows.some((row) => row.status === 'invalid') ? (
             <Alert
               type="warning"
               showIcon
-              message={`检测到 ${
-                importRows.filter((row) => row.status === 'invalid').length
-              } 行无效，将跳过这些行`}
-              description="仅导入可创建字段；CSV 中的 Namespace、Cluster ID 和运行状态列会被忽略。"
+              message={t('topic.importInvalidSkip', { count: importRows.filter((row) => row.status === 'invalid').length })}
+              description={t('topic.importFieldsOnly')}
             />
           ) : (
             <Alert
               type="info"
               showIcon
-              message={`检测到 ${importRows.length} 个 Topic，将通过后端批量导入`}
-              description="仅导入可创建字段；CSV 中的 Namespace、Cluster ID 和运行状态列会被忽略。"
+              message={t('topic.importWillImport', { count: importRows.length })}
+              description={t('topic.importFieldsOnly')}
             />
           )}
           <Table<ResourceImportRow<Partial<Topic>>>
@@ -1768,28 +1766,27 @@ const TopicPage = () => {
       </Modal>
 
       <Modal
-        title="同步数据"
+        title={t('topic.syncData')}
         open={syncModalOpen}
         onCancel={() => setSyncModalOpen(false)}
-        footer={<Button onClick={() => setSyncModalOpen(false)}>关闭</Button>}
+        footer={<Button onClick={() => setSyncModalOpen(false)}>{t('common.close')}</Button>}
         width={680}
         destroyOnHidden
       >
         {syncChecking ? (
           <Flex justify="center" align="center" style={{ padding: 48 }}>
-            <Spin tip="正在校验 Topic 路由…">
+            <Spin tip={t('topic.syncVerifying')}>
               <div style={{ width: 200 }} />
             </Spin>
           </Flex>
         ) : syncMissing.length === 0 ? (
           <div style={{ padding: '16px 0' }}>
-            <Text type="secondary">所有 Topic 在 Broker 上均有路由，无需同步。</Text>
+            <Text type="secondary">{t('topic.syncAllGood')}</Text>
           </div>
         ) : (
           <>
             <Text type="secondary" style={{ display: 'block', marginBottom: 12 }}>
-              以下 {syncMissing.length} 个 Topic 在 Broker 上找不到路由，可同步写入对应集群的
-              Broker（按元数据记录的队列数重建）。
+              {t('topic.syncMissingDesc', { count: syncMissing.length })}
             </Text>
             <Table<Topic>
               dataSource={syncMissing}
@@ -1799,25 +1796,25 @@ const TopicPage = () => {
               columns={[
                 { title: 'Topic', dataIndex: 'name', key: 'name' },
                 {
-                  title: '写/读队列数',
+                  title: t('topic.writeReadQueues'),
                   key: 'queues',
                   width: 110,
                   render: (_: unknown, topic: Topic) =>
                     `${topic.writeQueues ?? '-'} / ${topic.readQueues ?? '-'}`,
                 },
                 {
-                  title: '状态',
+                  title: t('common.status'),
                   key: 'status',
                   width: 100,
                   render: (_: unknown, topic: Topic) =>
                     syncedTopics.has(topic.name) ? (
-                      <Tag color="green">已同步</Tag>
+                      <Tag color="green">{t('topic.syncedTag')}</Tag>
                     ) : (
-                      <Tag color="orange">缺失路由</Tag>
+                      <Tag color="orange">{t('topic.missingRouteTag')}</Tag>
                     ),
                 },
                 {
-                  title: '操作',
+                  title: t('topic.action'),
                   key: 'action',
                   width: 90,
                   render: (_: unknown, topic: Topic) => (


### PR DESCRIPTION
## Summary

Localize the topic import and route-sync modals (`instance/topic.tsx`):

- Import modal: okText 重试失败项/开始导入, close button, CSV error/warning/info alert messages and their shared description
- Route-sync modal: title, close button, verifying spinner tip, all-synced and missing-route texts, 写/读队列数/状态/操作 columns and 已同步/缺失路由 tags

Thirteen new `topic.*` zh/en keys added; reused `common.close`, `common.status` and `topic.action`.

## Why

Both modals rendered entirely in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/TopicPage.test.tsx` → 16/16 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
