### PR TITLE
fix(i18n): localize topic type filter and create modal type cards

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1719,6 +1719,21 @@ const translations: Record<string, Record<Lang, string>> = {
   'topic.operationSuccess': { zh: 'Topic 操作成功', en: 'Topic operation successful' },
   'topic.filterType': { zh: '消息类型', en: 'Message Type' },
   'topic.filterAll': { zh: '全部类型', en: 'All Types' },
+  'topic.filterAll': { zh: '全部', en: 'All' },
+  'topic.filterDelay': { zh: '延迟', en: 'Delay' },
+  'topic.filterFifo': { zh: '顺序', en: 'FIFO' },
+  'topic.filterLite': { zh: 'LiteTopic', en: 'LiteTopic' },
+  'topic.filterNormal': { zh: '普通', en: 'Normal' },
+  'topic.filterTransaction': { zh: '事务', en: 'Transaction' },
+  'topic.typeDelay': { zh: '延迟消息', en: 'Delayed Message' },
+  'topic.typeDelayDesc': { zh: '消息在指定的延迟时间或定时后才投递给消费者。', en: 'Messages are delivered after the configured delay or at a scheduled time.' },
+  'topic.typeFifo': { zh: '顺序消息', en: 'FIFO Message' },
+  'topic.typeFifoDesc': { zh: '严格按照消息发送顺序消费，适用于顺序敏感的业务。', en: 'Consumed strictly in send order; for ordering-sensitive workloads.' },
+  'topic.typeLiteDesc': { zh: '轻量级主题，资源开销更低，适用于大规模轻量消息场景。', en: 'A lightweight topic with lower resource overhead for large-scale light messages.' },
+  'topic.typeNormal': { zh: '普通消息', en: 'Normal Message' },
+  'topic.typeNormalDesc': { zh: '适用于无特殊顺序要求的常规消息收发场景。', en: 'For routine message send/receive without special ordering requirements.' },
+  'topic.typeTransaction': { zh: '事务消息', en: 'Transactional Message' },
+  'topic.typeTransactionDesc': { zh: '支持分布式事务，保证本地事务与消息发送的最终一致性。', en: 'Supports distributed transactions, keeping the local transaction and message send eventually consistent.' },
 
   // ─── Group / Consumer (detailed) ───
   'group.subtitle': {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -120,28 +120,28 @@ const CLUSTER_NAME_MAP: Record<string, { name: string; type: string }> = {
 };
 
 const TYPE_OPTIONS = [
-  { label: '全部', value: '' },
-  { label: '普通', value: 'NORMAL' },
-  { label: '顺序', value: 'FIFO' },
-  { label: '延迟', value: 'DELAY' },
-  { label: '事务', value: 'TRANSACTION' },
-  { label: 'LiteTopic', value: 'LITE' },
+  { labelKey: 'topic.filterAll', value: '' },
+  { labelKey: 'topic.filterNormal', value: 'NORMAL' },
+  { labelKey: 'topic.filterFifo', value: 'FIFO' },
+  { labelKey: 'topic.filterDelay', value: 'DELAY' },
+  { labelKey: 'topic.filterTransaction', value: 'TRANSACTION' },
+  { labelKey: 'topic.filterLite', value: 'LITE' },
 ];
 
 // Topic 类型选项（描述参考阿里云 RocketMQ 消息类型语义），创建弹窗用 Segmented 展示
 const TOPIC_TYPE_CARDS = [
-  { value: 'NORMAL', label: '普通消息', desc: '适用于无特殊顺序要求的常规消息收发场景。' },
-  { value: 'FIFO', label: '顺序消息', desc: '严格按照消息发送顺序消费，适用于顺序敏感的业务。' },
-  { value: 'DELAY', label: '延迟消息', desc: '消息在指定的延迟时间或定时后才投递给消费者。' },
+  { value: 'NORMAL', labelKey: 'topic.typeNormal', descKey: 'topic.typeNormalDesc' },
+  { value: 'FIFO', labelKey: 'topic.typeFifo', descKey: 'topic.typeFifoDesc' },
+  { value: 'DELAY', labelKey: 'topic.typeDelay', descKey: 'topic.typeDelayDesc' },
   {
     value: 'TRANSACTION',
-    label: '事务消息',
-    desc: '支持分布式事务，保证本地事务与消息发送的最终一致性。',
+    labelKey: 'topic.typeTransaction',
+    descKey: 'topic.typeTransactionDesc',
   },
   {
     value: 'LITE',
-    label: 'LiteTopic',
-    desc: '轻量级主题，资源开销更低，适用于大规模轻量消息场景。',
+    labelKey: 'topic.filterLite',
+    descKey: 'topic.typeLiteDesc',
   },
 ];
 
@@ -1304,7 +1304,7 @@ const TopicPage = () => {
               setTypeFilter(value);
               resetTablePage();
             }}
-            options={TYPE_OPTIONS}
+            options={TYPE_OPTIONS.map((option) => ({ ...option, label: t(option.labelKey) }))}
             style={{ width: 140 }}
           />
         </Space>
@@ -1526,11 +1526,11 @@ const TopicPage = () => {
             label="类型"
             name="type"
             rules={[{ required: true }]}
-            extra={TOPIC_TYPE_CARDS.find((c) => c.value === createTopicType)?.desc}
+            extra={TOPIC_TYPE_CARDS.find((c) => c.value === createTopicType)?.descKey ? t(TOPIC_TYPE_CARDS.find((c) => c.value === createTopicType).descKey) : undefined}
           >
             <Segmented
               options={TOPIC_TYPE_CARDS.filter((c) => !isCloudInstance || c.value !== 'LITE').map(
-                ({ value, label }) => ({ value, label }),
+                ({ value, labelKey }) => ({ value, label: t(labelKey) }),
               )}
             />
           </Form.Item>


### PR DESCRIPTION
## Summary

Localize the topic type filter and create-modal type cards (`instance/topic.tsx`) via label-key refactor:

- `TYPE_OPTIONS` (filter Select: 全部/普通/顺序/延迟/事务/LiteTopic) now carries `labelKey`, mapped through `t()` at its single render site
- `TOPIC_TYPE_CARDS` (create modal: 普通消息/顺序消息/延迟消息/事务消息/LiteTopic with descriptions) now carries `labelKey`/`descKey`, rendered through `t()` for the Segmented label and the Form hint
- Fourteen new `topic.*` zh/en keys added

## Why

The type filter dropdown and the create-modal type cards (labels and their description hints) were the last hard-coded Chinese on the topic page's top-level flows.

## Testing

- `vitest run src/pages/instance/__tests__/TopicPage.test.tsx` → 16/16 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
