### PR TITLE
fix(i18n): localize topic instance banner and access descriptions

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1719,6 +1719,20 @@ const translations: Record<string, Record<Lang, string>> = {
   'topic.operationSuccess': { zh: 'Topic 操作成功', en: 'Topic operation successful' },
   'topic.filterType': { zh: '消息类型', en: 'Message Type' },
   'topic.filterAll': { zh: '全部类型', en: 'All Types' },
+  'topic.accessCloud': { zh: '云服务', en: 'Cloud' },
+  'topic.accessDirect': { zh: 'Direct', en: 'Direct' },
+  'topic.accessMode': { zh: '接入模式', en: 'Access Mode' },
+  'topic.accessPoint': { zh: '接入点', en: 'Access Point' },
+  'topic.accessProxyCluster': { zh: 'Proxy Cluster', en: 'Proxy Cluster' },
+  'topic.accessProxyLocal': { zh: 'Proxy Local', en: 'Proxy Local' },
+  'topic.accessVendor': { zh: '厂商', en: 'Vendor' },
+  'topic.aliyun': { zh: '阿里云', en: 'Alibaba Cloud' },
+  'topic.currentInstance': { zh: '当前实例', en: 'Current Instance' },
+  'topic.descCloud': { zh: '接入点为云厂商托管实例的接入地址，由云实例目录解析得出。若客户端环境无法解析该地址，请自行配置 DNS 解析或在客户端 hosts 中映射。', en: 'The access point is the endpoint of the cloud-managed instance, resolved from the cloud instance catalog. If the client cannot resolve it, configure DNS or map it in the client hosts file.' },
+  'topic.descDirect': { zh: '接入点为 NameServer SLB 地址（K8s 场景下一般为 NameServer Service 地址），Direct 模式客户端通过该地址发现 Broker。若客户端环境无法解析该地址，请自行配置 DNS 解析或在客户端 hosts 中映射。', en: 'The access point is the NameServer SLB address (typically the NameServer Service address in K8s); Direct-mode clients discover brokers through it. If the client cannot resolve it, configure DNS or map it in the client hosts file.' },
+  'topic.descProxyCluster': { zh: '接入点为独立 Proxy 集群的 SLB 内网地址。若客户端环境无法解析该地址，请自行配置 DNS 解析或在客户端 hosts 中映射。', en: 'The access point is the SLB intranet address of a standalone Proxy cluster. If the client cannot resolve it, configure DNS or map it in the client hosts file.' },
+  'topic.descProxyLocal': { zh: '接入点为与 Broker 同进程部署的 Proxy 地址。若客户端环境无法解析该地址，请自行配置 DNS 解析或在客户端 hosts 中映射。', en: 'The access point is the address of a Proxy co-deployed in the same process as the broker. If the client cannot resolve it, configure DNS or map it in the client hosts file.' },
+  'topic.tencent': { zh: '腾讯云', en: 'Tencent Cloud' },
 
   // ─── Group / Consumer (detailed) ───
   'group.subtitle': {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -96,21 +96,17 @@ import {
 const { Text } = Typography;
 
 const INSTANCE_ACCESS_LABEL: Record<Instance['type'], string> = {
-  CLOUD: '云服务',
-  PROXY_LOCAL: 'Proxy Local',
-  PROXY_CLUSTER: 'Proxy Cluster',
-  DIRECT: 'Direct',
+  CLOUD: 'topic.accessCloud',
+  PROXY_LOCAL: 'topic.accessProxyLocal',
+  PROXY_CLUSTER: 'topic.accessProxyCluster',
+  DIRECT: 'topic.accessDirect',
 };
 
 const INSTANCE_ACCESS_DESCRIPTION: Record<Instance['type'], string> = {
-  CLOUD:
-    '接入点为云厂商托管实例的接入地址，由云实例目录解析得出。若客户端环境无法解析该地址，请自行配置 DNS 解析或在客户端 hosts 中映射。',
-  PROXY_LOCAL:
-    '接入点为与 Broker 同进程部署的 Proxy 地址。若客户端环境无法解析该地址，请自行配置 DNS 解析或在客户端 hosts 中映射。',
-  PROXY_CLUSTER:
-    '接入点为独立 Proxy 集群的 SLB 内网地址。若客户端环境无法解析该地址，请自行配置 DNS 解析或在客户端 hosts 中映射。',
-  DIRECT:
-    '接入点为 NameServer SLB 地址（K8s 场景下一般为 NameServer Service 地址），Direct 模式客户端通过该地址发现 Broker。若客户端环境无法解析该地址，请自行配置 DNS 解析或在客户端 hosts 中映射。',
+  CLOUD: 'topic.descCloud',
+  PROXY_LOCAL: 'topic.descProxyLocal',
+  PROXY_CLUSTER: 'topic.descProxyCluster',
+  DIRECT: 'topic.descDirect',
 };
 
 // ─── Cluster name lookup ───────────────────────────────────────────
@@ -1225,41 +1221,41 @@ const TopicPage = () => {
   return (
     <div style={{ padding: 24 }}>
       {/* ── Header ────────────────────────────────────────────── */}
-      <PageHeader title={t('topic.title')} subtitle={`共 ${totalTopics} 个 Topic`} />
+      <PageHeader title={t('topic.title')} subtitle={t('topic.totalCount', { count: totalTopics })} />
 
       {/* ── Current instance banner ───────────────────────────── */}
       {selectedInstance && (
         <InfoBanner>
           <Flex align="center" wrap="wrap" gap="8px 28px" style={{ fontSize: 14 }}>
             <span>
-              <span style={{ color: '#8c8c8c', marginRight: 6 }}>当前实例</span>
+              <span style={{ color: '#8c8c8c', marginRight: 6 }}>{t('topic.currentInstance')}</span>
               <span>{selectedInstance.name}</span>
             </span>
             <span>
-              <span style={{ color: '#8c8c8c', marginRight: 6 }}>接入模式</span>
-              <span>{INSTANCE_ACCESS_LABEL[selectedInstance.type]}</span>
+              <span style={{ color: '#8c8c8c', marginRight: 6 }}>{t('topic.accessMode')}</span>
+              <span>{t(INSTANCE_ACCESS_LABEL[selectedInstance.type])}</span>
             </span>
             {selectedInstance.vendor === 'ALIYUN' && (
               <span>
-                <span style={{ color: '#8c8c8c', marginRight: 6 }}>厂商</span>
-                <span>阿里云</span>
+                <span style={{ color: '#8c8c8c', marginRight: 6 }}>{t('topic.accessVendor')}</span>
+                <span>{t('topic.aliyun')}</span>
               </span>
             )}
             {selectedInstance.vendor === 'TENCENT' && (
               <span>
-                <span style={{ color: '#8c8c8c', marginRight: 6 }}>厂商</span>
-                <span>腾讯云</span>
+                <span style={{ color: '#8c8c8c', marginRight: 6 }}>{t('topic.accessVendor')}</span>
+                <span>{t('topic.tencent')}</span>
               </span>
             )}
             <span>
-              <span style={{ color: '#8c8c8c', marginRight: 6 }}>接入点</span>
+              <span style={{ color: '#8c8c8c', marginRight: 6 }}>{t('topic.accessPoint')}</span>
               <Text code copyable style={{ fontSize: 16 }}>
                 {selectedInstance.endpoint}
               </Text>
             </span>
           </Flex>
           <div style={{ marginTop: 10, fontSize: 14, lineHeight: 1.6, color: '#8c8c8c' }}>
-            {INSTANCE_ACCESS_DESCRIPTION[selectedInstance.type]}
+            {t(INSTANCE_ACCESS_DESCRIPTION[selectedInstance.type])}
           </div>
         </InfoBanner>
       )}


### PR DESCRIPTION
## Summary

Localize the topic page's current-instance banner (`instance/topic.tsx`):

- Page-header subtitle → `topic.totalCount` (reused dormant key)
- Banner labels 当前实例/接入模式/厂商/接入点, and vendor values 阿里云/腾讯云
- `INSTANCE_ACCESS_LABEL` and `INSTANCE_ACCESS_DESCRIPTION` maps now carry i18n keys, rendered through `t()` for the access-mode tag and the per-mode endpoint description

Fifteen new `topic.*` zh/en keys added (mode labels + 4 access descriptions).

## Why

The instance banner on the topic page rendered its labels and the access-point explanation entirely in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/TopicPage.test.tsx` → 16/16 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
