### PR TITLE
fix(i18n): localize consumer configuration tab and thread stack modal

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1564,6 +1564,14 @@ const translations: Record<string, Record<Lang, string>> = {
   'consumer.subscriptionMode': { zh: '订阅模式', en: 'Subscription Mode' },
   'consumer.subGroupType': { zh: '订阅组类型', en: 'Subscription Group Type' },
   'consumer.maxRetry': { zh: '最大重试次数', en: 'Max Retries' },
+  'consumer.collectTime': { zh: '采集时间', en: 'Collected At' },
+  'consumer.configTab': { zh: '配置', en: 'Configuration' },
+  'consumer.maxRetryRequired': { zh: '请输入最大重试次数', en: 'Enter the max retry count' },
+  'consumer.retryQueueCount': { zh: '重试队列数', en: 'Retry Queue Count' },
+  'consumer.retryQueueRequired': { zh: '请输入重试队列数', en: 'Enter the retry queue count' },
+  'consumer.threadCol': { zh: '线程', en: 'Thread' },
+  'consumer.threadCount': { zh: '线程数', en: 'Threads' },
+  'consumer.threadStackModal': { zh: '消费者线程栈', en: 'Consumer Thread Stacks' },
 
   // ─── User Menu ───
   'user.profile': { zh: '个人中心', en: 'Profile' },

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -1798,27 +1798,27 @@ const ConsumerPageContent = ({
                 label: (
                   <Space size={4}>
                     <SlidersHorizontal size={14} />
-                    <span>配置</span>
+                    <span>{t('consumer.configTab')}</span>
                   </Space>
                 ),
                 disabled: isCloudInstance,
                 children: (
                   <Spin spinning={settingsLoading}>
                     <Form form={settingsForm} layout="vertical" style={{ maxWidth: 480 }}>
-                      <Form.Item label="Group 名称">
+                      <Form.Item label={t('consumer.name')}>
                         <Text strong>{selectedGroup.name}</Text>
                       </Form.Item>
                       <Form.Item
-                        label="重试队列数"
+                        label={t('consumer.retryQueueCount')}
                         name="retryQueueNums"
-                        rules={[{ required: true, message: '请输入重试队列数' }]}
+                        rules={[{ required: true, message: t('consumer.retryQueueRequired') }]}
                       >
                         <InputNumber min={1} max={128} style={{ width: '100%' }} />
                       </Form.Item>
                       <Form.Item
-                        label="最大重试次数"
+                        label={t('consumer.maxRetry')}
                         name="retryMaxTimes"
-                        rules={[{ required: true, message: '请输入最大重试次数' }]}
+                        rules={[{ required: true, message: t('consumer.maxRetryRequired') }]}
                       >
                         <InputNumber min={1} max={128} style={{ width: '100%' }} />
                       </Form.Item>
@@ -1828,7 +1828,7 @@ const ConsumerPageContent = ({
                           loading={settingsSubmitting}
                           onClick={() => void saveSettings()}
                         >
-                          保存
+                          {t('common.save')}
                         </Button>
                       </Form.Item>
                     </Form>
@@ -1847,7 +1847,7 @@ const ConsumerPageContent = ({
         title={
           <Space>
             <ListBullets size={18} color="#1677ff" />
-            <span>消费者线程栈</span>
+            <span>{t('consumer.threadStackModal')}</span>
           </Space>
         }
         open={stackModalOpen}
@@ -1872,16 +1872,16 @@ const ConsumerPageContent = ({
                 {selectedStack?.clientId ?? selectedStackClient?.clientId ?? '-'}
               </Text>
             </Descriptions.Item>
-            <Descriptions.Item label="采集时间">
+            <Descriptions.Item label={t('consumer.collectTime')}>
               {selectedStack?.capturedAt ? formatDateTime(selectedStack.capturedAt) : '-'}
             </Descriptions.Item>
-            <Descriptions.Item label="线程数">{selectedStack?.threadCount ?? 0}</Descriptions.Item>
+            <Descriptions.Item label={t('consumer.threadCount')}>{selectedStack?.threadCount ?? 0}</Descriptions.Item>
           </Descriptions>
 
           {stackLoading ? (
             <Table
               loading
-              columns={[{ title: '线程', dataIndex: 'threadName', key: 'threadName' }]}
+              columns={[{ title: t('consumer.threadCol'), dataIndex: 'threadName', key: 'threadName' }]}
               dataSource={[]}
               pagination={false}
               size="small"


### PR DESCRIPTION
## Summary

Localize the consumer detail drawer's configuration tab and the thread-stack modal (`instance/consumer.tsx`):

- Configuration tab: tab label, Group 名称 (reused `consumer.name`), 重试队列数/最大重试次数 form items and their validation messages (reused `consumer.maxRetry`), save button (`common.save`)
- Thread-stack modal: title, 采集时间/线程数 descriptions and the thread-name column header

Eight new `consumer.*` zh/en keys added.

## Why

The configuration tab and thread-stack modal rendered entirely in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` → 24/24 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
