### PR TITLE
fix(i18n): localize consumer group import modal

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1564,6 +1564,12 @@ const translations: Record<string, Record<Lang, string>> = {
   'consumer.subscriptionMode': { zh: '订阅模式', en: 'Subscription Mode' },
   'consumer.subGroupType': { zh: '订阅组类型', en: 'Subscription Group Type' },
   'consumer.maxRetry': { zh: '最大重试次数', en: 'Max Retries' },
+  'consumer.csvImportFailed': { zh: 'CSV 无法导入', en: 'CSV could not be imported' },
+  'consumer.importFieldsOnly': { zh: '仅导入可创建字段；CSV 中的 Namespace、Cluster ID 和运行状态列会被忽略。', en: 'Only importable fields are imported; the Namespace, Cluster ID and running-status columns in the CSV are ignored.' },
+  'consumer.importGroupInvalidSkip': { zh: '检测到 {count} 行无效，将跳过这些行', en: '{count} invalid row(s) detected; these rows will be skipped' },
+  'consumer.importGroupRetry': { zh: '重试失败项', en: 'Retry Failed Rows' },
+  'consumer.importGroupStart': { zh: '开始导入', en: 'Start Import' },
+  'consumer.importGroupWillImport': { zh: '检测到 {count} 个 Group，将通过后端批量导入', en: '{count} group(s) detected; they will be imported in batch through the backend' },
 
   // ─── User Menu ───
   'user.profile': { zh: '个人中心', en: 'Profile' },

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -2097,8 +2097,8 @@ const ConsumerPageContent = ({
           if (!importing) setImportModalOpen(false);
         }}
         onOk={() => void handleImportConsumerGroups()}
-        okText={importRows.some((row) => row.status === 'failed') ? '重试失败项' : '开始导入'}
-        cancelText="关闭"
+        okText={importRows.some((row) => row.status === 'failed') ? t('consumer.importGroupRetry') : t('consumer.importGroupStart')}
+        cancelText={t('common.close')}
         confirmLoading={importing}
         okButtonProps={{
           disabled:
@@ -2114,24 +2114,22 @@ const ConsumerPageContent = ({
             <Alert
               type="error"
               showIcon
-              message="CSV 无法导入"
+              message={t('consumer.csvImportFailed')}
               description={importErrors.join('；')}
             />
           ) : importRows.some((row) => row.status === 'invalid') ? (
             <Alert
               type="warning"
               showIcon
-              message={`检测到 ${
-                importRows.filter((row) => row.status === 'invalid').length
-              } 行无效，将跳过这些行`}
-              description="仅导入可创建字段；CSV 中的 Namespace、Cluster ID 和运行状态列会被忽略。"
+              message={t('consumer.importGroupInvalidSkip', { count: importRows.filter((row) => row.status === 'invalid').length })}
+              description={t('consumer.importFieldsOnly')}
             />
           ) : (
             <Alert
               type="info"
               showIcon
-              message={`检测到 ${importRows.length} 个 Group，将通过后端批量导入`}
-              description="仅导入可创建字段；CSV 中的 Namespace、Cluster ID 和运行状态列会被忽略。"
+              message={t('consumer.importGroupWillImport', { count: importRows.length })}
+              description={t('consumer.importFieldsOnly')}
             />
           )}
           <Table<ResourceImportRow<Partial<ConsumerGroup>>>


### PR DESCRIPTION
## Summary

Localize the consumer group import modal (`instance/consumer.tsx`):

- okText 重试失败项/开始导入 and the close button (`common.close`)
- The CSV error / invalid-rows / will-import alert messages and their shared description

Six new `consumer.*` zh/en keys added.

## Why

The import modal rendered entirely in Chinese in the English UI (same gap as the topic import modal fixed in #3003).

## Testing

- `vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` → 24/24 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
