### PR TITLE
fix(i18n): localize consumer offset reset modal header

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1564,6 +1564,15 @@ const translations: Record<string, Record<Lang, string>> = {
   'consumer.subscriptionMode': { zh: '订阅模式', en: 'Subscription Mode' },
   'consumer.subGroupType': { zh: '订阅组类型', en: 'Subscription Group Type' },
   'consumer.maxRetry': { zh: '最大重试次数', en: 'Max Retries' },
+  'consumer.noSubTopic': { zh: '该 Group 暂无订阅 Topic', en: 'This group has no subscribed topics' },
+  'consumer.resetConfirm': { zh: '确认重置', en: 'Confirm Reset' },
+  'consumer.resetImpactDesc': { zh: '请先预览每个 Queue 的目标位点和堆积变化，确认预览结果后再执行重置。预览为时点快照、属页面操作引导（非服务端控制），预览期间消息持续写入，实际效果以执行时 Broker 状态为准。', en: 'Preview each queue\'s target offset and backlog change first, then confirm before resetting. The preview is a point-in-time snapshot and a UI-side guide (not server-controlled); messages keep flowing during the preview, so the actual result follows the broker state at execution time.' },
+  'consumer.resetImpactWarning': { zh: '此操作将影响消息消费进度', en: 'This operation affects message consumption progress' },
+  'consumer.resetModalTitle': { zh: '重置消费位点', en: 'Reset Consumption Offset' },
+  'consumer.resetTopicPlaceholder': { zh: '选择要重置消费位点的 Topic', en: 'Select the topic to reset' },
+  'consumer.subTopicLoadFailed': { zh: '订阅 Topic 加载失败', en: 'Failed to load subscribed topics' },
+  'consumer.targetGroup': { zh: '目标 Group', en: 'Target Group' },
+  'consumer.targetTopic': { zh: '目标 Topic', en: 'Target Topic' },
 
   // ─── User Menu ───
   'user.profile': { zh: '个人中心', en: 'Profile' },

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -2001,7 +2001,7 @@ const ConsumerPageContent = ({
         }}
         confirmLoading={submitting}
         okText="创建"
-        cancelText="取消"
+        cancelText={t('common.cancel')}
         width={560}
         destroyOnHidden
       >
@@ -2151,7 +2151,7 @@ const ConsumerPageContent = ({
         title={
           <Space>
             <ArrowsCounterClockwise size={18} color="#fa8c16" />
-            <span>重置消费位点</span>
+            <span>{t('consumer.resetModalTitle')}</span>
           </Space>
         }
         open={resetModalOpen}
@@ -2169,8 +2169,8 @@ const ConsumerPageContent = ({
             resetPreviewLoading ||
             Boolean(subscriptionLoadingByGroup[resetDiagnosticKey]),
         }}
-        okText="确认重置"
-        cancelText="取消"
+        okText={t('consumer.resetConfirm')}
+        cancelText={t('common.cancel')}
         width={1200}
         destroyOnHidden
       >
@@ -2179,12 +2179,12 @@ const ConsumerPageContent = ({
             <Alert
               showIcon
               type="warning"
-              message="此操作将影响消息消费进度"
-              description="请先预览每个 Queue 的目标位点和堆积变化，确认预览结果后再执行重置。预览为时点快照、属页面操作引导（非服务端控制），预览期间消息持续写入，实际效果以执行时 Broker 状态为准。"
+              message={t('consumer.resetImpactWarning')}
+              description={t('consumer.resetImpactDesc')}
             />
             <div style={{ marginBottom: 16 }}>
               <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
-                目标 Group
+                {t('consumer.targetGroup')}
               </Text>
               <Text strong style={{ fontSize: 14 }}>
                 {resetGroup.name}
@@ -2192,25 +2192,25 @@ const ConsumerPageContent = ({
             </div>
             <div style={{ marginBottom: 16 }}>
               <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 8 }}>
-                目标 Topic
+                {t('consumer.targetTopic')}
               </Text>
               <Select
-                aria-label="目标 Topic"
+                aria-label={t('consumer.targetTopic')}
                 showSearch
                 optionFilterProp="label"
                 style={{ width: '100%' }}
                 value={resetTopic}
                 options={resetTopicOptions}
                 loading={subscriptionLoadingByGroup[resetDiagnosticKey]}
-                placeholder="选择要重置消费位点的 Topic"
+                placeholder={t('consumer.resetTopicPlaceholder')}
                 onChange={(value) => {
                   setResetTopic(value);
                   clearResetPreview();
                 }}
                 notFoundContent={
                   subscriptionErrorByGroup[resetDiagnosticKey]
-                    ? '订阅 Topic 加载失败'
-                    : '该 Group 暂无订阅 Topic'
+                    ? t('consumer.subTopicLoadFailed')
+                    : t('consumer.noSubTopic')
                 }
               />
             </div>


### PR DESCRIPTION
## Summary

Localize the consumer offset-reset modal header (`instance/consumer.tsx`):

- Modal title 重置消费位点, okText 确认重置, cancel (`common.cancel`)
- Impact warning alert (title + long description)
- Target group/topic labels (label + aria-label), topic-select placeholder, and the subscribed-topic loading/empty states

Nine new `consumer.*` zh/en keys added.

## Why

The reset-offset modal rendered its header, labels and states entirely in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` → 24/24 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
