### PR TITLE
fix(i18n): localize consumer toolbar actions

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1564,6 +1564,11 @@ const translations: Record<string, Record<Lang, string>> = {
   'consumer.subscriptionMode': { zh: '订阅模式', en: 'Subscription Mode' },
   'consumer.subGroupType': { zh: '订阅组类型', en: 'Subscription Group Type' },
   'consumer.maxRetry': { zh: '最大重试次数', en: 'Max Retries' },
+  'consumer.autoRefresh': { zh: '自动刷新', en: 'Auto Refresh' },
+  'consumer.createGroup': { zh: '创建 Group', en: 'Create Group' },
+  'consumer.autoRefreshTooltip': { zh: '开启后每 2 秒自动刷新列表', en: 'Refreshes the list every 2 seconds when enabled' },
+  'consumer.export': { zh: '导出', en: 'Export' },
+  'consumer.import': { zh: '导入', en: 'Import' },
 
   // ─── User Menu ───
   'user.profile': { zh: '个人中心', en: 'Profile' },

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -1375,10 +1375,10 @@ const ConsumerPageContent = ({
             disabled={!hasSelectedInstance || importing}
             onClick={() => importInputRef.current?.click()}
           >
-            导入
+            {t('consumer.import')}
           </Button>
           <Button icon={<ExportOutlined />} loading={exporting} onClick={() => void handleExport()}>
-            导出
+            {t('consumer.export')}
           </Button>
           <Button
             type="primary"
@@ -1386,9 +1386,9 @@ const ConsumerPageContent = ({
             disabled={!hasSelectedInstance}
             onClick={() => setCreateModalOpen(true)}
           >
-            创建 Group
+            {t('consumer.createGroup')}
           </Button>
-          <Tooltip title="开启后每 2 秒自动刷新列表">
+          <Tooltip title={t('consumer.autoRefreshTooltip')}>
             <Button
               icon={<SyncOutlined spin={autoRefresh} />}
               type={autoRefresh ? 'primary' : 'default'}
@@ -1400,7 +1400,7 @@ const ConsumerPageContent = ({
                 if (next) triggerRefresh(true);
               }}
             >
-              自动刷新
+              {t('consumer.autoRefresh')}
             </Button>
           </Tooltip>
         </Space>


### PR DESCRIPTION
## Summary

Localize the consumer page toolbar actions (`instance/consumer.tsx`):

- 导入/导出/创建 Group toolbar buttons
- Auto-refresh button label and its tooltip

Five new `consumer.*` zh/en keys added (import/export/autoRefresh/autoRefreshTooltip/createGroup).

## Why

The consumer page toolbar still showed Chinese-only labels in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` → 24/24 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
