### PR TITLE
fix(i18n): localize consumer row delete and thread stack notices

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1564,6 +1564,11 @@ const translations: Record<string, Record<Lang, string>> = {
   'consumer.subscriptionMode': { zh: '订阅模式', en: 'Subscription Mode' },
   'consumer.subGroupType': { zh: '订阅组类型', en: 'Subscription Group Type' },
   'consumer.maxRetry': { zh: '最大重试次数', en: 'Max Retries' },
+  'consumer.deleteGroupContent': { zh: '删除后该消费组的所有配置和消费进度将被清除，此操作不可恢复。', en: 'All configurations and consumption progress of this group will be cleared. This cannot be undone.' },
+  'consumer.deleteGroupTitle': { zh: '确认删除消费组 "{name}"？', en: 'Confirm deleting consumer group "{name}"?' },
+  'consumer.deleteOp': { zh: '删除', en: 'Delete' },
+  'consumer.stackUnsupported': { zh: '暂不支持采集该客户端的线程栈', en: 'Thread stacks cannot be collected for this client yet' },
+  'consumer.stackUnsupportedDesc': { zh: '经 Proxy 接入的客户端（gRPC、经 Proxy 的 Remoting）只在 Proxy 侧保持连接，Broker 看不到它们；而 Proxy 目前未开放线程栈采集接口，因此这类客户端暂时无法采集。 直连 Broker 的客户端可正常查看。', en: 'Clients connected through a Proxy (gRPC and Proxy-routed Remoting) only keep connections on the Proxy side, invisible to brokers; and the Proxy does not expose a stack-collection API yet, so these clients cannot be collected for now. Clients that connect directly to a broker work normally.' },
 
   // ─── User Menu ───
   'user.profile': { zh: '个人中心', en: 'Profile' },

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -932,11 +932,11 @@ const ConsumerPageContent = ({
             onClick={(e) => {
               e.stopPropagation();
               Modal.confirm({
-                title: `确认删除消费组 "${record.name}"？`,
-                content: '删除后该消费组的所有配置和消费进度将被清除，此操作不可恢复。',
-                okText: '删除',
+                title: t('consumer.deleteGroupTitle', { name: record.name }),
+                content: t('consumer.deleteGroupContent'),
+                okText: t('consumer.deleteOp'),
                 okButtonProps: { danger: true },
-                cancelText: '取消',
+                cancelText: t('common.cancel'),
                 onOk: async () => {
                   await deleteConsumerGroup(record.name, selectedInstanceId || undefined);
                   setGroups((prev) => prev.filter((group) => group.name !== record.name));
@@ -946,7 +946,7 @@ const ConsumerPageContent = ({
               });
             }}
           >
-            删除
+            {t('consumer.deleteOp')}
           </Button>
         </Flex>
       ),
@@ -1331,9 +1331,9 @@ const ConsumerPageContent = ({
                 Modal.confirm({
                   title: '确认批量删除',
                   content: `确定要删除选中的 ${selectedRowKeys.length} 个 Group 吗？`,
-                  okText: '删除',
+                  okText: t('consumer.deleteOp'),
                   okButtonProps: { danger: true },
-                  cancelText: '取消',
+                  cancelText: t('common.cancel'),
                   onOk: async () => {
                     const names = selectedRowKeys.map(String);
                     const { deleted, failed } = await batchDeleteConsumerGroups(
@@ -1920,14 +1920,10 @@ const ConsumerPageContent = ({
             <Alert
               type="info"
               showIcon
-              message="暂不支持采集该客户端的线程栈"
+              message={t('consumer.stackUnsupported')}
               description={
                 <>
-                  <div>
-                    经 Proxy 接入的客户端（gRPC、经 Proxy 的 Remoting）只在 Proxy 侧保持连接，Broker
-                    看不到它们；而 Proxy 目前未开放线程栈采集接口，因此这类客户端暂时无法采集。 直连
-                    Broker 的客户端可正常查看。
-                  </div>
+                  <div>{t('consumer.stackUnsupportedDesc')}</div>
                   {stackError && (
                     <div style={{ marginTop: 8, color: 'rgba(0,0,0,0.45)' }}>{stackError}</div>
                   )}
@@ -1966,7 +1962,7 @@ const ConsumerPageContent = ({
                 title: '确认创建',
                 content: `将创建消费组 "${values.name}"`,
                 okText: '确认创建',
-                cancelText: '取消',
+                cancelText: t('common.cancel'),
                 onOk: async () => {
                   setSubmitting(true);
                   try {


### PR DESCRIPTION
## Summary

Localize two remaining consumer dialogs (`instance/consumer.tsx`):

- Row delete confirmation: title (with group name), content, ok/cancel buttons and the delete row button
- Thread-stack modal's unsupported-client info alert (title + long description)

Five new `consumer.*` zh/en keys added.

## Why

The row-delete confirm and the thread-stack unsupported notice still rendered entirely in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` → 24/24 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
