### PR TITLE
fix(i18n): localize AI quick actions and thinking chain label

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1119,6 +1119,13 @@ const translations: Record<string, Record<Lang, string>> = {
 
   // ─── AI Page (additional) ───
   'ai.recommended': { zh: '推荐', en: 'Rec.' },
+  'ai.qaCheckStatus': { zh: '查看集群状态', en: 'Check Cluster Status' },
+  'ai.qaCreateTopic': { zh: '创建 Topic', en: 'Create a Topic' },
+  'ai.qaDiagnoseLag': { zh: '诊断消费延迟', en: 'Diagnose Consumption Lag' },
+  'ai.qaTop10Lag': { zh: 'Topic 堆积 Top10', en: 'Topic Backlog Top 10' },
+  'ai.qaTraceQuery': { zh: '消息轨迹查询', en: 'Query Message Trace' },
+  'ai.qaScaleEval': { zh: '扩缩容评估', en: 'Scaling Assessment' },
+  'ai.thinkingChainLabel': { zh: '思维链：Prompt 增强改写', en: 'Chain of Thought: Prompt-Enhanced Rewrite' },
 
   // ─── Theme Constants ───
   'theme.clusterV4': { zh: 'V4 直连', en: 'V4 Direct' },

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -123,6 +123,15 @@ const quickActions = [
   '扩缩容评估',
 ];
 
+const AI_QUICK_ACTION_KEYS: Record<string, string> = {
+  '查看集群状态': 'ai.qaCheckStatus',
+  'Topic 堆积 Top10': 'ai.qaTop10Lag',
+  '诊断消费延迟': 'ai.qaDiagnoseLag',
+  '创建 Topic': 'ai.qaCreateTopic',
+  '消息轨迹查询': 'ai.qaTraceQuery',
+  '扩缩容评估': 'ai.qaScaleEval',
+};
+
 const GLOBAL_TOOL_SCOPE = '__global__';
 
 const newConversationId = (): string =>
@@ -333,7 +342,7 @@ export const AiMessage = ({ msg }: { msg: Message }) => {
                 userSelect: 'none',
               }}
             >
-              思维链：Prompt 增强改写
+              {t('ai.thinkingChainLabel')}
             </summary>
             <div
               style={{
@@ -930,7 +939,7 @@ const AiPage = () => {
               color="blue"
               onClick={() => handleQuickAction(action)}
             >
-              {action}
+              {t(AI_QUICK_ACTION_KEYS[action] ?? action)}
             </Tag>
           ))}
         </Flex>


### PR DESCRIPTION
## Summary

Localize the AI page quick-actions and thinking-chain label (`pages/ai/index.tsx`):

- Six quick-action tags now render through `t()` via a zh→key map (display localized; the prompt payload stays as authored for the backend)
- 思维链：Prompt 增强改写 collapsible label

Seven new `ai.*` zh/en keys added.

## Why

The quick-action chips and the thinking-chain summary label rendered in Chinese in the English UI.

## Testing

- `vitest run src/pages/ai/__tests__/AiPage.test.tsx` → 13/13 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
