### PR TITLE
fix(i18n): localize DLQ load and export warnings

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1815,6 +1815,12 @@ const translations: Record<string, Record<Lang, string>> = {
   },
   'dlq.message': { zh: '死信消息', en: 'DLQ Message' },
   'dlq.consumerGroup': { zh: '消费者组', en: 'Consumer Group' },
+  'dlq.detailLoadFailed': { zh: '死信消息明细加载失败，请稍后重试', en: 'Failed to load DLQ message details, please retry later' },
+  'dlq.exportIncomplete': { zh: '导出可能不完整：{failed} 个队列无法扫描，导出上限 {limit} 条', en: 'Export may be incomplete: {failed} queue(s) could not be scanned; export limit is {limit}' },
+  'dlq.loadFailed': { zh: '死信队列加载失败，请稍后重试', en: 'Failed to load the DLQ list, please retry later' },
+  'dlq.rescanIncomplete': { zh: '重投扫描不完整：{failed} 个队列无法扫描，已重投 {resent} 条', en: 'Resend scan incomplete: {failed} queue(s) could not be scanned; {resent} message(s) resent' },
+  'dlq.resendMsgFailed': { zh: '重发死信消息失败，请稍后重试', en: 'Failed to resend DLQ messages, please retry later' },
+  'dlq.retryFailed': { zh: '提交重投任务失败，请稍后重试', en: 'Failed to submit the resend task, please retry later' },
 
   // ─── Message Trace ───
   'trace.title': { zh: '消息轨迹', en: 'Message Trace' },

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -52,8 +52,6 @@ import { tableScrollX } from '../../utils/table';
 
 const { Text } = Typography;
 const { RangePicker } = DatePicker;
-const DEFAULT_LOAD_ERROR = '死信队列加载失败，请稍后重试';
-const DEFAULT_RETRY_ERROR = '提交重投任务失败，请稍后重试';
 
 /* ─── Helpers ─── */
 
@@ -206,7 +204,7 @@ const DLQPage = () => {
       })
       .catch((error) => {
         if (groupRequestIdRef.current === requestId) {
-          setLoadError(getErrorMessage(error, DEFAULT_LOAD_ERROR));
+          setLoadError(getErrorMessage(error, t('dlq.loadFailed')));
           setLoading(false);
         }
       });
@@ -264,7 +262,7 @@ const DLQPage = () => {
       setRefreshKey((key) => key + 1);
       if (result.scanIncomplete) {
         message.warning(
-          `重投扫描不完整：${result.failedQueueCount ?? 0} 个队列无法扫描，已重投 ${result.resent} 条`,
+          t('dlq.rescanIncomplete', { failed: result.failedQueueCount ?? 0, resent: result.resent }),
         );
       } else if (result.failed > 0) {
         message.warning(`重投部分完成：成功 ${result.resent}，失败 ${result.failed}`);
@@ -276,7 +274,7 @@ const DLQPage = () => {
       setRetryError(null);
     } catch (error) {
       if (retryRequestIdRef.current === requestId) {
-        setRetryError(getErrorMessage(error, DEFAULT_RETRY_ERROR));
+        setRetryError(getErrorMessage(error, t('dlq.retryFailed')));
       }
     } finally {
       if (retryRequestIdRef.current === requestId) {
@@ -296,7 +294,7 @@ const DLQPage = () => {
       downloadBlob(blob, `${group.groupName}-dlq-messages.xlsx`);
       if (meta.truncated || meta.failedQueueCount > 0) {
         message.warning(
-          `导出可能不完整：${meta.failedQueueCount} 个队列无法扫描，导出上限 ${meta.limit} 条`,
+          t('dlq.exportIncomplete', { failed: meta.failedQueueCount, limit: meta.limit }),
         );
       } else {
         message.success(`已导出 ${group.groupName} 的死信消息（${blob.size} 字节）`);
@@ -342,7 +340,7 @@ const DLQPage = () => {
       setDetailPage(page);
     } catch (error) {
       if (detailRequestIdRef.current === requestId) {
-        setDetailError(getErrorMessage(error, '死信消息明细加载失败，请稍后重试'));
+        setDetailError(getErrorMessage(error, t('dlq.detailLoadFailed')));
       }
     } finally {
       if (detailRequestIdRef.current === requestId) {
@@ -371,7 +369,7 @@ const DLQPage = () => {
       setDetailSelectedMsgIds([]);
       await loadDetailMessages(detailGroup, detailPage, detailPageSize);
     } catch (error) {
-      setDetailError(getErrorMessage(error, '重发死信消息失败，请稍后重试'));
+      setDetailError(getErrorMessage(error, t('dlq.resendMsgFailed')));
     } finally {
       setDetailResending(false);
     }
@@ -390,7 +388,7 @@ const DLQPage = () => {
       downloadBlob(blob, `${detailGroup.groupName}-dlq-messages.xlsx`);
       if (meta.truncated || meta.failedQueueCount > 0) {
         message.warning(
-          `导出可能不完整：${meta.failedQueueCount} 个队列无法扫描，导出上限 ${meta.limit} 条`,
+          t('dlq.exportIncomplete', { failed: meta.failedQueueCount, limit: meta.limit }),
         );
       } else {
         message.success(


### PR DESCRIPTION
## Summary

Localize the DLQ page's remaining error/warning paths (`instance/dlq.tsx`):

- Module-level `DEFAULT_LOAD_ERROR` / `DEFAULT_RETRY_ERROR` constants are removed; the two call sites now pass `t('dlq.loadFailed')` / `t('dlq.retryFailed')`
- Resend-scan-incomplete warning and the export-may-be-incomplete warning (two sites)
- Detail-load and resend fallback messages

Six new `dlq.*` zh/en keys added.

## Why

These load/scan/export warnings and fallbacks were the last hard-coded Chinese paths on the DLQ page.

## Testing

- `vitest run src/pages/instance/__tests__/DLQPage.test.tsx` → 17/17 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
