### PR TITLE
fix(i18n): localize consumer delay formatting

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1564,6 +1564,16 @@ const translations: Record<string, Record<Lang, string>> = {
   'consumer.subscriptionMode': { zh: '订阅模式', en: 'Subscription Mode' },
   'consumer.subGroupType': { zh: '订阅组类型', en: 'Subscription Group Type' },
   'consumer.maxRetry': { zh: '最大重试次数', en: 'Max Retries' },
+  'consumer.delayDays': { zh: '{n}天', en: '{n} day' },
+  'consumer.delayDaysPlural': { zh: '{n}天', en: '{n} days' },
+  'consumer.delayHours': { zh: '{n}小时', en: '{n} hour' },
+  'consumer.delayHoursPlural': { zh: '{n}小时', en: '{n} hours' },
+  'consumer.delayMinutes': { zh: '{n}分钟', en: '{n} minute' },
+  'consumer.delayMinutesPlural': { zh: '{n}分钟', en: '{n} minutes' },
+  'consumer.delaySeconds': { zh: '{n}秒', en: '{n} second' },
+  'consumer.delaySecondsPlural': { zh: '{n}秒', en: '{n} seconds' },
+  'consumer.delayZero': { zh: '0秒', en: '0s' },
+  'consumer.langZh': { zh: 'zh', en: 'en' },
 
   // ─── User Menu ───
   'user.profile': { zh: '个人中心', en: 'Profile' },

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -121,12 +121,16 @@ const lagColor = (lag: number): string => {
 };
 
 /**
- * Format delay seconds into human-readable Chinese time.
+ * Format delay seconds into a human-readable duration.
  * Shows at most 3 units: days → hours → minutes → seconds.
- * e.g. 82500 → "22小时55分钟", 3725 → "1小时2分钟5秒"
+ * e.g. 82500 → "22小时55分钟" (zh) / "22 hours 55 minutes" (en)
  */
-const formatDelay = (totalSeconds: number): string => {
-  if (totalSeconds <= 0) return '0秒';
+const formatDelay = (
+  totalSeconds: number,
+  t: (key: string, params?: Record<string, string | number>) => string,
+  lang?: string,
+): string => {
+  if (totalSeconds <= 0) return t('consumer.delayZero');
 
   const days = Math.floor(totalSeconds / 86400);
   let remaining = totalSeconds % 86400;
@@ -135,13 +139,18 @@ const formatDelay = (totalSeconds: number): string => {
   const minutes = Math.floor(remaining / 60);
   const seconds = remaining % 60;
 
-  const parts: string[] = [];
-  if (days > 0) parts.push(`${days}天`);
-  if (hours > 0) parts.push(`${hours}小时`);
-  if (minutes > 0) parts.push(`${minutes}分钟`);
-  if (seconds > 0 && parts.length < 3) parts.push(`${seconds}秒`);
+  const unitKey = (count: number, singular: string, plural: string): string =>
+    t(count === 1 ? singular : plural, { n: count });
 
-  return parts.length > 0 ? parts.join('') : '0秒';
+  const parts: string[] = [];
+  if (days > 0) parts.push(unitKey(days, 'consumer.delayDays', 'consumer.delayDaysPlural'));
+  if (hours > 0) parts.push(unitKey(hours, 'consumer.delayHours', 'consumer.delayHoursPlural'));
+  if (minutes > 0)
+    parts.push(unitKey(minutes, 'consumer.delayMinutes', 'consumer.delayMinutesPlural'));
+  if (seconds > 0 && parts.length < 3)
+    parts.push(unitKey(seconds, 'consumer.delaySeconds', 'consumer.delaySecondsPlural'));
+
+  return parts.length > 0 ? parts.join(lang === 'zh' ? '' : ' ') : t('consumer.delayZero');
 };
 
 const visibleConsumerGroups = (groups: ConsumerGroup[], modeFilter: string): ConsumerGroup[] => {
@@ -229,7 +238,7 @@ const ConsumerPageContent = ({
   instanceOptions,
   instancesLoading,
 }: ConsumerPageContentProps) => {
-  const { t } = useLang();
+  const { t, lang } = useLang();
   const isCloudInstance =
     selectedInstance?.vendor === 'ALIYUN' || selectedInstance?.vendor === 'TENCENT';
   const hasSelectedInstance = Boolean(selectedInstanceId);
@@ -866,7 +875,7 @@ const ConsumerPageContent = ({
       width: 100,
       align: 'right',
       sorter: (a, b) => (a.delaySeconds ?? 0) - (b.delaySeconds ?? 0),
-      render: (seconds: number) => formatDelay(seconds ?? 0),
+      render: (seconds: number) => formatDelay(seconds ?? 0, t, lang),
     },
     {
       title: '创建时间',
@@ -1598,7 +1607,7 @@ const ConsumerPageContent = ({
                         </Tag>
                       </Descriptions.Item>
                       <Descriptions.Item label="消费延迟">
-                        <Text strong>{formatDelay(selectedGroup.delaySeconds)}</Text>
+                        <Text strong>{formatDelay(selectedGroup.delaySeconds, t, lang)}</Text>
                       </Descriptions.Item>
                       <Descriptions.Item label="最大重试次数">
                         <Text strong>{selectedGroup.retryMaxTimes}</Text> 次


### PR DESCRIPTION
## Summary

Localize the consumer delay formatter (`instance/consumer.tsx`):

- `formatDelay` now takes the `t` function (and `lang` for the join separator) and renders localized duration units: zh keeps its compact "22小时55分钟" style, en gets plural-aware "22 hours 55 minutes"
- Both call sites (lag table cell + overview descriptions) pass `t`/`lang`

Ten new `consumer.*` zh/en keys added (day/hour/minute/second singular+plural, zero-duration).

## Why

The lag column and overview rendered Chinese duration strings in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` → 24/24 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged (compact form preserved)
