### PR TITLE
fix(i18n): localize clients page retry button

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1469,6 +1469,7 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Broker 重启已提交: {name}',
     en: 'Broker restart submitted: {name}',
   },
+  'cluster.clientsRetry': { zh: '重试', en: 'Retry' },
 
   // ─── Topic ───
   'topic.type': { zh: '类型', en: 'Type' },

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -461,7 +461,7 @@ const ClientsPage = () => {
                 setConnectionLoadKey((key) => key + 1);
               }}
             >
-              重试
+              {t('cluster.clientsRetry')}
             </Button>
           }
         />


### PR DESCRIPTION
## Summary

Localize the last hard-coded string on the cluster clients page (`cluster/clients.tsx`):

- The load-error alert's retry button text → `cluster.clientsRetry`

One new `cluster.*` zh/en key added (complements the load-error fallback localized in #2977).

## Why

The retry button in the connection-load error alert was the final hard-coded Chinese string on the page.

## Testing

- `vitest run src/pages/cluster/__tests__/ClientsPage.test.tsx` → 15/15 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
