### PR TITLE
fix(i18n): localize topic permission tags

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1719,6 +1719,11 @@ const translations: Record<string, Record<Lang, string>> = {
   'topic.operationSuccess': { zh: 'Topic 操作成功', en: 'Topic operation successful' },
   'topic.filterType': { zh: '消息类型', en: 'Message Type' },
   'topic.filterAll': { zh: '全部类型', en: 'All Types' },
+  'topic.permRead': { zh: '读', en: 'Read' },
+  'topic.permRO': { zh: '只读', en: 'Read-Only' },
+  'topic.permRW': { zh: '读写', en: 'Read-Write' },
+  'topic.permWO': { zh: '只写', en: 'Write-Only' },
+  'topic.permWrite': { zh: '写', en: 'Write' },
 
   // ─── Group / Consumer (detailed) ───
   'group.subtitle': {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -146,7 +146,11 @@ const TOPIC_TYPE_CARDS = [
 ];
 
 // ─── Perm label ───────────────────────────────────────────────────
-const PERM_LABEL: Record<string, string> = { RW: '读写', RO: '只读', WO: '只写' };
+const PERM_LABEL: Record<string, string> = {
+  RW: 'topic.permRW',
+  RO: 'topic.permRO',
+  WO: 'topic.permWO',
+};
 
 const visibleTopics = (
   topics: Topic[],
@@ -786,10 +790,10 @@ const TopicPage = () => {
       width: 130,
       render: (_: string, record) => (
         <Space direction="vertical" size={4}>
-          <Tag>{PERM_LABEL[record.perm] || record.perm}</Tag>
+          <Tag>{t(PERM_LABEL[record.perm] || record.perm)}</Tag>
           <Space size={4}>
-            <Tag color={record.readable ? 'success' : 'error'}>读</Tag>
-            <Tag color={record.writable ? 'success' : 'error'}>写</Tag>
+            <Tag color={record.readable ? 'success' : 'error'}>{t('topic.permRead')}</Tag>
+            <Tag color={record.writable ? 'success' : 'error'}>{t('topic.permWrite')}</Tag>
           </Space>
         </Space>
       ),
@@ -1026,7 +1030,7 @@ const TopicPage = () => {
         <Descriptions.Item label="写队列数">{topic.writeQueues}</Descriptions.Item>
         <Descriptions.Item label="读队列数">{topic.readQueues}</Descriptions.Item>
         <Descriptions.Item label="权限">
-          <Tag>{PERM_LABEL[topic.perm]}</Tag>
+          <Tag>{t(PERM_LABEL[topic.perm])}</Tag>
         </Descriptions.Item>
         <Descriptions.Item label="今日消息量">{formatNumber(topic.messageCount)}</Descriptions.Item>
         <Descriptions.Item label="TPS">{formatNumber(topic.tps)}</Descriptions.Item>


### PR DESCRIPTION
## Summary

Localize the topic permission display (`instance/topic.tsx`):

- `PERM_LABEL` now maps RW/RO/WO to translation keys, rendered through `t()` in the subscription table and detail descriptions
- The readable/writable sub-tags 读/写 in the subscription table are localized too

New keys reuse the `topic.permRW/RO/WO` set (also defined by the create-modal PR with identical text) plus `topic.permRead/permWrite`.

## Why

The permission tags rendered hard-coded Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/TopicPage.test.tsx` → 16/16 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
