### PR TITLE
fix(i18n): localize topic route diagnostics

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1719,6 +1719,15 @@ const translations: Record<string, Record<Lang, string>> = {
   'topic.operationSuccess': { zh: 'Topic 操作成功', en: 'Topic operation successful' },
   'topic.filterType': { zh: '消息类型', en: 'Message Type' },
   'topic.filterAll': { zh: '全部类型', en: 'All Types' },
+  'topic.addressTopology': { zh: '地址拓扑', en: 'Address Topology' },
+  'topic.addrUnknown': { zh: '地址未知', en: 'Address Unknown' },
+  'topic.noIssues': { zh: '无', en: 'None' },
+  'topic.queueDistribution': { zh: '队列分布', en: 'Queue Distribution' },
+  'topic.readQueuesShort': { zh: '读队列 {n}', en: 'Read queues {n}' },
+  'topic.routeCritical': { zh: '异常', en: 'Critical' },
+  'topic.routeHealthy': { zh: '健康', en: 'Healthy' },
+  'topic.routeWarning': { zh: '关注', en: 'Warning' },
+  'topic.writeQueuesShort': { zh: '写队列 {n}', en: 'Write queues {n}' },
 
   // ─── Group / Consumer (detailed) ───
   'group.subtitle': {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -283,11 +283,11 @@ const formatDateTime = (iso?: string): string => {
 
 const ROUTE_STATUS_META: Record<
   RouteDiagnosticStatus,
-  { color: string; label: string; icon: React.ReactNode }
+  { color: string; labelKey: string; icon: React.ReactNode }
 > = {
-  healthy: { color: 'success', label: '健康', icon: <CheckCircleOutlined /> },
-  warning: { color: 'warning', label: '关注', icon: <WarningOutlined /> },
-  critical: { color: 'error', label: '异常', icon: <ExclamationCircleOutlined /> },
+  healthy: { color: 'success', labelKey: 'topic.routeHealthy', icon: <CheckCircleOutlined /> },
+  warning: { color: 'warning', labelKey: 'topic.routeWarning', icon: <WarningOutlined /> },
+  critical: { color: 'error', labelKey: 'topic.routeCritical', icon: <ExclamationCircleOutlined /> },
 };
 
 const ISSUE_SEVERITY_COLOR: Record<RouteDiagnosticIssue['severity'], string> = {
@@ -695,13 +695,13 @@ const TopicPage = () => {
     const meta = ROUTE_STATUS_META[status];
     return (
       <Tag color={meta.color} icon={meta.icon}>
-        {meta.label}
+        {t(meta.labelKey)}
       </Tag>
     );
   };
 
   const renderRouteIssueTags = (issues: RouteDiagnosticIssue[]) => {
-    if (issues.length === 0) return <Text type="secondary">无</Text>;
+    if (issues.length === 0) return <Text type="secondary">{t('topic.noIssues')}</Text>;
     return (
       <Space size={[4, 4]} wrap>
         {issues.slice(0, 3).map((item) => (
@@ -729,7 +729,7 @@ const TopicPage = () => {
       ),
     },
     {
-      title: '地址拓扑',
+      title: t('topic.addressTopology'),
       key: 'brokerAddr',
       width: 260,
       render: (_: unknown, record) => (
@@ -750,28 +750,28 @@ const TopicPage = () => {
                 </Tag>
               ))
             ) : (
-              <Tag color="warning">地址未知</Tag>
+              <Tag color="warning">{t('topic.addrUnknown')}</Tag>
             )}
           </Space>
         </Space>
       ),
     },
     {
-      title: '队列分布',
+      title: t('topic.queueDistribution'),
       key: 'queues',
       width: 220,
       render: (_: unknown, record) => (
         <Space direction="vertical" size={4} style={{ width: '100%' }}>
           <div>
             <Flex justify="space-between">
-              <Text>写队列 {record.writeQueues}</Text>
+              <Text>{t('topic.writeQueuesShort', { n: record.writeQueues })}</Text>
               <Text type="secondary">{formatPercent(record.writeShare)}</Text>
             </Flex>
             <Progress percent={record.writeShare} showInfo={false} size="small" />
           </div>
           <div>
             <Flex justify="space-between">
-              <Text>读队列 {record.readQueues}</Text>
+              <Text>{t('topic.readQueuesShort', { n: record.readQueues })}</Text>
               <Text type="secondary">{formatPercent(record.readShare)}</Text>
             </Flex>
             <Progress percent={record.readShare} showInfo={false} size="small" />


### PR DESCRIPTION
## Summary

Localize the topic route-diagnostics area (`instance/topic.tsx`):

- `ROUTE_STATUS_META` labels (健康/关注/异常) now use `labelKey`, rendered through `t()` in the status tag
- No-issue empty text, 地址拓扑/队列分布 section titles, 地址未知 tag, and the write/read queue counts

Nine new `topic.*` zh/en keys added.

## Why

The route-diagnostics panel rendered Chinese labels in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/TopicPage.test.tsx` → 16/16 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
