### PR TITLE
 fix(bug) Notification enqueue abnormal rollback

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertEvaluationService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertEvaluationService.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.cluster.metrics.MetricAvailability;
 import org.apache.rocketmq.studio.cluster.metrics.MetricSample;
 import org.apache.rocketmq.studio.cluster.metrics.MetricSnapshotRepository;
@@ -35,10 +36,12 @@ import java.util.Optional;
 import java.util.TreeMap;
 
 /**
- * Evaluates one rule against one native sample in an independent transaction. A failure rolls
- * back this evaluation's state, event, and outbox changes without invalidating other evaluations
- * from the same collection batch.
+ * Evaluates one rule against one native sample in an independent transaction. State transitions and
+ * alert events are persisted first; notification enqueuing runs in a separate transaction so that an
+ * outbox failure does not roll back the state transition or event, preventing alert silencing loss
+ * and ensuring notifications are retried on the next evaluation once the outbox recovers.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NativeAlertEvaluationService {
@@ -92,7 +95,13 @@ public class NativeAlertEvaluationService {
             alertRepository.markRuleTriggered(rule.getId(), eventTime.toString());
         }
         if (!event.isNotificationSuppressed()) {
-            notificationOutboxService.enqueue(event, rule, sample.labels());
+            try {
+                notificationOutboxService.enqueueSafely(event, rule, sample.labels());
+            } catch (Exception enqueueError) {
+                log.warn("Failed to enqueue notification for alert {} (rule={}, transition={}); "
+                        + "state transition and event were persisted and will not be rolled back",
+                        event.getId(), rule.getId(), update.transition(), enqueueError);
+            }
         }
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
@@ -150,6 +150,18 @@ public class NotificationOutboxService {
         enqueue(alert, rule, Map.of());
     }
 
+    /**
+     * Enqueues notification work in an independent transaction so that an outbox failure (e.g. table
+     * unavailable) does not roll back the caller's alert state transition and event persistence.
+     * Returns {@code true} on success, {@code false} if enqueuing failed; the caller retains its
+     * committed state and event either way.
+     */
+    @org.springframework.transaction.annotation.Transactional(propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW)
+    public boolean enqueueSafely(SystemAlertVO alert, AlertRuleVO rule, Map<String, String> labels) {
+        enqueue(alert, rule, labels);
+        return true;
+    }
+
     public void sendTestMessage(String channel) {
         if (!"dingtalk".equals(channel) && !"email".equals(channel) && !"sms".equals(channel)) {
             throw new IllegalArgumentException("Unsupported notification channel: " + channel);


### PR DESCRIPTION
## What is the purpose of the change

The Notification enqueue exception rolls back the entire evaluation transaction, resulting in permanent loss of state transitions and alert events.

fix:
1. NotificationOutboxService.java: — 新增 enqueueSafely 方法，使用 @Transactional(REQUIRES_NEW) 在独立事务中执行 enqueue，与主评估事务隔离。

2. NativeAlertEvaluationService.java — 将 enqueue 调用改为 try-catch 调用 enqueueSafely，异常仅记录 warn 日志不传播，确保主事务（状态转换+告警事件）正常提交。

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
