### PR TITLE
fix(tencent): report bounded message query truncation

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageProvider.java
@@ -24,6 +24,12 @@ public interface MessageProvider {
     List<MessageRecordVO> queryMessages(String instanceId, String topic, String msgId, String tag, String key, Long startTime,
                                         Long endTime);
 
+    default MessageQueryResult queryMessagesDetailed(String instanceId, String topic, String msgId,
+                                                      String tag, String key, Long startTime, Long endTime) {
+        return MessageQueryResult.complete(queryMessages(instanceId, topic, msgId, tag, key,
+                startTime, endTime));
+    }
+
     TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic);
 
     List<QueueOffsetVO> getQueueOffsets(String instanceId, String topic);

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageQueryResult.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageQueryResult.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import java.util.List;
+
+/**
+ * Message query outcome with a provider truncation signal.
+ *
+ * @param messages rows returned within the provider's bounded result budget
+ * @param mayBeTruncated true when the provider stopped because its result budget was reached,
+ *         not because the query was exhausted
+ */
+public record MessageQueryResult(
+        List<MessageRecordVO> messages,
+        boolean mayBeTruncated) {
+
+    public MessageQueryResult {
+        messages = messages == null ? List.of() : List.copyOf(messages);
+    }
+
+    public static MessageQueryResult complete(List<MessageRecordVO> messages) {
+        return new MessageQueryResult(messages, false);
+    }
+
+    public static MessageQueryResult truncated(List<MessageRecordVO> messages) {
+        return new MessageQueryResult(messages, true);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -42,19 +42,22 @@ public class MessageService {
 
     public List<MessageRecordVO> queryMessages(
             String instanceId, String topic, String msgId, String tag, String key, Long startTime, Long endTime) {
-        return queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime, true);
+        return queryMessagesDetailed(instanceId, topic, msgId, tag, key, startTime, endTime, true)
+                .messages();
     }
 
-    private List<MessageRecordVO> queryMessages(
+    private MessageQueryResult queryMessagesDetailed(
             String instanceId, String topic, String msgId, String tag, String key,
             Long startTime, Long endTime, boolean recordHistory) {
         validateTopicQueryWindow(topic, msgId, key, startTime, endTime);
         log.info("Querying messages: topic={}, msgId={}, tag={}, key={}", topic, msgId, tag, key);
-        List<MessageRecordVO> result = providerRegistry.byInstanceId(instanceId)
-                .map(provider -> provider.queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime))
-                .orElseGet(() -> messageProvider.queryMessages(instanceId, topic, msgId, tag, key, startTime, endTime));
+        MessageQueryResult result = providerRegistry.byInstanceId(instanceId)
+                .map(provider -> provider.queryMessagesDetailed(instanceId, topic, msgId, tag,
+                        key, startTime, endTime))
+                .orElseGet(() -> messageProvider.queryMessagesDetailed(instanceId, topic, msgId,
+                        tag, key, startTime, endTime));
         if (recordHistory) {
-            recordMessageQuery(instanceId, topic, msgId, tag, key, startTime, endTime, result);
+            recordMessageQuery(instanceId, topic, msgId, tag, key, startTime, endTime, result.messages());
         }
         return result;
     }
@@ -64,15 +67,17 @@ public class MessageService {
         if (page < 1 || pageSize < 1 || pageSize > MAX_PAGE_SIZE) {
             throw new BusinessException(400, "page must be positive and pageSize must be between 1 and 200");
         }
-        List<MessageRecordVO> result = queryMessages(
+        MessageQueryResult queryResult = queryMessagesDetailed(
                 instanceId, topic, msgId, tag, key, startTime, endTime, page == 1);
+        List<MessageRecordVO> result = queryResult.messages();
         long offset = (long) (page - 1) * pageSize;
         int from = (int) Math.min(offset, result.size());
         int to = Math.min(from + pageSize, result.size());
         boolean topicQuery = StringUtils.hasText(topic) && !StringUtils.hasText(msgId)
                 && !StringUtils.hasText(key);
         return MessageQueryPageVO.builder().items(result.subList(from, to)).total(result.size()).page(page)
-                .size(pageSize).resultMayBeTruncated(topicQuery && result.size() >= TOPIC_QUERY_RESULT_LIMIT).build();
+                .size(pageSize).resultMayBeTruncated(queryResult.mayBeTruncated()
+                        || topicQuery && result.size() >= TOPIC_QUERY_RESULT_LIMIT).build();
     }
 
     public TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/InstanceProvider.java
@@ -28,6 +28,7 @@ import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
 import org.apache.rocketmq.studio.instance.message.DirectConsumeMessageDTO;
 import org.apache.rocketmq.studio.instance.message.DirectConsumeMessageResultVO;
+import org.apache.rocketmq.studio.instance.message.MessageQueryResult;
 import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerPageVO;
@@ -157,6 +158,16 @@ public interface InstanceProvider {
 
     List<MessageRecordVO> queryMessages(String instanceId, String topic, String msgId,
                                         String tag, String key, Long startTime, Long endTime);
+
+    /**
+     * Message query with an explicit provider truncation signal. Providers that page remote APIs
+     * should return a bounded result and set {@code mayBeTruncated} when they stop at the budget.
+     */
+    default MessageQueryResult queryMessagesDetailed(String instanceId, String topic, String msgId,
+                                                      String tag, String key, Long startTime, Long endTime) {
+        return MessageQueryResult.complete(queryMessages(instanceId, topic, msgId, tag, key,
+                startTime, endTime));
+    }
 
     TraceRecordVO getMessageTrace(String instanceId, String msgId, String topic);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProvider.java
@@ -59,6 +59,7 @@ import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
 import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
 import org.apache.rocketmq.studio.instance.message.ConsumerStatusVO;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
+import org.apache.rocketmq.studio.instance.message.MessageQueryResult;
 import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
 import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
@@ -107,6 +108,7 @@ public class TencentInstanceProvider implements InstanceProvider {
     static final int MAX_QUEUE_NUM = 16;
     static final int DEFAULT_MAX_RETRY_TIMES = 16;
     static final int MESSAGE_LIMIT = 100;
+    static final int MESSAGE_QUERY_HARD_LIMIT = 2_000;
     private static final DateTimeFormatter TENCENT_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[,SSS][,SS]");
     private static final DateTimeFormatter[] TENCENT_TIME_FORMATTERS = {
         TENCENT_TIME_FORMATTER,
@@ -555,13 +557,21 @@ public class TencentInstanceProvider implements InstanceProvider {
     @Override
     public List<MessageRecordVO> queryMessages(String instanceId, String topic, String msgId,
                                                String tag, String key, Long startTime, Long endTime) {
+        return queryMessagesDetailed(instanceId, topic, msgId, tag, key, startTime, endTime).messages();
+    }
+
+    @Override
+    public MessageQueryResult queryMessagesDetailed(String instanceId, String topic, String msgId,
+                                                     String tag, String key, Long startTime, Long endTime) {
         Context context = resolve(instanceId);
         requireTopic(topic);
         // Querying by message ID returns the full detail (body, properties and tracks) via
         // DescribeMessage, mirroring the msgId path of the base provider.
         if (StringUtils.hasText(msgId)) {
             MessageRecordVO record = toRecordVO(describeMessage(context, topic, msgId));
-            return record == null ? Collections.emptyList() : Collections.singletonList(record);
+            return MessageQueryResult.complete(record == null
+                    ? Collections.emptyList()
+                    : Collections.singletonList(record));
         }
 
         long end = endTime != null ? endTime : System.currentTimeMillis();
@@ -576,7 +586,8 @@ public class TencentInstanceProvider implements InstanceProvider {
         // is not server-paginated (pagination=false), so page through the whole result set here.
         String taskRequestId = UUID.randomUUID().toString();
         List<MessageRecordVO> result = new ArrayList<>();
-        for (int page = 0; page < MAX_PAGES; page++) {
+        boolean mayBeTruncated = false;
+        for (int page = 0; page < MAX_PAGES && result.size() < MESSAGE_QUERY_HARD_LIMIT; page++) {
             DescribeMessageListRequest request = new DescribeMessageListRequest();
             request.setInstanceId(context.cloudInstanceId());
             request.setTopic(topic);
@@ -617,8 +628,12 @@ public class TencentInstanceProvider implements InstanceProvider {
             if (isLastPage(returned, total, result.size())) {
                 break;
             }
+            if (result.size() >= MESSAGE_QUERY_HARD_LIMIT) {
+                mayBeTruncated = true;
+                break;
+            }
         }
-        return result;
+        return mayBeTruncated ? MessageQueryResult.truncated(result) : MessageQueryResult.complete(result);
     }
 
     @Override

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -118,8 +118,9 @@ class MessageServiceTest {
         QueryHistoryService history = mock(QueryHistoryService.class);
         MessageService service = new MessageService(fallback, registry, history, mock(OperationAuditService.class));
         when(registry.byInstanceId("cloud-instance")).thenReturn(Optional.of(provider));
-        when(provider.queryMessages("cloud-instance", "orders", null, null, "ORDER-1", null, null))
-                .thenReturn(List.of(MessageRecordVO.builder().msgId("msg-1").build()));
+        when(provider.queryMessagesDetailed("cloud-instance", "orders", null, null, "ORDER-1", null, null))
+                .thenReturn(MessageQueryResult.complete(
+                        List.of(MessageRecordVO.builder().msgId("msg-1").build())));
 
         service.queryMessages("cloud-instance", "orders", null, null, "ORDER-1", null, null);
 
@@ -175,9 +176,10 @@ class MessageServiceTest {
         QueryHistoryService history = mock(QueryHistoryService.class);
         MessageService service = new MessageService(provider, registry, history, mock(OperationAuditService.class));
         when(registry.byInstanceId("instance-a")).thenReturn(Optional.empty());
-        when(provider.queryMessages("instance-a", "TopicA", null, null, null, 1000L, 2000L))
-                .thenReturn(java.util.stream.IntStream.range(0, 200)
-                        .mapToObj(index -> MessageRecordVO.builder().msgId("msg-" + index).build()).toList());
+        when(provider.queryMessagesDetailed("instance-a", "TopicA", null, null, null, 1000L, 2000L))
+                .thenReturn(MessageQueryResult.complete(java.util.stream.IntStream.range(0, 200)
+                        .mapToObj(index -> MessageRecordVO.builder().msgId("msg-" + index).build())
+                        .toList()));
 
         MessageQueryPageVO page = service.queryMessagesPage("instance-a", "TopicA", null, null, null,
                 1000L, 2000L, 2, 50);
@@ -188,14 +190,52 @@ class MessageServiceTest {
     }
 
     @Test
+    void pageQueryPropagatesProviderTruncationBelowTheGenericTopicThreshold() {
+        MessageProvider provider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        QueryHistoryService history = mock(QueryHistoryService.class);
+        MessageService service = new MessageService(provider, registry, history, mock(OperationAuditService.class));
+        when(registry.byInstanceId("instance-a")).thenReturn(Optional.empty());
+        when(provider.queryMessagesDetailed("instance-a", "TopicA", null, null, null, 1000L, 2000L))
+                .thenReturn(MessageQueryResult.truncated(
+                        java.util.stream.IntStream.range(0, 120)
+                                .mapToObj(index -> MessageRecordVO.builder().msgId("msg-" + index).build())
+                                .toList()));
+
+        MessageQueryPageVO page = service.queryMessagesPage("instance-a", "TopicA", null, null, null,
+                1000L, 2000L, 2, 50);
+
+        assertThat(page.getTotal()).isEqualTo(120);
+        assertThat(page.isResultMayBeTruncated()).isTrue();
+    }
+
+    @Test
+    void providerTruncationSignalIsAlsoReturnedForKeyAndIdQueries() {
+        MessageProvider provider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        QueryHistoryService history = mock(QueryHistoryService.class);
+        MessageService service = new MessageService(provider, registry, history, mock(OperationAuditService.class));
+        when(registry.byInstanceId("instance-a")).thenReturn(Optional.empty());
+        when(provider.queryMessagesDetailed("instance-a", "TopicA", null, null, "order-1", 1000L, 2000L))
+                .thenReturn(MessageQueryResult.truncated(List.of(
+                        MessageRecordVO.builder().msgId("msg-1").build())));
+
+        MessageQueryPageVO page = service.queryMessagesPage("instance-a", "TopicA", null, null,
+                "order-1", 1000L, 2000L, 1, 50);
+
+        assertThat(page.isResultMayBeTruncated()).isTrue();
+    }
+
+    @Test
     void pageQueryRecordsHistoryOnlyForTheFirstPage() {
         MessageProvider provider = mock(MessageProvider.class);
         InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
         QueryHistoryService history = mock(QueryHistoryService.class);
         MessageService service = new MessageService(provider, registry, history, mock(OperationAuditService.class));
         when(registry.byInstanceId("instance-a")).thenReturn(Optional.empty());
-        when(provider.queryMessages("instance-a", "TopicA", null, null, null, 1000L, 2000L))
-                .thenReturn(List.of(MessageRecordVO.builder().msgId("msg-1").build()));
+        when(provider.queryMessagesDetailed("instance-a", "TopicA", null, null, null, 1000L, 2000L))
+                .thenReturn(MessageQueryResult.complete(
+                        List.of(MessageRecordVO.builder().msgId("msg-1").build())));
 
         service.queryMessagesPage("instance-a", "TopicA", null, null, null,
                 1000L, 2000L, 1, 50);
@@ -203,7 +243,7 @@ class MessageServiceTest {
                 1000L, 2000L, 2, 50);
 
         verify(provider, org.mockito.Mockito.times(2))
-                .queryMessages("instance-a", "TopicA", null, null, null, 1000L, 2000L);
+                .queryMessagesDetailed("instance-a", "TopicA", null, null, null, 1000L, 2000L);
         verify(history, org.mockito.Mockito.times(1)).recordMessageQuery(
                 "instance-a", "TOPIC", "TopicA", null, null, null, 1000L, 2000L, 1, null);
     }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentInstanceProviderTest.java
@@ -55,6 +55,7 @@ import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
 import org.apache.rocketmq.studio.instance.group.ResetConsumerOffsetPreviewVO;
 import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
 import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
+import org.apache.rocketmq.studio.instance.message.MessageQueryResult;
 import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
 import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
 import org.apache.rocketmq.studio.instance.topic.TopicConsumerVO;
@@ -913,6 +914,51 @@ class TencentInstanceProviderTest {
         assertThat(requests.get(1).getTaskRequestId())
                 .isEqualTo(requests.get(0).getTaskRequestId())
                 .isNotBlank();
+    }
+
+    @Test
+    void queryMessagesShouldReportTheProviderResultBudget() throws Exception {
+        // A full first page and a large TotalCount mean the provider stopped because it reached
+        // its result budget, not because Tencent returned the final page.
+        MessageItem[] page1Items = new MessageItem[TencentInstanceProvider.MESSAGE_LIMIT];
+        for (int i = 0; i < page1Items.length; i++) {
+            MessageItem item = new MessageItem();
+            item.setMsgId("MSG-" + (i + 1));
+            item.setProduceTime("2024-09-12 14:06:55,591");
+            page1Items[i] = item;
+        }
+        DescribeMessageListResponse response = new DescribeMessageListResponse();
+        response.setData(page1Items);
+        response.setTotalCount((long) TencentInstanceProvider.MESSAGE_QUERY_HARD_LIMIT + 1L);
+        when(client.DescribeMessageList(any())).thenReturn(response);
+
+        MessageQueryResult result = provider.queryMessagesDetailed(
+                STUDIO_INSTANCE_ID, "orders", null, null, null,
+                1600000000000L, 1600001000000L);
+
+        assertThat(result.messages()).hasSize(TencentInstanceProvider.MESSAGE_QUERY_HARD_LIMIT);
+        assertThat(result.mayBeTruncated()).isTrue();
+        verify(client, org.mockito.Mockito.times(
+                        TencentInstanceProvider.MESSAGE_QUERY_HARD_LIMIT
+                                / TencentInstanceProvider.MESSAGE_LIMIT))
+                .DescribeMessageList(any());
+    }
+
+    @Test
+    void queryMessagesShouldReportCompleteWhenTencentReturnsAShortPage() throws Exception {
+        MessageItem one = new MessageItem();
+        one.setMsgId("MSG-1");
+        one.setProduceTime("2024-09-12 14:06:55,591");
+        DescribeMessageListResponse response = new DescribeMessageListResponse();
+        response.setData(new MessageItem[]{one});
+        when(client.DescribeMessageList(any())).thenReturn(response);
+
+        MessageQueryResult result = provider.queryMessagesDetailed(
+                STUDIO_INSTANCE_ID, "orders", null, null, null,
+                1600000000000L, 1600001000000L);
+
+        assertThat(result.messages()).hasSize(1);
+        assertThat(result.mayBeTruncated()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Tencent message queries page `DescribeMessageList` up to 100 pages of 100 rows, but the list-based provider API cannot say whether the query was exhausted or stopped at a provider cap. A large query could therefore return a partial result that looked complete, while retaining up to 10,000 rows in memory before `MessageService` sliced a small page.

## What changed

- add `MessageQueryResult` as the bounded provider query outcome with an explicit `mayBeTruncated` signal
- add `queryMessagesDetailed` default methods to `InstanceProvider` and `MessageProvider`; existing providers continue through their current list-based implementation
- implement the detailed query in the Tencent provider with a 2,000-record budget, matching the Apache provider hard cap
- stop Tencent paging at the budget and mark the result as possibly truncated; short pages and satisfied `TotalCount` remain complete results
- preserve task-request-id continuation across pages
- route `MessageService` through the detailed result and propagate provider truncation into `MessageQueryPageVO.resultMayBeTruncated`; the existing 200-row generic topic threshold remains an additional signal
- add regression tests for the budget, complete short-page results, provider truncation below the generic threshold, and truncation on key queries

## Verification

- before the fix, the new detailed-query regression could not compile because the provider had no truncation outcome; the current list path also returned 2,000 rows without any signal when Tencent reported a larger total
- focused tests: `TencentInstanceProviderTest,MessageServiceTest,MessageControllerTest,MessageQueryToolHandlerTest` (69 tests) passed
- Checkstyle: 0 violations
- full server suite: `mvn -DskipTests=false test` (1,964 tests, 0 failures, 0 errors)

Closes #3047