### PR TITLE
fix(alert): normalize native metric rule inputs

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTO.java
@@ -64,10 +64,11 @@ public class AlertRuleRequestDTO {
     private String notificationTemplate;
 
     public AlertRuleVO toAlertRuleVO() {
+        String normalizedMetric = metric == null ? null : metric.trim();
         return AlertRuleVO.builder()
                 .id(id)
                 .name(name)
-                .metric(metric)
+                .metric(normalizedMetric)
                 .operator(operator)
                 .threshold(threshold)
                 .thresholdUnit(thresholdUnit)

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferService.java
@@ -36,6 +36,9 @@ public class AlertRuleTransferService {
             AlertRuleVO candidate = request.toAlertRuleVO();
             candidate.setId(null);
             candidate.setDomain(domain);
+            if (candidate.getMetric() != null) {
+                candidate.setMetric(candidate.getMetric().trim());
+            }
             metricCatalogService.validate(candidate);
             return candidate;
         }).toList();

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleTestService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleTestService.java
@@ -40,6 +40,7 @@ public class NativeAlertRuleTestService {
     private final AlertRuleEvaluator evaluator;
 
     public AlertRuleTestResultVO test(AlertRuleVO rule) {
+        normalizeRule(rule);
         NativeAlertRulePolicy.validate(rule);
         InstanceVO instance = instanceRepository.findByIdentifier(rule.getInstanceId())
                 .orElseThrow(() -> new BusinessException(404, "Instance not found: " + rule.getInstanceId()));
@@ -77,6 +78,25 @@ public class NativeAlertRuleTestService {
                             .conditionMet(evaluation.conditionMet())
                             .unavailableReason(sample.unavailableReason()).build();
                 }).toList()).build();
+    }
+
+    /**
+     * Normalizes the fields used for exact native metric matching before policy validation and
+     * sample filtering. Existing callers may pass stored rules copied from older deployments.
+     */
+    private static void normalizeRule(AlertRuleVO rule) {
+        if (rule == null) {
+            return;
+        }
+        if (rule.getMetric() != null) {
+            rule.setMetric(rule.getMetric().trim());
+        }
+        if (rule.getInstanceId() != null) {
+            rule.setInstanceId(rule.getInstanceId().trim());
+        }
+        if (rule.getOperator() != null) {
+            rule.setOperator(rule.getOperator().trim());
+        }
     }
 
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTOTest.java
@@ -58,4 +58,13 @@ class AlertRuleRequestDTOTest {
 
         assertThat(request.toAlertRuleVO().getChannels()).containsExactly("email", "sms");
     }
+
+    @Test
+    void toAlertRuleVOShouldNormalizeTheNativeMetricKeyTest() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName("High Lag");
+        request.setMetric("  consumer.lag.total  ");
+
+        assertThat(request.toAlertRuleVO().getMetric()).isEqualTo("consumer.lag.total");
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleTestServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleTestServiceTest.java
@@ -79,6 +79,30 @@ class NativeAlertRuleTestServiceTest {
     }
 
     @Test
+    void normalizesTheMetricKeyBeforePolicyAndSampleFilteringTest() {
+        InstanceRepository instances = mock(InstanceRepository.class);
+        BusinessMetricsCollector collector = mock(BusinessMetricsCollector.class);
+        InstanceVO instance = InstanceVO.builder().name("local").build();
+        when(instances.findByIdentifier("local")).thenReturn(Optional.of(instance));
+        when(collector.supports(instance)).thenReturn(true);
+        when(collector.collect(instance)).thenReturn(List.of(sample("orders", 20)));
+        AlertRuleVO rule = AlertRuleVO.builder().domain(AlertDomain.BUSINESS)
+                .metric("  consumer.lag.total  ")
+                .instanceId(" local ")
+                .operator(" > ")
+                .threshold(10)
+                .build();
+
+        AlertRuleTestResultVO result = new NativeAlertRuleTestService(instances, List.of(), List.of(collector),
+                new AlertRuleEvaluator()).test(rule);
+
+        assertThat(result.samples()).singleElement().satisfies(sample -> {
+            assertThat(sample.currentValue()).isEqualTo(20);
+            assertThat(sample.conditionMet()).isTrue();
+        });
+    }
+
+    @Test
     void keepsResultsFromHealthyCollectorsWhenAnotherCollectorFailsTest() {
         InstanceRepository instances = mock(InstanceRepository.class);
         BusinessMetricsCollector failing = mock(BusinessMetricsCollector.class);


### PR DESCRIPTION
## What is the purpose of the change

Native alert rule metrics are compared with raw strings in some paths and trimmed strings in others. A metric copied with surrounding whitespace could bypass native policy validation, then be filtered out by the test service's exact sample match, while notification formatting and semantic fingerprints used the non-canonical value.

## What changed

- trim the metric when converting `AlertRuleRequestDTO` to the rule VO so create, update, and test requests enter validation with a canonical key
- normalize metric, instance ID, and operator in `NativeAlertRuleTestService` before policy validation and sample filtering; this also handles rules copied from older stored data
- trim imported metric keys before transfer-import catalog validation
- add regressions for DTO normalization and end-to-end native rule testing with padded metric, instance, and operator values

## Verification

- before the fix, the DTO regression returned `"  consumer.lag.total  "`, and the native test regression returned zero samples
- focused tests: `AlertRuleRequestDTOTest,NativeAlertRuleTestServiceTest,AlertRuleTransferServiceTest,NativeAlertRulePolicyTest,NativeAlertMetricCatalogServiceTest,AlertRuleEvaluatorTest` (30 tests) passed
- Checkstyle: 0 violations
- full server suite: `mvn -DskipTests=false test` (1,962 tests, 0 failures, 0 errors)

Closes #3049