### PR TITLE
fix(i18n): localize topic import preview and batch delete

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1719,6 +1719,17 @@ const translations: Record<string, Record<Lang, string>> = {
   'topic.operationSuccess': { zh: 'Topic 操作成功', en: 'Topic operation successful' },
   'topic.filterType': { zh: '消息类型', en: 'Message Type' },
   'topic.filterAll': { zh: '全部类型', en: 'All Types' },
+  'topic.batchDeleteTitle': { zh: '确认批量删除', en: 'Confirm Batch Delete' },
+  'topic.batchDeleteContent': { zh: '确定要删除选中的 {count} 个 Topic 吗？此操作不可撤销。', en: 'Delete the {count} selected topics? This cannot be undone.' },
+  'topic.importLineNo': { zh: '行号', en: 'Line' },
+  'topic.importNoteCol': { zh: '说明', en: 'Notes' },
+  'topic.importStatusCol': { zh: '状态', en: 'Status' },
+  'topic.importFailedTag': { zh: '失败', en: 'Failed' },
+  'topic.importInvalidTag': { zh: '无效', en: 'Invalid' },
+  'topic.importPendingTag': { zh: '待导入', en: 'Pending' },
+  'topic.importSuccessTag': { zh: '成功', en: 'Success' },
+  'topic.searchNamePlaceholder': { zh: '搜索 Topic 名称', en: 'Search topic name' },
+  'topic.typeFilterPlaceholder': { zh: '类型筛选', en: 'Filter by type' },
 
   // ─── Group / Consumer (detailed) ───
   'group.subtitle': {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -1155,22 +1155,22 @@ const TopicPage = () => {
   };
 
   const topicImportColumns: TableColumnsType<ResourceImportRow<Partial<Topic>>> = [
-    { title: '行号', dataIndex: 'lineNumber', key: 'lineNumber', width: 80 },
-    { title: 'Topic 名称', dataIndex: 'name', key: 'name' },
+    { title: t('topic.importLineNo'), dataIndex: 'lineNumber', key: 'lineNumber', width: 80 },
+    { title: t('topic.name'), dataIndex: 'name', key: 'name' },
     {
-      title: '状态',
+      title: t('topic.importStatusCol'),
       dataIndex: 'status',
       key: 'status',
       width: 100,
       render: (status: ResourceImportRow<Partial<Topic>>['status']) => {
-        if (status === 'success') return <Tag color="success">成功</Tag>;
-        if (status === 'failed') return <Tag color="error">失败</Tag>;
-        if (status === 'invalid') return <Tag color="warning">无效</Tag>;
-        return <Tag>待导入</Tag>;
+        if (status === 'success') return <Tag color="success">{t('topic.importSuccessTag')}</Tag>;
+        if (status === 'failed') return <Tag color="error">{t('topic.importFailedTag')}</Tag>;
+        if (status === 'invalid') return <Tag color="warning">{t('topic.importInvalidTag')}</Tag>;
+        return <Tag>{t('topic.importPendingTag')}</Tag>;
       },
     },
     {
-      title: '说明',
+      title: t('topic.importNoteCol'),
       dataIndex: 'message',
       key: 'message',
       render: (text?: string) => text || '-',
@@ -1283,7 +1283,7 @@ const TopicPage = () => {
             style={{ width: 220 }}
           />
           <Input.Search
-            placeholder="搜索 Topic 名称"
+            placeholder={t('topic.searchNamePlaceholder')}
             allowClear
             style={{ width: 260 }}
             onSearch={(value) => {
@@ -1298,7 +1298,7 @@ const TopicPage = () => {
             }}
           />
           <Select
-            placeholder="类型筛选"
+            placeholder={t('topic.typeFilterPlaceholder')}
             value={typeFilter}
             onChange={(value) => {
               setTypeFilter(value);
@@ -1315,11 +1315,11 @@ const TopicPage = () => {
               icon={<DeleteOutlined />}
               onClick={() => {
                 Modal.confirm({
-                  title: '确认批量删除',
-                  content: `确定要删除选中的 ${selectedRowKeys.length} 个 Topic 吗？此操作不可撤销。`,
-                  okText: '删除',
+                  title: t('topic.batchDeleteTitle'),
+                  content: t('topic.batchDeleteContent', { count: selectedRowKeys.length }),
+                  okText: t('topic.delete'),
                   okType: 'danger',
-                  cancelText: '取消',
+                  cancelText: t('common.cancel'),
                   onOk: async () => {
                     try {
                       const names = selectedRowKeys.map(String);


### PR DESCRIPTION
## Summary

Localize the topic import-preview table plus toolbar/batch-delete controls (`instance/topic.tsx`):

- Import preview table: 行号/Topic 名称/状态/说明 columns and the 成功/失败/无效/待导入 status tags
- Search placeholder (搜索 Topic 名称) and type-filter placeholder
- Batch-delete confirm modal title/content/ok/cancel

Eleven new `topic.*` zh/en keys added (reusing `topic.name` and `topic.delete`).

## Why

The import preview table, search/filter controls and batch-delete flow rendered in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/TopicPage.test.tsx` → 16/16 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
