### PR TITLE
fix(i18n): localize message query validation

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1807,6 +1807,9 @@ const translations: Record<string, Record<Lang, string>> = {
   'message.batchResend': { zh: '批量重发', en: 'Batch Resend' },
   'message.batchExport': { zh: '批量导出', en: 'Batch Export' },
   'message.noMatchResult': { zh: '没有查到符合条件的结果', en: 'No matching results' },
+  'message.queryKeyRequired': { zh: '请输入 Message Key', en: 'Enter the message key' },
+  'message.queryMsgIdRequired': { zh: '请输入 Message ID', en: 'Enter the message ID' },
+  'message.queryTopicRequired': { zh: '请选择 Topic', en: 'Select a topic' },
 
   // ─── DLQ (detailed) ───
   'dlq.subtitle': {

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -137,9 +137,9 @@ const formatBody = (body: string): string => {
 };
 
 const getQueryValidationError = (mode: QueryMode, params: MessageQuery): string | null => {
-  if (!params.topic?.trim()) return '请选择 Topic';
-  if (mode === 'key' && !params.key?.trim()) return '请输入 Message Key';
-  if (mode === 'msgid' && !params.msgId?.trim()) return '请输入 Message ID';
+  if (!params.topic?.trim()) return 'message.queryTopicRequired';
+  if (mode === 'key' && !params.key?.trim()) return 'message.queryKeyRequired';
+  if (mode === 'msgid' && !params.msgId?.trim()) return 'message.queryMsgIdRequired';
   return null;
 };
 
@@ -330,7 +330,7 @@ const MessagePageContent = ({
     const normalizedParams = normalizeMessageQuery(mode, params);
     const validationError = getQueryValidationError(mode, normalizedParams);
     if (validationError) {
-      setQueryError(validationError);
+      setQueryError(t(validationError));
       setQueryLoading(false);
       return;
     }
@@ -937,7 +937,7 @@ const MessagePageContent = ({
                 type="primary"
                 icon={<SearchOutlined />}
                 disabled={Boolean(queryDisabledReason)}
-                title={queryDisabledReason || undefined}
+                title={queryDisabledReason ? t(queryDisabledReason) : undefined}
                 onClick={() => {
                   void handleQuery();
                 }}


### PR DESCRIPTION
## Summary

Localize the message query validation texts (`instance/message.tsx`):

- `getQueryValidationError` now returns translation keys; the query-button disabled tooltip translates them at render (existing localized reasons pass through `t()` unchanged)
- The execute-query validation error is translated before being stored as the query error

Three new `message.*` zh/en keys added.

## Why

The query-validation messages (请选择 Topic / 请输入 Message Key / 请输入 Message ID) rendered in Chinese in the English UI.

## Testing

- `vitest run src/pages/instance/__tests__/MessagePage.test.tsx` → 9/9 passed
- `tsc --noEmit` → clean
- `eslint` on changed files → 0 errors
- zh render unchanged
