### PR TITLE
fix(i18n): localize queue browser tool

### DIFF
--- a/web/src/components/QueueBrowser.tsx
+++ b/web/src/components/QueueBrowser.tsx
@@ -34,6 +34,7 @@ import {
 import { CloseOutlined, SearchOutlined } from '@ant-design/icons';
 import type { MessageRecord, QueueOffset } from '../api/message';
 import { getQueueOffsets, pullMessageAtOffset } from '../api/message';
+import { useLang } from '../i18n/LangContext';
 
 const { Text, Paragraph } = Typography;
 
@@ -55,6 +56,7 @@ export interface PulledEntry {
 }
 
 export const useQueueBrowser = (instanceId?: string) => {
+  const { t } = useLang();
   const [topic, setTopic] = useState<string | undefined>();
   const [queues, setQueues] = useState<QueueOffset[]>([]);
   const [loading, setLoading] = useState(false);
@@ -94,12 +96,12 @@ export const useQueueBrowser = (instanceId?: string) => {
       setOffsets(initial);
     } catch (err) {
       if (requestId === requestSeqRef.current) {
-        message.error(err instanceof Error ? err.message : '加载队列信息失败');
+        message.error(err instanceof Error ? err.message : t('queueBrowser.loadQueueFailed'));
       }
     } finally {
       if (requestId === requestSeqRef.current) setLoading(false);
     }
-  }, [instanceId, topic]);
+  }, [instanceId, topic, t]);
 
   const handlePull = async (queue: QueueOffset) => {
     if (!instanceId || !topic) return;
@@ -122,7 +124,7 @@ export const useQueueBrowser = (instanceId?: string) => {
       ]);
     } catch (err) {
       if (requestId === requestSeqRef.current) {
-        message.error(err instanceof Error ? err.message : '拉取消息失败');
+        message.error(err instanceof Error ? err.message : t('queueBrowser.pullFailed'));
       }
     } finally {
       if (requestId === requestSeqRef.current) setPulling(null);
@@ -162,12 +164,14 @@ export const QueueBrowserControls = ({
   state,
   topicOptions,
   topicLoading,
-}: ControlsProps) => (
-  <Flex gap={12} align="center">
+}: ControlsProps) => {
+  const { t } = useLang();
+  return (
+    <Flex gap={12} align="center">
     <Select
       showSearch
       allowClear
-      placeholder="选择 Topic"
+      placeholder={t('queueBrowser.topicPlaceholder')}
       value={state.topic}
       onChange={state.setTopic}
       options={topicOptions}
@@ -181,13 +185,16 @@ export const QueueBrowserControls = ({
       loading={state.loading}
       onClick={() => void state.loadQueues()}
     >
-      加载队列
+      {t('queueBrowser.loadQueues')}
     </Button>
-  </Flex>
-);
+    </Flex>
+  );
+};
 
-export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => (
-  <Card>
+export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => {
+  const { t } = useLang();
+  return (
+    <Card>
     {state.loading ? (
       <Flex justify="center" style={{ padding: 32 }}>
         <Spin />
@@ -195,7 +202,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
     ) : state.queues.length === 0 ? (
       <Empty
         image={Empty.PRESENTED_IMAGE_SIMPLE}
-        description="选择 Topic 并点击「加载队列」，按队列浏览消息"
+        description={t('queueBrowser.emptySelectHint')}
         style={{ padding: '32px 0' }}
       />
     ) : (
@@ -229,7 +236,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                 render: (v: number) => <Text style={{ fontSize: 14 }}>{v}</Text>,
               },
               {
-                title: 'Offset 范围',
+                title: t('queueBrowser.offsetRange'),
                 key: 'offset',
                 width: 170,
                 render: (_: unknown, record: QueueOffset) => {
@@ -262,7 +269,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                 },
               },
               {
-                title: '操作',
+                title: t('queueBrowser.action'),
                 key: 'action',
                 width: 70,
                 align: 'center',
@@ -275,7 +282,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                       loading={state.pulling === key}
                       onClick={() => void state.handlePull(record)}
                     >
-                      查看
+                      {t('queueBrowser.view')}
                     </Button>
                   );
                 },
@@ -283,8 +290,10 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
             ]}
           />
           <Text type="secondary" style={{ display: 'block', marginTop: 8, fontSize: 14 }}>
-            共 {state.queues.length} 个队列，总消息量{' '}
-            {state.queues.reduce((sum, q) => sum + (q.maxOffset - q.minOffset), 0)} 条
+            {t('queueBrowser.queueSummary', {
+              count: state.queues.length,
+              total: state.queues.reduce((sum, q) => sum + (q.maxOffset - q.minOffset), 0),
+            })}
           </Text>
         </div>
 
@@ -293,7 +302,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
           {state.entries.length === 0 ? (
             <Empty
               image={Empty.PRESENTED_IMAGE_SIMPLE}
-              description="点击左侧「查看」，消息详情将显示在这里"
+              description={t('queueBrowser.emptyDetailHint')}
               style={{ padding: '32px 0' }}
             />
           ) : (
@@ -341,12 +350,12 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                             {entry.message.key || '-'}
                           </span>
                         </Descriptions.Item>
-                        <Descriptions.Item label="存储时间">
+                        <Descriptions.Item label={t('queueBrowser.storeTime')}>
                           <span style={{ fontFamily: 'monospace', fontSize: 14 }}>
                             {formatTimeMs(entry.message.storeTime)}
                           </span>
                         </Descriptions.Item>
-                        <Descriptions.Item label="大小">
+                        <Descriptions.Item label={t('queueBrowser.size')}>
                           {entry.message.size} bytes
                         </Descriptions.Item>
                         <Descriptions.Item label="Born Host">
@@ -372,7 +381,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                       )}
                     </>
                   ) : (
-                    <Text type="secondary">该 offset 处无消息</Text>
+                    <Text type="secondary">{t('queueBrowser.noMessageAtOffset')}</Text>
                   )}
                 </Card>
               ))}
@@ -382,4 +391,5 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
       </Flex>
     )}
   </Card>
-);
+  );
+};

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2368,6 +2368,19 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  'queueBrowser.topicPlaceholder': { zh: '选择 Topic', en: 'Select Topic' },
+  'queueBrowser.loadQueues': { zh: '加载队列', en: 'Load Queues' },
+  'queueBrowser.emptySelectHint': { zh: '选择 Topic 并点击「加载队列」，按队列浏览消息', en: 'Select a Topic and click “Load Queues” to browse messages by queue' },
+  'queueBrowser.offsetRange': { zh: 'Offset 范围', en: 'Offset Range' },
+  'queueBrowser.action': { zh: '操作', en: 'Actions' },
+  'queueBrowser.view': { zh: '查看', en: 'View' },
+  'queueBrowser.queueSummary': { zh: '共 {count} 个队列，总消息量 {total} 条', en: '{count} queues, {total} messages in total' },
+  'queueBrowser.emptyDetailHint': { zh: '点击左侧「查看」，消息详情将显示在这里', en: 'Click “View” on the left to show the message details here' },
+  'queueBrowser.storeTime': { zh: '存储时间', en: 'Store Time' },
+  'queueBrowser.size': { zh: '大小', en: 'Size' },
+  'queueBrowser.noMessageAtOffset': { zh: '该 offset 处无消息', en: 'No message at this offset' },
+  'queueBrowser.loadQueueFailed': { zh: '加载队列信息失败', en: 'Failed to load queue offsets' },
+  'queueBrowser.pullFailed': { zh: '拉取消息失败', en: 'Failed to pull the message' },
   // ─── BrokerCluster ───
 };
 


### PR DESCRIPTION
### Summary
Localize the **Queue Browser** tool (`QueueBrowser`) that lets operators pick a topic and browse a specific queue offset's raw message. Previously its controls, empty states, table headers, offset-summary footer and message detail labels were hardcoded in Chinese.

- Move 13 strings into the new `queueBrowser.*` translation namespace (zh/en), including a parameterized `queueSummary` (`{count}` / `{total}`).
- Thread `t` through `useQueueBrowser` (error fallbacks) and both presentational exports (`QueueBrowserControls`, `QueueBrowserResults`).

### Why
The Queue Browser is embedded in the already-localized Message page (`queryMode === 'queue'`) and was the last Chinese-only surface in that workflow; this keeps the whole page consistent in English mode.

### Testing
- `tsc --noEmit` passes (exit 0).
- `eslint` clean on changed files (0 errors; only the pre-existing hook/function fast-refresh warnings remain).
- `QueueBrowser` vitest suite passes (6/6) and the Message page suite still passes (9/9).
