### PR TITLE
fix(i18n): localize main layout shell leftovers

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2368,6 +2368,12 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  'nav.studioUsers': { zh: '用户管理', en: 'User Management' },
+  'layout.searchNotFound': { zh: '未找到匹配页面', en: 'No matching page' },
+  'layout.searchNavHint': { zh: '↑↓ 切换', en: '↑↓ Navigate' },
+  'layout.searchOpenHint': { zh: '↵ 打开', en: '↵ Open' },
+  'layout.searchCloseHint': { zh: 'ESC 关闭', en: 'ESC Close' },
+  'layout.logoutServerFailed': { zh: '服务端退出失败，已清除本地登录状态', en: 'Server-side logout failed; local login cleared' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -104,7 +104,7 @@ const MainLayout = () => {
     try {
       await requestLogout();
     } catch {
-      message.warning('服务端退出失败，已清除本地登录状态');
+      message.warning(t('layout.logoutServerFailed'));
     } finally {
       clearAiChatHistories();
       clearAuth();
@@ -267,7 +267,7 @@ const MainLayout = () => {
       '/ops/audit': t('nav.audit'),
       '/ai': t('nav.ai'),
       '/settings': t('nav.settings'),
-      '/studio/users': '用户管理',
+      '/studio/users': t('nav.studioUsers'),
     }),
     [t],
   );
@@ -321,7 +321,7 @@ const MainLayout = () => {
     onClick: handleUserMenuClick,
     items: [
       { key: 'profile', icon: <UserGear size={14} />, label: t('user.profile') },
-      ...(admin ? [{ key: 'users', icon: <UserGear size={14} />, label: '用户管理' }] : []),
+      ...(admin ? [{ key: 'users', icon: <UserGear size={14} />, label: t('nav.studioUsers') }] : []),
       { type: 'divider' as const },
       { key: 'logout', label: t('user.logout'), danger: true },
     ],
@@ -736,7 +736,7 @@ const MainLayout = () => {
           ) : (
             <Empty
               image={Empty.PRESENTED_IMAGE_SIMPLE}
-              description="未找到匹配页面"
+              description={t('layout.searchNotFound')}
               style={{ padding: '24px 0' }}
             />
           )}
@@ -752,9 +752,9 @@ const MainLayout = () => {
             background: darkMode ? '#26262a' : '#fafafa',
           }}
         >
-          <span>↑↓ 切换</span>
-          <span>↵ 打开</span>
-          <span>ESC 关闭</span>
+          <span>{t('layout.searchNavHint')}</span>
+          <span>{t('layout.searchOpenHint')}</span>
+          <span>{t('layout.searchCloseHint')}</span>
         </div>
       </Modal>
     </>


### PR DESCRIPTION
### Summary
Localize the last Chinese-only bits of the main application shell (`MainLayout`), keeping the whole layout consistent in English mode:

- Route-name map entry for `/studio/users` and the admin user-menu item now use a shared `nav.studioUsers` key.
- The navigation-search modal's "no matching page" empty state and its keyboard hint row (`↑↓ 切换` / `↵ 打开` / `ESC 关闭`) are now `layout.search*` keys.
- The "server-side logout failed" warning toast is localized.

### Why
`MainLayout` already rendered most of its chrome through `t()`, but these six spots were still hardcoded Chinese — visible to English users in the admin menu, the search modal and on logout failure. The language toggle itself keeps showing `中`/`En` by design so users can always find the switch.

### Testing
- `tsc --noEmit` passes (exit 0).
- `eslint` clean on changed files (0 errors).
- `MainLayout` vitest suite passes (4/4).
