### PR TITLE
fix(i18n): localize mini bar and instance select fallbacks

### DIFF
--- a/web/src/components/InstanceSelect.tsx
+++ b/web/src/components/InstanceSelect.tsx
@@ -17,6 +17,7 @@
 
 import { Select } from 'antd';
 import type { CSSProperties } from 'react';
+import { useLang } from '../i18n/LangContext';
 
 export interface InstanceOption {
   value: string;
@@ -40,13 +41,14 @@ export function InstanceSelect({
   onChange,
   options,
   style,
-  placeholder = '选择实例',
+  placeholder,
 }: InstanceSelectProps) {
+  const { t } = useLang();
   return (
     <Select
       showSearch
       allowClear
-      placeholder={placeholder}
+      placeholder={placeholder ?? t('instanceSelect.placeholder')}
       value={value ?? undefined}
       onChange={(next, option) => {
         if (next === undefined || next === null) {
@@ -65,7 +67,7 @@ export function InstanceSelect({
           .toLowerCase()
           .includes(input.toLowerCase())
       }
-      notFoundContent="暂无匹配实例"
+      notFoundContent={t('instanceSelect.notFound')}
       style={style ?? { width: 220 }}
     />
   );

--- a/web/src/components/MiniBar.tsx
+++ b/web/src/components/MiniBar.tsx
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { useLang } from '../i18n/LangContext';
+
 interface MiniBarProps {
   data: number[];
   color?: string;
@@ -24,9 +26,10 @@ interface MiniBarProps {
 }
 
 const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: MiniBarProps) => {
+  const { t, lang } = useLang();
   if (!data.length) {
     return (
-      <span aria-label={label || '暂无趋势数据'} style={{ color: '#8c8c8c' }}>
+      <span aria-label={label || t('miniBar.noTrendData')} style={{ color: '#8c8c8c' }}>
         —
       </span>
     );
@@ -38,7 +41,9 @@ const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: M
   return (
     <div
       role="img"
-      aria-label={label || `趋势数据：${data.join('、')}`}
+      aria-label={
+        label || t('miniBar.trendData', { values: data.join(lang === 'zh' ? '、' : ', ') })
+      }
       style={{
         display: 'inline-flex',
         alignItems: 'flex-end',

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2368,6 +2368,10 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  'miniBar.noTrendData': { zh: '暂无趋势数据', en: 'No trend data' },
+  'miniBar.trendData': { zh: '趋势数据：{values}', en: 'Trend data: {values}' },
+  'instanceSelect.placeholder': { zh: '选择实例', en: 'Select instance' },
+  'instanceSelect.notFound': { zh: '暂无匹配实例', en: 'No matching instance' },
   // ─── BrokerCluster ───
 };
 


### PR DESCRIPTION
### Summary
Localize the two still-active shared leaf components that render Chinese fallbacks:

- **MiniBar** (`home` dashboard sparklines): the no-data and `aria-label` fallbacks now use `miniBar.noTrendData` / parameterized `miniBar.trendData`; the joined series separator switches between `、` and `, ` by language.
- **InstanceSelect** (ACL / topic / message / consumer / DLQ pages): default `选择实例` placeholder and `暂无匹配实例` empty content moved to `instanceSelect.*` keys (behavior unchanged when pages pass their own placeholder).

### Why
Both components are used inside already-localized pages; their fallback copy was still hardcoded Chinese and showed up in English mode (e.g. unlabeled trend cells on the dashboard, instance picker empties).

### Testing
- `tsc --noEmit` passes (exit 0).
- `eslint` clean on changed files (0 errors).
- Vitest: `MiniBar` (2), `DashboardPage` and `AclPage` suites pass — 3 files / 25 tests total.
