### PR TITLE
fix(i18n): localize message property parse errors

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2368,6 +2368,10 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  'messageProperties.invalidProperties': { zh: '消息属性格式错误', en: 'Invalid message property format' },
+  'messageProperties.invalidFormat': { zh: '“{value}”应使用 key=value 格式', en: '“{value}” must use the key=value format' },
+  'messageProperties.emptyName': { zh: '“{value}”的属性名不能为空', en: 'The property name in “{value}” cannot be empty' },
+  'messageProperties.duplicate': { zh: '属性名“{key}”重复', en: 'Duplicate property name “{key}”' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -576,7 +576,7 @@ describe('TopicPage', () => {
   it('rejects malformed or duplicate batch message properties without sending', () => {
     expect(parseMessageProperties('traceId=abc\ntenant\ntraceId=duplicate')).toEqual({
       properties: { traceId: 'abc' },
-      errors: ['“tenant”应使用 key=value 格式', '属性名“traceId”重复'],
+      errors: [{ kind: 'invalidFormat', value: 'tenant' }, { kind: 'duplicate', key: 'traceId' }],
     });
   });
 

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -299,7 +299,7 @@ const formatPercent = (value: number) => `${value.toFixed(value % 1 === 0 ? 0 : 
 
 // ═══════════════════════════════════════════════════════════════════
 const TopicPage = () => {
-  const { t } = useLang();
+  const { t, lang } = useLang();
   const navigate = useNavigate();
   const {
     selectedInstanceId,
@@ -1193,7 +1193,19 @@ const TopicPage = () => {
       if (propsMode === 'text') {
         const parsed = parseMessageProperties(values.propsText || '');
         if (parsed.errors.length > 0) {
-          message.error(`消息属性格式错误：${parsed.errors.join('；')}`);
+          message.error(
+            `${t('messageProperties.invalidProperties')}${lang === 'zh' ? '：' : ': '}${parsed.errors
+              .map((error) => {
+                if (error.kind === 'invalidFormat') {
+                  return t('messageProperties.invalidFormat', { value: error.value });
+                }
+                if (error.kind === 'emptyName') {
+                  return t('messageProperties.emptyName', { value: error.value });
+                }
+                return t('messageProperties.duplicate', { key: error.key });
+              })
+              .join(lang === 'zh' ? '；' : '; ')}`,
+          );
           return;
         }
         props = parsed.properties;

--- a/web/src/utils/messageProperties.test.ts
+++ b/web/src/utils/messageProperties.test.ts
@@ -39,6 +39,6 @@ describe('parseMessageProperties', () => {
     const result = parseMessageProperties('__proto__=first\n__proto__=second');
 
     expect(result.properties['__proto__']).toBe('first');
-    expect(result.errors).toEqual(['属性名“__proto__”重复']);
+    expect(result.errors).toEqual([{ kind: 'duplicate', key: '__proto__' }]);
   });
 });

--- a/web/src/utils/messageProperties.ts
+++ b/web/src/utils/messageProperties.ts
@@ -15,9 +15,14 @@
  * limitations under the License.
  */
 
+export type PropertyParseError =
+  | { kind: 'invalidFormat'; value: string }
+  | { kind: 'emptyName'; value: string }
+  | { kind: 'duplicate'; key: string };
+
 interface ParsedProperties {
   properties: Record<string, string>;
-  errors: string[];
+  errors: PropertyParseError[];
 }
 
 // 解析批量粘贴的用户属性串：key=value 按换行或逗号分隔，等号只取第一个
@@ -29,14 +34,14 @@ export const parseMessageProperties = (text: string): ParsedProperties => {
     if (!trimmed) continue;
     const eqIndex = trimmed.indexOf('=');
     if (eqIndex <= 0) {
-      errors.push(`“${trimmed}”应使用 key=value 格式`);
+      errors.push({ kind: 'invalidFormat', value: trimmed });
       continue;
     }
     const key = trimmed.slice(0, eqIndex).trim();
     if (!key) {
-      errors.push(`“${trimmed}”的属性名不能为空`);
+      errors.push({ kind: 'emptyName', value: trimmed });
     } else if (entries.has(key)) {
-      errors.push(`属性名“${key}”重复`);
+      errors.push({ kind: 'duplicate', key });
     } else {
       entries.set(key, trimmed.slice(eqIndex + 1).trim());
     }


### PR DESCRIPTION
### Summary
Localize the batch message-property parser used by the Topic page's "send message" modal:

- `parseMessageProperties` no longer returns pre-rendered Chinese error strings; it returns structured `PropertyParseError` items (`invalidFormat` / `emptyName` / `duplicate` with the offending value/key).
- The Topic page submit handler translates each item with new `messageProperties.*` keys (`{value}` / `{key}` interpolation) and joins them with a language-aware separator (`；` vs `; `).
- Updated the parser unit test and the TopicPage contract assertions to the structured error shape.

### Why
Typing malformed `key=value` text (e.g. a bare `tenant` or a duplicated key) surfaced a hardcoded Chinese toast on an otherwise localized page; the parser was also the only remaining zh-producing util on that path.

### Testing
- `tsc --noEmit` passes (exit 0).
- `eslint` clean on changed files (0 errors).
- Vitest: `messageProperties` unit suite + full `TopicPage` suite pass (2 files / 18 tests).
