### PR TITLE
fix(i18n): localize dlq export detail hint

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2368,6 +2368,7 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  'dlq.exportDetailHint': { zh: '明细按「导出时间范围」查询（{range}）。勾选后可单条或批量重发、导出 Excel。', en: 'Details are queried by the export time range ({range}). After selecting, you can resend or export to Excel individually or in batch.' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -839,7 +839,9 @@ const DLQPage = () => {
             </Flex>
 
             <InfoBanner
-              description={`明细按「导出时间范围」查询（${exportRange[0].format('YYYY-MM-DD HH:mm:ss')} ~ ${exportRange[1].format('YYYY-MM-DD HH:mm:ss')}）。勾选后可单条或批量重发、导出 Excel。`}
+              description={t('dlq.exportDetailHint', {
+                range: `${exportRange[0].format('YYYY-MM-DD HH:mm:ss')} ~ ${exportRange[1].format('YYYY-MM-DD HH:mm:ss')}`,
+              })}
             />
 
             {detailError && (


### PR DESCRIPTION
### Summary
Localize the last uncovered copy on the DLQ page (`pages/instance/dlq.tsx`): the detail-list export hint.

- The `InfoBanner` description under the detail export toolbar now renders through the `dlq.exportDetailHint` key with the formatted export time range passed as a `{range}` parameter.

### Why
A full-literal audit (`git log -S`) showed this was the only remaining Chinese string on the page that no earlier i18n branch had removed; everything else (buttons, dialogs, toasts, export flow) was already localized.

### Testing
- `tsc --noEmit` passes (exit 0).
- `eslint` clean on changed files (0 errors; only the pre-existing hook/export fast-refresh warning remains).
- Vitest: full `DLQPage` suite passes (17/17).
