### PR TITLE
fix(i18n): localize acl secret reveal loading text

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2368,6 +2368,7 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  'acl.secretLoading': { zh: '加载中…', en: 'Loading…' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -754,7 +754,7 @@ const AclPageContent = ({
               copyable={revealed && secret ? { text: secret } : false}
               style={{ fontFamily: 'monospace', fontSize: 14 }}
             >
-              {revealed ? (secret ?? '加载中…') : '••••••••••••'}
+              {revealed ? (secret ?? t('acl.secretLoading')) : '••••••••••••'}
             </Typography.Text>
             <Button
               type="text"


### PR DESCRIPTION
### Summary
Localize the last uncovered copy on the ACL page (`pages/instance/acl.tsx`): the secret-key reveal fallback.

- When a revealed AccessKey secret has not finished loading, the cell now shows `t('acl.secretLoading')` instead of the hardcoded `加载中…`.

### Why
A full-literal audit (`git log -S` over all branches) showed this single cell fallback was the only remaining Chinese string on the page.

### Testing
- `tsc --noEmit` passes (exit 0).
- `eslint` clean on changed files (0 errors).
- Vitest: full `AclPage` suite passes (18/18).
