### PR TITLE
fix(i18n): localize shared api client error copy

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -17,11 +17,17 @@
 
 import axios from 'axios';
 import { message } from 'antd';
+import { getInitialLanguage } from '../i18n/languagePreference';
+import translations from '../i18n/translations';
 import { clearAuthSession } from '../stores/authStorage';
 import { clearAiChatHistories } from '../stores/aiChatHistoryStore';
 import { API_BASE_URL } from '../config';
 
 const SUCCESS_BUSINESS_CODES = new Set([0, 200]);
+
+function apiText(key: string): string {
+  return translations[key]?.[getInitialLanguage()] ?? key;
+}
 const PUBLIC_AUTH_PATHS = new Set(['/auth/login', '/auth/status']);
 
 interface BusinessResponse {
@@ -43,11 +49,8 @@ function getBusinessError(data: unknown): string | null {
   if (typeof data.code !== 'number' && !('message' in data) && !('data' in data)) {
     return null;
   }
-  return typeof data.message === 'string' && data.message.trim() ? data.message : '请求失败';
+  return typeof data.message === 'string' && data.message.trim() ? data.message : apiText('api.requestFailed');
 }
-
-const CORS_REJECTION_HINT =
-  '请求被服务端 CORS 策略拒绝（Invalid CORS request）：当前访问地址不在后端白名单，请检查部署的 STUDIO_CORS_ALLOWED_ORIGINS 配置';
 
 /**
  * Spring CORS rejects non-whitelisted origins with 403 and a plain-text body (often
@@ -103,9 +106,10 @@ client.interceptors.response.use(
       return Promise.reject(error);
     }
     if (isCorsRejection(error)) {
-      message.error(CORS_REJECTION_HINT);
+      const hint = apiText('api.corsRejection');
+      message.error(hint);
       if (error instanceof Error) {
-        error.message = CORS_REJECTION_HINT;
+        error.message = hint;
       }
       return Promise.reject(error);
     }

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2368,6 +2368,8 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  'api.requestFailed': { zh: '请求失败', en: 'Request failed' },
+  'api.corsRejection': { zh: '请求被服务端 CORS 策略拒绝（Invalid CORS request）：当前访问地址不在后端白名单，请检查部署的 STUDIO_CORS_ALLOWED_ORIGINS 配置', en: 'The request was rejected by the server CORS policy (Invalid CORS request): the current origin is not in the backend allowlist; check the deployed STUDIO_CORS_ALLOWED_ORIGINS configuration' },
   // ─── BrokerCluster ───
 };
 


### PR DESCRIPTION
### Summary
Localize the two user-facing error strings produced by the shared axios client (`web/src/api/client.ts`), which surface as toast messages on essentially every page:

- The generic business-error fallback `请求失败` now resolves through the new `api.requestFailed` key (default-zh safe).
- The CORS-rejection hint is no longer a module-level Chinese constant; it is resolved per occurrence through the `api.corsRejection` key with the current UI language (read via `getInitialLanguage`, so toggling language applies without a rebuild).
- Added a small `apiText(key)` helper that reads the current stored language on each call, keeping the module hook-free.

### Why
These two strings were the only remaining hardcoded Chinese in the shared request layer, so every English-mode page could still toast Chinese for network/business failures; the CORS hint especially matters for cross-origin deployments.

### Testing
- `tsc --noEmit` passes (exit 0).
- `eslint` clean on changed files (0 errors).
- Vitest: `api/client.test.ts` passes (14/14), including the request-failed fallback and CORS-hint assertions (default zh preserved).
