### PR TITLE
fix(i18n): localize mock import failure fallbacks in services

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2368,6 +2368,7 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  'common.createFailed': { zh: '创建失败', en: 'Creation failed' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/services/consumerService.ts
+++ b/web/src/services/consumerService.ts
@@ -18,6 +18,13 @@ import type {
 } from '../api/metadata';
 import { mockConsumerGroups, mockQueueProgress, mockSubscriptions } from '../mock/consumers';
 import { buildCsv, type CsvColumn } from '../utils/download';
+import { getInitialLanguage } from '../i18n/languagePreference';
+import translations from '../i18n/translations';
+
+function serviceText(key: string): string {
+  return translations[key]?.[getInitialLanguage()] ?? key;
+}
+
 
 const consumerGroupsState = mockConsumerGroups as unknown as ConsumerGroup[];
 const EXPORT_PAGE_SIZE = 100;
@@ -271,7 +278,7 @@ export async function importConsumerGroups(
         failures.push({
           index,
           name: group.name,
-          message: error instanceof Error ? error.message : '创建失败',
+          message: error instanceof Error ? error.message : serviceText('common.createFailed'),
         });
       }
     }

--- a/web/src/services/topicService.ts
+++ b/web/src/services/topicService.ts
@@ -14,6 +14,13 @@ import type {
 } from '../api/metadata';
 import { topics as mockTopics, topicRoutes, topicConsumers } from '../mock/topics';
 import { buildCsv, type CsvColumn } from '../utils/download';
+import { getInitialLanguage } from '../i18n/languagePreference';
+import translations from '../i18n/translations';
+
+function serviceText(key: string): string {
+  return translations[key]?.[getInitialLanguage()] ?? key;
+}
+
 
 const EXPORT_PAGE_SIZE = 100;
 const MAX_EXPORT_PAGES = 100;
@@ -139,7 +146,7 @@ export async function importTopics(
         failures.push({
           index,
           name: topic.name,
-          message: error instanceof Error ? error.message : '创建失败',
+          message: error instanceof Error ? error.message : serviceText('common.createFailed'),
         });
       }
     }


### PR DESCRIPTION
### Summary
Localize the last hardcoded Chinese in the service layer — the mock-mode batch import failure fallbacks:

- `topicService.importTopics` (mock path) and `consumerService.importConsumerGroups` (mock path) no longer emit `创建失败`; both resolve the message through a small hook-free `serviceText(key)` helper (current stored language read per call) and the shared `common.createFailed` key.

### Why
When a topic/group fails to import in the built-in demo (mock) mode, its per-row `message` surfaced the Chinese fallback in English UI; these were the only remaining non-test zh literals in the service layer (verified by literal audit).

### Testing
- `tsc --noEmit` passes (exit 0).
- `eslint` clean on changed files (0 errors).
- Vitest: `TopicPage` and `ConsumerPage` suites pass (2 files / 40 tests).
