### PR TITLE
fix(message-history): normalize cluster and type filters

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
@@ -159,12 +159,14 @@ public class QueryHistoryService {
 
     public PageResult<MessageQueryHistoryVO> listMessageQueries(String clusterId, String queryType,
                                                                  String search, int page, int pageSize) {
-        String pattern = escapeLike(search);
+        String normalizedCluster = normalizeOptional(clusterId);
+        String normalizedType = normalizeOptional(queryType);
+        String pattern = escapeLike(normalizeSearch(search));
         String queriedBy = AuthenticatedUserContext.currentUsernameOrSystem();
         QueryWrapper<RmqMessageQuery> query = new QueryWrapper<RmqMessageQuery>()
-                .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
+                .eq(normalizedCluster != null, "cluster_id", normalizedCluster)
                 .eq("queried_by", queriedBy)
-                .eq(StringUtils.hasText(queryType), "query_type", queryType)
+                .eq(normalizedType != null, "query_type", normalizedType)
                 .and(StringUtils.hasText(search), nested -> nested
                         .like("topic", pattern)
                         .or().like("msg_id", pattern)
@@ -179,10 +181,11 @@ public class QueryHistoryService {
 
     public PageResult<TraceQueryHistoryVO> listTraceQueries(String clusterId, String search,
                                                              int page, int pageSize) {
-        String pattern = escapeLike(search);
+        String normalizedCluster = normalizeOptional(clusterId);
+        String pattern = escapeLike(normalizeSearch(search));
         String queriedBy = AuthenticatedUserContext.currentUsernameOrSystem();
         QueryWrapper<RmqTraceQuery> query = new QueryWrapper<RmqTraceQuery>()
-                .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
+                .eq(normalizedCluster != null, "cluster_id", normalizedCluster)
                 .eq("queried_by", queriedBy)
                 .and(StringUtils.hasText(search), nested -> nested
                         .like("topic", pattern)
@@ -196,23 +199,24 @@ public class QueryHistoryService {
     }
 
     public QueryHistorySummaryVO summarize(String clusterId) {
+        String normalizedCluster = normalizeOptional(clusterId);
         String queriedBy = AuthenticatedUserContext.currentUsernameOrSystem();
         QueryWrapper<RmqMessageQuery> messageFilter = new QueryWrapper<RmqMessageQuery>()
-                .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
+                .eq(normalizedCluster != null, "cluster_id", normalizedCluster)
                 .eq("queried_by", queriedBy);
         QueryWrapper<RmqTraceQuery> traceFilter = new QueryWrapper<RmqTraceQuery>()
-                .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
+                .eq(normalizedCluster != null, "cluster_id", normalizedCluster)
                 .eq("queried_by", queriedBy);
         long messageCount = messageQueryMapper.selectCount(messageFilter);
         long traceCount = traceQueryMapper.selectCount(traceFilter);
         RmqMessageQuery latestMessage = messageQueryMapper.selectOne(
                 new QueryWrapper<RmqMessageQuery>()
-                        .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
+                        .eq(normalizedCluster != null, "cluster_id", normalizedCluster)
                         .eq("queried_by", queriedBy)
                         .orderByDesc("gmt_create", "id").last("LIMIT 1"));
         RmqTraceQuery latestTrace = traceQueryMapper.selectOne(
                 new QueryWrapper<RmqTraceQuery>()
-                        .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
+                        .eq(normalizedCluster != null, "cluster_id", normalizedCluster)
                         .eq("queried_by", queriedBy)
                         .orderByDesc("gmt_create", "id").last("LIMIT 1"));
         LocalDateTime latest = latestOf(
@@ -286,6 +290,14 @@ public class QueryHistoryService {
      * Escapes LIKE wildcards so user-supplied search terms match literally instead of being
      * interpreted as {@code %}/{@code _} patterns.
      */
+    static String normalizeSearch(String search) {
+        return search == null ? null : search.trim();
+    }
+
+    static String normalizeOptional(String value) {
+        return value == null ? null : value.trim();
+    }
+
     private static String escapeLike(String search) {
         if (!StringUtils.hasText(search)) {
             return search;

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
@@ -165,4 +165,13 @@ class QueryHistoryServiceTest {
         assertThat(messageCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
         assertThat(traceCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
     }
+
+    @Test
+    void normalizesClusterAndQueryTypeFilters() {
+        assertThat(QueryHistoryService.normalizeOptional(null)).isNull();
+        assertThat(QueryHistoryService.normalizeOptional("cluster-a ")).isEqualTo("cluster-a");
+        assertThat(QueryHistoryService.normalizeOptional("  KEY")).isEqualTo("KEY");
+        assertThat(QueryHistoryService.normalizeSearch(" orders ")).isEqualTo("orders");
+        assertThat(QueryHistoryService.normalizeSearch(null)).isNull();
+    }
 }


### PR DESCRIPTION
### Summary
Normalize optional filters in the message/trace query-history service so padded or mixed-case callers cannot silently scope to the wrong data:

- `listMessageQueries`, `listTraceQueries` and `summarize` now trim `clusterId` (and the message-list `queryType`) before building `eq` predicates, and trim the `search` term before LIKE escaping — all at the single service choke point instead of relying on each controller path.
- `normalizeSearch` / `normalizeOptional` are package-private helpers covered by direct unit tests.

### Why
Controller paths pass these parameters inconsistently (one endpoint trims clusterId, another does not); a trailing space in `clusterId` previously turned the equality predicate into a no-match and returned an empty history/summary for an existing cluster.

### Testing
- `mvn -f server/pom.xml -Dtest=QueryHistoryServiceTest test` passes: 7/7 (6 existing + 1 new covering both helpers).
