### PR TITLE
fix(message-history): store normalized cluster id for history records

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
@@ -82,7 +82,7 @@ public class QueryHistoryService {
         query.setEndTime(endTime);
         query.setResultCount(resultCount);
         query.setResultSnapshot(resultSnapshot);
-        query.setClusterId(clusterId);
+        query.setClusterId(normalizeOptional(clusterId));
         query.setQueriedBy(AuthenticatedUserContext.currentUsernameOrSystem());
         LocalDateTime now = LocalDateTime.now(clock);
         query.setGmtCreate(now);
@@ -148,7 +148,7 @@ public class QueryHistoryService {
         query.setTopic(topic);
         query.setNodeCount(nodeCount);
         query.setConsumerCount(consumerCount);
-        query.setClusterId(clusterId);
+        query.setClusterId(normalizeOptional(clusterId));
         query.setQueriedBy(AuthenticatedUserContext.currentUsernameOrSystem());
         LocalDateTime now = LocalDateTime.now(clock);
         query.setGmtCreate(now);
@@ -286,6 +286,10 @@ public class QueryHistoryService {
      * Escapes LIKE wildcards so user-supplied search terms match literally instead of being
      * interpreted as {@code %}/{@code _} patterns.
      */
+    static String normalizeOptional(String value) {
+        return value == null ? null : value.trim();
+    }
+
     private static String escapeLike(String search) {
         if (!StringUtils.hasText(search)) {
             return search;

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
@@ -165,4 +165,20 @@ class QueryHistoryServiceTest {
         assertThat(messageCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
         assertThat(traceCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
     }
+
+    @Test
+    void storesNormalizedClusterIdWhenRecordingQueries() {
+        AuthenticatedUserContext.setUsername("alice");
+        service.recordMessageQuery(" cluster-a ", "TOPIC", "orders", null, "tag-a", "key-a",
+                1L, 2L, 3, null);
+        service.recordTraceQuery(" cluster-a ", "msg-1", "orders", 2, 1);
+
+        ArgumentCaptor<RmqMessageQuery> messageCaptor = ArgumentCaptor.forClass(RmqMessageQuery.class);
+        verify(messageQueryMapper).insert(messageCaptor.capture());
+        assertThat(messageCaptor.getValue().getClusterId()).isEqualTo("cluster-a");
+
+        ArgumentCaptor<RmqTraceQuery> traceCaptor = ArgumentCaptor.forClass(RmqTraceQuery.class);
+        verify(traceQueryMapper).insert(traceCaptor.capture());
+        assertThat(traceCaptor.getValue().getClusterId()).isEqualTo("cluster-a");
+    }
 }


### PR DESCRIPTION
### Summary
Align the write side of the query-history service with its read side (#3082 normalized query filters): history records now persist a trimmed `clusterId`.

- `recordMessageQuery` / `recordTraceQuery` store `normalizeOptional(clusterId)`, so a padded cluster id cannot create rows that the (already normalized) history queries and summary would never return.

### Why
After #3082, reads always trim `clusterId`; without this change, records written with a trailing space would be orphaned (unreachable by any subsequent query/summary for the same cluster).

### Testing
- `mvn -f server/pom.xml -Dtest=QueryHistoryServiceTest test` passes: 7/7 (6 existing + 1 new asserting both record methods store the trimmed cluster id).
