### PR TITLE
fix(message): trim topic before message lookups

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -115,6 +115,7 @@ public class RocketMQMessageProvider implements MessageProvider {
                                                  String topic, String msgId, String tag, String key,
                                                  Long startTime, Long endTime) {
 
+        topic = normalizeTopic(topic);
         long end = endTime != null ? endTime : System.currentTimeMillis();
         long begin = startTime != null ? startTime : end - ONE_HOUR_MILLIS;
         if (begin >= end) {
@@ -137,6 +138,10 @@ public class RocketMQMessageProvider implements MessageProvider {
         }
 
         return result;
+    }
+
+    static String normalizeTopic(String topic) {
+        return StringUtils.hasText(topic) ? topic.trim() : null;
     }
 
     private List<MessageRecordVO> queryByMsgId(DefaultMQAdminExt adminExt, String topic, String msgId) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -767,4 +767,12 @@ class RocketMQMessageProviderTest {
                 .toList();
         return new PullResult(PullStatus.FOUND, batchEnd, 0L, endOffsetExclusive, messages);
     }
+
+    @Test
+    void normalizesTopicInputBeforeLookup() {
+        assertThat(RocketMQMessageProvider.normalizeTopic(null)).isNull();
+        assertThat(RocketMQMessageProvider.normalizeTopic("   ")).isNull();
+        assertThat(RocketMQMessageProvider.normalizeTopic(" topic-a ")).isEqualTo("topic-a");
+        assertThat(RocketMQMessageProvider.normalizeTopic("topic-a")).isEqualTo("topic-a");
+    }
 }


### PR DESCRIPTION
### Summary
Trim the Topic parameter before any RocketMQ message lookup in the Apache message provider:

- The private `queryMessages` overload (the single choke point for topic/message-key/msgId queries) now normalizes `topic` via the new package-private `normalizeTopic` helper (blank → null, otherwise trimmed) before branching into `viewMessage` / key / topic-scan lookups.

### Why
A topic typed or pasted with surrounding whitespace previously flowed into `queryMessage`/`viewMessage` and produced silent empty results or confusing broker-side failures, since RocketMQ topic names never contain surrounding spaces.

### Testing
- `mvn -f server/pom.xml -Dtest=RocketMQMessageProviderTest test` passes: 32/32 (31 existing + 1 new covering the helper).
