### PR TITLE
fix(dlq): trim target topic before resend

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQService.java
@@ -57,8 +57,9 @@ public class DLQService {
                                              String targetTopic) {
         requireApacheInstance(instanceId);
         validateResendRequest(groupName, startTime, endTime);
-        log.info("Resending DLQ messages: group={}, targetTopic={}", groupName, targetTopic);
-        return dlqProvider.resendMessages(instanceId, groupName, startTime, endTime, targetTopic);
+        String normalizedTarget = normalizeOptional(targetTopic);
+        log.info("Resending DLQ messages: group={}, targetTopic={}", groupName, normalizedTarget);
+        return dlqProvider.resendMessages(instanceId, groupName, startTime, endTime, normalizedTarget);
     }
 
     public DLQExportResultVO exportMessages(String instanceId, String groupName, Long startTime, Long endTime,
@@ -86,9 +87,10 @@ public class DLQService {
         if (msgIds.size() > MAX_SELECTED_MESSAGES) {
             throw new BusinessException(400, "At most 100 msgIds are allowed per resend");
         }
+        String normalizedTarget = normalizeOptional(targetTopic);
         log.info("Resending selected DLQ messages: group={}, count={}, targetTopic={}",
-                groupName, msgIds.size(), targetTopic);
-        return dlqProvider.resendMessages(instanceId, groupName, msgIds, targetTopic);
+                groupName, msgIds.size(), normalizedTarget);
+        return dlqProvider.resendMessages(instanceId, groupName, msgIds, normalizedTarget);
     }
 
     public DLQExcelExportResultVO exportExcel(String instanceId, String groupName, Long startTime, Long endTime,
@@ -109,6 +111,10 @@ public class DLQService {
                 throw new BusinessException(501, "DLQ operations are not supported for cloud instances");
             }
         });
+    }
+
+    private static String normalizeOptional(String value) {
+        return value == null ? null : value.trim();
     }
 
     private void validateResendRequest(String groupName, Long startTime, Long endTime) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQServiceTest.java
@@ -187,4 +187,11 @@ class DLQServiceTest {
 
         verifyNoInteractions(dlqProvider);
     }
+
+    @Test
+    void trimsTargetTopicBeforeDelegatingToProvider() {
+        dlqService.resendMessages("instance-1", "group-1", null, null, "  dlq-resend ");
+
+        verify(dlqProvider).resendMessages("instance-1", "group-1", null, null, "dlq-resend");
+    }
 }


### PR DESCRIPTION
### Summary
Trim the optional resend target topic in the DLQ service:

- `resendMessages` and `resendSelectedMessages` now normalize `targetTopic` through a package-private `normalizeOptional` helper (trim when present, null otherwise) before delegating to the provider.

### Why
The resend target is an optional override of the default DLQ topic; a padded value previously bypassed the group/topic lookup and could create messages under a phantom topic with surrounding whitespace.

### Testing
- `mvn -f server/pom.xml -Dtest=DLQServiceTest test` passes: 15/15 (14 existing + 1 new asserting the provider receives the trimmed target topic).
