### PR TITLE
fix(consumer): trim group and client id in stack diagnostics

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProvider.java
@@ -61,24 +61,26 @@ public class RocketMQConsumerDiagnosticsProvider implements ConsumerDiagnosticsP
 
     @Override
     public ConsumerStackTraceVO getConsumerStack(String instanceId, String groupName, String clientId) {
+        String normalizedGroup = normalizeOptional(groupName);
+        String normalizedClient = normalizeOptional(clientId);
         // Clients that connect through a proxy keep their channel on the proxy and never register
         // on a broker, so ask the proxy first; the broker only knows directly connected clients
         // and answers "not online" for everyone else.
         ConsumerRunningInfo viaProxy = proxyConsumerResolver == null
                 ? null
-                : proxyConsumerResolver.resolveConsumerRunningInfo(instanceId, groupName, clientId);
+                : proxyConsumerResolver.resolveConsumerRunningInfo(instanceId, normalizedGroup, normalizedClient);
         if (viaProxy != null) {
-            return toStackTrace(groupName, clientId, viaProxy);
+            return toStackTrace(normalizedGroup, normalizedClient, viaProxy);
         }
         if (StringUtils.hasText(instanceId)) {
             return runtimeAdminClientResolver.execute(instanceId,
-                    admin -> getConsumerStack(admin, groupName, clientId));
+                    admin -> getConsumerStack(admin, normalizedGroup, normalizedClient));
         }
         if (!StringUtils.hasText(properties.getNamesrvAddr())) {
             throw new BusinessException(503, "RocketMQ admin not connected");
         }
         return adminFactory.execute(properties.getNamesrvAddr(), null,
-                admin -> getConsumerStack(admin, groupName, clientId));
+                admin -> getConsumerStack(admin, normalizedGroup, normalizedClient));
     }
 
     private ConsumerStackTraceVO getConsumerStack(MQAdminExt admin, String groupName, String clientId) {
@@ -98,6 +100,10 @@ public class RocketMQConsumerDiagnosticsProvider implements ConsumerDiagnosticsP
         } catch (Exception e) {
             throw diagnosticsFailure(groupName, clientId, e);
         }
+    }
+
+    static String normalizeOptional(String value) {
+        return value == null ? null : value.trim();
     }
 
     private ConsumerStackTraceVO toStackTrace(String groupName, String clientId, ConsumerRunningInfo runningInfo) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProviderTest.java
@@ -237,4 +237,15 @@ class RocketMQConsumerDiagnosticsProviderTest {
                 .hasMessageContaining("Failed to get consumer stack for client-1")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(502));
     }
+
+    @Test
+    void trimsGroupAndClientBeforeQueryingRunningInfo() throws Exception {
+        when(adminExt.getConsumerRunningInfo("cg-orders", "client-1", true)).thenReturn(null);
+
+        assertThatThrownBy(() -> provider.getConsumerStack("instance-a", " cg-orders ", " client-1 "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("client-1");
+
+        verify(adminExt).getConsumerRunningInfo("cg-orders", "client-1", true);
+    }
 }


### PR DESCRIPTION
### Summary
Trim the consumer group and client id in the consumer stack diagnostics lookup:

- `getConsumerStack` normalizes `groupName` / `clientId` (final locals via `normalizeOptional`) before the proxy probe and the broker `getConsumerRunningInfo` call.

### Why
A group or client id carrying surrounding whitespace (paste artifacts) previously reached `getConsumerRunningInfo` verbatim and reported "client not online"-style failures even though the client was connected.

### Testing
- `mvn -f server/pom.xml -Dtest=RocketMQConsumerDiagnosticsProviderTest test` passes: 12/12 (11 existing + 1 new verifying the broker call receives the trimmed group/client).
