### PR TITLE
fix(metadata): guard and trim topic names in route lookups

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -401,6 +401,10 @@ public class RocketMQMetadataProvider implements MetadataProvider {
     }
 
     private List<BrokerRouteVO> getTopicRoutes(MQAdminExt admin, String name) {
+        if (!StringUtils.hasText(name)) {
+            return Collections.emptyList();
+        }
+        name = name.trim();
         try {
             TopicRouteData routeData = admin.examineTopicRouteInfo(name);
             if (routeData == null) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
@@ -759,4 +759,19 @@ class RocketMQMetadataProviderTest {
         offset.setConsumerOffset(consumerOffset);
         return offset;
     }
+
+    @Test
+    void getTopicRoutesTrimsAndGuardsTheName() throws Exception {
+        MQAdminExt admin = mock(MQAdminExt.class);
+        RocketMQMetadataProvider provider = newProvider();
+        lenient().when(runtimeAdminClientResolver.execute(anyString(), any())).thenAnswer(invocation ->
+                invocation.<org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory.AdminAction<Object>>getArgument(1).apply(admin));
+        when(admin.examineTopicRouteInfo("topic-a")).thenReturn(null);
+
+        assertThat(provider.getTopicRoutes("instance-a", " topic-a ")).isEmpty();
+        verify(admin).examineTopicRouteInfo("topic-a");
+
+        assertThat(provider.getTopicRoutes("instance-a", "   ")).isEmpty();
+        verify(admin, times(1)).examineTopicRouteInfo(anyString());
+    }
 }


### PR DESCRIPTION
### Summary
Guard and trim topic names in the metadata route lookup:

- The private `getTopicRoutes(admin, name)` now returns an empty list for blank names (no broker probe) and trims the name before `examineTopicRouteInfo`.

### Why
A topic pasted with surrounding whitespace previously reached the broker probe verbatim and produced confusing broker-side failures; a blank name triggered an unnecessary (and noisy) probe.

### Testing
- `mvn -f server/pom.xml -Dtest=RocketMQMetadataProviderTest test` passes: 36/36 (35 existing + 1 new asserting the trimmed probe and the blank-name short circuit).
