### PR TITLE
fix(metadata): escape like wildcards in page search terms

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -159,11 +159,12 @@ public class RocketMQMetadataProvider implements MetadataProvider {
     @Override
     public PageResult<TopicVO> listTopicsPage(String instanceId, String clusterId, String type,
             String search, int page, int pageSize) {
+        String pattern = escapeLike(normalizeSearch(search));
         LambdaQueryWrapper<RmqTopic> query = new LambdaQueryWrapper<RmqTopic>()
                 .eq(instanceId != null, RmqTopic::getInstanceId, normalizeMetadataScope(instanceId))
                 .eq(StringUtils.hasText(clusterId), RmqTopic::getClusterId, clusterId)
                 .eq(StringUtils.hasText(type), RmqTopic::getTopicType, type)
-                .like(StringUtils.hasText(search), RmqTopic::getName, search)
+                .like(StringUtils.hasText(pattern), RmqTopic::getName, pattern)
                 .notIn(RmqTopic::getName, TopicValidator.getSystemTopicSet())
                 .notLikeRight(RmqTopic::getName, "rmq_sys_")
                 .notLikeRight(RmqTopic::getName, "%RETRY%")
@@ -237,10 +238,11 @@ public class RocketMQMetadataProvider implements MetadataProvider {
     @Override
     public PageResult<ConsumerGroupVO> listConsumerGroupsPage(String instanceId, String clusterId,
             String search, int page, int pageSize) {
+        String pattern = escapeLike(normalizeSearch(search));
         LambdaQueryWrapper<RmqGroup> query = new LambdaQueryWrapper<RmqGroup>()
                 .eq(instanceId != null, RmqGroup::getInstanceId, normalizeMetadataScope(instanceId))
                 .eq(StringUtils.hasText(clusterId), RmqGroup::getClusterId, clusterId)
-                .like(StringUtils.hasText(search), RmqGroup::getName, search)
+                .like(StringUtils.hasText(pattern), RmqGroup::getName, pattern)
                 .orderByAsc(RmqGroup::getName, RmqGroup::getId);
         Page<RmqGroup> result = groupMapper.selectPage(new Page<>(page, pageSize), query);
         List<ConsumerGroupVO> groups = result.getRecords().stream()
@@ -398,6 +400,17 @@ public class RocketMQMetadataProvider implements MetadataProvider {
             return Collections.emptyList();
         }
         return adminExecute(admin -> getTopicRoutes(admin, name));
+    }
+
+    static String normalizeSearch(String value) {
+        return value == null ? null : value.trim();
+    }
+
+    static String escapeLike(String search) {
+        if (!StringUtils.hasText(search)) {
+            return search;
+        }
+        return search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 
     private List<BrokerRouteVO> getTopicRoutes(MQAdminExt admin, String name) {


### PR DESCRIPTION
### Summary
Escape LIKE wildcards in the DB-backed metadata page searches:

- `listTopicsPage` / `listConsumerGroupsPage` now escape `%`, `_` and `\` in the search term via `escapeLike` before building the `LambdaQueryWrapper` predicate, so searching for literal text such as `100%` or `a_b` no longer behaves as a wildcard match.

### Why
The plain-text search box treats input as a substring; an unescaped `%` previously matched every name and `_` matched any single character, surprising users who search names containing those symbols.

### Testing
- `mvn -f server/pom.xml -Dtest=RocketMQMetadataProviderTest test` passes: 35/35 (34 existing + 1 new covering the escape helper).
