### PR TITLE
fix(message-history): trim topic and msg id when recording history

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
@@ -74,8 +74,8 @@ public class QueryHistoryService {
                                    Long endTime, int resultCount, String resultSnapshot) {
         RmqMessageQuery query = new RmqMessageQuery();
         query.setQueryType(queryType);
-        query.setTopic(topic);
-        query.setMsgId(msgId);
+        query.setTopic(normalizeOptional(topic));
+        query.setMsgId(normalizeOptional(msgId));
         query.setTag(tag);
         query.setMessageKey(key);
         query.setStartTime(startTime);
@@ -144,8 +144,8 @@ public class QueryHistoryService {
 
     public void recordTraceQuery(String clusterId, String msgId, String topic, int nodeCount, int consumerCount) {
         RmqTraceQuery query = new RmqTraceQuery();
-        query.setMsgId(msgId);
-        query.setTopic(topic);
+        query.setMsgId(normalizeOptional(msgId));
+        query.setTopic(normalizeOptional(topic));
         query.setNodeCount(nodeCount);
         query.setConsumerCount(consumerCount);
         query.setClusterId(clusterId);
@@ -286,6 +286,10 @@ public class QueryHistoryService {
      * Escapes LIKE wildcards so user-supplied search terms match literally instead of being
      * interpreted as {@code %}/{@code _} patterns.
      */
+    static String normalizeOptional(String value) {
+        return value == null ? null : value.trim();
+    }
+
     private static String escapeLike(String search) {
         if (!StringUtils.hasText(search)) {
             return search;

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
@@ -165,4 +165,20 @@ class QueryHistoryServiceTest {
         assertThat(messageCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
         assertThat(traceCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
     }
+
+    @Test
+    void storesTrimmedTopicAndMsgIdWhenRecording() {
+        service.recordMessageQuery("cluster-a", "KEY", " orders ", " msg-1 ", "tag", "k", 1L, 2L, 3, null);
+        service.recordTraceQuery("cluster-a", " msg-1 ", " orders ", 2, 1);
+
+        ArgumentCaptor<RmqMessageQuery> messageCaptor = ArgumentCaptor.forClass(RmqMessageQuery.class);
+        verify(messageQueryMapper).insert(messageCaptor.capture());
+        assertThat(messageCaptor.getValue().getTopic()).isEqualTo("orders");
+        assertThat(messageCaptor.getValue().getMsgId()).isEqualTo("msg-1");
+
+        ArgumentCaptor<RmqTraceQuery> traceCaptor = ArgumentCaptor.forClass(RmqTraceQuery.class);
+        verify(traceQueryMapper).insert(traceCaptor.capture());
+        assertThat(traceCaptor.getValue().getTopic()).isEqualTo("orders");
+        assertThat(traceCaptor.getValue().getMsgId()).isEqualTo("msg-1");
+    }
 }


### PR DESCRIPTION
### Summary
Normalize topic / message-id text when writing query-history records:

- `recordMessageQuery` and `recordTraceQuery` now store `normalizeOptional(topic)` / `normalizeOptional(msgId)` (trimmed, null-safe).

### Why
Reads already trim search terms and cluster filters; records written with padded topic/msgId values would otherwise never match a later trimmed search — the same orphan-record class fixed for cluster ids earlier.

### Testing
- `mvn -f server/pom.xml -Dtest=QueryHistoryServiceTest test` passes: 7/7 (6 existing + 1 new asserting both record methods store trimmed topic/msgId).
