### PR TITLE
fix(metadata): escape like wildcards on full list queries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -139,11 +139,12 @@ public class RocketMQMetadataProvider implements MetadataProvider {
 
     @Override
     public List<TopicVO> listTopics(String instanceId, String clusterId, String type, String search) {
+        String pattern = escapeLike(normalizeSearch(search));
         LambdaQueryWrapper<RmqTopic> query = new LambdaQueryWrapper<RmqTopic>()
                 .eq(instanceId != null, RmqTopic::getInstanceId, normalizeMetadataScope(instanceId))
                 .eq(StringUtils.hasText(clusterId), RmqTopic::getClusterId, clusterId)
                 .eq(StringUtils.hasText(type), RmqTopic::getTopicType, type)
-                .like(StringUtils.hasText(search), RmqTopic::getName, search)
+                .like(StringUtils.hasText(pattern), RmqTopic::getName, pattern)
                 .orderByAsc(RmqTopic::getName);
 
         List<TopicVO> result = new ArrayList<>();
@@ -220,10 +221,11 @@ public class RocketMQMetadataProvider implements MetadataProvider {
 
     @Override
     public List<ConsumerGroupVO> listConsumerGroups(String instanceId, String clusterId, String search) {
+        String pattern = escapeLike(normalizeSearch(search));
         LambdaQueryWrapper<RmqGroup> query = new LambdaQueryWrapper<RmqGroup>()
                 .eq(instanceId != null, RmqGroup::getInstanceId, normalizeMetadataScope(instanceId))
                 .eq(StringUtils.hasText(clusterId), RmqGroup::getClusterId, clusterId)
-                .like(StringUtils.hasText(search), RmqGroup::getName, search)
+                .like(StringUtils.hasText(pattern), RmqGroup::getName, pattern)
                 .orderByAsc(RmqGroup::getName);
 
         List<ConsumerGroupVO> result = new ArrayList<>();
@@ -398,6 +400,17 @@ public class RocketMQMetadataProvider implements MetadataProvider {
             return Collections.emptyList();
         }
         return adminExecute(admin -> getTopicRoutes(admin, name));
+    }
+
+    static String normalizeSearch(String value) {
+        return value == null ? null : value.trim();
+    }
+
+    static String escapeLike(String search) {
+        if (!StringUtils.hasText(search)) {
+            return search;
+        }
+        return search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 
     private List<BrokerRouteVO> getTopicRoutes(MQAdminExt admin, String name) {


### PR DESCRIPTION
### Summary
Escape LIKE wildcards on the full (non-paged) metadata list queries too:

- `listTopics` and `listConsumerGroups` now escape `%`, `_`, `\` in the search term via `escapeLike` before the `LambdaQueryWrapper` predicate, matching the paged variants.

### Why
The non-paged lists back selector/search flows; an unescaped `%`/`_` there previously matched broadly instead of literal text.

### Testing
- `mvn -f server/pom.xml -Dtest=RocketMQMetadataProviderTest test` passes: 35/35 (existing suite; helper behavior covered by the paged-escape suite).
