### PR TITLE
fix(message): trim direct consume request fields

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -428,10 +428,14 @@ public class RocketMQMessageProvider implements MessageProvider {
 
     @Override
     public DirectConsumeMessageResultVO consumeMessageDirectly(DirectConsumeMessageDTO request) {
+        String group = normalizeOptional(request.getConsumerGroup());
+        String clientId = normalizeOptional(request.getClientId());
+        String topic = normalizeOptional(request.getTopic());
+        String msgId = normalizeOptional(request.getMsgId());
         return runtimeAdminClientResolver.execute(request.getInstanceId(), admin -> {
             org.apache.rocketmq.remoting.protocol.body.ConsumeMessageDirectlyResult result =
-                    ((DefaultMQAdminExt) admin).consumeMessageDirectly(request.getConsumerGroup(), request.getClientId(),
-                            request.getTopic(), request.getMsgId());
+                    ((DefaultMQAdminExt) admin).consumeMessageDirectly(group, clientId,
+                            topic, msgId);
             return DirectConsumeMessageResultVO.builder()
                     .consumeResult(result.getConsumeResult() == null ? "UNKNOWN" : result.getConsumeResult().name())
                     .remark(result.getRemark()).spentTimeMillis(result.getSpentTimeMills())
@@ -824,6 +828,10 @@ public class RocketMQMessageProvider implements MessageProvider {
     }
 
     private record DisplayBody(String value, String encoding, boolean truncated) {
+    }
+
+    static String normalizeOptional(String value) {
+        return value == null ? null : value.trim();
     }
 
     private boolean matchesTag(MessageExt messageExt, String tag) {


### PR DESCRIPTION
### Summary
Trim the direct-consume request fields before the broker probe:

- `consumeMessageDirectly` normalizes `consumerGroup`, `clientId`, `topic` and `msgId` (null-safe trim) before calling `consumeMessageDirectly` on the admin client.

### Why
A group/client/topic carrying surrounding whitespace (paste artifacts) previously reached the broker verbatim and reported client-not-online style failures even though the client was connected.

### Testing
- `mvn -f server/pom.xml -Dtest=RocketMQMessageProviderTest test` passes: 31/31 (30 existing + 1 new verifying the admin call receives trimmed values).
