### PR TITLE
fix(cluster): trim nameserver address before discovery

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -95,8 +95,9 @@ public class RocketMQClusterProvider implements ClusterProvider {
         if (!StringUtils.hasText(namesrvAddr)) {
             return Collections.emptyList();
         }
+        String trimmedAddr = namesrvAddr.trim();
         try {
-            return executeAdmin(instanceId, namesrvAddr, admin -> {
+            return executeAdmin(instanceId, trimmedAddr, admin -> {
                 ClusterInfo clusterInfo = admin.examineBrokerClusterInfo();
                 if (clusterInfo == null || clusterInfo.getClusterAddrTable() == null) {
                     return Collections.<ClusterVO>emptyList();
@@ -113,7 +114,7 @@ public class RocketMQClusterProvider implements ClusterProvider {
                     Set<String> brokerNames = entry.getValue();
 
                     List<BrokerVO> brokers = buildBrokerList(admin, brokerNames, brokerAddrTable);
-                    List<NameServerVO> nameServers = buildNameServerList(namesrvAddr);
+                    List<NameServerVO> nameServers = buildNameServerList(trimmedAddr);
 
                     ClusterVO cluster = buildClusterVO(clusterName, brokers, nameServers);
                     cluster.setProxies(proxies);


### PR DESCRIPTION
### Summary
Trim the NameServer address before cluster discovery:

- `discoverClustersAt` trims `namesrvAddr` before using it for the admin connection and for building the NameServer list.

### Why
An address pasted with surrounding whitespace previously connected/compared against a padded string, silently returning no clusters (or mismatched NameServer lists) for a valid endpoint.

### Testing
- `mvn -f server/pom.xml -Dtest=RocketMQClusterProviderTest test` passes: 14/14 (existing suite; behavior unchanged for clean input).
