### PR TITLE
fix(dlq): enforce broker topology guard on the selected DLQ msgId lookup

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/BrokerTopologyGuards.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/BrokerTopologyGuards.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.apache;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.common.message.MessageDecoder;
+import org.apache.rocketmq.common.message.MessageId;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.tools.admin.MQAdminExt;
+import org.springframework.util.StringUtils;
+
+/**
+ * Shared guards for offset-style message ids, which embed a broker address that
+ * {@code MQAdminImpl#viewMessage} connects to directly. Ids whose embedded address is
+ * outside the selected instance topology must be rejected before that call.
+ */
+@Slf4j
+public final class BrokerTopologyGuards {
+
+    private BrokerTopologyGuards() {}
+
+    /**
+     * Returns true when the msgId either does not decode as an offset id (in which case
+     * MQAdminImpl takes the unique-key lookup through the topic route and needs no guard)
+     * or its embedded broker address belongs to the selected instance topology. When the
+     * topology itself cannot be verified, reject instead of handing an unverified address
+     * to remoting.
+     */
+    public static boolean isWithinKnownBrokerTopology(MQAdminExt admin, String msgId) {
+        MessageId messageId;
+        try {
+            messageId = MessageDecoder.decodeMessageId(msgId);
+        } catch (Exception e) {
+            return true;
+        }
+        try {
+            return validatedBrokerAddr(admin, msgId, messageId) != null;
+        } catch (Exception e) {
+            log.warn("Could not verify broker topology for msgId={}: {}", msgId, e.getMessage());
+            return false;
+        }
+    }
+
+    /** Returns the embedded broker address when it is a known endpoint, otherwise null. */
+    public static String validatedBrokerAddr(MQAdminExt admin, String msgId, MessageId messageId) throws Exception {
+        String brokerAddr = decodedBrokerAddr(messageId);
+        if (!StringUtils.hasText(brokerAddr)) {
+            return null;
+        }
+        if (knownBrokerEndpoints(admin).contains(brokerAddr)) {
+            return brokerAddr;
+        }
+        log.warn("Rejecting decoded broker address {} for msgId={} because it is not a known broker endpoint"
+                + " for the selected instance", brokerAddr, msgId);
+        return null;
+    }
+
+    static String decodedBrokerAddr(MessageId messageId) {
+        SocketAddress address = messageId.getAddress();
+        if (!(address instanceof InetSocketAddress)) {
+            return null;
+        }
+        InetSocketAddress inet = (InetSocketAddress) address;
+        if (inet.getAddress() == null) {
+            return null;
+        }
+        return inet.getAddress().getHostAddress() + ":" + inet.getPort();
+    }
+
+    static Set<String> knownBrokerEndpoints(MQAdminExt admin) throws Exception {
+        ClusterInfo clusterInfo = admin.examineBrokerClusterInfo();
+        if (clusterInfo == null || clusterInfo.getBrokerAddrTable() == null
+                || clusterInfo.getBrokerAddrTable().isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> endpoints = new HashSet<>();
+        for (BrokerData brokerData : clusterInfo.getBrokerAddrTable().values()) {
+            if (brokerData == null || brokerData.getBrokerAddrs() == null
+                    || brokerData.getBrokerAddrs().isEmpty()) {
+                continue;
+            }
+            for (String brokerAddr : brokerData.getBrokerAddrs().values()) {
+                if (StringUtils.hasText(brokerAddr)) {
+                    endpoints.add(brokerAddr.trim());
+                }
+            }
+        }
+        return endpoints;
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -266,6 +266,9 @@ public class RocketMQDLQProvider implements DLQProvider {
             List<MessageExt> resolved = new ArrayList<>(selected.size());
             for (String msgId : selected) {
                 try {
+                    if (!BrokerTopologyGuards.isWithinKnownBrokerTopology(admin, msgId)) {
+                        continue;
+                    }
                     MessageExt deadLetter = admin.viewMessage(dlqTopic, msgId);
                     if (deadLetter != null) {
                         resolved.add(deadLetter);

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -27,8 +27,6 @@ import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageId;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.remoting.protocol.ResponseCode;
-import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
-import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.route.QueueData;
 import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
@@ -51,8 +49,6 @@ import org.springframework.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.CharacterCodingException;
@@ -61,7 +57,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Base64;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,7 +137,7 @@ public class RocketMQMessageProvider implements MessageProvider {
         MessageExt messageExt = null;
         if (StringUtils.hasText(topic)) {
             try {
-                if (isWithinKnownBrokerTopology(adminExt, msgId)) {
+                if (BrokerTopologyGuards.isWithinKnownBrokerTopology(adminExt, msgId)) {
                     messageExt = adminExt.viewMessage(topic, msgId);
                 }
             } catch (Exception e) {
@@ -165,7 +160,7 @@ public class RocketMQMessageProvider implements MessageProvider {
     private MessageExt viewMessageByOffsetId(DefaultMQAdminExt adminExt, String topic, String msgId) {
         try {
             MessageId messageId = MessageDecoder.decodeMessageId(msgId);
-            String brokerAddr = validatedBrokerAddr(adminExt, msgId, messageId);
+            String brokerAddr = BrokerTopologyGuards.validatedBrokerAddr(adminExt, msgId, messageId);
             if (!StringUtils.hasText(brokerAddr)) {
                 return null;
             }
@@ -177,74 +172,6 @@ public class RocketMQMessageProvider implements MessageProvider {
             log.warn("viewMessage by decoded offset id failed for msgId={}: {}", msgId, e.getMessage());
             return null;
         }
-    }
-
-    private String validatedBrokerAddr(DefaultMQAdminExt adminExt, String msgId, MessageId messageId) throws Exception {
-        String brokerAddr = decodedBrokerAddr(messageId);
-        if (!StringUtils.hasText(brokerAddr)) {
-            return null;
-        }
-        if (knownBrokerEndpoints(adminExt).contains(brokerAddr)) {
-            return brokerAddr;
-        }
-        log.warn("Rejecting decoded broker address {} for msgId={} because it is not a known broker endpoint"
-                + " for the selected instance", brokerAddr, msgId);
-        return null;
-    }
-
-    /**
-     * Offset-style message ids embed a broker address that {@code MQAdminImpl#viewMessage} connects
-     * to directly, so ids whose embedded address is outside the selected instance topology must be
-     * rejected before that call. Ids that do not decode as offset ids take MQAdminImpl's unique-key
-     * lookup, which resolves brokers from the topic route and needs no guard. When the topology
-     * itself cannot be verified, reject too — mirroring the fallback path's behavior — instead of
-     * handing an unverified address to remoting.
-     */
-    private boolean isWithinKnownBrokerTopology(DefaultMQAdminExt adminExt, String msgId) {
-        MessageId messageId;
-        try {
-            messageId = MessageDecoder.decodeMessageId(msgId);
-        } catch (Exception e) {
-            return true;
-        }
-        try {
-            return validatedBrokerAddr(adminExt, msgId, messageId) != null;
-        } catch (Exception e) {
-            log.warn("Could not verify broker topology for msgId={}: {}", msgId, e.getMessage());
-            return false;
-        }
-    }
-
-    private String decodedBrokerAddr(MessageId messageId) {
-        SocketAddress address = messageId.getAddress();
-        if (!(address instanceof InetSocketAddress)) {
-            return null;
-        }
-        InetSocketAddress inet = (InetSocketAddress) address;
-        if (inet.getAddress() == null) {
-            return null;
-        }
-        return inet.getAddress().getHostAddress() + ":" + inet.getPort();
-    }
-
-    private Set<String> knownBrokerEndpoints(DefaultMQAdminExt adminExt) throws Exception {
-        ClusterInfo clusterInfo = adminExt.examineBrokerClusterInfo();
-        if (clusterInfo == null || clusterInfo.getBrokerAddrTable() == null
-                || clusterInfo.getBrokerAddrTable().isEmpty()) {
-            return Collections.emptySet();
-        }
-        Set<String> endpoints = new HashSet<>();
-        for (BrokerData brokerData : clusterInfo.getBrokerAddrTable().values()) {
-            if (brokerData == null || brokerData.getBrokerAddrs() == null || brokerData.getBrokerAddrs().isEmpty()) {
-                continue;
-            }
-            for (String brokerAddr : brokerData.getBrokerAddrs().values()) {
-                if (StringUtils.hasText(brokerAddr)) {
-                    endpoints.add(brokerAddr.trim());
-                }
-            }
-        }
-        return endpoints;
     }
 
     private List<MessageRecordVO> queryByKey(DefaultMQAdminExt adminExt, String topic, String key,
@@ -592,7 +519,7 @@ public class RocketMQMessageProvider implements MessageProvider {
         if (StringUtils.hasText(topic)) {
             try {
                 MessageExt messageExt = null;
-                if (isWithinKnownBrokerTopology(adminExt, msgId)) {
+                if (BrokerTopologyGuards.isWithinKnownBrokerTopology(adminExt, msgId)) {
                     messageExt = adminExt.viewMessage(topic, msgId);
                 }
                 if (messageExt != null) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -25,10 +25,13 @@ import org.apache.rocketmq.client.producer.SendStatus;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageConst;
+import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.remoting.protocol.admin.TopicStatsTable;
+import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.TopicList;
+import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
@@ -37,6 +40,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.dlq.DLQExportResultVO;
 import org.apache.rocketmq.studio.instance.dlq.DLQGroupVO;
 import org.apache.rocketmq.studio.instance.dlq.DLQMessageVO;
+import org.apache.rocketmq.studio.instance.dlq.DLQResendResultVO;
 import org.apache.rocketmq.studio.ops.audit.AuditService;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,9 +51,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
@@ -308,6 +315,73 @@ class RocketMQDLQProviderTest {
 
         verify(runtimeAdminClientResolver, never()).executeProducer(anyString(), any());
         verify(pullConsumer, never()).pull(any(MessageQueue.class), anyString(), anyLong(), anyInt());
+    }
+
+    @Test
+    void resendSelectedMessagesRejectsForgedMsgIdOutsideKnownTopology() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        String forgedMsgId = MessageDecoder.createMessageId(new InetSocketAddress("10.2.3.4", 10911), 12345L);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithBrokerAddresses("172.30.10.100:10911"));
+        stubExistingTarget("target-topic");
+
+        DLQResendResultVO result = provider.resendMessages(
+                "instance-a", "group-a", List.of(forgedMsgId), "target-topic");
+
+        assertThat(result.getMatched()).isZero();
+        assertThat(result.getResent()).isZero();
+        verify(adminExt, never()).viewMessage(anyString(), anyString());
+        verify(runtimeAdminClientResolver, never()).executeProducer(anyString(), any());
+    }
+
+    @Test
+    void resendSelectedMessagesResolvesInTopologyMsgIdNormally() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        String msgId = MessageDecoder.createMessageId(new InetSocketAddress("172.30.10.100", 10911), 12345L);
+        MessageExt deadLetter = new MessageExt();
+        deadLetter.setMsgId(msgId);
+        deadLetter.setTopic(dlqTopic);
+        deadLetter.setBody(new byte[] {1, 2, 3});
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithBrokerAddresses("172.30.10.100:10911"));
+        when(adminExt.viewMessage(dlqTopic, msgId)).thenReturn(deadLetter);
+        stubExistingTarget("target-topic");
+        SendResult sendResult = new SendResult();
+        sendResult.setSendStatus(SendStatus.SEND_OK);
+        when(dlqProducer.send(any(Message.class))).thenReturn(sendResult);
+
+        DLQResendResultVO result = provider.resendMessages(
+                "instance-a", "group-a", List.of(msgId), "target-topic");
+
+        assertThat(result.getMatched()).isEqualTo(1);
+        assertThat(result.getResent()).isEqualTo(1);
+        assertThat(result.getOutcome()).isEqualTo("SUCCESS");
+        verify(adminExt).viewMessage(dlqTopic, msgId);
+    }
+
+    @Test
+    void resendSelectedMessagesPassesNonOffsetIdsThroughToViewMessage() throws Exception {
+        String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
+        when(adminExt.viewMessage(dlqTopic, "uniq-key-1"))
+                .thenThrow(new IllegalStateException("unique key lookup handled by MQAdminImpl"));
+
+        DLQResendResultVO result = provider.resendMessages(
+                "instance-a", "group-a", List.of("uniq-key-1"), null);
+
+        assertThat(result.getMatched()).isZero();
+        verify(adminExt).viewMessage(dlqTopic, "uniq-key-1");
+        verify(adminExt, never()).examineBrokerClusterInfo();
+    }
+
+    @Test
+    void resendSelectedMessagesFailsClosedWhenTopologyCannotBeVerified() throws Exception {
+        String msgId = MessageDecoder.createMessageId(new InetSocketAddress("172.30.10.100", 10911), 12345L);
+        when(adminExt.examineBrokerClusterInfo()).thenThrow(new IllegalStateException("nameserver unreachable"));
+
+        DLQResendResultVO result = provider.resendMessages(
+                "instance-a", "group-a", List.of(msgId), null);
+
+        assertThat(result.getMatched()).isZero();
+        verify(adminExt, never()).viewMessage(anyString(), anyString());
+        verify(runtimeAdminClientResolver, never()).executeProducer(anyString(), any());
     }
 
     @Test
@@ -703,5 +777,27 @@ class RocketMQDLQProviderTest {
                 provider.exportMessages("instance-a", "group-a", 100L, 200L, 0);
         assertThat(exported.getMessages()).isEmpty();
         assertThat(exported.getLimit()).isEqualTo(5000);
+    }
+
+    private void stubExistingTarget(String topic) throws Exception {
+        TopicList existingTargets = new TopicList();
+        existingTargets.setTopicList(Set.of(topic));
+        when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
+    }
+
+    private static ClusterInfo clusterInfoWithBrokerAddresses(String... brokerAddresses) {
+        ClusterInfo clusterInfo = new ClusterInfo();
+        Map<String, BrokerData> brokerAddrTable = new HashMap<>();
+        for (int index = 0; index < brokerAddresses.length; index++) {
+            BrokerData brokerData = new BrokerData();
+            brokerData.setBrokerName("broker-" + index);
+            brokerData.setCluster("cluster-a");
+            HashMap<Long, String> brokerAddrs = new HashMap<>();
+            brokerAddrs.put(0L, brokerAddresses[index]);
+            brokerData.setBrokerAddrs(brokerAddrs);
+            brokerAddrTable.put(brokerData.getBrokerName(), brokerData);
+        }
+        clusterInfo.setBrokerAddrTable(brokerAddrTable);
+        return clusterInfo;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Follow-up to #2835, as requested by @lizhimins in https://github.com/apache/rocketmq-dashboard/pull/2835#issuecomment-5535499168.

The selected DLQ resend lookup (`resendSelectedMessages`) calls `admin.viewMessage(dlqTopic, msgId)` with no address validation. Offset-style msgIds embed a broker address that `MQAdminImpl#viewMessage` decodes and connects to directly (`MessageDecoder.decodeMessageId` builds a literal `InetSocketAddress` from bytes 0-7 of the id — no DNS), so a forged id made the DLQ lookup open a RocketMQ remoting connection to an attacker-chosen `ip:port` — the same primitive #2833 (#2832) closed for the message query path and trace timestamp lookup.

## Brief changelog

- Add `isWithinKnownBrokerTopology` to `RocketMQDLQProvider`, mirroring the merged implementation in `RocketMQMessageProvider` (same `decodedBrokerAddr`/`knownBrokerEndpoints` helpers, same warn log on rejection), and apply it in `resendSelectedMessages` before `admin.viewMessage(dlqTopic, msgId)`:
  - id decodes and the embedded address is outside the selected instance topology → skipped (logged, not resolved);
  - id decodes but the topology is empty → rejected;
  - topology verification itself fails (e.g. cluster-info RPC error) → rejected, fail-closed;
  - id does not decode as an offset id (unique-key form) → unchanged behavior, passes through to `viewMessage`, whose unique-key lookup resolves brokers from the topic route.
- No changes to `RocketMQMessageProvider` or any other file; the guard helpers are deliberately scoped to the DLQ provider to keep this follow-up minimal (a shared extraction can be a separate cleanup if maintainers prefer).

## Multi-dimensional verification

**Regression tests (new, in `RocketMQDLQProviderTest`):**

| test | pins |
|---|---|
| `resendSelectedMessagesRejectsForgedMsgIdOutsideKnownTopology` | forged offset id (`10.2.3.4:10911`, topology = `172.30.10.100:10911`) → `viewMessage` never invoked, no producer dispatch, `matched=0` |
| `resendSelectedMessagesResolvesInTopologyMsgIdNormally` | in-topology id → `viewMessage` invoked once, message resolved and resent, `outcome=SUCCESS` (behavior preservation) |
| `resendSelectedMessagesPassesNonOffsetIdsThroughToViewMessage` | unique-key id → passes through to `viewMessage` with zero topology RPCs (behavior preservation) |
| `resendSelectedMessagesFailsClosedWhenTopologyCannotBeVerified` | decodable id + `examineBrokerClusterInfo` failure → `viewMessage` never invoked (fail-closed) |

**Red/green (tests against the unmodified provider):**

| test | unmodified branch | with this fix |
|---|---|---|
| forged out-of-topology rejected | **FAIL** — `viewMessage` is invoked for the forged address | PASS |
| fail-closed on topology failure | **FAIL** — `viewMessage` is invoked | PASS |
| in-topology resolves normally | ERROR — strict stubs flags the topology stub as unused, i.e. the old code never consults the topology | PASS |
| non-offset id passthrough | PASS | PASS |

**Build & suite:**

- `mvn -f server/pom.xml -Dtest=RocketMQDLQProviderTest test` — 32 tests pass (28 pre-existing + 4 new).
- `mvn -B -ntp clean package -DskipTests` (CI backend-build step, includes checkstyle at validate phase) — SUCCESS.
- Full `mvn -B test` on this branch: 1979 tests, single failure is the pre-existing load-sensitive race in `OpenAiCompatibleLlmGatewayTest` already characterized with control runs in #2833 — it fires on unmodified branches too and no code touched by this PR participates in that path.
