### PR TITLE
fix(consumer): require group and client id in stack diagnostics

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProvider.java
@@ -61,24 +61,32 @@ public class RocketMQConsumerDiagnosticsProvider implements ConsumerDiagnosticsP
 
     @Override
     public ConsumerStackTraceVO getConsumerStack(String instanceId, String groupName, String clientId) {
+        String normalizedGroup = groupName == null ? null : groupName.trim();
+        String normalizedClient = clientId == null ? null : clientId.trim();
+        if (normalizedGroup == null || normalizedGroup.isEmpty()) {
+            throw new BusinessException(400, "consumer group is required");
+        }
+        if (normalizedClient == null || normalizedClient.isEmpty()) {
+            throw new BusinessException(400, "consumer client id is required");
+        }
         // Clients that connect through a proxy keep their channel on the proxy and never register
         // on a broker, so ask the proxy first; the broker only knows directly connected clients
         // and answers "not online" for everyone else.
         ConsumerRunningInfo viaProxy = proxyConsumerResolver == null
                 ? null
-                : proxyConsumerResolver.resolveConsumerRunningInfo(instanceId, groupName, clientId);
+                : proxyConsumerResolver.resolveConsumerRunningInfo(instanceId, normalizedGroup, normalizedClient);
         if (viaProxy != null) {
-            return toStackTrace(groupName, clientId, viaProxy);
+            return toStackTrace(normalizedGroup, normalizedClient, viaProxy);
         }
         if (StringUtils.hasText(instanceId)) {
             return runtimeAdminClientResolver.execute(instanceId,
-                    admin -> getConsumerStack(admin, groupName, clientId));
+                    admin -> getConsumerStack(admin, normalizedGroup, normalizedClient));
         }
         if (!StringUtils.hasText(properties.getNamesrvAddr())) {
             throw new BusinessException(503, "RocketMQ admin not connected");
         }
         return adminFactory.execute(properties.getNamesrvAddr(), null,
-                admin -> getConsumerStack(admin, groupName, clientId));
+                admin -> getConsumerStack(admin, normalizedGroup, normalizedClient));
     }
 
     private ConsumerStackTraceVO getConsumerStack(MQAdminExt admin, String groupName, String clientId) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQConsumerDiagnosticsProviderTest.java
@@ -237,4 +237,14 @@ class RocketMQConsumerDiagnosticsProviderTest {
                 .hasMessageContaining("Failed to get consumer stack for client-1")
                 .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(502));
     }
+
+    @Test
+    void rejectsBlankGroupAndClientBeforeAnyLookup() {
+        assertThatThrownBy(() -> provider.getConsumerStack("instance-a", "   ", "client-1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("group");
+        assertThatThrownBy(() -> provider.getConsumerStack("instance-a", "cg-orders", " "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("client");
+    }
 }


### PR DESCRIPTION
### Summary
Require the consumer group and client id in the stack-diagnostics lookup:

- `getConsumerStack` trims both inputs and rejects blank values with a clear 400 (`consumer group is required` / `consumer client id is required`) before any proxy or broker probe.

### Why
A blank group/client previously flowed into the probes and surfaced as a confusing "consumer not online" style failure; an explicit 400 makes the contract clear at the boundary.

### Testing
- `mvn -f server/pom.xml -Dtest=RocketMQConsumerDiagnosticsProviderTest test` passes: 12/12 (11 existing + 1 new covering both blank guards).
