### PR TITLE
test(message-history): cover empty summarize output

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
@@ -165,4 +165,16 @@ class QueryHistoryServiceTest {
         assertThat(messageCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
         assertThat(traceCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
     }
+
+    @Test
+    void summarizesEmptyHistoryStreams() {
+        when(messageQueryMapper.selectCount(any())).thenReturn(0L);
+        when(traceQueryMapper.selectCount(any())).thenReturn(0L);
+
+        QueryHistorySummaryVO summary = service.summarize("cluster-a");
+
+        assertThat(summary.getMessageQueries()).isZero();
+        assertThat(summary.getTraceQueries()).isZero();
+        assertThat(summary.getLatestQueryAt()).isNull();
+    }
 }


### PR DESCRIPTION
### Summary
Cover the empty-stream path of the history summary:

- `summarize` with zero message/trace records returns zero counts and a null `latestQueryAt` (both `selectOne` lookups are null).

### Why
The latest-query computation (`latestOf` of two nullable values) previously had no direct coverage for the both-empty case.

### Testing
- `mvn -f server/pom.xml -Dtest=QueryHistoryServiceTest test` passes: 7/7 (6 existing + 1 new).
