### PR TITLE
test(audit): cover cleanup cutoff and return value

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
@@ -201,4 +201,18 @@ class AuditServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("beforeDays must not exceed 365");
     }
+
+    @Test
+    void cleanupLogsDeletesBeforeComputedCutoffAndReturnsCount() {
+        when(auditRepository.deleteBefore(any())).thenReturn(7);
+
+        int deleted = auditService.cleanupLogs(30);
+
+        assertThat(deleted).isEqualTo(7);
+        ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(auditRepository).deleteBefore(captor.capture());
+        LocalDateTime cutoff = captor.getValue();
+        LocalDateTime now = LocalDateTime.now();
+        assertThat(cutoff).isAfter(now.minusDays(31)).isBefore(now.minusDays(29));
+    }
 }


### PR DESCRIPTION
### Summary
Cover the audit cleanup execution path:

- `cleanupLogs` returns the repository's deleted count, and the deletion cutoff is computed as (now − beforeDays) — asserted within a tolerance window.

### Why
The cleanup bounds were covered but the actual cutoff computation and return-value propagation had no direct assertions.

### Testing
- `mvn -f server/pom.xml -Dtest=AuditServiceTest test` passes: 13/13 (12 existing + 1 new).
