### PR TITLE
fix(cluster): require nameserver address in connection test

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionService.java
@@ -17,8 +17,10 @@
 package org.apache.rocketmq.studio.cluster.broker;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -43,6 +45,9 @@ public class ClusterConnectionService {
      * @return a populated {@link ClusterProbeResult} on success
      */
     public ClusterProbeResult testConnection(TestConnectionDTO command) {
+        if (command == null || !StringUtils.hasText(command.getNamesrvAddr())) {
+            throw new BusinessException(400, "namesrvAddr is required");
+        }
         String namesrvAddr = command.getNamesrvAddr().trim();
         log.info("Testing connection to NameServer {}", namesrvAddr);
         long start = System.currentTimeMillis();

--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionServiceTest.java
@@ -76,4 +76,15 @@ class ClusterConnectionServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Failed to connect NameServer");
     }
+
+    @Test
+    void rejectsMissingNameserverAddress() {
+        TestConnectionDTO empty = new TestConnectionDTO();
+        assertThatThrownBy(() -> service.testConnection(empty))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("namesrvAddr");
+        assertThatThrownBy(() -> service.testConnection(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("namesrvAddr");
+    }
 }


### PR DESCRIPTION
### Summary
Guard the connection-test command:

- `testConnection` now rejects a null command or a blank/absent `namesrvAddr` with a clear 400 (`namesrvAddr is required`) instead of dereferencing and surfacing an internal error.

### Why
The action previously called `command.getNamesrvAddr().trim()` unconditionally, so an empty request (or blank address) produced an NPE-style failure instead of a validation message.

### Testing
- `mvn -f server/pom.xml -Dtest=ClusterConnectionServiceTest test` passes: 2/2 (existing suite; behavior unchanged for valid input).
