### PR TITLE
fix(broker): require broker address before config access

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigService.java
@@ -47,12 +47,13 @@ public class RocketMQBrokerConfigService {
     }
 
     public ClusterConfigVO getBrokerConfig(String brokerAddr, String instanceId) {
+        String normalizedAddr = requireBrokerAddress(brokerAddr);
         return execute(instanceId, admin -> {
             try {
-                Properties props = admin.getBrokerConfig(brokerAddr);
+                Properties props = admin.getBrokerConfig(normalizedAddr);
                 return mapToClusterConfigVO(props);
             } catch (Exception e) {
-                log.error("Failed to get broker config from {}", brokerAddr, e);
+                log.error("Failed to get broker config from {}", normalizedAddr, e);
                 throw new BusinessException(500, "Failed to get broker config: " + e.getMessage());
             }
         });
@@ -73,20 +74,28 @@ public class RocketMQBrokerConfigService {
     }
 
     public void updateBrokerConfig(String brokerAddr, String clusterId, String instanceId, Properties newConfig) {
+        String normalizedAddr = requireBrokerAddress(brokerAddr);
         execute(instanceId, admin -> {
             try {
-                admin.updateBrokerConfig(brokerAddr, newConfig);
-                String detail = "brokerAddr=" + brokerAddr + ", config=" + newConfig;
+                admin.updateBrokerConfig(normalizedAddr, newConfig);
+                String detail = "brokerAddr=" + normalizedAddr + ", config=" + newConfig;
                 recordAudit(clusterId, detail, "SUCCESS");
-                log.info("Broker config updated successfully: {}", brokerAddr);
+                log.info("Broker config updated successfully: {}", normalizedAddr);
                 return null;
             } catch (Exception e) {
-                log.error("Failed to update broker config at {}", brokerAddr, e);
-                String detail = "brokerAddr=" + brokerAddr + ", error=" + e.getMessage();
+                log.error("Failed to update broker config at {}", normalizedAddr, e);
+                String detail = "brokerAddr=" + normalizedAddr + ", error=" + e.getMessage();
                 recordAudit(clusterId, detail, "FAILED");
                 throw new BusinessException(500, "Failed to update broker config: " + e.getMessage());
             }
         });
+    }
+
+    private static String requireBrokerAddress(String brokerAddr) {
+        if (!StringUtils.hasText(brokerAddr)) {
+            throw new BusinessException(400, "brokerAddr is required");
+        }
+        return brokerAddr.trim();
     }
 
     private void recordAudit(String clusterId, String detail, String result) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigServiceTest.java
@@ -87,4 +87,14 @@ class RocketMQBrokerConfigServiceTest {
                 "UPDATE_BROKER_CONFIG", "BROKER", "CLUSTER:cluster-a", "cluster-a",
                 "brokerAddr=broker-a:10911, config={}", "SUCCESS");
     }
+
+    @Test
+    void rejectsBlankBrokerAddresses() {
+        assertThatThrownBy(() -> brokerConfigService.getBrokerConfig("   "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("brokerAddr");
+        assertThatThrownBy(() -> brokerConfigService.updateBrokerConfig(" ", "cluster-a", new Properties()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("brokerAddr");
+    }
 }


### PR DESCRIPTION
### Summary
Require and trim the broker address in the broker config service:

- `getBrokerConfig` and `updateBrokerConfig` reject a blank `brokerAddr` with a clear 400 (`brokerAddr is required`) and trim it before any admin call or audit detail.

### Why
A blank/padded address previously reached `admin.getBrokerConfig(...)`/`updateBrokerConfig(...)`, surfacing a 500-style broker failure instead of a validation error, and padded addresses produced inconsistent audit details.

### Testing
- `mvn -f server/pom.xml -Dtest=RocketMQBrokerConfigServiceTest test` passes: 4/4 (3 existing + 1 new covering both read and update guards).
