### PR TITLE
fix(ai): guard null tool input in alert rule list handler

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/AlertRuleListToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/AlertRuleListToolHandler.java
@@ -41,6 +41,10 @@ public class AlertRuleListToolHandler implements ToolHandler {
 
     @Override
     public Object execute(Map<String, Object> input) {
+        if (input == null) {
+            throw new org.apache.rocketmq.studio.common.exception.BusinessException(
+                    400, "tool input is required");
+        }
         String search = (String) input.get("search");
         Boolean enabled = (Boolean) input.get("enabled");
         return alertService.listRules().stream()

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/AlertRuleListToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/AlertRuleListToolHandlerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.ops.alert.AlertRuleVO;
+import org.apache.rocketmq.studio.ops.alert.AlertService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AlertRuleListToolHandlerTest {
+
+    @Mock
+    private AlertService alertService;
+
+    private AlertRuleListToolHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new AlertRuleListToolHandler(alertService);
+    }
+
+    @Test
+    void rejectsNullInput() {
+        assertThatThrownBy(() -> handler.execute(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("input");
+    }
+
+    @Test
+    void filtersBySearchAndProjectsFields() {
+        AlertRuleVO rule = new AlertRuleVO();
+        rule.setId(7L);
+        rule.setName("Broker disk usage high");
+        rule.setMetric("disk_usage");
+        rule.setEnabled(true);
+        when(alertService.listRules()).thenReturn(List.of(rule));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> result = (List<Map<String, Object>>) handler.execute(
+                Map.of("search", "disk", "enabled", true));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).containsEntry("id", 7L);
+        assertThat(result.get(0)).containsEntry("name", "Broker disk usage high");
+    }
+}


### PR DESCRIPTION
### Summary
Guard and cover the AI alert-rule list tool handler:

- `AlertRuleListToolHandler.execute` rejects a null input map with a clear 400 (`tool input is required`) instead of NPE-ing.
- New `AlertRuleListToolHandlerTest` (first coverage) verifies the null guard and the search/enabled filter + projection path.

### Why
Tool handlers run on LLM-produced inputs and had no automated coverage; a null input previously produced an opaque NPE inside the tool gateway.

### Testing
- `mvn -f server/pom.xml -Dtest=AlertRuleListToolHandlerTest test` passes: 2/2.
