### PR TITLE
fix(ai): guard null tool input in ns config diff handler

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/NameServerConfigDiffToolHandler.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/tool/NameServerConfigDiffToolHandler.java
@@ -38,6 +38,10 @@ public class NameServerConfigDiffToolHandler implements ToolHandler {
 
     @Override
     public Object execute(Map<String, Object> input) {
+        if (input == null) {
+            throw new org.apache.rocketmq.studio.common.exception.BusinessException(
+                    400, "tool input is required");
+        }
         return configDiffService.compare((String) input.get("cluster"));
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/NameServerConfigDiffToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/NameServerConfigDiffToolHandlerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai.tool;
+
+import org.apache.rocketmq.studio.cluster.nameserver.NameServerConfigDiffVO;
+import org.apache.rocketmq.studio.cluster.nameserver.NameServerConfigDiffService;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NameServerConfigDiffToolHandlerTest {
+
+    @Mock
+    private NameServerConfigDiffService configDiffService;
+
+    private NameServerConfigDiffToolHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new NameServerConfigDiffToolHandler(configDiffService);
+    }
+
+    @Test
+    void rejectsNullInput() {
+        assertThatThrownBy(() -> handler.execute(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("input");
+    }
+
+    @Test
+    void comparesClusterFromInput() {
+        NameServerConfigDiffVO diff = mock(NameServerConfigDiffVO.class);
+        when(configDiffService.compare("cluster-a")).thenReturn(diff);
+
+        Object result = handler.execute(Map.of("cluster", "cluster-a"));
+
+        assertThat(result).isSameAs(diff);
+    }
+}


### PR DESCRIPTION
### Summary
Guard and cover the AI NameServer-config-diff tool handler:

- `NameServerConfigDiffToolHandler.execute` rejects a null input map with a clear 400 (`tool input is required`) instead of NPE-ing.
- New `NameServerConfigDiffToolHandlerTest` (first coverage) verifies the null guard and the delegation to the diff service for the input cluster.

### Why
Tool handlers run on LLM-produced inputs and had no automated coverage; a null input previously produced an opaque NPE inside the tool gateway.

### Testing
- `mvn -f server/pom.xml -Dtest=NameServerConfigDiffToolHandlerTest test` passes: 2/2.
