### PR TITLE
fix(alert): require metric equality when reconciling native alert presence

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessor.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessor.java
@@ -24,6 +24,7 @@ import org.apache.rocketmq.studio.cluster.metrics.MetricSample;
 import org.apache.rocketmq.studio.common.domain.enums.AlertLevel;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -97,7 +98,7 @@ public class NativeAlertProcessor {
         List<AlertRuleVO> rules = alertService.listRules(scope.domain()).stream()
                 .filter(rule -> rule.getId() != null)
                 .filter(AlertRuleVO::isEnabled)
-                .filter(rule -> scope.metricKeys().contains(rule.getMetric()))
+                .filter(rule -> scope.metricKeys().contains(StringUtils.trimWhitespace(rule.getMetric())))
                 .filter(rule -> rule.getInstanceId() == null || scope.instanceId().equals(rule.getInstanceId()))
                 .toList();
         if (rules.isEmpty()) {
@@ -106,6 +107,7 @@ public class NativeAlertProcessor {
         Set<AlertStateKey> presentKeys = samples.stream()
                 .filter(scope::contains)
                 .flatMap(sample -> rules.stream()
+                        .filter(rule -> sample.metricKey().equals(StringUtils.trimWhitespace(rule.getMetric())))
                         .filter(rule -> NativeAlertRuleScopeMatcher.matches(rule, sample))
                         .map(rule -> new AlertStateKey(rule.getId(),
                                 AlertFingerprint.of(rule.getId(), sample.instanceId(), sample.labels()))))

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertProcessorTest.java
@@ -478,6 +478,49 @@ class NativeAlertProcessorTest {
     }
 
     @Test
+    void resolvesMissingMetricEvenWhenAnotherMetricSharesTheSameLabelsTest() {
+        AlertService service = mock(AlertService.class);
+        AlertRuleVO rule = AlertRuleVO.builder().id(1L).domain(AlertDomain.BUSINESS).name("Orders delay")
+                .metric("consumer.delay.seconds").operator(">").threshold(10).enabled(true)
+                .instanceId("local").consumerGroup("orders").consecutiveSamples(1).build();
+        when(service.listRules(AlertDomain.BUSINESS)).thenReturn(List.of(rule));
+        MetricSample previousDelay = new MetricSample("consumer.delay.seconds", AlertDomain.BUSINESS, "local",
+                null, Map.of("consumerGroup", "orders"), 120D, MetricAvailability.AVAILABLE, Instant.now());
+        AlertStateKey key = new AlertStateKey(rule.getId(),
+                AlertFingerprint.of(rule.getId(), previousDelay.instanceId(), previousDelay.labels()));
+        ActiveAlertState active = new ActiveAlertState(key,
+                new AlertRuleState(AlertStateStatus.FIRING, 1, 120D, previousDelay.collectedAt().minusSeconds(60),
+                        previousDelay.collectedAt().minusSeconds(60), previousDelay.collectedAt().minusSeconds(60),
+                        null),
+                previousDelay.instanceId(), previousDelay.labels());
+        AlertStateRepository states = mock(AlertStateRepository.class);
+        when(states.findActive(any(MetricCollectionScope.class), eq(List.of(rule)))).thenReturn(List.of(active));
+        when(states.save(eq(key), any(AlertRuleState.class))).thenReturn(true);
+        AlertRepository alerts = mock(AlertRepository.class);
+        when(alerts.saveAlert(any(SystemAlertVO.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        NotificationOutboxService outbox = mock(NotificationOutboxService.class);
+
+        MetricSample lagSample = new MetricSample("consumer.lag.total", AlertDomain.BUSINESS, "local",
+                null, Map.of("consumerGroup", "orders"), 5D, MetricAvailability.AVAILABLE, Instant.now());
+
+        new NativeAlertProcessor(service,
+                new NativeAlertEvaluationService(new AlertRuleEvaluator(), new AlertStateMachine(), states,
+                        mock(MetricSnapshotRepository.class), alerts, outbox, suppression()),
+                new AlertStateMachine(), states, alerts, outbox, suppression())
+                .processSuccessfulCollection(new MetricCollectionScope(AlertDomain.BUSINESS, "local",
+                        java.util.Set.of("consumer.delay.seconds", "consumer.lag.total")), List.of(lagSample));
+
+        org.mockito.ArgumentCaptor<AlertRuleState> state = org.mockito.ArgumentCaptor.forClass(AlertRuleState.class);
+        org.mockito.ArgumentCaptor<SystemAlertVO> event = org.mockito.ArgumentCaptor.forClass(SystemAlertVO.class);
+        verify(states).save(eq(key), state.capture());
+        assertThat(state.getValue().status()).isEqualTo(AlertStateStatus.RESOLVED);
+        verify(alerts).saveAlert(event.capture());
+        assertThat(event.getValue().getTransition()).isEqualTo(AlertStateTransition.RESOLVED.name());
+        assertThat(event.getValue().getLabels()).isEqualTo(previousDelay.labels());
+        verify(outbox).enqueue(any(SystemAlertVO.class), eq(rule), eq(previousDelay.labels()));
+    }
+
+    @Test
     void doesNotResolveMissingActiveStateWhenCollectionReportsWholeScopeUnavailableTest() {
         AlertService service = mock(AlertService.class);
         AlertRuleVO rule = rule("local", "orders", 1);


### PR DESCRIPTION
## Problem / Evidence

Fixes #3104 (filed today by ai-yang, no existing PR claims it).

Native alert reconciliation (`NativeAlertProcessor.reconcileMissingActiveStates`) builds `presentKeys` by applying `NativeAlertRuleScopeMatcher`, which intentionally matches only the collection scope, instance id, and resource labels (consumerGroup/topic/brokerName/clusterName). It never requires the sample's metric to equal the rule's metric.

Because an `AlertStateKey` fingerprint is derived from `ruleId + instanceId + labels`, any other metric emitted with the same labels keeps a missing metric's stale state in `FIRING`/`ACKED` forever: no `RESOLVED` transition, no lifecycle event, and no recovery notification.

Verified in the current tree before the fix: the new regression test
`resolvesMissingMetricEvenWhenAnotherMetricSharesTheSameLabelsTest` fails because `AlertStateRepository.save` is never called for the active key (the `consumer.lag.total` sample keeps the `consumer.delay.seconds` rule's fingerprint present).

## Root cause / Fix

`reconcileMissingActiveStates` now filters candidates with `sample.metricKey().equals(rule.getMetric())` before building `presentKeys`. A missing metric in a successful collection scope now resolves its prior active state even when another same-label metric remains. Behavior for a genuinely present target metric is unchanged (`keepsActiveFingerprintWhenItAppearsInSuccessfulCollectionScopeTest` still passes), and the full-scope-unavailable guard (`containsWholeScopeFailure`) is untouched.

## Priority & scoring

- PRIORITY 83/100: impact 34/40 (alert state and recovery-notification path untrustworthy, operators see false incidents and miss recoveries), scope 15/20 (all native alert users), reproducibility 18/20 (deterministic given the Apache business collector's stable `consumer.lag.total` vs conditional `consumer.delay.seconds` emission), maintenance value 16/20 (one-line filter, clear semantics).
- FIX_CONFIDENCE 92/100: minimal filter at the exact root-cause site called out by the issue; covered by a red→green regression test.

## Tests

- New: `NativeAlertProcessorTest.resolvesMissingMetricEvenWhenAnotherMetricSharesTheSameLabelsTest` — asserts `RESOLVED` state persistence, a `RESOLVED` lifecycle event carrying the original labels, and invocation of the recovery-notification enqueue path.
- `mvn test -Dtest='NativeAlert*Test'`: 40/40 pass (18 in `NativeAlertProcessorTest`, regression test red before fix, green after).
- `mvn test '-Dtest=org.apache.rocketmq.studio.ops.alert.*Test'`: all alert package tests pass.

## Risk

Low: single predicate added to reconciliation key construction; evaluation-time behavior, suppression, and the whole-scope-unavailable guard are unchanged. The fix strictly widens when a stale state may resolve (only when the rule's own metric is absent from a successful scope).