### PR TITLE
fix(cluster): discard superseded Broker config diff responses

### DIFF
--- a/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClusterPage.test.tsx
@@ -22,6 +22,7 @@ import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
+  BrokerConfigDiffResult,
   ClusterInfo,
   ClusterProbeResult,
   NameServerConfigDiffResult,
@@ -669,6 +670,117 @@ describe('Cluster page', () => {
     });
 
     expect(dialog).toHaveClass('ant-zoom-leave');
+  });
+
+  it('does not reopen a closed Broker config diff when its request finishes', async () => {
+    const pendingDiff = deferred<BrokerConfigDiffResult>();
+    clusterServiceMocks.getBrokerConfigDiff.mockReturnValue(pendingDiff.promise);
+    renderWithProviders(<ClusterPage />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /Broker 管理/ }));
+    const row = await screen.findByRole('row', { name: /10\.101\.2\.11:10911/ });
+    fireEvent.click(within(row).getByRole('button', { name: /配置差异/ }));
+    const dialog = await screen.findByRole('dialog', { name: /Broker 配置差异/ });
+    fireEvent.click(within(dialog).getByRole('button', { name: /关\s*闭/ }));
+    await waitFor(() => expect(dialog).toHaveClass('ant-zoom-leave'));
+
+    await act(async () => {
+      pendingDiff.resolve({
+        cluster: 'cluster-prod',
+        complete: true,
+        driftDetected: false,
+        brokerCount: 2,
+        reachableBrokerCount: 2,
+        comparedFields: ['flushDiskType', 'writeQueueNums'],
+        brokers: [
+          { name: 'rocketmq-prod-0', address: '10.101.2.11:10911', reachable: true },
+          { name: 'rocketmq-prod-1', address: '10.101.2.12:10911', reachable: true },
+        ],
+        differences: [],
+      });
+      await pendingDiff.promise;
+    });
+
+    expect(dialog).toHaveClass('ant-zoom-leave');
+  });
+
+  it('keeps the requested broker config diff when a slower response finishes last', async () => {
+    const staleDiff = deferred<BrokerConfigDiffResult>();
+    const latestDiff = deferred<BrokerConfigDiffResult>();
+    clusterServiceMocks.getBrokerConfigDiff
+      .mockReturnValueOnce(staleDiff.promise)
+      .mockReturnValueOnce(latestDiff.promise);
+    clusterServiceMocks.listRegistryClusters.mockResolvedValue([
+      {
+        ...buildCluster(),
+        id: 'cluster-stale',
+        nsClusterName: 'ns-stale',
+        brokers: [{ ...buildCluster().brokers[0], addr: '10.101.2.11:10911' }],
+      },
+      {
+        ...buildCluster(),
+        id: 'cluster-latest',
+        nsClusterName: 'ns-latest',
+        brokers: [{ ...buildCluster().brokers[0], addr: '10.101.2.99:10911' }],
+      },
+    ]);
+    renderWithProviders(<ClusterPage />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /Broker 管理/ }));
+    const staleRow = await screen.findByRole('row', { name: /10\.101\.2\.11:10911/ });
+    fireEvent.click(within(staleRow).getByRole('button', { name: /配置差异/ }));
+    const dialog = await screen.findByRole('dialog', { name: /Broker 配置差异/ });
+
+    const latestRow = await screen.findByRole('row', { name: /10\.101\.2\.99:10911/ });
+    fireEvent.click(within(latestRow).getByRole('button', { name: /配置差异/ }));
+
+    await act(async () => {
+      latestDiff.resolve({
+        cluster: 'cluster-latest',
+        complete: true,
+        driftDetected: false,
+        brokerCount: 2,
+        reachableBrokerCount: 2,
+        comparedFields: ['flushDiskType'],
+        brokers: [
+          { name: 'rocketmq-prod-0', address: '10.101.2.11:10911', reachable: true },
+          { name: 'rocketmq-prod-1', address: '10.101.2.12:10911', reachable: true },
+        ],
+        differences: [],
+      });
+      await latestDiff.promise;
+      staleDiff.resolve({
+        cluster: 'cluster-stale',
+        complete: true,
+        driftDetected: true,
+        brokerCount: 2,
+        reachableBrokerCount: 2,
+        comparedFields: ['flushDiskType'],
+        brokers: [
+          { name: 'rocketmq-prod-0', address: '10.101.2.11:10911', reachable: true },
+          { name: 'rocketmq-prod-1', address: '10.101.2.12:10911', reachable: true },
+        ],
+        differences: [
+          {
+            field: 'writeQueueNums',
+            brokerProperty: 'defaultTopicQueueNums',
+            values: [
+              {
+                brokerName: 'rocketmq-prod-0',
+                address: '10.101.2.11:10911',
+                configured: true,
+                value: '8',
+              },
+            ],
+          },
+        ],
+      });
+      await staleDiff.promise;
+    });
+
+    await waitFor(() => expect(within(dialog).getByText('Broker 配置一致')).toBeInTheDocument());
+    expect(within(dialog).getByText(/ns-latest/)).toBeInTheDocument();
+    expect(within(dialog).queryByText(/ns-stale/)).not.toBeInTheDocument();
   });
 
   it('keeps the latest connection result after closing and reopening the modal', async () => {

--- a/web/src/pages/cluster/index.tsx
+++ b/web/src/pages/cluster/index.tsx
@@ -170,6 +170,7 @@ const ClusterPage = () => {
   const registryClustersRequestRef = useRef(0);
   const k8sCertsRequestRef = useRef(0);
   const nsConfigDiffRequestRef = useRef(0);
+  const brokerConfigDiffRequestRef = useRef(0);
   const connectionTestRequestRef = useRef(0);
 
   const loadRegistryClusters = useCallback(async () => {
@@ -230,6 +231,7 @@ const ClusterPage = () => {
       registryClustersRequestRef.current += 1;
       k8sCertsRequestRef.current += 1;
       nsConfigDiffRequestRef.current += 1;
+      brokerConfigDiffRequestRef.current += 1;
       connectionTestRequestRef.current += 1;
     },
     [],
@@ -359,6 +361,7 @@ const ClusterPage = () => {
 
   const openBrokerConfigDiff = useCallback(
     async (cluster: ClusterInfo) => {
+      const requestId = ++brokerConfigDiffRequestRef.current;
       setBrokerConfigDiffState({
         open: true,
         loading: true,
@@ -367,6 +370,7 @@ const ClusterPage = () => {
       });
       try {
         const result = await getBrokerConfigDiff(cluster.id, selectedInstanceIdRef.current);
+        if (requestId !== brokerConfigDiffRequestRef.current) return;
         setBrokerConfigDiffState({
           open: true,
           loading: false,
@@ -374,6 +378,7 @@ const ClusterPage = () => {
           result,
         });
       } catch {
+        if (requestId !== brokerConfigDiffRequestRef.current) return;
         setBrokerConfigDiffState((current) => ({ ...current, loading: false }));
         message.error(t('cluster.brokerConfigDiffFailed'));
       }
@@ -994,14 +999,26 @@ const ClusterPage = () => {
       <Modal
         title={t('cluster.brokerConfigDiffTitle', { name: titleName })}
         open={open}
-        onCancel={() =>
-          setBrokerConfigDiffState({ open: false, loading: false, cluster: null, result: null })
-        }
+        onCancel={() => {
+          brokerConfigDiffRequestRef.current += 1;
+          setBrokerConfigDiffState({
+            open: false,
+            loading: false,
+            cluster: null,
+            result: null,
+          });
+        }}
         footer={
           <Button
-            onClick={() =>
-              setBrokerConfigDiffState({ open: false, loading: false, cluster: null, result: null })
-            }
+            onClick={() => {
+              brokerConfigDiffRequestRef.current += 1;
+              setBrokerConfigDiffState({
+                open: false,
+                loading: false,
+                cluster: null,
+                result: null,
+              });
+            }}
           >
             {t('common.close')}
           </Button>


### PR DESCRIPTION
Fixes #3292.

## Problem / Evidence

Found while fixing #3103 (a distinct defect in the same modal, now tracked in #3292; no other PR claims it).

`openBrokerConfigDiff` in `web/src/pages/cluster/index.tsx` awaited `getBrokerConfigDiff(...)` and then unconditionally applied the response to `brokerConfigDiffState`. Unlike its NameServer twin — which is guarded by `nsConfigDiffRequestRef` and covered by the regression test `does not reopen a closed NameServer config diff when its request finishes` — the Broker diff had no request generation:

1. **Self-reopening dialog:** click 配置差异 on a broker row, click 关闭 before the response arrives → the pending response re-opened the dialog with the requested diff.
2. **Wrong cluster's data:** while cluster A's diff was in flight, click 配置差异 on a cluster B row (its button is not disabled) → when A's slower response landed it overwrote the modal, showing A's title and differences as if they were B's.
3. A stale failure cleared `loading` with no request check, stopping a newer request's spinner.

Both triggers are deterministic and reproduced by the new tests, which fail on the unfixed source.

## Root cause / Fix

Mirror the NameServer pattern: `brokerConfigDiffRequestRef` is bumped when a request starts, when either close button is clicked, and on unmount; responses and error handling apply only while the request is still current.

## Priority & scoring

- PRIORITY 71/100: impact 26/40 (misleading read-only drift view — operator can read another cluster's diff believing it is the requested one; no writes involved), scope 12/20 (Broker 管理 tab diff action), reproducibility 17/20 (deterministic), maintenance value 16/20 (restores parity with the already-fixed NameServer twin; repo convention).
- FIX_CONFIDENCE 92/100: clone of the existing, tested NS pattern in the same file.

## Tests

- New in `ClusterPage.test.tsx` (red on unfixed source, green after):
  - `does not reopen a closed Broker config diff when its request finishes`;
  - `keeps the requested broker config diff when a slower response finishes last`.
- `npx vitest run src/pages/cluster/__tests__/ClusterPage.test.tsx`: 24/24 pass.
- `npx tsc -p tsconfig.app.json --noEmit`, `eslint` on changed files: clean.

## Risk

Low: read-only view change; guards strictly discard responses that are no longer current. No API or data contract changes.