### PR TITLE
fix(message): keep the trace tab responsive after an empty trace query

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -401,6 +401,36 @@ describe('MessagePage async request ownership', () => {
     expect(await within(dialog).findByText('key-trace description')).toBeInTheDocument();
   });
 
+  it('keeps the trace tab responsive when an empty trace query supersedes an in-flight load', async () => {
+    const pendingTrace = createDeferred<TraceRecord>();
+    serviceMocks.queryMessages.mockResolvedValue([createMessage('message-a')]);
+    serviceMocks.getMessageTrace.mockReturnValue(pendingTrace.promise);
+    const user = userEvent.setup();
+    renderPage();
+    await selectTopic(user);
+
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+    const row = await screen.findByRole('row', { name: /message-a/ });
+    await user.click(within(row).getByRole('button', { name: /轨迹/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: '消息详情' });
+    expect(await within(dialog).findByText('正在加载轨迹数据…')).toBeInTheDocument();
+
+    await user.clear(within(dialog).getByPlaceholderText('消息 ID（默认当前消息）'));
+    await user.click(within(dialog).getByRole('button', { name: /查询轨迹/ }));
+
+    expect(within(dialog).getByText('请输入 Message ID')).toBeInTheDocument();
+    expect(within(dialog).queryByText('正在加载轨迹数据…')).not.toBeInTheDocument();
+
+    await act(async () => {
+      pendingTrace.resolve(createTrace('late-trace'));
+      await pendingTrace.promise;
+    });
+
+    expect(within(dialog).queryByText('正在加载轨迹数据…')).not.toBeInTheDocument();
+    expect(within(dialog).getByText('请输入 Message ID')).toBeInTheDocument();
+  });
+
   it('shows trace diagnostics for slow and failed delivery paths', async () => {
     serviceMocks.queryMessages.mockResolvedValue([createMessage('message-a')]);
     serviceMocks.getMessageTrace.mockResolvedValue({

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -645,6 +645,10 @@ const MessagePageContent = ({
     traceGenerationRef.current = requestGeneration;
     const value = traceQueryValue.trim();
     if (!value) {
+      // The bump above already invalidated any in-flight trace load, so its guarded
+      // finally block will never reset traceLoading — stop it here instead.
+      setTraceData(null);
+      setTraceLoading(false);
       setTraceError(traceQueryMode === 'key' ? '请输入 Message Key' : '请输入 Message ID');
       return;
     }


### PR DESCRIPTION
Fixes #3293.

## Problem / Evidence

Found by code inspection; now tracked in #3293 (no existing PR covered it).

In `web/src/pages/instance/message.tsx`, `runTraceQuery` bumps `traceGenerationRef` **before** validating its input, and the empty-input branch returns without touching `traceLoading`:

1. Open a message's 消息轨迹 tab (or click 轨迹) — `loadMessageTrace` starts with generation G and `traceLoading = true`.
2. While that request is in flight, clear the Message ID input and click 查询轨迹 — the generation becomes G+1, the branch sets the validation error and returns.
3. The in-flight request's `finally { if (traceGenerationRef.current === requestGeneration) setTraceLoading(false); }` compares G ≠ G+1 and skips, and nothing else ever resets `traceLoading`.

Result: the 消息轨迹 tab shows 正在加载轨迹数据… indefinitely, and because the loading text takes render precedence over `traceError`, the validation hint (请输入 Message ID) that was set is never displayed. The tab only recovers if the user issues another non-empty trace query or reopens the dialog.

## Root cause / Fix

The generation bump orphaned the in-flight load, so its guarded `finally` can no longer reset `traceLoading`; the empty-input branch must own that cleanup. It now stops the spinner, clears stale trace data, and surfaces the validation error.

## Priority & scoring

- PRIORITY 72/100: impact 28/40 (trace tab hangs with an eternal spinner on a very plausible user sequence — click 轨迹, clear input, click 查询轨迹; recovery requires extra actions), scope 12/20 (message trace tab), reproducibility 17/20 (deterministic), maintenance value 15/20 (small fix inside the existing generation-guard pattern).
- FIX_CONFIDENCE 88/100: cleanup placed at the exact divergence point between the bump and the guarded finally; covered by a red→green regression test.

## Tests

- New: `MessagePageAsyncState.test.tsx` — `keeps the trace tab responsive when an empty trace query supersedes an in-flight load`: opens the trace tab against a pending `getMessageTrace`, submits an empty query, asserts the validation error is visible and the spinner is gone, then resolves the pending request and asserts the late response does not resurrect the spinner. Red on the unfixed source (error text unreachable behind the stuck spinner), green after.
- `npx vitest run src/pages/instance/__tests__/MessagePageAsyncState.test.tsx src/pages/instance/__tests__/MessagePage.test.tsx`: 28/28 pass.
- `npx tsc -p tsconfig.app.json --noEmit`, `eslint` on changed files: clean.

## Risk

Low: only the empty-input branch changed; non-empty trace queries and the in-flight load lifecycle are untouched. The late in-flight trace response remains discarded after an empty query — consistent with the user having superseded it.