### PR TITLE
fix(dlq): report failed resend message details

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQResendFailureVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQResendFailureVO.java
@@ -19,17 +19,11 @@ package org.apache.rocketmq.studio.instance.dlq;
 import lombok.Builder;
 import lombok.Value;
 
-import java.util.List;
-
+/** One bounded dead-letter resend failure returned to the caller. */
 @Value
 @Builder
-public class DLQResendResultVO {
-    int matched;
-    int resent;
-    int failed;
-    String outcome;
-    boolean scanIncomplete;
-    int failedQueueCount;
-    List<DLQResendFailureVO> failures;
-    boolean failuresTruncated;
+public class DLQResendFailureVO {
+    String msgId;
+    String targetTopic;
+    String reason;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -39,6 +39,7 @@ import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
 import org.apache.rocketmq.studio.instance.dlq.DLQExcelExportResultVO;
 import org.apache.rocketmq.studio.instance.dlq.DLQExportResultVO;
 import org.apache.rocketmq.studio.instance.dlq.DLQGroupVO;
+import org.apache.rocketmq.studio.instance.dlq.DLQResendFailureVO;
 import org.apache.rocketmq.studio.instance.dlq.DLQMessageExcelRow;
 import org.apache.rocketmq.studio.instance.dlq.DLQMessageVO;
 import org.apache.rocketmq.studio.instance.dlq.DLQProvider;
@@ -78,6 +79,7 @@ public class RocketMQDLQProvider implements DLQProvider {
 
     private static final long ONE_HOUR_MILLIS = 3600_000L;
     private static final int RESEND_HARD_CAP = 5000;
+    private static final int MAX_REPORTED_RESEND_FAILURES = 100;
     private static final int MAX_PAGE_SIZE = 100;
     private static final int MAX_CONSECUTIVE_OFFSET_ILLEGAL = 3;
     private static final String ORIGIN_MESSAGE_ID_PROPERTY = "studio_dlq_origin_message_id";
@@ -198,26 +200,22 @@ public class RocketMQDLQProvider implements DLQProvider {
             throw e;
         }
         List<MessageExt> deadLetters = scanResult.messages();
-        int[] counts = {0, 0};
+        ResendBatch batch = new ResendBatch();
         if (!deadLetters.isEmpty()) {
             try {
                 runtimeAdminClientResolver.executeProducer(instanceId, producer -> {
                     for (MessageExt deadLetter : deadLetters) {
-                        if (resendOne(producer, deadLetter, targetTopic)) {
-                            counts[0]++;
-                        } else {
-                            counts[1]++;
-                        }
+                        batch.record(resendOne(producer, deadLetter, targetTopic));
                     }
                     return null;
                 });
             } catch (Exception e) {
                 log.warn("Failed to resend dead letters for group {}: {}", groupName, e.getMessage());
-                counts[1] += deadLetters.size() - counts[0];
+                batch.recordProducerFailure(deadLetters, e);
             }
         }
-        int resent = counts[0];
-        int failed = counts[1];
+        int resent = batch.resent();
+        int failed = batch.failed();
 
         String outcome = classifyOutcome(deadLetters.size(), resent, failed, scanResult.scanIncomplete());
         String detail = String.format("instanceId=%s, group=%s, dlqTopic=%s, targetTopic=%s, matched=%d, resent=%d, "
@@ -225,7 +223,7 @@ public class RocketMQDLQProvider implements DLQProvider {
                 instanceId, groupName, dlqTopic, StringUtils.hasText(targetTopic) ? targetTopic : "<original>",
                 deadLetters.size(), resent, failed, scanResult.scanIncomplete(), scanResult.truncated(),
                 scanResult.failedQueueCount());
-        recordAudit(groupName, detail, outcome);
+        recordAudit(groupName, detail + batch.auditDetail(), outcome);
         log.info("DLQ resend completed: {}", detail);
         return DLQResendResultVO.builder()
                 .matched(deadLetters.size())
@@ -234,8 +232,12 @@ public class RocketMQDLQProvider implements DLQProvider {
                 .outcome(outcome)
                 .scanIncomplete(scanResult.scanIncomplete())
                 .failedQueueCount(scanResult.failedQueueCount())
+                .failures(batch.reportedFailures())
+                .failuresTruncated(batch.failuresTruncated())
                 .build();
     }
+
+
 
     @Override
     public DLQResendResultVO resendMessages(String instanceId, String groupName, List<String> msgIds,
@@ -280,32 +282,28 @@ public class RocketMQDLQProvider implements DLQProvider {
             }
             return resolved;
         });
-        int[] counts = {0, 0};
+        ResendBatch batch = new ResendBatch();
         if (!deadLetters.isEmpty()) {
             try {
                 runtimeAdminClientResolver.executeProducer(instanceId, producer -> {
                     for (MessageExt deadLetter : deadLetters) {
-                        if (resendOne(producer, deadLetter, targetTopic)) {
-                            counts[0]++;
-                        } else {
-                            counts[1]++;
-                        }
+                        batch.record(resendOne(producer, deadLetter, targetTopic));
                     }
                     return null;
                 });
             } catch (Exception e) {
                 log.warn("Failed to resend selected dead letters for group {}: {}", groupName, e.getMessage());
-                counts[1] += deadLetters.size() - counts[0];
+                batch.recordProducerFailure(deadLetters, e);
             }
         }
-        int resent = counts[0];
-        int failed = counts[1];
+        int resent = batch.resent();
+        int failed = batch.failed();
         boolean foundAll = deadLetters.size() == selected.size();
 
         String outcome = classifyOutcome(deadLetters.size(), resent, failed, !foundAll);
         String detail = String.format("instanceId=%s, group=%s, selected=%d, matched=%d, resent=%d, failed=%d",
                 instanceId, groupName, selected.size(), deadLetters.size(), resent, failed);
-        recordAudit(groupName, detail, outcome);
+        recordAudit(groupName, detail + batch.auditDetail(), outcome);
         log.info("Selected DLQ resend completed: {}", detail);
         return DLQResendResultVO.builder()
                 .matched(deadLetters.size())
@@ -313,6 +311,9 @@ public class RocketMQDLQProvider implements DLQProvider {
                 .failed(failed)
                 .outcome(outcome)
                 .scanIncomplete(!foundAll)
+                .failedQueueCount(0)
+                .failures(batch.reportedFailures())
+                .failuresTruncated(batch.failuresTruncated())
                 .build();
     }
 
@@ -512,11 +513,12 @@ public class RocketMQDLQProvider implements DLQProvider {
         return new DeadLetterScanResult(result, failedQueueCount, truncated);
     }
 
-    private boolean resendOne(DefaultMQProducer producer, MessageExt deadLetter, String targetTopic) {
+    private ResendOutcome resendOne(DefaultMQProducer producer, MessageExt deadLetter, String targetTopic) {
         String destination = resolveTargetTopic(deadLetter, targetTopic);
         if (!StringUtils.hasText(destination)) {
             log.warn("Skip resend of msgId={}: no target topic resolvable", deadLetter.getMsgId());
-            return false;
+            return ResendOutcome.failed(deadLetter.getMsgId(), destination,
+                    "No target topic resolvable from dead-letter properties");
         }
         try {
             Message message = new Message(destination, deadLetter.getBody());
@@ -547,15 +549,17 @@ public class RocketMQDLQProvider implements DLQProvider {
                 log.warn("DLQ resend was not accepted: msgId={} topic={} sendStatus={}",
                         deadLetter.getMsgId(), destination,
                         sendResult == null ? "<null>" : sendResult.getSendStatus());
-                return false;
+                return ResendOutcome.failed(deadLetter.getMsgId(), destination,
+                        "Producer returned " + (sendResult == null ? "null" : sendResult.getSendStatus()));
             }
             log.debug("Resent dead letter msgId={} to topic={}, sendStatus={}",
                     deadLetter.getMsgId(), destination, sendResult.getSendStatus());
-            return true;
+            return ResendOutcome.success();
         } catch (Exception e) {
             log.warn("Failed to resend dead letter msgId={} to topic={}: {}",
                     deadLetter.getMsgId(), destination, e.getMessage());
-            return false;
+            return ResendOutcome.failed(deadLetter.getMsgId(), destination,
+                    e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
         }
     }
 
@@ -640,6 +644,85 @@ public class RocketMQDLQProvider implements DLQProvider {
     private record DeadLetterScanResult(List<MessageExt> messages, int failedQueueCount, boolean truncated) {
         boolean scanIncomplete() {
             return failedQueueCount > 0 || truncated;
+        }
+    }
+
+    private final class ResendBatch {
+        private final List<DLQResendFailureVO> failures = new ArrayList<>();
+        private int resent;
+        private int failed;
+
+        void record(ResendOutcome outcome) {
+            if (outcome.succeeded()) {
+                resent++;
+                return;
+            }
+            failed++;
+            if (failures.size() < MAX_REPORTED_RESEND_FAILURES) {
+                failures.add(DLQResendFailureVO.builder()
+                        .msgId(outcome.msgId())
+                        .targetTopic(outcome.targetTopic())
+                        .reason(outcome.reason())
+                        .build());
+            }
+        }
+
+        void recordProducerFailure(List<MessageExt> deadLetters, Exception error) {
+            String reason = "Producer session failed: "
+                    + (error.getMessage() == null ? error.getClass().getSimpleName() : error.getMessage());
+            for (MessageExt deadLetter : deadLetters) {
+                record(ResendOutcome.failed(deadLetter.getMsgId(),
+                        resolveDestination(deadLetter), reason));
+            }
+        }
+
+        private static String resolveDestination(MessageExt deadLetter) {
+            Map<String, String> properties = deadLetter.getProperties();
+            if (properties == null) {
+                return null;
+            }
+            String origin = properties.get(MessageConst.PROPERTY_DLQ_ORIGIN_TOPIC);
+            return StringUtils.hasText(origin) ? origin : properties.get(MessageConst.PROPERTY_RETRY_TOPIC);
+        }
+
+        int resent() {
+            return resent;
+        }
+
+        int failed() {
+            return failed;
+        }
+
+        List<DLQResendFailureVO> reportedFailures() {
+            return List.copyOf(failures);
+        }
+
+        boolean failuresTruncated() {
+            return failed > failures.size();
+        }
+
+        String auditDetail() {
+            if (failures.isEmpty()) {
+                return "";
+            }
+            String sample = failures.stream()
+                    .limit(5)
+                    .map(failure -> failure.getMsgId() + "->" + failure.getTargetTopic()
+                            + "(" + failure.getReason() + ")")
+                    .collect(java.util.stream.Collectors.joining("; "));
+            return ", failureSample=" + sample + ", reportedFailures=" + failures.size()
+                    + ", failuresTruncated=" + failuresTruncated();
+        }
+    }
+
+    private record ResendOutcome(boolean succeeded, String msgId, String targetTopic, String reason) {
+
+        static ResendOutcome success() {
+            return new ResendOutcome(true, null, null, null);
+        }
+
+        static ResendOutcome failed(String msgId, String targetTopic, String reason) {
+            return new ResendOutcome(false, msgId, targetTopic, reason);
         }
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -581,9 +581,16 @@ class RocketMQDLQProviderTest {
         TopicList existingTargets = new TopicList();
         existingTargets.setTopicList(Set.of("target-topic"));
         when(adminExt.fetchAllTopicList()).thenReturn(existingTargets);
-        assertThat(provider.resendMessages("instance-a", "group-a", 100L, 200L, "target-topic"))
+        DLQResendResultVO result = provider.resendMessages(
+                "instance-a", "group-a", 100L, 200L, "target-topic");
+        assertThat(result)
                 .extracting("matched", "resent", "failed", "outcome")
                 .containsExactly(1, 0, 1, "FAILED");
+        assertThat(result.getFailures()).singleElement().satisfies(failure -> {
+            assertThat(failure.getMsgId()).isEqualTo("msg-1");
+            assertThat(failure.getTargetTopic()).isEqualTo("target-topic");
+            assertThat(failure.getReason()).contains("FLUSH_DISK_TIMEOUT");
+        });
 
         verify(runtimeAdminClientResolver).executePullConsumer(eq("instance-a"), any());
         verify(runtimeAdminClientResolver).executeProducer(eq("instance-a"), any());
@@ -593,7 +600,11 @@ class RocketMQDLQProviderTest {
                 eq("DLQ"),
                 eq("group-a"),
                 isNull(),
-                contains("matched=1, resent=0, failed=1"),
+                org.mockito.ArgumentMatchers.argThat(detail -> String.valueOf(detail)
+                        .contains("failed=1")
+                        && String.valueOf(detail).contains("failureSample=msg-1->target-topic")
+                        && String.valueOf(detail).contains("reportedFailures=1")
+                        && String.valueOf(detail).contains("failuresTruncated=false")),
                 eq("FAILED"));
     }
 

--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -106,6 +106,14 @@ export interface DLQResendResult {
   outcome: 'SUCCESS' | 'PARTIAL' | 'FAILED' | 'NO_MESSAGES';
   scanIncomplete?: boolean;
   failedQueueCount?: number;
+  failures?: DLQResendFailure[];
+  failuresTruncated?: boolean;
+}
+
+export interface DLQResendFailure {
+  msgId: string;
+  targetTopic: string | null;
+  reason: string;
 }
 
 export interface DLQMessage {

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -38,7 +38,7 @@ import PageHeader from '../../components/PageHeader';
 import InfoBanner from '../../components/InfoBanner';
 import { InstanceSelect } from '../../components/InstanceSelect';
 import { useLang } from '../../i18n/LangContext';
-import type { DLQGroup, DLQMessage } from '../../api/message';
+import type { DLQGroup, DLQMessage, DLQResendResult } from '../../api/message';
 import {
   exportDLQExcel,
   listDLQGroups,
@@ -76,6 +76,19 @@ const getErrorMessage = (error: unknown, fallback: string): string => {
     return apiError.message;
   }
   return fallback;
+};
+
+const describeResendFailures = (result: DLQResendResult): string | null => {
+  const failures = result.failures ?? [];
+  if (failures.length === 0) return null;
+  const lines = failures.slice(0, 5).map((failure) => {
+    const target = failure.targetTopic || '未知 Topic';
+    return `${failure.msgId} → ${target}：${failure.reason}`;
+  });
+  if (result.failuresTruncated || failures.length > lines.length) {
+    lines.push(`另有 ${result.failed - lines.length} 条失败消息未展示`);
+  }
+  return lines.join('\n');
 };
 
 export const formatDateTime = (value?: string | number | null): string => {
@@ -270,7 +283,13 @@ const DLQPage = () => {
           `重投扫描不完整：${result.failedQueueCount ?? 0} 个队列无法扫描，已重投 ${result.resent} 条`,
         );
       } else if (result.failed > 0) {
-        message.warning(`重投部分完成：成功 ${result.resent}，失败 ${result.failed}`);
+        const failureDetail = describeResendFailures(result);
+        message.warning({
+          content: failureDetail
+            ? `重投部分完成：成功 ${result.resent}，失败 ${result.failed}\n${failureDetail}`
+            : `重投部分完成：成功 ${result.resent}，失败 ${result.failed}`,
+          duration: 6,
+        });
       } else {
         message.success(`重投完成：${groupName} → ${targetTopic}（${result.resent} 条）`);
       }
@@ -368,9 +387,21 @@ const DLQPage = () => {
         msgIds,
       });
       if (result.outcome === 'FAILED' && result.failed > 0) {
-        message.error(`重发失败：成功 ${result.resent}，失败 ${result.failed}`);
+        const failureDetail = describeResendFailures(result);
+        message.error({
+          content: failureDetail
+            ? `重发失败：成功 ${result.resent}，失败 ${result.failed}\n${failureDetail}`
+            : `重发失败：成功 ${result.resent}，失败 ${result.failed}`,
+          duration: 6,
+        });
       } else if (result.resent > 0 && result.failed > 0) {
-        message.warning(`重发部分完成：成功 ${result.resent}，失败 ${result.failed}`);
+        const failureDetail = describeResendFailures(result);
+        message.warning({
+          content: failureDetail
+            ? `重发部分完成：成功 ${result.resent}，失败 ${result.failed}\n${failureDetail}`
+            : `重发部分完成：成功 ${result.resent}，失败 ${result.failed}`,
+          duration: 6,
+        });
       } else {
         message.success(`重发完成：成功 ${result.resent} 条`);
       }


### PR DESCRIPTION
## What is the purpose of the change

DLQ resend responses previously reported only aggregate counts. When a resend was `PARTIAL` or `FAILED`, operators could see how many messages failed but not which message IDs failed, where they were being sent, or why.

## What changed

- add `DLQResendFailureVO` with `msgId`, resolved `targetTopic`, and concise `reason`
- add `failures` and `failuresTruncated` to `DLQResendResultVO`
- track individual resend outcomes in `RocketMQDLQProvider` for both time-range resend and selected-message resend
- retain aggregate `matched`, `resent`, `failed`, `outcome`, `scanIncomplete`, and `failedQueueCount`
- cap reported failures at 100 entries and expose truncation
- include a bounded failure sample plus reported/truncated counts in the DLQ audit detail
- show failed msgId, target topic, and reason in the DLQ page warnings for partial or failed resends

## Verification

- focused backend tests: `RocketMQDLQProviderTest,DLQServiceTest,DLQControllerTest` passed
- Checkstyle: 0 violations
- focused frontend tests: `DLQPage.test.tsx`, `message.test.ts` passed (27 tests)
- frontend lint: 0 errors (existing warnings only)
- frontend production build: passed
- `git diff --check`: passed
- frontend focused suite was rerun on the current head after later mainline work: `DLQPage.test.tsx` and `message.test.ts` passed again (27 tests).
- A full-frontend run was also attempted twice on this head: the default parallel mode produced 106 timeout-related failures, and a single-worker run still produced 96 timeout-related failures across unrelated pages (for example ACL, Alerts, Audit, Cluster, DataSource, Instance, and Topic). These runs reflect environment/mainline test instability, not a DLQ patch failure; no full-frontend green claim is made for this head.
- full server suite: 2,035 tests with 3 failures in `AuthCorsIntegrationTest` (2) and `AliyunInstanceProviderTest#getGroupProgressShouldMapLagRowsTest`; all three failures reproduce identically on a clean `upstream/rocketmq-studio` worktree and are unrelated to this patch

Closes #3161



