### PR TITLE
fix(message): narrow key queries by time and tag

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/MessageService.java
@@ -205,7 +205,24 @@ public class MessageService {
         if (!hasTopic && !hasMessageId) {
             throw new BusinessException(400, "topic or msgId is required");
         }
-        if (hasMessageId || hasKey) {
+        if (hasMessageId) {
+            return;
+        }
+        if (hasKey) {
+            if (startTime == null || endTime == null) {
+                return;
+            }
+            long keyStart = startTime;
+            long keyEnd = endTime;
+            if (keyStart < 0 || keyEnd < 0) {
+                throw new BusinessException(400, "message query timestamps must not be negative");
+            }
+            if (keyStart >= keyEnd) {
+                throw new BusinessException(400, "startTime must be before endTime");
+            }
+            if (keyStart < keyEnd - MAX_TOPIC_QUERY_WINDOW_MILLIS) {
+                throw new BusinessException(400, "topic query time range must not exceed 7 days");
+            }
             return;
         }
         long end = endTime == null ? System.currentTimeMillis() : endTime;

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageServiceTest.java
@@ -21,6 +21,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verify;
@@ -94,6 +96,50 @@ class MessageServiceTest {
                 .hasMessage("startTime must be before endTime");
 
         verifyNoInteractions(provider);
+    }
+
+    @Test
+    void rejectsReversedMessageKeyQueryWindowBeforeCallingProvider() {
+        MessageProvider provider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(provider, registry, mock(QueryHistoryService.class), mock(OperationAuditService.class));
+
+        assertThatThrownBy(() -> service.queryMessages("instance-a", "TopicA", null, null, "order-1", 200L, 100L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("startTime must be before endTime");
+
+        verifyNoInteractions(provider);
+    }
+
+    @Test
+    void rejectsMessageKeyQueryWindowLongerThanSevenDaysBeforeCallingProvider() {
+        MessageProvider provider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(provider, registry, mock(QueryHistoryService.class), mock(OperationAuditService.class));
+
+        assertThatThrownBy(() -> service.queryMessages(
+                "instance-a", "TopicA", null, null, "order-1", 0L, 8L * 24 * 60 * 60 * 1000))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topic query time range must not exceed 7 days");
+
+        verifyNoInteractions(provider);
+    }
+
+    @Test
+    void acceptsMessageKeyQueryWithoutAnExplicitTimeWindow() {
+        MessageProvider provider = mock(MessageProvider.class);
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        MessageService service = new MessageService(provider, registry, mock(QueryHistoryService.class), mock(OperationAuditService.class));
+        when(registry.byInstanceId("instance-a")).thenReturn(Optional.empty());
+        when(provider.queryMessagesDetailed(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(MessageQueryResult.complete(List.of()));
+
+        assertThatCode(() -> service.queryMessages(
+                "instance-a", "TopicA", null, null, "order-1", null, null))
+                .doesNotThrowAnyException();
+
+        verify(provider).queryMessagesDetailed(
+                "instance-a", "TopicA", null, null, "order-1", null, null);
     }
 
     @Test

--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -135,44 +135,52 @@ describe('Message page query history', () => {
     expect(queryButton).toBeDisabled();
     await waitFor(() => expect(queryButton).toHaveAttribute('title', '请选择 Topic'));
 
+    const queryButtonElement = () => screen.getByRole('button', { name: /^search查询$/ });
     await user.click(lastElement(screen.getAllByRole('combobox')));
     await user.click(lastElement(await screen.findAllByText('order-create')));
-    expect(queryButton).toBeEnabled();
-    expect(queryButton).not.toHaveAttribute('title');
+    await waitFor(() => expect(queryButtonElement()).toBeEnabled());
+    expect(queryButtonElement()).not.toHaveAttribute('title');
 
     await user.click(screen.getByText('按 Message Key'));
-    expect(queryButton).toBeDisabled();
-    expect(queryButton).toHaveAttribute('title', '请输入 Message Key');
+    await waitFor(() => {
+      expect(queryButtonElement()).toBeDisabled();
+      expect(queryButtonElement()).toHaveAttribute('title', '请输入 Message Key');
+    });
 
     const keyInput = screen.getByPlaceholderText('输入 Message Key');
     await user.type(keyInput, '   ');
-    expect(queryButton).toBeDisabled();
+    await waitFor(() => expect(queryButtonElement()).toBeDisabled());
     expect(messageServiceMocks.queryMessages).not.toHaveBeenCalled();
 
     await user.clear(keyInput);
     await user.type(keyInput, '  ORDER-001  ');
-    expect(queryButton).toBeEnabled();
-    await user.click(queryButton);
+    await waitFor(() => expect(queryButtonElement()).toBeEnabled());
+    await user.click(queryButtonElement());
     await waitFor(() => {
-      expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith({
-        topic: 'order-create',
-        key: 'ORDER-001',
-        instanceId: 1,
-      });
+      expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          topic: 'order-create',
+          key: 'ORDER-001',
+          instanceId: 1,
+          startTime: expect.any(Number),
+          endTime: expect.any(Number),
+        }),
+      );
     });
-
     await user.click(screen.getByText('按 Message ID'));
-    expect(queryButton).toBeDisabled();
-    expect(queryButton).toHaveAttribute('title', '请输入 Message ID');
+    await waitFor(() => {
+      expect(queryButtonElement()).toBeDisabled();
+      expect(queryButtonElement()).toHaveAttribute('title', '请输入 Message ID');
+    });
 
     const messageIdInput = screen.getByPlaceholderText('输入 Message ID');
     await user.type(messageIdInput, '   ');
-    expect(queryButton).toBeDisabled();
+    await waitFor(() => expect(queryButtonElement()).toBeDisabled());
 
     await user.clear(messageIdInput);
     await user.type(messageIdInput, '  MID-001  ');
-    expect(queryButton).toBeEnabled();
-    await user.click(queryButton);
+    await waitFor(() => expect(queryButtonElement()).toBeEnabled());
+    await user.click(queryButtonElement());
     await waitFor(() => {
       expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith({
         topic: 'order-create',

--- a/web/src/pages/instance/__tests__/MessagePageKeyQuery.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageKeyQuery.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { App, ConfigProvider } from 'antd';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LangProvider } from '../../../i18n/LangContext';
+import MessagePage from '../message';
+
+const serviceMocks = vi.hoisted(() => ({
+  consumeMessageDirectly: vi.fn(),
+  getMessageTrace: vi.fn(),
+  getMessageTraceByKey: vi.fn(),
+  queryMessages: vi.fn(),
+}));
+const instanceFilterMocks = vi.hoisted(() => ({
+  useInstanceFilter: vi.fn(),
+}));
+
+vi.mock('../../../services/messageService', () => ({
+  ...serviceMocks,
+  queryMessagePage: ({ page = 1, pageSize = 50, ...params }: Record<string, unknown>) =>
+    Promise.resolve(serviceMocks.queryMessages(params)).then((items) => ({
+      items: Array.isArray(items) ? items : [],
+      total: Array.isArray(items) ? items.length : 0,
+      page,
+      size: pageSize,
+      resultMayBeTruncated: false,
+    })),
+}));
+vi.mock('../../../hooks/useInstanceFilter', () => instanceFilterMocks);
+vi.mock('../../../services/instanceService', () => ({
+  listInstances: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../../../services/topicService', () => ({
+  listTopics: vi.fn().mockResolvedValue([{ name: 'orders' }]),
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const renderPage = () =>
+  render(
+    <ConfigProvider theme={{ token: { motion: false } }}>
+      <App>
+        <LangProvider>
+          <MemoryRouter>
+            <MessagePage />
+          </MemoryRouter>
+        </LangProvider>
+      </App>
+    </ConfigProvider>,
+  );
+
+const selectTopic = async (user: ReturnType<typeof userEvent.setup>) => {
+  const topicSelects = screen.getAllByRole('combobox');
+  await user.click(topicSelects[topicSelects.length - 1]!);
+  const options = await screen.findAllByText('orders');
+  await user.click(options[options.length - 1]!);
+};
+
+describe('Message page key query', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    serviceMocks.getMessageTrace.mockResolvedValue(null);
+    serviceMocks.getMessageTraceByKey.mockResolvedValue(null);
+    serviceMocks.queryMessages.mockResolvedValue([]);
+    instanceFilterMocks.useInstanceFilter.mockReturnValue({
+      selectedInstanceId: 1,
+      selectInstance: vi.fn(),
+      instanceOptions: [{ value: 1, label: 'Instance A' }],
+    });
+  });
+
+  it('submits the selected time range and tag with a key query', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await selectTopic(user);
+    await user.click(screen.getByText('按 Message Key'));
+    await user.type(screen.getByPlaceholderText('输入 Message Key'), ' ORDER-001 ');
+    await user.type(screen.getByPlaceholderText('输入 Tag（可选）'), ' vip ');
+
+    const queryButton = screen.getByRole('button', { name: /^search查询$/ });
+    await waitFor(() => expect(queryButton).toBeEnabled());
+    await user.click(queryButton);
+
+    await waitFor(() => expect(serviceMocks.queryMessages).toHaveBeenCalled());
+    expect(serviceMocks.queryMessages).toHaveBeenLastCalledWith({
+      instanceId: 1,
+      topic: 'orders',
+      key: 'ORDER-001',
+      tag: 'vip',
+      startTime: expect.any(Number),
+      endTime: expect.any(Number),
+    });
+  });
+});

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -158,6 +158,14 @@ const getQueryValidationError = (mode: QueryMode, params: MessageQuery): string 
   if (!params.topic?.trim()) return '请选择 Topic';
   if (mode === 'key' && !params.key?.trim()) return '请输入 Message Key';
   if (mode === 'msgid' && !params.msgId?.trim()) return '请输入 Message ID';
+  if (mode === 'topic' || mode === 'key') {
+    if (params.startTime !== undefined && params.endTime !== undefined) {
+      if (params.startTime >= params.endTime) return '开始时间必须早于结束时间';
+      if (params.endTime - params.startTime > 7 * 24 * 60 * 60 * 1000) {
+        return '查询时间范围不能超过 7 天';
+      }
+    }
+  }
   return null;
 };
 
@@ -385,6 +393,7 @@ const MessagePageContent = ({
   const [selectedTopic, setSelectedTopic] = useState<string | undefined>();
   const [dateRange, setDateRange] = useState<[Dayjs, Dayjs]>(getDefaultRange);
   const [keyInput, setKeyInput] = useState('');
+  const [tagInput, setTagInput] = useState('');
   const [msgIdInput, setMsgIdInput] = useState('');
   const [messages, setMessages] = useState<MessageRecord[]>([]);
   const [messageTotal, setMessageTotal] = useState(0);
@@ -430,7 +439,13 @@ const MessagePageContent = ({
     queryMode === 'topic'
       ? { topic: selectedTopic, startTime: dateRange[0].valueOf(), endTime: dateRange[1].valueOf() }
       : queryMode === 'key'
-        ? { topic: selectedTopic, key: keyInput || undefined }
+        ? {
+            topic: selectedTopic,
+            key: keyInput || undefined,
+            tag: tagInput || undefined,
+            startTime: dateRange[0].valueOf(),
+            endTime: dateRange[1].valueOf(),
+          }
         : { topic: selectedTopic, msgId: msgIdInput || undefined };
   const queryValidationError = getQueryValidationError(queryMode, currentQueryParams);
   const queryDisabledReason = !selectedInstanceId
@@ -455,6 +470,7 @@ const MessagePageContent = ({
     queryGenerationRef.current += 1;
     setSelectedTopic(undefined);
     setKeyInput('');
+    setTagInput('');
     setMsgIdInput('');
     setDateRange(getDefaultRange());
     clearQueryResults();
@@ -525,6 +541,7 @@ const MessagePageContent = ({
     handleQueryModeChange(mode);
     setSelectedTopic(record.topic);
     setKeyInput(record.messageKey || '');
+    setTagInput(record.tag || '');
     setMsgIdInput(record.msgId || '');
     if (mode === 'topic' && record.startTime !== undefined && record.endTime !== undefined) {
       setDateRange([dayjs(record.startTime), dayjs(record.endTime)]);
@@ -1099,6 +1116,23 @@ const MessagePageContent = ({
                     style={{ width: 240 }}
                     value={keyInput}
                     onChange={(e) => setKeyInput(e.target.value)}
+                  />
+                  <Input
+                    placeholder="输入 Tag（可选）"
+                    style={{ width: 180 }}
+                    value={tagInput}
+                    onChange={(e) => setTagInput(e.target.value)}
+                    allowClear
+                  />
+                  <RangePicker
+                    showTime
+                    style={{ width: 400 }}
+                    value={dateRange}
+                    onChange={(vals) => {
+                      if (vals && vals[0] && vals[1]) {
+                        setDateRange([vals[0], vals[1]]);
+                      }
+                    }}
                   />
                 </>
               )}


### PR DESCRIPTION
## What happened

In the Message Explorer, `By Message Key` only accepted a Topic and Key. The backend already supported `tag`, `startTime`, and `endTime` for key queries, but the UI never sent them. Key searches also bypassed the seven-day window validation used by topic queries, so a caller could submit an unbounded or reversed key-query request directly to the API.

For on-call searches, this makes a common workflow unnecessarily broad: an incident usually has both a business key and a known time window, and sometimes a known tag. Without those filters, key searches can return many unrelated messages and require manual inspection.

## Change

Backend:

- Validate explicit key-query time windows before calling the provider:
  - reject negative timestamps
  - reject `startTime >= endTime`
  - reject ranges longer than seven days
- Keep key queries without explicit timestamps backward compatible; they continue to use provider defaults.
- Message ID lookups remain unchanged because their time window is not part of that lookup.

Frontend:

- Add optional Tag and time-range controls to the `By Message Key` form.
- Send trimmed `tag`, `startTime`, and `endTime` values with key queries.
- Apply the same start-before-end and seven-day maximum validation as Topic queries.
- Preserve Tag and time values when replaying a saved key query from history, and clear Tag on reset.

Tests:

- Backend service tests cover reversed, over-long, and omitted key-query windows, and verify the provider is not called for invalid requests.
- A focused UI test verifies that a key query submits the selected topic, trimmed key/tag, and explicit time range.
- Updated the existing message-page validation test to re-query the button after async mode switches and to expect the new key-query time parameters.

## Verification

Focused backend:

```
cd server
mvn -q '-Dtest=MessageServiceTest,MessageControllerTest' test
mvn -q checkstyle:check
```

Focused frontend:

```
cd web
npm test -- MessagePage.test.tsx MessagePageKeyQuery.test.tsx MessagePageAsyncState.test.tsx message.test.ts --run
```

Result: 5 files / 37 tests passed.

Full frontend:

```
cd web
npm test -- --run
```

Result: 116 files, 918 passed and 5 timeouts under the default parallel run. Re-running the affected files isolated the behavior:

- the new `MessagePageKeyQuery.test.tsx` passes when run alone and with the message-page suite;
- `ConsumerPage.test.tsx` has the same failures on clean upstream `36126024`, so those tests are pre-existing mainline instability.

Full backend:

```
cd server
mvn -q test
```

Result: 2,038 tests, 3 failures. The same three failures were previously reproduced on a clean `upstream/rocketmq-studio` worktree at `36126024` and are pre-existing mainline test drift, unrelated to this patch:

- `AuthCorsIntegrationTest.shouldStillRejectAnonymousProtectedRequests`
- `AuthCorsIntegrationTest.shouldRejectNonAdminMutationBeforeControllerExecution`
- `AliyunInstanceProviderTest.getGroupProgressShouldMapLagRowsTest`

Lint/build:

```
npm run lint -- --quiet
npm run build
```

Lint reported 0 errors and 10 pre-existing warnings elsewhere in the codebase. The production build completed successfully.

`git diff --check` passed before commit.

The production/config additions are 54 lines (19 backend, 35 frontend). This is the natural size for the UI/API gap; I did not pad the change with unrelated refactoring.

Closes #3163


