### PR TITLE
feat(alert): edit maintenance windows

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -51,6 +52,12 @@ public class AlertSilenceController {
     @PostMapping
     public Result<AlertSilenceVO> create(@Valid @RequestBody CreateAlertSilenceDTO request) {
         return Result.ok(silenceService.create(request));
+    }
+
+    @PutMapping("/{id}")
+    public Result<AlertSilenceVO> update(@PathVariable Long id,
+            @Valid @RequestBody CreateAlertSilenceDTO request) {
+        return Result.ok(silenceService.update(id, request));
     }
 
     @DeleteMapping("/{id}")

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceRepository.java
@@ -24,9 +24,13 @@ import java.util.List;
 public interface AlertSilenceRepository {
     AlertSilenceVO save(AlertSilenceVO silence);
 
+    AlertSilenceVO update(AlertSilenceVO silence);
+
     List<AlertSilenceVO> findAll();
 
     PageResult<AlertSilenceVO> findPage(int page, int pageSize);
+
+    AlertSilenceVO findById(Long id);
 
     List<AlertSilenceVO> findActiveCandidates(AlertDomain domain, Long ruleId, String instanceId, LocalDateTime now);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceService.java
@@ -52,27 +52,27 @@ public class AlertSilenceService {
     }
 
     public AlertSilenceVO create(CreateAlertSilenceDTO request) {
-        if (request == null || request.getStartsAt() == null || request.getEndsAt() == null) {
-            throw new BusinessException(400, "Silence start and end times are required");
-        }
-        if (!request.getEndsAt().toInstant().isAfter(request.getStartsAt().toInstant())) {
-            throw new BusinessException(400, "Silence end time must be after start time");
-        }
-        if (request.getReason() != null && request.getReason().length() > 512) {
-            throw new BusinessException(400, "Silence reason must not exceed 512 characters");
-        }
-        RecurrenceConfiguration recurrence = validateRecurrence(request);
-        AlertSilenceVO silence = AlertSilenceVO.builder().domain(request.getDomain())
-                .ruleId(request.getRuleId()).instanceId(trimToNull(request.getInstanceId()))
-                .labels(normalizeLabels(request.getLabels()))
-                .startsAt(LocalDateTime.ofInstant(request.getStartsAt().toInstant(), ZoneOffset.UTC))
-                .endsAt(LocalDateTime.ofInstant(request.getEndsAt().toInstant(), ZoneOffset.UTC))
-                .recurrence(recurrence.type()).timeZone(recurrence.timeZone())
-                .recurrenceDays(recurrence.days()).recurrenceUntil(recurrence.until())
-                .reason(trimToNull(request.getReason()))
-                .createdBy(AuthenticatedUserContext.currentUsernameOrSystem()).build();
+        AlertSilenceVO silence = buildSilence(request, null);
+        silence.setCreatedBy(AuthenticatedUserContext.currentUsernameOrSystem());
         AlertSilenceVO saved = repository.save(silence);
         operationAuditService.record("CREATE_ALERT_SILENCE", "ALERT_SILENCE", String.valueOf(saved.getId()),
+                saved.getInstanceId(), "ruleId=" + saved.getRuleId() + ", recurrence=" + saved.getRecurrence(),
+                "SUCCESS", null);
+        return saved;
+    }
+
+    public AlertSilenceVO update(Long id, CreateAlertSilenceDTO request) {
+        if (id == null) {
+            throw new BusinessException(400, "Silence ID is required");
+        }
+        AlertSilenceVO existing = repository.findById(id);
+        if (existing == null) {
+            throw new BusinessException(404, "Alert silence not found: " + id);
+        }
+        AlertSilenceVO silence = buildSilence(request, id);
+        silence.setCreatedBy(existing.getCreatedBy());
+        AlertSilenceVO saved = repository.update(silence);
+        operationAuditService.record("UPDATE_ALERT_SILENCE", "ALERT_SILENCE", String.valueOf(saved.getId()),
                 saved.getInstanceId(), "ruleId=" + saved.getRuleId() + ", recurrence=" + saved.getRecurrence(),
                 "SUCCESS", null);
         return saved;
@@ -119,6 +119,27 @@ public class AlertSilenceService {
         if (pageSize < 1 || pageSize > MAX_PAGE_SIZE) {
             throw new BusinessException(400, "pageSize must be between 1 and " + MAX_PAGE_SIZE);
         }
+    }
+
+    private static AlertSilenceVO buildSilence(CreateAlertSilenceDTO request, Long id) {
+        if (request == null || request.getStartsAt() == null || request.getEndsAt() == null) {
+            throw new BusinessException(400, "Silence start and end times are required");
+        }
+        if (!request.getEndsAt().toInstant().isAfter(request.getStartsAt().toInstant())) {
+            throw new BusinessException(400, "Silence end time must be after start time");
+        }
+        if (request.getReason() != null && request.getReason().length() > 512) {
+            throw new BusinessException(400, "Silence reason must not exceed 512 characters");
+        }
+        RecurrenceConfiguration recurrence = validateRecurrence(request);
+        return AlertSilenceVO.builder().id(id).domain(request.getDomain())
+                .ruleId(request.getRuleId()).instanceId(trimToNull(request.getInstanceId()))
+                .labels(normalizeLabels(request.getLabels()))
+                .startsAt(LocalDateTime.ofInstant(request.getStartsAt().toInstant(), ZoneOffset.UTC))
+                .endsAt(LocalDateTime.ofInstant(request.getEndsAt().toInstant(), ZoneOffset.UTC))
+                .recurrence(recurrence.type()).timeZone(recurrence.timeZone())
+                .recurrenceDays(recurrence.days()).recurrenceUntil(recurrence.until())
+                .reason(trimToNull(request.getReason())).build();
     }
 
     private static boolean matchesScope(AlertSilenceVO silence, Long ruleId, AlertDomain domain, String instanceId,

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepository.java
@@ -49,6 +49,22 @@ public class MybatisPlusAlertSilenceRepository implements AlertSilenceRepository
     }
 
     @Override
+    public AlertSilenceVO update(AlertSilenceVO silence) {
+        RmqAlertSilence entity = toEntity(silence);
+        entity.setId(silence.getId());
+        if (mapper.updateById(entity) <= 0) {
+            throw new IllegalStateException("Unable to update alert silence: " + silence.getId());
+        }
+        return silence;
+    }
+
+    @Override
+    public AlertSilenceVO findById(Long id) {
+        RmqAlertSilence entity = mapper.selectById(id);
+        return entity == null ? null : toVo(entity);
+    }
+
+    @Override
     public List<AlertSilenceVO> findAll() {
         return mapper.selectList(new QueryWrapper<RmqAlertSilence>()
                         .orderByDesc("ends_at").orderByDesc("id"))

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceControllerTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -107,5 +108,34 @@ class AlertSilenceControllerTest {
                 request.getRecurrence() == AlertSilenceRecurrence.WEEKLY
                         && request.getRecurrenceDays().equals(Set.of(1, 3, 5))
                         && "Asia/Shanghai".equals(request.getTimeZone())));
+    }
+
+    @Test
+    void updateShouldBindAndReturnUpdatedScheduleTest() throws Exception {
+        AlertSilenceVO silence = AlertSilenceVO.builder().id(13L)
+                .startsAt(LocalDateTime.of(2026, 9, 7, 1, 0))
+                .endsAt(LocalDateTime.of(2026, 9, 7, 3, 0))
+                .recurrence(AlertSilenceRecurrence.DAILY).timeZone("Asia/Shanghai")
+                .recurrenceUntil(LocalDateTime.of(2026, 10, 1, 0, 0)).createdBy("admin").build();
+        when(silenceService.update(eq(13L), any(CreateAlertSilenceDTO.class))).thenReturn(silence);
+
+        mockMvc.perform(put("/api/alert-silences/13")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "startsAt": "2026-09-07T09:00:00+08:00",
+                                  "endsAt": "2026-09-07T11:00:00+08:00",
+                                  "recurrence": "DAILY",
+                                  "timeZone": "Asia/Shanghai",
+                                  "recurrenceUntil": "2026-10-01T08:00:00+08:00"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(13))
+                .andExpect(jsonPath("$.data.endsAt").value("2026-09-07T03:00:00"))
+                .andExpect(jsonPath("$.data.recurrence").value("DAILY"));
+
+        verify(silenceService).update(eq(13L), org.mockito.ArgumentMatchers.argThat(request ->
+                request.getEndsAt().equals(java.time.OffsetDateTime.parse("2026-09-07T03:00:00Z"))));
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceServiceTest.java
@@ -34,6 +34,10 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -106,6 +110,49 @@ class AlertSilenceServiceTest {
         org.mockito.Mockito.verify(repository).save(org.mockito.ArgumentMatchers.argThat(silence ->
                 LocalDateTime.of(2026, 8, 22, 16, 0).equals(silence.getStartsAt())
                         && LocalDateTime.of(2026, 8, 22, 17, 0).equals(silence.getEndsAt())));
+    }
+
+    @Test
+    void updatesExistingSilenceWithCreateValidationAndOriginalCreatorTest() {
+        AlertSilenceService service = new AlertSilenceService(repository, operationAuditService);
+        CreateAlertSilenceDTO request = recurringRequest(AlertSilenceRecurrence.WEEKLY);
+        request.setRecurrenceDays(Set.of(1, 3));
+        request.setInstanceId(" local ");
+        request.setLabels(Map.of("brokerName", " broker-a "));
+        request.setReason(" extended maintenance ");
+        AlertSilenceVO existing = AlertSilenceVO.builder().id(9L).createdBy("alice").build();
+        when(repository.findById(9L)).thenReturn(existing);
+        when(repository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        AlertSilenceVO result = service.update(9L, request);
+
+        ArgumentCaptor<AlertSilenceVO> captured = ArgumentCaptor.forClass(AlertSilenceVO.class);
+        org.mockito.Mockito.verify(repository).update(captured.capture());
+        assertThat(result.getId()).isEqualTo(9L);
+        assertThat(result.getCreatedBy()).isEqualTo("alice");
+        assertThat(captured.getValue().getInstanceId()).isEqualTo("local");
+        assertThat(captured.getValue().getLabels()).containsEntry("brokerName", "broker-a");
+        assertThat(captured.getValue().getReason()).isEqualTo("extended maintenance");
+        assertThat(captured.getValue().getRecurrence()).isEqualTo(AlertSilenceRecurrence.WEEKLY);
+        verify(operationAuditService).record(eq("UPDATE_ALERT_SILENCE"), eq("ALERT_SILENCE"), eq("9"),
+                eq("local"), contains("recurrence=WEEKLY"), eq("SUCCESS"), isNull());
+    }
+
+    @Test
+    void updateShouldRejectUnknownOrMissingSilenceTest() {
+        AlertSilenceService service = new AlertSilenceService(repository, operationAuditService);
+        CreateAlertSilenceDTO request = recurringRequest(AlertSilenceRecurrence.DAILY);
+        when(repository.findById(404L)).thenReturn(null);
+
+        assertThatThrownBy(() -> service.update(null, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Silence ID is required");
+        assertThatThrownBy(() -> service.update(404L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Alert silence not found: 404");
+
+        org.mockito.Mockito.verify(repository, org.mockito.Mockito.never()).update(any());
+        verify(operationAuditService, org.mockito.Mockito.never()).record(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -155,5 +156,38 @@ class MybatisPlusAlertSilenceRepositoryTest {
         assertThat(restored.get(0).getRecurrenceDays()).containsExactlyInAnyOrder(1, 3, 5);
         assertThat(restored.get(1).getRecurrence()).isEqualTo(AlertSilenceRecurrence.ONCE);
         assertThat(restored.get(1).getRecurrenceDays()).isEmpty();
+    }
+
+    @Test
+    void updateShouldPersistTheProvidedIdAndScheduleTest() {
+        MybatisPlusAlertSilenceRepository repository = new MybatisPlusAlertSilenceRepository(
+                mapper, new ObjectMapper());
+        AlertSilenceVO silence = AlertSilenceVO.builder().id(31L)
+                .startsAt(LocalDateTime.of(2026, 9, 1, 10, 0))
+                .endsAt(LocalDateTime.of(2026, 9, 1, 11, 0))
+                .recurrence(AlertSilenceRecurrence.DAILY).timeZone("UTC")
+                .recurrenceUntil(LocalDateTime.of(2026, 10, 1, 0, 0)).createdBy("alice").build();
+        when(mapper.updateById(any(RmqAlertSilence.class))).thenReturn(1);
+
+        AlertSilenceVO updated = repository.update(silence);
+
+        ArgumentCaptor<RmqAlertSilence> captor = ArgumentCaptor.forClass(RmqAlertSilence.class);
+        verify(mapper).updateById(captor.capture());
+        assertThat(updated).isSameAs(silence);
+        assertThat(captor.getValue().getId()).isEqualTo(31L);
+        assertThat(captor.getValue().getRecurrence()).isEqualTo("DAILY");
+        assertThat(captor.getValue().getRecurrenceUntil()).isEqualTo(LocalDateTime.of(2026, 10, 1, 0, 0));
+    }
+
+    @Test
+    void updateShouldFailWhenNoRowChangesTest() {
+        MybatisPlusAlertSilenceRepository repository = new MybatisPlusAlertSilenceRepository(
+                mapper, new ObjectMapper());
+        AlertSilenceVO silence = AlertSilenceVO.builder().id(404L).createdBy("alice").build();
+        when(mapper.updateById(any(RmqAlertSilence.class))).thenReturn(0);
+
+        assertThatThrownBy(() -> repository.update(silence))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Unable to update alert silence: 404");
     }
 }

--- a/web/src/api/ops.test.ts
+++ b/web/src/api/ops.test.ts
@@ -46,6 +46,7 @@ import {
   listAlertSilences,
   listAlertSilencesPage,
   createAlertSilence,
+  updateAlertSilence,
   deleteAlertSilence,
   listAuditRecords,
   cleanupAuditLogs,
@@ -373,6 +374,7 @@ describe('Ops API - System Alerts & Audit', () => {
       return [200, { code: 200, data: { items: [silence], total: 21, page: 2, size: 10 } }];
     });
     mock.onPost('/alert-silences').reply(200, { code: 200, data: silence });
+    mock.onPut('/alert-silences/2').reply(200, { code: 200, data: silence });
     mock.onDelete('/alert-silences/2').reply(200, { code: 200 });
     await expect(listAlertSilences()).resolves.toEqual([silence]);
     await expect(listAlertSilencesPage({ page: 2, pageSize: 10 })).resolves.toEqual({
@@ -382,6 +384,7 @@ describe('Ops API - System Alerts & Audit', () => {
       size: 10,
     });
     await expect(createAlertSilence(silence)).resolves.toEqual(silence);
+    await expect(updateAlertSilence(2, silence)).resolves.toEqual(silence);
     await expect(deleteAlertSilence(2)).resolves.toBeUndefined();
   });
 

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -379,6 +379,11 @@ export async function createAlertSilence(data: CreateAlertSilence) {
   return res.data.data;
 }
 
+export async function updateAlertSilence(id: number, data: CreateAlertSilence) {
+  const res = await client.put<{ data: AlertSilence }>(`/alert-silences/${id}`, data);
+  return res.data.data;
+}
+
 export async function deleteAlertSilence(id: number) {
   await client.delete(`/alert-silences/${id}`);
 }

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1041,6 +1041,11 @@ const translations: Record<string, Record<Lang, string>> = {
     en: 'Failed to load maintenance windows. Please try again later.',
   },
   'sysAlerts.silenceCreated': { zh: '维护窗口已创建', en: 'Maintenance window created.' },
+  'sysAlerts.silenceUpdated': { zh: '维护窗口已更新', en: 'Maintenance window updated.' },
+  'sysAlerts.silenceUpdateFailed': {
+    zh: '更新维护窗口失败，请稍后重试。',
+    en: 'Failed to update maintenance window. Please try again later.',
+  },
   'sysAlerts.silenceCreateFailed': {
     zh: '维护窗口创建失败，请检查时间范围',
     en: 'Failed to create maintenance window. Check the time range.',

--- a/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/SystemAlertsPage.test.tsx
@@ -19,6 +19,7 @@ import {
   listAlertDeliveries,
   listRelatedSystemAlerts,
   retryAlertDelivery,
+  updateAlertSilence,
   deleteAlertSilence,
   listAlertSilences,
   listAlertSilencesPage,
@@ -37,7 +38,18 @@ vi.mock('../../../services/opsService', () => ({
   listAlertSilences: vi.fn(),
   listAlertSilencesPage: vi.fn(),
   createAlertSilence: vi.fn(),
+  updateAlertSilence: vi.fn(),
   deleteAlertSilence: vi.fn(),
+}));
+
+const authState = {
+  admin: false as boolean | null,
+  userId: 1 as number | null,
+  logout: vi.fn(),
+};
+
+vi.mock('../../../stores/authStore', () => ({
+  default: (selector: (state: typeof authState) => unknown) => selector(authState),
 }));
 
 vi.mock('../../../utils/download', async () => {
@@ -73,7 +85,10 @@ const renderPage = () =>
 
 describe('SystemAlertsPage', () => {
   beforeEach(() => {
+    localStorage.clear();
     vi.clearAllMocks();
+    authState.admin = null;
+    authState.userId = null;
     vi.mocked(listSystemAlertsPage).mockResolvedValue({
       items: [
         {
@@ -337,6 +352,7 @@ describe('SystemAlertsPage', () => {
       size: 20,
     });
     const user = userEvent.setup();
+    authState.admin = true;
     renderPage();
 
     await screen.findByText('Historical disk alert');
@@ -606,6 +622,83 @@ describe('SystemAlertsPage', () => {
 
     await waitFor(() => {
       expect(deleteAlertSilence).toHaveBeenCalledWith(10);
+      expect(listAlertSilencesPage).toHaveBeenLastCalledWith({ page: 1, pageSize: 10 });
+    });
+  });
+
+  it('edits an existing maintenance window and submits the updated schedule', async () => {
+    vi.mocked(listAlertSilencesPage)
+      .mockReset()
+      .mockResolvedValue({
+        items: [
+          {
+            id: 9,
+            domain: 'CLUSTER',
+            instanceId: 'local',
+            labels: { brokerName: 'broker-a' },
+            startsAt: '2026-08-10T01:00:00Z',
+            endsAt: '2026-08-10T02:00:00Z',
+            recurrence: 'WEEKLY',
+            timeZone: 'Asia/Shanghai',
+            recurrenceDays: [1, 3],
+            recurrenceUntil: '2026-09-01T00:00:00Z',
+            reason: 'deploy',
+            createdBy: 'alice',
+          },
+        ],
+        total: 1,
+        page: 1,
+        size: 10,
+      });
+    vi.mocked(updateAlertSilence).mockResolvedValue({
+      id: 9,
+      domain: 'CLUSTER',
+      instanceId: 'local',
+      startsAt: '2026-08-10T01:00:00Z',
+      endsAt: '2026-08-10T03:00:00Z',
+      recurrence: 'WEEKLY',
+      timeZone: 'Asia/Shanghai',
+      recurrenceDays: [1, 3],
+      recurrenceUntil: '2026-09-01T00:00:00Z',
+      createdBy: 'alice',
+    });
+    const user = userEvent.setup();
+    authState.admin = true;
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: '维护窗口' }));
+    expect(await screen.findByText(/CLUSTER.*local/)).toBeInTheDocument();
+    await user.click(await screen.findByRole('button', { name: /编\s*辑/ }));
+
+    expect(screen.getByLabelText('规则 ID')).toHaveValue('');
+    expect(screen.getByLabelText('实例 ID')).toHaveValue('local');
+    expect(screen.getByLabelText('标签范围')).toHaveValue('brokerName=broker-a');
+    expect(screen.getByLabelText('开始时间')).toHaveValue('2026-08-10T01:00');
+    expect(screen.getByLabelText('结束时间')).toHaveValue('2026-08-10T02:00');
+    expect(screen.getByLabelText('时区')).toHaveValue('Asia/Shanghai');
+    expect(screen.getByLabelText('重复至')).toHaveValue('2026-09-01T00:00');
+    expect(screen.getByLabelText('原因')).toHaveValue('deploy');
+    expect(screen.getByRole('button', { name: /保\s*存/ })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('结束时间'), { target: { value: '2026-08-10T10:00' } });
+    await user.click(screen.getByRole('button', { name: /保\s*存/ }));
+
+    await waitFor(() => {
+      expect(updateAlertSilence).toHaveBeenCalledWith(
+        9,
+        expect.objectContaining({
+          domain: 'CLUSTER',
+          instanceId: 'local',
+          labels: { brokerName: 'broker-a' },
+          startsAt: '2026-08-09T17:00:00.000Z',
+          endsAt: '2026-08-10T02:00:00.000Z',
+          recurrence: 'WEEKLY',
+          timeZone: 'Asia/Shanghai',
+          recurrenceDays: [1, 3],
+          recurrenceUntil: '2026-08-31T16:00:00.000Z',
+          reason: 'deploy',
+        }),
+      );
       expect(listAlertSilencesPage).toHaveBeenLastCalledWith({ page: 1, pageSize: 10 });
     });
   });

--- a/web/src/pages/ops/systemAlerts.tsx
+++ b/web/src/pages/ops/systemAlerts.tsx
@@ -44,6 +44,7 @@ import {
   retryAlertDelivery,
   listSystemAlertsPage,
   createAlertSilence,
+  updateAlertSilence,
   deleteAlertSilence,
   listAlertSilencesPage,
 } from '../../services/opsService';
@@ -104,6 +105,12 @@ const parseSilenceLabels = (
 const localDateTimeToUtc = (value: string) => new Date(`${value}:00`).toISOString();
 const localDateTimeToUtcDatabaseValue = (value: string) =>
   new Date(`${value}:00`).toISOString().replace('Z', '');
+const utcToLocalDateTimeValue = (value: string | null | undefined) =>
+  value ? value.replace('Z', '').slice(0, 16) : '';
+const formatSilenceLabels = (labels: AlertSilence['labels']) =>
+  Object.entries(labels ?? {})
+    .map(([key, labelValue]) => `${key}=${labelValue}`)
+    .join(', ');
 
 const ALERT_EXPORT_COLUMNS: CsvColumn<SystemAlert>[] = [
   { header: 'ID', value: (alert) => alert.id },
@@ -172,6 +179,7 @@ const SystemAlertsPage = () => {
   const [silencePage, setSilencePage] = useState(1);
   const [silenceTotal, setSilenceTotal] = useState(0);
   const [savingSilence, setSavingSilence] = useState(false);
+  const [editingSilenceId, setEditingSilenceId] = useState<number | null>(null);
   const [deletingSilenceId, setDeletingSilenceId] = useState<number | null>(null);
   const silencePageSize = 10;
   const [silenceForm] = Form.useForm();
@@ -379,7 +387,7 @@ const SystemAlertsPage = () => {
     void loadSilences(1);
   };
 
-  const createSilence = async () => {
+  const saveSilence = async () => {
     let values: {
       domain?: 'BUSINESS' | 'CLUSTER';
       ruleId?: string;
@@ -421,16 +429,49 @@ const SystemAlertsPage = () => {
             ? convertTime(values.recurrenceUntil)
             : undefined,
       };
-      await createAlertSilence(request);
+      if (editingSilenceId == null) {
+        await createAlertSilence(request);
+      } else {
+        await updateAlertSilence(editingSilenceId, request);
+      }
       silenceForm.resetFields();
+      setEditingSilenceId(null);
       setSilencePage(1);
       await loadSilences(1);
-      message.success(t('sysAlerts.silenceCreated'));
+      message.success(
+        editingSilenceId == null ? t('sysAlerts.silenceCreated') : t('sysAlerts.silenceUpdated'),
+      );
     } catch {
-      message.error(t('sysAlerts.silenceCreateFailed'));
+      message.error(
+        editingSilenceId == null
+          ? t('sysAlerts.silenceCreateFailed')
+          : t('sysAlerts.silenceUpdateFailed'),
+      );
     } finally {
       setSavingSilence(false);
     }
+  };
+
+  const startEditSilence = (silence: AlertSilence) => {
+    setEditingSilenceId(silence.id);
+    silenceForm.setFieldsValue({
+      domain: silence.domain ?? undefined,
+      ruleId: silence.ruleId != null ? String(silence.ruleId) : undefined,
+      instanceId: silence.instanceId ?? undefined,
+      labelsText: formatSilenceLabels(silence.labels) || undefined,
+      startsAt: utcToLocalDateTimeValue(silence.startsAt),
+      endsAt: utcToLocalDateTimeValue(silence.endsAt),
+      recurrence: silence.recurrence ?? 'ONCE',
+      timeZone: silence.timeZone ?? DEFAULT_TIME_ZONE,
+      recurrenceDays: silence.recurrenceDays,
+      recurrenceUntil: utcToLocalDateTimeValue(silence.recurrenceUntil),
+      reason: silence.reason ?? undefined,
+    });
+  };
+
+  const resetSilenceForm = () => {
+    setEditingSilenceId(null);
+    silenceForm.resetFields();
   };
 
   const deleteSilence = async (id: number) => {
@@ -828,9 +869,12 @@ const SystemAlertsPage = () => {
       <Modal
         title={t('sysAlerts.maintenanceWindows')}
         open={silencesVisible}
-        onCancel={() => setSilencesVisible(false)}
-        onOk={() => void createSilence()}
-        okText={t('sysAlerts.create')}
+        onCancel={() => {
+          setSilencesVisible(false);
+          resetSilenceForm();
+        }}
+        onOk={() => void saveSilence()}
+        okText={editingSilenceId == null ? t('sysAlerts.create') : t('common.save')}
         okButtonProps={{ style: { display: canManageSilences ? undefined : 'none' } }}
         confirmLoading={savingSilence}
         width={680}
@@ -840,6 +884,7 @@ const SystemAlertsPage = () => {
             form={silenceForm}
             layout="vertical"
             initialValues={{ domain: 'BUSINESS', recurrence: 'ONCE', timeZone: DEFAULT_TIME_ZONE }}
+            key={editingSilenceId == null ? 'create' : `edit-${editingSilenceId}`}
           >
             <Flex gap={8}>
               <Form.Item name="domain" label={t('sysAlerts.domain')} style={{ flex: 1 }}>
@@ -973,14 +1018,19 @@ const SystemAlertsPage = () => {
                     : ''}
                 </Text>
                 {canManageSilences && (
-                  <Button
-                    size="small"
-                    danger
-                    loading={deletingSilenceId === silence.id}
-                    onClick={() => void deleteSilence(silence.id)}
-                  >
-                    {t('sysAlerts.end')}
-                  </Button>
+                  <Flex gap={4}>
+                    <Button size="small" onClick={() => startEditSilence(silence)}>
+                      {t('common.edit')}
+                    </Button>
+                    <Button
+                      size="small"
+                      danger
+                      loading={deletingSilenceId === silence.id}
+                      onClick={() => void deleteSilence(silence.id)}
+                    >
+                      {t('sysAlerts.end')}
+                    </Button>
+                  </Flex>
                 )}
               </Flex>
             ))}

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -467,6 +467,21 @@ export async function createAlertSilence(data: CreateAlertSilence): Promise<Aler
   return silence;
 }
 
+export async function updateAlertSilence(
+  id: number,
+  data: CreateAlertSilence,
+): Promise<AlertSilence> {
+  if (!isMockMode()) return opsApi.updateAlertSilence(id, data);
+  let updated: AlertSilence | undefined;
+  alertSilencesState = alertSilencesState.map((silence) => {
+    if (silence.id !== id) return silence;
+    updated = { ...silence, ...data } as AlertSilence;
+    return updated;
+  });
+  if (!updated) throw new Error(`Maintenance window not found: ${id}`);
+  return updated;
+}
+
 export async function deleteAlertSilence(id: number): Promise<void> {
   if (!isMockMode()) return opsApi.deleteAlertSilence(id);
   alertSilencesState = alertSilencesState.filter((silence) => silence.id !== id);


### PR DESCRIPTION
## What happened

Maintenance windows can currently only be created and ended. Once a window exists, its schedule and scope cannot be changed.

This is inconvenient in normal operations:

- a window created too short must be ended and recreated;
- a wrong recurring time zone, weekday, or recurrence end must be recreated;
- a too-broad scope (for example, all instances instead of one) creates a new record and loses the original creator.

The backend had no update endpoint: `AlertSilenceController` supported list, create, and delete only.

## Change

Backend:

- Add `PUT /api/alert-silences/{id}`.
- Add `AlertSilenceService.update(...)`, which:
  - rejects missing IDs;
  - returns 404 when the window no longer exists;
  - reuses the exact create validation for time window, recurrence, time zone, weekdays, recurrence end, labels, and reason;
  - preserves the existing ID and original creator;
  - records an `UPDATE_ALERT_SILENCE` audit entry.
- Add repository `findById` and `update`; the MyBatis implementation updates the existing row and fails if no row changes.
- Extract create/update input normalization into a shared builder so create and edit cannot drift.

Frontend:

- Add an **Edit** action for each maintenance window.
- Prefill the existing form with domain, rule, instance, labels, start/end, recurrence, time zone, weekdays, recurrence end, and reason.
- Reuse the same create form and validation; switching the modal to edit mode changes the primary action to Save.
- Reset edit state when the dialog is closed or after a successful save.
- Add API/service methods and mock-mode behavior for updating a silence.

Tests:

- Service: update normalization, original creator preservation, audit write, unknown/missing ID rejection.
- Repository: update row mapping and no-row failure.
- Controller: `PUT` request binding and response.
- API: update endpoint contract.
- UI: prefill an existing recurring window, submit the updated schedule, and refresh the list.

## Verification

Focused backend:

```
cd server
mvn -q '-Dtest=AlertSilenceServiceTest,MybatisPlusAlertSilenceRepositoryTest,AlertSilenceControllerTest' test
mvn -q checkstyle:check
```

Focused frontend:

```
cd web
npm test -- SystemAlertsPage.test.tsx ops.test.ts opsService.test.ts --run
```

Result: 4 files / 60 tests passed.

Full frontend:

```
cd web
npm test -- --run
```

Result: 115 files / 923 tests passed.

Full backend:

```
cd server
mvn -q test
```

Result: 2,040 tests, 3 failures. The same three failures were previously reproduced on a clean `upstream/rocketmq-studio` worktree at `36126024` and are pre-existing mainline test drift, unrelated to this patch:

- `AuthCorsIntegrationTest.shouldStillRejectAnonymousProtectedRequests`
- `AuthCorsIntegrationTest.shouldRejectNonAdminMutationBeforeControllerExecution`
- `AliyunInstanceProviderTest.getGroupProgressShouldMapLagRowsTest`

Lint/build:

```
npm run lint -- --quiet
npm run build
```

Lint reported 0 errors and 10 pre-existing warnings elsewhere. The production build completed successfully.

`git diff --check` passed before commit.

Production/config additions are 164 lines (67 backend, 97 frontend), naturally exceeding 100 lines without unrelated padding.

Closes #3165


