### PR TITLE
perf(dlq): parallelize group stats and debounce search

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProvider.java
@@ -65,6 +65,12 @@ import java.util.Locale;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Real {@link DLQProvider} backed by the RocketMQ admin API. Lists dead-letter groups by scanning
@@ -80,11 +86,24 @@ public class RocketMQDLQProvider implements DLQProvider {
     private static final int RESEND_HARD_CAP = 5000;
     private static final int MAX_PAGE_SIZE = 100;
     private static final int MAX_CONSECUTIVE_OFFSET_ILLEGAL = 3;
+    private static final int STATS_THREADS = 8;
+    private static final long STATS_TIMEOUT_SECONDS = 5;
     private static final String ORIGIN_MESSAGE_ID_PROPERTY = "studio_dlq_origin_message_id";
     private static final String ORIGIN_TOPIC_PROPERTY = "studio_dlq_origin_topic";
 
     private final RuntimeAdminClientResolver runtimeAdminClientResolver;
     private final AuditService auditService;
+
+    private final ExecutorService statsExecutor = Executors.newFixedThreadPool(STATS_THREADS, runnable -> {
+        Thread thread = new Thread(runnable, "dlq-topic-stats");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    @jakarta.annotation.PreDestroy
+    void shutdownStatsExecutor() {
+        statsExecutor.shutdownNow();
+    }
 
     @Override
     public List<DLQGroupVO> listDLQGroups(String instanceId) {
@@ -122,11 +141,36 @@ public class RocketMQDLQProvider implements DLQProvider {
         long offset = Pagination.pageOffset(page, pageSize);
         int from = (int) Math.min(offset, dlqTopics.size());
         int to = (int) Math.min(offset + pageSize, dlqTopics.size());
-        List<DLQGroupVO> groups = dlqTopics.subList(from, to).stream()
-                .map(topic -> buildDLQGroup(adminExt,
-                        topic.substring(MixAll.DLQ_GROUP_TOPIC_PREFIX.length()), topic))
-                .toList();
+        List<String> pageTopics = dlqTopics.subList(from, to);
+        List<DLQGroupVO> groups = loadGroupStatsInParallel(adminExt, pageTopics);
         return PageResult.of(groups, dlqTopics.size(), page, pageSize);
+    }
+
+    private List<DLQGroupVO> loadGroupStatsInParallel(MQAdminExt adminExt, List<String> pageTopics) {
+        List<Future<DLQGroupVO>> futures = new ArrayList<>(pageTopics.size());
+        for (String topic : pageTopics) {
+            String groupName = topic.substring(MixAll.DLQ_GROUP_TOPIC_PREFIX.length());
+            futures.add(statsExecutor.submit(() -> buildDLQGroup(adminExt, groupName, topic)));
+        }
+        List<DLQGroupVO> groups = new ArrayList<>(futures.size());
+        for (Future<DLQGroupVO> future : futures) {
+            groups.add(awaitGroupStats(future));
+        }
+        return groups;
+    }
+
+    private DLQGroupVO awaitGroupStats(Future<DLQGroupVO> future) {
+        try {
+            return future.get(STATS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+        } catch (InterruptedException e) {
+            future.cancel(true);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            // buildDLQGroup reports single-topic failures inside the row itself.
+        }
+        return DLQGroupVO.builder().statsAvailable(false).status("UNAVAILABLE").build();
     }
 
     private DLQGroupVO buildDLQGroup(MQAdminExt adminExt, String groupName, String dlqTopic) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDLQProviderTest.java
@@ -136,6 +136,29 @@ class RocketMQDLQProviderTest {
     }
 
     @Test
+    void listDLQGroupsShouldRunPageStatsWithBoundedParallelismTest() throws Exception {
+        TopicList topicList = new TopicList();
+        topicList.setTopicList(Set.of(
+                MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a",
+                MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-b",
+                MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-c"));
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList);
+        when(adminExt.examineTopicStats(anyString())).thenAnswer(invocation -> {
+            TimeUnit.MILLISECONDS.sleep(150);
+            return new TopicStatsTable();
+        });
+
+        long startedAt = System.nanoTime();
+        PageResult<DLQGroupVO> page = provider.listDLQGroups("instance-a", null, 1, 3);
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+
+        assertThat(page.getItems()).extracting(DLQGroupVO::getGroupName)
+                .containsExactly("group-a", "group-b", "group-c");
+        assertThat(elapsedMillis).isLessThan(3 * 150);
+        verify(adminExt, times(3)).examineTopicStats(anyString());
+    }
+
+    @Test
     void keepsEmptyStatusWhenTopicStatsAreSuccessfullyRead() throws Exception {
         String dlqTopic = MixAll.DLQ_GROUP_TOPIC_PREFIX + "group-a";
         TopicList topicList = new TopicList();

--- a/web/src/pages/instance/__tests__/DLQPage.test.tsx
+++ b/web/src/pages/instance/__tests__/DLQPage.test.tsx
@@ -206,6 +206,29 @@ describe('DLQ page', () => {
     );
   });
 
+  it('debounces DLQ search requests while the user types', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DLQPage />);
+
+    await screen.findByText('cg-order');
+    const callsAfterInitialLoad = vi.mocked(messageService.listDLQGroups).mock.calls.length;
+    const searchInput = screen.getByPlaceholderText('搜索 Group 名称或 DLQ Topic');
+    await user.type(searchInput, 'o');
+    await user.type(searchInput, 'rd');
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 120));
+    });
+    expect(vi.mocked(messageService.listDLQGroups).mock.calls.length).toBe(callsAfterInitialLoad);
+
+    await waitFor(() =>
+      expect(messageService.listDLQGroups).toHaveBeenLastCalledWith('instance-1', 'ord', 1, 20),
+    );
+    expect(vi.mocked(messageService.listDLQGroups).mock.calls.length).toBe(
+      callsAfterInitialLoad + 1,
+    );
+  });
+
   it('surfaces unavailable DLQ provider errors when loading groups', async () => {
     vi.mocked(messageService.listDLQGroups).mockRejectedValue(
       new Error('DLQ provider is not configured'),

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -112,6 +112,7 @@ const DLQPage = () => {
   const [loading, setLoading] = useState(true);
   const [refreshKey, setRefreshKey] = useState(0);
   const [search, setSearch] = useState('');
+  const [searchInput, setSearchInput] = useState('');
   const [retryModalOpen, setRetryModalOpen] = useState(false);
   const [retryGroup, setRetryGroup] = useState<DLQGroup | null>(null);
   const [retryRange, setRetryRange] = useState<[Dayjs, Dayjs]>([
@@ -144,6 +145,36 @@ const DLQPage = () => {
   const retryRequestIdRef = useRef(0);
   const groupRequestIdRef = useRef(0);
   const resendInFlightRef = useRef(false);
+  const searchDebounceRef = useRef<number>();
+
+  useEffect(
+    () => () => {
+      if (searchDebounceRef.current !== undefined) {
+        window.clearTimeout(searchDebounceRef.current);
+      }
+    },
+    [],
+  );
+
+  const queueSearch = (value: string) => {
+    setSearchInput(value);
+    if (searchDebounceRef.current !== undefined) {
+      window.clearTimeout(searchDebounceRef.current);
+    }
+    searchDebounceRef.current = window.setTimeout(() => {
+      setSearch(value);
+      setPage(1);
+    }, 300);
+  };
+
+  const submitSearch = (value: string) => {
+    if (searchDebounceRef.current !== undefined) {
+      window.clearTimeout(searchDebounceRef.current);
+    }
+    setSearchInput(value);
+    setSearch(value);
+    setPage(1);
+  };
 
   useEffect(
     () => () => {
@@ -600,14 +631,12 @@ const DLQPage = () => {
           <Input.Search
             placeholder="搜索 Group 名称或 DLQ Topic"
             allowClear
-            value={search}
+            value={searchInput}
             onChange={(e) => {
-              setSearch(e.target.value);
-              setPage(1);
+              queueSearch(e.target.value);
             }}
             onSearch={(value) => {
-              setSearch(value);
-              setPage(1);
+              submitSearch(value);
             }}
             style={{ width: 320 }}
             prefix={<MagnifyingGlass size={14} color="#9CA3AF" />}


### PR DESCRIPTION
## What happened

The DLQ group page made its latency worse than necessary in two places.

Backend:

- `RocketMQDLQProvider.listDLQGroups(...)` sliced the current page and then called `adminExt.examineTopicStats(dlqTopic)` for every `%DLQ%` topic serially.
- With the default page size of 20, the page waited for up to 20 sequential admin RPCs. Slow brokers made this especially visible.

Frontend:

- The search input updated `search` state on every keystroke.
- That state is in the group-loading effect's dependency list, so every character started a new backend group-list request. The request-generation guard prevented stale responses from overwriting newer data, but it did not prevent the redundant requests from being sent.

## Change

Backend:

- Load topic statistics for the current page on a bounded daemon thread pool with 8 workers.
- Preserve the current deterministic page order by collecting futures in input order.
- Cap each stats lookup at 5 seconds; cancel timed-out work.
- Preserve row-level degradation: a failed or timed-out stats call only marks that row `UNAVAILABLE`.
- Shut down the stats executor on bean destruction.

Frontend:

- Split visible search input from the search value used for requests.
- Debounce typing by 300 ms.
- Submit immediately when the user presses Enter or clicks the search action.
- Clear pending debounce timers on unmount.

Tests:

- Backend test proves three simulated 150 ms stats calls complete in less than the serial sum, preserve order, and still call stats once per topic.
- Frontend test proves two rapid keystrokes produce only one request and that the request uses the final search value.

## Verification

Focused backend:

```
cd server
mvn -q '-Dtest=RocketMQDLQProviderTest,DLQServiceTest,DLQControllerTest' test
mvn -q checkstyle:check
```

Focused frontend:

```
cd web
npm test -- DLQPage.test.tsx message.test.ts --run
```

Result: 3 files / 28 tests passed.

Full frontend:

```
cd web
npm test -- --run
```

Result: 115 files / 923 tests passed.

Full backend:

```
cd server
mvn -q test
```

Result: 2,036 tests, 3 failures. The same three failures were previously reproduced on a clean `upstream/rocketmq-studio` worktree at `36126024` and are pre-existing mainline test drift, unrelated to this patch:

- `AuthCorsIntegrationTest.shouldStillRejectAnonymousProtectedRequests`
- `AuthCorsIntegrationTest.shouldRejectNonAdminMutationBeforeControllerExecution`
- `AliyunInstanceProviderTest.getGroupProgressShouldMapLagRowsTest`

Lint/build:

```
npm run lint -- --quiet
npm run build
```

Lint reported 0 errors and 10 pre-existing warnings elsewhere. The production build completed successfully.

`git diff --check` passed before commit.

Production/config additions are 82 lines (48 backend, 34 frontend). This is the natural size of the bounded-executor and debounce change; no unrelated refactoring was added.

Closes #3167


