### PR TITLE
fix(i18n): localize demo subscription consistency and filter mode

### DIFF
--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -125,6 +125,17 @@ const lagColor = (lag: number): string => {
  * Shows at most 3 units: days → hours → minutes → seconds.
  * e.g. 82500 → "22小时55分钟", 3725 → "1小时2分钟5秒"
  */
+const CONSISTENCY_DISPLAY: Record<string, string> = {
+  一致: 'Consistent',
+  不一致: 'Inconsistent',
+};
+
+const FILTER_MODE_DISPLAY: Record<string, string> = {
+  全量: 'Full',
+  'Tag 过滤': 'Tag filter',
+  'SQL92 过滤': 'SQL92 filter',
+};
+
 const formatDelay = (totalSeconds: number): string => {
   if (totalSeconds <= 0) return '0秒';
 
@@ -229,7 +240,7 @@ const ConsumerPageContent = ({
   instanceOptions,
   instancesLoading,
 }: ConsumerPageContentProps) => {
-  const { t } = useLang();
+  const { t, lang } = useLang();
   const isCloudInstance =
     selectedInstance?.vendor === 'ALIYUN' || selectedInstance?.vendor === 'TENCENT';
   const hasSelectedInstance = Boolean(selectedInstanceId);
@@ -979,7 +990,7 @@ const ConsumerPageContent = ({
             isConsistentValue(value) ? 'green' : isInconsistentValue(value) ? 'orange' : 'default'
           }
         >
-          {value}
+          {lang === 'en' ? (CONSISTENCY_DISPLAY[value] ?? value) : value}
         </Tag>
       ),
     },
@@ -994,7 +1005,8 @@ const ConsumerPageContent = ({
           'Tag 过滤': 'blue',
           'SQL92 过滤': 'purple',
         };
-        return <Tag color={colorMap[mode] || 'default'}>{mode}</Tag>;
+        const display = lang === 'en' ? (FILTER_MODE_DISPLAY[mode] ?? mode) : mode;
+        return <Tag color={colorMap[mode] || 'default'}>{display}</Tag>;
       },
     },
     {


### PR DESCRIPTION
### Summary
Localize the demo subscription values shown on the Consumer page:

- The `订阅一致性` (consistency) and `订阅模式` (filter mode) cells now render English display copy (`Consistent`/`Inconsistent`, `Full`/`Tag filter`/`SQL92 filter`) when the UI language is English, while color and consistency checks keep operating on the underlying values.

### Why
In demo mode these subscription cells were the remaining Chinese values on the consumer page in English UI.

### Testing
- `tsc --noEmit` passes (exit 0).
- `eslint` clean on the changed file (0 errors).
- Vitest: full `ConsumerPage` suite passes (24/24, default-zh assertions unchanged).
