### PR TITLE
fix(i18n): localize demo consume mode labels on topic consumer panel

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2542,6 +2542,7 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  'topic.unavailable': { zh: '不可用', en: 'Unavailable' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -166,6 +166,12 @@ type SendMessageFormValues = {
   properties?: MessagePropertyInput[];
 };
 
+// Demo consume-mode labels shown in the topic consumer panel (mock data is zh).
+const CONSUME_MODE_DISPLAY: Record<string, string> = {
+  '集群消费': 'Clustering',
+  '广播消费': 'Broadcasting',
+};
+
 const visibleTopics = (
   topics: Topic[],
   selectedInstanceId: string | undefined,
@@ -335,7 +341,7 @@ const PAYLOAD_ISSUE_COLOR: Record<MessagePayloadIssue['severity'], string> = {
 
 // ═══════════════════════════════════════════════════════════════════
 const TopicPage = () => {
-  const { t } = useLang();
+  const { t, lang } = useLang();
   const navigate = useNavigate();
   const {
     selectedInstanceId,
@@ -886,7 +892,7 @@ const TopicPage = () => {
   // ─── Consumer table columns ───────────────────────────────────
   const consumerColumns: TableColumnsType<ConsumerGroupInfo> = [
     {
-      title: '消费者组',
+      title: t('topic.consumerGroup'),
       dataIndex: 'group',
       key: 'group',
       render: (group: string) =>
@@ -905,25 +911,33 @@ const TopicPage = () => {
         ),
     },
     {
-      title: '消费模式',
+      title: t('topic.consumeMode'),
       dataIndex: 'messageModel',
       key: 'messageModel',
-      render: (m: string) => <Tag color={m === '广播消费' ? 'orange' : 'blue'}>{m}</Tag>,
+      render: (m: string) => (
+        <Tag color={m === '广播消费' ? 'orange' : 'blue'}>
+          {lang === 'en' ? (CONSUME_MODE_DISPLAY[m] ?? m) : m}
+        </Tag>
+      ),
     },
     {
-      title: '消费 TPS',
+      title: t('topic.consumeTps'),
       dataIndex: 'consumeTps',
       key: 'consumeTps',
       render: (n: number, record) =>
-        record.metricsAvailable === false ? <Text type="secondary">不可用</Text> : formatNumber(n),
+        record.metricsAvailable === false ? (
+          <Text type="secondary">{t('topic.unavailable')}</Text>
+        ) : (
+          formatNumber(n)
+        ),
     },
     {
-      title: '堆积量',
+      title: t('topic.backlog'),
       dataIndex: 'diffTotal',
       key: 'diffTotal',
       render: (n: number, record) =>
         record.metricsAvailable === false ? (
-          <Text type="secondary">不可用</Text>
+          <Text type="secondary">{t('topic.unavailable')}</Text>
         ) : (
           <Text type={n > 100 ? 'warning' : undefined}>{formatNumber(n)}</Text>
         ),


### PR DESCRIPTION
## Summary

The topic detail modal renders a demo consumer-group panel whose column headers and consume-mode tags still come straight from the zh mock data (集群消费 / 广播消费). In English mode those cells stay Chinese while the rest of the page is localized.

This PR completes the panel for en mode:
- Column headers now route through existing translations keys (`topic.consumerGroup`, `topic.consumeMode`, `topic.consumeTps`, `topic.backlog`) instead of hard-coded zh strings.
- The demo consume-mode tag maps `集群消费`/`广播消费` to Clustering/Broadcasting when `lang === en`, falling back to the raw value otherwise.
- The unavailable-metric placeholder uses the new `topic.unavailable` translation key.

The tag color decision still keys off the underlying mock value, so visuals are unchanged.

## Why

Consistent with the demo-data localization done for the consumer page (filter mode / consistency): demo content should read in the active language instead of leaking Chinese mock labels into English mode.

## Testing

- `tsc --noEmit` passes
- `eslint` clean on the changed files
- `vitest run TopicPage` - 21/21 tests pass