### PR TITLE
fix(i18n): localize DLQ page

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2542,6 +2542,87 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  // ─── Dead Letter Queue page ───
+  'dlq.loadFailed': { zh: '死信队列加载失败，请稍后重试', en: 'Failed to load the dead letter queue, please retry later' },
+  'dlq.retrySubmitFailed': { zh: '提交重投任务失败，请稍后重试', en: 'Failed to submit the resend task, please retry later' },
+  'dlq.exportFailed': { zh: '导出死信消息失败，请稍后重试', en: 'Failed to export dead letter messages, please retry later' },
+  'dlq.detailLoadFailed': { zh: '死信消息明细加载失败，请稍后重试', en: 'Failed to load dead letter message details, please retry later' },
+  'dlq.resendFailed': { zh: '重发死信消息失败，请稍后重试', en: 'Failed to resend dead letter messages, please retry later' },
+  'dlq.enterTargetTopic': { zh: '请输入目标 Topic', en: 'Enter a target Topic' },
+  'dlq.rescanIncomplete': {
+    zh: '重投扫描不完整：{count} 个队列无法扫描，已重投 {resent} 条',
+    en: 'Resend scan incomplete: {count} queues could not be scanned, {resent} messages resent',
+  },
+  'dlq.retryPartial': {
+    zh: '重投部分完成：成功 {succeeded}，失败 {failed}',
+    en: 'Resend partially completed: {succeeded} succeeded, {failed} failed',
+  },
+  'dlq.retryComplete': {
+    zh: '重投完成：{group} → {topic}（{count} 条）',
+    en: 'Resend complete: {group} → {topic} ({count} messages)',
+  },
+  'dlq.exportIncomplete': {
+    zh: '导出可能不完整：{count} 个队列无法扫描，导出上限 {limit} 条',
+    en: 'Export may be incomplete: {count} queues could not be scanned, export cap {limit} messages',
+  },
+  'dlq.exportDone': {
+    zh: '已导出 {group} 的死信消息（{bytes} 字节）',
+    en: 'Exported dead letter messages of {group} ({bytes} bytes)',
+  },
+  'dlq.exportSelectedDone': {
+    zh: '已导出选中的 {count} 条死信消息（{bytes} 字节）',
+    en: 'Exported {count} selected dead letter messages ({bytes} bytes)',
+  },
+  'dlq.exportAllDone': {
+    zh: '已导出全部死信消息（{bytes} 字节）',
+    en: 'Exported all dead letter messages ({bytes} bytes)',
+  },
+  'dlq.resendFailedToast': {
+    zh: '重发失败：成功 {succeeded}，失败 {failed}',
+    en: 'Resend failed: {succeeded} succeeded, {failed} failed',
+  },
+  'dlq.resendPartial': {
+    zh: '重发部分完成：成功 {succeeded}，失败 {failed}',
+    en: 'Resend partially completed: {succeeded} succeeded, {failed} failed',
+  },
+  'dlq.resendComplete': { zh: '重发完成：成功 {count} 条', en: 'Resend complete: {count} messages resent' },
+  'dlq.groupName': { zh: 'Group 名称', en: 'Group Name' },
+  'dlq.deadCount': { zh: '死信数量', en: 'Dead Letter Count' },
+  'dlq.unavailable': { zh: '不可用', en: 'Unavailable' },
+  'dlq.lastEnqueue': { zh: '最近入队时间', en: 'Last Enqueue Time' },
+  'dlq.messageDetails': { zh: '消息明细', en: 'Message Details' },
+  'dlq.resendMessages': { zh: '重投消息', en: 'Resend Messages' },
+  'dlq.export': { zh: '导出', en: 'Export' },
+  'dlq.enqueueTime': { zh: '入队时间', en: 'Enqueue Time' },
+  'dlq.resend': { zh: '重发', en: 'Resend' },
+  'dlq.subtitle': {
+    zh: '管理消费失败进入死信队列的消息',
+    en: 'Manage messages routed to the dead letter queue after consumption failures',
+  },
+  'dlq.searchPlaceholder': { zh: '搜索 Group 名称或 DLQ Topic', en: 'Search group name or DLQ Topic' },
+  'dlq.exportRange': { zh: '导出时间范围', en: 'Export Time Range' },
+  'dlq.groupsTotal': { zh: '共 {count} 个 Group', en: '{count} Groups total' },
+  'dlq.retryTitle': { zh: '重投死信消息', en: 'Resend Dead Letter Messages' },
+  'dlq.confirmRetry': { zh: '确认重投', en: 'Confirm Resend' },
+  'dlq.retryNotice': {
+    zh: '⚠️ 重投操作将把死信消息重新发送到指定 Topic，请确认目标 Topic 正确。',
+    en: '⚠️ Resend will re-deliver the dead letter messages to the specified Topic. Make sure the target Topic is correct.',
+  },
+  'dlq.sourceGroup': { zh: '源 Group', en: 'Source Group' },
+  'dlq.messages': { zh: '{count} 条', en: '{count} messages' },
+  'dlq.retryRange': { zh: '重投时间范围', en: 'Resend Time Range' },
+  'dlq.targetTopic': { zh: '目标 Topic', en: 'Target Topic' },
+  'dlq.targetTopicPlaceholder': { zh: '输入目标 Topic 名称', en: 'Enter the target Topic name' },
+  'dlq.detailTitle': { zh: 'DLQ 消息明细 · {group}', en: 'DLQ Message Details · {group}' },
+  'dlq.detailTitleShort': { zh: 'DLQ 消息明细', en: 'DLQ Message Details' },
+  'dlq.exportSelected': { zh: '导出选中 ({count})', en: 'Export Selected ({count})' },
+  'dlq.exportAll': { zh: '导出全部', en: 'Export All' },
+  'dlq.detailRangeNotice': {
+    zh: '明细按「导出时间范围」查询（{from} ~ {to}）。勾选后可单条或批量重发、导出 Excel。',
+    en: 'Details are queried by the export time range ({from} ~ {to}). Select rows to resend individually or in batch, or export to Excel.',
+  },
+  'dlq.messagesTotal': { zh: '共 {count} 条消息', en: '{count} messages total' },
+  'dlq.batchResend': { zh: '批量重发选中 ({count})', en: 'Batch Resend Selected ({count})' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -52,8 +52,6 @@ import { tableScrollX } from '../../utils/table';
 
 const { Text } = Typography;
 const { RangePicker } = DatePicker;
-const DEFAULT_LOAD_ERROR = '死信队列加载失败，请稍后重试';
-const DEFAULT_RETRY_ERROR = '提交重投任务失败，请稍后重试';
 
 /* ─── Helpers ─── */
 
@@ -207,11 +205,11 @@ const DLQPage = () => {
       })
       .catch((error) => {
         if (groupRequestIdRef.current === requestId) {
-          setLoadError(getErrorMessage(error, DEFAULT_LOAD_ERROR));
+          setLoadError(getErrorMessage(error, t('dlq.loadFailed')));
           setLoading(false);
         }
       });
-  }, [refreshKey, selectedInstanceId, search, page, pageSize]);
+  }, [refreshKey, selectedInstanceId, search, page, pageSize, t]);
 
   useEffect(
     () => () => {
@@ -242,7 +240,7 @@ const DLQPage = () => {
 
   const handleRetry = async () => {
     if (!retryTargetTopic) {
-      message.warning('请输入目标 Topic');
+      message.warning(t('dlq.enterTargetTopic'));
       return;
     }
     if (!retryGroup || !selectedInstanceId) return;
@@ -267,19 +265,33 @@ const DLQPage = () => {
       setRefreshKey((key) => key + 1);
       if (result.scanIncomplete) {
         message.warning(
-          `重投扫描不完整：${result.failedQueueCount ?? 0} 个队列无法扫描，已重投 ${result.resent} 条`,
+          t('dlq.rescanIncomplete', {
+            count: String(result.failedQueueCount ?? 0),
+            resent: String(result.resent),
+          }),
         );
       } else if (result.failed > 0) {
-        message.warning(`重投部分完成：成功 ${result.resent}，失败 ${result.failed}`);
+        message.warning(
+          t('dlq.retryPartial', {
+            succeeded: String(result.resent),
+            failed: String(result.failed),
+          }),
+        );
       } else {
-        message.success(`重投完成：${groupName} → ${targetTopic}（${result.resent} 条）`);
+        message.success(
+          t('dlq.retryComplete', {
+            group: groupName,
+            topic: targetTopic,
+            count: String(result.resent),
+          }),
+        );
       }
       setRetryModalOpen(false);
       setRetryGroup(null);
       setRetryError(null);
     } catch (error) {
       if (retryRequestIdRef.current === requestId) {
-        setRetryError(getErrorMessage(error, DEFAULT_RETRY_ERROR));
+        setRetryError(getErrorMessage(error, t('dlq.retrySubmitFailed')));
       }
     } finally {
       resendInFlightRef.current = false;
@@ -300,13 +312,16 @@ const DLQPage = () => {
       downloadBlob(blob, `${group.groupName}-dlq-messages.xlsx`);
       if (meta.truncated || meta.failedQueueCount > 0) {
         message.warning(
-          `导出可能不完整：${meta.failedQueueCount} 个队列无法扫描，导出上限 ${meta.limit} 条`,
+          t('dlq.exportIncomplete', {
+            count: String(meta.failedQueueCount),
+            limit: String(meta.limit),
+          }),
         );
       } else {
-        message.success(`已导出 ${group.groupName} 的死信消息（${blob.size} 字节）`);
+        message.success(t('dlq.exportDone', { group: group.groupName, bytes: String(blob.size) }));
       }
     } catch (error) {
-      message.error(getErrorMessage(error, '导出死信消息失败，请稍后重试'));
+      message.error(getErrorMessage(error, t('dlq.exportFailed')));
     }
   };
 
@@ -346,7 +361,7 @@ const DLQPage = () => {
       setDetailPage(page);
     } catch (error) {
       if (detailRequestIdRef.current === requestId) {
-        setDetailError(getErrorMessage(error, '死信消息明细加载失败，请稍后重试'));
+        setDetailError(getErrorMessage(error, t('dlq.detailLoadFailed')));
       }
     } finally {
       if (detailRequestIdRef.current === requestId) {
@@ -368,16 +383,26 @@ const DLQPage = () => {
         msgIds,
       });
       if (result.outcome === 'FAILED' && result.failed > 0) {
-        message.error(`重发失败：成功 ${result.resent}，失败 ${result.failed}`);
+        message.error(
+          t('dlq.resendFailedToast', {
+            succeeded: String(result.resent),
+            failed: String(result.failed),
+          }),
+        );
       } else if (result.resent > 0 && result.failed > 0) {
-        message.warning(`重发部分完成：成功 ${result.resent}，失败 ${result.failed}`);
+        message.warning(
+          t('dlq.resendPartial', {
+            succeeded: String(result.resent),
+            failed: String(result.failed),
+          }),
+        );
       } else {
-        message.success(`重发完成：成功 ${result.resent} 条`);
+        message.success(t('dlq.resendComplete', { count: String(result.resent) }));
       }
       setDetailSelectedMsgIds([]);
       await loadDetailMessages(detailGroup, detailPage, detailPageSize);
     } catch (error) {
-      setDetailError(getErrorMessage(error, '重发死信消息失败，请稍后重试'));
+      setDetailError(getErrorMessage(error, t('dlq.resendFailed')));
     } finally {
       resendInFlightRef.current = false;
       setDetailResending(false);
@@ -397,22 +422,30 @@ const DLQPage = () => {
       downloadBlob(blob, `${detailGroup.groupName}-dlq-messages.xlsx`);
       if (meta.truncated || meta.failedQueueCount > 0) {
         message.warning(
-          `导出可能不完整：${meta.failedQueueCount} 个队列无法扫描，导出上限 ${meta.limit} 条`,
+          t('dlq.exportIncomplete', {
+            count: String(meta.failedQueueCount),
+            limit: String(meta.limit),
+          }),
+        );
+      } else if (detailSelectedMsgIds.length > 0) {
+        message.success(
+          t('dlq.exportSelectedDone', {
+            count: String(detailSelectedMsgIds.length),
+            bytes: String(blob.size),
+          }),
         );
       } else {
-        message.success(
-          `已导出 ${detailSelectedMsgIds.length > 0 ? `选中的 ${detailSelectedMsgIds.length} 条` : '全部'}死信消息（${blob.size} 字节）`,
-        );
+        message.success(t('dlq.exportAllDone', { bytes: String(blob.size) }));
       }
     } catch (error) {
-      message.error(getErrorMessage(error, '导出死信消息失败，请稍后重试'));
+      message.error(getErrorMessage(error, t('dlq.exportFailed')));
     }
   };
 
   /* ─── Table Columns ─── */
   const columns: ColumnsType<DLQGroup> = [
     {
-      title: 'Group 名称',
+      title: t('dlq.groupName'),
       dataIndex: 'groupName',
       key: 'groupName',
       width: 200,
@@ -433,7 +466,7 @@ const DLQPage = () => {
       ),
     },
     {
-      title: '死信数量',
+      title: t('dlq.deadCount'),
       dataIndex: 'messageCount',
       key: 'messageCount',
       width: 100,
@@ -454,12 +487,12 @@ const DLQPage = () => {
                     : undefined,
           }}
         >
-          {record.statsAvailable === false ? '不可用' : count.toLocaleString()}
+          {record.statsAvailable === false ? t('dlq.unavailable') : count.toLocaleString()}
         </Text>
       ),
     },
     {
-      title: '最近入队时间',
+      title: t('dlq.lastEnqueue'),
       dataIndex: 'lastEnqueueTime',
       key: 'lastEnqueueTime',
       width: 180,
@@ -471,7 +504,7 @@ const DLQPage = () => {
       ),
     },
     {
-      title: '操作',
+      title: t('common.actions'),
       key: 'actions',
       width: 280,
       render: (_: unknown, record: DLQGroup) => (
@@ -482,7 +515,7 @@ const DLQPage = () => {
             style={{ borderColor: '#1677ff', color: '#1677ff' }}
             onClick={() => openDetailDrawer(record)}
           >
-            消息明细
+            {t('dlq.messageDetails')}
           </Button>
           <Button
             size="small"
@@ -491,7 +524,7 @@ const DLQPage = () => {
             onClick={() => openRetryModal(record)}
             disabled={record.statsAvailable === false || record.messageCount === 0}
           >
-            重投消息
+            {t('dlq.resendMessages')}
           </Button>
           <Button
             size="small"
@@ -500,7 +533,7 @@ const DLQPage = () => {
             onClick={() => handleExport(record)}
             disabled={record.statsAvailable === false || record.messageCount === 0}
           >
-            导出
+            {t('dlq.export')}
           </Button>
         </Flex>
       ),
@@ -536,7 +569,7 @@ const DLQPage = () => {
       render: (offset: number) => <Text style={{ fontFamily: 'monospace' }}>{offset}</Text>,
     },
     {
-      title: '入队时间',
+      title: t('dlq.enqueueTime'),
       dataIndex: 'storeTime',
       key: 'storeTime',
       width: 160,
@@ -565,7 +598,7 @@ const DLQPage = () => {
       ),
     },
     {
-      title: '操作',
+      title: t('common.actions'),
       key: 'actions',
       width: 100,
       render: (_: unknown, record: DLQMessage) => (
@@ -575,7 +608,7 @@ const DLQPage = () => {
           loading={detailResending}
           onClick={() => void resendSelectedMessages([record.msgId])}
         >
-          重发
+          {t('dlq.resend')}
         </Button>
       ),
     },
@@ -586,7 +619,7 @@ const DLQPage = () => {
      ═══════════════════════════════════════════ */
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader title={t('dlq.title')} subtitle="管理消费失败进入死信队列的消息" />
+      <PageHeader title={t('dlq.title')} subtitle={t('dlq.subtitle')} />
 
       {/* ── Filter Bar ── */}
       <Flex justify="space-between" align="center" style={{ marginBottom: 16 }}>
@@ -598,7 +631,7 @@ const DLQPage = () => {
             style={{ width: 220 }}
           />
           <Input.Search
-            placeholder="搜索 Group 名称或 DLQ Topic"
+            placeholder={t('dlq.searchPlaceholder')}
             allowClear
             value={search}
             onChange={(e) => {
@@ -614,7 +647,7 @@ const DLQPage = () => {
           />
           <Space size={8}>
             <Text type="secondary" style={{ fontSize: 14 }}>
-              导出时间范围
+              {t('dlq.exportRange')}
             </Text>
             <RangePicker
               showTime
@@ -664,7 +697,7 @@ const DLQPage = () => {
             total,
             showSizeChanger: true,
             pageSizeOptions: [20, 50, 100],
-            showTotal: (totalCount) => `共 ${totalCount} 个 Group`,
+            showTotal: (totalCount) => t('dlq.groupsTotal', { count: String(totalCount) }),
             onChange: (nextPage, nextPageSize) => {
               setPage(nextPage);
               setPageSize(nextPageSize);
@@ -683,7 +716,7 @@ const DLQPage = () => {
         title={
           <Space>
             <ArrowsCounterClockwise size={18} color="#fa8c16" />
-            <span>重投死信消息</span>
+            <span>{t('dlq.retryTitle')}</span>
           </Space>
         }
         open={retryModalOpen}
@@ -694,8 +727,8 @@ const DLQPage = () => {
         }}
         onOk={handleRetry}
         confirmLoading={retrySubmitting}
-        okText="确认重投"
-        cancelText="取消"
+        okText={t('dlq.confirmRetry')}
+        cancelText={t('common.cancel')}
         width={520}
         destroyOnHidden
       >
@@ -715,13 +748,13 @@ const DLQPage = () => {
               }}
             >
               <Text type="warning" style={{ fontSize: 14 }}>
-                ⚠️ 重投操作将把死信消息重新发送到指定 Topic，请确认目标 Topic 正确。
+                {t('dlq.retryNotice')}
               </Text>
             </div>
 
             <div style={{ marginBottom: 16 }}>
               <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
-                源 Group
+                {t('dlq.sourceGroup')}
               </Text>
               <Text strong style={{ fontSize: 14 }}>
                 {retryGroup.groupName}
@@ -730,16 +763,16 @@ const DLQPage = () => {
 
             <div style={{ marginBottom: 16 }}>
               <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 4 }}>
-                死信数量
+                {t('dlq.deadCount')}
               </Text>
               <Text strong style={{ fontSize: 14, color: '#fa8c16' }}>
-                {retryGroup.messageCount.toLocaleString()} 条
+                {t('dlq.messages', { count: retryGroup.messageCount.toLocaleString() })}
               </Text>
             </div>
 
             <div style={{ marginBottom: 16 }}>
               <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 8 }}>
-                重投时间范围
+                {t('dlq.retryRange')}
               </Text>
               <RangePicker
                 showTime
@@ -756,10 +789,10 @@ const DLQPage = () => {
 
             <div>
               <Text type="secondary" style={{ fontSize: 14, display: 'block', marginBottom: 8 }}>
-                目标 Topic
+                {t('dlq.targetTopic')}
               </Text>
               <Input
-                placeholder="输入目标 Topic 名称"
+                placeholder={t('dlq.targetTopicPlaceholder')}
                 value={retryTargetTopic}
                 onChange={(e) => setRetryTargetTopic(e.target.value)}
               />
@@ -772,7 +805,11 @@ const DLQPage = () => {
          Message Detail Drawer
          ═══════════════════════════════════════════ */}
       <Drawer
-        title={detailGroup ? `DLQ 消息明细 · ${detailGroup.groupName}` : 'DLQ 消息明细'}
+        title={
+          detailGroup
+            ? t('dlq.detailTitle', { group: detailGroup.groupName })
+            : t('dlq.detailTitleShort')
+        }
         width={1080}
         open={detailOpen}
         onClose={() => {
@@ -811,14 +848,14 @@ const DLQPage = () => {
                     type="secondary"
                     style={{ fontSize: 14, display: 'block', marginBottom: 4 }}
                   >
-                    死信数量
+                    {t('dlq.deadCount')}
                   </Text>
                   <Text
                     strong
                     style={{ color: detailGroup.messageCount > 0 ? '#fa8c16' : undefined }}
                   >
                     {detailGroup.statsAvailable === false
-                      ? '不可用'
+                      ? t('dlq.unavailable')
                       : detailGroup.messageCount.toLocaleString()}
                   </Text>
                 </div>
@@ -827,7 +864,7 @@ const DLQPage = () => {
                     type="secondary"
                     style={{ fontSize: 14, display: 'block', marginBottom: 4 }}
                   >
-                    最近入队时间
+                    {t('dlq.lastEnqueue')}
                   </Text>
                   <Text style={{ fontFamily: 'monospace' }}>
                     {formatDateTime(detailGroup.lastEnqueueTime)}
@@ -840,13 +877,16 @@ const DLQPage = () => {
                 onClick={() => void exportDetailExcel()}
               >
                 {detailSelectedMsgIds.length > 0
-                  ? `导出选中 (${detailSelectedMsgIds.length})`
-                  : '导出全部'}
+                  ? t('dlq.exportSelected', { count: String(detailSelectedMsgIds.length) })
+                  : t('dlq.exportAll')}
               </Button>
             </Flex>
 
             <InfoBanner
-              description={`明细按「导出时间范围」查询（${exportRange[0].format('YYYY-MM-DD HH:mm:ss')} ~ ${exportRange[1].format('YYYY-MM-DD HH:mm:ss')}）。勾选后可单条或批量重发、导出 Excel。`}
+              description={t('dlq.detailRangeNotice', {
+                from: exportRange[0].format('YYYY-MM-DD HH:mm:ss'),
+                to: exportRange[1].format('YYYY-MM-DD HH:mm:ss'),
+              })}
             />
 
             {detailError && (
@@ -868,7 +908,7 @@ const DLQPage = () => {
                 total: detailTotal,
                 showSizeChanger: true,
                 pageSizeOptions: [10, 20, 50],
-                showTotal: (totalCount) => `共 ${totalCount} 条消息`,
+                showTotal: (totalCount) => t('dlq.messagesTotal', { count: String(totalCount) }),
                 onChange: (nextPage, nextPageSize) => {
                   setDetailPage(nextPage);
                   setDetailPageSize(nextPageSize);
@@ -890,7 +930,7 @@ const DLQPage = () => {
                   loading={detailResending}
                   onClick={() => void resendSelectedMessages(detailSelectedMsgIds)}
                 >
-                  批量重发选中 ({detailSelectedMsgIds.length})
+                  {t('dlq.batchResend', { count: String(detailSelectedMsgIds.length) })}
                 </Button>
               </Flex>
             )}


### PR DESCRIPTION
## Summary

The DLQ page (instance/dlq.tsx) only localized its page header; every other visible string was hard-coded zh, so the page stayed Chinese in English mode. This PR completes the page localization:

- Routes all visible copy through translation keys - table headers, action buttons (消息明细 / 重投消息 / 导出 / 重发), the filter bar, pagination totals, the retry modal (title, notice, labels, confirm), the message detail drawer (title, summary labels, export actions, range notice) and every toast / error fallback.
- Toasts and confirmations use parameterized keys (`dlq.rescanIncomplete`, `dlq.exportIncomplete`, `dlq.detailTitle`, `dlq.batchResend`, ...) so numbers, group names and topics interpolate in the active language.
- The module-level zh error constants were removed; each error path now passes its own localized fallback (`dlq.loadFailed`, `dlq.exportFailed`, ...).
- Reuses existing `common.actions`, `common.cancel` and `message.batchExport` keys.

## Why

The DLQ management flow is one of the most action-heavy Studio surfaces (scan/retry/export with many result states); leaving its feedback text in zh made en-mode operation confusing.

## Testing

- `tsc --noEmit` passes
- `eslint` - 0 errors (1 pre-existing fast-refresh warning on the exported `formatDateTime` helper)
- `vitest run DLQPage` - 18/18 tests pass