### PR TITLE
feat: add Message Explorer result analytics

### DIFF
--- a/web/src/components/MessageResultInsightsDrawer.tsx
+++ b/web/src/components/MessageResultInsightsDrawer.tsx
@@ -1,0 +1,243 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. */
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Drawer,
+  Flex,
+  Input,
+  Progress,
+  Row,
+  Select,
+  Space,
+  Statistic,
+  Table,
+  Tabs,
+  Tag,
+  Typography,
+} from 'antd';
+import { DownloadOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import type { MessageRecord } from '../api/message';
+import { buildCsv, downloadCsv } from '../utils/download';
+import {
+  buildMessageResultInsights,
+  filterMessageDimensionRows,
+  type MessageDimensionRow,
+} from '../utils/messageResultInsights';
+
+interface Props {
+  open: boolean;
+  messages: MessageRecord[];
+  serverTotal: number;
+  truncated: boolean;
+  onClose: () => void;
+}
+const formatBytes = (bytes: number) =>
+  bytes >= 1024 * 1024
+    ? `${(bytes / 1024 / 1024).toFixed(2)} MiB`
+    : bytes >= 1024
+      ? `${(bytes / 1024).toFixed(2)} KiB`
+      : `${bytes} B`;
+const dimensionLabel: Record<MessageDimensionRow['dimension'], string> = {
+  TAG: 'Tag',
+  BROKER: 'Broker',
+  QUEUE: 'Broker / Queue',
+  BORN_HOST: '生产主机',
+  STORE_HOST: '存储主机',
+  HOUR: '小时',
+};
+
+export const MessageResultInsightsDrawer = ({
+  open,
+  messages,
+  serverTotal,
+  truncated,
+  onClose,
+}: Props) => {
+  const [dimension, setDimension] = useState<MessageDimensionRow['dimension']>();
+  const [search, setSearch] = useState('');
+  const insights = useMemo(
+    () => buildMessageResultInsights(messages, serverTotal),
+    [messages, serverTotal],
+  );
+  const rows = useMemo(
+    () => filterMessageDimensionRows(insights.dimensions, dimension, search),
+    [dimension, insights.dimensions, search],
+  );
+  const columns: ColumnsType<MessageDimensionRow> = [
+    {
+      title: '维度',
+      dataIndex: 'dimension',
+      key: 'dimension',
+      width: 130,
+      render: (value: MessageDimensionRow['dimension']) => <Tag>{dimensionLabel[value]}</Tag>,
+    },
+    { title: '值', dataIndex: 'value', key: 'value' },
+    {
+      title: '消息数',
+      dataIndex: 'count',
+      key: 'count',
+      width: 100,
+      sorter: (a, b) => a.count - b.count,
+    },
+    {
+      title: '占比',
+      dataIndex: 'percent',
+      key: 'percent',
+      width: 180,
+      render: (value: number) => <Progress percent={value} size="small" />,
+    },
+    { title: '消息体积', dataIndex: 'bytes', key: 'bytes', width: 130, render: formatBytes },
+  ];
+  const exportRows = () =>
+    downloadCsv(
+      `rocketmq-message-result-insights-${new Date().toISOString().slice(0, 10)}.csv`,
+      buildCsv(
+        [
+          { header: 'Dimension', value: (row) => row.dimension },
+          { header: 'Value', value: (row) => row.value },
+          { header: 'Count', value: (row) => row.count },
+          { header: 'Percent', value: (row) => row.percent },
+          { header: 'Bytes', value: (row) => row.bytes },
+        ],
+        rows,
+      ),
+    );
+  const cards = [
+    ['当前页消息', insights.summary.loadedMessages],
+    ['服务端总数', insights.summary.serverTotal],
+    ['Broker 数', insights.summary.uniqueBrokers],
+    ['队列数', insights.summary.uniqueQueues],
+  ] as const;
+  return (
+    <Drawer
+      title="消息查询结果分析"
+      open={open}
+      onClose={onClose}
+      width={1000}
+      destroyOnHidden
+      extra={
+        <Button icon={<DownloadOutlined />} disabled={!rows.length} onClick={exportRows}>
+          导出维度数据
+        </Button>
+      }
+    >
+      <Alert
+        type={truncated || messages.length < serverTotal ? 'warning' : 'info'}
+        showIcon
+        message={
+          truncated
+            ? '服务端扫描结果可能被截断'
+            : messages.length < serverTotal
+              ? '分析范围仅包含当前加载页'
+              : '分析覆盖全部返回结果'
+        }
+        description={`已加载 ${messages.length} / ${serverTotal} 条；统计不会额外请求或推断未加载消息。`}
+        style={{ marginBottom: 16 }}
+      />
+      <Row gutter={[12, 12]} style={{ marginBottom: 16 }}>
+        {cards.map(([title, value]) => (
+          <Col xs={12} lg={6} key={title}>
+            <Card size="small">
+              <Statistic title={title} value={value} />
+            </Card>
+          </Col>
+        ))}
+      </Row>
+      <Tabs
+        items={[
+          {
+            key: 'distribution',
+            label: '维度分布',
+            children: (
+              <>
+                <Flex gap={12} wrap style={{ marginBottom: 16 }}>
+                  <Select
+                    allowClear
+                    value={dimension}
+                    onChange={setDimension}
+                    placeholder="全部维度"
+                    style={{ width: 180 }}
+                    options={Object.entries(dimensionLabel).map(([value, label]) => ({
+                      value,
+                      label,
+                    }))}
+                  />
+                  <Input.Search
+                    allowClear
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder="搜索维度值"
+                    style={{ width: 260 }}
+                  />
+                  <Typography.Text type="secondary">{rows.length} 个分组</Typography.Text>
+                </Flex>
+                <Table
+                  rowKey={(row) => `${row.dimension}-${row.value}`}
+                  size="small"
+                  columns={columns}
+                  dataSource={rows}
+                  pagination={{ pageSize: 20, showSizeChanger: true }}
+                />
+              </>
+            ),
+          },
+          {
+            key: 'size',
+            label: '消息大小',
+            children: (
+              <Space direction="vertical" size={12} style={{ width: '100%' }}>
+                <Flex gap={24} wrap>
+                  <Statistic title="总体积" value={formatBytes(insights.summary.totalBytes)} />
+                  <Statistic title="平均大小" value={formatBytes(insights.summary.averageBytes)} />
+                  <Statistic title="最大消息" value={formatBytes(insights.summary.largestBytes)} />
+                </Flex>
+                {insights.sizeBuckets.map((bucket) => (
+                  <Card size="small" key={bucket.bucket}>
+                    <Flex justify="space-between" align="center">
+                      <Typography.Text>{bucket.bucket}</Typography.Text>
+                      <Space>
+                        <Typography.Text>
+                          {bucket.count} 条 / {formatBytes(bucket.bytes)}
+                        </Typography.Text>
+                        <Progress percent={bucket.percent} size="small" style={{ width: 180 }} />
+                      </Space>
+                    </Flex>
+                  </Card>
+                ))}
+              </Space>
+            ),
+          },
+          {
+            key: 'quality',
+            label: '元数据完整性',
+            children: (
+              <Row gutter={[12, 12]}>
+                {[
+                  ['缺少 Key', insights.summary.missingKeys],
+                  ['缺少 Tag', insights.summary.missingTags],
+                  ['缺少路由', insights.summary.missingRoutes],
+                  ['无效时间', insights.summary.invalidTimestamps],
+                ].map(([title, value]) => (
+                  <Col xs={12} md={6} key={String(title)}>
+                    <Card size="small">
+                      <Statistic
+                        title={title}
+                        value={value}
+                        valueStyle={{ color: value ? '#d46b08' : undefined }}
+                      />
+                    </Card>
+                  </Col>
+                ))}
+              </Row>
+            ),
+          },
+        ]}
+      />
+    </Drawer>
+  );
+};
+export default MessageResultInsightsDrawer;

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -46,6 +46,7 @@ import {
   CheckCircleOutlined,
   DownloadOutlined,
   HistoryOutlined,
+  BarChartOutlined,
 } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import dayjs from 'dayjs';
@@ -81,6 +82,7 @@ import {
   type MessageTraceDiagnostics,
   type TraceDiagnosticStatus,
 } from '../../utils/messageTraceDiagnostics';
+import MessageResultInsightsDrawer from '../../components/MessageResultInsightsDrawer';
 
 const { Paragraph, Text } = Typography;
 const { RangePicker } = DatePicker;
@@ -405,6 +407,7 @@ const MessagePageContent = ({
     readMessageTraceTopic(selectedInstanceId),
   );
   const [historyDrawerOpen, setHistoryDrawerOpen] = useState(false);
+  const [insightsDrawerOpen, setInsightsDrawerOpen] = useState(false);
   const [directConsumeOpen, setDirectConsumeOpen] = useState(false);
   const [directConsumeGroup, setDirectConsumeGroup] = useState('');
   const [directConsumeClientId, setDirectConsumeClientId] = useState('');
@@ -1145,6 +1148,13 @@ const MessagePageContent = ({
               <Button icon={<HistoryOutlined />} onClick={() => setHistoryDrawerOpen(true)}>
                 服务端历史
               </Button>
+              <Button
+                icon={<BarChartOutlined />}
+                disabled={messages.length === 0}
+                onClick={() => setInsightsDrawerOpen(true)}
+              >
+                结果分析
+              </Button>
             </Space>
           )}
 
@@ -1181,6 +1191,13 @@ const MessagePageContent = ({
         onClose={() => setHistoryDrawerOpen(false)}
         onSelectMessage={replayHistoryRecord}
         onSelectTrace={replayTraceRecord}
+      />
+      <MessageResultInsightsDrawer
+        open={insightsDrawerOpen}
+        messages={messages}
+        serverTotal={messageTotal}
+        truncated={resultMayBeTruncated}
+        onClose={() => setInsightsDrawerOpen(false)}
       />
 
       {queryError && (

--- a/web/src/utils/messageResultInsights.test.ts
+++ b/web/src/utils/messageResultInsights.test.ts
@@ -1,0 +1,124 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. */
+import { describe, expect, it } from 'vitest';
+import type { MessageRecord } from '../api/message';
+import { buildMessageResultInsights, filterMessageDimensionRows } from './messageResultInsights';
+
+const message = (overrides: Partial<MessageRecord> = {}): MessageRecord => ({
+  msgId: 'msg-1',
+  topic: 'orders',
+  tag: 'created',
+  key: 'order-1',
+  brokerName: 'broker-a',
+  queueId: 0,
+  queueOffset: 10,
+  body: '{}',
+  storeTime: '2026-09-05T01:15:00Z',
+  bornHost: 'producer-a:8080',
+  storeHost: 'broker-a:10911',
+  properties: {},
+  size: 512,
+  ...overrides,
+});
+
+describe('message result insights', () => {
+  it('summarizes loaded and server result coverage', () => {
+    const result = buildMessageResultInsights([message(), message({ msgId: 'msg-2' })], 10);
+    expect(result.summary).toMatchObject({ loadedMessages: 2, serverTotal: 10, loadedPercent: 20 });
+  });
+
+  it('groups tags with deterministic percentages and bytes', () => {
+    const result = buildMessageResultInsights([
+      message({ msgId: '1', tag: 'created', size: 512 }),
+      message({ msgId: '2', tag: 'created', size: 1024 }),
+      message({ msgId: '3', tag: 'paid', size: 2048 }),
+    ]);
+    expect(result.dimensions.filter((row) => row.dimension === 'TAG')).toEqual([
+      { dimension: 'TAG', value: 'created', count: 2, percent: 66.67, bytes: 1536 },
+      { dimension: 'TAG', value: 'paid', count: 1, percent: 33.33, bytes: 2048 },
+    ]);
+  });
+
+  it('builds Broker and queue dimensions independently', () => {
+    const result = buildMessageResultInsights([
+      message(),
+      message({ msgId: '2', queueId: 1 }),
+      message({ msgId: '3', brokerName: 'broker-b', queueId: 0 }),
+    ]);
+    expect(result.summary).toMatchObject({ uniqueBrokers: 2, uniqueQueues: 3 });
+    expect(result.dimensions.filter((row) => row.dimension === 'BROKER')).toHaveLength(2);
+    expect(result.dimensions.filter((row) => row.dimension === 'QUEUE')).toHaveLength(3);
+  });
+
+  it('groups valid timestamps by UTC hour and reports the time span', () => {
+    const result = buildMessageResultInsights([
+      message({ storeTime: '2026-09-05T01:15:00Z' }),
+      message({ msgId: '2', storeTime: '2026-09-05T01:55:00Z' }),
+      message({ msgId: '3', storeTime: '2026-09-05T03:00:00Z' }),
+    ]);
+    expect(result.dimensions.filter((row) => row.dimension === 'HOUR')[0]).toMatchObject({
+      value: '2026-09-05T01:00Z',
+      count: 2,
+    });
+    expect(result.summary.firstStoreTime).toBe(Date.parse('2026-09-05T01:15:00Z'));
+    expect(result.summary.lastStoreTime).toBe(Date.parse('2026-09-05T03:00:00Z'));
+  });
+
+  it('classifies message sizes into ordered buckets', () => {
+    const result = buildMessageResultInsights([
+      message({ size: 100 }),
+      message({ msgId: '2', size: 1024 }),
+      message({ msgId: '3', size: 20 * 1024 }),
+      message({ msgId: '4', size: 200 * 1024 }),
+      message({ msgId: '5', size: 2 * 1024 * 1024 }),
+    ]);
+    expect(result.sizeBuckets.map((bucket) => bucket.count)).toEqual([1, 1, 1, 1, 1]);
+    expect(result.summary.largestBytes).toBe(2 * 1024 * 1024);
+  });
+
+  it('does not let non-finite or negative sizes corrupt totals', () => {
+    const result = buildMessageResultInsights([
+      message({ size: Number.NaN }),
+      message({ msgId: '2', size: -1 }),
+    ]);
+    expect(result.summary).toMatchObject({ totalBytes: 0, averageBytes: 0, largestBytes: 0 });
+  });
+
+  it('counts missing routing and optional metadata', () => {
+    const result = buildMessageResultInsights([
+      message({ key: null, tag: null, brokerName: null, queueId: null }),
+    ]);
+    expect(result.summary).toMatchObject({ missingKeys: 1, missingTags: 1, missingRoutes: 1 });
+    expect(result.dimensions.find((row) => row.dimension === 'QUEUE')).toMatchObject({
+      value: '(missing)',
+    });
+  });
+
+  it('counts invalid timestamps without inventing a range', () => {
+    const result = buildMessageResultInsights([message({ storeTime: 'not-a-time' })]);
+    expect(result.summary).toMatchObject({
+      invalidTimestamps: 1,
+      firstStoreTime: null,
+      lastStoreTime: null,
+    });
+  });
+
+  it('filters dimensions and values case-insensitively', () => {
+    const result = buildMessageResultInsights([message({ brokerName: 'Broker-PROD' })]);
+    expect(filterMessageDimensionRows(result.dimensions, 'BROKER')).toHaveLength(1);
+    expect(filterMessageDimensionRows(result.dimensions, undefined, 'broker-prod')).toHaveLength(2);
+    expect(filterMessageDimensionRows(result.dimensions, 'TAG', 'missing')).toHaveLength(0);
+  });
+
+  it('returns stable zero-valued insight data for no results', () => {
+    const result = buildMessageResultInsights([], 0);
+    expect(result.summary).toMatchObject({
+      loadedMessages: 0,
+      serverTotal: 0,
+      loadedPercent: 0,
+      totalBytes: 0,
+      firstStoreTime: null,
+      lastStoreTime: null,
+    });
+    expect(result.sizeBuckets).toHaveLength(5);
+  });
+});

--- a/web/src/utils/messageResultInsights.ts
+++ b/web/src/utils/messageResultInsights.ts
@@ -1,0 +1,152 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. */
+import type { MessageRecord } from '../api/message';
+
+export interface MessageDimensionRow {
+  dimension: 'TAG' | 'BROKER' | 'QUEUE' | 'BORN_HOST' | 'STORE_HOST' | 'HOUR';
+  value: string;
+  count: number;
+  percent: number;
+  bytes: number;
+}
+export interface MessageResultInsights {
+  dimensions: MessageDimensionRow[];
+  summary: {
+    loadedMessages: number;
+    serverTotal: number;
+    loadedPercent: number;
+    totalBytes: number;
+    averageBytes: number;
+    largestBytes: number;
+    uniqueTags: number;
+    uniqueBrokers: number;
+    uniqueQueues: number;
+    firstStoreTime: number | null;
+    lastStoreTime: number | null;
+    invalidTimestamps: number;
+    missingKeys: number;
+    missingTags: number;
+    missingRoutes: number;
+  };
+  sizeBuckets: Array<{ bucket: string; count: number; percent: number; bytes: number }>;
+}
+
+const timestamp = (value: number | string) => {
+  const parsed = typeof value === 'number' ? value : Date.parse(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+};
+const safeSize = (value: number) => (Number.isFinite(value) && value > 0 ? value : 0);
+const percent = (count: number, total: number) =>
+  total ? Number(((count * 100) / total).toFixed(2)) : 0;
+
+const dimensionRows = (
+  messages: MessageRecord[],
+  dimension: MessageDimensionRow['dimension'],
+  valueOf: (message: MessageRecord) => string,
+) => {
+  const groups = new Map<string, { count: number; bytes: number }>();
+  messages.forEach((message) => {
+    const value = valueOf(message) || '(missing)';
+    const current = groups.get(value) ?? { count: 0, bytes: 0 };
+    current.count += 1;
+    current.bytes += safeSize(message.size);
+    groups.set(value, current);
+  });
+  return [...groups.entries()]
+    .map<MessageDimensionRow>(([value, group]) => ({
+      dimension,
+      value,
+      count: group.count,
+      percent: percent(group.count, messages.length),
+      bytes: group.bytes,
+    }))
+    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
+};
+
+export const buildMessageResultInsights = (
+  messages: MessageRecord[],
+  serverTotal = messages.length,
+): MessageResultInsights => {
+  const validTimes = messages
+    .map((message) => timestamp(message.storeTime))
+    .filter((value): value is number => value !== null);
+  const dimensions = [
+    ...dimensionRows(messages, 'TAG', (message) => message.tag ?? '(missing)'),
+    ...dimensionRows(messages, 'BROKER', (message) => message.brokerName ?? '(missing)'),
+    ...dimensionRows(messages, 'QUEUE', (message) =>
+      message.brokerName !== null && message.queueId !== null
+        ? `${message.brokerName} / ${message.queueId}`
+        : '(missing)',
+    ),
+    ...dimensionRows(messages, 'BORN_HOST', (message) => message.bornHost || '(missing)'),
+    ...dimensionRows(messages, 'STORE_HOST', (message) => message.storeHost || '(missing)'),
+    ...dimensionRows(messages, 'HOUR', (message) => {
+      const value = timestamp(message.storeTime);
+      if (value === null) return '(invalid)';
+      return new Date(value).toISOString().slice(0, 13) + ':00Z';
+    }),
+  ];
+  const bucketFor = (size: number) =>
+    size < 1024
+      ? '< 1 KiB'
+      : size < 16 * 1024
+        ? '1–16 KiB'
+        : size < 128 * 1024
+          ? '16–128 KiB'
+          : size < 1024 * 1024
+            ? '128 KiB–1 MiB'
+            : '>= 1 MiB';
+  const sizeGroups = new Map<string, { count: number; bytes: number }>();
+  messages.forEach((message) => {
+    const bytes = safeSize(message.size);
+    const bucket = bucketFor(bytes);
+    const current = sizeGroups.get(bucket) ?? { count: 0, bytes: 0 };
+    current.count += 1;
+    current.bytes += bytes;
+    sizeGroups.set(bucket, current);
+  });
+  const bucketOrder = ['< 1 KiB', '1–16 KiB', '16–128 KiB', '128 KiB–1 MiB', '>= 1 MiB'];
+  const totalBytes = messages.reduce((sum, message) => sum + safeSize(message.size), 0);
+  return {
+    dimensions,
+    summary: {
+      loadedMessages: messages.length,
+      serverTotal,
+      loadedPercent: percent(messages.length, Math.max(serverTotal, messages.length)),
+      totalBytes,
+      averageBytes: messages.length ? Math.round(totalBytes / messages.length) : 0,
+      largestBytes: Math.max(0, ...messages.map((message) => safeSize(message.size))),
+      uniqueTags: new Set(messages.map((message) => message.tag).filter(Boolean)).size,
+      uniqueBrokers: new Set(messages.map((message) => message.brokerName).filter(Boolean)).size,
+      uniqueQueues: new Set(
+        messages
+          .map((message) => `${message.brokerName}/${message.queueId}`)
+          .filter((value) => !value.includes('null')),
+      ).size,
+      firstStoreTime: validTimes.length ? Math.min(...validTimes) : null,
+      lastStoreTime: validTimes.length ? Math.max(...validTimes) : null,
+      invalidTimestamps: messages.length - validTimes.length,
+      missingKeys: messages.filter((message) => !message.key).length,
+      missingTags: messages.filter((message) => !message.tag).length,
+      missingRoutes: messages.filter(
+        (message) => message.brokerName === null || message.queueId === null,
+      ).length,
+    },
+    sizeBuckets: bucketOrder.map((bucket) => ({
+      bucket,
+      count: sizeGroups.get(bucket)?.count ?? 0,
+      percent: percent(sizeGroups.get(bucket)?.count ?? 0, messages.length),
+      bytes: sizeGroups.get(bucket)?.bytes ?? 0,
+    })),
+  };
+};
+
+export const filterMessageDimensionRows = (
+  rows: MessageDimensionRow[],
+  dimension?: MessageDimensionRow['dimension'],
+  search = '',
+) => {
+  const keyword = search.trim().toLocaleLowerCase();
+  return rows
+    .filter((row) => !dimension || row.dimension === dimension)
+    .filter((row) => !keyword || row.value.toLocaleLowerCase().includes(keyword));
+};


### PR DESCRIPTION
## Summary

- analyze the currently loaded Message Explorer results without issuing extra queries
- show Broker, queue, tag, producer/store host, and UTC-hour distributions
- summarize message size buckets and missing metadata
- disclose loaded/server coverage and server scan truncation explicitly
- add filtered dimension CSV export and deterministic analytics tests

## 原提交验证记录
- focused analytics and existing Message page suites: 19 tests passed
- `npm run lint` (0 errors; 10 pre-existing warnings)
- `npm run build` (8,040 modules transformed)
- scope audit: 536 additions across 4 files

Fixes #3200
