### PR TITLE
feat: add full DLQ backlog and aging analysis

### DIFF
--- a/web/src/components/DLQBacklogPortfolioDrawer.tsx
+++ b/web/src/components/DLQBacklogPortfolioDrawer.tsx
@@ -1,0 +1,299 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. */
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Drawer,
+  Flex,
+  Input,
+  Progress,
+  Row,
+  Select,
+  Space,
+  Statistic,
+  Table,
+  Tabs,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
+import { DownloadOutlined, ReloadOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { listDLQGroups } from '../services/messageService';
+import { buildCsv, downloadCsv } from '../utils/download';
+import {
+  buildDLQBacklogPortfolio,
+  filterDLQBacklogRows,
+  type DLQAgeBucket,
+  type DLQBacklogRow,
+} from '../utils/dlqBacklogPortfolio';
+
+interface Props {
+  open: boolean;
+  instanceId?: string;
+  onClose: () => void;
+}
+const PAGE_SIZE = 100;
+const MAX_PAGES = 100;
+const ageLabels: Record<DLQAgeBucket, string> = {
+  EMPTY: '无积压',
+  LAST_HOUR: '最近 1 小时',
+  TODAY: '1–24 小时',
+  THIS_WEEK: '1–7 天',
+  DORMANT: '超过 7 天',
+  UNKNOWN: '时间未知',
+  UNAVAILABLE: '统计不可用',
+};
+const loadAll = async (instanceId: string) => {
+  const result = [];
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const response = await listDLQGroups(instanceId, undefined, page, PAGE_SIZE);
+    result.push(...response.items);
+    if (result.length >= response.total || response.items.length < PAGE_SIZE) return result;
+  }
+  throw new Error('DLQ portfolio exceeded page limit');
+};
+
+export const DLQBacklogPortfolioDrawer = ({ open, instanceId, onClose }: Props) => {
+  const [groups, setGroups] = useState<Awaited<ReturnType<typeof loadAll>>>([]);
+  const [snapshotAt, setSnapshotAt] = useState<number>();
+  const [loading, setLoading] = useState(false);
+  const [search, setSearch] = useState('');
+  const [bucket, setBucket] = useState<DLQAgeBucket>();
+  const portfolio = useMemo(
+    () => buildDLQBacklogPortfolio(groups, snapshotAt),
+    [groups, snapshotAt],
+  );
+  const filtered = useMemo(
+    () => filterDLQBacklogRows(portfolio.rows, search, bucket),
+    [bucket, portfolio.rows, search],
+  );
+  const load = async () => {
+    if (!instanceId) return;
+    setLoading(true);
+    try {
+      const result = await loadAll(instanceId);
+      setGroups(result);
+      setSnapshotAt(Date.now());
+    } catch {
+      message.error('DLQ 全量积压分析加载失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+  const columns: ColumnsType<DLQBacklogRow> = [
+    {
+      title: 'Consumer Group',
+      dataIndex: 'groupName',
+      key: 'groupName',
+      fixed: 'left',
+      width: 220,
+    },
+    { title: 'DLQ Topic', dataIndex: 'dlqTopic', key: 'dlqTopic', width: 220 },
+    {
+      title: '消息数',
+      dataIndex: 'messageCount',
+      key: 'messageCount',
+      width: 110,
+      sorter: (a, b) => a.messageCount - b.messageCount,
+    },
+    {
+      title: '积压占比',
+      dataIndex: 'backlogShare',
+      key: 'backlogShare',
+      width: 180,
+      render: (value: number) => <Progress percent={value} size="small" />,
+    },
+    {
+      title: '最近入队年龄',
+      dataIndex: 'ageBucket',
+      key: 'ageBucket',
+      width: 140,
+      render: (value: DLQAgeBucket) => (
+        <Tag
+          color={
+            value === 'DORMANT'
+              ? 'orange'
+              : value === 'UNKNOWN' || value === 'UNAVAILABLE'
+                ? 'default'
+                : 'blue'
+          }
+        >
+          {ageLabels[value]}
+        </Tag>
+      ),
+    },
+    { title: '累计重试', dataIndex: 'retryCount', key: 'retryCount', width: 110 },
+    { title: '状态', dataIndex: 'status', key: 'status', width: 120 },
+  ];
+  const exportRows = () =>
+    downloadCsv(
+      `rocketmq-dlq-backlog-${new Date().toISOString().slice(0, 10)}.csv`,
+      buildCsv(
+        [
+          { header: 'Consumer Group', value: (row) => row.groupName },
+          { header: 'DLQ Topic', value: (row) => row.dlqTopic },
+          { header: 'Messages', value: (row) => row.messageCount },
+          { header: 'Backlog share', value: (row) => row.backlogShare },
+          { header: 'Age bucket', value: (row) => row.ageBucket },
+          { header: 'Last enqueue', value: (row) => row.lastEnqueueTime },
+          { header: 'Retry count', value: (row) => row.retryCount },
+          { header: 'Status', value: (row) => row.status },
+          { header: 'Stats available', value: (row) => row.statsAvailable !== false },
+        ],
+        filtered,
+      ),
+    );
+  const cards = [
+    ['消费组', portfolio.summary.groups],
+    ['积压消息', portfolio.summary.totalMessages],
+    ['有积压组', portfolio.summary.groupsWithBacklog],
+    ['超过 7 天', portfolio.summary.dormantGroups],
+  ] as const;
+  return (
+    <Drawer
+      title="DLQ 全量积压与老化分析"
+      open={open}
+      onClose={onClose}
+      width={1050}
+      destroyOnHidden
+      extra={
+        <Space>
+          <Button icon={<DownloadOutlined />} disabled={!filtered.length} onClick={exportRows}>
+            导出当前结果
+          </Button>
+          <Button
+            type="primary"
+            icon={<ReloadOutlined />}
+            loading={loading}
+            disabled={!instanceId}
+            onClick={load}
+          >
+            {snapshotAt ? '刷新快照' : '加载全量'}
+          </Button>
+        </Space>
+      }
+    >
+      <Alert
+        showIcon
+        type="info"
+        message="只读全量快照"
+        description={`按每页 ${PAGE_SIZE} 个消费组读取当前实例，最多 ${MAX_PAGES} 页；不读取消息正文，也不触发重投。${snapshotAt ? ` 快照时间：${new Date(snapshotAt).toLocaleString()}` : ''}`}
+        style={{ marginBottom: 16 }}
+      />
+      {!snapshotAt ? (
+        <Card>
+          <Flex vertical align="center" gap={12}>
+            <Typography.Text type="secondary">
+              加载后分析全部 DLQ 消费组，而不是仅分析当前表格页。
+            </Typography.Text>
+            <Button type="primary" loading={loading} disabled={!instanceId} onClick={load}>
+              加载全量积压
+            </Button>
+          </Flex>
+        </Card>
+      ) : (
+        <>
+          <Row gutter={[12, 12]} style={{ marginBottom: 16 }}>
+            {cards.map(([title, value]) => (
+              <Col xs={12} lg={6} key={title}>
+                <Card size="small">
+                  <Statistic title={title} value={value} />
+                </Card>
+              </Col>
+            ))}
+          </Row>
+          {(portfolio.summary.unavailableGroups > 0 || portfolio.summary.unknownAgeGroups > 0) && (
+            <Alert
+              type="warning"
+              showIcon
+              message={`统计不可用 ${portfolio.summary.unavailableGroups} 组，入队时间未知 ${portfolio.summary.unknownAgeGroups} 组`}
+              style={{ marginBottom: 16 }}
+            />
+          )}
+          <Tabs
+            items={[
+              {
+                key: 'groups',
+                label: `消费组 (${filtered.length})`,
+                children: (
+                  <>
+                    <Flex gap={12} wrap style={{ marginBottom: 16 }}>
+                      <Input.Search
+                        allowClear
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        placeholder="搜索 Group、Topic 或状态"
+                        style={{ width: 300 }}
+                      />
+                      <Select
+                        allowClear
+                        value={bucket}
+                        onChange={setBucket}
+                        placeholder="全部年龄"
+                        style={{ width: 180 }}
+                        options={Object.entries(ageLabels).map(([value, label]) => ({
+                          value,
+                          label,
+                        }))}
+                      />
+                    </Flex>
+                    <Table
+                      rowKey="groupName"
+                      size="small"
+                      columns={columns}
+                      dataSource={filtered}
+                      scroll={{ x: 1100 }}
+                      pagination={{ pageSize: 20 }}
+                    />
+                  </>
+                ),
+              },
+              {
+                key: 'age',
+                label: '年龄分层',
+                children: (
+                  <Space direction="vertical" style={{ width: '100%' }}>
+                    {portfolio.ageBuckets.map((item) => (
+                      <Card size="small" key={item.bucket}>
+                        <Flex justify="space-between">
+                          <Typography.Text>{ageLabels[item.bucket]}</Typography.Text>
+                          <Space>
+                            <Typography.Text>
+                              {item.groups} 组 / {item.messages} 条
+                            </Typography.Text>
+                            <Progress percent={item.percent} size="small" style={{ width: 220 }} />
+                          </Space>
+                        </Flex>
+                      </Card>
+                    ))}
+                  </Space>
+                ),
+              },
+              {
+                key: 'status',
+                label: '状态分布',
+                children: (
+                  <Table
+                    rowKey="status"
+                    size="small"
+                    pagination={false}
+                    dataSource={portfolio.statusBuckets}
+                    columns={[
+                      { title: '状态', dataIndex: 'status' },
+                      { title: '消费组', dataIndex: 'groups' },
+                      { title: '消息数', dataIndex: 'messages' },
+                    ]}
+                  />
+                ),
+              },
+            ]}
+          />
+        </>
+      )}
+    </Drawer>
+  );
+};
+export default DLQBacklogPortfolioDrawer;

--- a/web/src/pages/instance/dlq.tsx
+++ b/web/src/pages/instance/dlq.tsx
@@ -49,6 +49,7 @@ import {
 import { useInstanceFilter } from '../../hooks/useInstanceFilter';
 import { buildCsv, downloadBlob, downloadCsv, type CsvColumn } from '../../utils/download';
 import { tableScrollX } from '../../utils/table';
+import DLQBacklogPortfolioDrawer from '../../components/DLQBacklogPortfolioDrawer';
 
 const { Text } = Typography;
 const { RangePicker } = DatePicker;
@@ -112,6 +113,7 @@ const DLQPage = () => {
   const [loading, setLoading] = useState(true);
   const [refreshKey, setRefreshKey] = useState(0);
   const [search, setSearch] = useState('');
+  const [portfolioOpen, setPortfolioOpen] = useState(false);
   const [retryModalOpen, setRetryModalOpen] = useState(false);
   const [retryGroup, setRetryGroup] = useState<DLQGroup | null>(null);
   const [retryRange, setRetryRange] = useState<[Dayjs, Dayjs]>([
@@ -629,14 +631,19 @@ const DLQPage = () => {
             />
           </Space>
         </Space>
-        <Button
-          icon={<Download size={16} />}
-          disabled={selectedGroups.length === 0}
-          onClick={handleBatchExport}
-        >
-          {t('message.batchExport')}
-          {selectedGroups.length > 0 ? ` (${selectedGroups.length})` : ''}
-        </Button>
+        <Space>
+          <Button disabled={!selectedInstanceId} onClick={() => setPortfolioOpen(true)}>
+            全量积压分析
+          </Button>
+          <Button
+            icon={<Download size={16} />}
+            disabled={selectedGroups.length === 0}
+            onClick={handleBatchExport}
+          >
+            {t('message.batchExport')}
+            {selectedGroups.length > 0 ? ` (${selectedGroups.length})` : ''}
+          </Button>
+        </Space>
       </Flex>
 
       {loadError && (
@@ -675,6 +682,11 @@ const DLQPage = () => {
           scroll={{ x: tableScrollX(columns, { selection: true }) }}
         />
       </Card>
+      <DLQBacklogPortfolioDrawer
+        open={portfolioOpen}
+        instanceId={selectedInstanceId}
+        onClose={() => setPortfolioOpen(false)}
+      />
 
       {/* ═══════════════════════════════════════════
          Retry Modal

--- a/web/src/utils/dlqBacklogPortfolio.test.ts
+++ b/web/src/utils/dlqBacklogPortfolio.test.ts
@@ -1,0 +1,160 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. */
+import { describe, expect, it } from 'vitest';
+import type { DLQGroup } from '../api/message';
+import { buildDLQBacklogPortfolio, filterDLQBacklogRows } from './dlqBacklogPortfolio';
+
+const NOW = Date.parse('2026-09-05T10:00:00Z');
+const group = (overrides: Partial<DLQGroup> = {}): DLQGroup => ({
+  groupName: 'orders-consumer',
+  dlqTopic: '%DLQ%orders-consumer',
+  messageCount: 10,
+  lastEnqueueTime: '2026-09-05T09:30:00Z',
+  retryCount: 3,
+  status: 'active',
+  statsAvailable: true,
+  ...overrides,
+});
+
+describe('DLQ backlog portfolio', () => {
+  it('summarizes available backlog and retry counts', () => {
+    const result = buildDLQBacklogPortfolio(
+      [group(), group({ groupName: 'payment', messageCount: 30, retryCount: 5 })],
+      NOW,
+    );
+    expect(result.summary).toMatchObject({
+      groups: 2,
+      availableGroups: 2,
+      groupsWithBacklog: 2,
+      totalMessages: 40,
+      largestGroupMessages: 30,
+      averageMessages: 20,
+      retryCount: 8,
+    });
+    expect(result.rows[0].groupName).toBe('payment');
+    expect(result.rows[0].backlogShare).toBe(75);
+  });
+
+  it('classifies all documented age buckets', () => {
+    const result = buildDLQBacklogPortfolio(
+      [
+        group({ groupName: 'empty', messageCount: 0 }),
+        group({ groupName: 'hour', lastEnqueueTime: '2026-09-05T09:30:00Z' }),
+        group({ groupName: 'today', lastEnqueueTime: '2026-09-05T05:00:00Z' }),
+        group({ groupName: 'week', lastEnqueueTime: '2026-09-03T10:00:00Z' }),
+        group({ groupName: 'dormant', lastEnqueueTime: '2026-08-01T10:00:00Z' }),
+        group({ groupName: 'unknown', lastEnqueueTime: 'invalid' }),
+        group({ groupName: 'unavailable', statsAvailable: false }),
+      ],
+      NOW,
+    );
+    expect(new Set(result.rows.map((row) => row.ageBucket))).toEqual(
+      new Set(['EMPTY', 'LAST_HOUR', 'TODAY', 'THIS_WEEK', 'DORMANT', 'UNKNOWN', 'UNAVAILABLE']),
+    );
+    expect(result.summary).toMatchObject({
+      dormantGroups: 1,
+      unknownAgeGroups: 1,
+      unavailableGroups: 1,
+    });
+  });
+
+  it('does not include unavailable group counters in totals', () => {
+    const result = buildDLQBacklogPortfolio(
+      [
+        group({ messageCount: 10 }),
+        group({
+          groupName: 'unavailable',
+          messageCount: 9999,
+          retryCount: 9999,
+          statsAvailable: false,
+        }),
+      ],
+      NOW,
+    );
+    expect(result.summary).toMatchObject({ totalMessages: 10, retryCount: 3, availableGroups: 1 });
+  });
+
+  it('normalizes negative and non-finite counters', () => {
+    const result = buildDLQBacklogPortfolio(
+      [
+        group({ messageCount: -1, retryCount: Number.NaN }),
+        group({ groupName: 'infinite', messageCount: Number.POSITIVE_INFINITY }),
+      ],
+      NOW,
+    );
+    expect(result.summary).toMatchObject({ totalMessages: 0, retryCount: 3, groupsWithBacklog: 0 });
+  });
+
+  it('clamps future enqueue times to the newest age bucket', () => {
+    const result = buildDLQBacklogPortfolio(
+      [group({ lastEnqueueTime: '2026-09-06T10:00:00Z' })],
+      NOW,
+    );
+    expect(result.rows[0]).toMatchObject({ ageBucket: 'LAST_HOUR', ageMs: 0 });
+  });
+
+  it('builds status groups with message totals', () => {
+    const result = buildDLQBacklogPortfolio(
+      [
+        group({ status: 'active', messageCount: 30 }),
+        group({ groupName: 'two', status: 'paused', messageCount: 10 }),
+        group({ groupName: 'three', status: 'active', messageCount: 20 }),
+      ],
+      NOW,
+    );
+    expect(result.statusBuckets).toEqual([
+      { status: 'active', groups: 2, messages: 50 },
+      { status: 'paused', groups: 1, messages: 10 },
+    ]);
+  });
+
+  it('builds ordered age bucket totals and percentages', () => {
+    const result = buildDLQBacklogPortfolio(
+      [
+        group({ groupName: 'recent', messageCount: 25 }),
+        group({ groupName: 'old', messageCount: 75, lastEnqueueTime: '2026-08-01T00:00:00Z' }),
+      ],
+      NOW,
+    );
+    expect(result.ageBuckets[0]).toMatchObject({
+      bucket: 'DORMANT',
+      groups: 1,
+      messages: 75,
+      percent: 75,
+    });
+    expect(result.ageBuckets.reduce((sum, bucket) => sum + bucket.messages, 0)).toBe(100);
+  });
+
+  it('filters by age and across group, topic, and status', () => {
+    const rows = buildDLQBacklogPortfolio(
+      [
+        group({ groupName: 'order-prod', status: 'ACTIVE' }),
+        group({
+          groupName: 'payment',
+          dlqTopic: '%DLQ%billing',
+          lastEnqueueTime: '2026-08-01T00:00:00Z',
+          status: 'PAUSED',
+        }),
+      ],
+      NOW,
+    ).rows;
+    expect(filterDLQBacklogRows(rows, '', 'DORMANT')).toHaveLength(1);
+    expect(filterDLQBacklogRows(rows, 'ORDER')).toHaveLength(1);
+    expect(filterDLQBacklogRows(rows, 'billing')).toHaveLength(1);
+    expect(filterDLQBacklogRows(rows, 'active')).toHaveLength(1);
+  });
+
+  it('returns stable empty totals', () => {
+    expect(buildDLQBacklogPortfolio([], NOW).summary).toEqual({
+      groups: 0,
+      availableGroups: 0,
+      unavailableGroups: 0,
+      groupsWithBacklog: 0,
+      totalMessages: 0,
+      largestGroupMessages: 0,
+      averageMessages: 0,
+      retryCount: 0,
+      dormantGroups: 0,
+      unknownAgeGroups: 0,
+    });
+  });
+});

--- a/web/src/utils/dlqBacklogPortfolio.ts
+++ b/web/src/utils/dlqBacklogPortfolio.ts
@@ -1,0 +1,130 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. */
+import type { DLQGroup } from '../api/message';
+
+export type DLQAgeBucket =
+  'EMPTY' | 'LAST_HOUR' | 'TODAY' | 'THIS_WEEK' | 'DORMANT' | 'UNKNOWN' | 'UNAVAILABLE';
+export interface DLQBacklogRow extends DLQGroup {
+  ageBucket: DLQAgeBucket;
+  ageMs: number | null;
+  backlogShare: number;
+}
+export interface DLQBacklogPortfolio {
+  rows: DLQBacklogRow[];
+  ageBuckets: Array<{ bucket: DLQAgeBucket; groups: number; messages: number; percent: number }>;
+  statusBuckets: Array<{ status: string; groups: number; messages: number }>;
+  summary: {
+    groups: number;
+    availableGroups: number;
+    unavailableGroups: number;
+    groupsWithBacklog: number;
+    totalMessages: number;
+    largestGroupMessages: number;
+    averageMessages: number;
+    retryCount: number;
+    dormantGroups: number;
+    unknownAgeGroups: number;
+  };
+}
+const safeCount = (value: number) => (Number.isFinite(value) && value > 0 ? Math.floor(value) : 0);
+const parsedTime = (value?: string | null) => {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+const classifyAge = (
+  group: DLQGroup,
+  now: number,
+): { bucket: DLQAgeBucket; ageMs: number | null } => {
+  if (group.statsAvailable === false) return { bucket: 'UNAVAILABLE', ageMs: null };
+  if (safeCount(group.messageCount) === 0) return { bucket: 'EMPTY', ageMs: null };
+  const time = parsedTime(group.lastEnqueueTime);
+  if (time === null) return { bucket: 'UNKNOWN', ageMs: null };
+  const ageMs = Math.max(0, now - time);
+  if (ageMs < 60 * 60 * 1000) return { bucket: 'LAST_HOUR', ageMs };
+  if (ageMs < 24 * 60 * 60 * 1000) return { bucket: 'TODAY', ageMs };
+  if (ageMs < 7 * 24 * 60 * 60 * 1000) return { bucket: 'THIS_WEEK', ageMs };
+  return { bucket: 'DORMANT', ageMs };
+};
+const percent = (value: number, total: number) =>
+  total ? Number(((value * 100) / total).toFixed(2)) : 0;
+const ageOrder: DLQAgeBucket[] = [
+  'DORMANT',
+  'UNKNOWN',
+  'THIS_WEEK',
+  'TODAY',
+  'LAST_HOUR',
+  'EMPTY',
+  'UNAVAILABLE',
+];
+
+export const buildDLQBacklogPortfolio = (
+  groups: DLQGroup[],
+  now = Date.now(),
+): DLQBacklogPortfolio => {
+  const totalMessages = groups.reduce(
+    (sum, group) => sum + (group.statsAvailable === false ? 0 : safeCount(group.messageCount)),
+    0,
+  );
+  const rows = groups
+    .map<DLQBacklogRow>((group) => {
+      const age = classifyAge(group, now);
+      const messages = group.statsAvailable === false ? 0 : safeCount(group.messageCount);
+      return {
+        ...group,
+        messageCount: messages,
+        retryCount: safeCount(group.retryCount),
+        ageBucket: age.bucket,
+        ageMs: age.ageMs,
+        backlogShare: percent(messages, totalMessages),
+      };
+    })
+    .sort((a, b) => b.messageCount - a.messageCount || a.groupName.localeCompare(b.groupName));
+  const ageBuckets = ageOrder.map((bucket) => {
+    const matches = rows.filter((row) => row.ageBucket === bucket);
+    const messages = matches.reduce((sum, row) => sum + row.messageCount, 0);
+    return { bucket, groups: matches.length, messages, percent: percent(messages, totalMessages) };
+  });
+  const statusMap = new Map<string, DLQBacklogRow[]>();
+  rows.forEach((row) =>
+    statusMap.set(row.status || '(unknown)', [
+      ...(statusMap.get(row.status || '(unknown)') ?? []),
+      row,
+    ]),
+  );
+  const statusBuckets = [...statusMap.entries()]
+    .map(([status, matches]) => ({
+      status,
+      groups: matches.length,
+      messages: matches.reduce((sum, row) => sum + row.messageCount, 0),
+    }))
+    .sort((a, b) => b.messages - a.messages || a.status.localeCompare(b.status));
+  const available = rows.filter((row) => row.statsAvailable !== false);
+  return {
+    rows,
+    ageBuckets,
+    statusBuckets,
+    summary: {
+      groups: rows.length,
+      availableGroups: available.length,
+      unavailableGroups: rows.length - available.length,
+      groupsWithBacklog: available.filter((row) => row.messageCount > 0).length,
+      totalMessages,
+      largestGroupMessages: Math.max(0, ...available.map((row) => row.messageCount)),
+      averageMessages: available.length ? Math.round(totalMessages / available.length) : 0,
+      retryCount: available.reduce((sum, row) => sum + row.retryCount, 0),
+      dormantGroups: rows.filter((row) => row.ageBucket === 'DORMANT').length,
+      unknownAgeGroups: rows.filter((row) => row.ageBucket === 'UNKNOWN').length,
+    },
+  };
+};
+
+export const filterDLQBacklogRows = (rows: DLQBacklogRow[], search = '', bucket?: DLQAgeBucket) => {
+  const keyword = search.trim().toLocaleLowerCase();
+  return rows
+    .filter((row) => !bucket || row.ageBucket === bucket)
+    .filter(
+      (row) =>
+        !keyword ||
+        [row.groupName, row.dlqTopic, row.status].join('\n').toLocaleLowerCase().includes(keyword),
+    );
+};


### PR DESCRIPTION
## Summary

- load all DLQ groups for the selected instance in bounded pages
- summarize backlog totals, retry totals, largest-group concentration, and unavailable statistics
- classify non-empty groups by last-enqueue age and aggregate status distribution
- support group/topic/status search, age filtering, and CSV export
- keep the analysis read-only and avoid loading message bodies

## 原提交验证记录
- focused portfolio and existing DLQ page suites: 27 tests passed
- `npm run lint` (0 errors; 10 pre-existing warnings)
- `npm run build` (8,040 modules transformed)
- scope audit: 609 additions, 8 deletions across 4 files

Fixes #3203
