### PR TITLE
fix(i18n): localize consumer detail progress, config and thread stack

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2542,6 +2542,25 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  // ─── Consumer detail progress / config / stack ───
+  'consumer.allTopics': { zh: '全部 Topic', en: 'All Topics' },
+  'consumer.capturedAt': { zh: '采集时间', en: 'Captured At' },
+  'consumer.maxRetryRequired': { zh: '请输入最大重试次数', en: 'Enter the maximum retry count' },
+  'consumer.noProgressData': { zh: '消费组不在线，暂无队列进度数据', en: 'Consumer group is offline; no queue progress data' },
+  'consumer.progressBacklog': { zh: '堆积量', en: 'Backlog' },
+  'consumer.retryQueueNums': { zh: '重试队列数', en: 'Retry Queue Count' },
+  'consumer.retryQueueNumsRequired': { zh: '请输入重试队列数', en: 'Enter the retry queue count' },
+  'consumer.stackUnsupported': { zh: '暂不支持采集该客户端的线程栈', en: 'Thread stack capture is not supported for this client' },
+  'consumer.stackUnsupportedDesc': { zh: '经 Proxy 接入的客户端（gRPC、经 Proxy 的 Remoting）只在 Proxy 侧保持连接，Broker 看不到它们；而 Proxy 目前未开放线程栈采集接口，因此这类客户端暂时无法采集。直连 Broker 的客户端可正常查看。', en: 'Clients connected through the Proxy (gRPC, and Remoting via the Proxy) only keep their connection on the Proxy side, so the Broker cannot see them; since the Proxy does not expose a thread-stack capture endpoint yet, these clients cannot be captured for now. Clients that connect directly to the Broker can be viewed normally.' },
+  'consumer.tabConfig': { zh: '配置', en: 'Configuration' },
+  'consumer.tabProgress': { zh: '消费进度', en: 'Consumption Progress' },
+  'consumer.threadCol': { zh: '线程', en: 'Thread' },
+  'consumer.threadCount': { zh: '线程数', en: 'Threads' },
+  'consumer.threadStacks': { zh: '消费者线程栈', en: 'Consumer Thread Stacks' },
+  'consumer.topicFilterLabel': { zh: 'Topic 筛选:', en: 'Topic filter:' },
+  'consumer.totalBrokersLabel': { zh: '总 Broker 数:', en: 'Total Brokers:' },
+  'consumer.totalLagLabel': { zh: '总堆积:', en: 'Total lag:' },
+  'consumer.totalQueuesLabel': { zh: '总 Queue 数:', en: 'Total Queues:' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -1229,7 +1229,7 @@ const ConsumerPageContent = ({
       ),
     },
     {
-      title: '堆积量',
+      title: t('consumer.progressBacklog'),
       dataIndex: 'diffTotal',
       key: 'diffTotal',
       width: 120,
@@ -1238,7 +1238,7 @@ const ConsumerPageContent = ({
         if (!isLagAvailable(diff)) {
           return (
             <Text type="secondary" style={{ fontWeight: 600 }}>
-              {UNAVAILABLE_LAG_LABEL}
+              {t('groupMgmt.lagUnavailable')}
             </Text>
           );
         }
@@ -1944,19 +1944,19 @@ const ConsumerPageContent = ({
                 label: (
                   <Space size={4}>
                     <ArrowsClockwise size={14} />
-                    <span>消费进度</span>
+                    <span>{t('consumer.tabProgress')}</span>
                   </Space>
                 ),
                 children: (
                   <div>
                     {progressTopicOptions.length > 0 && (
                       <Flex align="center" gap={8} style={{ marginBottom: 12 }}>
-                        <Text type="secondary">Topic 筛选:</Text>
+                        <Text type="secondary">{t('consumer.topicFilterLabel')}</Text>
                         <Select
                           size="small"
                           style={{ minWidth: 240 }}
                           allowClear
-                          placeholder="全部 Topic"
+                          placeholder={t('consumer.allTopics')}
                           value={
                             progressTopic && progressTopicOptions.includes(progressTopic)
                               ? progressTopic
@@ -1981,18 +1981,18 @@ const ConsumerPageContent = ({
                     >
                       <Space size={24}>
                         <Space size={4}>
-                          <Text type="secondary">总 Broker 数:</Text>
+                          <Text type="secondary">{t('consumer.totalBrokersLabel')}</Text>
                           <Text strong>{new Set(visibleProgress.map((q) => q.broker)).size}</Text>
                         </Space>
                         <Space size={4}>
-                          <Text type="secondary">总 Queue 数:</Text>
+                          <Text type="secondary">{t('consumer.totalQueuesLabel')}</Text>
                           <Text strong>{visibleProgress.length}</Text>
                         </Space>
                         <Space size={4}>
-                          <Text type="secondary">总堆积:</Text>
+                          <Text type="secondary">{t('consumer.totalLagLabel')}</Text>
                           {hasUnknownProgressLag ? (
                             <Text strong style={{ color: UNKNOWN_LAG_COLOR }}>
-                              {UNAVAILABLE_LAG_LABEL}
+                              {t('groupMgmt.lagUnavailable')}
                             </Text>
                           ) : (
                             <Text
@@ -2015,7 +2015,7 @@ const ConsumerPageContent = ({
                       pagination={false}
                       size="small"
                       scroll={{ x: tableScrollX(queueColumns), y: 380 }}
-                      locale={{ emptyText: '消费组不在线，暂无队列进度数据' }}
+                      locale={{ emptyText: t('consumer.noProgressData') }}
                     />
                   </div>
                 ),
@@ -2026,27 +2026,27 @@ const ConsumerPageContent = ({
                 label: (
                   <Space size={4}>
                     <SlidersHorizontal size={14} />
-                    <span>配置</span>
+                    <span>{t('consumer.tabConfig')}</span>
                   </Space>
                 ),
                 disabled: isCloudInstance,
                 children: (
                   <Spin spinning={settingsLoading}>
                     <Form form={settingsForm} layout="vertical" style={{ maxWidth: 480 }}>
-                      <Form.Item label="Group 名称">
+                      <Form.Item label={t('consumer.name')}>
                         <Text strong>{selectedGroup.name}</Text>
                       </Form.Item>
                       <Form.Item
-                        label="重试队列数"
+                        label={t('consumer.retryQueueNums')}
                         name="retryQueueNums"
-                        rules={[{ required: true, message: '请输入重试队列数' }]}
+                        rules={[{ required: true, message: t('consumer.retryQueueNumsRequired') }]}
                       >
                         <InputNumber min={1} max={128} style={{ width: '100%' }} />
                       </Form.Item>
                       <Form.Item
-                        label="最大重试次数"
+                        label={t('consumer.maxRetry')}
                         name="retryMaxTimes"
-                        rules={[{ required: true, message: '请输入最大重试次数' }]}
+                        rules={[{ required: true, message: t('consumer.maxRetryRequired') }]}
                       >
                         <InputNumber min={1} max={128} style={{ width: '100%' }} />
                       </Form.Item>
@@ -2056,7 +2056,7 @@ const ConsumerPageContent = ({
                           loading={settingsSubmitting}
                           onClick={() => void saveSettings()}
                         >
-                          保存
+                          {t('common.save')}
                         </Button>
                       </Form.Item>
                     </Form>
@@ -2075,7 +2075,7 @@ const ConsumerPageContent = ({
         title={
           <Space>
             <ListBullets size={18} color="#1677ff" />
-            <span>消费者线程栈</span>
+            <span>{t('consumer.threadStacks')}</span>
           </Space>
         }
         open={stackModalOpen}
@@ -2100,16 +2100,18 @@ const ConsumerPageContent = ({
                 {selectedStack?.clientId ?? selectedStackClient?.clientId ?? '-'}
               </Text>
             </Descriptions.Item>
-            <Descriptions.Item label="采集时间">
+            <Descriptions.Item label={t('consumer.capturedAt')}>
               {selectedStack?.capturedAt ? formatDateTime(selectedStack.capturedAt) : '-'}
             </Descriptions.Item>
-            <Descriptions.Item label="线程数">{selectedStack?.threadCount ?? 0}</Descriptions.Item>
+            <Descriptions.Item label={t('consumer.threadCount')}>
+              {selectedStack?.threadCount ?? 0}
+            </Descriptions.Item>
           </Descriptions>
 
           {stackLoading ? (
             <Table
               loading
-              columns={[{ title: '线程', dataIndex: 'threadName', key: 'threadName' }]}
+              columns={[{ title: t('consumer.threadCol'), dataIndex: 'threadName', key: 'threadName' }]}
               dataSource={[]}
               pagination={false}
               size="small"
@@ -2148,14 +2150,10 @@ const ConsumerPageContent = ({
             <Alert
               type="info"
               showIcon
-              message="暂不支持采集该客户端的线程栈"
+              message={t('consumer.stackUnsupported')}
               description={
                 <>
-                  <div>
-                    经 Proxy 接入的客户端（gRPC、经 Proxy 的 Remoting）只在 Proxy 侧保持连接，Broker
-                    看不到它们；而 Proxy 目前未开放线程栈采集接口，因此这类客户端暂时无法采集。 直连
-                    Broker 的客户端可正常查看。
-                  </div>
+                  <div>{t('consumer.stackUnsupportedDesc')}</div>
                   {stackError && (
                     <div style={{ marginTop: 8, color: 'rgba(0,0,0,0.45)' }}>{stackError}</div>
                   )}


### PR DESCRIPTION
## Summary

The consumer group page is being localized in slices (offset reset, create/import, list, detail overview & health done previously); this PR covers the remaining detail tabs: queue progress, configuration and the consumer thread-stack modal.

Localized in instance/consumer.tsx:
- Progress tab: tab label, the Topic filter label and placeholder (全部 Topic), the total Brokers / Queues / lag summary labels (with the unavailable-lag placeholder reusing the existing `groupMgmt.lagUnavailable` key), the 堆积量 table column and the empty-state text.
- Config tab: tab label, Group 名称 display label, 重试队列数 / 最大重试次数 form labels with their required-validation messages, and the 保存 button (reusing `common.save`).
- Thread-stack modal: title, captured-at / thread-count description labels, the thread table column, and the unsupported-capture notice with its long explanation paragraph.
- 18 new `consumer.*` keys; zh byte-identical.

## Why

Queue progress, settings and thread-stack inspection are operator surfaces whose labels and feedback must follow the active language.

## Testing

- `tsc --noEmit` passes
- `eslint` clean on the changed files
- `vitest run ConsumerPage` - 29/29 tests pass