### PR TITLE
fix(i18n): finish localizing audit page and summary cards

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2542,6 +2542,19 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  // ─── Audit page ───
+  'audit.loadFailed': { zh: '审计日志加载失败，请稍后重试', en: 'Failed to load audit logs, please retry later' },
+  'audit.overviewLoadFailed': { zh: '审计概览加载失败，请稍后重试', en: 'Failed to load the audit overview, please retry later' },
+  'audit.cleanupFailed': { zh: '清理审计日志失败，请稍后重试', en: 'Failed to clean up audit logs, please retry later' },
+  'audit.exportFailed': { zh: '导出审计日志失败，请稍后重试', en: 'Failed to export audit logs, please retry later' },
+  'audit.retentionDaysSuffix': { zh: '天之前的日志', en: 'days old or older' },
+  'audit.noData': { zh: '暂无数据', en: 'No data' },
+  'audit.matchingRecords': { zh: '匹配记录', en: 'Matching Records' },
+  'audit.successRate': { zh: '成功率', en: 'Success Rate' },
+  'audit.failedPartial': { zh: '失败 / 部分成功', en: 'Failed / Partially Successful' },
+  'audit.uniqueOperators': { zh: '操作人数', en: 'Unique Operators' },
+  'audit.topOperations': { zh: '高频操作', en: 'Top Operations' },
+  'audit.resourceTypeDistribution': { zh: '资源类型分布', en: 'By Resource Type' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/pages/ops/AuditSummaryCards.tsx
+++ b/web/src/pages/ops/AuditSummaryCards.tsx
@@ -17,6 +17,7 @@
 
 import { Card, Col, Empty, Flex, Progress, Row, Skeleton, Statistic, Tag, Typography } from 'antd';
 import type { AuditSummary, AuditSummaryBucket } from '../../api/audit';
+import { useLang } from '../../i18n/LangContext';
 
 const { Text } = Typography;
 
@@ -26,7 +27,8 @@ interface Props {
 }
 
 const BucketList = ({ items, total }: { items: AuditSummaryBucket[]; total: number }) => {
-  if (!items.length) return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无数据" />;
+  const { t } = useLang();
+  if (!items.length) return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('audit.noData')} />;
   return (
     <Flex vertical gap={10}>
       {items.slice(0, 5).map((item) => (
@@ -49,6 +51,7 @@ const BucketList = ({ items, total }: { items: AuditSummaryBucket[]; total: numb
 };
 
 const AuditSummaryCards = ({ summary, loading }: Props) => {
+  const { t } = useLang();
   // Show the placeholder while any fetch is in flight so a filter change does
   // not keep painting a stale summary until the refreshed aggregate arrives.
   if (loading) return <Skeleton active paragraph={{ rows: 4 }} />;
@@ -67,13 +70,13 @@ const AuditSummaryCards = ({ summary, loading }: Props) => {
     <Row gutter={[12, 12]} style={{ marginBottom: 16 }}>
       <Col xs={12} lg={6}>
         <Card size="small">
-          <Statistic title="匹配记录" value={data.total} />
+          <Statistic title={t('audit.matchingRecords')} value={data.total} />
         </Card>
       </Col>
       <Col xs={12} lg={6}>
         <Card size="small">
           <Statistic
-            title="成功率"
+            title={t('audit.successRate')}
             value={successRate}
             suffix="%"
             valueStyle={{ color: '#52c41a' }}
@@ -83,7 +86,7 @@ const AuditSummaryCards = ({ summary, loading }: Props) => {
       <Col xs={12} lg={6}>
         <Card size="small">
           <Statistic
-            title="失败 / 部分成功"
+            title={t('audit.failedPartial')}
             value={`${data.failed} / ${data.partial}`}
             valueStyle={{ color: data.failed ? '#cf1322' : undefined }}
           />
@@ -91,16 +94,16 @@ const AuditSummaryCards = ({ summary, loading }: Props) => {
       </Col>
       <Col xs={12} lg={6}>
         <Card size="small">
-          <Statistic title="操作人数" value={data.uniqueOperators} />
+          <Statistic title={t('audit.uniqueOperators')} value={data.uniqueOperators} />
         </Card>
       </Col>
       <Col xs={24} lg={12}>
-        <Card size="small" title="高频操作">
+        <Card size="small" title={t('audit.topOperations')}>
           <BucketList items={data.byOperation} total={data.total} />
         </Card>
       </Col>
       <Col xs={24} lg={12}>
-        <Card size="small" title="资源类型分布">
+        <Card size="small" title={t('audit.resourceTypeDistribution')}>
           <BucketList items={data.byResourceType} total={data.total} />
         </Card>
       </Col>

--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -158,7 +158,7 @@ const AuditPage: React.FC = () => {
       })
       .catch(() => {
         if (recordsRequestRef.current === requestId) {
-          message.error('审计日志加载失败，请稍后重试');
+          message.error(t('audit.loadFailed'));
         }
       })
       .finally(() => {
@@ -174,6 +174,7 @@ const AuditPage: React.FC = () => {
     dateRange,
     resultFilter,
     refreshKey,
+    t,
   ]);
 
   useEffect(
@@ -217,7 +218,7 @@ const AuditPage: React.FC = () => {
         if (!cancelled) setSummary(value);
       })
       .catch(() => {
-        if (!cancelled) message.error('审计概览加载失败，请稍后重试');
+        if (!cancelled) message.error(t('audit.overviewLoadFailed'));
       })
       .finally(() => {
         if (!cancelled) setSummaryLoading(false);
@@ -225,7 +226,7 @@ const AuditPage: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [activeFilter, refreshKey]);
+  }, [activeFilter, refreshKey, t]);
 
   const { Text } = Typography;
 
@@ -291,7 +292,7 @@ const AuditPage: React.FC = () => {
       message.success(t('audit.cleanupSuccess', { n: cleanupDays }));
       setCleanupModalOpen(false);
     } catch {
-      message.error('清理审计日志失败，请稍后重试');
+      message.error(t('audit.cleanupFailed'));
     }
   };
 
@@ -302,7 +303,7 @@ const AuditPage: React.FC = () => {
       const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
       downloadBlob(blob, `rocketmq-audit-logs-${dayjs().format('YYYY-MM-DD')}.csv`);
     } catch {
-      message.error('导出审计日志失败，请稍后重试');
+      message.error(t('audit.exportFailed'));
     } finally {
       setExporting(false);
     }
@@ -537,7 +538,7 @@ const AuditPage: React.FC = () => {
               value={cleanupDays}
               onChange={(v) => setCleanupDays(v ?? 30)}
             />
-            <span>天之前的日志</span>
+            <span>{t('audit.retentionDaysSuffix')}</span>
           </Flex>
         </Flex>
       </Modal>


### PR DESCRIPTION
## Summary

The audit page was already mostly localized; this PR removes the last hard-coded zh strings on the page and fully localizes its summary-cards component.

Localized:
- ops/audit.tsx: the four remaining error toasts (audit load, overview load, cleanup, export) and the retention-days suffix in the cleanup modal (天之前的日志).
- ops/AuditSummaryCards.tsx (no i18n wiring before): the four stat cards (匹配记录 / 成功率 / 失败 / 部分成功 / 操作人数), the two distribution card titles (高频操作 / 资源类型分布) and the empty state (暂无数据); both components call `useLang` themselves.
- 12 new `audit.*` keys; zh byte-identical.

## Why

These feedback strings and summary labels complete the audit surface in the active language.

## Testing

- `tsc --noEmit` passes
- `eslint` clean on the changed files
- `vitest run AuditPage` - 8/8 tests pass