### PR TITLE
fix(i18n): localize settings about tab

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2542,6 +2542,14 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  // ─── Settings About ───
+  'about.version': { zh: '版本', en: 'Version' },
+  'about.buildCommit': { zh: '构建提交', en: 'Build Commit' },
+  'about.buildTime': { zh: '构建时间', en: 'Build Time' },
+  'about.rocketmqSupport': { zh: 'RocketMQ 支持版本', en: 'RocketMQ Support' },
+  'about.frontend': { zh: '前端框架', en: 'Frontend' },
+  'about.backend': { zh: '后端框架', en: 'Backend' },
+  'about.linksTitle': { zh: '相关链接', en: 'Related Links' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/pages/settings/AboutTab.tsx
+++ b/web/src/pages/settings/AboutTab.tsx
@@ -17,33 +17,36 @@
 
 import { Descriptions, Divider, Space, Typography } from 'antd';
 import { BookOutlined, GithubOutlined, GlobalOutlined } from '@ant-design/icons';
+import { useLang } from '../../i18n/LangContext';
 
 const { Title, Text, Link: TypoLink } = Typography;
 
-export const AboutTab = () => (
+export const AboutTab = () => {
+  const { t } = useLang();
+  return (
   <div style={{ maxWidth: 800 }}>
     <Descriptions column={1} bordered size="small">
-      <Descriptions.Item label="版本">0.1.0</Descriptions.Item>
-      <Descriptions.Item label="构建提交">{__BUILD_COMMIT__}</Descriptions.Item>
-      <Descriptions.Item label="构建时间">{__BUILD_TIME__}</Descriptions.Item>
-      <Descriptions.Item label="RocketMQ 支持版本">4.x / 5.x</Descriptions.Item>
-      <Descriptions.Item label="前端框架">React 18 + Ant Design 5</Descriptions.Item>
-      <Descriptions.Item label="后端框架">Spring Boot 3 + RocketMQ MCP Server</Descriptions.Item>
+      <Descriptions.Item label={t('about.version')}>0.1.0</Descriptions.Item>
+      <Descriptions.Item label={t('about.buildCommit')}>{__BUILD_COMMIT__}</Descriptions.Item>
+      <Descriptions.Item label={t('about.buildTime')}>{__BUILD_TIME__}</Descriptions.Item>
+      <Descriptions.Item label={t('about.rocketmqSupport')}>4.x / 5.x</Descriptions.Item>
+      <Descriptions.Item label={t('about.frontend')}>React 18 + Ant Design 5</Descriptions.Item>
+      <Descriptions.Item label={t('about.backend')}>Spring Boot 3 + RocketMQ MCP Server</Descriptions.Item>
       <Descriptions.Item label="License">Apache 2.0</Descriptions.Item>
     </Descriptions>
 
     <Divider />
 
-    <Title level={5}>相关链接</Title>
+    <Title level={5}>{t('about.linksTitle')}</Title>
     <Space size="middle" style={{ marginBottom: 24 }}>
       <TypoLink href="https://github.com/apache/rocketmq" target="_blank" rel="noopener noreferrer">
         <GithubOutlined /> GitHub
       </TypoLink>
       <TypoLink href="https://rocketmq.apache.org/docs/" target="_blank" rel="noopener noreferrer">
-        <BookOutlined /> 文档中心
+        <BookOutlined /> {t('home.docs')}
       </TypoLink>
       <TypoLink href="https://rocketmq.apache.org/" target="_blank" rel="noopener noreferrer">
-        <GlobalOutlined /> RocketMQ 社区
+        <GlobalOutlined /> {t('home.community')}
       </TypoLink>
     </Space>
 
@@ -54,6 +57,7 @@ export const AboutTab = () => (
       License, Version 2.0.
     </Text>
   </div>
-);
+  );
+};
 
 export default AboutTab;


### PR DESCRIPTION
## Summary

The settings About tab had no i18n wiring at all: the version metadata table labels and the related-links heading were hard-coded zh.

Localized in settings/AboutTab.tsx:
- Adds `useLang`; the metadata labels (版本 / 构建提交 / 构建时间 / RocketMQ 支持版本 / 前端框架 / 后端框架) and the 相关链接 heading now resolve through translation keys.
- The 文档中心 and RocketMQ 社区 links reuse the existing `home.docs` / `home.community` keys.
- 7 new `about.*` keys; zh byte-identical.

## Why

The About tab is the settings surface shown in both languages; its labels should follow the active language.

## Testing

- `tsc --noEmit` passes
- `eslint` clean on the changed files
- `vitest run AboutTab` - 1/1 test passes