### PR TITLE
fix(auth): enforce public path boundaries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/auth/AuthInterceptor.java
@@ -185,9 +185,13 @@ public class AuthInterceptor implements HandlerInterceptor {
                 || path.equals("/api/auth/status")
                 || path.equals("/livez")
                 || path.equals("/readyz")
-                || path.startsWith("/api-docs")
-                || path.startsWith("/swagger-ui")
-                || path.startsWith("/actuator/health");
+                || isPathOrDescendant(path, "/api-docs")
+                || isPathOrDescendant(path, "/swagger-ui")
+                || isPathOrDescendant(path, "/actuator/health");
+    }
+
+    private boolean isPathOrDescendant(String path, String root) {
+        return path.equals(root) || path.startsWith(root + "/");
     }
 
     private String normalizePath(String path) {

--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthInterceptorTest.java
@@ -245,6 +245,45 @@ class AuthInterceptorTest {
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "/api-docs",
+        "/api-docs/openapi.json",
+        "/swagger-ui",
+        "/swagger-ui/index.html",
+        "/actuator/health",
+        "/actuator/health/readiness"
+    })
+    void shouldAllowDocumentedPublicPathTreesWhenLoginIsEnabled(String path) throws Exception {
+        AuthProperties properties = new AuthProperties();
+        properties.setLoginRequired(true);
+        AuthInterceptor interceptor = interceptor(properties, authService(properties), settingsRepository());
+
+        boolean allowed = interceptor.preHandle(new MockHttpServletRequest("GET", path),
+                new MockHttpServletResponse(), new Object());
+
+        assertThat(allowed).as(path).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "/api-docs-private",
+        "/swagger-ui-admin",
+        "/actuator/healthcheck"
+    })
+    void shouldProtectPathsThatOnlyShareAPublicPrefix(String path) throws Exception {
+        AuthProperties properties = new AuthProperties();
+        properties.setLoginRequired(true);
+        AuthInterceptor interceptor = interceptor(properties, authService(properties), settingsRepository());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        boolean allowed = interceptor.preHandle(new MockHttpServletRequest("GET", path),
+                response, new Object());
+
+        assertThat(allowed).as(path).isFalse();
+        assertThat(response.getStatus()).as(path).isEqualTo(401);
+    }
+
     private AuthService authService(AuthProperties properties) {
         return new AuthService(properties, settingsRepositoryWithTimeout(30));
     }


### PR DESCRIPTION
## Summary
- require public documentation and health endpoints to match a complete path segment
- keep valid descendants such as `/swagger-ui/index.html` and `/actuator/health/readiness` public
- add regression coverage for lookalike protected paths

## Why
The authentication interceptor previously used raw prefix checks for public endpoint trees. That also exempted unrelated paths such as `/api-docs-private` and `/actuator/healthcheck` whenever login enforcement was enabled.

## Verification on Linux

Ubuntu 22.04, OpenJDK 21.0.12, Maven 3.6.3, rebased onto `rocketmq-studio` `6c24d2ed`, run from
`server/`:

```
$ mvn -B -ntp test
Tests run: 2160, Failures: 2, Errors: 0, Skipped: 0
```

Both failures are `AuthCorsIntegrationTest`, which fails on the branch head *without* this
change too (the test still stubs the pre-#2895 `isAuthenticated` call). #4217 repairs it.
Every other test, including the ones added here, passes.