### PR TITLE
fix(i18n): localize queue browser component

### DIFF
--- a/web/src/components/QueueBrowser.tsx
+++ b/web/src/components/QueueBrowser.tsx
@@ -32,6 +32,7 @@ import {
   message,
 } from 'antd';
 import { CloseOutlined, SearchOutlined } from '@ant-design/icons';
+import { useLang } from '../i18n/LangContext';
 import type { MessageRecord, QueueOffset } from '../api/message';
 import { getQueueOffsets, pullMessageAtOffset } from '../api/message';
 
@@ -55,6 +56,7 @@ export interface PulledEntry {
 }
 
 export const useQueueBrowser = (instanceId?: string) => {
+  const { t } = useLang();
   const [topic, setTopic] = useState<string | undefined>();
   const [queues, setQueues] = useState<QueueOffset[]>([]);
   const [loading, setLoading] = useState(false);
@@ -99,7 +101,7 @@ export const useQueueBrowser = (instanceId?: string) => {
       setOffsets(initial);
     } catch (err) {
       if (requestId === requestSeqRef.current) {
-        message.error(err instanceof Error ? err.message : '加载队列信息失败');
+        message.error(err instanceof Error ? err.message : t('queueBrowser.loadFailed'));
       }
     } finally {
       if (requestId === requestSeqRef.current) {
@@ -107,7 +109,7 @@ export const useQueueBrowser = (instanceId?: string) => {
         setLoading(false);
       }
     }
-  }, [instanceId, topic]);
+  }, [instanceId, topic, t]);
 
   const handlePull = async (queue: QueueOffset) => {
     if (!instanceId || !topic) return;
@@ -132,7 +134,7 @@ export const useQueueBrowser = (instanceId?: string) => {
       ]);
     } catch (err) {
       if (requestId === requestSeqRef.current) {
-        message.error(err instanceof Error ? err.message : '拉取消息失败');
+        message.error(err instanceof Error ? err.message : t('queueBrowser.pullFailed'));
       }
     } finally {
       pullingRef.current.delete(key);
@@ -173,31 +175,36 @@ export const QueueBrowserControls = ({
   state,
   topicOptions,
   topicLoading,
-}: ControlsProps) => (
-  <Flex gap={12} align="center">
-    <Select
-      showSearch
-      allowClear
-      placeholder="选择 Topic"
-      value={state.topic}
-      onChange={state.setTopic}
-      options={topicOptions}
-      loading={topicLoading}
-      style={{ width: 280 }}
-    />
-    <Button
-      type="primary"
-      icon={<SearchOutlined />}
-      disabled={!instanceId || !state.topic}
-      loading={state.loading}
-      onClick={() => void state.loadQueues()}
-    >
-      加载队列
-    </Button>
-  </Flex>
-);
+}: ControlsProps) => {
+  const { t } = useLang();
+  return (
+    <Flex gap={12} align="center">
+      <Select
+        showSearch
+        allowClear
+        placeholder={t('queueBrowser.selectTopic')}
+        value={state.topic}
+        onChange={state.setTopic}
+        options={topicOptions}
+        loading={topicLoading}
+        style={{ width: 280 }}
+      />
+      <Button
+        type="primary"
+        icon={<SearchOutlined />}
+        disabled={!instanceId || !state.topic}
+        loading={state.loading}
+        onClick={() => void state.loadQueues()}
+      >
+        {t('queueBrowser.loadQueues')}
+      </Button>
+    </Flex>
+  );
+};
 
-export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => (
+export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => {
+  const { t } = useLang();
+  return (
   <Card>
     {state.loading ? (
       <Flex justify="center" style={{ padding: 32 }}>
@@ -206,7 +213,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
     ) : state.queues.length === 0 ? (
       <Empty
         image={Empty.PRESENTED_IMAGE_SIMPLE}
-        description="选择 Topic 并点击「加载队列」，按队列浏览消息"
+        description={t('queueBrowser.emptyHint')}
         style={{ padding: '32px 0' }}
       />
     ) : (
@@ -240,7 +247,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                 render: (v: number) => <Text style={{ fontSize: 14 }}>{v}</Text>,
               },
               {
-                title: 'Offset 范围',
+                title: t('queueBrowser.offsetRange'),
                 key: 'offset',
                 width: 170,
                 render: (_: unknown, record: QueueOffset) => {
@@ -273,7 +280,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                 },
               },
               {
-                title: '操作',
+                title: t('common.actions'),
                 key: 'action',
                 width: 70,
                 align: 'center',
@@ -286,7 +293,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                       loading={state.pulling.has(key)}
                       onClick={() => void state.handlePull(record)}
                     >
-                      查看
+                      {t('queueBrowser.view')}
                     </Button>
                   );
                 },
@@ -294,8 +301,12 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
             ]}
           />
           <Text type="secondary" style={{ display: 'block', marginTop: 8, fontSize: 14 }}>
-            共 {state.queues.length} 个队列，总消息量{' '}
-            {state.queues.reduce((sum, q) => sum + (q.maxOffset - q.minOffset), 0)} 条
+            {t('queueBrowser.queueTotal', {
+              count: String(state.queues.length),
+              messages: String(
+                state.queues.reduce((sum, q) => sum + (q.maxOffset - q.minOffset), 0),
+              ),
+            })}
           </Text>
         </div>
 
@@ -304,7 +315,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
           {state.entries.length === 0 ? (
             <Empty
               image={Empty.PRESENTED_IMAGE_SIMPLE}
-              description="点击左侧「查看」，消息详情将显示在这里"
+              description={t('queueBrowser.detailHint')}
               style={{ padding: '32px 0' }}
             />
           ) : (
@@ -352,12 +363,12 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                             {entry.message.key || '-'}
                           </span>
                         </Descriptions.Item>
-                        <Descriptions.Item label="存储时间">
+                        <Descriptions.Item label={t('queueBrowser.storeTime')}>
                           <span style={{ fontFamily: 'monospace', fontSize: 14 }}>
                             {formatTimeMs(entry.message.storeTime)}
                           </span>
                         </Descriptions.Item>
-                        <Descriptions.Item label="大小">
+                        <Descriptions.Item label={t('queueBrowser.size')}>
                           {entry.message.size} bytes
                         </Descriptions.Item>
                         <Descriptions.Item label="Born Host">
@@ -383,7 +394,7 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                       )}
                     </>
                   ) : (
-                    <Text type="secondary">该 offset 处无消息</Text>
+                    <Text type="secondary">{t('queueBrowser.noMessage')}</Text>
                   )}
                 </Card>
               ))}
@@ -393,4 +404,5 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
       </Flex>
     )}
   </Card>
-);
+  );
+};

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2542,6 +2542,19 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  // ─── Message Queue Browser ───
+  'queueBrowser.loadFailed': { zh: '加载队列信息失败', en: 'Failed to load queue information' },
+  'queueBrowser.pullFailed': { zh: '拉取消息失败', en: 'Failed to pull the message' },
+  'queueBrowser.selectTopic': { zh: '选择 Topic', en: 'Select Topic' },
+  'queueBrowser.loadQueues': { zh: '加载队列', en: 'Load Queues' },
+  'queueBrowser.emptyHint': { zh: '选择 Topic 并点击「加载队列」，按队列浏览消息', en: 'Select a Topic and click "Load Queues" to browse messages by queue' },
+  'queueBrowser.offsetRange': { zh: 'Offset 范围', en: 'Offset Range' },
+  'queueBrowser.view': { zh: '查看', en: 'View' },
+  'queueBrowser.queueTotal': { zh: '共 {count} 个队列，总消息量 {messages} 条', en: '{count} queues, {messages} messages total' },
+  'queueBrowser.detailHint': { zh: '点击左侧「查看」，消息详情将显示在这里', en: 'Click "View" on the left and the message details will appear here' },
+  'queueBrowser.storeTime': { zh: '存储时间', en: 'Store Time' },
+  'queueBrowser.size': { zh: '大小', en: 'Size' },
+  'queueBrowser.noMessage': { zh: '该 offset 处无消息', en: 'No message at this offset' },
   // ─── BrokerCluster ───
 };
 


### PR DESCRIPTION
## Summary

The shared QueueBrowser component (used by the message query page in queue-browse mode) had no i18n wiring: selectors, buttons, table headers, empty states and toasts were hard-coded zh.

Localized in components/QueueBrowser.tsx:
- `useQueueBrowser`: load-queues and pull-message failure fallbacks now come from translation keys (the hook calls `useLang`; the two callbacks list `t` in their deps).
- `QueueBrowserControls`: the Topic placeholder and the 加载队列 button.
- `QueueBrowserResults`: the empty hints (no queues / no details), the Offset 范围 table column and 操作 column (reusing `common.actions`), the 查看 action, the queue summary line (count and total messages parameterized), and the message detail card labels (存储时间 / 大小) plus the no-message-at-offset text.
- 12 new `queueBrowser.*` keys; zh byte-identical.

## Why

The queue-browse mode is part of the message page; its guidance and labels must follow the active language.

## Testing

- `tsc --noEmit` passes
- `eslint` - 0 errors (2 pre-existing fast-refresh warnings on the existing hook/helper exports)
- `vitest run` MessagePage + QueueBrowser - 17/17 tests pass