### PR TITLE
fix(i18n): localize main layout leftovers

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2542,6 +2542,13 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  // ─── Main layout ───
+  'nav.userManagement': { zh: '用户管理', en: 'User Management' },
+  'layout.logoutLocalFailed': { zh: '服务端退出失败，已清除本地登录状态', en: 'Server logout failed; local login state has been cleared' },
+  'layout.commandEmpty': { zh: '未找到匹配页面', en: 'No matching pages' },
+  'layout.commandUpDown': { zh: '↑↓ 切换', en: '↑↓ Navigate' },
+  'layout.commandEnter': { zh: '↵ 打开', en: '↵ Open' },
+  'layout.commandEsc': { zh: 'ESC 关闭', en: 'ESC Close' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -104,7 +104,7 @@ const MainLayout = () => {
     try {
       await requestLogout();
     } catch {
-      message.warning('服务端退出失败，已清除本地登录状态');
+      message.warning(t('layout.logoutLocalFailed'));
     } finally {
       clearAiChatHistories();
       clearAuth();
@@ -267,7 +267,7 @@ const MainLayout = () => {
       '/ops/audit': t('nav.audit'),
       '/ai': t('nav.ai'),
       '/settings': t('nav.settings'),
-      '/studio/users': '用户管理',
+      '/studio/users': t('nav.userManagement'),
     }),
     [t],
   );
@@ -321,7 +321,7 @@ const MainLayout = () => {
     onClick: handleUserMenuClick,
     items: [
       { key: 'profile', icon: <UserGear size={14} />, label: t('user.profile') },
-      ...(admin ? [{ key: 'users', icon: <UserGear size={14} />, label: '用户管理' }] : []),
+      ...(admin ? [{ key: 'users', icon: <UserGear size={14} />, label: t('nav.userManagement') }] : []),
       { type: 'divider' as const },
       { key: 'logout', label: t('user.logout'), danger: true },
     ],
@@ -736,7 +736,7 @@ const MainLayout = () => {
           ) : (
             <Empty
               image={Empty.PRESENTED_IMAGE_SIMPLE}
-              description="未找到匹配页面"
+              description={t('layout.commandEmpty')}
               style={{ padding: '24px 0' }}
             />
           )}
@@ -752,9 +752,9 @@ const MainLayout = () => {
             background: darkMode ? '#26262a' : '#fafafa',
           }}
         >
-          <span>↑↓ 切换</span>
-          <span>↵ 打开</span>
-          <span>ESC 关闭</span>
+          <span>{t('layout.commandUpDown')}</span>
+          <span>{t('layout.commandEnter')}</span>
+          <span>{t('layout.commandEsc')}</span>
         </div>
       </Modal>
     </>


### PR DESCRIPTION
## Summary

The main layout was already localized except for a handful of strings: a logout failure toast, the user-management nav label and the command-palette footer.

Localized in layouts/MainLayout.tsx:
- The logout failure toast now uses `layout.logoutLocalFailed`.
- The 用户管理 breadcrumb map entry and the user-menu item both use the new shared `nav.userManagement` key.
- The command palette empty state and its footer shortcut hints (↑↓ 切换 / ↵ 打开 / ESC 关闭) use new `layout.command*` keys.
- The language-toggle button label (showing the target language) is intentionally left as-is.
- 6 new keys (`nav.userManagement` + 5 `layout.*`); zh byte-identical.

## Why

The layout is global; these toast, breadcrumb and palette strings should follow the active language.

## Testing

- `tsc --noEmit` passes
- `eslint` clean on the changed files