### PR TITLE
fix(i18n): localize home dashboard load failure

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2542,6 +2542,10 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  // ─── Home dashboard ───
+  'dashboard.loadFailed': { zh: '仪表盘加载失败', en: 'Failed to load the dashboard' },
+  'dashboard.loadFailedDesc': { zh: '无法获取集群概览，请检查网络连接后重试。', en: 'Could not fetch the cluster overview. Check the network connection and retry.' },
+  'dashboard.retry': { zh: '重试', en: 'Retry' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/pages/home/dashboard.tsx
+++ b/web/src/pages/home/dashboard.tsx
@@ -126,11 +126,11 @@ const DashboardPage = () => {
         <Alert
           type="error"
           showIcon
-          message="仪表盘加载失败"
-          description="无法获取集群概览，请检查网络连接后重试。"
+          message={t('dashboard.loadFailed')}
+          description={t('dashboard.loadFailedDesc')}
           action={
             <Button size="small" onClick={() => void loadDashboard()} loading={loading}>
-              重试
+              {t('dashboard.retry')}
             </Button>
           }
         />


### PR DESCRIPTION
## Summary

The home dashboard page was mostly localized but its load-failure alert was still hard-coded zh.

Localized in pages/home/dashboard.tsx:
- The error alert message (仪表盘加载失败) and description (无法获取集群概览...) now come from translation keys, and the 重试 action reuses the new `dashboard.retry` key.
- 3 new `dashboard.*` keys; zh byte-identical.

## Why

The dashboard failure state is a first-run experience; its guidance should follow the active language.

## Testing

- `tsc --noEmit` passes
- `eslint` clean on the changed files