### PR TITLE
fix(i18n): localize resource CSV import validation

### DIFF
--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -253,7 +253,7 @@ const ConsumerPageContent = ({
   instanceOptions,
   instancesLoading,
 }: ConsumerPageContentProps) => {
-  const { t } = useLang();
+  const { t, lang } = useLang();
   const isCloudInstance =
     selectedInstance?.vendor === 'ALIYUN' || selectedInstance?.vendor === 'TENCENT';
   const hasSelectedInstance = Boolean(selectedInstanceId);
@@ -722,8 +722,12 @@ const ConsumerPageContent = ({
     setImporting(false);
     setImportModalOpen(true);
     try {
-      const records = parseCsvTable(await file.text());
-      const validation = validateConsumerGroupCsvImport(records, selectedInstanceId || undefined);
+      const records = parseCsvTable(await file.text(), lang);
+      const validation = validateConsumerGroupCsvImport(
+        records,
+        selectedInstanceId || undefined,
+        lang,
+      );
       setImportRows(validation.rows);
       setImportErrors(validation.errors);
     } catch (error) {

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -335,7 +335,7 @@ const PAYLOAD_ISSUE_COLOR: Record<MessagePayloadIssue['severity'], string> = {
 
 // ═══════════════════════════════════════════════════════════════════
 const TopicPage = () => {
-  const { t } = useLang();
+  const { t, lang } = useLang();
   const navigate = useNavigate();
   const {
     selectedInstanceId,
@@ -1157,8 +1157,8 @@ const TopicPage = () => {
     setImporting(false);
     setImportModalOpen(true);
     try {
-      const records = parseCsvTable(await file.text());
-      const validation = validateTopicCsvImport(records, selectedInstanceId || undefined);
+      const records = parseCsvTable(await file.text(), lang);
+      const validation = validateTopicCsvImport(records, selectedInstanceId || undefined, lang);
       setImportRows(validation.rows);
       setImportErrors(validation.errors);
     } catch (error) {

--- a/web/src/utils/resourceCsvImport.ts
+++ b/web/src/utils/resourceCsvImport.ts
@@ -53,16 +53,24 @@ export const RESOURCE_NAME_MAX_LENGTH = { topic: 127, group: 120 } as const;
 
 export type ResourceNameKind = keyof typeof RESOURCE_NAME_MAX_LENGTH;
 
-export const validateResourceName = (name: string, kind: ResourceNameKind): string | null => {
+export const validateResourceName = (
+  name: string,
+  kind: ResourceNameKind,
+  lang: 'zh' | 'en' = 'zh',
+): string | null => {
   if (!name) {
-    return 'Name 不能为空';
+    return lang === 'en' ? 'Name is required' : 'Name 不能为空';
   }
   const maxLength = RESOURCE_NAME_MAX_LENGTH[kind];
   if (name.length > maxLength) {
-    return `Name 长度不能超过 ${maxLength} 个字符`;
+    return lang === 'en'
+      ? `Name must not exceed ${maxLength} characters`
+      : `Name 长度不能超过 ${maxLength} 个字符`;
   }
   if (!RESOURCE_NAME_PATTERN.test(name)) {
-    return 'Name 仅支持字母、数字、下划线、短横线、% 和 |';
+    return lang === 'en'
+      ? 'Name supports only letters, digits, underscores, hyphens, % and |'
+      : 'Name 仅支持字母、数字、下划线、短横线、% 和 |';
   }
   return null;
 };
@@ -91,22 +99,29 @@ const parseInteger = (
   max: number,
   fallback: number,
   errors: string[],
+  lang: 'zh' | 'en' = 'zh',
 ): number => {
   if (!value) return fallback;
   if (!/^-?\d+$/.test(value)) {
-    errors.push(`${fieldName} 必须是整数`);
+    errors.push(
+      lang === 'en' ? `${fieldName} must be an integer` : `${fieldName} 必须是整数`,
+    );
     return fallback;
   }
 
   const parsed = Number(value);
   if (parsed < min || parsed > max) {
-    errors.push(`${fieldName} 必须在 ${min}..${max} 之间`);
+    errors.push(
+      lang === 'en'
+        ? `${fieldName} must be between ${min} and ${max}`
+        : `${fieldName} 必须在 ${min}..${max} 之间`,
+    );
     return fallback;
   }
   return parsed;
 };
 
-const readCsvRows = (content: string): ParsedCsvRow[] => {
+const readCsvRows = (content: string, lang: 'zh' | 'en' = 'zh'): ParsedCsvRow[] => {
   const rows: ParsedCsvRow[] = [];
   const text = content.startsWith('\uFEFF') ? content.slice(1) : content;
   let cells: string[] = [];
@@ -151,12 +166,20 @@ const readCsvRows = (content: string): ParsedCsvRow[] => {
     }
 
     if (quoteJustClosed && char !== ',' && char !== '\r' && char !== '\n') {
-      throw new Error(`第 ${lineNumber} 行 CSV 引号格式错误`);
+      throw new Error(
+        lang === 'en'
+          ? `Malformed CSV quotes on line ${lineNumber}`
+          : `第 ${lineNumber} 行 CSV 引号格式错误`,
+      );
     }
 
     if (char === '"') {
       if (cell.length > 0) {
-        throw new Error(`第 ${lineNumber} 行 CSV 引号格式错误`);
+        throw new Error(
+          lang === 'en'
+            ? `Malformed CSV quotes on line ${lineNumber}`
+            : `第 ${lineNumber} 行 CSV 引号格式错误`,
+        );
       }
       inQuotes = true;
       quoteJustClosed = false;
@@ -183,17 +206,21 @@ const readCsvRows = (content: string): ParsedCsvRow[] => {
   }
 
   if (inQuotes) {
-    throw new Error(`第 ${rowStartLine} 行 CSV 引号未闭合`);
+    throw new Error(
+      lang === 'en'
+        ? `Unclosed CSV quote starting on line ${rowStartLine}`
+        : `第 ${rowStartLine} 行 CSV 引号未闭合`,
+    );
   }
 
   pushRow();
   return rows;
 };
 
-export const parseCsvTable = (content: string): CsvRecord[] => {
-  const rows = readCsvRows(content);
+export const parseCsvTable = (content: string, lang: 'zh' | 'en' = 'zh'): CsvRecord[] => {
+  const rows = readCsvRows(content, lang);
   if (rows.length === 0) {
-    throw new Error('CSV 文件为空');
+    throw new Error(lang === 'en' ? 'CSV file is empty' : 'CSV 文件为空');
   }
 
   const headers = rows[0].cells.map(normalizeHeader);
@@ -201,15 +228,23 @@ export const parseCsvTable = (content: string): CsvRecord[] => {
     (header, index) => header && headers.indexOf(header) !== index,
   );
   if (headers.some((header) => !header)) {
-    throw new Error('CSV 表头不能为空');
+    throw new Error(lang === 'en' ? 'CSV headers cannot be empty' : 'CSV 表头不能为空');
   }
   if (duplicateHeaders.length > 0) {
-    throw new Error(`CSV 表头重复：${Array.from(new Set(duplicateHeaders)).join(', ')}`);
+    throw new Error(
+      lang === 'en'
+        ? `Duplicate CSV headers: ${Array.from(new Set(duplicateHeaders)).join(', ')}`
+        : `CSV 表头重复：${Array.from(new Set(duplicateHeaders)).join(', ')}`,
+    );
   }
 
   const records = rows.slice(1).map((row) => {
     if (row.cells.length > headers.length) {
-      throw new Error(`第 ${row.lineNumber} 行字段数超过表头字段数`);
+      throw new Error(
+        lang === 'en'
+          ? `Row ${row.lineNumber} has more fields than the header`
+          : `第 ${row.lineNumber} 行字段数超过表头字段数`,
+      );
     }
 
     return {
@@ -222,16 +257,23 @@ export const parseCsvTable = (content: string): CsvRecord[] => {
   });
 
   if (records.length === 0) {
-    throw new Error('CSV 没有可导入的数据行');
+    throw new Error(lang === 'en' ? 'CSV has no importable data rows' : 'CSV 没有可导入的数据行');
   }
   if (records.length > RESOURCE_IMPORT_ROW_LIMIT) {
-    throw new Error(`一次最多导入 ${RESOURCE_IMPORT_ROW_LIMIT} 行`);
+    throw new Error(
+      lang === 'en'
+        ? `At most ${RESOURCE_IMPORT_ROW_LIMIT} rows can be imported at once`
+        : `一次最多导入 ${RESOURCE_IMPORT_ROW_LIMIT} 行`,
+    );
   }
 
   return records;
 };
 
-const buildDuplicateNameMessages = (records: CsvRecord[]): Map<number, string> => {
+const buildDuplicateNameMessages = (
+  records: CsvRecord[],
+  lang: 'zh' | 'en' = 'zh',
+): Map<number, string> => {
   const firstLineByName = new Map<string, number>();
   const messagesByLine = new Map<number, string>();
 
@@ -241,7 +283,12 @@ const buildDuplicateNameMessages = (records: CsvRecord[]): Map<number, string> =
 
     const firstLine = firstLineByName.get(name);
     if (firstLine != null) {
-      messagesByLine.set(record.lineNumber, `Name 与第 ${firstLine} 行重复：${name}`);
+      messagesByLine.set(
+        record.lineNumber,
+        lang === 'en'
+          ? `Name duplicates line ${firstLine}: ${name}`
+          : `Name 与第 ${firstLine} 行重复：${name}`,
+      );
     } else {
       firstLineByName.set(name, record.lineNumber);
     }
@@ -253,8 +300,9 @@ const buildDuplicateNameMessages = (records: CsvRecord[]): Map<number, string> =
 export const validateTopicCsvImport = (
   records: CsvRecord[],
   selectedInstanceId?: string,
+  lang: 'zh' | 'en' = 'zh',
 ): ResourceImportValidation<Partial<Topic>> => {
-  const duplicateMessages = buildDuplicateNameMessages(records);
+  const duplicateMessages = buildDuplicateNameMessages(records, lang);
   const rows: ResourceImportRow<Partial<Topic>>[] = [];
 
   records.forEach((record, index) => {
@@ -268,6 +316,7 @@ export const validateTopicCsvImport = (
       256,
       8,
       rowErrors,
+      lang,
     );
     const readQueues = parseInteger(
       normalizeValue(record.values['Read Queues']),
@@ -276,21 +325,24 @@ export const validateTopicCsvImport = (
       256,
       8,
       rowErrors,
+      lang,
     );
     const perm = normalizeValue(record.values.Permission) || 'RW';
     const remark = normalizeValue(record.values.Remark);
     const duplicateMessage = duplicateMessages.get(record.lineNumber);
     if (duplicateMessage) rowErrors.push(duplicateMessage);
 
-    const nameError = validateResourceName(name, 'topic');
+    const nameError = validateResourceName(name, 'topic', lang);
     if (nameError) {
       rowErrors.push(nameError);
     }
     if (!TOPIC_TYPES.has(type)) {
-      rowErrors.push(`Type 不支持：${type}`);
+      rowErrors.push(lang === 'en' ? `Type is not supported: ${type}` : `Type 不支持：${type}`);
     }
     if (!TOPIC_PERMISSIONS.has(perm)) {
-      rowErrors.push(`Permission 不支持：${perm}`);
+      rowErrors.push(
+        lang === 'en' ? `Permission is not supported: ${perm}` : `Permission 不支持：${perm}`,
+      );
     }
 
     rows.push({
@@ -307,7 +359,7 @@ export const validateTopicCsvImport = (
         ...(selectedInstanceId ? { instanceId: selectedInstanceId } : {}),
       },
       status: rowErrors.length > 0 ? 'invalid' : 'pending',
-      message: rowErrors.join('；') || undefined,
+      message: rowErrors.join(lang === 'en' ? '; ' : '；') || undefined,
     });
   });
 
@@ -317,8 +369,9 @@ export const validateTopicCsvImport = (
 export const validateConsumerGroupCsvImport = (
   records: CsvRecord[],
   selectedInstanceId?: string,
+  lang: 'zh' | 'en' = 'zh',
 ): ResourceImportValidation<Partial<ConsumerGroup>> => {
-  const duplicateMessages = buildDuplicateNameMessages(records);
+  const duplicateMessages = buildDuplicateNameMessages(records, lang);
   const rows: ResourceImportRow<Partial<ConsumerGroup>>[] = [];
 
   records.forEach((record, index) => {
@@ -333,6 +386,7 @@ export const validateConsumerGroupCsvImport = (
       128,
       16,
       rowErrors,
+      lang,
     );
     const subscriptionDataType =
       normalizeValue(record.values['Subscription Data Type']) || 'NORMAL';
@@ -342,25 +396,39 @@ export const validateConsumerGroupCsvImport = (
     const duplicateMessage = duplicateMessages.get(record.lineNumber);
     if (duplicateMessage) rowErrors.push(duplicateMessage);
 
-    const nameError = validateResourceName(name, 'group');
+    const nameError = validateResourceName(name, 'group', lang);
     if (nameError) {
       rowErrors.push(nameError);
     }
     if (!GROUP_SUBSCRIPTION_MODES.has(subscriptionMode)) {
-      rowErrors.push(`Subscription Mode 不支持：${subscriptionMode}`);
+      rowErrors.push(
+        lang === 'en'
+          ? `Subscription Mode is not supported: ${subscriptionMode}`
+          : `Subscription Mode 不支持：${subscriptionMode}`,
+      );
     }
     if (!GROUP_CONSUME_TYPES.has(consumeType)) {
-      rowErrors.push(`Consume Type 不支持：${consumeType}`);
+      rowErrors.push(
+        lang === 'en' ? `Consume Type is not supported: ${consumeType}` : `Consume Type 不支持：${consumeType}`,
+      );
     }
     if (!GROUP_SUBSCRIPTION_DATA_TYPES.has(subscriptionDataType)) {
-      rowErrors.push(`Subscription Data Type 不支持：${subscriptionDataType}`);
+      rowErrors.push(
+        lang === 'en'
+          ? `Subscription Data Type is not supported: ${subscriptionDataType}`
+          : `Subscription Data Type 不支持：${subscriptionDataType}`,
+      );
     }
     if (
       deliveryOrderType &&
       subscriptionDataType === 'FIFO' &&
       !GROUP_DELIVERY_ORDER_TYPES.has(deliveryOrderType)
     ) {
-      rowErrors.push(`Delivery Order Type 不支持：${deliveryOrderType}`);
+      rowErrors.push(
+        lang === 'en'
+          ? `Delivery Order Type is not supported: ${deliveryOrderType}`
+          : `Delivery Order Type 不支持：${deliveryOrderType}`,
+      );
     }
 
     rows.push({
@@ -378,7 +446,7 @@ export const validateConsumerGroupCsvImport = (
         ...(selectedInstanceId ? { instanceId: selectedInstanceId } : {}),
       },
       status: rowErrors.length > 0 ? 'invalid' : 'pending',
-      message: rowErrors.join('；') || undefined,
+      message: rowErrors.join(lang === 'en' ? '; ' : '；') || undefined,
     });
   });
 


### PR DESCRIPTION
## Summary

The Topic / consumer-group CSV import flows validate rows in a shared utility that returned hard-coded zh errors, so imported rows and parse failures still showed Chinese messages in English mode.

Localized in utils/resourceCsvImport.ts (all functions accept `lang`, default `zh`):
- `validateResourceName` (empty / max length / pattern errors), `parseInteger` (integer and range errors) and `parseCsvTable` (empty file, empty/duplicate headers, malformed quotes, unclosed quotes, too many fields, no data rows, row limit) - including `readCsvRows` and the duplicate-name message builder.
- `validateTopicCsvImport` and `validateConsumerGroupCsvImport`: unsupported Type / Permission / Subscription Mode / Consume Type / Subscription Data Type / Delivery Order Type errors; per-row messages join with the active-language separator.
- pages/instance/topic.tsx and pages/instance/consumer.tsx pass the current language into `parseCsvTable` / the matching validator.
- No behavior change in zh; en now renders English validation copy.

## Why

Import feedback (row status explanations, parse errors) must follow the active language.

## Testing

- `tsc --noEmit` passes
- `eslint` clean on the changed files
- `vitest run` resourceCsvImport + TopicPage + ConsumerPage - 64/64 tests pass