### PR TITLE
fix(i18n): localize studio ops runtime config notice

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2542,6 +2542,9 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  // ─── Studio Ops ───
+  'ops.runtimeConfigUnavailable': { zh: '运行时配置不可用', en: 'Runtime configuration is unavailable' },
+  'ops.runtimeConfigUnavailableFallback': { zh: '当前集群不支持读取或更新 Ops 配置。', en: 'This cluster does not support reading or updating Ops configuration.' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/pages/studio/Ops.tsx
+++ b/web/src/pages/studio/Ops.tsx
@@ -195,8 +195,10 @@ const OpsPage: React.FC = () => {
         <Alert
           type="info"
           showIcon
-          message="运行时配置不可用"
-          description={unavailableReason || '当前集群不支持读取或更新 Ops 配置。'}
+          message={t('ops.runtimeConfigUnavailable')}
+          description={
+            unavailableReason || t('ops.runtimeConfigUnavailableFallback')
+          }
           style={{ marginBottom: 24 }}
         />
       )}


### PR DESCRIPTION
## Summary

The Studio Ops page was fully localized except the runtime-configuration-unavailable banner.

Localized in pages/studio/Ops.tsx:
- Alert message (运行时配置不可用) and its fallback description (当前集群不支持读取或更新 Ops 配置。) now route through keys.
- 2 new `ops.*` keys; zh byte-identical.

## Why

This banner explains why the page is read-only; it must follow the active language.

## Testing

- `tsc --noEmit` passes
- `eslint` clean on the changed files