### PR TITLE
fix(i18n): localize client connection diagnostics

### DIFF
--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -155,7 +155,7 @@ const displayMetadata = (value: string | null | undefined) => value || '-';
    ClientsPage
    ═══════════════════════════════════════════ */
 const ClientsPage = () => {
-  const { t } = useLang();
+  const { t, lang } = useLang();
   const { token } = theme.useToken();
   const [connections, setConnections] = useState<ClientConnection[]>([]);
   const [registryClusters, setRegistryClusters] = useState<ClusterInfo[]>([]);
@@ -299,8 +299,8 @@ const ClientsPage = () => {
   }, [clusterConnections]);
 
   const clientDiagnostics = useMemo(
-    () => analyzeClientConnections(clusterConnections),
-    [clusterConnections],
+    () => analyzeClientConnections(clusterConnections, lang),
+    [clusterConnections, lang],
   );
 
   const diagnosticProgressStatus =

--- a/web/src/utils/clientConnectionDiagnostics.ts
+++ b/web/src/utils/clientConnectionDiagnostics.ts
@@ -97,6 +97,12 @@ const STATUS_TEXT: Record<ClientConnectionHealthStatus, string> = {
   critical: '客户端连接存在高风险',
 };
 
+const STATUS_TEXT_EN: Record<ClientConnectionHealthStatus, string> = {
+  healthy: 'Client connections healthy',
+  warning: 'Client connections need attention',
+  critical: 'Client connections carry high risk',
+};
+
 const STATUS_COLOR: Record<ClientConnectionHealthStatus, 'success' | 'warning' | 'error'> = {
   healthy: 'success',
   warning: 'warning',
@@ -200,15 +206,19 @@ const resourceSeverity = (issues: ClientConnectionIssue[]): ClientConnectionHeal
   return 'healthy';
 };
 
-const addInventoryIssues = (connections: ClientConnection[], issues: ClientConnectionIssue[]) => {
+const addInventoryIssues = (
+  connections: ClientConnection[],
+  issues: ClientConnectionIssue[],
+  lang: 'zh' | 'en' = 'zh',
+) => {
   if (connections.length === 0) {
     issues.push(
       issue(
         'NO_CONNECTIONS',
         'critical',
-        '未发现客户端连接',
-        '当前 NameServer 查询没有返回任何 Producer 或 Consumer 连接。',
-        '确认目标 NameServer、Proxy 和 Broker 侧客户端注册链路是否正常。',
+        (lang === 'en' ? 'No client connections found' : '未发现客户端连接'),
+        (lang === 'en' ? 'The NameServer query returned no Producer or Consumer connections.' : '当前 NameServer 查询没有返回任何 Producer 或 Consumer 连接。'),
+        (lang === 'en' ? 'Confirm the client registration path on the target NameServer, Proxy and Broker is healthy.' : '确认目标 NameServer、Proxy 和 Broker 侧客户端注册链路是否正常。'),
       ),
     );
     return;
@@ -220,16 +230,20 @@ const addInventoryIssues = (connections: ClientConnection[], issues: ClientConne
       issue(
         'PARTIAL_CONNECTION_SCAN',
         'warning',
-        '客户端扫描结果不完整',
-        '部分 Producer 连接来自受限 Topic 扫描，当前列表可能不是完整客户端清单。',
-        '缩小 Topic 或集群范围后重新查询，并在排障时避免把当前列表视为全集。',
+        (lang === 'en' ? 'Client scan is incomplete' : '客户端扫描结果不完整'),
+        (lang === 'en' ? 'Some Producer connections come from a scoped Topic scan, so this list may not cover every client.' : '部分 Producer 连接来自受限 Topic 扫描，当前列表可能不是完整客户端清单。'),
+        (lang === 'en' ? 'Re-query with a narrower Topic or cluster scope and avoid treating this list as the full inventory during troubleshooting.' : '缩小 Topic 或集群范围后重新查询，并在排障时避免把当前列表视为全集。'),
         { evidence: [`partial=${partialCount}`] },
       ),
     );
   }
 };
 
-const addClientIdIssues = (connections: ClientConnection[], issues: ClientConnectionIssue[]) => {
+const addClientIdIssues = (
+  connections: ClientConnection[],
+  issues: ClientConnectionIssue[],
+  lang: 'zh' | 'en' = 'zh',
+) => {
   const connectionsByClient = new Map<string, ClientConnection[]>();
   const identityCounts = new Map<string, number>();
 
@@ -250,9 +264,9 @@ const addClientIdIssues = (connections: ClientConnection[], issues: ClientConnec
         issue(
           'CLIENT_ID_COLLISION',
           'critical',
-          'Client ID 连接到多个地址',
-          '同一个 Client ID 同时出现在多个远端地址，可能是实例 ID 配置冲突或旧连接未及时清理。',
-          '检查客户端 instanceName/clientId 配置，确保同一进程实例使用唯一标识。',
+          (lang === 'en' ? 'Client ID connected to multiple addresses' : 'Client ID 连接到多个地址'),
+          (lang === 'en' ? 'The same Client ID appears at multiple remote addresses; instance ID conflicts or stale connections may be the cause.' : '同一个 Client ID 同时出现在多个远端地址，可能是实例 ID 配置冲突或旧连接未及时清理。'),
+          (lang === 'en' ? 'Check the client instanceName/clientId configuration so each process instance uses a unique identifier.' : '检查客户端 instanceName/clientId 配置，确保同一进程实例使用唯一标识。'),
           {
             clientId,
             evidence: addresses,
@@ -269,9 +283,9 @@ const addClientIdIssues = (connections: ClientConnection[], issues: ClientConnec
       issue(
         'EXACT_DUPLICATE_CONNECTION',
         'info',
-        '连接记录重复',
-        '相同客户端、资源和地址出现了重复记录，可能来自采集侧合并或上游返回重复项。',
-        '刷新连接清单；若重复持续存在，检查客户端连接采集路径是否重复汇总。',
+        (lang === 'en' ? 'Duplicate connection records' : '连接记录重复'),
+        (lang === 'en' ? 'Duplicate records exist for the same client, resource and address; collection-side merging or upstream duplicates may be the cause.' : '相同客户端、资源和地址出现了重复记录，可能来自采集侧合并或上游返回重复项。'),
+        (lang === 'en' ? 'Refresh the connection inventory; if duplicates persist, check whether the collection path aggregates connections twice.' : '刷新连接清单；若重复持续存在，检查客户端连接采集路径是否重复汇总。'),
         {
           clientId,
           resource,
@@ -286,6 +300,7 @@ const addClientIdIssues = (connections: ClientConnection[], issues: ClientConnec
 const addUnknownFieldIssues = (
   connections: ClientConnection[],
   issues: ClientConnectionIssue[],
+  lang: 'zh' | 'en' = 'zh',
 ) => {
   connections.forEach((connection, index) => {
     const clientId = normalizeText(connection.clientId);
@@ -299,9 +314,9 @@ const addUnknownFieldIssues = (
         issue(
           'UNKNOWN_PROTOCOL',
           'warning',
-          '协议类型未知',
-          '该客户端连接的协议不在 Studio 已知协议列表中，统计和排障可能不准确。',
-          '确认客户端协议版本和服务端采集字段，必要时补充协议映射。',
+          (lang === 'en' ? 'Unknown protocol type' : '协议类型未知'),
+          (lang === 'en' ? 'The protocol of this connection is not in Studio\'s known list, so statistics and troubleshooting may be inaccurate.' : '该客户端连接的协议不在 Studio 已知协议列表中，统计和排障可能不准确。'),
+          (lang === 'en' ? 'Confirm the client protocol version and the collected server fields, adding protocol mappings if needed.' : '确认客户端协议版本和服务端采集字段，必要时补充协议映射。'),
           {
             clientId,
             resource,
@@ -317,9 +332,9 @@ const addUnknownFieldIssues = (
         issue(
           'UNKNOWN_LANGUAGE',
           'info',
-          '客户端语言未知',
-          '该客户端连接的语言不在 Studio 已知语言列表中。',
-          '确认客户端 SDK 语言和采集字段，必要时补充语言展示映射。',
+          (lang === 'en' ? 'Unknown client language' : '客户端语言未知'),
+          (lang === 'en' ? 'The language of this connection is not in Studio\'s known language list.' : '该客户端连接的语言不在 Studio 已知语言列表中。'),
+          (lang === 'en' ? 'Confirm the client SDK language and collected fields, adding display mappings if needed.' : '确认客户端 SDK 语言和采集字段，必要时补充语言展示映射。'),
           {
             clientId,
             resource,
@@ -335,9 +350,9 @@ const addUnknownFieldIssues = (
         issue(
           'UNKNOWN_VERSION',
           'warning',
-          '客户端版本未知',
-          '该客户端没有上报明确版本，升级治理和兼容性判断缺少依据。',
-          '升级客户端 SDK 或检查版本字段采集，确保连接清单能展示真实客户端版本。',
+          (lang === 'en' ? 'Unknown client version' : '客户端版本未知'),
+          (lang === 'en' ? 'The client did not report a clear version, so upgrade governance and compatibility checks lack evidence.' : '该客户端没有上报明确版本，升级治理和兼容性判断缺少依据。'),
+          (lang === 'en' ? 'Upgrade the client SDK or fix version-field collection so the inventory shows the real client version.' : '升级客户端 SDK 或检查版本字段采集，确保连接清单能展示真实客户端版本。'),
           {
             clientId,
             resource,
@@ -353,9 +368,9 @@ const addUnknownFieldIssues = (
         issue(
           'INVALID_CONNECTION_TIME',
           'info',
-          '连接时间无法解析',
-          '该连接的时间字段无法被浏览器解析，排序和人工判断可能受影响。',
-          '统一连接时间格式，优先返回 ISO-8601 或 yyyy-MM-dd HH:mm:ss。',
+          (lang === 'en' ? 'Connection time cannot be parsed' : '连接时间无法解析'),
+          (lang === 'en' ? 'The time fields of this connection cannot be parsed by the browser, which may affect sorting and manual review.' : '该连接的时间字段无法被浏览器解析，排序和人工判断可能受影响。'),
+          (lang === 'en' ? 'Use a consistent time format, preferring ISO-8601 or yyyy-MM-dd HH:mm:ss.' : '统一连接时间格式，优先返回 ISO-8601 或 yyyy-MM-dd HH:mm:ss。'),
           {
             clientId,
             resource,
@@ -368,7 +383,11 @@ const addUnknownFieldIssues = (
   });
 };
 
-const addResourceIssues = (groups: ConnectionGroup[], issues: ClientConnectionIssue[]) => {
+const addResourceIssues = (
+  groups: ConnectionGroup[],
+  issues: ClientConnectionIssue[],
+  lang: 'zh' | 'en' = 'zh',
+) => {
   groups.forEach((group) => {
     const protocols = uniqueSorted(group.connections.map((connection) => connection.protocol));
     const versions = uniqueSorted(group.connections.map((connection) => connection.version));
@@ -382,9 +401,9 @@ const addResourceIssues = (groups: ConnectionGroup[], issues: ClientConnectionIs
         issue(
           'MIXED_PROTOCOL_RESOURCE',
           'warning',
-          '同一资源存在多协议连接',
-          '同一个 Group 或 Topic 同时存在 gRPC 与 Remoting 客户端，迁移期排障需要区分控制面来源。',
-          '确认该资源是否处于协议迁移期，并分别检查 Proxy 与 Broker 侧连接状态。',
+          (lang === 'en' ? 'Multiple protocols for one resource' : '同一资源存在多协议连接'),
+          (lang === 'en' ? 'A Group or Topic has both gRPC and Remoting clients; troubleshooting during migration must distinguish their control-plane sources.' : '同一个 Group 或 Topic 同时存在 gRPC 与 Remoting 客户端，迁移期排障需要区分控制面来源。'),
+          (lang === 'en' ? 'Confirm whether the resource is mid protocol migration and check Proxy and Broker side connections separately.' : '确认该资源是否处于协议迁移期，并分别检查 Proxy 与 Broker 侧连接状态。'),
           {
             resource,
             evidence: protocols,
@@ -398,9 +417,9 @@ const addResourceIssues = (groups: ConnectionGroup[], issues: ClientConnectionIs
         issue(
           'MIXED_VERSION_RESOURCE',
           'warning',
-          '同一资源存在多版本客户端',
-          '同一个 Group 或 Topic 内客户端版本不一致，可能导致重试、负载均衡或协议能力差异。',
-          '按资源维度收敛客户端 SDK 版本，升级后再次确认连接清单。',
+          (lang === 'en' ? 'Multiple client versions for one resource' : '同一资源存在多版本客户端'),
+          (lang === 'en' ? 'Client versions differ within a Group or Topic, which may cause retry, load balancing or protocol capability differences.' : '同一个 Group 或 Topic 内客户端版本不一致，可能导致重试、负载均衡或协议能力差异。'),
+          (lang === 'en' ? 'Converge client SDK versions per resource and re-check the inventory after upgrading.' : '按资源维度收敛客户端 SDK 版本，升级后再次确认连接清单。'),
           {
             resource,
             evidence: versions,
@@ -414,9 +433,9 @@ const addResourceIssues = (groups: ConnectionGroup[], issues: ClientConnectionIs
         issue(
           'SINGLE_CONSUMER_INSTANCE',
           'warning',
-          'Consumer Group 只有单实例在线',
-          '该 Consumer Group 当前只有一个客户端实例，进程故障会直接影响消费连续性。',
-          '为关键 Consumer Group 保持至少两个实例在线，并确认负载均衡后队列分配正常。',
+          (lang === 'en' ? 'Only one instance online in the Consumer Group' : 'Consumer Group 只有单实例在线'),
+          (lang === 'en' ? 'This Consumer Group currently has one client instance; a process failure directly impacts consumption continuity.' : '该 Consumer Group 当前只有一个客户端实例，进程故障会直接影响消费连续性。'),
+          (lang === 'en' ? 'Keep at least two instances online for critical Consumer Groups and confirm queue assignment after rebalancing.' : '为关键 Consumer Group 保持至少两个实例在线，并确认负载均衡后队列分配正常。'),
           {
             resource,
             evidence: [`address=${addresses[0]}`],
@@ -430,9 +449,9 @@ const addResourceIssues = (groups: ConnectionGroup[], issues: ClientConnectionIs
         issue(
           'MIXED_VERSION_RESOURCE',
           'info',
-          '同一资源存在多语言多版本客户端',
-          '该资源由多语言 SDK 共同访问，升级治理和兼容性排查需要同时关注语言与版本。',
-          '记录各语言 SDK 的目标版本矩阵，避免只按单一语言判断升级完成度。',
+          (lang === 'en' ? 'Multiple languages and versions for one resource' : '同一资源存在多语言多版本客户端'),
+          (lang === 'en' ? 'The resource is accessed by SDKs in multiple languages; governance and compatibility checks must cover language and version together.' : '该资源由多语言 SDK 共同访问，升级治理和兼容性排查需要同时关注语言与版本。'),
+          (lang === 'en' ? 'Track a target version matrix per SDK language to avoid judging upgrade completeness by one language alone.' : '记录各语言 SDK 的目标版本矩阵，避免只按单一语言判断升级完成度。'),
           {
             resource,
             evidence: [...languages, ...versions],
@@ -447,6 +466,7 @@ const addResourceIssues = (groups: ConnectionGroup[], issues: ClientConnectionIs
 const addAddressConcentrationIssues = (
   connections: ClientConnection[],
   issues: ClientConnectionIssue[],
+  lang: 'zh' | 'en' = 'zh',
 ) => {
   if (connections.length < 4) return;
 
@@ -459,9 +479,9 @@ const addAddressConcentrationIssues = (
       issue(
         'ADDRESS_CONCENTRATION',
         'warning',
-        '连接集中在单一地址',
-        '较多客户端连接集中在同一个地址，主机或网关故障会影响多个生产或消费链路。',
-        '检查该地址上的客户端部署密度，必要时拆分实例或调整负载分布。',
+        (lang === 'en' ? 'Connections concentrated on a single address' : '连接集中在单一地址'),
+        (lang === 'en' ? 'Many client connections share one address; a host or gateway failure would affect multiple produce or consume paths.' : '较多客户端连接集中在同一个地址，主机或网关故障会影响多个生产或消费链路。'),
+        (lang === 'en' ? 'Review the client deployment density on that address; split instances or rebalance if necessary.' : '检查该地址上的客户端部署密度，必要时拆分实例或调整负载分布。'),
         {
           evidence: [`${address}: ${count}/${connections.length}`],
           id: `${address}:ADDRESS_CONCENTRATION`,
@@ -551,7 +571,10 @@ const statusFromIssues = (
   return 'healthy';
 };
 
-const buildRecommendations = (issues: ClientConnectionIssue[]): string[] => {
+const buildRecommendations = (
+  issues: ClientConnectionIssue[],
+  lang: 'zh' | 'en' = 'zh',
+): string[] => {
   const recommendations: string[] = [];
   const seen = new Set<string>();
 
@@ -562,7 +585,11 @@ const buildRecommendations = (issues: ClientConnectionIssue[]): string[] => {
   });
 
   if (recommendations.length === 0) {
-    recommendations.push('保持客户端连接清单按集群定期巡检，重点关注协议和 SDK 版本收敛。');
+    recommendations.push(
+      lang === 'en'
+        ? 'Keep a periodic per-cluster review of the connection inventory, focusing on protocol and SDK version convergence.'
+        : '保持客户端连接清单按集群定期巡检，重点关注协议和 SDK 版本收敛。',
+    );
   }
 
   return recommendations.slice(0, 6);
@@ -570,6 +597,7 @@ const buildRecommendations = (issues: ClientConnectionIssue[]): string[] => {
 
 export const analyzeClientConnections = (
   connections: ClientConnection[],
+  lang: 'zh' | 'en' = 'zh',
 ): ClientConnectionDiagnostics => {
   const normalizedConnections = connections.map((connection) => ({
     ...connection,
@@ -584,11 +612,11 @@ export const analyzeClientConnections = (
   const groups = groupConnections(normalizedConnections);
   const issues: ClientConnectionIssue[] = [];
 
-  addInventoryIssues(normalizedConnections, issues);
-  addClientIdIssues(normalizedConnections, issues);
-  addUnknownFieldIssues(normalizedConnections, issues);
-  addResourceIssues(groups, issues);
-  addAddressConcentrationIssues(normalizedConnections, issues);
+  addInventoryIssues(normalizedConnections, issues, lang);
+  addClientIdIssues(normalizedConnections, issues, lang);
+  addUnknownFieldIssues(normalizedConnections, issues, lang);
+  addResourceIssues(groups, issues, lang);
+  addAddressConcentrationIssues(normalizedConnections, issues, lang);
 
   const resources = buildResourceSummaries(groups, issues);
   const score = scoreDiagnostics(issues);
@@ -596,12 +624,12 @@ export const analyzeClientConnections = (
 
   return {
     status,
-    statusText: STATUS_TEXT[status],
+    statusText: lang === 'en' ? STATUS_TEXT_EN[status] : STATUS_TEXT[status],
     statusColor: STATUS_COLOR[status],
     score,
     summary: buildSummary(normalizedConnections, issues, resources),
     resources,
     issues,
-    recommendations: buildRecommendations(issues),
+    recommendations: buildRecommendations(issues, lang),
   };
 };


### PR DESCRIPTION
## Summary

The client connections page renders diagnostics issues (each with title, description and recommendation) built by a pure utility that returned hard-coded zh.

Localized in utils/clientConnectionDiagnostics.ts:
- `analyzeClientConnections` accepts `lang` (default `zh`); status text resolves through a new English status map in en.
- All five collectors (`addInventoryIssues`, `addClientIdIssues`, `addUnknownFieldIssues`, `addResourceIssues`, `addAddressConcentrationIssues`) accept `lang`; every issue title/description/recommendation returns active-language text (empty inventory, partial scans, client-ID collisions, duplicate records, unknown protocol/language/version, unparseable times, mixed protocols/versions, single consumer instance, mixed languages, address concentration).
- `buildRecommendations` is bilingual, including its default fallback.
- pages/cluster/clients.tsx passes the current language (memo deps updated).
- No behavior change in zh.

## Why

The client inventory diagnostics are the health surface of the connections page; issue text and advice must follow the active language.

## Testing

- `tsc --noEmit` passes
- `eslint` clean on the changed files
- `vitest run` clientConnectionDiagnostics + ClientsPage - 23/23 tests pass