### PR TITLE
fix(i18n): localize ACL risk diagnostics

### DIFF
--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -124,7 +124,7 @@ const AclPageContent = ({
   instanceOptions,
   instances,
 }: AclPageContentProps) => {
-  const { t } = useLang();
+  const { t, lang } = useLang();
   const hasSelectedInstance = Boolean(selectedInstanceId);
   const selectedInstance = instances.find((instance) => instance.name === selectedInstanceId);
   const tencentRoleMode = selectedInstance?.vendor === 'TENCENT';
@@ -954,7 +954,7 @@ const AclPageContent = ({
     },
   ];
 
-  const aclRiskDiagnostics = clusterConfig ? analyzeAclRisk(clusterConfig) : null;
+  const aclRiskDiagnostics = clusterConfig ? analyzeAclRisk(clusterConfig, lang) : null;
 
   const aclRiskProgressStatus =
     aclRiskDiagnostics?.status === 'critical'

--- a/web/src/utils/aclRiskDiagnostics.ts
+++ b/web/src/utils/aclRiskDiagnostics.ts
@@ -82,6 +82,12 @@ const STATUS_TEXT: Record<AclRiskStatus, string> = {
   critical: 'ACL 配置存在高风险',
 };
 
+const STATUS_TEXT_EN: Record<AclRiskStatus, string> = {
+  healthy: 'ACL configuration healthy',
+  warning: 'ACL configuration needs attention',
+  critical: 'ACL configuration carries high risk',
+};
+
 const STATUS_COLOR: Record<AclRiskStatus, 'success' | 'warning' | 'error'> = {
   healthy: 'success',
   warning: 'warning',
@@ -226,6 +232,7 @@ const addDefaultPermissionIssues = (
   issues: AclRiskIssue[],
   account: PlainAccessConfig,
   accessKey: string,
+  lang: 'zh' | 'en' = 'zh',
 ) => {
   const topicPermission = normalizePermission(account.defaultTopicPerm);
   const groupPermission = normalizePermission(account.defaultGroupPerm);
@@ -235,9 +242,9 @@ const addDefaultPermissionIssues = (
       issue(
         'DEFAULT_TOPIC_ALLOW',
         'critical',
-        '默认 Topic 权限过大',
-        '该账号默认允许所有 Topic 操作，新增 Topic 会自动继承高权限。',
-        '将默认 Topic 权限改为 DENY，并为确需访问的 Topic 配置最小权限。',
+        (lang === 'en' ? 'Default Topic permission is too broad' : '默认 Topic 权限过大'),
+        (lang === 'en' ? 'This account defaults to all Topic operations, so new Topics inherit high permissions automatically.' : '该账号默认允许所有 Topic 操作，新增 Topic 会自动继承高权限。'),
+        (lang === 'en' ? 'Change the default Topic permission to DENY and grant minimal permissions per Topic that truly needs access.' : '将默认 Topic 权限改为 DENY，并为确需访问的 Topic 配置最小权限。'),
         { account: accessKey, evidence: [`defaultTopicPerm=${account.defaultTopicPerm ?? '-'}`] },
       ),
     );
@@ -246,9 +253,9 @@ const addDefaultPermissionIssues = (
       issue(
         'DEFAULT_TOPIC_ALLOW',
         'warning',
-        '默认 Topic 权限非 DENY',
-        '该账号会自动获得新增 Topic 的默认访问能力，权限边界依赖命名规范。',
-        '优先使用 DENY 作为默认 Topic 权限，再通过 Topic 权限列表授权。',
+        (lang === 'en' ? 'Default Topic permission is not DENY' : '默认 Topic 权限非 DENY'),
+        (lang === 'en' ? 'The account automatically gains default access to new Topics; the boundary relies on naming conventions.' : '该账号会自动获得新增 Topic 的默认访问能力，权限边界依赖命名规范。'),
+        (lang === 'en' ? 'Prefer DENY as the default Topic permission and authorize through the Topic permission list.' : '优先使用 DENY 作为默认 Topic 权限，再通过 Topic 权限列表授权。'),
         { account: accessKey, evidence: [`defaultTopicPerm=${account.defaultTopicPerm ?? '-'}`] },
       ),
     );
@@ -259,9 +266,9 @@ const addDefaultPermissionIssues = (
       issue(
         'DEFAULT_GROUP_ALLOW',
         'critical',
-        '默认 Group 权限过大',
-        '该账号默认允许所有 Consumer Group 操作，新增 Group 会自动继承高权限。',
-        '将默认 Group 权限改为 DENY，并为确需订阅的 Group 配置最小权限。',
+        (lang === 'en' ? 'Default Group permission is too broad' : '默认 Group 权限过大'),
+        (lang === 'en' ? 'This account defaults to all Consumer Group operations, so new Groups inherit high permissions automatically.' : '该账号默认允许所有 Consumer Group 操作，新增 Group 会自动继承高权限。'),
+        (lang === 'en' ? 'Change the default Group permission to DENY and grant minimal permissions per Group that truly needs it.' : '将默认 Group 权限改为 DENY，并为确需订阅的 Group 配置最小权限。'),
         { account: accessKey, evidence: [`defaultGroupPerm=${account.defaultGroupPerm ?? '-'}`] },
       ),
     );
@@ -270,9 +277,9 @@ const addDefaultPermissionIssues = (
       issue(
         'DEFAULT_GROUP_ALLOW',
         'warning',
-        '默认 Group 权限非 DENY',
-        '该账号会自动获得新增 Consumer Group 的默认访问能力。',
-        '优先使用 DENY 作为默认 Group 权限，再通过 Group 权限列表授权。',
+        (lang === 'en' ? 'Default Group permission is not DENY' : '默认 Group 权限非 DENY'),
+        (lang === 'en' ? 'The account automatically gains default access to new Consumer Groups.' : '该账号会自动获得新增 Consumer Group 的默认访问能力。'),
+        (lang === 'en' ? 'Prefer DENY as the default Group permission and authorize through the Group permission list.' : '优先使用 DENY 作为默认 Group 权限，再通过 Group 权限列表授权。'),
         { account: accessKey, evidence: [`defaultGroupPerm=${account.defaultGroupPerm ?? '-'}`] },
       ),
     );
@@ -283,6 +290,7 @@ const addWildcardPermissionIssues = (
   issues: AclRiskIssue[],
   account: PlainAccessConfig,
   accessKey: string,
+  lang: 'zh' | 'en' = 'zh',
 ) => {
   const topicWildcards = wildcardEntries(parsePermissionEntries(account.topicPerms));
   const groupWildcards = wildcardEntries(parsePermissionEntries(account.groupPerms));
@@ -292,9 +300,9 @@ const addWildcardPermissionIssues = (
       issue(
         'WILDCARD_TOPIC_PERMISSION',
         entry.permission === 'ALL' ? 'critical' : 'warning',
-        'Topic 通配授权过大',
-        '该账号通过通配资源获得 Topic 访问能力，可能覆盖未来新增 Topic。',
-        '将通配 Topic 授权收敛为具体 Topic 或业务前缀，并避免 *=ALL。',
+        (lang === 'en' ? 'Topic wildcard grants are too broad' : 'Topic 通配授权过大'),
+        (lang === 'en' ? 'The account gains Topic access through wildcard resources, which may cover Topics created later.' : '该账号通过通配资源获得 Topic 访问能力，可能覆盖未来新增 Topic。'),
+        (lang === 'en' ? 'Narrow wildcard Topic grants to specific Topics or business prefixes and avoid *=ALL.' : '将通配 Topic 授权收敛为具体 Topic 或业务前缀，并避免 *=ALL。'),
         { account: accessKey, evidence: [entry.raw] },
       ),
     );
@@ -305,9 +313,9 @@ const addWildcardPermissionIssues = (
       issue(
         'WILDCARD_GROUP_PERMISSION',
         entry.permission === 'ALL' ? 'critical' : 'warning',
-        'Group 通配授权过大',
-        '该账号通过通配资源获得 Consumer Group 访问能力，可能覆盖未来新增 Group。',
-        '将通配 Group 授权收敛为具体 Group 或业务前缀，并避免 *=ALL。',
+        (lang === 'en' ? 'Group wildcard grants are too broad' : 'Group 通配授权过大'),
+        (lang === 'en' ? 'The account gains Consumer Group access through wildcard resources, which may cover Groups created later.' : '该账号通过通配资源获得 Consumer Group 访问能力，可能覆盖未来新增 Group。'),
+        (lang === 'en' ? 'Narrow wildcard Group grants to specific Groups or business prefixes and avoid *=ALL.' : '将通配 Group 授权收敛为具体 Group 或业务前缀，并避免 *=ALL。'),
         { account: accessKey, evidence: [entry.raw] },
       ),
     );
@@ -318,6 +326,7 @@ const addInvalidPermissionEntryIssues = (
   issues: AclRiskIssue[],
   account: PlainAccessConfig,
   accessKey: string,
+  lang: 'zh' | 'en' = 'zh',
 ) => {
   const invalidEntries = [
     ...parsePermissionEntries(account.topicPerms),
@@ -329,9 +338,9 @@ const addInvalidPermissionEntryIssues = (
       issue(
         'INVALID_PERMISSION_ENTRY',
         'warning',
-        '权限条目格式无法识别',
-        '该权限条目没有明确的 PUB、SUB、ALL 或 DENY 决策，诊断无法判断最终权限。',
-        '按 resource=PUB、resource=SUB、resource=ALL 或 resource=DENY 的格式修正条目。',
+        (lang === 'en' ? 'Permission entry format is unrecognized' : '权限条目格式无法识别'),
+        (lang === 'en' ? 'The entry has no clear PUB, SUB, ALL or DENY decision, so the effective permission cannot be judged.' : '该权限条目没有明确的 PUB、SUB、ALL 或 DENY 决策，诊断无法判断最终权限。'),
+        (lang === 'en' ? 'Fix entries to the resource=PUB, resource=SUB, resource=ALL or resource=DENY format.' : '按 resource=PUB、resource=SUB、resource=ALL 或 resource=DENY 的格式修正条目。'),
         { account: accessKey, evidence: [entry.raw] },
       ),
     );
@@ -343,6 +352,7 @@ const addAccountIssues = (
   account: PlainAccessConfig,
   index: number,
   duplicateAccessKeys: Set<string>,
+  lang: 'zh' | 'en' = 'zh',
 ) => {
   const accessKey = accountKey(account, index);
   const whitelistClass = accountWhitelistClass(account);
@@ -353,9 +363,9 @@ const addAccountIssues = (
       issue(
         'MISSING_ACCESS_KEY',
         'critical',
-        'Access Key 缺失',
-        'Plain Access 账号缺少 Access Key，无法形成可审计的身份边界。',
-        '补全 Access Key，或删除无法识别身份的账号配置。',
+        (lang === 'en' ? 'Missing Access Key' : 'Access Key 缺失'),
+        (lang === 'en' ? 'A Plain Access account without an Access Key cannot form an auditable identity boundary.' : 'Plain Access 账号缺少 Access Key，无法形成可审计的身份边界。'),
+        (lang === 'en' ? 'Fill in the Access Key or remove account configurations without a recognizable identity.' : '补全 Access Key，或删除无法识别身份的账号配置。'),
         { account: accessKey, id: `${index}:MISSING_ACCESS_KEY` },
       ),
     );
@@ -366,9 +376,9 @@ const addAccountIssues = (
       issue(
         'DUPLICATE_ACCESS_KEY',
         'critical',
-        'Access Key 重复',
-        '同一个 Access Key 出现在多个 Plain Access 账号中，权限合并结果容易被误判。',
-        '保留唯一账号定义，合并必要权限后删除重复条目。',
+        (lang === 'en' ? 'Duplicate Access Key' : 'Access Key 重复'),
+        (lang === 'en' ? 'The same Access Key appears in multiple Plain Access accounts, so merged permissions can be misjudged.' : '同一个 Access Key 出现在多个 Plain Access 账号中，权限合并结果容易被误判。'),
+        (lang === 'en' ? 'Keep a single account definition, merge needed permissions and remove duplicates.' : '保留唯一账号定义，合并必要权限后删除重复条目。'),
         {
           account: accessKey,
           evidence: [accessKey],
@@ -383,9 +393,9 @@ const addAccountIssues = (
       issue(
         'BROAD_ACCOUNT_WHITELIST',
         whitelistClass === 'open' ? 'critical' : 'warning',
-        '账号 IP 白名单范围过大',
-        '该账号的 IP 白名单覆盖范围过宽，弱化了 ACL 账号和网络来源的双重约束。',
-        '将账号白名单收敛到应用出口地址或可信网段。',
+        (lang === 'en' ? 'Account IP whitelist is too broad' : '账号 IP 白名单范围过大'),
+        (lang === 'en' ? 'The whitelist is too wide and weakens the dual constraint of the ACL account and network source.' : '该账号的 IP 白名单覆盖范围过宽，弱化了 ACL 账号和网络来源的双重约束。'),
+        (lang === 'en' ? 'Narrow the account whitelist to application egress addresses or trusted subnets.' : '将账号白名单收敛到应用出口地址或可信网段。'),
         { account: accessKey, evidence: whitelist.length ? whitelist : ['<empty>'] },
       ),
     );
@@ -396,17 +406,17 @@ const addAccountIssues = (
       issue(
         'ADMIN_WITH_BROAD_ACCESS',
         'critical',
-        '管理员账号可从宽网段访问',
-        '管理员账号叠加宽松 IP 白名单后，误用或泄露影响范围会扩大到整个集群。',
-        '为管理员账号配置专用 Access Key、强约束 IP 白名单，并尽量减少长期管理员账号。',
+        (lang === 'en' ? 'Admin account accessible from broad networks' : '管理员账号可从宽网段访问'),
+        (lang === 'en' ? 'An admin account with a loose IP whitelist widens the blast radius of misuse or leaks to the whole cluster.' : '管理员账号叠加宽松 IP 白名单后，误用或泄露影响范围会扩大到整个集群。'),
+        (lang === 'en' ? 'Give admin accounts dedicated Access Keys and tightly constrained IP whitelists, and minimize long-lived admins.' : '为管理员账号配置专用 Access Key、强约束 IP 白名单，并尽量减少长期管理员账号。'),
         { account: accessKey, evidence: whitelist.length ? whitelist : ['<empty>'] },
       ),
     );
   }
 
-  addDefaultPermissionIssues(issues, account, accessKey);
-  addWildcardPermissionIssues(issues, account, accessKey);
-  addInvalidPermissionEntryIssues(issues, account, accessKey);
+  addDefaultPermissionIssues(issues, account, accessKey, lang);
+  addWildcardPermissionIssues(issues, account, accessKey, lang);
+  addInvalidPermissionEntryIssues(issues, account, accessKey, lang);
 };
 
 const buildSummary = (config: AclClusterConfig): AclRiskSummary => {
@@ -446,7 +456,10 @@ const statusFromIssues = (issues: AclRiskIssue[], score: number): AclRiskStatus 
   return 'healthy';
 };
 
-const buildRecommendations = (issues: AclRiskIssue[]): string[] => {
+const buildRecommendations = (
+  issues: AclRiskIssue[],
+  lang: 'zh' | 'en' = 'zh',
+): string[] => {
   const recommendations: string[] = [];
   const seen = new Set<string>();
 
@@ -457,13 +470,20 @@ const buildRecommendations = (issues: AclRiskIssue[]): string[] => {
   });
 
   if (recommendations.length === 0) {
-    recommendations.push('保持默认权限为 DENY，新增账号时继续按业务资源最小授权。');
+    recommendations.push(
+      lang === 'en'
+        ? 'Keep the default permission as DENY and grant new accounts minimal access per business resource.'
+        : '保持默认权限为 DENY，新增账号时继续按业务资源最小授权。',
+    );
   }
 
   return recommendations.slice(0, 6);
 };
 
-export const analyzeAclRisk = (config: AclClusterConfig): AclRiskDiagnostics => {
+export const analyzeAclRisk = (
+  config: AclClusterConfig,
+  lang: 'zh' | 'en' = 'zh',
+): AclRiskDiagnostics => {
   const issues: AclRiskIssue[] = [];
   const accounts = config.accounts ?? [];
   const duplicateAccessKeys = collectDuplicateAccessKeys(accounts);
@@ -474,9 +494,9 @@ export const analyzeAclRisk = (config: AclClusterConfig): AclRiskDiagnostics => 
       issue(
         'ACL_DISABLED',
         'critical',
-        'ACL 未启用',
-        '当前集群没有启用 ACL，客户端访问主要依赖网络边界。',
-        '在生产集群启用 ACL，并为管理员和应用账号配置最小权限。',
+        (lang === 'en' ? 'ACL is disabled' : 'ACL 未启用'),
+        (lang === 'en' ? 'ACL is not enabled on this cluster; client access relies mainly on the network boundary.' : '当前集群没有启用 ACL，客户端访问主要依赖网络边界。'),
+        (lang === 'en' ? 'Enable ACL on production clusters and grant minimal permissions to admin and application accounts.' : '在生产集群启用 ACL，并为管理员和应用账号配置最小权限。'),
         { evidence: [`clusterId=${config.clusterId}`] },
       ),
     );
@@ -487,9 +507,9 @@ export const analyzeAclRisk = (config: AclClusterConfig): AclRiskDiagnostics => 
       issue(
         'LEGACY_ACL_VERSION',
         'info',
-        'ACL 版本较旧或未知',
-        '当前版本不是明确的 ACL 2.0，部分细粒度权限能力可能不可用。',
-        '确认集群 ACL 版本，并在升级窗口评估迁移到 ACL 2.0。',
+        (lang === 'en' ? 'ACL version is old or unknown' : 'ACL 版本较旧或未知'),
+        (lang === 'en' ? 'The current version is not clearly ACL 2.0, so some fine-grained permission capabilities may be unavailable.' : '当前版本不是明确的 ACL 2.0，部分细粒度权限能力可能不可用。'),
+        (lang === 'en' ? 'Confirm the cluster ACL version and evaluate migrating to ACL 2.0 in an upgrade window.' : '确认集群 ACL 版本，并在升级窗口评估迁移到 ACL 2.0。'),
         { evidence: [config.aclVersion || '<unknown>'] },
       ),
     );
@@ -500,9 +520,9 @@ export const analyzeAclRisk = (config: AclClusterConfig): AclRiskDiagnostics => 
       issue(
         'NO_PLAIN_ACCESS_ACCOUNTS',
         config.aclEnabled ? 'critical' : 'warning',
-        '未配置 Plain Access 账号',
-        '集群配置中没有 Plain Access 账号，启用 ACL 后可能导致客户端或运维账号无法认证。',
-        '至少配置一个受控管理员账号和必要的应用账号，再启用严格 ACL 策略。',
+        (lang === 'en' ? 'No Plain Access accounts configured' : '未配置 Plain Access 账号'),
+        (lang === 'en' ? 'No Plain Access accounts are configured; enabling ACL may block client or operator authentication.' : '集群配置中没有 Plain Access 账号，启用 ACL 后可能导致客户端或运维账号无法认证。'),
+        (lang === 'en' ? 'Configure at least one controlled admin account plus the needed application accounts before enabling strict ACL.' : '至少配置一个受控管理员账号和必要的应用账号，再启用严格 ACL 策略。'),
         { evidence: [`accountCount=${config.accountCount ?? 0}`] },
       ),
     );
@@ -513,9 +533,9 @@ export const analyzeAclRisk = (config: AclClusterConfig): AclRiskDiagnostics => 
       issue(
         'BROAD_GLOBAL_WHITELIST',
         globalWhitelistClass === 'open' ? 'critical' : 'warning',
-        '全局 IP 白名单范围过大',
-        '全局白名单会绕过账号级权限判断，过宽网段会降低 ACL 的实际隔离效果。',
-        '删除全局通配白名单，改为按账号配置必要的应用出口地址。',
+        (lang === 'en' ? 'Global IP whitelist is too broad' : '全局 IP 白名单范围过大'),
+        (lang === 'en' ? 'The global whitelist bypasses account-level checks; overly broad networks weaken ACL isolation.' : '全局白名单会绕过账号级权限判断，过宽网段会降低 ACL 的实际隔离效果。'),
+        (lang === 'en' ? 'Remove the global wildcard whitelist and configure per-account application egress addresses instead.' : '删除全局通配白名单，改为按账号配置必要的应用出口地址。'),
         { evidence: config.globalWhiteRemoteAddresses },
       ),
     );
@@ -527,16 +547,16 @@ export const analyzeAclRisk = (config: AclClusterConfig): AclRiskDiagnostics => 
       issue(
         'MULTIPLE_ADMIN_ACCOUNTS',
         'warning',
-        '管理员账号数量偏多',
-        '多个长期管理员账号会增加凭据轮转和误授权的管理成本。',
-        '保留最少数量的管理员账号，并将日常应用访问改为非管理员账号。',
+        (lang === 'en' ? 'Too many admin accounts' : '管理员账号数量偏多'),
+        (lang === 'en' ? 'Multiple long-lived admin accounts raise the cost of credential rotation and misauthorization.' : '多个长期管理员账号会增加凭据轮转和误授权的管理成本。'),
+        (lang === 'en' ? 'Keep the fewest admin accounts and move routine application access to non-admin accounts.' : '保留最少数量的管理员账号，并将日常应用访问改为非管理员账号。'),
         { evidence: adminAccounts.map((account, index) => accountKey(account, index)) },
       ),
     );
   }
 
   accounts.forEach((account, index) => {
-    addAccountIssues(issues, account, index, duplicateAccessKeys);
+    addAccountIssues(issues, account, index, duplicateAccessKeys, lang);
   });
 
   const score = scoreDiagnostics(issues);
@@ -544,7 +564,7 @@ export const analyzeAclRisk = (config: AclClusterConfig): AclRiskDiagnostics => 
 
   return {
     status,
-    statusText: STATUS_TEXT[status],
+    statusText: lang === 'en' ? STATUS_TEXT_EN[status] : STATUS_TEXT[status],
     statusColor: STATUS_COLOR[status],
     score,
     summary: buildSummary({
@@ -552,6 +572,6 @@ export const analyzeAclRisk = (config: AclClusterConfig): AclRiskDiagnostics => 
       accounts,
     }),
     issues,
-    recommendations: buildRecommendations(issues),
+    recommendations: buildRecommendations(issues, lang),
   };
 };


### PR DESCRIPTION
## Summary

The ACL page renders risk diagnostics issues (title/description/recommendation triples) built by a pure utility that returned hard-coded zh.

Localized in utils/aclRiskDiagnostics.ts:
- `analyzeAclRisk` accepts `lang` (default `zh`); status text resolves through a new English status map in en.
- All collectors (`addDefaultPermissionIssues`, `addWildcardPermissionIssues`, `addInvalidPermissionEntryIssues`, `addAccountIssues`) accept `lang`; every issue triple is bilingual (broad / non-DENY default Topic & Group permissions, broad Topic/Group wildcards, unrecognized permission entries, missing/duplicate Access Keys, broad account whitelists, admin accounts on broad networks).
- Cluster-level issues (ACL disabled, legacy ACL version, no Plain Access accounts, broad global whitelist, too many admins) are bilingual; `buildRecommendations` bilingual including its default fallback.
- pages/instance/acl.tsx passes the current language.
- No behavior change in zh.

## Why

The ACL risk diagnostics are the security surface of the ACL page; issue text and advice must follow the active language.

## Testing

- `tsc --noEmit` passes
- `eslint` clean on the changed files
- `vitest run` aclRiskDiagnostics + AclPage - 25/25 tests pass