### PR TITLE
fix(i18n): localize shared component labels

### DIFF
--- a/web/src/components/InstanceSelect.tsx
+++ b/web/src/components/InstanceSelect.tsx
@@ -17,6 +17,7 @@
 
 import { Select } from 'antd';
 import type { CSSProperties } from 'react';
+import { useLang } from '../i18n/LangContext';
 
 export interface InstanceOption {
   value: string;
@@ -40,13 +41,14 @@ export function InstanceSelect({
   onChange,
   options,
   style,
-  placeholder = '选择实例',
+  placeholder,
 }: InstanceSelectProps) {
+  const { t } = useLang();
   return (
     <Select
       showSearch
       allowClear
-      placeholder={placeholder}
+      placeholder={placeholder ?? t('instanceSelect.placeholder')}
       value={value ?? undefined}
       onChange={(next, option) => {
         if (next === undefined || next === null) {
@@ -65,7 +67,7 @@ export function InstanceSelect({
           .toLowerCase()
           .includes(input.toLowerCase())
       }
-      notFoundContent="暂无匹配实例"
+      notFoundContent={t('instanceSelect.notFound')}
       style={style ?? { width: 220 }}
     />
   );

--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -732,7 +732,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
 
         <Flex gap={8} wrap="wrap" align="center" style={{ maxWidth: '100%' }}>
           <Select
-            aria-label="数据源"
+            aria-label={lang === 'zh' ? '数据源' : 'Data source'}
             value={dataSourceKey}
             loading={dataSourcesLoading}
             onChange={handleDataSourceChange}

--- a/web/src/components/MiniBar.tsx
+++ b/web/src/components/MiniBar.tsx
@@ -23,10 +23,13 @@ interface MiniBarProps {
   label?: string;
 }
 
+import { useLang } from '../i18n/LangContext';
+
 const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: MiniBarProps) => {
+  const { t, lang } = useLang();
   if (!data.length) {
     return (
-      <span aria-label={label || '暂无趋势数据'} style={{ color: '#8c8c8c' }}>
+      <span aria-label={label || t('miniBar.noTrend')} style={{ color: '#8c8c8c' }}>
         —
       </span>
     );
@@ -38,7 +41,12 @@ const MiniBar = ({ data, color = '#1677ff', height = 32, width = 120, label }: M
   return (
     <div
       role="img"
-      aria-label={label || `趋势数据：${data.join('、')}`}
+      aria-label={
+        label ||
+        (lang === 'en'
+          ? `Trend data: ${data.join(', ')}`
+          : `趋势数据：${data.join('、')}`)
+      }
       style={{
         display: 'inline-flex',
         alignItems: 'flex-end',

--- a/web/src/components/ResultEmpty.tsx
+++ b/web/src/components/ResultEmpty.tsx
@@ -16,14 +16,16 @@
  */
 
 import { Result } from 'antd';
+import { useLang } from '../i18n/LangContext';
 
 interface ResultEmptyProps {
   title?: string;
   subTitle?: string;
 }
 
-const ResultEmpty = ({ title = '暂无数据', subTitle }: ResultEmptyProps) => (
-  <Result status="info" title={title} subTitle={subTitle} />
-);
+const ResultEmpty = ({ title, subTitle }: ResultEmptyProps) => {
+  const { t } = useLang();
+  return <Result status="info" title={title ?? t('resultEmpty.title')} subTitle={subTitle} />;
+};
 
 export default ResultEmpty;

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2542,6 +2542,12 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  // ─── Shared components ───
+  'miniBar.noTrend': { zh: '暂无趋势数据', en: 'No trend data' },
+  'miniBar.trendLabel': { zh: '趋势数据：{data}', en: 'Trend data: {data}' },
+  'instanceSelect.placeholder': { zh: '选择实例', en: 'Select instance' },
+  'instanceSelect.notFound': { zh: '暂无匹配实例', en: 'No matching instance' },
+  'resultEmpty.title': { zh: '暂无数据', en: 'No data' },
   // ─── BrokerCluster ───
 };
 


### PR DESCRIPTION
## Summary

Small shared components still carried hard-coded zh in a few aria labels, placeholders and empty-state texts.

Localized:
- components/MiniBar.tsx: the no-data and trend-data aria labels (with a language-aware separator in the trend list).
- components/InstanceSelect.tsx: the default placeholder (选择实例) and the no-match empty text (暂无匹配实例).
- components/ResultEmpty.tsx: the default title (暂无数据).
- components/MetricsExplorer.tsx: the data-source select aria label (the page already used a bilingual copy map otherwise).
- 5 new keys (`miniBar.*`, `instanceSelect.*`, `resultEmpty.*`); zh byte-identical.

## Why

These shared components render across instance-scoped pages; their labels should follow the active language.

## Testing

- `tsc --noEmit` passes
- `eslint` clean on the changed files