### PR TITLE
fix(i18n): localize broker cluster instance selector

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -2542,6 +2542,8 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: 'Claude / Titan / Llama (AWS)',
     en: 'Claude / Titan / Llama (AWS)',
   },
+  // ─── Studio BrokerCluster ───
+  'brokerCluster.selectInstance': { zh: '选择实例', en: 'Select instance' },
   // ─── BrokerCluster ───
 };
 

--- a/web/src/pages/studio/BrokerCluster.tsx
+++ b/web/src/pages/studio/BrokerCluster.tsx
@@ -519,10 +519,10 @@ const BrokerClusterPage = () => {
         </h2>
         <Space size="middle">
           <Select
-            aria-label="选择实例"
+            aria-label={t('brokerCluster.selectInstance')}
             value={selectedInstanceId}
             onChange={setSelectedInstanceId}
-            placeholder="选择实例"
+            placeholder={t('brokerCluster.selectInstance')}
             style={{ minWidth: 180 }}
             options={instances.map((instance) => ({ value: instance.name, label: instance.name }))}
           />


### PR DESCRIPTION
## Summary

The Studio BrokerCluster page toolbar instance selector still used hard-coded zh for its accessible name and placeholder.

Localized in pages/studio/BrokerCluster.tsx:
- The select aria-label and placeholder (选择实例) now use the new `brokerCluster.selectInstance` key.
- 1 new `brokerCluster.*` key; zh byte-identical.

## Why

The toolbar selector is the primary instance switch on the page; its accessible name must follow the active language.

## Testing

- `tsc --noEmit` passes
- `eslint` clean on the changed files