### PR TITLE
test(metrics): cover MetricsSourceFactory backend selection and client wiring

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsSourceFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsSourceFactoryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.metrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.studio.common.util.NoRedirectClientHttpRequestFactory;
+import org.apache.rocketmq.studio.model.MetricsDataSourceConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link MetricsSourceFactory}: each stored provider type resolves to the
+ * concrete Prometheus-compatible backend that shares query/parse semantics but differs in
+ * the URL path it mounts the API under, and every source is wired through the shared
+ * redirect-guarded {@link RestClient} configuration.
+ */
+class MetricsSourceFactoryTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static MetricsDataSourceConfig config(String providerType) {
+        MetricsDataSourceConfig config = new MetricsDataSourceConfig();
+        config.setProviderType(providerType);
+        config.setUrl("http://metrics:9090");
+        return config;
+    }
+
+    private static RestClient.Builder mockBuilder() {
+        RestClient.Builder builder = mock(RestClient.Builder.class);
+        when(builder.requestFactory(any())).thenReturn(builder);
+        return builder;
+    }
+
+    @Test
+    void mapsEachProviderTypeToItsConcreteBackendSource() {
+        MetricsSourceFactory factory = new MetricsSourceFactory(mockBuilder(), objectMapper);
+
+        assertSource(factory, "Prometheus", PrometheusMetricsSource.class, MetricsBackendType.PROMETHEUS);
+        assertSource(factory, "VictoriaMetrics", VictoriaMetricsMetricsSource.class,
+                MetricsBackendType.VICTORIA_METRICS);
+        assertSource(factory, "Thanos", ThanosMetricsSource.class, MetricsBackendType.THANOS);
+        assertSource(factory, "Cortex", CortexMetricsSource.class, MetricsBackendType.CORTEX);
+        assertSource(factory, "Mimir", MimirMetricsSource.class, MetricsBackendType.MIMIR);
+        assertSource(factory, "ARMS", ArmsMetricsSource.class, MetricsBackendType.ARMS);
+        // CUSTOM shares the Prometheus implementation but keeps its own backend identity.
+        assertSource(factory, "Custom", PrometheusMetricsSource.class, MetricsBackendType.CUSTOM);
+    }
+
+    @Test
+    void defaultsUnknownAndMissingProviderTypesToPrometheus() {
+        MetricsSourceFactory factory = new MetricsSourceFactory(mockBuilder(), objectMapper);
+
+        assertSource(factory, null, PrometheusMetricsSource.class, MetricsBackendType.PROMETHEUS);
+        assertSource(factory, "some future backend", PrometheusMetricsSource.class,
+                MetricsBackendType.PROMETHEUS);
+        // Provider name normalization also tolerates whitespace/underscores.
+        assertSource(factory, "victoria_metrics", VictoriaMetricsMetricsSource.class,
+                MetricsBackendType.VICTORIA_METRICS);
+    }
+
+    @Test
+    void configuresARedirectGuardedRestClientPerSource() {
+        RestClient.Builder builder = mock(RestClient.Builder.class);
+        when(builder.requestFactory(any())).thenReturn(builder);
+        MetricsSourceFactory factory = new MetricsSourceFactory(builder, objectMapper);
+
+        factory.create(config("Mimir"));
+
+        verify(builder).requestFactory(any(NoRedirectClientHttpRequestFactory.class));
+        verify(builder).build();
+    }
+
+    private static void assertSource(MetricsSourceFactory factory, String providerType,
+            Class<?> expectedType, MetricsBackendType expectedBackend) {
+        MetricsSource source = factory.create(config(providerType));
+        assertThat(source).isInstanceOf(expectedType);
+        assertThat(((AbstractPrometheusCompatibleMetricsSource) source).backendType())
+                .isEqualTo(expectedBackend);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `MetricsSourceFactoryTest`, a first unit test for the metrics backend factory. It verifies the provider-type → concrete-source mapping without any network: the shared `RestClient` configuration is asserted via a mocked `RestClient.Builder`.

Coverage:
- each provider type (`Prometheus`, `VictoriaMetrics`, `Thanos`, `Cortex`, `Mimir`, `ARMS`) resolves to its concrete `AbstractPrometheusCompatibleMetricsSource` subclass with the matching `MetricsBackendType`; `Custom` shares the Prometheus implementation but keeps its `CUSTOM` backend identity;
- missing and unknown provider types default to Prometheus, and provider-name normalization tolerates whitespace/underscores (`victoria_metrics`);
- every created source is configured through the shared redirect-guarded client chain: `NoRedirectClientHttpRequestFactory` is installed and `build()` is invoked.

## Why

The factory decides which query-path semantics a configured data source gets; `MetricsBackendType` was already covered but the factory wiring was not.

## Testing

`mvn -B test -Dtest=MetricsSourceFactoryTest` — 3/3 pass; checkstyle (validate) clean.