### PR TITLE
fix(i18n): localize alert assets page subtitle

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1854,6 +1854,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'grafana.exportAllFailed': { zh: '导出全部看板失败', en: 'Failed to export dashboards' },
   // ─── Alert rule templates ───
   'alertAssets.title': { zh: '业务告警', en: 'Business Alerts' },
+  'alertAssets.subtitle': { zh: '可复用的业务告警规则模板资产', en: 'Reusable business alert rule templates' },
   'alertAssets.name': { zh: '名称', en: 'Name' },
   'alertAssets.group': { zh: '规则组', en: 'Group' },
   'alertAssets.ruleCount': { zh: '规则数', en: 'Rules' },

--- a/web/src/pages/studio/AlertRuleAssets.tsx
+++ b/web/src/pages/studio/AlertRuleAssets.tsx
@@ -26,7 +26,7 @@ const AlertRuleAssetsPage: React.FC = () => {
 
   return (
     <div style={{ padding: 24 }}>
-      <PageHeader title={t('alertAssets.title')} subtitle="可复用的业务告警规则模板资产" />
+      <PageHeader title={t('alertAssets.title')} subtitle={t('alertAssets.subtitle')} />
       <Card styles={{ body: { padding: 0 } }}>
         <div style={{ padding: 16 }}>
           <AlertRuleAssetList />


### PR DESCRIPTION
## Summary

Keys the hard-coded subtitle of the Alert Rule Assets page (`可复用的业务告警规则模板资产`) into `translations.ts` as `alertAssets.subtitle`, next to the existing `alertAssets.title` entry, and renders it through `useLang`.

- `web/src/i18n/translations.ts`: adds `alertAssets.subtitle` (zh byte-identical to the removed literal, en: "Reusable business alert rule templates");
- `web/src/pages/studio/AlertRuleAssets.tsx`: `subtitle={t("alertAssets.subtitle")}`.

## Why

The page header was the last untranslated string on this page; everything else already flows through the `alertAssets.*` key set.

## Testing

`tsc --noEmit` clean; `eslint` clean.