### PR TITLE
test(broker): cover MqClientPool lifecycle guards

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqClientPoolTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/MqClientPoolTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the lifecycle guards of {@link MqClientPool}. Client creation is excluded
+ * on purpose: creating a pull consumer/producer would start remoting against a live
+ * NameServer, so these tests pin down the deterministic guard paths only (address
+ * requirement, closed-pool rejection, and no-op releases).
+ */
+class MqClientPoolTest {
+
+    @Test
+    void requiresANameServerAddressBeforeAnyClientWork() {
+        MqClientPool pool = new MqClientPool();
+
+        assertThatThrownBy(() -> pool.withPullConsumer("   ", null, "anonymous", client -> "unused"))
+                .isInstanceOfSatisfying(BusinessException.class,
+                        exception -> assertThat(exception.getCode()).isEqualTo(400));
+        assertThatThrownBy(() -> pool.withProducer("\n", null, null, client -> "unused"))
+                .isInstanceOfSatisfying(BusinessException.class,
+                        exception -> assertThat(exception.getCode()).isEqualTo(400));
+    }
+
+    @Test
+    void rejectsClientUseAfterThePoolIsClosed() {
+        MqClientPool pool = new MqClientPool();
+        pool.shutdown();
+
+        assertThatThrownBy(() -> pool.withPullConsumer("127.0.0.1:9876", null, "anonymous",
+                client -> "unused"))
+                .isInstanceOfSatisfying(BusinessException.class,
+                        exception -> assertThat(exception.getCode()).isEqualTo(503));
+        assertThatThrownBy(() -> pool.withProducer("127.0.0.1:9876", null, "anonymous",
+                client -> "unused"))
+                .isInstanceOfSatisfying(BusinessException.class,
+                        exception -> assertThat(exception.getCode()).isEqualTo(503));
+    }
+
+    @Test
+    void addressCheckTakesPrecedenceOverTheClosedFlag() {
+        MqClientPool pool = new MqClientPool();
+        pool.shutdown();
+
+        assertThatThrownBy(() -> pool.withPullConsumer("  ", null, "anonymous", client -> "unused"))
+                .isInstanceOfSatisfying(BusinessException.class,
+                        exception -> assertThat(exception.getCode()).isEqualTo(400));
+    }
+
+    @Test
+    void releaseIsANoOpForBlankOrUnknownEndpoints() {
+        MqClientPool pool = new MqClientPool();
+
+        assertThatCode(() -> pool.release("  ")).doesNotThrowAnyException();
+        assertThatCode(() -> pool.release(null, "anonymous")).doesNotThrowAnyException();
+        // An endpoint that was never pooled has nothing to release.
+        assertThatCode(() -> pool.release("10.0.0.1:9876")).doesNotThrowAnyException();
+        assertThatCode(() -> pool.release("10.0.0.1:9876", "other-identity"))
+                .doesNotThrowAnyException();
+        pool.shutdown();
+    }
+}


### PR DESCRIPTION
## Summary

Adds `MqClientPoolTest`, first unit tests for the lifecycle guards of the long-lived RocketMQ client pool. Client creation is deliberately excluded (starting a pull consumer/producer would open remoting against a live NameServer), so the deterministic guard paths are pinned down instead.

Coverage:
- blank/whitespace NameServer addresses are rejected with `BusinessException` 400 before any client work, for both the pull-consumer and producer entry points;
- after `shutdown()` the pool rejects further use with `BusinessException` 503;
- the address check takes precedence over the closed flag (a blank address still yields 400 on a closed pool);
- `release` is a no-op for blank endpoints, unknown identities, and endpoints that were never pooled.

## Why

The pool is the shared owner of producer/consumer clients across requests; the failure modes that do not require network had no direct test.

## Testing

`mvn -B test -Dtest=MqClientPoolTest` — 4/4 pass; checkstyle (validate) clean.