### PR TITLE
test(alert): deepen AlertRuleDuration parse coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleDurationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleDurationTest.java
@@ -30,4 +30,44 @@ class AlertRuleDurationTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Invalid alert duration");
     }
+
+    @Test
+    void parsesEverySupportedUnitTest() {
+        assertThat(AlertRuleDuration.parse("500ms")).isEqualTo(Duration.ofMillis(500));
+        assertThat(AlertRuleDuration.parse("45s")).isEqualTo(Duration.ofSeconds(45));
+        assertThat(AlertRuleDuration.parse("5m")).isEqualTo(Duration.ofMinutes(5));
+        assertThat(AlertRuleDuration.parse("2h")).isEqualTo(Duration.ofHours(2));
+        assertThat(AlertRuleDuration.parse("3d")).isEqualTo(Duration.ofDays(3));
+        assertThat(AlertRuleDuration.parse("2w")).isEqualTo(Duration.ofDays(14));
+        assertThat(AlertRuleDuration.parse("1y")).isEqualTo(Duration.ofDays(365));
+    }
+
+    @Test
+    void parsesBlankAndZeroValuesAsNoDurationTest() {
+        assertThat(AlertRuleDuration.parse("")).isEqualTo(Duration.ZERO);
+        assertThat(AlertRuleDuration.parse("   ")).isEqualTo(Duration.ZERO);
+        assertThat(AlertRuleDuration.parse("0s")).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    void parsesCompoundDurationsAcrossUnitsTest() {
+        assertThat(AlertRuleDuration.parse("2d12h")).isEqualTo(Duration.ofHours(60));
+        assertThat(AlertRuleDuration.parse("1w2d3h")).isEqualTo(Duration.ofHours(219));
+        assertThat(AlertRuleDuration.parse("1m30s500ms")).isEqualTo(Duration.ofMillis(90_500));
+    }
+
+    @Test
+    void trimsOuterWhitespaceBeforeParsingTest() {
+        assertThat(AlertRuleDuration.parse("  5m  ")).isEqualTo(Duration.ofMinutes(5));
+    }
+
+    @Test
+    void rejectsMalformedSyntaxTest() {
+        for (String malformed : new String[] {"5", "h30m", "1h 30m", "1h30", "1.5h", "5x", "-5m"}) {
+            assertThatThrownBy(() -> AlertRuleDuration.parse(malformed))
+                    .as("malformed duration %s", malformed)
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("Invalid alert duration");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `AlertRuleDurationTest` from two assertions to full parser coverage.

Added cases:
- every supported unit: `ms`, `s`, `m`, `h`, `d`, `w` (7 days), `y` (365 days);
- blank strings and `0s` parse to `Duration.ZERO`;
- compound durations across units (`2d12h`, `1w2d3h`, `1m30s500ms`);
- outer whitespace is trimmed before parsing;
- malformed inputs (`5`, `h30m`, `1h 30m`, `1h30`, `1.5h`, `5x`, `-5m`) are rejected with the `Invalid alert duration` business error.

## Why

The parser gates alert-rule request payloads; the previous suite only covered a single compound value, null, and overflow, leaving unit/grammar handling unpinned.

## Testing

`mvn -B test -Dtest=AlertRuleDurationTest` — 7/7 pass; checkstyle (validate) clean.