### PR TITLE
test(alert): deepen AlertFingerprint uniqueness coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprintTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprintTest.java
@@ -46,4 +46,33 @@ class AlertFingerprintTest {
         assertThat(AlertFingerprint.of(7L, "local", embeddedLabel))
                 .isNotEqualTo(AlertFingerprint.of(7L, "local", separateLabels));
     }
+
+    @Test
+    void treatsNullLabelsLikeEmptyLabelsTest() {
+        assertThat(AlertFingerprint.of(7L, "local", null))
+                .isEqualTo(AlertFingerprint.of(7L, "local", Map.of()))
+                .hasSize(64);
+    }
+
+    @Test
+    void distinguishesRulesInstancesAndLabelValuesTest() {
+        Map<String, String> labels = Map.of("broker", "a");
+        String baseline = AlertFingerprint.of(7L, "local", labels);
+
+        assertThat(AlertFingerprint.of(8L, "local", labels)).isNotEqualTo(baseline);
+        assertThat(AlertFingerprint.of(7L, "other", labels)).isNotEqualTo(baseline);
+        assertThat(AlertFingerprint.of(7L, "local", Map.of("broker", "b"))).isNotEqualTo(baseline);
+    }
+
+    @Test
+    void escapesBackslashesNewlinesAndEqualsSignsInValuesTest() {
+        String plain = AlertFingerprint.of(7L, "local", Map.of("k", "xy"));
+        String backslash = AlertFingerprint.of(7L, "local", Map.of("k", "x\\y"));
+        String newline = AlertFingerprint.of(7L, "local", Map.of("k", "x\ny"));
+        String equals = AlertFingerprint.of(7L, "local", Map.of("k", "x=y"));
+
+        assertThat(backslash).isNotEqualTo(plain).isNotEqualTo(newline).isNotEqualTo(equals);
+        assertThat(newline).isNotEqualTo(plain).isNotEqualTo(equals);
+        assertThat(equals).isNotEqualTo(plain);
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `AlertFingerprintTest` (2 → 5 tests) to pin down the fingerprint uniqueness contract used for alert state keys.

Added cases:
- `null` labels produce the same fingerprint as an empty label map (64 hex chars);
- changing the rule id, the instance id, or a single label value each yields a different fingerprint;
- escaping: label values containing backslashes, newlines, or equals signs each produce fingerprints distinct from the plain value and from each other, so embedded separators cannot forge collisions.

## Why

The fingerprint keys the per-rule/resource alert state; collision resistance and stability are what make state transitions deterministic across replicas.

## Testing

`mvn -B test -Dtest=AlertFingerprintTest` — 5/5 pass; checkstyle (validate) clean.