### PR TITLE
test(common): deepen CsvUtil formula-injection and quoting coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/CsvUtilTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/CsvUtilTest.java
@@ -35,4 +35,34 @@ class CsvUtilTest {
         assertThat(CsvUtil.toCell("=SUM(A1)")).isEqualTo("\"'=SUM(A1)\"");
         assertThat(CsvUtil.toCell("+cmd")).isEqualTo("\"'+cmd\"");
     }
+
+    @Test
+    void prefixesEveryFormulaInjectionCharacterTest() {
+        for (char prefix : new char[] {'=', '+', '-', '@', '\t', '\r', '\n'}) {
+            String cell = CsvUtil.toCell(prefix + "payload");
+            assertThat(cell).as("prefix char %s", prefix).isEqualTo("\"'" + prefix + "payload\"");
+        }
+    }
+
+    @Test
+    void leavesSafeValuesUnprefixedTest() {
+        assertThat(CsvUtil.toCell("123")).isEqualTo("\"123\"");
+        assertThat(CsvUtil.toCell("hello")).isEqualTo("\"hello\"");
+        assertThat(CsvUtil.toCell("'=already")).isEqualTo("\"'=already\"");
+        assertThat(CsvUtil.toCell("")).isEqualTo("\"\"");
+        assertThat(CsvUtil.toCell(null)).isEqualTo("\"\"");
+    }
+
+    @Test
+    void escapesEveryEmbeddedQuoteTest() {
+        assertThat(CsvUtil.toCell("say \"hi\" then \"bye\"")).isEqualTo("\"say \"\"hi\"\" then \"\"bye\"\"\"");
+    }
+
+    @Test
+    void keepsCommasInsideQuotedCellsTest() {
+        StringBuilder csv = new StringBuilder();
+        CsvUtil.appendRow(csv, "a,b", "x");
+        assertThat(csv.toString()).isEqualTo("\"a,b\",\"x\"\r\n");
+        assertThat(CsvUtil.toCell("a,b")).isEqualTo("\"a,b\"");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `CsvUtilTest` (2 to 6 tests) to pin down the spreadsheet-safe CSV rendering contract used by export endpoints.

Added cases:
- every formula-injection character (`=`, `+`, `-`, `@`, tab, CR, LF) as a leading character gets the defensive quote prefix;
- safe values (`123`, plain text, an already-quoted string, empty, null) stay unprefixed and are rendered as quoted cells;
- every embedded quote is doubled, not just the first;
- commas inside cell values survive inside the quoted cell, and `appendRow` keeps them intact across columns.

## Why

The renderer is the guard against spreadsheet formula injection in every CSV export; the previous suite only exercised two of the prefix characters and a single quote.

## Testing

`mvn -B test -Dtest=CsvUtilTest` — 6/6 pass; checkstyle (validate) clean.