### PR TITLE
test(common): deepen SystemTopicFilter overload and broker-set coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemTopicFilterTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemTopicFilterTest.java
@@ -46,4 +46,31 @@ class SystemTopicFilterTest {
         assertThat(SystemTopicFilter.isSystem("BenchmarkTestOrders", brokerNames)).isFalse();
         assertThat(SystemTopicFilter.isSystem("SCHEDULE_TOPIC_orders", brokerNames)).isFalse();
     }
+
+    @Test
+    void convenienceOverloadRecognizesSystemTopicsTest() {
+        assertThat(SystemTopicFilter.isSystem(null)).isTrue();
+        assertThat(SystemTopicFilter.isSystem("")).isTrue();
+        assertThat(SystemTopicFilter.isSystem("RMQ_SYS_TRANS_HALF_TOPIC")).isTrue();
+        assertThat(SystemTopicFilter.isSystem("%RETRY%consumer-a")).isTrue();
+        assertThat(SystemTopicFilter.isSystem("%DLQ%consumer-a")).isTrue();
+
+        assertThat(SystemTopicFilter.isSystem("orders")).isFalse();
+        assertThat(SystemTopicFilter.isSystem("broker-prod-a")).isFalse();
+    }
+
+    @Test
+    void brokerNamesCountOnlyWhenProvidedInTheSetTest() {
+        assertThat(SystemTopicFilter.isSystem("orders", Set.of("orders"))).isTrue();
+        assertThat(SystemTopicFilter.isSystem("orders", null)).isFalse();
+        assertThat(SystemTopicFilter.isSystem("orders", Set.of())).isFalse();
+        assertThat(SystemTopicFilter.isSystem("orders", Set.of("broker-prod-a"))).isFalse();
+    }
+
+    @Test
+    void nullTopicRemainsSystemRegardlessOfBrokerSetTest() {
+        assertThat(SystemTopicFilter.isSystem(null, null)).isTrue();
+        assertThat(SystemTopicFilter.isSystem("", Set.of())).isTrue();
+        assertThat(SystemTopicFilter.isSystem("broker-prod-a", null)).isFalse();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `SystemTopicFilterTest` (1 to 4 tests) to pin down the remaining branches of the system-topic filter.

Added cases:
- the one-argument overload recognizes canonical system topics and retry/DLQ prefixes while keeping plain topics (including broker-like names) visible;
- broker names only count as system topics when they are actually present in the provided broker set (null and empty sets behave the same);
- a null/empty topic is always treated as system regardless of the broker set.

## Why

The filter hides system topics from user-facing lists and dashboard counts; the convenience overload and the optional broker-set semantics had no direct coverage.

## Testing

`mvn -B test -Dtest=SystemTopicFilterTest` — 4/4 pass; checkstyle (validate) clean.