### PR TITLE
test(common): deepen SystemGroupFilter prefix-boundary coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemGroupFilterTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemGroupFilterTest.java
@@ -45,4 +45,32 @@ class SystemGroupFilterTest {
         assertThat(SystemGroupFilter.isSystem("FILTERSRV_CONSUMER_filter")).isFalse();
         assertThat(SystemGroupFilter.isSystem("SELF_TEST_GROUP")).isFalse();
     }
+
+    @Test
+    void embeddedTokensDoNotMarkUserGroupsAsSystemTest() {
+        for (String group : new String[] {
+            "app_TOOLS_CONSUMER",
+            "xCID_SYS_custom",
+            "xCID_HOUSEKEEPING_x",
+            "orders-CID_RMQ_SYS_TRANS",
+            "yrmq_sys_custom",
+            "pre%RETRY%consumer",
+            "suffix_%DLQ%consumer"}) {
+            assertThat(SystemGroupFilter.isSystem(group))
+                    .as("user group %s", group)
+                    .isFalse();
+        }
+    }
+
+    @Test
+    void prefixMatchingRequiresTheTokenAtTheStartTest() {
+        assertThat(SystemGroupFilter.isSystem("CID_SYS_RMQ_TRANS")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("rmq_sys_TRACE_DATA")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("%RETRY%consumer-a")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("%DLQ%consumer-a")).isTrue();
+
+        assertThat(SystemGroupFilter.isSystem("CID_SYS_")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("rmq_sys_")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("%RETRY%")).isTrue();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `SystemGroupFilterTest` (1 to 3 tests) to pin down the prefix-boundary contract of the system consumer-group filter.

Added cases:
- system tokens embedded anywhere but the start of the name do not mark a user group as system (`app_TOOLS_CONSUMER`, `xCID_SYS_custom`, `xCID_HOUSEKEEPING_x`, `orders-CID_RMQ_SYS_TRANS`, `yrmq_sys_custom`, `pre%RETRY%consumer`, `suffix_%DLQ%consumer`);
- bare prefix tokens (`CID_SYS_`, `rmq_sys_`, `%RETRY%`) and the canonical prefixed names are still recognized as system.

## Why

The filter hides system consumer groups from user-facing lists and dashboard counts; its prefix-boundary semantics (token must start the name) had no negative coverage.

## Testing

`mvn -B test -Dtest=SystemGroupFilterTest` — 3/3 pass; checkstyle (validate) clean.