### PR TITLE
test(auth): deepen PasswordHasher malformed and tamper coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/PasswordHasherTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/PasswordHasherTest.java
@@ -46,4 +46,55 @@ class PasswordHasherTest {
                 "pbkdf2$210000$" + parts[2] + "$AA==")).isFalse();
     }
 
+    @Test
+    void rejectsMalformedStoredHashFormatsTest() {
+        PasswordHasher hasher = new PasswordHasher();
+        String salt = "AAAAAAAAAAAAAAAAAAAAAAAA";
+        String digest = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        assertThat(hasher.matches("password", "plain-text")).isFalse();
+        assertThat(hasher.matches("password", "argon2$1$AAAA$AAAA")).isFalse();
+        assertThat(hasher.matches("password", "pbkdf2$210000$AAAA")).isFalse();
+        // A non-numeric iteration count is treated as a mismatch, not a crash.
+        assertThat(hasher.matches("password", "pbkdf2$abc$" + salt + "$" + digest)).isFalse();
+        // An undecodable salt/digest pair is rejected without deriving anything.
+        assertThat(hasher.matches("password", "pbkdf2$210000$" + salt + "$" + digest)).isFalse();
+    }
+
+    @Test
+    void rejectsIterationCountsOutsideTheSafeRangeTest() {
+        PasswordHasher hasher = new PasswordHasher();
+        String salt = "AAAAAAAAAAAAAAAAAAAAAAAA";
+        String digest = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        assertThat(hasher.matches("password", "pbkdf2$99999$" + salt + "$" + digest)).isFalse();
+        assertThat(hasher.matches("password", "pbkdf2$1000001$" + salt + "$" + digest)).isFalse();
+    }
+
+    @Test
+    void rejectsNullArgumentsTest() {
+        PasswordHasher hasher = new PasswordHasher();
+
+        assertThat(hasher.matches(null, "pbkdf2$210000$AAAA$AAAA")).isFalse();
+        assertThat(hasher.matches("password", null)).isFalse();
+    }
+
+    @Test
+    void rejectsTamperedSaltOrDigestTest() {
+        PasswordHasher hasher = new PasswordHasher();
+        String validHash = hasher.hash("a-long-enough-password");
+        String[] parts = validHash.split("\\$", -1);
+
+        char[] saltChars = parts[2].toCharArray();
+        saltChars[5] = saltChars[5] == 'A' ? 'B' : 'A';
+        String tamperedSalt = new String(saltChars);
+        assertThat(hasher.matches("a-long-enough-password",
+                "pbkdf2$" + parts[1] + "$" + tamperedSalt + "$" + parts[3])).isFalse();
+
+        char[] digestChars = parts[3].toCharArray();
+        digestChars[10] = digestChars[10] == 'A' ? 'B' : 'A';
+        String tamperedDigest = new String(digestChars);
+        assertThat(hasher.matches("a-long-enough-password",
+                "pbkdf2$" + parts[1] + "$" + parts[2] + "$" + tamperedDigest)).isFalse();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `PasswordHasherTest` (2 to 6 tests) to pin down the stored-hash validation contract.

Added cases:
- malformed formats are mismatches, never crashes: plain text, a foreign algorithm prefix, a truncated field count, a non-numeric iteration count, and an undecodable/oversized salt-digest pair (all rejected before any PBKDF2 derivation);
- iteration counts outside the safe range (below 100k / above 1M) are rejected;
- null password and null stored hash are both mismatches;
- a single flipped character in either the stored salt or the digest turns a valid hash into a mismatch.

## Why

`matches` is the gate for every login; the validation branches (algorithm, field count, iteration bounds, encoded lengths) had no direct coverage beyond oversized fields.

## Testing

`mvn -B test -Dtest=PasswordHasherTest` — 6/6 pass; checkstyle (validate) clean.