### PR TITLE
test(common): deepen EntityIds parsing coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/EntityIdsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/EntityIdsTest.java
@@ -39,4 +39,34 @@ class EntityIdsTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("positive numeric value");
     }
+
+    @Test
+    void rejectsBlankAndNullIdentifiersTest() {
+        for (String blank : new String[] {null, "", "   "}) {
+            assertThatThrownBy(() -> EntityIds.parseId(blank))
+                    .as("blank id %s", blank)
+                    .isInstanceOfSatisfying(BusinessException.class,
+                            error -> assertThat(error.getCode()).isEqualTo(400))
+                    .hasMessageContaining("id is required");
+        }
+    }
+
+    @Test
+    void rejectsNonNumericIdentifiersTest() {
+        for (String invalid : new String[] {"abc", "42.0", "42abc", "0x2A",
+            "99999999999999999999"}) {
+            assertThatThrownBy(() -> EntityIds.parseId(invalid))
+                    .as("invalid id %s", invalid)
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("numeric value")
+                    .hasMessageContaining(invalid);
+        }
+    }
+
+    @Test
+    void acceptsSignedAndZeroPaddedIdentifiersTest() {
+        assertThat(EntityIds.parseId("+7")).isEqualTo(7L);
+        assertThat(EntityIds.parseId(" 007 ")).isEqualTo(7L);
+        assertThat(EntityIds.parseId("2147483648")).isEqualTo(2147483648L);
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `EntityIdsTest` (2 to 5 tests) to pin down the external-string-to-primary-key conversion used across the persistence API boundary.

Added cases:
- blank and null identifiers are rejected with the `id is required` 400 error;
- non-numeric identifiers (letters, decimals, suffixes, hex prefixes, and values overflowing `long`) are rejected with the `numeric value` 400 error that echoes the offending value;
- signed (`+7`) and zero-padded (`007`) identifiers parse to the expected key, and values above 32-bit range are preserved (`2147483648`).

## Why

Every entity id arriving as an API string is converted here, so the exact 400 contract shapes client error handling; only trimming and zero/negative cases were covered before.

## Testing

`mvn -B test -Dtest=EntityIdsTest` — 5/5 pass; checkstyle (validate) clean.