### PR TITLE
test(metrics): deepen MetricSample record validation coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricSampleTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricSampleTest.java
@@ -20,7 +20,9 @@ import org.apache.rocketmq.studio.ops.alert.AlertDomain;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MetricSampleTest {
@@ -39,5 +41,72 @@ class MetricSampleTest {
                 null, null, MetricAvailability.AVAILABLE, Instant.now()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Available metric samples require a value");
+    }
+
+    @Test
+    void rejectsMissingOrBlankCoreFieldsTest() {
+        Instant now = Instant.now();
+        assertThatThrownBy(() -> new MetricSample("", AlertDomain.CLUSTER, "local", null, null,
+                1D, MetricAvailability.AVAILABLE, now))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("metricKey is required");
+        assertThatThrownBy(() -> new MetricSample(null, AlertDomain.CLUSTER, "local", null, null,
+                1D, MetricAvailability.AVAILABLE, now))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("metricKey is required");
+        assertThatThrownBy(() -> new MetricSample("cpu", null, "local", null, null,
+                1D, MetricAvailability.AVAILABLE, now))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("domain is required");
+        assertThatThrownBy(() -> new MetricSample("cpu", AlertDomain.CLUSTER, "  ", null, null,
+                1D, MetricAvailability.AVAILABLE, now))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("instanceId is required");
+        assertThatThrownBy(() -> new MetricSample("cpu", AlertDomain.CLUSTER, "local", null, null,
+                1D, null, now))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("availability is required");
+        assertThatThrownBy(() -> new MetricSample("cpu", AlertDomain.CLUSTER, "local", null, null,
+                1D, MetricAvailability.AVAILABLE, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("collectedAt is required");
+    }
+
+    @Test
+    void availableSamplesCannotCarryAnUnavailableReasonTest() {
+        assertThatThrownBy(() -> new MetricSample("cpu", AlertDomain.CLUSTER, "local", null, null,
+                1D, MetricAvailability.AVAILABLE, Instant.now(), "not-available"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Available metric samples cannot have an unavailable reason");
+    }
+
+    @Test
+    void copiesLabelsDefensivelyAndDefaultsNullToEmptyTest() {
+        Map<String, String> mutable = new java.util.HashMap<>();
+        mutable.put("broker", "b1");
+        MetricSample sample = new MetricSample("cpu", AlertDomain.CLUSTER, "local", null, mutable,
+                1D, MetricAvailability.AVAILABLE, Instant.now());
+
+        mutable.put("extra", "e1");
+        assertThat(sample.labels()).containsExactlyEntriesOf(Map.of("broker", "b1"));
+        assertThatThrownBy(() -> sample.labels().put("k", "v"))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        MetricSample nullLabels = new MetricSample("cpu", AlertDomain.CLUSTER, "local", null, null,
+                1D, MetricAvailability.AVAILABLE, Instant.now());
+        assertThat(nullLabels.labels()).isEmpty();
+    }
+
+    @Test
+    void carriesTheUnavailableReasonForUnavailableSamplesTest() {
+        MetricSample sample = new MetricSample("cpu", AlertDomain.CLUSTER, "local", null, null,
+                null, MetricAvailability.UNAVAILABLE, Instant.now(), "broker unreachable");
+        assertThat(sample.availability()).isEqualTo(MetricAvailability.UNAVAILABLE);
+        assertThat(sample.value()).isNull();
+        assertThat(sample.unavailableReason()).isEqualTo("broker unreachable");
+
+        MetricSample viaConvenienceCtor = new MetricSample("cpu", AlertDomain.CLUSTER, "local", null,
+                null, null, MetricAvailability.UNAVAILABLE, Instant.now());
+        assertThat(viaConvenienceCtor.unavailableReason()).isNull();
     }
 }


### PR DESCRIPTION
## Summary

Extends the existing `MetricSampleTest` (2 to 6 tests) to pin down the remaining branches of the sample record contract.

Added cases:
- missing/blank `metricKey` and blank `instanceId` are rejected with their messages, and null `domain`, `availability`, and `collectedAt` fail fast with NPEs carrying the field name;
- an available sample cannot carry an unavailable reason;
- labels are defensively copied into an unmodifiable snapshot (later source mutation does not leak in), and null labels normalize to an empty map;
- unavailable samples carry their reason through the full constructor, while the convenience constructor leaves the reason null.

## Why

The record is the unit that flows through native collection, snapshots, and alert evaluation; only the value-availability invariants were covered before.

## Testing

`mvn -B test -Dtest=MetricSampleTest` — 6/6 pass; checkstyle (validate) clean.