### PR TITLE
test(common): deepen PageResult factory and window coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/domain/PageResultTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/domain/PageResultTest.java
@@ -44,4 +44,24 @@ class PageResultTest {
         assertThatThrownBy(() -> result.getItems().add("mutated"))
                 .isInstanceOf(UnsupportedOperationException.class);
     }
+
+    @Test
+    void emptyFactoryBuildsAnEmptyPageWithTheRequestedWindowTest() {
+        PageResult<String> result = PageResult.empty(3, 50);
+
+        assertThat(result.getItems()).isEmpty();
+        assertThat(result.getTotal()).isZero();
+        assertThat(result.getPage()).isEqualTo(3);
+        assertThat(result.getSize()).isEqualTo(50);
+    }
+
+    @Test
+    void ofCarriesTheWindowAndKeepsItemOrderTest() {
+        PageResult<String> result = PageResult.of(List.of("first", "second"), 42L, 2, 10);
+
+        assertThat(result.getItems()).containsExactly("first", "second");
+        assertThat(result.getTotal()).isEqualTo(42L);
+        assertThat(result.getPage()).isEqualTo(2);
+        assertThat(result.getSize()).isEqualTo(10);
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `PageResultTest` (2 to 4 tests) to pin down the page-envelope contract.

Added cases:
- the `empty(page, size)` factory builds an empty page with zero total while preserving the requested window;
- `of(items, total, page, size)` carries the total/page/size through the getters and keeps item order intact.

## Why

`PageResult` is the shared envelope for every paged server feed; the window fields had no direct coverage beyond the null/isolation normalization.

## Testing

`mvn -B test -Dtest=PageResultTest` — 4/4 pass; checkstyle (validate) clean.