### PR TITLE
test(auth): deepen LoginDTO data and redaction coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/LoginDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/LoginDTOTest.java
@@ -33,4 +33,37 @@ class LoginDTOTest {
         assertThat(value).contains("username=admin");
         assertThat(value).doesNotContain("plain-secret");
     }
+
+    @Test
+    void dataEqualityCoversUsernameAndPasswordTest() {
+        LoginDTO first = new LoginDTO();
+        first.setUsername("admin");
+        first.setPassword("secret-a");
+
+        LoginDTO same = new LoginDTO();
+        same.setUsername("admin");
+        same.setPassword("secret-a");
+
+        LoginDTO differentPassword = new LoginDTO();
+        differentPassword.setUsername("admin");
+        differentPassword.setPassword("secret-b");
+
+        LoginDTO differentUser = new LoginDTO();
+        differentUser.setUsername("reader");
+        differentUser.setPassword("secret-a");
+
+        assertThat(first).isEqualTo(same).hasSameHashCodeAs(same);
+        assertThat(first).isNotEqualTo(differentPassword).isNotEqualTo(differentUser);
+    }
+
+    @Test
+    void toStringOmitsThePasswordFieldEntirelyTest() {
+        LoginDTO request = new LoginDTO();
+        request.setUsername("admin");
+        request.setPassword("plain-secret");
+
+        String value = request.toString();
+
+        assertThat(value).doesNotContain("password").doesNotContain("plain-secret");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `LoginDTOTest` (1 to 3 tests) to pin down the login payload contract.

Added cases:
- `@Data` equality/hashCode cover both username and password: identical payloads are equal with the same hash, while a different password or a different username breaks equality;
- `toString` omits the password field entirely (neither the field name nor its value appears), extending the existing secret-redaction check to the field name itself.

## Why

The DTO is the login request boundary; equality semantics matter for tests and caching, and password redaction is a security invariant.

## Testing

`mvn -B test -Dtest=LoginDTOTest` — 3/3 pass; checkstyle (validate) clean.