### PR TITLE
test(common): cover NoRedirectClientHttpRequestFactory end-to-end

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/NoRedirectClientHttpRequestFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/NoRedirectClientHttpRequestFactoryTest.java
@@ -16,11 +16,16 @@
  */
 package org.apache.rocketmq.studio.common.util;
 
+import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
 
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,6 +51,38 @@ class NoRedirectClientHttpRequestFactoryTest {
 
         void prepare(HttpURLConnection connection, String httpMethod) throws Exception {
             prepareConnection(connection, httpMethod);
+        }
+    }
+
+    @Test
+    void doesNotFollowHttpRedirectsEndToEndTest() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        AtomicBoolean redirectedEndpointHit = new AtomicBoolean(false);
+        server.createContext("/target", exchange -> {
+            redirectedEndpointHit.set(true);
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.createContext("/start", exchange -> {
+            exchange.getResponseHeaders().set("Location",
+                    "http://127.0.0.1:" + server.getAddress().getPort() + "/target");
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+        server.start();
+        try {
+            NoRedirectClientHttpRequestFactory requestFactory =
+                    new NoRedirectClientHttpRequestFactory();
+            URI startUri = URI.create("http://127.0.0.1:"
+                    + server.getAddress().getPort() + "/start");
+
+            ClientHttpRequest request = requestFactory.createRequest(startUri, HttpMethod.GET);
+            ClientHttpResponse response = request.execute();
+
+            assertThat(response.getStatusCode().value()).isEqualTo(302);
+            assertThat(redirectedEndpointHit).isFalse();
+        } finally {
+            server.stop(0);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds an end-to-end behavior test to the existing `NoRedirectClientHttpRequestFactoryTest`, complementing the flag-level check.

Coverage:
- a local `HttpServer` serves a `302` from `/start` pointing at `/target`; executing a request through the factory returns the `302` and the redirect target is never hit, proving redirects are not followed over the wire (not just that the instance flag is flipped).

## Why

The factory backs every Studio outbound HTTP call so metrics/alert queries cannot be steered to unintended hosts; the previous test only asserted the internal flag, not the actual request behavior.

## Testing

`mvn -B test -Dtest=NoRedirectClientHttpRequestFactoryTest` — 2/2 pass; checkstyle (validate) clean.