### PR TITLE
test(ai): deepen LlmConfigVO readiness and secret coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVOTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
@@ -35,5 +36,58 @@ class LlmConfigVOTest {
         } finally {
             Locale.setDefault(original);
         }
+    }
+
+    @Test
+    void exposesApiKeyConfigurationStateTest() {
+        LlmConfigVO withKey = LlmConfigVO.builder().apiKey("sk-live").build();
+        LlmConfigVO withoutKey = LlmConfigVO.builder().apiKey("  ").build();
+
+        assertThat(withKey.isApiKeyConfigured()).isTrue();
+        assertThat(withoutKey.isApiKeyConfigured()).isFalse();
+    }
+
+    @Test
+    void readinessDependsOnEngineProviderAndCredentialsTest() {
+        assertThat(LlmConfigVO.builder().enabled(false).model("m").build().isReady()).isFalse();
+        assertThat(LlmConfigVO.builder().enabled(true).build().isReady()).isFalse();
+
+        // CLI engines authenticate through the subprocess environment.
+        assertThat(LlmConfigVO.builder().enabled(true).model("m").engine("claude-code")
+                .build().isReady()).isTrue();
+
+        // HTTP + ollama needs an api base but no key.
+        assertThat(LlmConfigVO.builder().enabled(true).model("m").engine("http")
+                .provider("ollama").apiBase("http://localhost:11434").build().isReady()).isTrue();
+        assertThat(LlmConfigVO.builder().enabled(true).model("m").engine("http")
+                .provider("ollama").build().isReady()).isFalse();
+
+        // HTTP + other providers need both an api base and a key.
+        LlmConfigVO openAi = LlmConfigVO.builder().enabled(true).model("m").engine("http")
+                .provider("openai").apiBase("https://api.openai.com").build();
+        assertThat(openAi.isReady()).isFalse();
+        openAi.setApiKey("sk-live");
+        assertThat(openAi.isReady()).isTrue();
+    }
+
+    @Test
+    void serializationHidesSecretsAndExposesDerivedFlagsTest() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        LlmConfigVO config = LlmConfigVO.builder()
+                .provider("openai")
+                .engine("http")
+                .apiKey("sk-secret")
+                .apiBase("https://api.openai.com")
+                .model("gpt-4o")
+                .build();
+
+        String json = mapper.writeValueAsString(config);
+
+        assertThat(json).doesNotContain("sk-secret").doesNotContain("apiKey\"");
+        assertThat(json).contains("\"apiKeyConfigured\":true");
+
+        LlmConfigVO readBack = mapper.readValue(
+                "{\"provider\":\"openai\",\"apiKey\":\"sk-2\"}", LlmConfigVO.class);
+        assertThat(readBack.getApiKey()).isEqualTo("sk-2");
     }
 }


### PR DESCRIPTION
## Summary

Extends the existing `LlmConfigVOTest` (1 to 4 tests) to pin down the LLM configuration readiness and secret-handling contract.

Added cases:
- `isApiKeyConfigured` reflects only textual api keys;
- the full `isReady` matrix: disabled or model-less configs are never ready; CLI engines need only enabled + model (credentials come from the subprocess environment); HTTP + `ollama` needs an api base but no key; HTTP + other providers need both an api base and a key;
- Jackson serialization never emits the `apiKey` (write-only) while exposing the derived `apiKeyConfigured` flag, and a write-only field still accepts input on deserialization.

## Why

The VO drives the settings page state and gateway readiness checks; only engine normalization was covered before.

## Testing

`mvn -B test -Dtest=LlmConfigVOTest` — 4/4 pass; checkstyle (validate) clean.