### PR TITLE
test(settings): deepen DataSourceTestDTO redaction and equality coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceTestDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceTestDTOTest.java
@@ -40,4 +40,46 @@ class DataSourceTestDTOTest {
         assertThat(value).doesNotContain("plain-password");
         assertThat(value).doesNotContain("plain-token");
     }
+
+    @Test
+    void toStringOmitsCredentialFieldNamesEntirelyTest() {
+        DataSourceTestDTO request = DataSourceTestDTO.builder()
+            .url("http://prometheus:9090")
+            .type("prometheus")
+            .password("plain-password")
+            .bearerToken("plain-token")
+            .build();
+
+        String value = request.toString();
+
+        assertThat(value).doesNotContain("password").doesNotContain("bearerToken");
+    }
+
+    @Test
+    void dataEqualityCoversAllFieldsIncludingCredentialsTest() {
+        DataSourceTestDTO first = DataSourceTestDTO.builder()
+            .url("http://prometheus:9090")
+            .type("prometheus")
+            .auth("bearer")
+            .username("prometheus-user")
+            .password("plain-password")
+            .bearerToken("plain-token")
+            .build();
+        DataSourceTestDTO same = DataSourceTestDTO.builder()
+            .url("http://prometheus:9090")
+            .type("prometheus")
+            .auth("bearer")
+            .username("prometheus-user")
+            .password("plain-password")
+            .bearerToken("plain-token")
+            .build();
+
+        assertThat(first).isEqualTo(same).hasSameHashCodeAs(same);
+        assertThat(first).isNotEqualTo(DataSourceTestDTO.builder()
+            .url("http://prometheus:9090")
+            .type("prometheus")
+            .password("different-password")
+            .bearerToken("plain-token")
+            .build());
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `DataSourceTestDTOTest` (1 to 3 tests) to pin down the data-source connectivity-test request contract.

Added cases:
- `toString` omits the credential field names entirely (`password`, `bearerToken`), not just their values;
- `@Data` equality/hashCode cover every field including the credentials, so a different password breaks equality while identical payloads are equal with the same hash.

## Why

The DTO is the boundary for ad-hoc data source connectivity tests; log redaction and equality semantics are client-visible contracts.

## Testing

`mvn -B test -Dtest=DataSourceTestDTOTest` — 3/3 pass; checkstyle (validate) clean.