### PR TITLE
test(credential): deepen CreateCloudCredentialDTO vendor and mapping coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CreateCloudCredentialDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CreateCloudCredentialDTOTest.java
@@ -39,4 +39,46 @@ class CreateCloudCredentialDTOTest {
 
         assertThat(vendor).isEqualTo(InstanceVendor.ALIYUN);
     }
+
+    @Test
+    void parseVendorNormalizesAndDefaultsUnknownValuesTest() {
+        assertThat(CreateCloudCredentialDTO.parseVendor("tencent")).isEqualTo(InstanceVendor.TENCENT);
+        assertThat(CreateCloudCredentialDTO.parseVendor(" ALIYUN ")).isEqualTo(InstanceVendor.ALIYUN);
+        assertThat(CreateCloudCredentialDTO.parseVendor(null)).isNull();
+        assertThat(CreateCloudCredentialDTO.parseVendor("")).isNull();
+        assertThat(CreateCloudCredentialDTO.parseVendor("vmware")).isNull();
+    }
+
+    @Test
+    void mapsToTheCloudCredentialViewTest() {
+        CreateCloudCredentialDTO dto = new CreateCloudCredentialDTO();
+        dto.setName("production");
+        dto.setVendor("aliyun");
+        dto.setAccessKey("cloud-access-key");
+        dto.setSecretKey("cloud-secret-key");
+        dto.setRemark("prod account");
+
+        CloudCredentialVO vo = dto.toCloudCredentialVO();
+
+        assertThat(vo.getName()).isEqualTo("production");
+        assertThat(vo.getVendor()).isEqualTo(InstanceVendor.ALIYUN);
+        assertThat(vo.getAccessKey()).isEqualTo("cloud-access-key");
+        assertThat(vo.getSecretKey()).isEqualTo("cloud-secret-key");
+        assertThat(vo.getRemark()).isEqualTo("prod account");
+    }
+
+    @Test
+    void toStringRedactsCredentialsTest() {
+        CreateCloudCredentialDTO dto = new CreateCloudCredentialDTO();
+        dto.setName("production");
+        dto.setVendor("aliyun");
+        dto.setAccessKey("cloud-access-key");
+        dto.setSecretKey("cloud-secret-key");
+
+        String value = dto.toString();
+
+        assertThat(value).contains("name=production").contains("vendor=aliyun");
+        assertThat(value).doesNotContain("accessKey").doesNotContain("secretKey");
+        assertThat(value).doesNotContain("cloud-access-key").doesNotContain("cloud-secret-key");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `CreateCloudCredentialDTOTest` (1 to 4 tests) to pin down the cloud credential creation payload contract.

Added cases:
- `parseVendor` normalizes vendor names (trimmed, case-insensitive) for known vendors and returns null for missing, blank, or unknown values;
- `toCloudCredentialVO` maps name, normalized vendor, credentials, and remark onto the view;
- `toString` redacts both credential field names and their values.

## Why

The DTO is the create boundary for cloud credentials; vendor normalization drives instance provider routing and had only locale coverage before.

## Testing

`mvn -B test -Dtest=CreateCloudCredentialDTOTest` — 4/4 pass; checkstyle (validate) clean.