### PR TITLE
test(model): deepen LiteTopicSession state logic coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSessionTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSessionTest.java
@@ -38,4 +38,57 @@ class LiteTopicSessionTest {
 
         assertThat(session.getConsumptionProgress()).isEqualTo(40.0);
     }
+
+    @Test
+    void activeConsumptionRequiresActiveStatusAndPositiveRate() {
+        LiteTopicSession session = new LiteTopicSession();
+
+        session.setStatus("ACTIVE");
+        session.setConsumptionRate(5.0);
+        assertThat(session.hasActiveConsumption()).isTrue();
+
+        session.setConsumptionRate(0.0);
+        assertThat(session.hasActiveConsumption()).isFalse();
+
+        session.setConsumptionRate(null);
+        assertThat(session.hasActiveConsumption()).isFalse();
+
+        session.setStatus("EXPIRED");
+        session.setConsumptionRate(5.0);
+        assertThat(session.hasActiveConsumption()).isFalse();
+    }
+
+    @Test
+    void expirationComesFromStatusOrTtlRemaining() {
+        LiteTopicSession session = new LiteTopicSession();
+
+        session.setStatus("EXPIRED");
+        assertThat(session.isExpired()).isTrue();
+
+        session.setStatus("ACTIVE");
+        session.setTtlRemaining(0L);
+        assertThat(session.isExpired()).isTrue();
+
+        session.setTtlRemaining(-5L);
+        assertThat(session.isExpired()).isTrue();
+
+        session.setTtlRemaining(10L);
+        assertThat(session.isExpired()).isFalse();
+
+        session.setTtlRemaining(null);
+        assertThat(session.isExpired()).isFalse();
+    }
+
+    @Test
+    void progressHandlesNullOrZeroTotals() {
+        LiteTopicSession session = new LiteTopicSession();
+
+        assertThat(session.getConsumptionProgress()).isZero();
+
+        session.setConsumedMessages(4L);
+        assertThat(session.getConsumptionProgress()).isZero();
+
+        session.setTotalMessages(0L);
+        assertThat(session.getConsumptionProgress()).isZero();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `LiteTopicSessionTest` (2 to 5 tests) to pin down the session state logic used by the Lite Topic pages.

Added cases:
- `hasActiveConsumption` requires the `ACTIVE` status together with a positive consumption rate (zero, null rate, and non-ACTIVE status all disqualify);
- `isExpired` reflects either the `EXPIRED` status or a non-positive `ttlRemaining`, and stays false when both are absent;
- consumption progress returns 0.0 for null/zero totals and for a null consumed count, in addition to the existing percentage case.

## Why

These computed states drive the Lite Topic session list status, expiry handling, and progress bars; only the percentage math was covered before.

## Testing

`mvn -B test -Dtest=LiteTopicSessionTest` — 5/5 pass; checkstyle (validate) clean.