### PR TITLE
test(alert): deepen AlertRuleTransferDTO validation coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTOTest.java
@@ -29,4 +29,19 @@ class AlertRuleTransferDTOTest {
                 .extracting(violation -> violation.getMessage())
                 .contains("rule must not be null");
     }
+
+    @Test
+    void rejectsMissingVersionDomainAndEmptyRulesTest() {
+        AlertRuleTransferDTO transfer = new AlertRuleTransferDTO();
+        transfer.setRules(Collections.emptyList());
+
+        assertThat(validator.validate(transfer))
+                .extracting(violation -> violation.getMessage())
+                .contains("version is required", "domain is required", "rules must not be empty");
+    }
+
+    @Test
+    void declaresTheCurrentTransferVersionTest() {
+        assertThat(AlertRuleTransferDTO.VERSION).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `AlertRuleTransferDTOTest` (1 to 3 tests) to pin down the rule transfer/import payload validation.

Added cases:
- a transfer missing version, domain, or carrying an empty rule list is rejected with the respective `version is required`, `domain is required`, and `rules must not be empty` violations (bean validation);
- the transfer format version constant is pinned to 1.

## Why

The DTO gates alert rule import payloads; only the null-rule-entry violation was covered before.

## Testing

`mvn -B test -Dtest=AlertRuleTransferDTOTest` — 3/3 pass; checkstyle (validate) clean.