### PR TITLE
test(metrics): deepen CollectorStatusController registration coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/CollectorStatusControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/CollectorStatusControllerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class CollectorStatusControllerTest {
     @Test
@@ -31,5 +32,29 @@ class CollectorStatusControllerTest {
         CollectorStatusVO status = new CollectorStatusController(properties, List.of(), List.of()).status().getData();
 
         assertThat(status.collectionInterval()).isEqualTo("PT1M");
+    }
+
+    @Test
+    void reportsRegisteredCollectorCountsTest() {
+        AlertingProperties properties = new AlertingProperties();
+
+        CollectorStatusVO status = new CollectorStatusController(properties,
+                List.of(mock(ClusterMetricsCollector.class)),
+                List.of(mock(BusinessMetricsCollector.class), mock(BusinessMetricsCollector.class)))
+                .status().getData();
+
+        assertThat(status.clusterCollectorCount()).isEqualTo(1);
+        assertThat(status.businessCollectorCount()).isEqualTo(2);
+    }
+
+    @Test
+    void reportsZeroCollectorsWhenNoneAreRegisteredTest() {
+        AlertingProperties properties = new AlertingProperties();
+
+        CollectorStatusVO status = new CollectorStatusController(
+                properties, List.of(), List.of()).status().getData();
+
+        assertThat(status.clusterCollectorCount()).isZero();
+        assertThat(status.businessCollectorCount()).isZero();
     }
 }


### PR DESCRIPTION
## Summary

Extends the existing `CollectorStatusControllerTest` (1 to 3 tests) to pin down the native collection status endpoint.

Added cases:
- with registered collectors, the status VO reports the cluster and business collector counts from the injected Spring lists;
- with no collectors registered, both counts are zero.

## Why

The endpoint is the UI signal for native alert collection configuration; only the interval field was covered before.

## Testing

`mvn -B test -Dtest=CollectorStatusControllerTest` — 3/3 pass; checkstyle (validate) clean.