### PR TITLE
test(provider): cover Aliyun catalog controller delegation

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunCatalogControllerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.alibaba;
+
+import org.apache.rocketmq.studio.provider.CloudInstanceOptionVO;
+import org.apache.rocketmq.studio.provider.CloudRegionVO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AliyunCatalogController}: the cloud-catalog endpoints delegate to
+ * the catalog service with the credential/region/search parameters intact.
+ */
+@ExtendWith(MockitoExtension.class)
+class AliyunCatalogControllerTest {
+
+    @Mock
+    private AliyunCatalogService catalogService;
+
+    @InjectMocks
+    private AliyunCatalogController controller;
+
+    @Test
+    void listsRegionsForACredential() {
+        List<CloudRegionVO> regions = List.of();
+        when(catalogService.listRegions(9L)).thenReturn(regions);
+
+        assertThat(controller.listRegions(9L).getData()).isSameAs(regions);
+        verify(catalogService).listRegions(9L);
+    }
+
+    @Test
+    void listsInstancesWithRegionAndSearch() {
+        List<CloudInstanceOptionVO> instances = List.of();
+        when(catalogService.listCloudInstances(9L, "cn-hangzhou", "prod")).thenReturn(instances);
+
+        assertThat(controller.listInstances(9L, "cn-hangzhou", "prod").getData())
+                .isSameAs(instances);
+        verify(catalogService).listCloudInstances(9L, "cn-hangzhou", "prod");
+    }
+
+    @Test
+    void passesNullSearchThroughWhenAbsent() {
+        when(catalogService.listCloudInstances(9L, "cn-hangzhou", null))
+                .thenReturn(List.of());
+
+        assertThat(controller.listInstances(9L, "cn-hangzhou", null).getData()).isEmpty();
+        verify(catalogService).listCloudInstances(9L, "cn-hangzhou", null);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `AliyunCatalogControllerTest`, a first unit test for the Aliyun cloud-catalog REST endpoints. The catalog service is mocked.

Coverage:
- `GET /regions` delegates with the credential id and returns the service payload;
- `GET /instances` delegates with the credential, region, and search term intact;
- a missing (null) search term is passed through as null rather than being dropped or replaced.

## Why

These endpoints drive the cloud instance picker for the Aliyun vendor type; the delegation contract had no direct test (only the Tencent web API module was covered).

## Testing

`mvn -B test -Dtest=AliyunCatalogControllerTest` — 3/3 pass; checkstyle (validate) clean.