### PR TITLE
test(model): deepen LiteTopicQuota rate and threshold coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
@@ -65,4 +65,29 @@ class LiteTopicQuotaTest {
         assertThat(quota.getSessionUsageRate()).isZero();
         assertThat(quota.getRemainingQuota()).isEqualTo(10);
     }
+
+    @Test
+    void usageRatesReflectCurrentOverMaxFractions() {
+        LiteTopicQuota quota = new LiteTopicQuota();
+        quota.setMaxTopicCount(10);
+        quota.setCurrentTopicCount(5);
+        quota.setMaxSessionCount(8);
+        quota.setCurrentSessionCount(2);
+
+        assertThat(quota.getUsageRate()).isEqualTo(0.5);
+        assertThat(quota.getSessionUsageRate()).isEqualTo(0.25);
+    }
+
+    @Test
+    void nearQuotaLimitUsesTheUsageRateThreshold() {
+        LiteTopicQuota quota = new LiteTopicQuota();
+        quota.setMaxTopicCount(10);
+        quota.setCurrentTopicCount(9);
+
+        assertThat(quota.isNearQuotaLimit(0.9)).isTrue();
+        assertThat(quota.isNearQuotaLimit(0.91)).isFalse();
+
+        quota.setCurrentTopicCount(5);
+        assertThat(quota.isNearQuotaLimit(0.5)).isTrue();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `LiteTopicQuotaTest` (4 to 6 tests) to pin down the remaining quota math.

Added cases:
- `getUsageRate`/`getSessionUsageRate` reflect the current-over-max fractions (5/10 → 0.5, 2/8 → 0.25);
- `isNearQuotaLimit` compares the topic usage rate against the threshold inclusively (9/10 is near 0.9 but not 0.91; 5/10 is near 0.5).

## Why

The quota view drives the Lite Topic creation warning banner; only guard/edge behavior was covered before, not the actual rate values or thresholds.

## Testing

`mvn -B test -Dtest=LiteTopicQuotaTest` — 6/6 pass; checkstyle (validate) clean.