### PR TITLE
test(model): deepen LiteTopicSummary ttl and aggregation coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSummaryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSummaryTest.java
@@ -52,4 +52,48 @@ class LiteTopicSummaryTest {
         assertThat(summary.getConsumerDensity()).isZero();
         assertThat(summary.isEmptyAggregation()).isTrue();
     }
+
+    @Test
+    void ttlStatusIsUnknownWithoutALastActiveTime() {
+        LiteTopicSummary summary = new LiteTopicSummary();
+        summary.setAverageTTL(10_000L);
+
+        assertThat(summary.getTTLStatus()).isEqualTo("UNKNOWN");
+    }
+
+    @Test
+    void ttlStatusSeparatesActiveAndExpiringBoundaries() {
+        long now = System.currentTimeMillis();
+        long averageTtl = 60_000L;
+        LiteTopicSummary summary = new LiteTopicSummary();
+        summary.setAverageTTL(averageTtl);
+
+        summary.setLastActiveTime(new Date(now - 30_000));
+        assertThat(summary.getTTLStatus()).isEqualTo("ACTIVE");
+
+        summary.setLastActiveTime(new Date(now - 50_000));
+        assertThat(summary.getTTLStatus()).isEqualTo("EXPIRING_SOON");
+    }
+
+    @Test
+    void consumerDensityAndEmptyAggregationSemantics() {
+        LiteTopicSummary summary = new LiteTopicSummary();
+        summary.setTopicCount(6);
+        summary.setConsumerCount(3);
+
+        assertThat(summary.getConsumerDensity()).isEqualTo(0.5);
+        assertThat(summary.isEmptyAggregation()).isFalse();
+
+        summary.setConsumerCount(null);
+        summary.setTotalBacklog(5L);
+        assertThat(summary.isEmptyAggregation()).isFalse();
+
+        summary.setConsumerCount(0);
+        summary.setTotalBacklog(0L);
+        assertThat(summary.isEmptyAggregation()).isTrue();
+
+        LiteTopicSummary unset = new LiteTopicSummary();
+        assertThat(unset.getConsumerDensity()).isZero();
+        assertThat(unset.isEmptyAggregation()).isTrue();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `LiteTopicSummaryTest` (4 to 7 tests) to pin down the remaining Lite Topic summary logic.

Added cases:
- `getTTLStatus` is `UNKNOWN` without a last-active time;
- the ACTIVE / EXPIRING_SOON boundary is separated with comfortable margins (0.5x vs 0.83x of the average TTL);
- `getConsumerDensity` returns the consumer/topic fraction (3/6 → 0.5) and zero for unset counts;
- `isEmptyAggregation` is true only when both consumer count and backlog are absent/zero — a present consumer count or backlog makes the aggregation non-empty.

## Why

These computed fields drive the Lite Topic aggregate view (TTL chips and empty-aggregation placeholders); only the EXPIRED-first ordering and one unset-count case were covered before.

## Testing

`mvn -B test -Dtest=LiteTopicSummaryTest` — 7/7 pass; checkstyle (validate) clean.