### PR TITLE
fix(message): show backend message properties

### DIFF
--- a/web/src/api/message.ts
+++ b/web/src/api/message.ts
@@ -14,6 +14,7 @@ export interface MessageRecord {
   bornHost: string;
   storeHost: string;
   properties: Record<string, string>;
+  propertiesTruncated?: boolean;
   size: number;
 }
 

--- a/web/src/components/QueueBrowser.tsx
+++ b/web/src/components/QueueBrowser.tsx
@@ -16,6 +16,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  Alert,
   Button,
   Card,
   Descriptions,
@@ -47,6 +48,9 @@ export const formatTimeMs = (value: number | string) => {
   if (!Number.isFinite(ts)) return '-';
   return new Date(ts).toLocaleString('zh-CN', { hour12: false });
 };
+
+const messageProperties = (message: MessageRecord | null) =>
+  Object.entries(message?.properties ?? {});
 
 export interface PulledEntry {
   key: string;
@@ -364,6 +368,34 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
                           {entry.message.bornHost || '-'}
                         </Descriptions.Item>
                       </Descriptions>
+                      {messageProperties(entry.message).length > 0 && (
+                        <Card size="small" title="Properties" style={{ marginTop: 12 }}>
+                          {entry.message.propertiesTruncated && (
+                            <Alert
+                              showIcon
+                              type="warning"
+                              message="服务端已截断消息属性"
+                              style={{ marginBottom: 8 }}
+                            />
+                          )}
+                          <Descriptions
+                            column={1}
+                            size="small"
+                            items={messageProperties(entry.message).map(([name, value]) => ({
+                              key: name,
+                              label: <span style={{ fontFamily: 'monospace' }}>{name}</span>,
+                              children: (
+                                <Paragraph
+                                  copyable
+                                  style={{ marginBottom: 0, fontFamily: 'monospace' }}
+                                >
+                                  {value}
+                                </Paragraph>
+                              ),
+                            }))}
+                          />
+                        </Card>
+                      )}
                       {entry.message.body && (
                         <Card size="small" title="Body" style={{ marginTop: 12 }}>
                           <pre

--- a/web/src/components/__tests__/QueueBrowser.test.tsx
+++ b/web/src/components/__tests__/QueueBrowser.test.tsx
@@ -55,6 +55,7 @@ const messageRecord = (msgId: string): MessageRecord => ({
   bornHost: '127.0.0.1:1000',
   storeHost: '127.0.0.1:10911',
   properties: {},
+  propertiesTruncated: false,
   size: 2,
 });
 

--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -70,6 +70,7 @@ const createMessage = (msgId: string): MessageRecord => ({
   bornHost: '127.0.0.1:1000',
   storeHost: '127.0.0.1:10911',
   properties: {},
+  propertiesTruncated: false,
   size: 2,
 });
 

--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -104,6 +104,7 @@ const createMessage = (msgId: string): MessageRecord => ({
   bornHost: '127.0.0.1:1000',
   storeHost: '127.0.0.1:10911',
   properties: {},
+  propertiesTruncated: false,
   size: 2,
 });
 
@@ -314,6 +315,28 @@ describe('MessagePage async request ownership', () => {
     expect(
       await within(dialog).findByText('Message query provider is not configured'),
     ).toBeInTheDocument();
+  });
+
+  it('shows backend message properties and truncation in the detail modal', async () => {
+    const message = createMessage('message-with-properties');
+    message.properties = { traceId: 'trace-001', orderType: 'vip' };
+    message.propertiesTruncated = true;
+    serviceMocks.queryMessages.mockResolvedValue([message]);
+    const user = userEvent.setup();
+    renderPage();
+    await selectTopic(user);
+
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+    const row = await screen.findByRole('row', { name: /message-with-properties/ });
+    await user.click(within(row).getByRole('button', { name: /详情/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: '消息详情' });
+    expect(within(dialog).getByText('消息属性')).toBeInTheDocument();
+    expect(within(dialog).getByText('traceId')).toBeInTheDocument();
+    expect(within(dialog).getByText('trace-001')).toBeInTheDocument();
+    expect(within(dialog).getByText('orderType')).toBeInTheDocument();
+    expect(within(dialog).getByText('vip')).toBeInTheDocument();
+    expect(within(dialog).getByText('服务端已截断消息属性')).toBeInTheDocument();
   });
 
   it('loads a message trace lazily and reuses it for the same message', async () => {

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -147,6 +147,9 @@ const formatBody = (body: string): string => {
   }
 };
 
+const messageProperties = (record: MessageRecord | null) =>
+  Object.entries(record?.properties ?? {});
+
 const formatDurationMs = (value: number | null): string => {
   if (value == null) return '-';
   if (value >= 60000) return `${(value / 60000).toFixed(1)} min`;
@@ -917,6 +920,37 @@ const MessagePageContent = ({
           <Typography.Title level={5} style={{ marginBottom: 8 }}>
             消息体
           </Typography.Title>
+          {messageProperties(selectedMsg).length > 0 && (
+            <>
+              <Typography.Title level={5} style={{ marginBottom: 8, marginTop: 24 }}>
+                消息属性
+              </Typography.Title>
+              {selectedMsg.propertiesTruncated && (
+                <Alert
+                  showIcon
+                  type="warning"
+                  message="服务端已截断消息属性"
+                  description="属性数量或属性值超过服务端展示上限，此处仅显示截断后的内容。"
+                  style={{ marginBottom: 12 }}
+                />
+              )}
+              <Descriptions
+                bordered
+                size="small"
+                column={1}
+                style={{ marginBottom: 24 }}
+                items={messageProperties(selectedMsg).map(([name, value]) => ({
+                  key: name,
+                  label: <span style={{ fontFamily: 'monospace' }}>{name}</span>,
+                  children: (
+                    <Paragraph copyable style={{ marginBottom: 0, fontFamily: 'monospace' }}>
+                      {value}
+                    </Paragraph>
+                  ),
+                }))}
+              />
+            </>
+          )}
           <Paragraph
             copyable
             style={{


### PR DESCRIPTION
## What happened

The backend already returns message properties with every message record:

```java
private Map<String, String> properties;
private boolean propertiesTruncated;
```

The Apache provider bounds this payload to 64 properties and 1,024 characters per value, and sets `propertiesTruncated` when that display contract shortens the payload.

The frontend never showed it:

- the Message Explorer detail modal displayed basic metadata and the body only;
- queue-browser message cards showed Message ID, Tag, Key, store time, size, born host, and body;
- the frontend `MessageRecord` type did not include `propertiesTruncated`.

Operators therefore could not inspect trace flags, retry context, routing metadata, or business user properties in the UI even though the backend delivered them.

## Change

- Add `propertiesTruncated` to the frontend message contract.
- Show a bounded **消息属性** section in the message detail modal.
- Show a **Properties** card in queue-browser message cards.
- When the server shortened the payload, show a warning explaining that properties were truncated.
- Keep body display and existing metadata unchanged.
- Update message fixtures and add a regression test for property rendering and truncation.

## Verification

Focused frontend:

```
cd web
npm test -- MessagePageAsyncState.test.tsx MessagePage.test.tsx QueueBrowser.test.tsx message.test.ts --run
```

Result: 5 files / 45 tests passed.

Lint/build:

```
npm run lint -- --quiet
npm run build
```

Lint reported 0 errors and 10 pre-existing warnings elsewhere. The production build passed.

`git diff --check` passed before commit.

This is a 92-line frontend-only change. It is the natural size for surfacing data that the backend already returns; no unrelated backend or padding changes were added.

Closes #3282
