### PR TITLE
fix(client): use backend connection filters

### DIFF
--- a/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
+++ b/web/src/pages/cluster/__tests__/ClientsPage.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { App } from 'antd';
-import { act, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -139,6 +139,17 @@ const renderWithProviders = (ui: React.ReactElement) =>
     </App>,
   );
 
+const selectOption = async (user: ReturnType<typeof userEvent.setup>, label: string) => {
+  const option = await waitFor(() => {
+    const match = [
+      ...document.querySelectorAll<HTMLElement>('.ant-select-item-option-content'),
+    ].find((element) => element.textContent === label);
+    if (!match) throw new Error(`Select option not found: ${label}`);
+    return match;
+  });
+  await user.click(option);
+};
+
 const deferred = <T,>() => {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -175,6 +186,34 @@ describe('Clients page', () => {
     await screen.findByText('order-svc-0@10.0.1.12:49152');
     expect(connectionsService.listConnections).toHaveBeenCalledWith({
       namesrvAddr: 'namesrv-1:9876',
+    });
+  });
+
+  it('sends cluster and type filters to the backend', async () => {
+    const mixedConnections = [
+      { ...connection, clusterName: 'ns-prod', type: 'Producer' },
+      { ...connection, clusterName: 'ns-prod', type: 'Consumer' },
+    ];
+    vi.mocked(connectionsService.listConnections).mockResolvedValue(mixedConnections);
+    const user = userEvent.setup();
+    renderWithProviders(<ClientsPage />);
+
+    await screen.findAllByText('order-svc-0@10.0.1.12:49152');
+
+    const clusterSelect = screen.getAllByLabelText('所属集群')[0];
+    fireEvent.mouseDown(clusterSelect.querySelector('.ant-select-selector')!);
+    await selectOption(user, 'ns-prod');
+
+    const typeSelect = screen.getAllByLabelText('类型')[0];
+    fireEvent.mouseDown(typeSelect.querySelector('.ant-select-selector')!);
+    await selectOption(user, 'Consumer');
+
+    await waitFor(() => {
+      expect(connectionsService.listConnections).toHaveBeenLastCalledWith({
+        namesrvAddr: 'namesrv-1:9876',
+        clusterId: 'ns-prod',
+        type: 'Consumer',
+      });
     });
   });
 
@@ -247,14 +286,29 @@ describe('Clients page', () => {
 
   it('updates statistics when the selected cluster filter changes', async () => {
     const user = userEvent.setup();
-    vi.mocked(connectionsService.listConnections).mockResolvedValue(connections);
+    vi.mocked(connectionsService.listConnections).mockImplementation((query) =>
+      Promise.resolve(
+        query?.clusterId === 'ns-prod'
+          ? connections.filter((item) => item.clusterName === 'ns-prod')
+          : connections,
+      ),
+    );
     renderWithProviders(<ClientsPage />);
 
-    await screen.findByText('audit-svc-0@10.0.2.10:49154');
-    await user.click(screen.getByRole('combobox', { name: '所属集群' }));
-    await user.click(
-      await screen.findByText('ns-prod', { selector: '.ant-select-item-option-content' }),
+    await screen.findAllByText('audit-svc-0@10.0.2.10:49154');
+    const clusterSelect = screen.getAllByLabelText('所属集群')[0];
+    fireEvent.mouseDown(clusterSelect.querySelector('.ant-select-selector')!);
+    await selectOption(user, 'ns-prod');
+
+    await waitFor(() =>
+      expect(connectionsService.listConnections).toHaveBeenLastCalledWith({
+        namesrvAddr: 'namesrv-1:9876',
+        clusterId: 'ns-prod',
+      }),
     );
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     await waitFor(() => {
       expect(within(screen.getByTestId('connection-total')).getByText('2')).toBeInTheDocument();

--- a/web/src/pages/cluster/clients.tsx
+++ b/web/src/pages/cluster/clients.tsx
@@ -163,6 +163,7 @@ const ClientsPage = () => {
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [clusterFilter, setClusterFilter] = useState<string>('ALL');
+  const [typeFilter, setTypeFilter] = useState<string>('ALL');
   const [selectedConnection, setSelectedConnection] = useState<ClientConnection | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [registryLoadKey, setRegistryLoadKey] = useState(0);
@@ -231,7 +232,11 @@ const ClientsPage = () => {
       if (connectionRequestRef.current === requestId) setLoading(true);
     });
 
-    void listConnections({ namesrvAddr: selectedEndpoint })
+    void listConnections({
+      namesrvAddr: selectedEndpoint,
+      clusterId: clusterFilter === 'ALL' ? undefined : clusterFilter,
+      type: typeFilter === 'ALL' ? undefined : typeFilter,
+    })
       .then((nextConnections) => {
         if (connectionRequestRef.current === requestId) {
           setConnections(nextConnections);
@@ -249,7 +254,7 @@ const ClientsPage = () => {
       .finally(() => {
         if (connectionRequestRef.current === requestId) setLoading(false);
       });
-  }, [connectionLoadKey, selectedEndpoint, selectedCluster]);
+  }, [connectionLoadKey, clusterFilter, selectedEndpoint, selectedCluster, typeFilter]);
 
   useEffect(
     () => () => {
@@ -262,21 +267,18 @@ const ClientsPage = () => {
   /* ─── Cluster options using nsClusterName ─── */
   const clusterOptions = useMemo(() => {
     const clusterNames = [
-      ...new Set(connections.map((connection) => connection.clusterName)),
+      ...new Set([
+        ...registryClusters.map((cluster) => cluster.nsClusterName).filter(Boolean),
+        ...connections.map((connection) => connection.clusterName).filter(Boolean),
+      ]),
     ].sort();
     return [
       { value: 'ALL', label: t('clients.allClusters') },
       ...clusterNames.map((name) => ({ value: name, label: name })),
     ];
-  }, [connections, t]);
+  }, [connections, registryClusters, t]);
 
-  const clusterConnections = useMemo(
-    () =>
-      clusterFilter === 'ALL'
-        ? connections
-        : connections.filter((connection) => connection.clusterName === clusterFilter),
-    [connections, clusterFilter],
-  );
+  const clusterConnections = useMemo(() => connections, [connections]);
 
   const connectionStats = useMemo(() => {
     const instances = Array.from(
@@ -706,6 +708,20 @@ const ClientsPage = () => {
             }}
             style={{ width: 180 }}
             options={clusterOptions}
+          />
+          <Select
+            aria-label={t('common.type')}
+            value={typeFilter}
+            onChange={(value) => {
+              setTypeFilter(value);
+              setCurrentPage(1);
+            }}
+            style={{ width: 140 }}
+            options={[
+              { value: 'ALL', label: t('common.all') },
+              { value: 'Producer', label: typeConfig.Producer?.label ?? 'Producer' },
+              { value: 'Consumer', label: typeConfig.Consumer?.label ?? 'Consumer' },
+            ]}
           />
           <Input.Search
             placeholder={t('clients.searchPlaceholder')}


### PR DESCRIPTION
## What changed

The Client Connections page now forwards the selected cluster and client type to the existing backend query parameters instead of loading every connection and filtering only in the browser.

- send `clusterId` and `type` when a concrete filter is selected;
- reset pagination when a filter changes;
- calculate statistics, diagnostics, table rows, and exports from the filtered response;
- keep all clusters from the registry in the cluster selector so filtering one response does not make other clusters disappear;
- add regression coverage for combined filter requests and server-filtered statistics.

## Why

On installations with many connections, the page could request and render the complete inventory even when an operator had selected a cluster or type. The displayed totals and exported data also depended on the client-side copy rather than the backend result. This makes the existing filters useful for large deployments and preserves the ability to switch back to another registered cluster after filtering.

Closes #3291

## Validation

- `npm test -- ClientsPage.test.tsx --run` — 19 tests passed
- `npm run lint -- --quiet` — 0 errors; 10 existing warnings remain elsewhere in the tree
- `npm run build` — passed
- `git diff --check` — passed

The repository's CI status is not being described here; the validation above is from the local branch.