### PR TITLE
feat(message): manage query history

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryController.java
@@ -11,6 +11,7 @@ import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -58,6 +59,24 @@ public class QueryHistoryController {
     @GetMapping("/messages/{id}/results")
     public Result<List<MessageRecordVO>> messageQueryResults(@PathVariable long id) {
         return Result.ok(queryHistoryService.getMessageQueryResults(id));
+    }
+
+    @DeleteMapping("/messages/{id}")
+    public Result<Void> deleteMessageQuery(@PathVariable long id) {
+        queryHistoryService.deleteMessageQuery(id);
+        return Result.ok(null);
+    }
+
+    @DeleteMapping("/traces/{id}")
+    public Result<Void> deleteTraceQuery(@PathVariable long id) {
+        queryHistoryService.deleteTraceQuery(id);
+        return Result.ok(null);
+    }
+
+    @DeleteMapping
+    public Result<QueryHistoryDeleteResultVO> clearHistory(
+            @RequestParam(required = false) String clusterId) {
+        return Result.ok(queryHistoryService.clearHistory(normalizeFilter(clusterId)));
     }
 
     private void validatePage(int page, int pageSize) {

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryDeleteResultVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryDeleteResultVO.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import lombok.Builder;
+import lombok.Value;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Counts returned after an operator removes query history. */
+@Value
+@Builder
+public class QueryHistoryDeleteResultVO {
+    int messageQueries;
+    int traceQueries;
+
+    @JsonProperty("total")
+    public int total() {
+        return messageQueries + traceQueries;
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
@@ -244,6 +244,53 @@ public class QueryHistoryService {
                 .build();
     }
 
+    /**
+     * Deletes one message-query record only when it belongs to the current operator.
+     * Returning a not-found result for another operator's record avoids exposing ownership.
+     */
+    public void deleteMessageQuery(long id) {
+        String queriedBy = AuthenticatedUserContext.currentUsernameOrSystem();
+        int deleted = messageQueryMapper.delete(new QueryWrapper<RmqMessageQuery>()
+                .eq("id", id)
+                .eq("queried_by", queriedBy));
+        if (deleted == 0) {
+            throw new org.apache.rocketmq.studio.common.exception.BusinessException(
+                    404, "Message query history record not found");
+        }
+    }
+
+    /** Deletes one trace-query record only when it belongs to the current operator. */
+    public void deleteTraceQuery(long id) {
+        String queriedBy = AuthenticatedUserContext.currentUsernameOrSystem();
+        int deleted = traceQueryMapper.delete(new QueryWrapper<RmqTraceQuery>()
+                .eq("id", id)
+                .eq("queried_by", queriedBy));
+        if (deleted == 0) {
+            throw new org.apache.rocketmq.studio.common.exception.BusinessException(
+                    404, "Trace query history record not found");
+        }
+    }
+
+    /**
+     * Clears both history streams for the current operator and optional cluster scope.
+     * The delete predicates deliberately include the authenticated operator in both tables.
+     */
+    public QueryHistoryDeleteResultVO clearHistory(String clusterId) {
+        String queriedBy = AuthenticatedUserContext.currentUsernameOrSystem();
+        QueryWrapper<RmqMessageQuery> messageFilter = new QueryWrapper<RmqMessageQuery>()
+                .eq("queried_by", queriedBy)
+                .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId);
+        QueryWrapper<RmqTraceQuery> traceFilter = new QueryWrapper<RmqTraceQuery>()
+                .eq("queried_by", queriedBy)
+                .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId);
+        int messageQueries = messageQueryMapper.delete(messageFilter);
+        int traceQueries = traceQueryMapper.delete(traceFilter);
+        return QueryHistoryDeleteResultVO.builder()
+                .messageQueries(messageQueries)
+                .traceQueries(traceQueries)
+                .build();
+    }
+
     @Scheduled(fixedDelayString = "${studio.query-history.cleanup-interval:PT24H}")
     public void purgeExpiredQueries() {
         int retentionDays = properties.getRetentionDays();

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryControllerTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -96,5 +97,28 @@ class QueryHistoryControllerTest {
         verify(queryHistoryService).listMessageQueries("instance-a", "TOPIC", null, 1, 20);
         verify(queryHistoryService).listTraceQueries("instance-a", null, 1, 20);
         verify(queryHistoryService).summarize(null);
+    }
+
+    @Test
+    void deletesSingleMessageHistoryRecord() throws Exception {
+        mockMvc.perform(delete("/api/query-history/messages/17"))
+                .andExpect(status().isOk());
+
+        verify(queryHistoryService).deleteMessageQuery(17L);
+    }
+
+    @Test
+    void clearsHistoryForNormalizedCluster() throws Exception {
+        when(queryHistoryService.clearHistory("instance-a"))
+                .thenReturn(QueryHistoryDeleteResultVO.builder()
+                        .messageQueries(3).traceQueries(2).build());
+
+        mockMvc.perform(delete("/api/query-history").param("clusterId", " instance-a "))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.messageQueries").value(3))
+                .andExpect(jsonPath("$.data.traceQueries").value(2))
+                .andExpect(jsonPath("$.data.total").value(5));
+
+        verify(queryHistoryService).clearHistory("instance-a");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
@@ -267,6 +267,38 @@ class QueryHistoryServiceTest {
         assertThat(traceCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
     }
 
+    @Test
+    void deletesOnlyCurrentOperatorsMessageHistory() {
+        AuthenticatedUserContext.setUsername("alice");
+        when(messageQueryMapper.delete(any(Wrapper.class))).thenReturn(1);
+
+        service.deleteMessageQuery(17L);
+
+        ArgumentCaptor<Wrapper<RmqMessageQuery>> captor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(messageQueryMapper).delete(captor.capture());
+        assertThat(captor.getValue().getCustomSqlSegment()).contains("id", "queried_by");
+        verify(traceQueryMapper, never()).delete(any(Wrapper.class));
+    }
+
+    @Test
+    void clearsBothHistoryTablesWithinClusterAndOperatorScope() {
+        AuthenticatedUserContext.setUsername("alice");
+        when(messageQueryMapper.delete(any(Wrapper.class))).thenReturn(4);
+        when(traceQueryMapper.delete(any(Wrapper.class))).thenReturn(2);
+
+        QueryHistoryDeleteResultVO result = service.clearHistory("cluster-a");
+
+        assertThat(result.getMessageQueries()).isEqualTo(4);
+        assertThat(result.getTraceQueries()).isEqualTo(2);
+        assertThat(result.total()).isEqualTo(6);
+        ArgumentCaptor<Wrapper<RmqMessageQuery>> messageCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        ArgumentCaptor<Wrapper<RmqTraceQuery>> traceCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(messageQueryMapper).delete(messageCaptor.capture());
+        verify(traceQueryMapper).delete(traceCaptor.capture());
+        assertThat(messageCaptor.getValue().getCustomSqlSegment()).contains("queried_by", "cluster_id");
+        assertThat(traceCaptor.getValue().getCustomSqlSegment()).contains("queried_by", "cluster_id");
+    }
+
     private static RmqMessageQuery messageQuery(Long id) {
         RmqMessageQuery query = new RmqMessageQuery();
         query.setId(id);

--- a/web/src/api/messageHistory.ts
+++ b/web/src/api/messageHistory.ts
@@ -47,6 +47,12 @@ export interface QueryHistorySummary {
   latestQueryAt?: string;
 }
 
+export interface QueryHistoryDeleteResult {
+  messageQueries: number;
+  traceQueries: number;
+  total: number;
+}
+
 export async function listMessageQueryHistory(params: {
   clusterId?: string;
   queryType?: string;
@@ -76,6 +82,21 @@ export async function listTraceQueryHistory(params: {
 
 export async function getQueryHistorySummary(clusterId?: string) {
   const response = await client.get<{ data: QueryHistorySummary }>('/query-history/summary', {
+    params: clusterId ? { clusterId } : undefined,
+  });
+  return response.data.data;
+}
+
+export async function deleteMessageQueryHistory(id: number) {
+  await client.delete(`/query-history/messages/${id}`);
+}
+
+export async function deleteTraceQueryHistory(id: number) {
+  await client.delete(`/query-history/traces/${id}`);
+}
+
+export async function clearQueryHistory(clusterId?: string) {
+  const response = await client.delete<{ data: QueryHistoryDeleteResult }>('/query-history', {
     params: clusterId ? { clusterId } : undefined,
   });
   return response.data.data;

--- a/web/src/components/MessageQueryHistoryDrawer.tsx
+++ b/web/src/components/MessageQueryHistoryDrawer.tsx
@@ -5,10 +5,25 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Alert, Button, Drawer, Flex, Input, Statistic, Table, Tabs, Tag } from 'antd';
+import {
+  Alert,
+  Button,
+  Drawer,
+  Flex,
+  Input,
+  Modal,
+  Popconfirm,
+  Statistic,
+  Table,
+  Tabs,
+  Tag,
+} from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import {
   getQueryHistorySummary,
+  clearQueryHistory,
+  deleteMessageQueryHistory,
+  deleteTraceQueryHistory,
   listMessageQueryHistory,
   listTraceQueryHistory,
   type MessageQueryHistory,
@@ -45,6 +60,10 @@ const MessageQueryHistoryDrawer = ({
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [deleteError, setDeleteError] = useState('');
+  const [deletingKey, setDeletingKey] = useState<string>();
+  const [clearModalOpen, setClearModalOpen] = useState(false);
+  const [clearing, setClearing] = useState(false);
   const [summary, setSummary] = useState<QueryHistorySummary>();
   const [messageRows, setMessageRows] = useState<MessageQueryHistory[]>([]);
   const [traceRows, setTraceRows] = useState<TraceQueryHistory[]>([]);
@@ -56,6 +75,7 @@ const MessageQueryHistoryDrawer = ({
     const id = ++requestId.current;
     setLoading(true);
     setError('');
+    setDeleteError('');
     setSummary(undefined);
     setMessageRows([]);
     setTraceRows([]);
@@ -91,6 +111,53 @@ const MessageQueryHistoryDrawer = ({
     }
   }, [clusterId, open, page, search, t, tab]);
 
+  const deleteMessage = async (id: number) => {
+    setDeletingKey(`message-${id}`);
+    setDeleteError('');
+    try {
+      await deleteMessageQueryHistory(id);
+      if (messageRows.length === 1 && page > 1) setPage((current) => current - 1);
+      else await load();
+    } catch (deleteLoadError) {
+      setDeleteError(
+        deleteLoadError instanceof Error ? deleteLoadError.message : '删除查询历史失败',
+      );
+    } finally {
+      setDeletingKey(undefined);
+    }
+  };
+
+  const deleteTrace = async (id: number) => {
+    setDeletingKey(`trace-${id}`);
+    setDeleteError('');
+    try {
+      await deleteTraceQueryHistory(id);
+      if (traceRows.length === 1 && page > 1) setPage((current) => current - 1);
+      else await load();
+    } catch (deleteLoadError) {
+      setDeleteError(
+        deleteLoadError instanceof Error ? deleteLoadError.message : '删除查询历史失败',
+      );
+    } finally {
+      setDeletingKey(undefined);
+    }
+  };
+
+  const clearHistory = async () => {
+    setClearing(true);
+    setDeleteError('');
+    try {
+      await clearQueryHistory(clusterId);
+      setClearModalOpen(false);
+      if (page !== 1) setPage(1);
+      else await load();
+    } catch (clearLoadError) {
+      setDeleteError(clearLoadError instanceof Error ? clearLoadError.message : '清空查询历史失败');
+    } finally {
+      setClearing(false);
+    }
+  };
+
   useEffect(() => {
     // Loading is asynchronous; state updates happen after the history API resolves.
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -117,6 +184,29 @@ const MessageQueryHistoryDrawer = ({
       width: 180,
       render: formatTime,
     },
+    {
+      title: t('common.actions'),
+      key: 'actions',
+      width: 90,
+      render: (_: unknown, row) => (
+        <Popconfirm
+          title={t('messageHistory.deleteConfirm')}
+          okText={t('common.delete')}
+          cancelText={t('common.cancel')}
+          onConfirm={() => void deleteMessage(row.id)}
+        >
+          <Button
+            danger
+            type="link"
+            size="small"
+            loading={deletingKey === `message-${row.id}`}
+            onClick={(event) => event.stopPropagation()}
+          >
+            {t('common.delete')}
+          </Button>
+        </Popconfirm>
+      ),
+    },
   ];
   const traceColumns: ColumnsType<TraceQueryHistory> = [
     { title: 'Message ID', dataIndex: 'msgId', ellipsis: true },
@@ -136,6 +226,29 @@ const MessageQueryHistoryDrawer = ({
       width: 180,
       render: formatTime,
     },
+    {
+      title: t('common.actions'),
+      key: 'actions',
+      width: 90,
+      render: (_: unknown, row) => (
+        <Popconfirm
+          title={t('messageHistory.deleteConfirm')}
+          okText={t('common.delete')}
+          cancelText={t('common.cancel')}
+          onConfirm={() => void deleteTrace(row.id)}
+        >
+          <Button
+            danger
+            type="link"
+            size="small"
+            loading={deletingKey === `trace-${row.id}`}
+            onClick={(event) => event.stopPropagation()}
+          >
+            {t('common.delete')}
+          </Button>
+        </Popconfirm>
+      ),
+    },
   ];
 
   return (
@@ -146,16 +259,25 @@ const MessageQueryHistoryDrawer = ({
       onClose={onClose}
       destroyOnHidden
     >
-      <Flex gap={32} style={{ marginBottom: 16 }}>
-        <Statistic
-          title={t('messageHistory.messageQueries')}
-          value={summary?.messageQueries ?? 0}
-        />
-        <Statistic title={t('messageHistory.traceQueries')} value={summary?.traceQueries ?? 0} />
-        <Statistic
-          title={t('messageHistory.latestQuery')}
-          value={formatTime(summary?.latestQueryAt)}
-        />
+      <Flex justify="space-between" align="center" style={{ marginBottom: 16 }}>
+        <Flex gap={32}>
+          <Statistic
+            title={t('messageHistory.messageQueries')}
+            value={summary?.messageQueries ?? 0}
+          />
+          <Statistic title={t('messageHistory.traceQueries')} value={summary?.traceQueries ?? 0} />
+          <Statistic
+            title={t('messageHistory.latestQuery')}
+            value={formatTime(summary?.latestQueryAt)}
+          />
+        </Flex>
+        <Button
+          danger
+          onClick={() => setClearModalOpen(true)}
+          disabled={!summary?.messageQueries && !summary?.traceQueries}
+        >
+          {t('messageHistory.clearHistory')}
+        </Button>
       </Flex>
       <Input.Search
         allowClear
@@ -177,6 +299,17 @@ const MessageQueryHistoryDrawer = ({
               {t('common.retry')}
             </Button>
           }
+          style={{ marginBottom: 12 }}
+        />
+      )}
+      {deleteError && (
+        <Alert
+          type="error"
+          showIcon
+          message="查询历史操作失败"
+          description={deleteError}
+          closable
+          onClose={() => setDeleteError('')}
           style={{ marginBottom: 12 }}
         />
       )}
@@ -231,6 +364,21 @@ const MessageQueryHistoryDrawer = ({
           },
         ]}
       />
+      <Modal
+        title="清空查询历史"
+        open={clearModalOpen}
+        okText="清空"
+        cancelText="取消"
+        okButtonProps={{ danger: true, loading: clearing }}
+        onOk={() => void clearHistory()}
+        onCancel={() => setClearModalOpen(false)}
+      >
+        <p>
+          {clusterId
+            ? '这会删除当前操作员在所选集群下的消息查询和轨迹查询历史，操作不可撤销。'
+            : '这会删除当前操作员的全部消息查询和轨迹查询历史，操作不可撤销。'}
+        </p>
+      </Modal>
     </Drawer>
   );
 };

--- a/web/src/components/__tests__/MessageQueryHistoryDrawer.test.tsx
+++ b/web/src/components/__tests__/MessageQueryHistoryDrawer.test.tsx
@@ -12,12 +12,17 @@ import MessageQueryHistoryDrawer from '../MessageQueryHistoryDrawer';
 import { LangProvider } from '../../i18n/LangContext';
 import { LANGUAGE_STORAGE_KEY } from '../../i18n/languagePreference';
 import {
+  clearQueryHistory,
+  deleteMessageQueryHistory,
   getQueryHistorySummary,
   listMessageQueryHistory,
   listTraceQueryHistory,
 } from '../../api/messageHistory';
 
 vi.mock('../../api/messageHistory', () => ({
+  clearQueryHistory: vi.fn(),
+  deleteMessageQueryHistory: vi.fn(),
+  deleteTraceQueryHistory: vi.fn(),
   getQueryHistorySummary: vi.fn(),
   listMessageQueryHistory: vi.fn(),
   listTraceQueryHistory: vi.fn(),
@@ -41,6 +46,12 @@ describe('MessageQueryHistoryDrawer', () => {
     vi.clearAllMocks();
     localStorage.clear();
     vi.mocked(getQueryHistorySummary).mockResolvedValue({ messageQueries: 4, traceQueries: 2 });
+    vi.mocked(clearQueryHistory).mockResolvedValue({
+      messageQueries: 0,
+      traceQueries: 0,
+      total: 0,
+    });
+    vi.mocked(deleteMessageQueryHistory).mockResolvedValue(undefined);
     vi.mocked(listMessageQueryHistory).mockResolvedValue({
       items: [
         {
@@ -137,5 +148,22 @@ describe('MessageQueryHistoryDrawer', () => {
       screen.getByPlaceholderText('Search Topic, trace Topic, Message ID, Key or operator'),
     ).toBeInTheDocument();
     expect(screen.queryByText('服务端查询历史')).not.toBeInTheDocument();
+  });
+
+  it('deletes one message history record and reloads the current scope', async () => {
+    const user = userEvent.setup();
+    render(
+      <App>
+        <MessageQueryHistoryDrawer open clusterId="instance-a" onClose={vi.fn()} />
+      </App>,
+    );
+
+    expect(await screen.findByText('order-1')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: '删除' }));
+    expect(await screen.findByText('删除这条查询历史？')).toBeInTheDocument();
+    await user.click(document.querySelector('.ant-popconfirm-buttons .ant-btn-primary')!);
+
+    await waitFor(() => expect(deleteMessageQueryHistory).toHaveBeenCalledWith(1));
+    expect(getQueryHistorySummary).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -525,6 +525,8 @@ const translations: Record<string, Record<Lang, string>> = {
   'messageHistory.traceTopic': { zh: '轨迹 Topic', en: 'Trace Topic' },
   'messageHistory.traceNodes': { zh: '轨迹节点', en: 'Trace Nodes' },
   'messageHistory.consumers': { zh: '消费者', en: 'Consumers' },
+  'messageHistory.deleteConfirm': { zh: '删除这条查询历史？', en: 'Delete this query history?' },
+  'messageHistory.clearHistory': { zh: '清空查询历史', en: 'Clear History' },
 
   // ─── Dead Letter Queue ───
   'dlq.title': { zh: '死信队列', en: 'Dead Letter Queue' },


### PR DESCRIPTION
## What changed

The dashboard stores server-side message and trace query history, but operators previously had no way to remove a record before the scheduled retention job ran. This change adds scoped deletion while preserving the existing retention cleanup.

- add authenticated, operator-scoped deletion for one message-query or trace-query record;
- add a clear-history endpoint for the current operator, optionally limited to the selected cluster;
- return deletion counts for the message and trace streams;
- add delete actions to both history tables;
- add a confirmation dialog for clearing the selected scope;
- reload rows and summary after deletion, including page correction when the last row is removed;
- keep deletion failures visible without losing the current table state.

Every delete predicate includes `queried_by`; a user cannot delete another operator's history, and missing/foreign records return the same not-found response.

Closes #3295

## Validation

- `mvn -q '-Dtest=QueryHistoryControllerTest,QueryHistoryServiceTest' test` — passed (18 tests)
- `npm test -- MessageQueryHistoryDrawer.test.tsx --run` — 3 tests passed
- `npm run lint -- --quiet` — 0 errors; 10 existing warnings remain elsewhere in the tree
- `npm run build` — passed
- `git diff --check` — passed

The repository's GitHub Actions status is not being described as green here; the checks above are local validation on this branch.