### PR TITLE
fix(message): bound trace request cache

### DIFF
--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -80,11 +80,13 @@ import {
   type MessageTraceDiagnostics,
   type TraceDiagnosticStatus,
 } from '../../utils/messageTraceDiagnostics';
+import { BoundedPromiseCache } from '../../utils/boundedPromiseCache';
 
 const { Paragraph, Text } = Typography;
 const { RangePicker } = DatePicker;
 const DEFAULT_QUERY_ERROR = '消息查询失败，请稍后重试';
 const DEFAULT_TRACE_ERROR = '消息轨迹加载失败，请稍后重试';
+const TRACE_CACHE_MAX_ENTRIES = 32;
 
 /* ─── Constants ─── */
 
@@ -413,7 +415,9 @@ const MessagePageContent = ({
   // committed query, not whatever the form inputs hold at the moment a page is clicked.
   const committedQueryRef = useRef<{ mode: QueryMode; params: MessageQuery } | null>(null);
   const traceGenerationRef = useRef(0);
-  const traceCacheRef = useRef(new Map<string, Promise<TraceRecord | null>>());
+  const traceCacheRef = useRef(
+    new BoundedPromiseCache<string, TraceRecord | null>(TRACE_CACHE_MAX_ENTRIES),
+  );
   const traceDiagnostics = useMemo(() => analyzeMessageTrace(traceData), [traceData]);
 
   useEffect(

--- a/web/src/utils/boundedPromiseCache.test.ts
+++ b/web/src/utils/boundedPromiseCache.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { BoundedPromiseCache } from './boundedPromiseCache';
+
+describe('BoundedPromiseCache', () => {
+  it('rejects an invalid capacity', () => {
+    expect(() => new BoundedPromiseCache(0)).toThrow('maxEntries must be a positive integer');
+    expect(() => new BoundedPromiseCache(1.5)).toThrow('maxEntries must be a positive integer');
+  });
+
+  it('evicts the least recently used entry when capacity is exceeded', async () => {
+    const cache = new BoundedPromiseCache<string, string>(2);
+    const first = Promise.resolve('first');
+    const second = Promise.resolve('second');
+    const third = Promise.resolve('third');
+    cache.set('a', first);
+    cache.set('b', second);
+    expect(cache.get('a')).toBe(first);
+    cache.set('c', third);
+
+    expect(cache.size).toBe(2);
+    expect(cache.get('a')).toBe(first);
+    expect(cache.get('b')).toBeUndefined();
+    expect(await cache.get('c')).toBe('third');
+  });
+
+  it('refreshes recency on a cache hit and replaces duplicate keys', () => {
+    const cache = new BoundedPromiseCache<string, number>(2);
+    const first = Promise.resolve(1);
+    const replacement = Promise.resolve(2);
+    cache.set('a', first);
+    cache.set('b', Promise.resolve(3));
+    expect(cache.get('a')).toBe(first);
+    cache.set('a', replacement);
+    expect(cache.get('a')).toBe(replacement);
+    expect(cache.size).toBe(2);
+  });
+
+  it('supports explicit deletion for rejected requests and cleanup', () => {
+    const cache = new BoundedPromiseCache<string, string>(2);
+    cache.set('a', Promise.resolve('a'));
+    cache.set('b', Promise.resolve('b'));
+    expect(cache.delete('a')).toBe(true);
+    expect(cache.delete('a')).toBe(false);
+    cache.clear();
+    expect(cache.size).toBe(0);
+  });
+});

--- a/web/src/utils/boundedPromiseCache.ts
+++ b/web/src/utils/boundedPromiseCache.ts
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/** A bounded LRU cache for in-flight or recently completed promise requests. */
+export class BoundedPromiseCache<K, V> {
+  private readonly entries = new Map<K, Promise<V>>();
+
+  constructor(private readonly maxEntries: number) {
+    if (!Number.isInteger(maxEntries) || maxEntries < 1) {
+      throw new Error('maxEntries must be a positive integer');
+    }
+  }
+
+  get(key: K): Promise<V> | undefined {
+    const value = this.entries.get(key);
+    if (value === undefined) return undefined;
+    this.entries.delete(key);
+    this.entries.set(key, value);
+    return value;
+  }
+
+  set(key: K, value: Promise<V>): void {
+    this.entries.delete(key);
+    this.entries.set(key, value);
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value as K | undefined;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+  }
+
+  delete(key: K): boolean {
+    return this.entries.delete(key);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}


### PR DESCRIPTION
## What changed

Message Explorer deduplicates trace lookups in a page-local `Map`, but successful promises were retained indefinitely. A long investigation session with many distinct messages could therefore keep every resolved trace response referenced until the page was destroyed.

This change replaces the unbounded map with a small LRU promise cache:

- cap retained trace requests at 32 entries;
- refresh recency when an existing trace is reopened;
- evict the least-recently-used entry when the cap is exceeded;
- keep in-flight request de-duplication unchanged;
- continue removing rejected requests so a failed lookup can be retried;
- add focused tests for capacity validation, LRU eviction, replacement, deletion, and cleanup.

The cache is page-local and does not alter trace query results or server-side history recording.

Closes #3297

## Validation

- `npm test -- boundedPromiseCache.test.ts --run` — 4 tests passed
- `npm test -- MessagePageAsyncState.test.tsx MessagePage.test.tsx --run` — 27 tests passed
- `npm run lint -- --quiet` — 0 errors; 10 existing warnings remain elsewhere in the tree
- `npm run build` — passed
- `git diff --check` — passed

The GitHub Actions status is not being described as green here; the checks above are local validation on this branch.