### PR TITLE
fix(metrics): give profile panels and the custom query independent request guards

### DIFF
--- a/web/src/components/MetricsExplorer.tsx
+++ b/web/src/components/MetricsExplorer.tsx
@@ -423,7 +423,12 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
   const [dataSourceKey, setDataSourceKey] = useState('');
   const [dataSourcesLoading, setDataSourcesLoading] = useState(true);
   const [pendingDataSource, setPendingDataSource] = useState<DataSource | null>(null);
-  const requestId = useRef(0);
+  // Profile panels and the custom query panel are independent state domains, so each
+  // flow tracks its own request generation: sharing one counter would let the two
+  // bumpers in the same synchronous handler (e.g. the refresh action) invalidate
+  // each other's in-flight results and leave every panel stuck on its spinner.
+  const panelRequestIdRef = useRef(0);
+  const customRequestIdRef = useRef(0);
   // Keeps the latest data source readable from the stable callbacks so switching
   // the source uses the new key instead of a stale closure value.
   const dataSourceKeyRef = useRef(dataSourceKey);
@@ -483,7 +488,7 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
   const loadAll = useCallback(
     async (profile: MetricProfile | undefined, range: RangeOption) => {
       if (!profile) return;
-      const currentRequest = ++requestId.current;
+      const currentRequest = ++panelRequestIdRef.current;
       const loadingPatch = Object.fromEntries(
         profile.metrics.map((metric) => [metric.semanticMetric, { loading: true } as PanelState]),
       );
@@ -492,14 +497,14 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
         profile.metrics.map(async (metric) => {
           try {
             const result = await runQuery(metric.promql, range);
-            if (currentRequest === requestId.current) {
+            if (currentRequest === panelRequestIdRef.current) {
               setPanels((previous) => ({
                 ...previous,
                 [metric.semanticMetric]: { loading: false, data: result },
               }));
             }
           } catch (error) {
-            if (currentRequest === requestId.current) {
+            if (currentRequest === panelRequestIdRef.current) {
               setPanels((previous) => ({
                 ...previous,
                 [metric.semanticMetric]: {
@@ -535,7 +540,8 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
       });
     return () => {
       cancelled = true;
-      requestId.current += 1;
+      panelRequestIdRef.current += 1;
+      customRequestIdRef.current += 1;
     };
   }, [loadAll]);
 
@@ -557,16 +563,16 @@ const MetricsExplorer = ({ instanceId }: MetricsExplorerProps) => {
     async (promql: string, range: RangeOption) => {
       const trimmed = promql.trim();
       if (!trimmed) return;
-      const currentRequest = ++requestId.current;
+      const currentRequest = ++customRequestIdRef.current;
       setCustomPanel({ loading: true });
       setAppliedCustomPromql(trimmed);
       try {
         const result = await runQuery(trimmed, range);
-        if (currentRequest === requestId.current) {
+        if (currentRequest === customRequestIdRef.current) {
           setCustomPanel({ loading: false, data: result });
         }
       } catch (error) {
-        if (currentRequest === requestId.current) {
+        if (currentRequest === customRequestIdRef.current) {
           setCustomPanel({
             loading: false,
             error: getQueryErrorMessage(error, queryErrorFallback),

--- a/web/src/components/__tests__/MetricsExplorer.test.tsx
+++ b/web/src/components/__tests__/MetricsExplorer.test.tsx
@@ -285,6 +285,23 @@ describe('MetricsExplorer', () => {
     expect(await screen.findAllByText('cluster=prod / node_id=broker-a')).not.toHaveLength(0);
   });
 
+  it('reloads profile panels when refresh also reruns the applied custom query', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<MetricsExplorer />);
+    await screen.findByRole('img', { name: 'Message In TPS time series' });
+
+    await user.type(screen.getByLabelText('自定义查询'), 'sum(rocketmq_topic_number)');
+    await user.click(screen.getByRole('button', { name: /查\s*询/ }));
+    await screen.findAllByText('cluster=prod / node_id=broker-a');
+
+    await user.click(screen.getByRole('button', { name: '刷新全部面板' }));
+
+    expect(
+      await screen.findByRole('img', { name: 'Message In TPS time series' }, { timeout: 3000 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('42 messages/s')).toBeInTheDocument();
+  });
+
   it('queries the first metric when the version profile changes', async () => {
     const user = userEvent.setup();
     renderWithProviders(<MetricsExplorer />);


### PR DESCRIPTION
Fixes #3304.

## Problem / Evidence
Metrics Explorer uses one shared monotonic `requestId` ref for two independent flows: `loadAll` (profile panels) and `runCustomQuery` (custom query panel). Any action that triggers both synchronously makes the second flow bump the counter while the first is in flight, so the first flow's results always fail their freshness guard and are silently dropped:

- Clicking 刷新全部面板 with an applied custom query (`MetricsExplorer.tsx` refresh handler: `void loadAll(...)` then `void runCustomQuery(...)`): `loadAll` captures N, `runCustomQuery` bumps to N+1 in the same tick → every profile panel stays on its spinner forever; the refresh button (loading = anyLoading) spins until page reload. 100% reproducible.
- Switching data sources while a custom query is applied (`activateDataSource` runs both).
- Running a custom query while the initial panel load is still in flight.

Regression test added: `reloads profile panels when refresh also reruns the applied custom query` — red on pristine (panel chart never re-renders), green after the fix.

## Root cause / Fix
`loadAll` and `runCustomQuery` guard two disjoint state slices (`panels` vs `customPanel`), so sharing one request generation counter is wrong: each flow invalidates the other's in-flight results without producing anything to replace them.

Fix: split the counter into `panelRequestIdRef` / `customRequestIdRef` (unmount cleanup bumps both). No behavioral change to single-flow ordering semantics (profile/profile and custom/custom still supersede older results).

## Priority & scoring
PRIORITY 79 = 影响 32 (entire metrics dashboard view permanently frozen after a routine action; requires page reload) + 波及范围 13 (core Metrics Explorer used on the home dashboard) + 可复现性 18 (deterministic, one click with an applied custom query) + 维护价值 16 (clear root cause, minimal split). FIX_CONFIDENCE 92.

## Tests
- New regression test red on pristine (observed red: the Message In TPS chart never re-appeared after refresh), green after fix.
- `npx vitest run src/components/__tests__/MetricsExplorer.test.tsx` → 20/20 pass.
- Full web suite (`npx vitest run --testTimeout=60000`): 923 tests, 922 pass; the single failure is `ConsumerPage.test.tsx` "shows group health diagnostics…", a documented load-fragile file untouched by this PR — isolated rerun of that file: 29/29 pass.
- `npm run build` ✓ (CI frontend-build equivalent); `npx tsc --noEmit` clean; `npx eslint` on touched files clean.
- CI note: the upstream workflow is in a repo-wide `startup_failure` state (zero jobs run, including other contributors' branches), so CI-equivalent verification was run locally — see the verification comment below.

## Risk
Low. The two refs only affect result-application guards; existing tests covering range/profile superseding still pass unchanged.