### PR TITLE
fix(acl): reload the user page after creating or deleting a user

### DIFF
--- a/web/src/pages/instance/__tests__/AclPage.test.tsx
+++ b/web/src/pages/instance/__tests__/AclPage.test.tsx
@@ -597,6 +597,55 @@ describe('ACL page', () => {
     });
   });
 
+  it('reloads the server user page after creating an ACL user', async () => {
+    const user = userEvent.setup();
+    vi.mocked(aclService.createAclUser).mockResolvedValue({
+      id: 13,
+      username: 'orders-service',
+      accessKey: 'acce****3456',
+      secretKey: 'secr****7654',
+      admin: false,
+      clusters: ['cluster-a', 'cluster-b'],
+      gmtCreate: '2026-08-01T00:00:00Z',
+    });
+    renderWithProviders(<AclPage />);
+
+    await user.click(await screen.findByText('用户管理'));
+    const userPanel = screen.getByRole('tabpanel', { name: '用户管理' });
+    await user.click(within(userPanel).getByRole('button', { name: /添加用户/ }));
+    const dialog = await screen.findByRole('dialog');
+
+    await user.type(
+      within(dialog).getByPlaceholderText('例：user-order-service'),
+      'orders-service',
+    );
+    const clusterInput = within(dialog).getByRole('combobox');
+    await user.type(clusterInput, 'cluster-a,cluster-b,');
+    await user.click(within(dialog).getByRole('button', { name: /添\s*加/ }));
+
+    await waitFor(() => expect(aclService.createAclUser).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(aclService.pageAclUsers).toHaveBeenCalledTimes(2));
+  });
+
+  it('reloads the server user page after deleting one ACL user', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
+      void config.onOk?.();
+      return { destroy: vi.fn(), update: vi.fn() } as unknown as ReturnType<typeof Modal.confirm>;
+    });
+    vi.mocked(aclService.deleteAclUser).mockResolvedValue(undefined);
+    renderWithProviders(<AclPage />);
+
+    await user.click(await screen.findByText('用户管理'));
+    const userPanel = screen.getByRole('tabpanel', { name: '用户管理' });
+    const row = await within(userPanel).findByRole('row', { name: /remote-admin/ });
+    await user.click(within(row).getByRole('button', { name: /删除/ }));
+
+    await waitFor(() => expect(aclService.deleteAclUser).toHaveBeenCalledWith(11, undefined));
+    await waitFor(() => expect(aclService.pageAclUsers).toHaveBeenCalledTimes(2));
+    confirmSpy.mockRestore();
+  });
+
   it('replaces the cluster scope of an existing user', async () => {
     const user = userEvent.setup();
     vi.mocked(aclService.updateAclUser).mockResolvedValue({

--- a/web/src/pages/instance/acl.tsx
+++ b/web/src/pages/instance/acl.tsx
@@ -142,6 +142,7 @@ const AclPageContent = ({
   const [userSubmitting, setUserSubmitting] = useState(false);
   const [activeTab, setActiveTab] = useState('rules');
   const [ruleRefreshKey, setRuleRefreshKey] = useState(0);
+  const [userRefreshKey, setUserRefreshKey] = useState(0);
   const [ruleTotal, setRuleTotal] = useState(0);
   const [rulePage, setRulePage] = useState(1);
   const [rulePageSize, setRulePageSize] = useState(20);
@@ -251,6 +252,7 @@ const AclPageContent = ({
     userPage,
     userPageSize,
     userKeyword,
+    userRefreshKey,
   ]);
 
   /* ─── Rule helpers ─── */
@@ -417,13 +419,15 @@ const AclPageContent = ({
         setUsers((prev) => prev.map((u) => (u.id === editingUser.id ? normalized : u)));
         message.success(t('acl.userUpdated'));
       } else {
-        const created = await createAclUser({
+        await createAclUser({
           username: values.username,
           admin: values.admin ?? false,
           clusters: values.clusters ?? [],
           instanceId: selectedInstanceId,
         });
-        setUsers((prev) => [normalizeUser(created), ...prev]);
+        // Reload the authoritative server page so the pagination total and page count
+        // stay consistent with the created row (same refresh pattern as the rules tab).
+        setUserRefreshKey((prev) => prev + 1);
         message.success(t('acl.userAdded'));
       }
       setUserModalOpen(false);
@@ -438,7 +442,9 @@ const AclPageContent = ({
   const handleDeleteUser = async (id: AclEntityId) => {
     try {
       await deleteAclUser(id, selectedInstanceId);
-      setUsers((prev) => prev.filter((u) => u.id !== id));
+      // Reload the authoritative server page so the pagination total follows the delete
+      // and an emptied last page falls back to the previous one (same as the rules tab).
+      setUserRefreshKey((prev) => prev + 1);
       message.success(t('acl.userDeleted'));
     } catch {
       message.error(t('common.operationFailed'));


### PR DESCRIPTION
Fixes #3306.

## Problem / Evidence
On the ACL page 用户管理 tab, create/delete only mutate the local page array and never update the cached server total nor refetch (contrast: the rules tab bumps `ruleRefreshKey` after its mutations, `acl.tsx` handleRuleSubmit/handleDeleteRule):

- Create with a full page: the new row is prepended, the previous last row is silently pushed out of view, and the header/pagination keeps showing the stale total.
- Delete the last row on the last page: the table goes empty, the total stays too high, and the empty-page auto-correction (which lives inside the fetch effect) never runs because nothing refetches.

Regression tests added: `reloads the server user page after creating an ACL user` and `reloads the server user page after deleting one ACL user` — both red on pristine (`pageAclUsers` called once instead of twice), green after the fix.

## Root cause / Fix
List mutations bypass the server-paginated inventory contract.

Fix: add a `userRefreshKey` state next to `ruleRefreshKey`, include it in the fetch effect deps, and bump it after successful create/delete so the authoritative server page is reloaded — totals stay correct and an emptied page falls back to the previous one (the effect's existing correction logic). Update-in-place is untouched (no total change).

## Priority & scoring
PRIORITY 72 = 影响 26 (wrong pagination totals, hidden rows, unrecoverable empty page until manual pagination) + 波及范围 12 (ACL user inventory) + 可复现性 19 (fully deterministic) + 维护价值 15 (mirrors the established rules-tab pattern). FIX_CONFIDENCE 88.

## Tests
- New regression tests red on pristine, green after fix.
- `npx vitest run src/pages/instance/__tests__/AclPage.test.tsx` → 23/23 pass.
- Full web suite (`npx vitest run --testTimeout=60000`, two runs): 924 tests; the only stable failure is `ConsumerPage.test.tsx` "keeps the latest client stack…", a documented load-fragile file untouched by this PR (the first run had one additional transient failure in the same file). AclPage including both new tests passes in the full run and in isolation.
- `npm run build` ✓ (CI frontend-build equivalent); `npx tsc --noEmit` clean; `npx eslint` on touched files clean.
- CI note: the upstream workflow is in a repo-wide `startup_failure` state (zero jobs run, including other contributors' branches), so CI-equivalent verification was run locally — see the verification comment below.

## Risk
Low. Create/delete now refetch like the rules tab already does; the extra request is an idempotent page GET.