### PR TITLE
fix(topic): search topics with the trimmed term on the client too

### DIFF
--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -292,6 +292,25 @@ describe('TopicPage', () => {
     clickSpy.mockRestore();
   });
 
+  it('keeps matching rows when the search term has leading or trailing spaces', async () => {
+    const user = userEvent.setup();
+    // The server query uses the trimmed term, so it returns the matching topic; the
+    // client-side row filter must not re-filter with the padded raw input.
+    mockTopicsList([{ ...buildTopics(1)[0], name: 'orders-topic' }]);
+    renderWithProviders();
+
+    expect(await screen.findByText('orders-topic')).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('搜索 Topic 名称'), ' orders ');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() =>
+      expect(topicServiceMocks.listTopicsPage).toHaveBeenCalledWith(
+        expect.objectContaining({ search: 'orders' }),
+      ),
+    );
+    expect(await screen.findByText('orders-topic')).toBeInTheDocument();
+  });
+
   it('keeps the current table page after opening and closing topic details', async () => {
     const user = userEvent.setup();
     instanceServiceMocks.listInstances.mockResolvedValue([

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -1462,7 +1462,9 @@ const TopicPage = () => {
             allowClear
             style={{ width: 260 }}
             onSearch={(value) => {
-              setSearchText(value);
+              // Store the trimmed term so the client-side row filter matches what the
+              // server query used; padded input would otherwise filter out every row.
+              setSearchText(value.trim());
               resetTablePage();
             }}
             onChange={(e) => {


### PR DESCRIPTION
Fixes #3307.

## Problem / Evidence
The topic list fetches with `search: searchText.trim()` (`loadTopicPage`) but passes the raw input to the client-side row filter `visibleTopics`, which does `topic.name.toLowerCase().includes(searchText.toLowerCase())`. A search term with leading/trailing whitespace (e.g. from a paste) queries the server with the trimmed term, receives the matching topics, then filters every returned row out because no topic name contains the padded string — the table shows empty despite matches existing.

Regression test added: `keeps matching rows when the search term has leading or trailing spaces` — red on pristine (row disappears after submitting " orders "), green after the fix.

## Root cause / Fix
Two different search terms are in play: the trimmed one used for the server query and the raw one used for client re-filtering.

Fix: trim once when the term is stored in `onSearch` (`setSearchText(value.trim())`), so the server query, the client filter, and the export all use the same effective term. Precedent: closed issue #911 fixed the same defect class for consumer-group search.

## Priority & scoring
PRIORITY 72 = 影响 26 (primary search interaction on the topic page returns an empty table for padded input) + 波及范围 12 (topic page) + 可复现性 19 (deterministic, trivial steps) + 维护价值 15 (single normalization point). FIX_CONFIDENCE 90.

## Tests
- New regression test red on pristine, green after fix.
- `npx vitest run src/pages/instance/__tests__/TopicPage.test.tsx` → 22/22 pass.
- Full web suite (`npx vitest run --testTimeout=60000`): 923 tests, 922 pass; the single failure is `ConsumerPage.test.tsx` "shows group health diagnostics…", a documented load-fragile file untouched by this PR. TopicPage passes in the full run and in isolation.
- `npm run build` ✓ (CI frontend-build equivalent); `npx tsc --noEmit` clean; `npx eslint` on touched files clean.
- CI note: the upstream workflow is in a repo-wide `startup_failure` state (zero jobs run, including other contributors' branches), so CI-equivalent verification was run locally — see the verification comment below.

## Risk
Low. Only the stored search term changes; the input box itself still displays what the user typed.