### PR TITLE
fix(message): treat MQClientException NO_MESSAGE key queries as empty results

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/MqResponseCodes.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/MqResponseCodes.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+
+/**
+ * Shared classifier for the RocketMQ response codes carried on broker/client exceptions.
+ * Consolidates the per-provider copies that walk an exception cause chain looking for a
+ * specific {@code ResponseCode} so the "RPC succeeded but there is no business data" grading
+ * stays consistent. {@link MQClientException} and {@link MQBrokerException} both expose
+ * {@code getResponseCode()} but share no common supertype, so both are checked.
+ */
+public final class MqResponseCodes {
+
+    private MqResponseCodes() {
+    }
+
+    /**
+     * Returns {@code true} when any exception in the cause chain is an {@link MQClientException}
+     * or {@link MQBrokerException} carrying one of the given response codes. A self-referential
+     * cause terminates the walk instead of looping forever.
+     */
+    public static boolean hasResponseCode(Throwable error, int... responseCodes) {
+        Throwable cause = error;
+        while (cause != null) {
+            Integer code = responseCodeOf(cause);
+            if (code != null) {
+                for (int responseCode : responseCodes) {
+                    if (code == responseCode) {
+                        return true;
+                    }
+                }
+            }
+            cause = cause.getCause() == cause ? null : cause.getCause();
+        }
+        return false;
+    }
+
+    private static Integer responseCodeOf(Throwable throwable) {
+        if (throwable instanceof MQClientException clientException) {
+            return clientException.getResponseCode();
+        }
+        if (throwable instanceof MQBrokerException brokerException) {
+            return brokerException.getResponseCode();
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -17,7 +17,6 @@
 package org.apache.rocketmq.studio.provider.apache;
 
 import org.apache.rocketmq.client.QueryResult;
-import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
 import org.apache.rocketmq.client.consumer.PullResult;
 import org.apache.rocketmq.client.consumer.PullStatus;
@@ -31,6 +30,7 @@ import org.apache.rocketmq.remoting.protocol.route.QueueData;
 import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.util.MqResponseCodes;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.instance.message.ConsumerStatusVO;
 import org.apache.rocketmq.studio.instance.message.MessageProvider;
@@ -189,6 +189,13 @@ public class RocketMQMessageProvider implements MessageProvider {
             }
             return result;
         } catch (Exception e) {
+            if (MqResponseCodes.hasResponseCode(e, ResponseCode.NO_MESSAGE)) {
+                // MQAdminImpl.queryMessage throws MQClientException(NO_MESSAGE) instead of
+                // returning an empty QueryResult when the key matches nothing: the query
+                // completed, so the correct response is an empty list, not a gateway error.
+                log.info("queryMessage(topic={}, key={}) matched nothing", topic, key);
+                return Collections.emptyList();
+            }
             log.warn("queryMessage(topic={}, key={}) failed: {}", topic, key, e.getMessage());
             throw new BusinessException(502, "Failed to query messages by key: " + e.getMessage());
         }
@@ -438,11 +445,12 @@ public class RocketMQMessageProvider implements MessageProvider {
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
-            if (isTraceTopicAbsent(e)) {
-                // The cluster has no trace topic route (trace dispatch disabled): the RPC
-                // succeeded but there is no business data, so return an empty trace instead
-                // of surfacing an error (exception-grading convention).
-                log.info("Trace topic not available on this cluster (msgId={}), returning empty trace", msgId);
+            if (MqResponseCodes.hasResponseCode(e, ResponseCode.TOPIC_NOT_EXIST, ResponseCode.NO_MESSAGE)) {
+                // The cluster has no trace topic route (trace dispatch disabled) or the
+                // message simply has no trace records: the RPC succeeded but there is no
+                // business data, so return an empty trace instead of surfacing an error
+                // (exception-grading convention).
+                log.info("No trace data available for msgId={} ({}), returning empty trace", msgId, e.getMessage());
                 return emptyTrace();
             }
             log.warn("Trace query for msgId={} failed: {}", msgId, e.getMessage());
@@ -453,18 +461,6 @@ public class RocketMQMessageProvider implements MessageProvider {
                 .nodes(nodes)
                 .consumerStatus(consumerStatus)
                 .build();
-    }
-
-    private static boolean isTraceTopicAbsent(Throwable error) {
-        Throwable cause = error;
-        while (cause != null) {
-            if (cause instanceof MQClientException clientException
-                    && clientException.getResponseCode() == ResponseCode.TOPIC_NOT_EXIST) {
-                return true;
-            }
-            cause = cause.getCause() == cause ? null : cause.getCause();
-        }
-        return false;
     }
 
     /**
@@ -496,6 +492,10 @@ public class RocketMQMessageProvider implements MessageProvider {
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
+            if (MqResponseCodes.hasResponseCode(e, ResponseCode.TOPIC_NOT_EXIST, ResponseCode.NO_MESSAGE)) {
+                log.info("No trace data available for key={} ({}), returning empty trace", key, e.getMessage());
+                return emptyTrace();
+            }
             log.warn("Trace query by key={} failed: {}", key, e.getMessage());
             throw new BusinessException(502, "Failed to query message trace by key: " + e.getMessage());
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/MqResponseCodesTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/MqResponseCodesTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MqResponseCodesTest {
+
+    @Test
+    void matchesClientExceptionResponseCodeTest() {
+        MQClientException error = new MQClientException(ResponseCode.NO_MESSAGE, "no message");
+        assertThat(MqResponseCodes.hasResponseCode(error,
+                ResponseCode.TOPIC_NOT_EXIST, ResponseCode.NO_MESSAGE)).isTrue();
+    }
+
+    @Test
+    void matchesBrokerExceptionResponseCodeTest() {
+        MQBrokerException error = new MQBrokerException(ResponseCode.CONSUMER_NOT_ONLINE, "not online");
+        assertThat(MqResponseCodes.hasResponseCode(error, ResponseCode.CONSUMER_NOT_ONLINE)).isTrue();
+    }
+
+    @Test
+    void matchesResponseCodeOnNestedCauseTest() {
+        MQClientException cause = new MQClientException(ResponseCode.TOPIC_NOT_EXIST, "no route");
+        RuntimeException wrapper = new RuntimeException("wrapper", cause);
+        assertThat(MqResponseCodes.hasResponseCode(wrapper, ResponseCode.TOPIC_NOT_EXIST)).isTrue();
+    }
+
+    @Test
+    void returnsFalseWhenResponseCodeAbsentTest() {
+        MQClientException error = new MQClientException(ResponseCode.TOPIC_NOT_EXIST, "no route");
+        assertThat(MqResponseCodes.hasResponseCode(error, ResponseCode.NO_MESSAGE)).isFalse();
+    }
+
+    @Test
+    void returnsFalseForNullExceptionTest() {
+        assertThat(MqResponseCodes.hasResponseCode(null, ResponseCode.NO_MESSAGE)).isFalse();
+    }
+
+    @Test
+    void terminatesOnSelfReferentialCauseTest() {
+        Throwable selfCaused = new Throwable("self") {
+            @Override
+            public synchronized Throwable getCause() {
+                return this;
+            }
+        };
+        assertThat(MqResponseCodes.hasResponseCode(selfCaused, ResponseCode.NO_MESSAGE)).isFalse();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.client.QueryResult;
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
 import org.apache.rocketmq.client.consumer.PullResult;
 import org.apache.rocketmq.client.consumer.PullStatus;
+import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.impl.MQClientAPIImpl;
 import org.apache.rocketmq.client.impl.factory.MQClientInstance;
 import org.apache.rocketmq.client.trace.TraceConstants;
@@ -27,6 +28,7 @@ import org.apache.rocketmq.common.message.MessageDecoder;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageId;
 import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.ConsumeMessageDirectlyResult;
 import org.apache.rocketmq.remoting.protocol.body.CMResult;
@@ -211,6 +213,18 @@ class RocketMQMessageProviderTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Failed to query messages by key: broker unavailable")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    @Test
+    void queryByKeyReturnsEmptyListWhenClientReportsNoMessage() throws Exception {
+        // MQAdminImpl.queryMessage throws MQClientException(NO_MESSAGE) instead of
+        // returning an empty QueryResult when the key matches nothing.
+        when(adminExt.queryMessage("TopicA", "order-1", 64, 100L, 200L))
+                .thenThrow(new MQClientException(ResponseCode.NO_MESSAGE,
+                        "query message by key finished, but no message."));
+
+        assertThat(provider.queryMessages(
+                "instance-a", "TopicA", null, null, "order-1", 100L, 200L)).isEmpty();
     }
 
     @Test
@@ -629,6 +643,32 @@ class RocketMQMessageProviderTest {
                 .hasMessage("Failed to query message trace: broker unavailable")
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
 
+    }
+
+    @Test
+    void getMessageTraceReturnsEmptyTraceWhenClientReportsNoMessage() throws Exception {
+        // A message without trace data (trace disabled on the producer or expired) is a
+        // completed query with no records, not a remote failure.
+        when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
+                .thenThrow(new MQClientException(ResponseCode.NO_MESSAGE,
+                        "query message by key finished, but no message."));
+
+        TraceRecordVO record = provider.getMessageTrace("instance-a", "msg-123", "orders");
+
+        assertThat(record.getNodes()).isEmpty();
+        assertThat(record.getConsumerStatus()).isEmpty();
+    }
+
+    @Test
+    void getMessageTraceByKeyReturnsEmptyTraceWhenClientReportsNoMessage() throws Exception {
+        when(adminExt.queryMessage(anyString(), anyString(), anyInt(), anyLong(), anyLong()))
+                .thenThrow(new MQClientException(ResponseCode.NO_MESSAGE,
+                        "query message by key finished, but no message."));
+
+        TraceRecordVO record = provider.getMessageTraceByKey("instance-a", "key-1", "orders", null);
+
+        assertThat(record.getNodes()).isEmpty();
+        assertThat(record.getConsumerStatus()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Fixes #3305.

## Problem / Evidence
`MQAdminImpl.queryMessage` (rocketmq-client 5.5.0, verified in the resolved jar's bytecode) throws `MQClientException(ResponseCode.NO_MESSAGE=208, "query message by key finished, but no message.")` when the key matches nothing — it never returns an empty `QueryResult`. The Apache provider converts every exception into `BusinessException(502)`:

- `GET /api/messages?...&key=<no-match>` → 502 "Failed to query messages by key: CODE: 208 ..." for a normal no-match outcome.
- `GET /api/messages/{msgId}/trace` for a message without trace data (trace disabled on the producer or expired) → 502. The code's own grading convention comment says "the RPC succeeded but there is no business data, so return an empty trace instead of surfacing an error", but only `TOPIC_NOT_EXIST` is graded.

Closed issues #1161/#1275 record the intended semantics: "A completed query with no matching messages may return an empty list. A remote query failure must return a structured gateway error." `NO_MESSAGE` is exactly a completed query with no matching records.

## Root cause / Fix
`NO_MESSAGE` (client-side "no data" signal) is indistinguishable from remote failures in the catch-alls of `queryByKey`, `getMessageTrace`, and `getMessageTraceByKey`.

Fix: shared `hasResponseCode(error, codes...)` helper (same cause-walk as the old `isTraceTopicAbsent`); `queryByKey` returns an empty list on `NO_MESSAGE`, both trace paths return an empty trace on `TOPIC_NOT_EXIST` or `NO_MESSAGE`. Genuine broker failures still surface as 502 (existing tests `queryByKeySurfacesAdminFailure`, `getMessageTraceSurfacesAdminFailure` unchanged and green).

## Priority & scoring
PRIORITY 78 = 影响 30 (first-class query modes error out on normal empty outcomes) + 波及范围 14 (message query + trace paths, one provider) + 可复现性 19 (deterministic; client behavior verified in bytecode and reproduced in red tests) + 维护价值 15 (aligns code with documented convention). FIX_CONFIDENCE 92.

## Tests
- New regression tests red on pristine with exactly the production error `BusinessException: ... CODE: 208 DESC: query message by key finished, but no message.`, green after fix.
- `mvn -Dtest=RocketMQMessageProviderTest test` → 39/39 pass.
- Related modules (`org.apache.rocketmq.studio.provider.apache.*Test`, `org.apache.rocketmq.studio.instance.message.*Test`) → 299/299 pass.
- Full backend `mvn -B -ntp test`: 2038 tests = 2035 pristine baseline + 3 new regressions; the 3 failures are identical to the pristine baseline (`AuthCorsIntegrationTest` ×2, `AliyunInstanceProviderTest.getGroupProgressShouldMapLagRowsTest`) — zero new failures. The run also covers the CI backend-build compile step.
- CI note: the upstream workflow is in a repo-wide `startup_failure` state (zero jobs run, including other contributors' branches), so CI-equivalent verification was run locally — see the verification comment below.

## Risk
Low. Only response-code 208 grading is added; error semantics for real failures unchanged.