### PR TITLE
fix(alert): keep 7-day weekly silence windows active through day 7

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceSchedule.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceSchedule.java
@@ -47,7 +47,9 @@ final class AlertSilenceSchedule {
         ZonedDateTime seedStart = silence.getStartsAt().toInstant(ZoneOffset.UTC).atZone(zone);
         ZonedDateTime seedEnd = silence.getEndsAt().toInstant(ZoneOffset.UTC).atZone(zone);
         Duration wallDuration = Duration.between(seedStart.toLocalDateTime(), seedEnd.toLocalDateTime());
-        int daysToInspect = recurrence == AlertSilenceRecurrence.DAILY ? 1 : 6;
+        // A weekly window may span up to 7 days, so an occurrence anchored 7 days
+        // back can still be in its final hours; daily windows span at most 24 hours.
+        int daysToInspect = recurrence == AlertSilenceRecurrence.DAILY ? 1 : 7;
 
         for (int offset = 0; offset <= daysToInspect; offset++) {
             LocalDate candidateDate = localNow.toLocalDate().minusDays(offset);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceScheduleTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceScheduleTest.java
@@ -80,6 +80,17 @@ class AlertSilenceScheduleTest {
     }
 
     @Test
+    void weeklyWindowRemainsActiveThroughItsSeventhDayTest() {
+        AlertSilenceVO silence = recurring(AlertSilenceRecurrence.WEEKLY, "UTC", Set.of(2),
+                "2026-09-01T10:00:00", "2026-09-08T10:00:00", "2026-10-01T00:00:00");
+
+        assertThat(AlertSilenceSchedule.activeUntil(silence, at("2026-09-14T12:00:00")))
+                .isEqualTo(at("2026-09-15T10:00:00"));
+        assertThat(AlertSilenceSchedule.activeUntil(silence, at("2026-09-15T09:59:59")))
+                .isEqualTo(at("2026-09-15T10:00:00"));
+    }
+
+    @Test
     void recurrenceNeverStartsBeforeSeedWindowTest() {
         AlertSilenceVO silence = recurring(AlertSilenceRecurrence.DAILY, "UTC", Set.of(),
                 "2026-09-10T10:00:00", "2026-09-10T11:00:00", "2026-09-20T00:00:00");


### PR DESCRIPTION
## Problem

`AlertSilenceSchedule.activeUntil` resolves a recurring window by inspecting candidate anchor dates back from today. For weekly recurrences it only inspected up to **6** days back:

```java
int daysToInspect = recurrence == AlertSilenceRecurrence.DAILY ? 1 : 6;
```

But `AlertSilenceService.validateRecurrence` allows weekly windows of **exactly 7 days** (it only rejects windows longer than `Duration.ofDays(7)`), so a 7-day weekly window is legal input. Such a window anchored 7 days back can still be active (its seventh day, any time before the configured end wall-time), yet that anchor date was never inspected. Result: recurring silences silently stopped suppressing notifications during the final hours of a max-length weekly maintenance window — exactly when operators rely on them.

## Fix

Extend the weekly lookback from 6 to 7 days (`daily` is unchanged — daily windows span at most 24 hours, so a 1-day lookback is already complete):

```java
// A weekly window may span up to 7 days, so an occurrence anchored 7 days
// back can still be in its final hours; daily windows span at most 24 hours.
int daysToInspect = recurrence == AlertSilenceRecurrence.DAILY ? 1 : 7;
```

Any window that would NOT still be active fails the existing `now.isBefore(end)` check, so the extra inspected day cannot produce false positives.

## Verification

New test `weeklyWindowRemainsActiveThroughItsSeventhDayTest` in `AlertSilenceScheduleTest` — a WEEKLY silence (UTC, Tuesdays, seed `2026-09-01T10:00` → `2026-09-08T10:00`, i.e. exactly 7 days):

- fail-before on `36126024`: at `2026-09-15T09:59:59` (the last minute of the occurrence anchored `2026-09-08`) `activeUntil` returned `null`:
  `expected: 2026-09-15T10:00 but was: null` — the silence stopped suppressing on its seventh day
- pass-after with this change: returns `2026-09-15T10:00` (suppressed until the window ends)
- `AlertSilenceScheduleTest`: 9/9 pass
- full `ops.alert` test package: 281 tests run; the only failures are the pre-existing `NotificationOutboxServiceTest` mock-expectation failures (4F/1E), which reproduce identically on the pristine base commit `36126024` (verified by stashing this change) and are unrelated to silence scheduling

Build: `mvn test -Dtest='org.apache.rocketmq.studio.ops.alert.**'` (Temurin 21)

---

**AI disclosure:** This change was prepared with AI assistance (GitHub Copilot/Claude-style tooling guided by a human contributor).