### PR TITLE
fix(acl): reject IPv6 range expressions anchored on the first group

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/PlainAclRemoteAddressValidator.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/PlainAclRemoteAddressValidator.java
@@ -152,6 +152,7 @@ final class PlainAclRemoteAddressValidator {
         }
         String[] segments = expression.split(":", -1);
         int nonEmptySegments = 0;
+        int prefixGroups = 0;
         int firstVariable = -1;
         for (int i = 0; i < segments.length; i++) {
             String segment = segments[i];
@@ -166,6 +167,7 @@ final class PlainAclRemoteAddressValidator {
                 continue;
             }
             if (firstVariable < 0 && ("*".equals(segment) || isValidRange(segment, 16, 0xffff))) {
+                prefixGroups = nonEmptySegments - 1;
                 firstVariable = i;
                 continue;
             }
@@ -174,7 +176,10 @@ final class PlainAclRemoteAddressValidator {
             }
             return false;
         }
-        if (firstVariable <= 0 || nonEmptySegments > 8) {
+        // split(":", -1) keeps the empty tokens of a leading "::", so the variable's array index
+        // alone cannot prove a concrete prefix exists. Expressions like "::*" or "::1-20" anchor
+        // the range on the first group and cannot be used by the plain ACL address parser.
+        if (prefixGroups < 1 || nonEmptySegments > 8) {
             return false;
         }
         String variable = segments[firstVariable];

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/PlainAclRemoteAddressValidatorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/PlainAclRemoteAddressValidatorTest.java
@@ -56,6 +56,9 @@ class PlainAclRemoteAddressValidatorTest {
         "2001:db8::gggg",
         "1050::0005:0600:300c:200-1",
         "1050::0005:*:300c:1",
+        "::*",
+        "::1-20",
+        "::1-20:*",
         "not-an-address"
     })
     void shouldRejectExpressionsThePlainAclParserCannotUse(String expression) {


### PR DESCRIPTION
## Problem

`PlainAclRemoteAddressValidator.isValidIpv6Range` splits the expression with `split(":", -1)`, which **keeps the empty tokens produced by a leading `::`**. The guard meant to require a concrete prefix before the variable — `firstVariable <= 0 → reject` — therefore passes for expressions whose variable is the *first non-empty group*: its array index is already 2 because the two empty tokens of `::` occupy indices 0 and 1. As a result the validator **accepts**:

- `::*`
- `::1-20`
- `::1-20:*`

None of these can be used by the plain ACL address parser on the broker (the legacy `RemoteAddressStrategyFactory` that evaluates `whiteRemoteAddress`):

- For `::*` and `::1-20`, its analysis loop `for (int i = 1; i < StringUtils.split(remoteAddr, ":").length; i++)` never runs over the single token, so a `RangeRemoteAddressStrategy` is built with `head = null` — every subsequent `match()` call throws `NullPointerException` for that account.
- For `::1-20:*`, the head expands to `0000:0000` and the range is applied to the wrong group, silently matching far more addresses than the written range (an over-broad whitelist).

The validator's contract is to reject exactly this class of input ("forms understood by RocketMQ's legacy RemoteAddressStrategyFactory").

## Fix

Track how many concrete hex groups precede the variable (`prefixGroups`) and require at least one, instead of relying on the variable's array index:

```java
if (firstVariable < 0 && ("*".equals(segment) || isValidRange(segment, 16, 0xffff))) {
    prefixGroups = nonEmptySegments - 1;
    firstVariable = i;
    continue;
}
...
if (prefixGroups < 1 || nonEmptySegments > 8) {
    return false;
}
```

Well-formed expressions with a real prefix (`1050::0005:0600:300c:1-200`, `1050::0005:0600:300c:1-20:*`, `::ffff:*` …) keep at least one concrete group before the variable and stay accepted.

## Verification

Added the three expressions to `shouldRejectExpressionsThePlainAclParserCannotUse` in `PlainAclRemoteAddressValidatorTest`:

- fail-before on `36126024`: 3 failures — the validator returned `true` for all three
- pass-after with this change: `PlainAclRemoteAddressValidatorTest` 28/28 pass (including all previously accepted forms)
- full `org.apache.rocketmq.studio.instance.**` package: 449 tests, 0 failures

Build: `mvn test -Dtest='org.apache.rocketmq.studio.instance.**'` (Temurin 21)

---

**AI disclosure:** This change was prepared with AI assistance (GitHub Copilot/Claude-style tooling guided by a human contributor).