### PR TITLE
fix(message): enumerate read queues when listing queue offsets

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProvider.java
@@ -204,7 +204,7 @@ public class RocketMQMessageProvider implements MessageProvider {
                     return Collections.emptyList();
                 }
                 for (QueueData queueData : route.getQueueDatas()) {
-                    for (int queueId = 0; queueId < queueData.getWriteQueueNums(); queueId++) {
+                    for (int queueId = 0; queueId < queueData.getReadQueueNums(); queueId++) {
                         MessageQueue queue = new MessageQueue(topic, queueData.getBrokerName(), queueId);
                         result.add(QueueOffsetVO.builder()
                                 .brokerName(queue.getBrokerName())

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMessageProviderTest.java
@@ -31,6 +31,8 @@ import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
 import org.apache.rocketmq.remoting.protocol.body.ConsumeMessageDirectlyResult;
 import org.apache.rocketmq.remoting.protocol.body.CMResult;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
+import org.apache.rocketmq.remoting.protocol.route.QueueData;
+import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.cluster.broker.MqClientPool;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
@@ -40,6 +42,7 @@ import org.apache.rocketmq.studio.instance.message.MessageRecordVO;
 import org.apache.rocketmq.studio.instance.message.DirectConsumeMessageDTO;
 import org.apache.rocketmq.studio.instance.message.TraceNodeVO;
 import org.apache.rocketmq.studio.instance.message.TraceRecordVO;
+import org.apache.rocketmq.studio.instance.message.QueueOffsetVO;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExt;
 import org.apache.rocketmq.tools.admin.DefaultMQAdminExtImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -776,6 +779,44 @@ class RocketMQMessageProviderTest {
         assertThat(pulledOffsets).allMatch(offset -> offset >= expectedFirstOffset);
     }
 
+    @Test
+    void getQueueOffsetsListsReadQueuesWhenReadCountExceedsWriteCount() throws Exception {
+        // Shrinking first lowers writeQueueNums while reads keep draining the tail
+        // queues, so queues in [writeQueueNums, readQueueNums) still hold browsable
+        // messages and must appear in the browser (fetchSubscribeMessageQueues, used
+        // by queryByTopic, enumerates the same read queues).
+        when(adminExt.examineTopicRouteInfo("TopicA"))
+                .thenReturn(routeWithQueueCounts("broker-a", 2, 4));
+        when(adminExt.minOffset(any(MessageQueue.class))).thenAnswer(invocation ->
+                invocation.<MessageQueue>getArgument(0).getQueueId() * 10L);
+        when(adminExt.maxOffset(any(MessageQueue.class))).thenAnswer(invocation ->
+                invocation.<MessageQueue>getArgument(0).getQueueId() * 10L + 5L);
+
+        List<QueueOffsetVO> offsets = provider.getQueueOffsets("instance-a", "TopicA");
+
+        assertThat(offsets).extracting(QueueOffsetVO::getBrokerName)
+                .containsOnly("broker-a");
+        assertThat(offsets).extracting(QueueOffsetVO::getQueueId)
+                .containsExactly(0, 1, 2, 3);
+        assertThat(offsets).extracting(QueueOffsetVO::getMinOffset)
+                .containsExactly(0L, 10L, 20L, 30L);
+        assertThat(offsets).extracting(QueueOffsetVO::getMaxOffset)
+                .containsExactly(5L, 15L, 25L, 35L);
+    }
+
+    @Test
+    void getQueueOffsetsSkipsWriteOnlyQueuesWhenWriteCountExceedsReadCount() throws Exception {
+        // The broker's PullMessageProcessor rejects queueId >= readQueueNums with
+        // SYSTEM_ERROR, so write-only queues cannot be browsed and must not be listed.
+        when(adminExt.examineTopicRouteInfo("TopicA"))
+                .thenReturn(routeWithQueueCounts("broker-a", 4, 2));
+
+        List<QueueOffsetVO> offsets = provider.getQueueOffsets("instance-a", "TopicA");
+
+        assertThat(offsets).extracting(QueueOffsetVO::getQueueId)
+                .containsExactly(0, 1);
+    }
+
     private MQClientAPIImpl mockOffsetLookupClient() {
         DefaultMQAdminExtImpl adminExtImpl = mock(DefaultMQAdminExtImpl.class);
         MQClientInstance clientInstance = mock(MQClientInstance.class);
@@ -786,6 +827,17 @@ class RocketMQMessageProviderTest {
         return clientApi;
     }
 
+
+    private static TopicRouteData routeWithQueueCounts(
+            String brokerName, int writeQueueNums, int readQueueNums) {
+        QueueData queueData = new QueueData();
+        queueData.setBrokerName(brokerName);
+        queueData.setWriteQueueNums(writeQueueNums);
+        queueData.setReadQueueNums(readQueueNums);
+        TopicRouteData route = new TopicRouteData();
+        route.setQueueDatas(List.of(queueData));
+        return route;
+    }
 
     private static ClusterInfo clusterInfoWithBrokerAddresses(String... brokerAddresses) {
         ClusterInfo clusterInfo = new ClusterInfo();


### PR DESCRIPTION
## Problem

`RocketMQMessageProvider.getQueueOffsets` lists the Queue Browser's queues with `queueData.getWriteQueueNums()`, but every other message-browse path is **read-queue** based:

- the broker's `PullMessageProcessor` rejects any pull with `queueId >= topicConfig.getReadQueueNums()` (`SYSTEM_ERROR` "queueId is illegal");
- `fetchSubscribeMessageQueues` — used by this provider's own `queryByTopic` and by the classic console's `queryMessageByTopic` — enumerates `[0, readQueueNums)`.

So whenever a topic has `readQueueNums != writeQueueNums` (the standard expansion/shrink procedure sets the two counts independently, e.g. `updateTopic -r 16 -w 8`), the Queue Browser is wrong:

- **read > write** (shrink draining): queues in `[write, read)` are still readable and still hold messages, but they never appear in the browser — the user cannot browse them at all, and the queue list disagrees with what `queryByTopic` scans.
- **write > read** (queues not yet readable): queues in `[read, write)` are listed, but each one is a dead end — pulling from it fails with "queueId is illegal".

The `writeQueueNums` iteration was introduced incidentally by the admin-client pooling refactor b5a7d6c0 (#2544), not as a deliberate queue-selection choice.

## Fix

Enumerate `[0, queueData.getReadQueueNums())` in `getQueueOffsets`, matching the broker's pull validation and the read-queue enumeration used by the other browse paths. One-line change.

## Verification

Base SHA: 36126024 (rocketmq-studio)

Fail-before / pass-after on the two new tests in `RocketMQMessageProviderTest`:

- `getQueueOffsetsListsReadQueuesWhenReadCountExceedsWriteCount` (read=4, write=2): failed with `[0, 1]` vs expected `[0, 1, 2, 3]`; passes after the fix (also asserts min/max offsets are wired per queue).
- `getQueueOffsetsSkipsWriteOnlyQueuesWhenWriteCountExceedsReadCount` (read=2, write=4): failed with `[0, 1, 2, 3]` vs expected `[0, 1]`; passes after the fix.

Full run after the fix:

- `RocketMQMessageProviderTest`: 38/38 pass (36 pre-existing + 2 new)
- whole `org.apache.rocketmq.studio.provider.apache` package: 256/256 pass

**AI disclosure:** This change was prepared with AI assistance (GitHub Copilot/Claude-style tooling guided by a human contributor).