### PR TITLE
fix(group): apply reset offsets with force and offline fallback

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -883,14 +883,19 @@ public class RocketMQAdminClientImpl implements AdminClient {
             throw new BusinessException(400, "topic is required for offset reset");
         }
         try {
+            // resetOffsetNew applies the searched offset even when it is ahead of the
+            // current offset (the preview offers "skip unconsumed messages") and falls
+            // back to direct offset writes when the group is offline; the non-forcing
+            // resetOffsetByTimestamp silently capped forward targets to the current
+            // offset and failed with CONSUMER_NOT_ONLINE for offline groups.
             if (StringUtils.hasText(instanceId)) {
                 runtimeAdminClientResolver.execute(instanceId, admin -> {
-                    admin.resetOffsetByTimestamp(getClusterName(admin), topic, name, timestamp, false);
+                    admin.resetOffsetNew(name, topic, timestamp);
                     return null;
                 });
             } else {
                 adminFactory.execute(namesrvAddr(), null, admin -> {
-                    admin.resetOffsetByTimestamp(getClusterName(admin), topic, name, timestamp, false);
+                    admin.resetOffsetNew(name, topic, timestamp);
                     return null;
                 });
             }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -283,6 +283,39 @@ class RocketMQAdminClientImplTest {
     }
 
     @Test
+    void resetOffsetShouldApplyPreviewedTargetsAndSupportOfflineGroups() throws Exception {
+        // resetOffsetNew is the API the classic console uses: it forces the broker to
+        // apply the searched offset even when the target is ahead of the current offset
+        // (the preview explicitly offers "skip unconsumed messages"), and it falls back
+        // to direct offset writes when the group is offline instead of failing with
+        // CONSUMER_NOT_ONLINE.
+        DefaultMQAdminExt selectedAdmin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("instance-a"), any()))
+                .thenAnswer(invocation -> {
+                    MqAdminExtFactory.AdminAction<?> action = invocation.getArgument(1);
+                    return action.apply(selectedAdmin);
+                });
+        long timestamp = 1784246400000L;
+
+        adminClient.resetOffset("instance-a", "cg-orders", timestamp, "orders");
+
+        verify(selectedAdmin).resetOffsetNew("cg-orders", "orders", timestamp);
+        verify(selectedAdmin, never()).resetOffsetByTimestamp(
+                anyString(), anyString(), anyString(), anyLong(), anyBoolean());
+    }
+
+    @Test
+    void resetOffsetWithoutInstanceShouldUseForceAndOfflineFallbackSemantics() throws Exception {
+        long timestamp = 1784246400000L;
+
+        adminClient.resetOffset(null, "cg-orders", timestamp, "orders");
+
+        verify(adminExt).resetOffsetNew("cg-orders", "orders", timestamp);
+        verify(adminExt, never()).resetOffsetByTimestamp(
+                anyString(), anyString(), anyString(), anyLong(), anyBoolean());
+    }
+
+    @Test
     void previewResetOffsetShouldComputeQueueImpactWithoutMutatingBrokerOffsets() throws Exception {
         long timestamp = 1784246400000L;
         ConsumeStats stats = new ConsumeStats();


### PR DESCRIPTION
## Problem

`RocketMQAdminClientImpl.resetOffset` applied consumer-group offset resets with `admin.resetOffsetByTimestamp(cluster, topic, group, timestamp, false)` — the non-forcing variant. On the broker (RocketMQ 5.5.0 `Broker2Client.resetOffset`, the default path while `useServerSideResetOffset=false`) that flag has two effects the Studio UI does not expect:

1. **Offline groups cannot be reset at all.** The non-forcing path only pushes `RESET_CONSUMER_CLIENT_OFFSET` to consumers that are currently connected and answers `CONSUMER_NOT_ONLINE` otherwise (`invokeBrokerToResetOffset` turns that into an `MQClientException`), so the endpoint always fails for an offline group — yet offline groups are the primary scenario for timestamp-based resets, and Studio's own preview handles them fine: `examineConsumeStats` reads persisted broker-side offsets, so the preview computes real per-queue targets and returns `allowReset=true`, then the apply 500s with "Failed to reset offset: Consumer not online...".

2. **Forward resets silently no-op.** Without `force` the broker caps each pushed offset at the group's current offset (`if (isForce || timeStampOffset < consumerOffset)`), so a timestamp ahead of the current position — which the preview explicitly supports, showing "Skips N unconsumed message(s)" and only a warning — is converted per queue into a reset to the *current* offset, i.e. nothing happens.

## Fix

Route the apply through `admin.resetOffsetNew(name, topic, timestamp)` — the same API the classic rocketmq-console uses for this operation. `DefaultMQAdminExtImpl.resetOffsetNew` (5.5.0) forces the searched offset onto the reset request (`resetOffsetByTimestamp(topic, group, timestamp, true)`) and falls back to `resetOffsetByTimestampOld(group, topic, timestamp, true)` — direct `UPDATE_CONSUMER_OFFSET` writes per queue — when the broker answers `CONSUMER_NOT_ONLINE`, so both cases above now behave the way the preview promises. Both call sites (instance-scoped and legacy global) use it; no signature or controller changes.

## Verification

Base SHA: 36126024 (rocketmq-studio)

Fail-before / pass-after on the two new tests in `RocketMQAdminClientImplTest`:

- `resetOffsetShouldApplyPreviewedTargetsAndSupportOfflineGroups` — failed showing the actual invocation `resetOffsetByTimestamp("DefaultCluster", "orders", "cg-orders", 1784246400000L, false)`; passes after the fix (`resetOffsetNew` invoked, non-forcing variant never called).
- `resetOffsetWithoutInstanceShouldUseForceAndOfflineFallbackSemantics` — same for the legacy global path.

Full run after the fix:

- `RocketMQAdminClientImplTest`: 43/43 pass (41 pre-existing + 2 new)
- whole `org.apache.rocketmq.studio.provider.apache` package: 256/256 pass

Broker-side semantics quoted from the `rocketmq-all-5.5.0` sources of `AdminBrokerProcessor.resetOffset`, `Broker2Client.resetOffset`, `MQClientAPIImpl.invokeBrokerToResetOffset` and `DefaultMQAdminExtImpl.resetOffsetNew`.

**AI disclosure:** This change was prepared with AI assistance (GitHub Copilot/Claude-style tooling guided by a human contributor).