### PR TITLE
fix(cors): expose DLQ export scan headers to cross-origin clients

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/config/CorsConfig.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/config/CorsConfig.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.studio.common.config;
 
 import java.util.Arrays;
 
+import org.apache.rocketmq.studio.common.util.DlqExportHeaders;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -42,6 +43,10 @@ public class CorsConfig implements WebMvcConfigurer {
                 .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
+                // Without exposedHeaders, browsers hide the DLQ export scan-completeness
+                // headers from cross-origin JavaScript and the export truncation warning
+                // in the web UI is silently lost.
+                .exposedHeaders(DlqExportHeaders.ALL.toArray(new String[0]))
                 .allowCredentials(true);
     }
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/DlqExportHeaders.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/DlqExportHeaders.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.studio.common.util;
+
+import java.util.List;
+
+/**
+ * Names of the response headers the DLQ export endpoints attach to describe scan
+ * completeness. The web UI reads them to warn when an export is truncated or some
+ * queues could not be scanned, so they must also be declared in the CORS
+ * {@code exposedHeaders} list — browsers only let cross-origin JavaScript read
+ * response headers that appear in {@code Access-Control-Expose-Headers}.
+ */
+public final class DlqExportHeaders {
+
+    public static final String TRUNCATED = "X-DLQ-Export-Truncated";
+    public static final String FAILED_QUEUES = "X-DLQ-Export-FailedQueues";
+    public static final String LIMIT = "X-DLQ-Export-Limit";
+
+    public static final List<String> ALL = List.of(TRUNCATED, FAILED_QUEUES, LIMIT);
+
+    private DlqExportHeaders() {
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/dlq/DLQController.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.util.DlqExportHeaders;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -48,9 +49,9 @@ import java.util.List;
 @Validated
 public class DLQController {
 
-    private static final String HEADER_EXPORT_TRUNCATED = "X-DLQ-Export-Truncated";
-    private static final String HEADER_EXPORT_FAILED_QUEUES = "X-DLQ-Export-FailedQueues";
-    private static final String HEADER_EXPORT_LIMIT = "X-DLQ-Export-Limit";
+    private static final String HEADER_EXPORT_TRUNCATED = DlqExportHeaders.TRUNCATED;
+    private static final String HEADER_EXPORT_FAILED_QUEUES = DlqExportHeaders.FAILED_QUEUES;
+    private static final String HEADER_EXPORT_LIMIT = DlqExportHeaders.LIMIT;
     private static final String EXCEL_MEDIA_TYPE =
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
     private static final int MAX_SELECTED_MESSAGES = 100;

--- a/server/src/test/java/org/apache/rocketmq/studio/common/config/CorsConfigTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/config/CorsConfigTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.studio.common.config;
+
+import org.apache.rocketmq.studio.instance.dlq.DLQController;
+import org.apache.rocketmq.studio.instance.dlq.DLQExcelExportResultVO;
+import org.apache.rocketmq.studio.instance.dlq.DLQExportResultVO;
+import org.apache.rocketmq.studio.instance.dlq.DLQService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The DLQ export endpoints report scan completeness (truncation, failed queues, export
+ * limit) through {@code X-DLQ-Export-*} response headers, and the web UI turns them into
+ * its "export may be incomplete" warning. Browsers only let cross-origin JavaScript read
+ * response headers that the server declares in {@code Access-Control-Expose-Headers}, so
+ * the CORS mapping must list them — otherwise split frontend/backend deployments silently
+ * lose the truncation signal.
+ */
+@WebMvcTest(value = DLQController.class, properties = "studio.cors.allowed-origins=http://localhost:5173")
+@AutoConfigureMockMvc(addFilters = false)
+@Import(CorsConfig.class)
+class CorsConfigTest {
+
+    private static final String FRONTEND_ORIGIN = "http://localhost:5173";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DLQService dlqService;
+
+    @Test
+    void corsMappingShouldDeclareTheDlqExportHeaders() {
+        ExposingCorsRegistry registry = new ExposingCorsRegistry();
+        new CorsConfig(FRONTEND_ORIGIN).addCorsMappings(registry);
+
+        CorsConfiguration configuration = registry.getCorsConfigurations().get("/**");
+        assertNotNull(configuration);
+        List<String> exposed = configuration.getExposedHeaders();
+        assertNotNull(exposed, "CORS mapping must expose the DLQ export scan headers");
+        List<String> lowerCased = exposed.stream().map(String::toLowerCase).toList();
+        assertTrue(lowerCased.containsAll(List.of(
+                        "x-dlq-export-truncated", "x-dlq-export-failedqueues", "x-dlq-export-limit")),
+                () -> "CORS mapping must expose the DLQ export scan headers, but declared: " + exposed);
+    }
+
+    @Test
+    void excelExportShouldExposeScanHeadersToCrossOriginClients() throws Exception {
+        when(dlqService.exportExcel(eq("instance-1"), eq("test-group"), isNull(), isNull(), isNull()))
+                .thenReturn(DLQExcelExportResultVO.builder()
+                        .data(new byte[0])
+                        .truncated(true)
+                        .failedQueueCount(2)
+                        .limit(5000)
+                        .build());
+
+        MvcResult result = mockMvc.perform(get("/api/dlq/export-excel")
+                        .param("instanceId", "instance-1")
+                        .param("groupName", "test-group")
+                        .header(HttpHeaders.ORIGIN, FRONTEND_ORIGIN))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-DLQ-Export-Truncated", "true"))
+                .andReturn();
+
+        assertExposeHeadersDeclareDlqExportHeaders(result);
+    }
+
+    @Test
+    void jsonExportShouldExposeScanHeadersToCrossOriginClients() throws Exception {
+        when(dlqService.exportMessages(eq("instance-1"), eq("test-group"), isNull(), isNull(), isNull()))
+                .thenReturn(DLQExportResultVO.builder()
+                        .messages(List.of())
+                        .truncated(true)
+                        .failedQueueCount(2)
+                        .limit(5000)
+                        .build());
+
+        MvcResult result = mockMvc.perform(get("/api/dlq/export")
+                        .param("instanceId", "instance-1")
+                        .param("groupName", "test-group")
+                        .header(HttpHeaders.ORIGIN, FRONTEND_ORIGIN))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-DLQ-Export-Truncated", "true"))
+                .andReturn();
+
+        assertExposeHeadersDeclareDlqExportHeaders(result);
+    }
+
+    private static void assertExposeHeadersDeclareDlqExportHeaders(MvcResult result) {
+        List<?> declared = result.getResponse()
+                .getHeaderValues(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS);
+        String exposed = declared.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(","))
+                .toLowerCase();
+        assertTrue(exposed.contains("x-dlq-export-truncated")
+                        && exposed.contains("x-dlq-export-failedqueues")
+                        && exposed.contains("x-dlq-export-limit"),
+                () -> "Cross-origin browsers cannot read the DLQ export scan headers; "
+                        + "Access-Control-Expose-Headers was: " + declared);
+    }
+
+    /** {@link CorsRegistry#getCorsConfigurations} is protected; widen it for assertions. */
+    private static final class ExposingCorsRegistry extends CorsRegistry {
+        @Override
+        public Map<String, CorsConfiguration> getCorsConfigurations() {
+            return super.getCorsConfigurations();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The DLQ export endpoints (`GET /api/dlq/export` and `GET /api/dlq/export-excel`) report scan completeness through `X-DLQ-Export-Truncated`, `X-DLQ-Export-FailedQueues` and `X-DLQ-Export-Limit` response headers, and the web UI reads exactly those headers to decide whether to show its "export may be incomplete" warning (`web/src/api/message.ts`, consumed in `web/src/pages/instance/dlq.tsx`).

However, `CorsConfig` never declared `exposedHeaders`. Per the Fetch specification, browsers only let cross-origin JavaScript read response headers that the server lists in `Access-Control-Expose-Headers` (plus the safelisted ones). So in any split frontend/backend deployment — precisely the setup `studio.cors.allowed-origins` exists for, and whose default value is the Vite dev-server origins — the `X-DLQ-Export-*` headers were still sent on the wire but invisible to JavaScript:

- `res.headers['x-dlq-export-truncated']` came back `undefined`,
- the frontend export meta silently degraded to `{truncated: false, failedQueueCount: 0, limit: 0}`,
- and a truncated export (hard cap hit, or queues that could not be scanned) was presented to the user as complete.

Same-origin deployments (default `/api` reverse proxy) are unaffected, which is why this went unnoticed.

## Fix

Declare the three header names in the CORS mapping via `exposedHeaders(...)` in `CorsConfig`. The names now live in a small shared `DlqExportHeaders` constants holder (common/util) that both `DLQController` and `CorsConfig` reference, so the endpoint and its CORS declaration cannot drift apart.

## Verification

Base SHA: `36126024` (current `rocketmq-studio` head).

Fail-before on base (`mvn test -Dtest=CorsConfigTest`), new test class:

```
[ERROR] Tests run: 3, Failures: 3, Errors: 0, Skipped: 0
[ERROR] CorsConfigTest.corsMappingShouldDeclareTheDlqExportHeaders:78 CORS mapping must expose the DLQ export scan headers ==> expected: not <null>
[ERROR] CorsConfigTest.excelExportShouldExposeScanHeadersToCrossOriginClients: Cross-origin browsers cannot read the DLQ export scan headers; Access-Control-Expose-Headers was: []
[ERROR] CorsConfigTest.jsonExportShouldExposeScanHeadersToCrossOriginClients:  Cross-origin browsers cannot read the DLQ export scan headers; Access-Control-Expose-Headers was: []
```

The two MockMvc tests issue real cross-origin GETs (with `Origin: http://localhost:5173`) against the export endpoints; on base the `X-DLQ-Export-Truncated: true` header is set on the response but `Access-Control-Expose-Headers` stays empty.

Pass-after with the fix:

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0 -- in org.apache.rocketmq.studio.common.config.CorsConfigTest
```

Surrounding suites with the fix applied:

```
[INFO] Tests run: 24, Failures: 0 ... -- in org.apache.rocketmq.studio.instance.dlq.DLQControllerTest
[INFO] Tests run: 17, Failures: 0 ... -- in org.apache.rocketmq.studio.instance.dlq.DLQServiceTest
[INFO] all org.apache.rocketmq.studio.common.* tests green
```

Note: `AuthCorsIntegrationTest` has 2 failures on pristine base `36126024` as well (it still verifies the old `AuthService.isAuthenticated` API while `AuthInterceptor` now calls `getAuthenticatedUser`) — pre-existing and unrelated to this change.

**AI disclosure:** This change was prepared with AI assistance (GitHub Copilot/Claude-style tooling guided by a human contributor).