### PR TITLE
[studio] fix(message): keep the trace tab responsive when an empty trace query supersedes an in-flight load

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePageAsyncState.test.tsx
@@ -710,4 +710,33 @@ describe('MessagePage async request ownership', () => {
     expect(screen.getAllByText('message-b trace')).not.toHaveLength(0);
     expect(screen.queryByText('message-a stale trace')).not.toBeInTheDocument();
   });
+
+  it('keeps the trace tab responsive when an empty trace query supersedes an in-flight load', async () => {
+    const pendingTrace = createDeferred<TraceRecord | null>();
+    serviceMocks.queryMessages.mockResolvedValue([createMessage('message-a')]);
+    serviceMocks.getMessageTrace.mockReturnValue(pendingTrace.promise);
+    const user = userEvent.setup();
+    renderPage();
+    await selectTopic(user);
+
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+    const row = await screen.findByRole('row', { name: /message-a/ });
+    await user.click(within(row).getByRole('button', { name: /轨迹/ }));
+    const dialog = await screen.findByRole('dialog', { name: '消息详情' });
+    expect(within(dialog).getByText('正在加载轨迹数据…')).toBeInTheDocument();
+
+    await user.clear(within(dialog).getByPlaceholderText('消息 ID（默认当前消息）'));
+    await user.click(within(dialog).getByRole('button', { name: /查询轨迹/ }));
+
+    expect(within(dialog).getByText('请输入 Message ID')).toBeInTheDocument();
+    expect(within(dialog).queryByText('正在加载轨迹数据…')).not.toBeInTheDocument();
+
+    await act(async () => {
+      pendingTrace.resolve(createTrace('message-a trace'));
+    });
+
+    expect(within(dialog).getByText('请输入 Message ID')).toBeInTheDocument();
+    expect(screen.queryByText('message-a trace')).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('正在加载轨迹数据…')).not.toBeInTheDocument();
+  });
 });

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -645,6 +645,7 @@ const MessagePageContent = ({
     traceGenerationRef.current = requestGeneration;
     const value = traceQueryValue.trim();
     if (!value) {
+      setTraceLoading(false);
       setTraceError(traceQueryMode === 'key' ? '请输入 Message Key' : '请输入 Message ID');
       return;
     }


### PR DESCRIPTION
## Summary

Fixes #3293.

`runTraceQuery` in `web/src/pages/instance/message.tsx` bumped `traceGenerationRef` before validating its input, and its empty-input branch returned without resetting `traceLoading`. Any in-flight `loadMessageTrace` was invalidated by the bump, so the generation-guarded `finally` - the only place that resets `traceLoading` - was skipped:

- The ???? tab showed `????????.` indefinitely.
- The validation hint (`??? Message ID` / `??? Message Key`) set by the empty-input branch was never displayed, because the loading text takes render precedence over `traceError`.

## Fix

Reset `traceLoading` in the empty-input branch of `runTraceQuery`, so the tab immediately shows the validation hint while the generation bump keeps superseding the stale in-flight request. No change to the supersede semantics themselves.

## Test plan

- Added regression test `keeps the trace tab responsive when an empty trace query supersedes an in-flight load` in `MessagePageAsyncState.test.tsx`:
  - Verified red on the unfixed source (fails with `Unable to find an element with the text: ??? Message ID`), green with the fix.
  - Asserts the spinner clears, the hint shows, and the stale in-flight trace result stays dropped.
- `npx vitest run src/pages/instance/__tests__/MessagePageAsyncState.test.tsx`: 19/19 pass.
- `eslint` and `tsc --noEmit` clean on the touched files.