### PR TITLE
test(broker): deepen ClusterConnectionService summary coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionServiceTest.java
@@ -76,4 +76,32 @@ class ClusterConnectionServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Failed to connect NameServer");
     }
+
+    @Test
+    void connectionSummarisesClustersWithoutBrokerListsTest() {
+        when(clusterProvider.describeCluster(eq("10.0.0.2:9876")))
+                .thenReturn(ClusterVO.builder().name("DefaultCluster").brokers(null).build());
+
+        ClusterProbeResult result = service.testConnection(
+                TestConnectionDTO.builder().namesrvAddr("10.0.0.2:9876").build());
+
+        assertThat(result.isConnected()).isTrue();
+        assertThat(result.getClusterName()).isEqualTo("DefaultCluster");
+        assertThat(result.getBrokerCount()).isZero();
+        assertThat(result.getBrokerNames()).isEmpty();
+        assertThat(result.getMessage()).contains("0 broker(s)");
+    }
+
+    @Test
+    void connectionReportsTheBrokerSummaryInItsMessageTest() {
+        when(clusterProvider.describeCluster(eq("10.0.0.3:9876")))
+                .thenReturn(clusterWith("broker-a", "broker-b"));
+
+        ClusterProbeResult result = service.testConnection(
+                TestConnectionDTO.builder().namesrvAddr("10.0.0.3:9876").build());
+
+        assertThat(result.getMessage())
+                .startsWith("Connected to 2 broker(s) in ")
+                .endsWith("ms");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `ClusterConnectionServiceTest` (2 to 4 tests) to pin down the connection probe summary.

Added cases:
- a cluster whose broker list is null is summarized as connected with zero brokers and an empty broker-name list, and the message reports `0 broker(s)`;
- with two brokers, the probe message carries the expected `Connected to 2 broker(s) in ... ms` summary.

## Why

The probe powers the cluster UI test-connection action; the null-broker and message-summary branches had no coverage (only success + failure propagation existed).

## Testing

`mvn -B test -Dtest=ClusterConnectionServiceTest` — 4/4 pass; checkstyle (validate) clean.