### PR TITLE
test(alert): deepen NativeAlertMetricCatalogService coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertMetricCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertMetricCatalogServiceTest.java
@@ -7,6 +7,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -58,5 +60,58 @@ class NativeAlertMetricCatalogServiceTest {
 
         assertThat(nativeRule.getMetric()).isEqualTo("broker.disk.usage_ratio");
         assertThat(customRule.getMetric()).isEqualTo("custom.metric");
+    }
+
+    @Test
+    void listRejectsBlankAndUnknownInstanceIdsTest() {
+        InstanceRepository repository = mock(InstanceRepository.class);
+        when(repository.findByIdentifier("ghost")).thenReturn(Optional.empty());
+        NativeAlertMetricCatalogService service = new NativeAlertMetricCatalogService(repository);
+
+        assertThatThrownBy(() -> service.list("  ", AlertDomain.BUSINESS))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("instanceId is required");
+        assertThatThrownBy(() -> service.list("ghost", AlertDomain.BUSINESS))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Instance not found");
+    }
+
+    @Test
+    void tencentVendorReturnsTheCloudMetricSetsTest() {
+        InstanceRepository repository = mock(InstanceRepository.class);
+        when(repository.findByIdentifier("tencent")).thenReturn(Optional.of(InstanceVO.builder()
+                .name("tencent").vendor(InstanceVendor.TENCENT).build()));
+        NativeAlertMetricCatalogService service = new NativeAlertMetricCatalogService(repository);
+
+        assertThat(service.list("tencent", AlertDomain.BUSINESS)).extracting(NativeAlertMetricInfo::key)
+                .containsExactly("consumer.lag.total", "consumer.lag.max_queue", "topic.backlog.total");
+        assertThat(service.list("tencent", AlertDomain.CLUSTER)).extracting(NativeAlertMetricInfo::key)
+                .containsExactly("cloud.instance.availability");
+    }
+
+    @Test
+    void missingVendorFallsBackToTheApacheSetsTest() {
+        InstanceRepository repository = mock(InstanceRepository.class);
+        when(repository.findByIdentifier("local")).thenReturn(Optional.of(InstanceVO.builder()
+                .name("local").vendor(null).build()));
+        NativeAlertMetricCatalogService service = new NativeAlertMetricCatalogService(repository);
+
+        assertThat(service.list("local", AlertDomain.BUSINESS)).extracting(NativeAlertMetricInfo::key)
+                .contains("consumer.lag.total", "dlq.message.count");
+        assertThat(service.list("local", AlertDomain.CLUSTER)).extracting(NativeAlertMetricInfo::key)
+                .contains("broker.availability", "proxy.availability");
+    }
+
+    @Test
+    void validateAcceptsSupportedNativeMetricsAndNullRulesTest() {
+        InstanceRepository repository = mock(InstanceRepository.class);
+        when(repository.findByIdentifier("apache")).thenReturn(Optional.of(InstanceVO.builder()
+                .name("apache").vendor(InstanceVendor.APACHE).build()));
+        NativeAlertMetricCatalogService service = new NativeAlertMetricCatalogService(repository);
+
+        service.validate(null);
+        assertThatCode(() -> service.validate(AlertRuleVO.builder().domain(AlertDomain.CLUSTER)
+                .instanceId("apache").metric("broker.availability").build()))
+                .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## Summary

Extends the existing `NativeAlertMetricCatalogServiceTest` (2 to 6 tests) to pin down metric catalog resolution and validation.

Added cases:
- `list` rejects blank instance ids (400) and unknown instances (404);
- a Tencent instance resolves the cloud metric sets for both business and cluster domains (previously only Aliyun was covered);
- an instance without a vendor falls back to the Apache metric sets;
- `validate` accepts supported native metrics and tolerates null rules.

## Why

The catalog declares which native metrics alert rules may use per provider; instance/vendor resolution branches had no coverage beyond Aliyun/Apache happy paths.

## Testing

`mvn -B test -Dtest=NativeAlertMetricCatalogServiceTest` — 6/6 pass; checkstyle (validate) clean.