### PR TITLE
test(tool): deepen MessageTraceToolHandler projection coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/MessageTraceToolHandlerTest.java
@@ -83,4 +83,39 @@ class MessageTraceToolHandlerTest {
 
         verify(messageService).getMessageTrace("instance-a", "msg-1", "TopicA");
     }
+
+    @Test
+    void reportsItsToolName() {
+        assertThat(handler.name()).isEqualTo("rmq.message.trace");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void projectsNullTextFieldsAsBlank() {
+        TraceRecordVO trace = TraceRecordVO.builder()
+                .nodes(List.of(TraceNodeVO.builder()
+                        .timestamp(1000L)
+                        .costTime(5L)
+                        .build()))
+                .consumerStatus(List.of(ConsumerStatusVO.builder()
+                        .consumeTime(2000L)
+                        .retryCount(0)
+                        .build()))
+                .build();
+        when(messageService.getMessageTrace(eq("instance-a"), eq("msg-1"), eq("TopicA")))
+                .thenReturn(trace);
+
+        Map<String, Object> row = (Map<String, Object>) handler.execute(Map.of(
+                "cluster", "instance-a", "msgId", "msg-1", "topic", "TopicA"));
+
+        Map<String, Object> node = (Map<String, Object>) ((List<?>) row.get("nodes")).get(0);
+        assertThat(node.get("title")).isEqualTo("");
+        assertThat(node.get("status")).isEqualTo("");
+        assertThat(node.get("description")).isEqualTo("");
+        assertThat(node.get("timestamp")).isEqualTo(1000L);
+
+        Map<String, Object> status = (Map<String, Object>) ((List<?>) row.get("consumerStatus")).get(0);
+        assertThat(status.get("group")).isEqualTo("");
+        assertThat(status.get("deliveryStatus")).isEqualTo("");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `MessageTraceToolHandlerTest` (1 to 3 tests) to pin down the trace tool projection contract.

Added cases:
- the tool reports its canonical name `rmq.message.trace`;
- null text fields (node title/status/description, consumer group) and a null delivery status project to blank strings instead of `null`, while numeric fields are preserved.

## Why

The tool serves AI/MCP/CLI read-only trace lookups, so its projection must stay null-safe for partially populated trace records.

## Testing

`mvn -B test -Dtest=MessageTraceToolHandlerTest` — 3/3 pass; checkstyle (validate) clean.