### PR TITLE
test(tool): deepen CapabilitiesToolHandler projection coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/CapabilitiesToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/CapabilitiesToolHandlerTest.java
@@ -57,4 +57,33 @@ class CapabilitiesToolHandlerTest {
         assertThat(result.get("version")).isEqualTo("");
         assertThat(result.get("capabilities")).isEqualTo(List.of("REMOTING"));
     }
+
+    @Test
+    void reportsItsToolName() {
+        CapabilitiesToolHandler handler = new CapabilitiesToolHandler(
+                mock(ClusterService.class), mock(CapabilityResolver.class));
+
+        assertThat(handler.name()).isEqualTo("rmq.capabilities");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void handlesMissingTypeAndBlankVersionFields() {
+        ClusterVO cluster = ClusterVO.builder().name("DefaultCluster").build();
+        cluster.setId("DefaultCluster");
+
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getCluster("DefaultCluster")).thenReturn(cluster);
+        CapabilityResolver capabilityResolver = mock(CapabilityResolver.class);
+        when(capabilityResolver.resolve(cluster)).thenReturn(List.of("ACL_V2", "GRPC"));
+
+        Object output = new CapabilitiesToolHandler(clusterService, capabilityResolver)
+                .execute(Map.of("cluster", "DefaultCluster"));
+
+        Map<String, Object> result = (Map<String, Object>) output;
+        assertThat(result.get("cluster")).isEqualTo("DefaultCluster");
+        assertThat(result.get("type")).isEqualTo("");
+        assertThat(result.get("version")).isEqualTo("");
+        assertThat(result.get("capabilities")).isEqualTo(List.of("ACL_V2", "GRPC"));
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `CapabilitiesToolHandlerTest` (1 to 3 tests) to pin down the capabilities tool projection.

Added cases:
- the tool reports its canonical name `rmq.capabilities`;
- a cluster without a type and version projects blank strings (not nulls) for the schema-required fields while the resolved capability list is emitted as-is.

## Why

The tool exposes cluster capabilities to AI/MCP/CLI callers; only the fully-populated happy path was covered before.

## Testing

`mvn -B test -Dtest=CapabilitiesToolHandlerTest` — 3/3 pass; checkstyle (validate) clean.