### PR TITLE
test(alert): deepen AlertSilenceController list and delete coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceControllerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -107,5 +108,30 @@ class AlertSilenceControllerTest {
                 request.getRecurrence() == AlertSilenceRecurrence.WEEKLY
                         && request.getRecurrenceDays().equals(Set.of(1, 3, 5))
                         && "Asia/Shanghai".equals(request.getTimeZone())));
+    }
+
+    @Test
+    void listShouldReturnAllSilencesTest() throws Exception {
+        AlertSilenceVO silence = AlertSilenceVO.builder()
+                .id(14L)
+                .domain(AlertDomain.CLUSTER)
+                .createdBy("admin")
+                .build();
+        when(silenceService.list()).thenReturn(List.of(silence));
+
+        mockMvc.perform(get("/api/alert-silences"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data[0].id").value(14));
+
+        verify(silenceService).list();
+    }
+
+    @Test
+    void deleteShouldParseTheIdAndDelegateTest() throws Exception {
+        mockMvc.perform(delete("/api/alert-silences/12"))
+                .andExpect(status().isOk());
+
+        verify(silenceService).delete(12L);
     }
 }


### PR DESCRIPTION
## Summary

Extends the existing `@WebMvcTest` `AlertSilenceControllerTest` (2 to 4 tests) to pin down the remaining silence endpoints.

Added cases:
- `GET /api/alert-silences` returns the full silence list from the service;
- `DELETE /api/alert-silences/{id}` parses the path id and delegates to the service.

## Why

The suite covered the paged list and recurring-create endpoints only; the unpaged list and delete flows had no coverage.

## Testing

`mvn -B test -Dtest=AlertSilenceControllerTest` — 4/4 pass; checkstyle (validate) clean.