### PR TITLE
test(metrics): deepen snapshot repository query coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusMetricSnapshotRepositoryTest.java
@@ -68,4 +68,39 @@ class MybatisPlusMetricSnapshotRepositoryTest {
         QueryWrapper<RmqMetricSnapshot> query = (QueryWrapper<RmqMetricSnapshot>) queryCaptor.getValue();
         assertThat(query.getSqlSegment()).contains("cluster_id IS NULL");
     }
+
+    @Test
+    void clusterScopedQueryFiltersByClusterAvailabilityAndTimeTest() {
+        when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of());
+        MybatisPlusMetricSnapshotRepository repository =
+                new MybatisPlusMetricSnapshotRepository(mapper, new ObjectMapper());
+        MetricSample scope = new MetricSample("broker.availability", AlertDomain.CLUSTER,
+                "local", "cluster-1", Map.of("broker", "b1"), 1D, MetricAvailability.AVAILABLE,
+                Instant.parse("2026-07-01T10:00:00Z"));
+
+        repository.findRecent(scope, Instant.parse("2026-07-01T09:00:00Z"));
+
+        ArgumentCaptor<Wrapper<RmqMetricSnapshot>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(mapper).selectList(queryCaptor.capture());
+        QueryWrapper<RmqMetricSnapshot> query = (QueryWrapper<RmqMetricSnapshot>) queryCaptor.getValue();
+        String sql = query.getSqlSegment();
+        assertThat(sql).contains("instance_id =").contains("metric_key =").contains("domain =")
+                .contains("labels_hash =").contains("cluster_id =").contains("availability =")
+                .contains("collected_at >=").contains("ORDER BY collected_at");
+    }
+
+    @Test
+    void deleteBeforeBuildsACutoffQueryAndReturnsTheDeletedCountTest() {
+        when(mapper.delete(any(Wrapper.class))).thenReturn(3);
+        MybatisPlusMetricSnapshotRepository repository =
+                new MybatisPlusMetricSnapshotRepository(mapper, new ObjectMapper());
+
+        int deleted = repository.deleteBefore(Instant.parse("2026-07-01T10:00:00Z"));
+
+        assertThat(deleted).isEqualTo(3);
+        ArgumentCaptor<Wrapper<RmqMetricSnapshot>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(mapper).delete(queryCaptor.capture());
+        QueryWrapper<RmqMetricSnapshot> query = (QueryWrapper<RmqMetricSnapshot>) queryCaptor.getValue();
+        assertThat(query.getSqlSegment()).contains("collected_at <");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `MybatisPlusMetricSnapshotRepositoryTest` (2 to 4 tests) to pin down the snapshot query builder.

Added cases:
- a cluster-scoped `findRecent` builds a query filtering by instance id, metric key, domain, labels hash, cluster id, availability, and the `collected_at >=` cutoff, ordered ascending;
- `deleteBefore` builds a `collected_at <` cutoff query and returns the mapper's deleted count.

## Why

The repository feeds native alert evaluation windows and retention cleanup; only the null-cluster scope and the transaction annotation were covered before.

## Testing

`mvn -B test -Dtest=MybatisPlusMetricSnapshotRepositoryTest` — 4/4 pass; checkstyle (validate) clean.