### PR TITLE
test(provider): deepen Aliyun message key joining coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersMessageKeysTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersMessageKeysTest.java
@@ -33,4 +33,26 @@ class AliyunConvertersMessageKeysTest {
 
         assertThat(AliyunConverters.toMessageRecord(data).getKey()).isEqualTo("key-a key-b");
     }
+
+    @Test
+    void toMessageRecordShouldHandleSingleAndAllBlankKeys() {
+        ListMessagesResponseBody.List single = ListMessagesResponseBody.List.builder()
+                .messageKeys(java.util.Collections.singletonList("key-a"))
+                .build();
+        assertThat(AliyunConverters.toMessageRecord(single).getKey()).isEqualTo("key-a");
+
+        ListMessagesResponseBody.List allBlank = ListMessagesResponseBody.List.builder()
+                .messageKeys(Arrays.asList(null, " ", null))
+                .build();
+        assertThat(AliyunConverters.toMessageRecord(allBlank).getKey()).isNull();
+    }
+
+    @Test
+    void toMessageRecordShouldKeepInternalSpacesInsideKeys() {
+        ListMessagesResponseBody.List data = ListMessagesResponseBody.List.builder()
+                .messageKeys(Arrays.asList("k a", "key-b"))
+                .build();
+
+        assertThat(AliyunConverters.toMessageRecord(data).getKey()).isEqualTo("k a key-b");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `AliyunConvertersMessageKeysTest` (1 to 3 tests) to pin down the message-key join contract.

Added cases:
- a single key passes through unchanged;
- a list containing only null/blank keys yields a null message key (no empty-string artifact);
- internal spaces inside a key are preserved when keys are joined (`k a` + `key-b` → `k a key-b`).

## Why

The converter emits the message key column from Aliyun payloads; only the skip-null-and-blank case was covered before.

## Testing

`mvn -B test -Dtest=AliyunConvertersMessageKeysTest` — 3/3 pass; checkstyle (validate) clean.