### PR TITLE
[studio] fix: refresh paginated Topic inventory after create

### DIFF
--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -219,6 +219,51 @@ describe('TopicPage', () => {
     expect(screen.getByText(/与 Broker 同进程部署的 Proxy 地址/)).toBeInTheDocument();
   });
 
+  it('reloads the authoritative server page after creating a topic', async () => {
+    const existingTopic = { ...buildTopics(1)[0], name: 'topic-b' };
+    const createdTopic = {
+      ...buildTopics(1)[0],
+      name: 'topic-a',
+      clusterId: 'server-cluster',
+      remark: 'create response',
+      gmtCreate: '2026-01-02T00:00:00Z',
+      gmtModified: '2026-01-02T00:00:00Z',
+    };
+    const serverCreatedTopic = { ...createdTopic, remark: 'server page response' };
+    topicServiceMocks.listTopicsPage
+      .mockResolvedValueOnce({ items: [existingTopic], total: 1, page: 1, size: 20 })
+      .mockResolvedValueOnce({
+        items: [serverCreatedTopic, existingTopic],
+        total: 2,
+        page: 1,
+        size: 20,
+      });
+    topicServiceMocks.createTopic.mockResolvedValue(createdTopic);
+    const user = userEvent.setup();
+    renderWithProviders();
+
+    expect(await screen.findByText('共 1 个 Topic')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /创建 Topic/ }));
+    const dialog = await screen.findByRole('dialog');
+    await user.type(within(dialog).getByLabelText('Topic 名称'), 'topic-a');
+    await user.click(within(dialog).getByRole('button', { name: /创\s*建/ }));
+
+    await waitFor(() => expect(topicServiceMocks.createTopic).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(topicServiceMocks.listTopicsPage).toHaveBeenCalledTimes(2));
+    expect(topicServiceMocks.listTopicsPage).toHaveBeenLastCalledWith({
+      instanceId: 'instance-proxy-1',
+      type: undefined,
+      search: undefined,
+      page: 1,
+      pageSize: 20,
+    });
+    expect(screen.getByText('共 2 个 Topic')).toBeInTheDocument();
+    expect(within(getTableBody()).getByText('topic-a')).toBeInTheDocument();
+    expect(within(getTableBody()).getByText('topic-b')).toBeInTheDocument();
+    expect(within(getTableBody()).getByText('server page response')).toBeInTheDocument();
+    expect(within(getTableBody()).queryByText('create response')).not.toBeInTheDocument();
+  });
+
   it('ignores duplicate Topic creates while the first request is pending', async () => {
     topicServiceMocks.createTopic.mockImplementation(() => new Promise(() => {}));
     const user = userEvent.setup();

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -453,7 +453,7 @@ const TopicPage = () => {
     [selectedInstanceId, typeFilter, searchText],
   );
 
-  const reloadTopicPageAfterDelete = useCallback(async () => {
+  const reloadTopicPage = useCallback(async () => {
     await loadTopicPage(tablePage, tablePageSize);
   }, [loadTopicPage, tablePage, tablePageSize]);
 
@@ -644,7 +644,7 @@ const TopicPage = () => {
         onOk: async () => {
           try {
             await deleteTopic(topic.name, selectedInstanceId || undefined);
-            await reloadTopicPageAfterDelete();
+            await reloadTopicPage();
             message.success(`Topic「${topic.name}」已删除`);
           } catch {
             message.error('删除 Topic 失败，请稍后重试');
@@ -1134,7 +1134,7 @@ const TopicPage = () => {
         ...values,
         instanceId: selectedInstanceId,
       });
-      setTopics((previous) => [created, ...previous]);
+      await reloadTopicPage();
       message.success(`Topic「${created.name}」创建成功`);
       setModalOpen(false);
       form.resetFields();
@@ -1504,7 +1504,7 @@ const TopicPage = () => {
                         names,
                         selectedInstanceId || undefined,
                       );
-                      if (deleted.length > 0) await reloadTopicPageAfterDelete();
+                      if (deleted.length > 0) await reloadTopicPage();
                       setSelectedRowKeys(failed);
 
                       if (failed.length === 0) {


### PR DESCRIPTION
## Summary

- Reload the current server-backed Topic page after a successful create.
- Replace the local optimistic prepend with the authoritative page items and total.
- Reuse the existing reload path without changing delete behavior.
- Add a regression test covering the follow-up query, updated total, and server-returned row data.

## Why

Creating a Topic only updated the in-memory rows. The header and pagination kept the stale server total until a manual page reload, and the local row could diverge from server ordering and pagination.

## Verification

- RED: the new regression test failed before the fix because listTopicsPage was called once instead of twice.
- npm test -- src/pages/instance/__tests__/TopicPage.test.tsx: 22 passed.
- npm run lint: 0 errors, 10 existing warnings.
- npm run build: passed.
- Prettier check and git diff --check: passed.

Fixes #3337