### PR TITLE
test(provider): deepen Aliyun consumer lag conversion coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersLagTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersLagTest.java
@@ -57,4 +57,29 @@ class AliyunConvertersLagTest {
                     assertThat(row.getDiffTotal()).isEqualTo(100L);
                 });
     }
+
+    @Test
+    void missingOrNullReadyCountsProduceZeroRows() {
+        java.util.Map<String, DataTopicLagMapValue> topicLagMap = new java.util.HashMap<>();
+        topicLagMap.put("orders", DataTopicLagMapValue.builder().readyCount(null).build());
+        topicLagMap.put("payments", null);
+        GetConsumerGroupLagResponseBody.Data data = GetConsumerGroupLagResponseBody.Data.builder()
+                .topicLagMap(topicLagMap)
+                .build();
+
+        List<QueueProgressVO> rows = AliyunConverters.toQueueProgressRows(data);
+
+        assertThat(rows).hasSize(2)
+                .allSatisfy(row -> assertThat(row.getDiffTotal()).isZero());
+        assertThat(rows).extracting(QueueProgressVO::getTopic)
+                .containsExactlyInAnyOrder("orders", "payments");
+    }
+
+    @Test
+    void returnsEmptyWhenBreakdownAndTotalAreBothMissing() {
+        GetConsumerGroupLagResponseBody.Data data = GetConsumerGroupLagResponseBody.Data.builder()
+                .build();
+
+        assertThat(AliyunConverters.toQueueProgressRows(data)).isEmpty();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `AliyunConvertersLagTest` (2 to 4 tests) to pin down the consumer-lag breakdown conversion.

Added cases:
- topic entries with a null ready count (or a null entry value) still produce per-topic rows with a zero diff, one row per topic;
- when both the topic breakdown and the aggregate total are missing, the conversion returns an empty row list.

## Why

The converter feeds the consumer group progress tables; only the aggregate-vs-breakdown dedup and the total-only fallback were covered before.

## Testing

`mvn -B test -Dtest=AliyunConvertersLagTest` — 4/4 pass; checkstyle (validate) clean.