### PR TITLE
fix(acl): assign cleared list columns explicitly when updating users and rules

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepository.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.instance.acl;
 
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
@@ -79,6 +80,7 @@ public class MybatisPlusAclRepository implements AclRepository {
     }
 
     @Override
+    @Transactional
     public Optional<AclRuleVO> replaceRule(AclRuleVO rule) {
         RmqAclRule existing = ruleMapper.selectById(rule.getId());
         if (existing == null) {
@@ -88,6 +90,10 @@ public class MybatisPlusAclRepository implements AclRepository {
         entity.setGmtCreate(existing.getGmtCreate());
         if (ruleMapper.updateById(entity) == 0) {
             return Optional.empty();
+        }
+        if (rule.getActions() != null && entity.getActions() == null) {
+            // Clearing the actions list must persist as a null column; updateById skips null fields.
+            clearColumn(ruleMapper, entity.getId(), "actions");
         }
         rule.setGmtCreate(existing.getGmtCreate());
         return Optional.of(rule);
@@ -144,6 +150,7 @@ public class MybatisPlusAclRepository implements AclRepository {
     }
 
     @Override
+    @Transactional
     public Optional<AclUserVO> replaceUser(AclUserVO user) {
         RmqAclUser existing = userMapper.selectById(user.getId());
         if (existing == null) {
@@ -153,6 +160,10 @@ public class MybatisPlusAclRepository implements AclRepository {
         entity.setGmtCreate(existing.getGmtCreate());
         if (userMapper.updateById(entity) == 0) {
             return Optional.empty();
+        }
+        if (user.getClusters() != null && entity.getClusters() == null) {
+            // Clearing the cluster bindings must persist as a null column; updateById skips null fields.
+            clearColumn(userMapper, entity.getId(), "clusters");
         }
         user.setGmtCreate(existing.getGmtCreate());
         return Optional.of(user);
@@ -231,11 +242,8 @@ public class MybatisPlusAclRepository implements AclRepository {
         if (existing != null) {
             userMapper.updateById(entity);
             if (entity.getWhiteRemoteAddress() == null) {
-                // MyBatis-Plus omits null entity fields from updateById. Assign this column
-                // explicitly so clearing the whitelist does not silently retain its old value.
-                userMapper.update(null, new UpdateWrapper<RmqAclUser>()
-                        .eq("id", entity.getId())
-                        .set("white_remote_address", null));
+                // Clearing the whitelist must persist as a null column; updateById skips null fields.
+                clearColumn(userMapper, entity.getId(), "white_remote_address");
             }
         } else {
             try {
@@ -272,6 +280,15 @@ public class MybatisPlusAclRepository implements AclRepository {
         }
         String trimmed = value.trim();
         return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    /**
+     * MyBatis-Plus {@code updateById} omits null entity fields, so an update that clears a column
+     * to null is silently skipped and the previous value is retained. Assign the column explicitly
+     * so emptied list/whitelist columns persist as null.
+     */
+    private static <T> void clearColumn(BaseMapper<T> mapper, Long id, String column) {
+        mapper.update(null, new UpdateWrapper<T>().eq("id", id).set(column, null));
     }
 
     private void upsertPlainAccessRules(PlainAccessConfigVO config) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/MybatisPlusAclRepositoryTest.java
@@ -210,6 +210,78 @@ class MybatisPlusAclRepositoryTest {
     }
 
     @Test
+    void replaceUserShouldExplicitlyClearClusterBindingsWhenListIsEmpty() {
+        RmqAclUser existing = new RmqAclUser();
+        existing.setId(1L);
+        existing.setClusters("cluster-a,cluster-b");
+        existing.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
+        when(userMapper.selectById(1L)).thenReturn(existing);
+        when(userMapper.updateById(any(RmqAclUser.class))).thenReturn(1);
+        when(userMapper.update(isNull(), any(UpdateWrapper.class))).thenReturn(1);
+
+        AclUserVO replacement = AclUserVO.builder()
+                .id(1L)
+                .username("svc-a")
+                .accessKey("access-key")
+                .secretKey("secret-key")
+                .clusters(List.of())
+                .build();
+
+        assertThat(repository.replaceUser(replacement)).isPresent();
+
+        @SuppressWarnings("rawtypes")
+        ArgumentCaptor<UpdateWrapper> captor = ArgumentCaptor.forClass(UpdateWrapper.class);
+        verify(userMapper).update(isNull(), captor.capture());
+        assertThat(captor.getValue().getSqlSet()).contains("clusters");
+        assertThat(captor.getValue().getParamNameValuePairs()).containsValue(null);
+    }
+
+    @Test
+    void replaceUserShouldKeepClusterBindingsWhenNoneProvided() {
+        RmqAclUser existing = new RmqAclUser();
+        existing.setId(1L);
+        existing.setClusters("cluster-a");
+        existing.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
+        when(userMapper.selectById(1L)).thenReturn(existing);
+        when(userMapper.updateById(any(RmqAclUser.class))).thenReturn(1);
+
+        AclUserVO replacement = AclUserVO.builder()
+                .id(1L)
+                .username("renamed")
+                .build();
+
+        assertThat(repository.replaceUser(replacement)).isPresent();
+
+        verify(userMapper, never()).update(any(), any());
+    }
+
+    @Test
+    void replaceRuleShouldExplicitlyClearActionsWhenListIsEmpty() {
+        RmqAclRule existing = new RmqAclRule();
+        existing.setId(1L);
+        existing.setActions("PUB,SUB");
+        existing.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
+        when(ruleMapper.selectById(1L)).thenReturn(existing);
+        when(ruleMapper.updateById(any(RmqAclRule.class))).thenReturn(1);
+        when(ruleMapper.update(isNull(), any(UpdateWrapper.class))).thenReturn(1);
+
+        AclRuleVO replacement = AclRuleVO.builder()
+                .id(1L)
+                .principal("svc-a")
+                .resource("orders")
+                .actions(List.of())
+                .build();
+
+        assertThat(repository.replaceRule(replacement)).isPresent();
+
+        @SuppressWarnings("rawtypes")
+        ArgumentCaptor<UpdateWrapper> captor = ArgumentCaptor.forClass(UpdateWrapper.class);
+        verify(ruleMapper).update(isNull(), captor.capture());
+        assertThat(captor.getValue().getSqlSet()).contains("actions");
+        assertThat(captor.getValue().getParamNameValuePairs()).containsValue(null);
+    }
+
+    @Test
     void upsertShouldAssignUniqueRuleIdPerPermission() {
         when(userMapper.selectList(any(QueryWrapper.class))).thenReturn(List.of());
         when(userMapper.insert(any(RmqAclUser.class))).thenReturn(1);


### PR DESCRIPTION
Fixes #3357.

### Problem / Evidence

Editing an ACL user and clearing the **Associated clusters** tag select (or clearing a rule's actions through `POST /api/acl/rules/update` with `actions: []`) reports success — the UI even shows the cleared list — but the next reload brings the old values back: the update was never written to the database.

Trigger path (user update): ACL page user modal (clusters `Select mode="tags" allowClear`, sends `clusters: []`) → `POST /api/acl/users/update` → `AclService.updateUser` merges `[]` as the explicit new value → `MybatisPlusAclRepository.replaceUser` → `toUserEntity` maps `[]` to `clusters = null` via `joinNormalizedCsv` → MyBatis-Plus default `NOT_NULL` update strategy omits the column from `updateById`, so the old CSV survives.

The regression test fails before the fix with:

```
Wanted but not invoked:
userMapper.update(isNull(), <Capturing argument: UpdateWrapper>);
userMapper.updateById(RmqAclUser(id=1, ..., clusters=null, ...))
```

### Root cause / Fix

`replaceUser`/`replaceRule` rely on `updateById` with a null field for a "clear" intent, which MyBatis-Plus silently skips. This exact trap is already known in the same class: `createAndUpdatePlainAccessConfig` assigns `white_remote_address` explicitly for the cleared case ("MyBatis-Plus omits null entity fields from updateById"). The user/rule list columns got no such handling.

Fix: in `replaceUser`, after a successful `updateById`, issue an explicit `UpdateWrapper.set("clusters", null)` when the incoming VO carries a non-null list that normalizes to empty. Same for `replaceRule` and `actions`. Null still means "keep existing", so partial updates are unaffected, and the plain-access path that intentionally passes `clusters = null` (relying on the skip) is untouched.

### Priority & scoring

- Impact 34/40 — silent data loss masked as success on a core admin flow (a user believed to be cluster-unbound keeps its bindings).
- Scope 14/20 — ACL user update (UI-reachable) and rule update (API-reachable), one repository.
- Reproducibility 20/20 — deterministic; UI-only trigger for the user case.
- Maintenance value 16/20 — follows an existing in-repo workaround pattern; low-risk addition.
- **PRIORITY = 84, FIX_CONFIDENCE = 85** (≥70/≥80 per the contribution bar).

### Tests

- New `MybatisPlusAclRepositoryTest` cases: `replaceUserShouldExplicitlyClearClusterBindingsWhenListIsEmpty`, `replaceUserShouldKeepClusterBindingsWhenNoneProvided`, `replaceRuleShouldExplicitlyClearActionsWhenListIsEmpty`. The two clear-cases failed before the fix and pass after; the keep-case pins the null-keeps-existing semantics.
- `mvn -B -ntp test -Dtest='MybatisPlusAclRepositoryTest,AclServiceTest,AclControllerTest'` → 22/22, 64/64, 27/27 passing.
- Full `mvn -B -ntp test` on this branch: 2038 tests (pristine baseline 2035 + 3 new). Failures: `AuthCorsIntegrationTest` ×2 and `AliyunInstanceProviderTest.getGroupProgressShouldMapLagRowsTest` — identical to the recorded pristine baseline — plus one load-flaky `OpenAiCompatibleLlmGatewayTest` case ("AI chat capacity is temporarily exhausted") that passes 9/9 in isolation and touches no ACL code. Zero new failures.

### Risk

Low. The extra statement runs only when a non-null list normalizes to empty (the clear case); every other update path keeps the previous behavior. The explicit set uses the same `UpdateWrapper` shape as the existing `white_remote_address` workaround.
