### PR TITLE
fix(metadata): return empty results for topics without a broker route

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -22,6 +22,7 @@ import org.apache.rocketmq.common.constant.PermName;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.TopicConfig;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.admin.ConsumeStats;
 import org.apache.rocketmq.remoting.protocol.admin.OffsetWrapper;
 import org.apache.rocketmq.remoting.protocol.body.ClusterInfo;
@@ -40,6 +41,7 @@ import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.util.Pagination;
+import org.apache.rocketmq.studio.common.util.MqResponseCodes;
 import org.apache.rocketmq.studio.common.util.SubscriptionFilterModes;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
 import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
@@ -447,6 +449,12 @@ public class RocketMQMetadataProvider implements MetadataProvider {
             }
             return routes;
         } catch (Exception e) {
+            if (MqResponseCodes.hasResponseCode(e, ResponseCode.TOPIC_NOT_EXIST)) {
+                // A record created in the metadata database without a broker route is a
+                // normal "not synced yet" state — surface an empty route list, not a 502.
+                log.info("Topic {} has no broker route yet: {}", name, e.getMessage());
+                return Collections.emptyList();
+            }
             log.warn("Failed to get routes for topic {}: {}", name, e.getMessage());
             throw new BusinessException(502, "Failed to get routes for topic " + name + ": " + e.getMessage());
         }
@@ -574,6 +582,17 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                     .pageSize(pageSize)
                     .build();
         } catch (Exception e) {
+            if (MqResponseCodes.hasResponseCode(e, ResponseCode.TOPIC_NOT_EXIST)) {
+                // Same as routes: a metadata record without a broker route is a normal
+                // "not synced yet" state, so the consumer page comes back empty.
+                log.info("Topic {} has no broker route yet: {}", name, e.getMessage());
+                return TopicConsumerPageVO.builder()
+                        .items(List.of())
+                        .total(0)
+                        .page(page)
+                        .pageSize(pageSize)
+                        .build();
+            }
             log.warn("Failed to get consumers for topic {}: {}", name, e.getMessage());
             throw new BusinessException(502, "Failed to get consumers for topic " + name + ": " + e.getMessage());
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProviderTest.java
@@ -27,6 +27,8 @@ import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.remoting.protocol.admin.ConsumeStats;
 import org.apache.rocketmq.remoting.protocol.admin.OffsetWrapper;
 import org.apache.rocketmq.remoting.protocol.body.GroupList;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.remoting.protocol.ResponseCode;
 import org.apache.rocketmq.remoting.protocol.route.BrokerData;
 import org.apache.rocketmq.remoting.protocol.route.QueueData;
 import org.apache.rocketmq.remoting.protocol.route.TopicRouteData;
@@ -408,6 +410,60 @@ class RocketMQMetadataProviderTest {
         assertThatThrownBy(() -> newLiveProvider(admin).getTopicRoutes(null, "TopicA"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Failed to get routes for topic TopicA: broker unavailable")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    @Test
+    void getTopicRoutesShouldReturnEmptyListWhenTopicHasNoBrokerRoute() throws Exception {
+        DefaultMQAdminExt admin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        // Exception shape captured against a live RocketMQ 5.5.0 name server:
+        // MQClientException(responseCode=17, errorMessage="No topic route info in name
+        // server for the topic: <topic>").
+        when(admin.examineTopicRouteInfo("TopicA")).thenThrow(new MQClientException(
+                ResponseCode.TOPIC_NOT_EXIST,
+                "No topic route info in name server for the topic: TopicA"));
+
+        assertThat(newLiveProvider(admin).getTopicRoutes(null, "TopicA")).isEmpty();
+    }
+
+    @Test
+    void getTopicRoutesGradesByResponseCodeOnly() throws Exception {
+        DefaultMQAdminExt admin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        // A failure carrying route-absent-looking text but a different response code is
+        // a real error and must surface, proving grading no longer keys on the message.
+        when(admin.examineTopicRouteInfo("TopicA")).thenThrow(new MQClientException(
+                ResponseCode.SYSTEM_ERROR,
+                "No topic route info in name server for the topic: TopicA"));
+
+        assertThatThrownBy(() -> newLiveProvider(admin).getTopicRoutes(null, "TopicA"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
+    }
+
+    @Test
+    void getTopicConsumersShouldReturnEmptyPageWhenTopicHasNoBrokerRoute() throws Exception {
+        DefaultMQAdminExt admin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        when(admin.queryTopicConsumeByWho("TopicA")).thenThrow(new MQClientException(
+                ResponseCode.TOPIC_NOT_EXIST,
+                "No topic route info in name server for the topic: TopicA"));
+
+        TopicConsumerPageVO page = newLiveProvider(admin).getTopicConsumersPage(null, "TopicA", 1, 20);
+
+        assertThat(page.getItems()).isEmpty();
+        assertThat(page.getTotal()).isZero();
+        assertThat(page.getPage()).isEqualTo(1);
+        assertThat(page.getPageSize()).isEqualTo(20);
+    }
+
+    @Test
+    void getTopicConsumersGradesByResponseCodeOnly() throws Exception {
+        DefaultMQAdminExt admin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        when(admin.queryTopicConsumeByWho("TopicA")).thenThrow(new MQClientException(
+                ResponseCode.SYSTEM_ERROR,
+                "No topic route info in name server for the topic: TopicA"));
+
+        assertThatThrownBy(() -> newLiveProvider(admin).getTopicConsumersPage(null, "TopicA", 1, 20))
+                .isInstanceOf(BusinessException.class)
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(502));
     }
 


### PR DESCRIPTION
Fixes #3359.

### Problem / Evidence

A topic that exists in the Studio metadata database but has no broker route (partially failed create, replaced cluster, DB import) makes two flows fail instead of reporting the documented empty state:

- **Topic detail modal** — `GET /topics/{name}/routes` and `GET /topics/{name}/consumers` both return 502, so `openDetail` (web/src/pages/instance/topic.tsx:511) shows "Topic 详情加载失败，请稍后重试" instead of the modal.
- **Sync DB topics to broker** — `openSyncModal` (topic.tsx:576) catches the 502 per topic as `routes: null` and filters it out, so `syncMissing` (populated from `routes.length === 0`) never contains the missing-route topics the feature exists to find; the user only sees "部分 Topic 路由校验失败".

Backend trigger: `examineTopicRouteInfo`/`queryTopicConsumeByWho` throw `MQClientException` `CODE: 17` (`TOPIC_NOT_EXIST`) which both methods' catch-alls turn into `BusinessException(502)`. Captured against a live RocketMQ 5.5.0 name server (docker `apache/rocketmq:5.5.0`, `sh mqnamesrv`, route queried via the repo's `rocketmq-tools` 5.5.0 client for a topic with no route):

```
== examineTopicRouteInfo threw ==
  [0] org.apache.rocketmq.client.exception.MQClientException
      responseCode=17
      errorMessage=No topic route info in name server for the topic: no-such-topic
      message=CODE: 17  DESC: No topic route info in name server for the topic: no-such-topic
== queryTopicConsumeByWho threw ==
  [0] org.apache.rocketmq.client.exception.MQClientException
      responseCode=17
      errorMessage=No topic route info in name server for the topic: no-such-topic
      message=CODE: 17  DESC: No topic route info in name server for the topic: no-such-topic
```

(An earlier revision of this description quoted a different message string; that output did not match the 5.5.0 client and has been replaced with the capture above.)

### Root cause / Fix

`RocketMQMetadataProvider` has no benign-outcome classification for the "topic not on the broker yet" state, unlike its siblings (`RocketMQClientProvider.isTopicNotExist` → `List.of()` for producer connections, merged in #1043; `isGroupNotOnline` → empty for progress/subscriptions in this same class).

Fix: grade the exception with the shared `MqResponseCodes.hasResponseCode(e, ResponseCode.TOPIC_NOT_EXIST)` classifier (landed on this branch's base in #3302, same convention as `RocketMQMessageProvider`'s trace/NO_MESSAGE grading) inside the generic catch blocks of `getTopicRoutes` and `getTopicConsumersPage`, and return an empty route list / empty consumer page when it matches. The hand-rolled response-code check and the message-substring fallback from the first revision are gone entirely — grading keys on the response code only, so real failures carrying route-absent-looking text with a different response code still surface as 502 (new `getTopicRoutesGradesByResponseCodeOnly` / `getTopicConsumersGradesByResponseCodeOnly` tests). The existing `getTopicRoutesSurfacesAdminFailure` and `getTopicConsumersSurfacesAdminFailure` tests pass unchanged, which honors the concern raised in #1163 (real failures must not be disguised as empty data).

### Priority & scoring

- Impact 30/40 — breaks the topic detail modal and defeats the whole sync-DB-topics feature for route-less records.
- Scope 12/20 — topic page detail/sync/rebuild flows, two endpoints, one provider.
- Reproducibility 20/20 — deterministic once a metadata record lacks a broker route.
- Maintenance value 14/20 — documented contract in the class javadoc ("a record without a broker route surfaces as an empty route list instead of being hidden") plus an in-repo precedent to follow.
- **PRIORITY = 76, FIX_CONFIDENCE = 90** (≥70/≥80 per the contribution bar).

### Tests

- `RocketMQMetadataProviderTest` on this branch: `getTopicRoutesShouldReturnEmptyListWhenTopicHasNoBrokerRoute` and `getTopicConsumersShouldReturnEmptyPageWhenTopicHasNoBrokerRoute` mock the genuine 5.5.0 exception shape (`responseCode=17`, "No topic route info in name server for the topic: TopicA") and pass; the two `...GradesByResponseCodeOnly` cases prove a different response code carrying the same text still throws 502. Class result: 40/40.
- `mvn -B -ntp test -Dtest='MetadataServiceTest,TopicControllerTest,MqResponseCodesTest'` → 36/36, 16/16, 6/6 passing.
- Full `mvn -B -ntp test` on this branch: 2094 tests, 3 failures (`AuthCorsIntegrationTest` ×2, `AliyunInstanceProviderTest.getGroupProgressShouldMapLagRowsTest`) — re-verified to fail identically on pristine `origin/rocketmq-studio` (f5519e87) in this environment, so they are pre-existing baseline failures, not introduced here. Zero new failures.

### Risk

Low. Grading now keys on the definitive `TOPIC_NOT_EXIST` response code from the name server via the shared classifier; transport failures, broker errors and timeouts keep the existing 502 behavior. The related open PR #3102 (name trim/blank guard in `getTopicRoutes`) targets a different defect in the same method; the hunks do not overlap.
