### PR TITLE
fix(aliyun): populate subscription filter mode like the other providers

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/SubscriptionFilterModes.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/SubscriptionFilterModes.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+/**
+ * Maps a subscription filter expression type to the studio {@code filterMode} display value.
+ * Shared by the Apache and Aliyun providers so consumer-group subscription tables render the
+ * same values across instance types: {@code SQL92} is normalized to {@code SQL}, {@code CLASS_FILTER}
+ * is kept, and anything else (including a null/unknown type) defaults to {@code TAG}.
+ */
+public final class SubscriptionFilterModes {
+
+    private SubscriptionFilterModes() {
+    }
+
+    public static String fromExpressionType(String expressionType) {
+        if ("SQL92".equals(expressionType)) {
+            return "SQL";
+        }
+        if ("CLASS_FILTER".equals(expressionType)) {
+            return "CLASS_FILTER";
+        }
+        return "TAG";
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConverters.java
@@ -30,6 +30,7 @@ import com.aliyun.sdk.service.rocketmq20220801.models.ListTopicsResponseBody;
 import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.DeliveryStatus;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
+import org.apache.rocketmq.studio.common.util.SubscriptionFilterModes;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
 import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
@@ -212,6 +213,7 @@ final class AliyunConverters {
                 .topic(data.getTopicName())
                 .expression(data.getFilterExpression())
                 .type(data.getFilterExpressionType())
+                .filterMode(SubscriptionFilterModes.fromExpressionType(data.getFilterExpressionType()))
                 .consistency(data.getConsistency() == null ? null : String.valueOf(data.getConsistency()))
                 .build();
     }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQMetadataProvider.java
@@ -40,6 +40,7 @@ import org.apache.rocketmq.studio.common.domain.enums.ConsumeType;
 import org.apache.rocketmq.studio.common.domain.enums.SubscriptionMode;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.util.Pagination;
+import org.apache.rocketmq.studio.common.util.SubscriptionFilterModes;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
 import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
 import org.apache.rocketmq.common.topic.TopicValidator;
@@ -688,7 +689,7 @@ public class RocketMQMetadataProvider implements MetadataProvider {
                     .topic(sd.getTopic())
                     .expression(sd.getSubString())
                     .type(sd.getExpressionType())
-                    .filterMode(filterMode(sd.getExpressionType()))
+                    .filterMode(SubscriptionFilterModes.fromExpressionType(sd.getExpressionType()))
                     // The broker/proxy expose the group's merged subscription set only; with at
                     // least one client connected that merged view is the consistent observable
                     // state. Without connections the consistency status stays unknown (null).
@@ -760,15 +761,6 @@ public class RocketMQMetadataProvider implements MetadataProvider {
      */
     private long resolveDiff(long brokerOffset, long consumerOffset) {
         return ConsumerLagResolver.resolve(brokerOffset - consumerOffset, proxyStatsProvider);
-    }
-    private String filterMode(String expressionType) {
-        if ("SQL92".equals(expressionType)) {
-            return "SQL";
-        }
-        if ("CLASS_FILTER".equals(expressionType)) {
-            return "CLASS_FILTER";
-        }
-        return "TAG";
     }
 
     private boolean isSystemTopic(String topicName, Set<String> brokerNames) {

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/SubscriptionFilterModesTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/SubscriptionFilterModesTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubscriptionFilterModesTest {
+
+    @Test
+    void normalizesSql92ToSqlTest() {
+        assertThat(SubscriptionFilterModes.fromExpressionType("SQL92")).isEqualTo("SQL");
+    }
+
+    @Test
+    void keepsClassFilterTest() {
+        assertThat(SubscriptionFilterModes.fromExpressionType("CLASS_FILTER")).isEqualTo("CLASS_FILTER");
+    }
+
+    @Test
+    void defaultsToTagForTagUnknownAndNullTest() {
+        assertThat(SubscriptionFilterModes.fromExpressionType("TAG")).isEqualTo("TAG");
+        assertThat(SubscriptionFilterModes.fromExpressionType("SQL")).isEqualTo("TAG");
+        assertThat(SubscriptionFilterModes.fromExpressionType(null)).isEqualTo("TAG");
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.rocketmq.studio.provider.alibaba;
 
+import com.aliyun.sdk.service.rocketmq20220801.models.ListConsumerGroupSubscriptionsResponseBody;
 import com.aliyun.sdk.service.rocketmq20220801.models.ListInstancesResponseBody;
+import org.apache.rocketmq.studio.instance.group.SubscriptionEntryVO;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,5 +36,34 @@ class AliyunConvertersTest {
 
         assertThat(result.getTopicCount()).isEqualTo(Integer.MAX_VALUE);
         assertThat(result.getGroupCount()).isZero();
+    }
+
+    @Test
+    void toSubscriptionEntryShouldDeriveFilterModeFromTheExpressionType() {
+        ListConsumerGroupSubscriptionsResponseBody.Data data =
+                ListConsumerGroupSubscriptionsResponseBody.Data.builder()
+                        .topicName("orders")
+                        .filterExpression("orderType = 'A'")
+                        .filterExpressionType("SQL92")
+                        .consistency(true)
+                        .build();
+
+        SubscriptionEntryVO entry = AliyunConverters.toSubscriptionEntry(data);
+
+        assertThat(entry.getFilterMode()).isEqualTo("SQL");
+    }
+
+    @Test
+    void toSubscriptionEntryShouldKeepTagFilterMode() {
+        ListConsumerGroupSubscriptionsResponseBody.Data data =
+                ListConsumerGroupSubscriptionsResponseBody.Data.builder()
+                        .topicName("orders")
+                        .filterExpression("tag-a")
+                        .filterExpressionType("TAG")
+                        .build();
+
+        SubscriptionEntryVO entry = AliyunConverters.toSubscriptionEntry(data);
+
+        assertThat(entry.getFilterMode()).isEqualTo("TAG");
     }
 }


### PR DESCRIPTION
Fixes #3360.

### Problem / Evidence

On an Aliyun instance, the consumer-group subscription table renders an **empty 订阅模式 (filter mode) cell for every row**: the red test showed `expected: "SQL" but was: null` (and `expected: "TAG" but was: null`). Apache instances show `TAG`/`SQL` (`RocketMQMetadataProvider` line 691 via its `filterMode` normalizer) and Tencent instances show the expression type (`TencentInstanceProvider` line 984), so the same column is blank only for Aliyun.

Trigger path: consumer group page subscriptions sub-table (web/src/pages/instance/consumer.tsx:1038, renders `filterMode`) → `GET /api/groups/{name}/subscriptions` → `MetadataService.getGroupSubscriptions` → `AliyunInstanceProvider.getGroupSubscriptions` (line 413) → `AliyunConverters.toSubscriptionEntry` (line 210) — which maps `expression` and `type` from the SDK model but never derives `filterMode`, leaving the VO field null.

### Root cause / Fix

Field-mapping gap: `toSubscriptionEntry` skips the `filterMode` builder field. The data to derive it is already consumed — `data.getFilterExpressionType()`.

Fix: derive `filterMode` with the same mapping the Apache provider uses (`SQL92` → `SQL`, `CLASS_FILTER` → `CLASS_FILTER`, otherwise `TAG`), so the three providers render identical values for identical subscription types.

### Priority & scoring

- Impact 28/40 — a visible column of a core diagnostics table is empty for every Aliyun instance.
- Scope 10/20 — one column, one provider; page still usable.
- Reproducibility 20/20 — deterministic for all Aliyun subscription rows.
- Maintenance value 14/20 — cross-provider consistency with an established normalization pattern.
- **PRIORITY = 72, FIX_CONFIDENCE = 92** (≥70/≥80 per the contribution bar).

### Tests

- New `AliyunConvertersTest` cases: `toSubscriptionEntryShouldDeriveFilterModeFromTheExpressionType` (SQL92 → SQL) and `toSubscriptionEntryShouldKeepTagFilterMode` (TAG → TAG). Both failed before the fix with `null` and pass after.
- `mvn -B -ntp test -Dtest='AliyunConvertersTest,AliyunInstanceProviderTest'` → AliyunConvertersTest 3/3; AliyunInstanceProviderTest keeps only its pre-existing baseline failure (`getGroupProgressShouldMapLagRowsTest`, unrelated to subscriptions).
- Full `mvn -B -ntp test` on this branch: 2037 tests (pristine baseline 2035 + 2 new); the only 3 failures (`AuthCorsIntegrationTest` ×2, `AliyunInstanceProviderTest.getGroupProgressShouldMapLagRowsTest`) are identical to the recorded pristine baseline. Zero new failures.

### Risk

Low. Adds one builder field plus a small pure mapping function; no other converter or provider path is affected.
