### PR TITLE
test(metrics): deepen Apache proxy collector coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqProxyMetricsCollectorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqProxyMetricsCollectorTest.java
@@ -96,4 +96,49 @@ class ApacheRocketMqProxyMetricsCollectorTest {
             assertThat(sample.labels()).containsEntry("proxyAddr", "unknown");
         });
     }
+
+    @Test
+    void supportsApacheAndVendorLessInstancesWithNameAndEndpoint() {
+        ApacheRocketMqProxyMetricsCollector collector = new ApacheRocketMqProxyMetricsCollector(
+                mock(ClusterService.class), mock(ProxyHealthProbe.class));
+
+        assertThat(collector.supports(InstanceVO.builder().name("local").endpoint("localhost:9876")
+                .vendor(InstanceVendor.APACHE).build())).isTrue();
+        assertThat(collector.supports(InstanceVO.builder().name("local").endpoint("localhost:9876").build()))
+                .isTrue();
+        assertThat(collector.supports(InstanceVO.builder().name("cloud").endpoint("x")
+                .vendor(InstanceVendor.ALIYUN).build())).isFalse();
+        assertThat(collector.supports(InstanceVO.builder().name("local")
+                .vendor(InstanceVendor.APACHE).build())).isFalse();
+        assertThat(collector.supports(null)).isFalse();
+    }
+
+    @Test
+    void exposesTheProxyAvailabilityMetricKey() {
+        assertThat(new ApacheRocketMqProxyMetricsCollector(mock(ClusterService.class),
+                mock(ProxyHealthProbe.class)).metricKeys()).containsExactly("proxy.availability");
+    }
+
+    @Test
+    void collectsAcrossClustersAndSkipsClustersWithoutProxiesTest() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ProxyHealthProbe probe = mock(ProxyHealthProbe.class);
+        InstanceVO instance = InstanceVO.builder().name("local").endpoint("localhost:9876")
+                .vendor(InstanceVendor.APACHE).build();
+        when(clusterService.listClusters("local")).thenReturn(List.of(
+                ClusterVO.builder().id("empty-cluster").build(),
+                ClusterVO.builder().id("cluster-a")
+                        .proxies(List.of(ProxyVO.builder().addr("proxy-a:8080").grpcPort(8081).build()))
+                        .build()));
+        when(probe.probe("proxy-a", 8081, 2_000)).thenReturn(ProxyHealthProbe.ProbeResult.reachable(3));
+
+        List<MetricSample> samples = new ApacheRocketMqProxyMetricsCollector(clusterService, probe)
+                .collect(instance);
+
+        assertThat(samples).singleElement().satisfies(sample -> {
+            assertThat(sample.clusterId()).isEqualTo("cluster-a");
+            assertThat(sample.value()).isEqualTo(1D);
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.AVAILABLE);
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `ApacheRocketMqProxyMetricsCollectorTest` (3 to 6 tests) to pin down the proxy collector contract.

Added cases:
- `supports` accepts Apache and vendor-less instances with a name and endpoint, and rejects cloud vendors, missing endpoints, and null instances;
- `metricKeys` exposes only `proxy.availability`;
- discovery iterates every cluster while skipping clusters without proxies, collecting a reachable sample from the remaining cluster.

## Why

The collector feeds native Apache proxy availability alerting; only probe/discovery-failure branches were covered before.

## Testing

`mvn -B test -Dtest=ApacheRocketMqProxyMetricsCollectorTest` — 6/6 pass; checkstyle (validate) clean.