### PR TITLE
test(metrics): deepen Apache DLQ collector coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqDlqMetricsCollectorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqDlqMetricsCollectorTest.java
@@ -87,4 +87,24 @@ class ApacheRocketMqDlqMetricsCollectorTest {
     private static InstanceVO apacheInstance() {
         return InstanceVO.builder().name("local").endpoint("localhost:9876").vendor(InstanceVendor.APACHE).build();
     }
+
+    @Test
+    void supportsApacheAndVendorLessInstancesWithAName() {
+        ApacheRocketMqDlqMetricsCollector collector =
+                new ApacheRocketMqDlqMetricsCollector(mock(DLQProvider.class));
+
+        assertThat(collector.supports(apacheInstance())).isTrue();
+        assertThat(collector.supports(InstanceVO.builder().name("local").endpoint("localhost:9876").build()))
+                .isTrue();
+        assertThat(collector.supports(InstanceVO.builder().name("cloud").endpoint("x")
+                .vendor(InstanceVendor.TENCENT).build())).isFalse();
+        assertThat(collector.supports(InstanceVO.builder().vendor(InstanceVendor.APACHE).build())).isFalse();
+        assertThat(collector.supports(null)).isFalse();
+    }
+
+    @Test
+    void exposesTheDlqMetricKey() {
+        assertThat(new ApacheRocketMqDlqMetricsCollector(mock(DLQProvider.class)).metricKeys())
+                .containsExactly("dlq.message.count");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `ApacheRocketMqDlqMetricsCollectorTest` (4 to 6 tests) to pin down the DLQ collector contract.

Added cases:
- `supports` accepts Apache and vendor-less instances with a name, and rejects cloud vendors, unnamed instances, and null;
- `metricKeys` exposes only `dlq.message.count`.

## Why

The collector feeds native DLQ alerting; the vendor/name gate and the metric-key contract were not covered before.

## Testing

`mvn -B test -Dtest=ApacheRocketMqDlqMetricsCollectorTest` — 6/6 pass; checkstyle (validate) clean.