### PR TITLE
test(metrics): deepen Apache business collector coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqBusinessMetricsCollectorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqBusinessMetricsCollectorTest.java
@@ -142,4 +142,25 @@ class ApacheRocketMqBusinessMetricsCollectorTest {
     private static InstanceVO apacheInstance() {
         return InstanceVO.builder().name("local").endpoint("localhost:9876").vendor(InstanceVendor.APACHE).build();
     }
+
+    @Test
+    void supportsApacheAndVendorLessInstancesWithAName() {
+        ApacheRocketMqBusinessMetricsCollector collector =
+                new ApacheRocketMqBusinessMetricsCollector(mock(InstanceProviderRegistry.class));
+
+        assertThat(collector.supports(apacheInstance())).isTrue();
+        assertThat(collector.supports(InstanceVO.builder().name("local").endpoint("localhost:9876").build()))
+                .isTrue();
+        assertThat(collector.supports(InstanceVO.builder().name("cloud").endpoint("x")
+                .vendor(InstanceVendor.TENCENT).build())).isFalse();
+        assertThat(collector.supports(InstanceVO.builder().vendor(InstanceVendor.APACHE).build())).isFalse();
+        assertThat(collector.supports(null)).isFalse();
+    }
+
+    @Test
+    void exposesTheBusinessMetricKeys() {
+        assertThat(new ApacheRocketMqBusinessMetricsCollector(mock(InstanceProviderRegistry.class)).metricKeys())
+                .containsExactlyInAnyOrder("consumer.lag.total", "consumer.lag.max_queue",
+                        "consumer.delay.seconds", "topic.backlog.total");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `ApacheRocketMqBusinessMetricsCollectorTest` (5 to 7 tests) to pin down the Apache business collector contract.

Added cases:
- `supports` accepts Apache and vendor-less instances with a name, and rejects cloud vendors, unnamed instances, and null;
- `metricKeys` exposes the four business metrics (`consumer.lag.total`, `consumer.lag.max_queue`, `consumer.delay.seconds`, `topic.backlog.total`).

## Why

The collector feeds native Apache business alerting; the vendor/name gate and the metric-key contract were not covered before.

## Testing

`mvn -B test -Dtest=ApacheRocketMqBusinessMetricsCollectorTest` — 7/7 pass; checkstyle (validate) clean.