### PR TITLE
test(settings): deepen DataSourceDTO validation coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceDTOTest.java
@@ -64,4 +64,34 @@ class DataSourceDTOTest {
         request.setUrl("https://metrics.example.test");
         return request;
     }
+
+    @Test
+    void shouldRejectUnsupportedTypeAuthAndMissingCoreFields() {
+        DataSourceDTO request = validDataSource();
+        request.setType("influxdb");
+        request.setAuth("api-key");
+        request.setName(" ");
+        request.setUrl("");
+
+        try (ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            var messages = validatorFactory.getValidator().validate(request).stream()
+                    .map(violation -> violation.getMessage()).toList();
+            assertThat(messages)
+                    .contains("Unsupported metrics data source type",
+                            "Unsupported metrics data source authentication",
+                            "name is required", "url is required");
+        }
+    }
+
+    @Test
+    void toDataSourceVONormalizesAuthAndDefaultsUnknownType() {
+        DataSourceDTO request = validDataSource();
+        request.setType("future-backend");
+        request.setAuth(" bearer token ");
+
+        DataSourceVO dataSource = request.toDataSourceVO();
+
+        assertThat(dataSource.getType()).isEqualTo("Prometheus");
+        assertThat(dataSource.getAuth()).isEqualTo("bearer token");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `DataSourceDTOTest` (3 to 5 tests) to pin down the data-source payload validation.

Added cases:
- unsupported `type` and `auth` values are rejected with their dedicated messages, and blank `name`/`url` produce `name is required`/`url is required`;
- `toDataSourceVO` trims the auth value and falls back to `Prometheus` for an unknown type (the bean pattern is a validation-layer guard only).

## Why

The DTO gates data-source registration; only the instance-binding and canonicalization branches were covered before.

## Testing

`mvn -B test -Dtest=DataSourceDTOTest` — 5/5 pass; checkstyle (validate) clean.