### PR TITLE
test(alert): deepen notification template token coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplateTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplateTest.java
@@ -51,4 +51,31 @@ class AlertNotificationTemplateTest {
         assertThat(AlertNotificationTemplate.render("${title}", alert, null))
                 .isEqualTo("${description}");
     }
+
+    @Test
+    void expandsEveryRemainingDocumentedTokenTest() {
+        AlertRuleVO rule = AlertRuleVO.builder().name("Orders rate").metric("orders.total")
+                .thresholdUnit("%").build();
+        SystemAlertVO alert = SystemAlertVO.builder().level(AlertLevel.warning)
+                .title("Orders rate")
+                .description("orders above threshold")
+                .transition("FIRING")
+                .instanceId("local")
+                .currentValue(0.5)
+                .time(LocalDateTime.of(2026, 8, 23, 9, 30))
+                .build();
+
+        String rendered = AlertNotificationTemplate.render(
+                "${title}|${description}|${metric}|${instanceId}|${level}|${time}|${value}", alert, rule);
+
+        assertThat(rendered).isEqualTo(
+                "Orders rate|orders above threshold|orders.total|local|warning|2026-08-23T09:30|0.5");
+    }
+
+    @Test
+    void emptiesMissingTimesAndValuesTest() {
+        SystemAlertVO alert = SystemAlertVO.builder().title("x").build();
+
+        assertThat(AlertNotificationTemplate.render("${time}|${value}", alert, null)).isEqualTo("|");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `AlertNotificationTemplateTest` (3 to 5 tests) to pin down the remaining documented template tokens.

Added cases:
- `title`, `description`, `metric`, `instanceId`, `level`, `time`, and raw `value` all expand to their alert/rule values (non-ratio metrics keep the raw value even with a `%` threshold unit);
- missing alert times and current values expand to empty strings instead of `null`.

## Why

The template engine builds every channel notification; only the rule/transition/value/labels tokens and the default format were covered before.

## Testing

`mvn -B test -Dtest=AlertNotificationTemplateTest` — 5/5 pass; checkstyle (validate) clean.