### PR TITLE
test(alert): deepen native rule scope matcher coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleScopeMatcherTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleScopeMatcherTest.java
@@ -62,4 +62,34 @@ class NativeAlertRuleScopeMatcherTest {
         return new MetricSample("broker.availability", AlertDomain.CLUSTER, "local", clusterId,
                 Map.of("brokerName", brokerName), 1D, MetricAvailability.AVAILABLE, Instant.now());
     }
+
+    @Test
+    void requiresAnInstanceSelectorThatMatchesTest() {
+        MetricSample sample = sample("cluster-a", "broker-a");
+
+        assertThat(NativeAlertRuleScopeMatcher.matches(AlertRuleVO.builder().build(), sample)).isFalse();
+        assertThat(NativeAlertRuleScopeMatcher.matches(
+                AlertRuleVO.builder().instanceId(" local ").build(), sample)).isTrue();
+        assertThat(NativeAlertRuleScopeMatcher.matches(
+                AlertRuleVO.builder().instanceId("other").build(), sample)).isFalse();
+    }
+
+    @Test
+    void blankSelectorsMatchAnyValueIncludingMissingLabelsTest() {
+        AlertRuleVO rule = AlertRuleVO.builder().instanceId("local").brokerName("  ")
+                .clusterName("").consumerGroup(" ").topic(null).build();
+        MetricSample withoutBroker = new MetricSample("broker.availability", AlertDomain.CLUSTER, "local",
+                null, Map.of("brokerName", "broker-a"), 1D, MetricAvailability.AVAILABLE, Instant.now());
+
+        assertThat(NativeAlertRuleScopeMatcher.matches(rule, withoutBroker)).isTrue();
+    }
+
+    @Test
+    void trimsSelectorsBeforeComparisonTest() {
+        AlertRuleVO rule = AlertRuleVO.builder().instanceId("local").brokerName(" broker-a ")
+                .clusterName(" cluster-a ").build();
+
+        assertThat(NativeAlertRuleScopeMatcher.matches(rule, sample("cluster-a", "broker-a"))).isTrue();
+        assertThat(NativeAlertRuleScopeMatcher.matches(rule, sample(null, "broker-a"))).isFalse();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `NativeAlertRuleScopeMatcherTest` (3 to 6 tests) to pin down the scope matcher contract.

Added cases:
- a rule without an instance selector never matches; the selector is trimmed before comparison and mismatching instances are rejected;
- blank/wildcard selectors match any value, including samples that do not carry the corresponding label at all;
- broker and cluster selectors are trimmed before comparison, and an explicit cluster selector does not match a sample without a cluster id.

## Why

The matcher decides which native samples a rule evaluates; the instance gate, blank-selector, and trimming branches were uncovered.

## Testing

`mvn -B test -Dtest=NativeAlertRuleScopeMatcherTest` — 6/6 pass; checkstyle (validate) clean.