### PR TITLE
test(alert): deepen rule semantic fingerprint coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleSemanticFingerprintTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleSemanticFingerprintTest.java
@@ -77,4 +77,37 @@ class AlertRuleSemanticFingerprintTest {
                 .isEqualTo(AlertRuleSemanticFingerprint.of(fraction))
                 .isNotEqualTo(AlertRuleSemanticFingerprint.of(rawValue));
     }
+
+    @Test
+    void changesWhenTheMetricOrOperatorChangesTest() {
+        AlertRuleVO base = AlertRuleVO.builder()
+                .domain(AlertDomain.CLUSTER).instanceId("local").metric("broker.disk.usage_ratio")
+                .operator(">=").threshold(85).build();
+        AlertRuleVO otherMetric = AlertRuleVO.builder()
+                .domain(AlertDomain.CLUSTER).instanceId("local").metric("broker.jvm.heap.usage_ratio")
+                .operator(">=").threshold(85).build();
+        AlertRuleVO otherOperator = AlertRuleVO.builder()
+                .domain(AlertDomain.CLUSTER).instanceId("local").metric("broker.disk.usage_ratio")
+                .operator(">").threshold(85).build();
+
+        assertThat(AlertRuleSemanticFingerprint.of(otherMetric))
+                .isNotEqualTo(AlertRuleSemanticFingerprint.of(base));
+        assertThat(AlertRuleSemanticFingerprint.of(otherOperator))
+                .isNotEqualTo(AlertRuleSemanticFingerprint.of(base));
+    }
+
+    @Test
+    void ignoresNameSeverityEnabledAndChannelsTest() {
+        AlertRuleVO base = AlertRuleVO.builder()
+                .domain(AlertDomain.CLUSTER).instanceId("local").metric("broker.disk.usage_ratio")
+                .operator(">=").threshold(85).build();
+        AlertRuleVO cosmeticOnly = AlertRuleVO.builder()
+                .domain(AlertDomain.CLUSTER).name("Any label").instanceId("local")
+                .metric("broker.disk.usage_ratio").operator(">=").threshold(85)
+                .severity("critical").enabled(false).channels(List.of("sms", "dingtalk"))
+                .description("cosmetic").build();
+
+        assertThat(AlertRuleSemanticFingerprint.of(cosmeticOnly))
+                .isEqualTo(AlertRuleSemanticFingerprint.of(base));
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `AlertRuleSemanticFingerprintTest` (3 to 5 tests) to pin down the semantic-identity contract.

Added cases:
- changing the metric or the operator changes the fingerprint;
- cosmetic fields (name, description, severity, enabled, channels) do not change the fingerprint when the evaluation core is identical.

## Why

The fingerprint deduplicates alert rules on import; only scope/window/ratio-threshold effects were covered before.

## Testing

`mvn -B test -Dtest=AlertRuleSemanticFingerprintTest` — 5/5 pass; checkstyle (validate) clean.