### PR TITLE
test(auth): deepen AuthCookie coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCookieTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCookieTest.java
@@ -66,4 +66,44 @@ class AuthCookieTest {
         assertThat(AuthCookie.authorization(nonBearerRequest, properties))
                 .isEqualTo("Bearer cookie-token");
     }
+
+    @Test
+    void returnsNullWhenNeitherHeaderNorCookieIsPresent() {
+        AuthProperties properties = new AuthProperties();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        assertThat(AuthCookie.authorization(request, properties)).isNull();
+    }
+
+    @Test
+    void passesThroughNonBearerHeadersWithoutACookie() {
+        AuthProperties properties = new AuthProperties();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Basic credentials");
+
+        assertThat(AuthCookie.authorization(request, properties)).isEqualTo("Basic credentials");
+    }
+
+    @Test
+    void honorsACustomCookieNameAndClearsWithZeroMaxAge() {
+        AuthProperties properties = new AuthProperties();
+        properties.setSessionCookieName("custom_session");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        AuthCookie.write(response, properties, "token", java.time.Duration.ofMinutes(5));
+        assertThat(response.getHeader("Set-Cookie")).contains("custom_session=token");
+
+        MockHttpServletResponse cleared = new MockHttpServletResponse();
+        AuthCookie.clear(cleared, properties);
+        assertThat(cleared.getHeader("Set-Cookie")).contains("custom_session=").contains("Max-Age=0");
+    }
+
+    @Test
+    void bearerSessionDeliveryHeaderIsCaseInsensitive() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        assertThat(AuthCookie.requestsBearerToken(request)).isFalse();
+
+        request.addHeader(AuthCookie.SESSION_DELIVERY_HEADER, "BEARER");
+        assertThat(AuthCookie.requestsBearerToken(request)).isTrue();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `AuthCookieTest` (3 to 7 tests) to pin down the remaining session-cookie branches.

Added cases:
- no authorization header and no session cookie yields null;
- a non-bearer header passes through unchanged when no cookie matches;
- a custom cookie name is honored on write, and `clear` emits an empty value with `Max-Age=0`;
- the bearer session-delivery header is matched case-insensitively and absent by default.

## Why

The helper gates every session-authenticated request; only the cookie flags, header precedence, and cookie fallback were covered before.

## Testing

`mvn -B test -Dtest=AuthCookieTest` — 7/7 pass; checkstyle (validate) clean.