### PR TITLE
test(ai): deepen QoderAgentProvider coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/QoderAgentProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/QoderAgentProviderTest.java
@@ -49,4 +49,17 @@ class QoderAgentProviderTest {
         assertThat(provider.buildCommand(config, null, null))
                 .containsExactly("qodercli", "-p", "");
     }
+
+    @Test
+    void reportsTheQoderEngine() {
+        assertThat(provider.engine()).isEqualTo("qoder");
+    }
+
+    @Test
+    void blankModelOverrideFallsBackToTheConfiguredModel() {
+        LlmConfigVO config = LlmConfigVO.builder().model("qoder-configured").build();
+
+        assertThat(provider.buildCommand(config, "prompt", "  "))
+                .containsExactly("qodercli", "-p", "prompt", "-m", "qoder-configured");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `QoderAgentProviderTest` (3 to 5 tests) to pin down the remaining qoder CLI provider branches.

Added cases:
- the provider reports the `qoder` engine name;
- a blank model override falls back to the configured model (trimmed) instead of being emitted.

## Why

The provider builds the CLI command for every qoder-backed AI execution; engine identity and model fallback were uncovered.

## Testing

`mvn -B test -Dtest=QoderAgentProviderTest` — 5/5 pass; checkstyle (validate) clean.