### PR TITLE
test(alert): cover unknown asset 404 for view and export

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleAssetControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -77,5 +78,18 @@ class AlertRuleAssetControllerTest {
                 .andExpect(header().string("Content-Type", "application/x-yaml"))
                 .andExpect(header().string("Content-Disposition",
                         "form-data; name=\"attachment\"; filename=\"rocketmq-broker-down.yaml\""));
+    }
+
+    @Test
+    void unknownAssetIsNotFoundForViewAndExport() throws Exception {
+        org.apache.rocketmq.studio.common.exception.BusinessException missing =
+                new org.apache.rocketmq.studio.common.exception.BusinessException(
+                        404, "Alert rule asset not found: ghost");
+        doThrow(missing).when(alertRuleAssetService).getAssetYaml("ghost");
+
+        mockMvc.perform(get("/api/alert-rules/assets/ghost"))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(get("/api/alert-rules/assets/ghost/export"))
+                .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
## Summary

Extends the existing `AlertRuleAssetControllerTest` (3 to 4 tests) with the unknown-asset branch.

Added case:
- requesting an unknown asset through either the view or the export endpoint surfaces the service's `BusinessException` (404) as an HTTP 404 response.

## Why

The bundled-asset endpoints document 404 for unknown names; the error path was not covered before (only list/get/export happy paths).

## Testing

`mvn -B test -Dtest=AlertRuleAssetControllerTest` — 4/4 pass; checkstyle (validate) clean.