### PR TITLE
test(metrics): deepen alert collection lease coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusAlertCollectionLeaseTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusAlertCollectionLeaseTest.java
@@ -16,14 +16,21 @@
  */
 package org.apache.rocketmq.studio.cluster.metrics;
 
+import org.apache.rocketmq.studio.persistence.entity.RmqAlertCollectionLease;
 import org.apache.rocketmq.studio.persistence.mapper.RmqAlertCollectionLeaseMapper;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -52,5 +59,69 @@ class MybatisPlusAlertCollectionLeaseTest {
 
         assertThat(lease.renew()).isFalse();
         verify(mapper).renew(eq("native-alert-collection"), anyString(), any(), any());
+    }
+
+    @Test
+    void tryAcquireRenewsTheLiveRowWhenPossible() {
+        AlertingProperties properties = new AlertingProperties();
+        properties.setCollectionLeaseDuration("PT30S");
+        RmqAlertCollectionLeaseMapper mapper = mock(RmqAlertCollectionLeaseMapper.class);
+        when(mapper.acquire(eq("native-alert-collection"), anyString(), any(), any())).thenReturn(1);
+
+        MybatisPlusAlertCollectionLease lease = new MybatisPlusAlertCollectionLease(properties, mapper);
+
+        assertThat(lease.tryAcquire()).isTrue();
+        verify(mapper, never()).insert(any(RmqAlertCollectionLease.class));
+    }
+
+    @Test
+    void tryAcquireInsertsItsOwnLeaseWhenNoLiveRowCanBeRenewed() {
+        AlertingProperties properties = new AlertingProperties();
+        properties.setCollectionLeaseDuration("PT30S");
+        RmqAlertCollectionLeaseMapper mapper = mock(RmqAlertCollectionLeaseMapper.class);
+        when(mapper.acquire(eq("native-alert-collection"), anyString(), any(), any())).thenReturn(0);
+        when(mapper.insert(any(RmqAlertCollectionLease.class))).thenReturn(1);
+
+        MybatisPlusAlertCollectionLease lease = new MybatisPlusAlertCollectionLease(properties, mapper);
+
+        assertThat(lease.tryAcquire()).isTrue();
+        ArgumentCaptor<String> holder = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<RmqAlertCollectionLease> inserted = ArgumentCaptor.forClass(RmqAlertCollectionLease.class);
+        verify(mapper).acquire(eq("native-alert-collection"), holder.capture(), any(), any());
+        verify(mapper).insert(inserted.capture());
+        assertThat(inserted.getValue().getHolderId()).isEqualTo(holder.getValue());
+        assertThat(inserted.getValue().getLeaseName()).isEqualTo("native-alert-collection");
+    }
+
+    @Test
+    void tryAcquireLosesTheRaceWhenAnotherReplicaInsertsFirst() {
+        AlertingProperties properties = new AlertingProperties();
+        properties.setCollectionLeaseDuration("PT30S");
+        RmqAlertCollectionLeaseMapper mapper = mock(RmqAlertCollectionLeaseMapper.class);
+        when(mapper.acquire(eq("native-alert-collection"), anyString(), any(), any())).thenReturn(0);
+        when(mapper.insert(any(RmqAlertCollectionLease.class)))
+                .thenThrow(new DuplicateKeyException("duplicate lease"));
+
+        MybatisPlusAlertCollectionLease lease = new MybatisPlusAlertCollectionLease(properties, mapper);
+
+        assertThat(lease.tryAcquire()).isFalse();
+    }
+
+    @Test
+    void renewFallsBackToOneMinuteForMalformedDurations() {
+        AlertingProperties properties = new AlertingProperties();
+        properties.setCollectionLeaseDuration("garbage");
+        RmqAlertCollectionLeaseMapper mapper = mock(RmqAlertCollectionLeaseMapper.class);
+        when(mapper.renew(eq("native-alert-collection"), anyString(), any(), any())).thenReturn(1);
+
+        MybatisPlusAlertCollectionLease lease = new MybatisPlusAlertCollectionLease(properties, mapper);
+
+        assertThat(lease.renew()).isTrue();
+        ArgumentCaptor<LocalDateTime> renewedAt = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> expiresAt = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(mapper).renew(eq("native-alert-collection"), anyString(),
+                renewedAt.capture(), expiresAt.capture());
+        assertThat(Duration.between(renewedAt.getValue(), expiresAt.getValue()))
+                .isEqualTo(Duration.ofMinutes(1));
     }
 }


### PR DESCRIPTION
## Summary

Extends the existing `MybatisPlusAlertCollectionLeaseTest` (2 to 6 tests) to pin down the lease acquisition paths that were untested.

Added cases:
- `tryAcquire` renews the live row when the conditional update succeeds (no insert happens);
- when no live row can be renewed, `tryAcquire` inserts its own row sharing the acquire-attempt holder id and lease name;
- the insert-race is lost gracefully when another replica inserts first (`DuplicateKeyException` → false);
- `renew` falls back to a one-minute lease window for a malformed configured duration (window asserted via argument capture).

## Why

The lease coordinates native collection across replicas; the upstream suite covered only the two `renew` outcomes.

## Testing

`mvn -B test -Dtest=MybatisPlusAlertCollectionLeaseTest` — 6/6 pass; checkstyle (validate) clean.