### PR TITLE
test(auth): cover studio user DTO password redaction

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/SensitiveRequestToStringTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/SensitiveRequestToStringTest.java
@@ -66,4 +66,22 @@ class SensitiveRequestToStringTest {
                 .contains("instanceId=instance-1")
                 .doesNotContain("metrics-password", "metrics-bearer-token");
     }
+
+    @Test
+    void studioUserDtoRedactsPlainAndResetPasswords() {
+        CreateStudioUserDTO create = new CreateStudioUserDTO();
+        create.setUsername("alice");
+        create.setPassword("plain-create-password");
+
+        ResetPasswordDTO reset = new ResetPasswordDTO();
+        reset.setNewPassword("plain-reset-password");
+
+        assertThat(create.toString())
+                .contains("username=alice")
+                .doesNotContain("plain-create-password")
+                .doesNotContain("password");
+        assertThat(reset.toString())
+                .doesNotContain("plain-reset-password")
+                .doesNotContain("password");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `SensitiveRequestToStringTest` (1 to 2 tests) to cover the studio user DTOs, which the request-redaction sweep did not include yet.

Added case:
- `CreateStudioUserDTO` keeps `username` visible but never emits the plain password or even the field name, and `ResetPasswordDTO` never emits its new password or field name through `toString`.

## Why

Both DTOs carry plaintext passwords at the API boundary; the sweep already covered credential, LLM, and data-source DTOs but not these.

## Testing

`mvn -B test -Dtest=SensitiveRequestToStringTest` — 2/2 pass; checkstyle (validate) clean.