### PR TITLE
fix(acl): redact plain access keys from VO toString

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/acl/PlainAccessConfigVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/acl/PlainAccessConfigVO.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.instance.acl;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -39,6 +40,7 @@ import java.util.List;
 public class PlainAccessConfigVO {
 
     /** Unique access key identifying the account. */
+    @ToString.Exclude
     private String accessKey;
 
     /**
@@ -46,6 +48,7 @@ public class PlainAccessConfigVO {
      * when it was just provided. Read-back views return a masked value, and the plaintext is
      * available solely through the explicit per-user credentials endpoint.
      */
+    @ToString.Exclude
     private String secretKey;
 
     /** IP whitelist pattern for this account; persisted, empty/null means no restriction. */

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/PlainAccessConfigVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/PlainAccessConfigVOTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.acl;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link PlainAccessConfigVO}: the plain-access view must never leak its
+ * access/secret keys through {@code toString} while still comparing equal on them.
+ */
+class PlainAccessConfigVOTest {
+
+    @Test
+    void toStringRedactsTheCredentialKeys() {
+        PlainAccessConfigVO config = PlainAccessConfigVO.builder()
+                .accessKey("rocketmq-access-key")
+                .secretKey("rocketmq-secret-key")
+                .whiteRemoteAddress("10.0.0.0/8")
+                .admin(true)
+                .defaultTopicPerm("DENY")
+                .topicPerms(List.of("order-*=PUB"))
+                .build();
+
+        String value = config.toString();
+
+        assertThat(value).contains("whiteRemoteAddress=10.0.0.0/8").contains("defaultTopicPerm=DENY");
+        assertThat(value).doesNotContain("accessKey").doesNotContain("secretKey");
+        assertThat(value).doesNotContain("rocketmq-access-key").doesNotContain("rocketmq-secret-key");
+    }
+
+    @Test
+    void dataEqualityCoversTheCredentialKeys() {
+        PlainAccessConfigVO first = PlainAccessConfigVO.builder()
+                .accessKey("ak-1").secretKey("sk-1").build();
+        PlainAccessConfigVO same = PlainAccessConfigVO.builder()
+                .accessKey("ak-1").secretKey("sk-1").build();
+        PlainAccessConfigVO rotated = PlainAccessConfigVO.builder()
+                .accessKey("ak-1").secretKey("sk-2").build();
+
+        assertThat(first).isEqualTo(same).hasSameHashCodeAs(same);
+        assertThat(first).isNotEqualTo(rotated);
+    }
+}


### PR DESCRIPTION
## Summary

Marks the plain-access view's `accessKey` and `secretKey` as `@ToString.Exclude` and adds `PlainAccessConfigVOTest` locking the contract.

Coverage:
- `toString` keeps the non-secret fields (`whiteRemoteAddress`, `defaultTopicPerm`) while omitting both credential field names and values;
- `@Data` equality/hashCode still cover the keys, so a rotated secret is not equal.

## Why

The VO carries plaintext credentials on the ACL write/read paths and is logged during ACL operations; exposing AK/SK through `toString` is a credential leak vector (same class of issue as the credential/acl-user rows).

## Testing

`mvn -B test -Dtest=PlainAccessConfigVOTest` — 2/2 pass; checkstyle (validate) clean.