### PR TITLE
fix(metrics): redact data source credentials from config toString

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/model/MetricsDataSourceConfig.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/model/MetricsDataSourceConfig.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.studio.model;
 
 import lombok.Data;
+import lombok.ToString;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -58,11 +59,13 @@ public class MetricsDataSourceConfig implements Serializable {
     /**
      * Password for basic authentication (encrypted in storage).
      */
+    @ToString.Exclude
     private String password;
 
     /**
      * Bearer token for bearer authentication.
      */
+    @ToString.Exclude
     private String bearerToken;
 
     /**

--- a/server/src/test/java/org/apache/rocketmq/studio/model/MetricsDataSourceConfigTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/MetricsDataSourceConfigTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link MetricsDataSourceConfig}: the raw data-source configuration model
+ * carries credentials and must never leak them through {@code toString} while still
+ * comparing equal on them.
+ */
+class MetricsDataSourceConfigTest {
+
+    @Test
+    void toStringRedactsPasswordAndBearerToken() {
+        MetricsDataSourceConfig config = new MetricsDataSourceConfig();
+        config.setName("prometheus");
+        config.setUrl("https://metrics.example.test");
+        config.setPassword("plain-password");
+        config.setBearerToken("plain-bearer");
+
+        String value = config.toString();
+
+        assertThat(value).contains("name=prometheus").contains("url=https://metrics.example.test");
+        assertThat(value).doesNotContain("password").doesNotContain("bearerToken");
+        assertThat(value).doesNotContain("plain-password").doesNotContain("plain-bearer");
+    }
+
+    @Test
+    void dataEqualityCoversPasswordAndBearerToken() {
+        MetricsDataSourceConfig first = new MetricsDataSourceConfig();
+        first.setName("prometheus");
+        first.setPassword("pw-1");
+        first.setBearerToken("bt-1");
+
+        MetricsDataSourceConfig same = new MetricsDataSourceConfig();
+        same.setName("prometheus");
+        same.setPassword("pw-1");
+        same.setBearerToken("bt-1");
+
+        MetricsDataSourceConfig rotated = new MetricsDataSourceConfig();
+        rotated.setName("prometheus");
+        rotated.setPassword("pw-1");
+        rotated.setBearerToken("bt-2");
+
+        assertThat(first).isEqualTo(same).hasSameHashCodeAs(same);
+        assertThat(first).isNotEqualTo(rotated);
+    }
+}


### PR DESCRIPTION
## Summary

Marks `MetricsDataSourceConfig.password`/`bearerToken` as `@ToString.Exclude` and adds `MetricsDataSourceConfigTest` locking the contract.

Coverage:
- `toString` keeps the non-secret fields (`name`, `url`) while omitting both credential field names and values;
- `@Data` equality/hashCode still cover the credentials, so a rotated token is not equal.

## Why

The raw config model holds credentials that are encrypted only at rest; logs and debug output must not surface them through `toString`.

## Testing

`mvn -B test -Dtest=MetricsDataSourceConfigTest` — 2/2 pass; checkstyle (validate) clean.