### PR TITLE
test(alert): deepen alert rule request DTO coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTOTest.java
@@ -67,4 +67,49 @@ class AlertRuleRequestDTOTest {
 
         assertThat(request.toAlertRuleVO().getMetric()).isEqualTo("consumer.lag.total");
     }
+
+    @Test
+    void rejectsInvalidEnumsAndOutOfRangeValuesTest() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName(" ");
+        request.setOperator("like");
+        request.setDuration("abc");
+        request.setAggregation("custom");
+        request.setSeverity("fatal");
+        request.setWindowSeconds(-1);
+        request.setConsecutiveSamples(0);
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .contains("name is required", "operator is invalid", "duration is invalid",
+                        "aggregation is invalid", "severity is invalid",
+                        "windowSeconds must not be negative",
+                        "consecutiveSamples must be at least 1");
+    }
+
+    @Test
+    void fillsSensibleDefaultsForMissingOptionalFieldsTest() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName("High Lag");
+
+        AlertRuleVO vo = request.toAlertRuleVO();
+
+        assertThat(vo.getAggregation()).isEqualTo("LAST");
+        assertThat(vo.getWindowSeconds()).isZero();
+        assertThat(vo.getConsecutiveSamples()).isEqualTo(1);
+        assertThat(vo.getReminderInterval()).isEqualTo("30m");
+        assertThat(vo.getMetric()).isNull();
+    }
+
+    @Test
+    void acceptsCaseInsensitiveEnumsAndValidCompositeDurationTest() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName("High Lag");
+        request.setOperator(">=");
+        request.setDuration("2h30m");
+        request.setAggregation("max");
+        request.setSeverity("WARNING");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `AlertRuleRequestDTOTest` (4 to 7 tests) to pin down the alert-rule request validation contract.

Added cases:
- invalid operators, durations, aggregations, severities, a negative window, zero consecutive samples, and a blank name are each rejected with their dedicated messages;
- `toAlertRuleVO` fills sensible defaults for omitted optionals (aggregation `LAST`, window 0, consecutive samples 1, reminder `30m`, null metric);
- case-insensitive enum values (`max`, `WARNING`) and a valid composite duration pass validation.

## Why

The DTO gates every alert rule create/update payload; only channel/duration/metric normalization branches were covered before.

## Testing

`mvn -B test -Dtest=AlertRuleRequestDTOTest` — 7/7 pass; checkstyle (validate) clean.