### PR TITLE
test(group): cover consumer diagnostics blank instance handling

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerDiagnosticsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerDiagnosticsServiceTest.java
@@ -95,4 +95,21 @@ class ConsumerDiagnosticsServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("clientId is required");
     }
+
+    @Test
+    void getConsumerStackTreatsBlankInstanceAsUnscoped() {
+        ConsumerStackTraceVO stackTrace = ConsumerStackTraceVO.builder()
+                .groupName("cg-orders")
+                .clientId("client-1")
+                .threads(List.of())
+                .build();
+        when(diagnosticsProvider.getConsumerStack(null, "cg-orders", "client-1"))
+                .thenReturn(stackTrace);
+
+        ConsumerStackTraceVO result = diagnosticsService.getConsumerStack(
+                "   ", "cg-orders", "client-1");
+
+        assertThat(result.getGroupName()).isEqualTo("cg-orders");
+        verify(diagnosticsProvider).getConsumerStack(null, "cg-orders", "client-1");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `ConsumerDiagnosticsServiceTest` (4 to 5 tests) with the blank-instance branch.

Added case:
- a blank/whitespace instance id is normalized to `null` (unscoped) before delegation, while group and client id remain required.

## Why

The instance selector is optional for unscoped stack lookups; only group/client validation and trimming were covered before.

## Testing

`mvn -B test -Dtest=ConsumerDiagnosticsServiceTest` — 5/5 pass; checkstyle (validate) clean.