### PR TITLE
test(instance): deepen instance capability service coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceCapabilityServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceCapabilityServiceTest.java
@@ -101,4 +101,32 @@ class InstanceCapabilityServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
     }
+
+    @Test
+    void getCapabilitiesShouldReturnEmptyListWhenProviderHasNoneTest() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("cloud-1").vendor(InstanceVendor.ALIYUN).type(InstanceType.CLOUD).build();
+        instance.setId(3L);
+        when(instanceRepository.findById(3L)).thenReturn(Optional.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(instanceProvider);
+        when(instanceProvider.capabilities()).thenReturn(Set.of());
+
+        assertThat(service.getCapabilities(3L).capabilities()).isEmpty();
+    }
+
+    @Test
+    void getCapabilitiesShouldPreserveTencentVendorAndTypeTest() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("cloud-2").vendor(InstanceVendor.TENCENT).type(InstanceType.CLOUD).build();
+        instance.setId(4L);
+        when(instanceRepository.findById(4L)).thenReturn(Optional.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.TENCENT)).thenReturn(instanceProvider);
+        when(instanceProvider.capabilities()).thenReturn(Set.of(InstanceCapability.DLQ_MANAGEMENT));
+
+        InstanceCapabilitiesVO result = service.getCapabilities(4L);
+
+        assertThat(result.vendor()).isEqualTo(InstanceVendor.TENCENT);
+        assertThat(result.accessType()).isEqualTo(InstanceType.CLOUD);
+        assertThat(result.capabilities()).containsExactly(InstanceCapability.DLQ_MANAGEMENT);
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `InstanceCapabilityServiceTest` (3 to 5 tests) to pin down the remaining resolution branches.

Added cases:
- a provider exposing no capabilities yields an empty capability list (not an error);
- a Tencent cloud instance keeps its vendor and access type through the view with its provider capabilities.

## Why

The service advertises the capability contract per instance; only Aliyun/DIRECT and unknown-instance branches were covered before.

## Testing

`mvn -B test -Dtest=InstanceCapabilityServiceTest` — 5/5 pass; checkstyle (validate) clean.