### PR TITLE
test(audit): cover full audit field mapping

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/audit/OperationAuditServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/audit/OperationAuditServiceTest.java
@@ -79,4 +79,25 @@ class OperationAuditServiceTest {
                 "cluster-a", "result=SUCCESS", "SUCCESS", null))
                 .doesNotThrowAnyException();
     }
+
+    @Test
+    void recordShouldMapEveryFieldAndStampBothTimestamps() {
+        OperationAuditService service = new OperationAuditService(auditMapper);
+
+        service.record("DELETE", "GROUP", "cg-orders", "cluster-a",
+                "removed consumer group", "SUCCESS", "no-error");
+
+        ArgumentCaptor<RmqOperationAudit> captor = ArgumentCaptor.forClass(RmqOperationAudit.class);
+        verify(auditMapper).insert(captor.capture());
+        RmqOperationAudit audit = captor.getValue();
+        assertThat(audit.getOperation()).isEqualTo("DELETE");
+        assertThat(audit.getResourceType()).isEqualTo("GROUP");
+        assertThat(audit.getResourceName()).isEqualTo("cg-orders");
+        assertThat(audit.getClusterId()).isEqualTo("cluster-a");
+        assertThat(audit.getDetail()).isEqualTo("removed consumer group");
+        assertThat(audit.getResult()).isEqualTo("SUCCESS");
+        assertThat(audit.getErrorMessage()).isEqualTo("no-error");
+        assertThat(audit.getGmtCreate()).isNotNull();
+        assertThat(audit.getGmtCreate()).isEqualTo(audit.getGmtModified());
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `OperationAuditServiceTest` (3 to 4 tests) with the full field-mapping branch.

Added case:
- `record` maps operation, resource type/name, cluster id, detail, result, and error message onto the persisted row, and stamps both create and modified timestamps (non-null and equal).

## Why

The suite previously covered only the operator resolution and failure swallowing; the row content contract was unverified.

## Testing

`mvn -B test -Dtest=OperationAuditServiceTest` — 4/4 pass; checkstyle (validate) clean.