### PR TITLE
test(grafana): cover unknown dashboard 404

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -96,5 +97,19 @@ class GrafanaDashboardControllerTest {
                 .andExpect(header().string("Content-Disposition",
                         "attachment; filename=\"rocketmq-grafana-dashboards.zip\""))
                 .andExpect(content().bytes(archive));
+    }
+
+    @Test
+    void unknownDashboardIsNotFoundForModelAndExport() throws Exception {
+        org.apache.rocketmq.studio.common.exception.BusinessException missing =
+                new org.apache.rocketmq.studio.common.exception.BusinessException(
+                        404, "Grafana dashboard not found: ghost");
+        doThrow(missing).when(grafanaDashboardService).getDashboard("ghost");
+        doThrow(missing).when(grafanaDashboardService).getDashboardJson("ghost");
+
+        mockMvc.perform(get("/api/metrics/grafana/dashboards/ghost"))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(get("/api/metrics/grafana/dashboards/ghost/export"))
+                .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
## Summary

Extends the existing `GrafanaDashboardControllerTest` (4 to 5 tests) with the unknown-uid branch.

Added case:
- requesting an unknown dashboard uid through either the model or export endpoint surfaces the service's `BusinessException` (404) as an HTTP 404 response.

## Why

The endpoints document 404 for unknown uids; only the happy paths (list/model/export/zip) were covered before.

## Testing

`mvn -B test -Dtest=GrafanaDashboardControllerTest` — 5/5 pass; checkstyle (validate) clean.