### PR TITLE
test(broker): cover cluster repository empty lookups

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
@@ -82,4 +82,18 @@ class ClusterRepositoryImplTest {
         assertThat(repository.findById("cluster-001").orElseThrow().getConfig().getFileReservedTime())
                 .isEqualTo(24);
     }
+
+    @Test
+    void findByIdShouldBeEmptyForUnknownIds() {
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(true);
+
+        assertThat(repository.findById("no-such-cluster")).isEmpty();
+    }
+
+    @Test
+    void findByIdShouldBeEmptyWhenDemoDataIsDisabled() {
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(false);
+
+        assertThat(repository.findById("cluster-001")).isEmpty();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `ClusterRepositoryImplTest` (4 to 6 tests) with the empty-lookup branches.

Added cases:
- `findById` is empty for an unknown cluster id;
- with demo data disabled, `findById` is empty even for known demo ids.

## Why

The demo-backed repository is a fallback used in no-auth deployments; only enabled-path ordering and deep-copy semantics were covered before.

## Testing

`mvn -B test -Dtest=ClusterRepositoryImplTest` — 6/6 pass; checkstyle (validate) clean.