### PR TITLE
test(alert): cover state repository empty and failed lookups

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepositoryTest.java
@@ -141,4 +141,26 @@ class MybatisPlusAlertStateRepositoryTest {
         alert.setLabelsJson(labelsJson);
         return alert;
     }
+
+    @Test
+    void findReturnsEmptyWhenNoStateRowExistsTest() {
+        RmqAlertStateMapper mapper = mock(RmqAlertStateMapper.class);
+        when(mapper.selectOne(any())).thenReturn(null);
+        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper,
+                mock(RmqSystemAlertMapper.class));
+
+        assertThat(repository.find(new AlertStateKey(4L, "fingerprint"))).isEmpty();
+    }
+
+    @Test
+    void acknowledgeReportsFalseWhenNoFiringRowIsUpdatedTest() {
+        RmqAlertStateMapper mapper = mock(RmqAlertStateMapper.class);
+        Instant firedAt = Instant.parse("2026-08-22T12:00:00Z");
+        when(mapper.acknowledgeFiring(eq(4L), eq("fingerprint"),
+                eq(LocalDateTime.ofInstant(firedAt, ZoneOffset.UTC)), any())).thenReturn(0);
+        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper,
+                mock(RmqSystemAlertMapper.class));
+
+        assertThat(repository.acknowledge(new AlertStateKey(4L, "fingerprint"), firedAt)).isFalse();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `MybatisPlusAlertStateRepositoryTest` (4 to 6 tests) with the failure branches.

Added cases:
- `find` returns empty when no state row exists for the key;
- `acknowledge` reports false when the conditional firing-state update matches no row (e.g. the alert already resolved or the key moved on).

## Why

The repository guards state transitions against concurrent acks; only the success and active-state branches were covered before.

## Testing

`mvn -B test -Dtest=MybatisPlusAlertStateRepositoryTest` — 6/6 pass; checkstyle (validate) clean.