### PR TITLE
test(alert): cover alert silence delete outcome

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
@@ -156,4 +156,15 @@ class MybatisPlusAlertSilenceRepositoryTest {
         assertThat(restored.get(1).getRecurrence()).isEqualTo(AlertSilenceRecurrence.ONCE);
         assertThat(restored.get(1).getRecurrenceDays()).isEmpty();
     }
+
+    @Test
+    void deleteByIdShouldReflectTheMapperOutcomeTest() {
+        MybatisPlusAlertSilenceRepository repository = new MybatisPlusAlertSilenceRepository(
+                mapper, new ObjectMapper());
+        when(mapper.deleteById(12L)).thenReturn(1);
+        assertThat(repository.deleteById(12L)).isTrue();
+
+        when(mapper.deleteById(13L)).thenReturn(0);
+        assertThat(repository.deleteById(13L)).isFalse();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `MybatisPlusAlertSilenceRepositoryTest` (4 to 5 tests) with the delete branch.

Added case:
- `deleteById` reflects the mapper outcome (true when a row was deleted, false when nothing matched).

## Why

The delete flow drives the silence removal action; the repository suite previously covered page/find/save/all restore paths only.

## Testing

`mvn -B test -Dtest=MybatisPlusAlertSilenceRepositoryTest` — 5/5 pass; checkstyle (validate) clean.