### PR TITLE
test(alert): deepen alert rule evaluator coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleEvaluatorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleEvaluatorTest.java
@@ -88,4 +88,27 @@ class AlertRuleEvaluatorTest {
         return new MetricSample("broker.disk.usage_ratio", AlertDomain.CLUSTER, "local", null, null, value,
                 availability, Instant.now());
     }
+
+    @Test
+    void numericLessThanOperatorMatchesWhenBelowThresholdTest() {
+        AlertRuleVO rule = AlertRuleVO.builder().domain(AlertDomain.CLUSTER).metric("broker.disk.usage_ratio")
+                .operator("<").threshold(0.1).enabled(true).build();
+
+        AlertEvaluationResult result = evaluator.evaluate(rule,
+                sample(MetricAvailability.AVAILABLE, 0.05));
+
+        assertThat(result.matches()).isTrue();
+        assertThat(result.conditionMet()).isTrue();
+        assertThat(result.currentValue()).isEqualTo(0.05);
+    }
+
+    @Test
+    void doesNotEvaluateSamplesForOtherMetricKeysTest() {
+        AlertRuleVO rule = AlertRuleVO.builder().domain(AlertDomain.CLUSTER).metric("broker.disk.usage_ratio")
+                .operator(">=").threshold(0.85).enabled(true).build();
+        MetricSample other = new MetricSample("broker.jvm.heap.usage_ratio", AlertDomain.CLUSTER,
+                "local", null, null, 0.9, MetricAvailability.AVAILABLE, Instant.now());
+
+        assertThat(evaluator.evaluate(rule, other).matches()).isFalse();
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `AlertRuleEvaluatorTest` (5 to 7 tests) to pin down two more evaluation branches.

Added cases:
- a numeric less-than rule matches when the available value is below the threshold;
- samples for a different metric key are never evaluated/matched, even when the domain matches.

## Why

The evaluator decides native alert triggering; only >=, percent, unavailable, and domain-mismatch branches were covered before.

## Testing

`mvn -B test -Dtest=AlertRuleEvaluatorTest` — 7/7 pass; checkstyle (validate) clean.