### PR TITLE
test(provider): cover broker config numeric parsing fallbacks

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQBrokerConfigServiceTest.java
@@ -6,6 +6,8 @@
  */
 package org.apache.rocketmq.studio.provider.apache;
 
+import org.apache.rocketmq.studio.cluster.config.ClusterConfigVO;
+
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.cluster.broker.MqAdminExtFactory;
 import org.apache.rocketmq.studio.common.domain.enums.FlushDiskType;
@@ -106,5 +108,25 @@ class RocketMQBrokerConfigServiceTest {
 
         assertThat(brokerConfigService.getBrokerConfig("broker-b:10911").getFlushDiskType())
                 .isEqualTo(FlushDiskType.ASYNC_FLUSH);
+    }
+
+    @Test
+    void configParsingFallsBackOnMissingAndMalformedNumericValues() throws Exception {
+        Properties malformed = new Properties();
+        malformed.setProperty("defaultTopicQueueNums", "abc");
+        when(adminExt.getBrokerConfig("broker-a:10911")).thenReturn(malformed);
+
+        ClusterConfigVO vo = brokerConfigService.getBrokerConfig("broker-a:10911");
+        assertThat(vo.getWriteQueueNums()).isEqualTo(8);
+        assertThat(vo.getReadQueueNums()).isEqualTo(8);
+        assertThat(vo.getMaxMessageSize()).isEqualTo(4194304);
+
+        Properties valid = new Properties();
+        valid.setProperty("defaultTopicQueueNums", "16");
+        valid.setProperty("maxMessageSize", "5242880");
+        when(adminExt.getBrokerConfig("broker-b:10911")).thenReturn(valid);
+        ClusterConfigVO parsed = brokerConfigService.getBrokerConfig("broker-b:10911");
+        assertThat(parsed.getWriteQueueNums()).isEqualTo(16);
+        assertThat(parsed.getMaxMessageSize()).isEqualTo(5242880);
     }
 }


### PR DESCRIPTION
## Summary

Extends the existing `RocketMQBrokerConfigServiceTest` (4 to 5 tests) with the numeric parsing branch.

Added case:
- malformed or missing numeric broker properties fall back to the documented defaults (`defaultTopicQueueNums` → 8, `maxMessageSize` → 4194304), while well-formed values parse through.

## Why

The service shapes broker configs for the cluster UI; only flush-disk parsing, update, and audit branches were covered before.

## Testing

`mvn -B test -Dtest=RocketMQBrokerConfigServiceTest` — 5/5 pass; checkstyle (validate) clean.