### PR TITLE
test(topic): cover lite topic extend TTL input guards

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicServiceTest.java
@@ -79,4 +79,17 @@ class LiteTopicServiceTest {
     void getCapabilityShouldReportUnsupportedByDefault() {
         assertThat(liteTopicService.getCapability().isSupported()).isFalse();
     }
+
+    @Test
+    void extendTTLShouldRejectNullAndNegativeInputs() {
+        assertThatThrownBy(() -> liteTopicService.extendTTL(null, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topicPattern is required");
+        assertThatThrownBy(() -> liteTopicService.extendTTL("chat/{sessionId}", null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("newTTL must be positive");
+        assertThatThrownBy(() -> liteTopicService.extendTTL("chat/{sessionId}", -1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("newTTL must be positive");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `LiteTopicServiceTest` (6 to 7 tests) with the remaining input guards.

Added case:
- `extendTTL` rejects a null topic pattern, and a null or negative TTL, with the same 400 messages as the blank/zero cases.

## Why

The service is a placeholder for provider integrations but still validates caller input; only blank/zero inputs were covered before.

## Testing

`mvn -B test -Dtest=LiteTopicServiceTest` — 7/7 pass; checkstyle (validate) clean.