### PR TITLE
test(client): cover producer groups parameter handling

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerControllerTest.java
@@ -143,4 +143,22 @@ class ProducerControllerTest {
 
         verifyNoInteractions(producerConnectionService);
     }
+
+    @Test
+    void listProducerGroupsShouldRejectAMissingInstanceId() throws Exception {
+        mockMvc.perform(get("/api/producer/groups").param("topic", "order-topic"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void listProducerGroupsShouldForwardOptionalDefaults() throws Exception {
+        when(producerConnectionService.listProducerGroups("instance-1", null, null, null))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/producer/groups").param("instanceId", "instance-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isEmpty());
+
+        verify(producerConnectionService).listProducerGroups("instance-1", null, null, null);
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `ProducerControllerTest` (6 to 8 tests) with the groups-endpoint parameter branches.

Added cases:
- a missing required `instanceId` on `GET /api/producer/groups` is rejected with HTTP 400;
- when only the instance id is supplied, the optional topic/query/limit parameters are forwarded as null.

## Why

The suite covered the connection endpoint deeply but only the groups happy path.

## Testing

`mvn -B test -Dtest=ProducerControllerTest` — 8/8 pass; checkstyle (validate) clean.