### PR TITLE
test(alert): cover cluster alert rule update delete and bulk toggle

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/ClusterAlertRuleControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/ClusterAlertRuleControllerTest.java
@@ -153,4 +153,47 @@ class ClusterAlertRuleControllerTest {
 
         verify(alertService).toggleRule(AlertDomain.CLUSTER, 7L, false);
     }
+
+    @Test
+    void updateRuleShouldRequireAnId() throws Exception {
+        mockMvc.perform(post("/api/cluster-alert-rules/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Broker unavailable\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("id is required"));
+    }
+
+    @Test
+    void updateRuleShouldForceClusterDomain() throws Exception {
+        AlertRuleVO updated = AlertRuleVO.builder().id(7L).name("Broker unavailable")
+                .domain(AlertDomain.CLUSTER).build();
+        when(alertService.updateRule(eq(AlertDomain.CLUSTER), any(AlertRuleVO.class)))
+                .thenReturn(updated);
+
+        mockMvc.perform(post("/api/cluster-alert-rules/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"id\":7,\"name\":\"Broker unavailable\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.domain").value("CLUSTER"));
+
+        verify(alertService).updateRule(eq(AlertDomain.CLUSTER), any(AlertRuleVO.class));
+    }
+
+    @Test
+    void deleteAndBulkToggleShouldUseClusterDomain() throws Exception {
+        mockMvc.perform(post("/api/cluster-alert-rules/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"id\":7}"))
+                .andExpect(status().isOk());
+        verify(alertService).deleteRule(AlertDomain.CLUSTER, 7L);
+
+        AlertRuleBulkResultVO bulkResult = AlertRuleBulkResultVO.builder().build();
+        when(alertService.bulkToggleRules(AlertDomain.CLUSTER, java.util.List.of(7L, 8L), true))
+                .thenReturn(bulkResult);
+        mockMvc.perform(post("/api/cluster-alert-rules/bulk-toggle")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"ids\":[7,8],\"enabled\":true}"))
+                .andExpect(status().isOk());
+        verify(alertService).bulkToggleRules(AlertDomain.CLUSTER, java.util.List.of(7L, 8L), true);
+    }
 }


### PR DESCRIPTION
## Summary

Extends the existing `ClusterAlertRuleControllerTest` (6 to 9 tests) with the remaining mutation endpoints.

Added cases:
- `POST /update` rejects a body without an id with `id is required`;
- `POST /update` forces the CLUSTER domain on the updated rule;
- `POST /delete` delegates with the CLUSTER domain, and `POST /bulk-toggle` delegates the id list/enabled flag.

## Why

The suite covered list/page/runtime/transfer/create/toggle only; update/delete/bulk flows drive the cluster alert rule management page.

## Testing

`mvn -B test -Dtest=ClusterAlertRuleControllerTest` — 9/9 pass; checkstyle (validate) clean.