### PR TITLE
feat(audit): add operator filter

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditController.java
@@ -41,13 +41,14 @@ public class AuditController {
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "20") int pageSize,
             @RequestParam(required = false) String search,
+            @RequestParam(required = false) String operator,
             @RequestParam(required = false) String operationType,
             @RequestParam(required = false) String resourceType,
             @RequestParam(required = false) String clusterId,
             @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate,
             @RequestParam(required = false) String result) {
-        return Result.ok(auditService.queryLogs(page, pageSize, search, operationType,
+        return Result.ok(auditService.queryLogs(page, pageSize, search, operator, operationType,
                 resourceType, clusterId, startDate, endDate, result));
     }
 
@@ -59,26 +60,28 @@ public class AuditController {
     @GetMapping("/summary")
     public Result<AuditSummaryVO> summarize(
             @RequestParam(required = false) String search,
+            @RequestParam(required = false) String operator,
             @RequestParam(required = false) String operationType,
             @RequestParam(required = false) String resourceType,
             @RequestParam(required = false) String clusterId,
             @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate,
             @RequestParam(required = false) String result) {
-        return Result.ok(auditService.summarize(search, operationType, resourceType,
+        return Result.ok(auditService.summarize(search, operator, operationType, resourceType,
                 clusterId, startDate, endDate, result));
     }
 
     @GetMapping("/export")
     public Result<String> exportLogs(
             @RequestParam(required = false) String search,
+            @RequestParam(required = false) String operator,
             @RequestParam(required = false) String operationType,
             @RequestParam(required = false) String resourceType,
             @RequestParam(required = false) String clusterId,
             @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate,
             @RequestParam(required = false) String result) {
-        return Result.ok(auditService.exportLogs(search, operationType, resourceType,
+        return Result.ok(auditService.exportLogs(search, operator, operationType, resourceType,
                 clusterId, startDate, endDate, result));
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditFilterOptionsVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditFilterOptionsVO.java
@@ -28,6 +28,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AuditFilterOptionsVO {
+    private List<String> operators;
     private List<String> operationTypes;
     private List<String> resourceTypes;
     private List<String> clusterIds;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditRepository.java
@@ -20,14 +20,14 @@ import java.time.LocalDateTime;
 import org.apache.rocketmq.studio.common.domain.PageResult;
 
 public interface AuditRepository {
-    PageResult<AuditRecordVO> findPage(String search, String operationType,
+    PageResult<AuditRecordVO> findPage(String search, String operator, String operationType,
                                        String resourceType, String clusterId,
                                        LocalDateTime startDate, LocalDateTime endDate,
                                        String result, int page, int pageSize);
 
     AuditFilterOptionsVO findFilterOptions();
 
-    AuditSummaryVO summarize(String search, String operationType, String resourceType,
+    AuditSummaryVO summarize(String search, String operator, String operationType, String resourceType,
                              String clusterId, LocalDateTime startDate, LocalDateTime endDate,
                              String result);
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/AuditService.java
@@ -45,15 +45,15 @@ public class AuditService {
     private final AuditRepository auditRepository;
 
 
-    public PageResult<AuditRecordVO> queryLogs(int page, int pageSize, String search,
+    public PageResult<AuditRecordVO> queryLogs(int page, int pageSize, String search, String operator,
                                              String operationType, String resourceType,
                                              String clusterId, String startDate,
                                              String endDate, String result) {
         validatePagination(page, pageSize);
-        log.info("Querying audit logs, page={}, pageSize={}, search={}, operationType={}, result={}",
-                page, pageSize, search, operationType, result);
+        log.info("Querying audit logs, page={}, pageSize={}, search={}, operator={}, operationType={}, result={}",
+                page, pageSize, search, operator, operationType, result);
 
-        return findPage(search, operationType, resourceType, clusterId,
+        return findPage(search, operator, operationType, resourceType, clusterId,
                 startDate, endDate, result, page, pageSize);
     }
 
@@ -61,17 +61,17 @@ public class AuditService {
         return auditRepository.findFilterOptions();
     }
 
-    public AuditSummaryVO summarize(String search, String operationType, String resourceType,
+    public AuditSummaryVO summarize(String search, String operator, String operationType, String resourceType,
                                     String clusterId, String startDate, String endDate, String result) {
         DateRange range = parseDateRange(startDate, endDate);
-        return auditRepository.summarize(search, operationType, resourceType, clusterId,
+        return auditRepository.summarize(search, operator, operationType, resourceType, clusterId,
                 range.start(), range.end(), result);
     }
 
-    public String exportLogs(String search, String operationType, String resourceType,
+    public String exportLogs(String search, String operator, String operationType, String resourceType,
                              String clusterId, String startDate, String endDate, String result) {
         PageResult<AuditRecordVO> page = findPage(
-                search, operationType, resourceType, clusterId,
+                search, operator, operationType, resourceType, clusterId,
                 startDate, endDate, result, 1, MAX_EXPORT_RECORDS);
         if (page.getTotal() > MAX_EXPORT_RECORDS) {
             throw new BusinessException(400,
@@ -139,12 +139,12 @@ public class AuditService {
         }
     }
 
-    private PageResult<AuditRecordVO> findPage(String search, String operationType,
+    private PageResult<AuditRecordVO> findPage(String search, String operator, String operationType,
                                                String resourceType, String clusterId,
                                                String startDate, String endDate,
                                                String result, int page, int pageSize) {
         DateRange range = parseDateRange(startDate, endDate);
-        return auditRepository.findPage(search, operationType, resourceType, clusterId,
+        return auditRepository.findPage(search, operator, operationType, resourceType, clusterId,
                 range.start(), range.end(), result, page, pageSize);
     }
 

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepository.java
@@ -53,7 +53,7 @@ public class MybatisPlusAuditRepository implements AuditRepository {
     private volatile CachedFilterOptions cachedFilterOptions;
 
     @Override
-    public PageResult<AuditRecordVO> findPage(String search, String operationType,
+    public PageResult<AuditRecordVO> findPage(String search, String operator, String operationType,
                                               String resourceType, String clusterId,
                                               LocalDateTime startDate, LocalDateTime endDate,
                                               String result, int page, int pageSize) {
@@ -62,6 +62,7 @@ public class MybatisPlusAuditRepository implements AuditRepository {
                         .like("operator", search)
                         .or().like("resource_name", search)
                         .or().like("detail", search))
+                .eq(StringUtils.hasText(operator), "operator", operator)
                 .eq(StringUtils.hasText(operationType), "operation", operationType)
                 .eq(StringUtils.hasText(resourceType), "resource_type", resourceType)
                 .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)
@@ -98,9 +99,10 @@ public class MybatisPlusAuditRepository implements AuditRepository {
     private AuditFilterOptionsVO loadFilterOptions() {
         List<Map<String, Object>> values = auditMapper.selectMaps(
                 new QueryWrapper<RmqOperationAudit>()
-                        .select("operation", "resource_type", "cluster_id", "result")
-                        .groupBy("operation", "resource_type", "cluster_id", "result"));
+                        .select("operation", "resource_type", "cluster_id", "result", "operator")
+                        .groupBy("operation", "resource_type", "cluster_id", "result", "operator"));
         return AuditFilterOptionsVO.builder()
+                .operators(findDistinctValues(values, "operator"))
                 .operationTypes(findDistinctValues(values, "operation"))
                 .resourceTypes(findDistinctValues(values, "resource_type"))
                 .clusterIds(findDistinctValues(values, "cluster_id"))
@@ -109,11 +111,12 @@ public class MybatisPlusAuditRepository implements AuditRepository {
     }
 
     @Override
-    public AuditSummaryVO summarize(String search, String operationType, String resourceType,
-                                    String clusterId, LocalDateTime startDate, LocalDateTime endDate,
+    public AuditSummaryVO summarize(String search, String operator, String operationType,
+                                    String resourceType, String clusterId,
+                                    LocalDateTime startDate, LocalDateTime endDate,
                                     String result) {
         Consumer<QueryWrapper<RmqOperationAudit>> filters = query -> applyFilters(query, search,
-                operationType, resourceType, clusterId, startDate, endDate, result);
+                operator, operationType, resourceType, clusterId, startDate, endDate, result);
 
         // One GROUP BY result query computes total / SUCCESS / FAILED / PARTIAL in a single
         // round trip instead of four separate COUNT(*) statements. Note that when the caller
@@ -195,12 +198,13 @@ public class MybatisPlusAuditRepository implements AuditRepository {
     }
 
     private void applyFilters(QueryWrapper<RmqOperationAudit> query, String search,
-                              String operationType, String resourceType, String clusterId,
+                              String operator, String operationType, String resourceType, String clusterId,
                               LocalDateTime startDate, LocalDateTime endDate, String result) {
         query.and(StringUtils.hasText(search), w -> w
                         .like("operator", search)
                         .or().like("resource_name", search)
                         .or().like("detail", search))
+                .eq(StringUtils.hasText(operator), "operator", operator)
                 .eq(StringUtils.hasText(operationType), "operation", operationType)
                 .eq(StringUtils.hasText(resourceType), "resource_type", resourceType)
                 .eq(StringUtils.hasText(clusterId), "cluster_id", clusterId)

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditControllerTest.java
@@ -61,7 +61,7 @@ class AuditControllerTest {
                 .target("topic-a")
                 .result("SUCCESS")
                 .build();
-        when(auditService.queryLogs(eq(2), eq(10), eq("topic"), eq("DELETE"),
+        when(auditService.queryLogs(eq(2), eq(10), eq("topic"), eq("admin"), eq("DELETE"),
                 eq("TOPIC"), eq("prod-cn"), eq("2026-07-01"), eq("2026-07-24"), eq("SUCCESS")))
                 .thenReturn(PageResult.of(List.of(record), 1, 2, 10));
 
@@ -69,6 +69,7 @@ class AuditControllerTest {
                         .param("page", "2")
                         .param("pageSize", "10")
                         .param("search", "topic")
+                        .param("operator", "admin")
                         .param("operationType", "DELETE")
                         .param("resourceType", "TOPIC")
                         .param("clusterId", "prod-cn")
@@ -81,7 +82,7 @@ class AuditControllerTest {
                 .andExpect(jsonPath("$.data.items[0].operationType").value("DELETE"))
                 .andExpect(jsonPath("$.data.total").value(1));
 
-        verify(auditService).queryLogs(eq(2), eq(10), eq("topic"), eq("DELETE"),
+        verify(auditService).queryLogs(eq(2), eq(10), eq("topic"), eq("admin"), eq("DELETE"),
                 eq("TOPIC"), eq("prod-cn"), eq("2026-07-01"), eq("2026-07-24"), eq("SUCCESS"));
     }
 
@@ -161,7 +162,7 @@ class AuditControllerTest {
 
     @Test
     void queryLogsShouldUseDefaultPagination() throws Exception {
-        when(auditService.queryLogs(eq(1), eq(20), isNull(), isNull(), isNull(), isNull(),
+        when(auditService.queryLogs(eq(1), eq(20), isNull(), isNull(), isNull(), isNull(), isNull(),
                 isNull(), isNull(), isNull()))
                 .thenReturn(PageResult.of(List.of(), 0, 1, 20));
 
@@ -171,18 +172,19 @@ class AuditControllerTest {
                 .andExpect(jsonPath("$.data.page").value(1))
                 .andExpect(jsonPath("$.data.size").value(20));
 
-        verify(auditService).queryLogs(eq(1), eq(20), isNull(), isNull(), isNull(), isNull(),
+        verify(auditService).queryLogs(eq(1), eq(20), isNull(), isNull(), isNull(), isNull(), isNull(),
                 isNull(), isNull(), isNull());
     }
 
     @Test
     void exportLogsShouldForwardFilters() throws Exception {
         String csv = "\uFEFFtimestamp,operator\r\n\"2026-08-01T09:30\",\"admin\"\r\n";
-        when(auditService.exportLogs(eq("topic"), eq("DELETE"), eq("TOPIC"), eq("prod-cn"),
+        when(auditService.exportLogs(eq("topic"), eq("admin"), eq("DELETE"), eq("TOPIC"), eq("prod-cn"),
                 eq("2026-08-01"), eq("2026-08-02"), eq("SUCCESS"))).thenReturn(csv);
 
         mockMvc.perform(get("/api/audit-logs/export")
                         .param("search", "topic")
+                        .param("operator", "admin")
                         .param("operationType", "DELETE")
                         .param("resourceType", "TOPIC")
                         .param("clusterId", "prod-cn")
@@ -193,13 +195,14 @@ class AuditControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").value(csv));
 
-        verify(auditService).exportLogs(eq("topic"), eq("DELETE"), eq("TOPIC"), eq("prod-cn"),
+        verify(auditService).exportLogs(eq("topic"), eq("admin"), eq("DELETE"), eq("TOPIC"), eq("prod-cn"),
                 eq("2026-08-01"), eq("2026-08-02"), eq("SUCCESS"));
     }
 
     @Test
     void getFilterOptionsShouldReturnPersistedFacets() throws Exception {
         AuditFilterOptionsVO options = AuditFilterOptionsVO.builder()
+                .operators(List.of("admin", "ops-user"))
                 .operationTypes(List.of("CREATE_TOPIC", "DELETE_TOPIC"))
                 .resourceTypes(List.of("TOPIC"))
                 .clusterIds(List.of("prod-cn"))
@@ -209,6 +212,7 @@ class AuditControllerTest {
 
         mockMvc.perform(get("/api/audit-logs/filter-options"))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.operators[0]").value("admin"))
                 .andExpect(jsonPath("$.data.operationTypes[0]").value("CREATE_TOPIC"))
                 .andExpect(jsonPath("$.data.resourceTypes[0]").value("TOPIC"))
                 .andExpect(jsonPath("$.data.clusterIds[0]").value("prod-cn"))
@@ -225,11 +229,12 @@ class AuditControllerTest {
                 .byOperation(List.of(new AuditSummaryBucketVO("DELETE_TOPIC", 5)))
                 .byResourceType(List.of(new AuditSummaryBucketVO("TOPIC", 8)))
                 .build();
-        when(auditService.summarize(eq("topic"), eq("DELETE_TOPIC"), eq("TOPIC"), eq("prod-cn"),
+        when(auditService.summarize(eq("topic"), eq("admin"), eq("DELETE_TOPIC"), eq("TOPIC"), eq("prod-cn"),
                 eq("2026-08-01"), eq("2026-08-12"), eq("SUCCESS"))).thenReturn(summary);
 
         mockMvc.perform(get("/api/audit-logs/summary")
                         .param("search", "topic")
+                        .param("operator", "admin")
                         .param("operationType", "DELETE_TOPIC")
                         .param("resourceType", "TOPIC")
                         .param("clusterId", "prod-cn")
@@ -242,7 +247,7 @@ class AuditControllerTest {
                 .andExpect(jsonPath("$.data.uniqueOperators").value(3))
                 .andExpect(jsonPath("$.data.byOperation[0].name").value("DELETE_TOPIC"));
 
-        verify(auditService).summarize(eq("topic"), eq("DELETE_TOPIC"), eq("TOPIC"), eq("prod-cn"),
+        verify(auditService).summarize(eq("topic"), eq("admin"), eq("DELETE_TOPIC"), eq("TOPIC"), eq("prod-cn"),
                 eq("2026-08-01"), eq("2026-08-12"), eq("SUCCESS"));
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditServiceTest.java
@@ -88,31 +88,31 @@ class AuditServiceTest {
     @Test
     void queryLogsDelegatesPaginationAndFiltersToRepository() {
         AuditRecordVO record = AuditRecordVO.builder().operationType("CREATE").build();
-        when(auditRepository.findPage(eq("topic-a"), eq("CREATE"), eq("TOPIC"), eq("prod-cn"),
+        when(auditRepository.findPage(eq("topic-a"), eq("admin"), eq("CREATE"), eq("TOPIC"), eq("prod-cn"),
                 isNull(), isNull(), eq("SUCCESS"), eq(2), eq(20)))
                 .thenReturn(PageResult.of(List.of(record), 21, 2, 20));
 
         PageResult<AuditRecordVO> result = auditService.queryLogs(
-                2, 20, "topic-a", "CREATE", "TOPIC", "prod-cn", null, null, "SUCCESS");
+                2, 20, "topic-a", "admin", "CREATE", "TOPIC", "prod-cn", null, null, "SUCCESS");
 
         assertThat(result.getItems()).containsExactly(record);
         assertThat(result.getTotal()).isEqualTo(21);
-        verify(auditRepository).findPage(eq("topic-a"), eq("CREATE"), eq("TOPIC"), eq("prod-cn"),
+        verify(auditRepository).findPage(eq("topic-a"), eq("admin"), eq("CREATE"), eq("TOPIC"), eq("prod-cn"),
                 isNull(), isNull(), eq("SUCCESS"), eq(2), eq(20));
     }
 
     @Test
     void queryLogsParsesDateRangeBeforeDelegating() {
-        when(auditRepository.findPage(isNull(), isNull(), isNull(), isNull(),
+        when(auditRepository.findPage(isNull(), isNull(), isNull(), isNull(), isNull(),
                 any(LocalDateTime.class), any(LocalDateTime.class), isNull(), eq(1), eq(10)))
                 .thenReturn(PageResult.empty(1, 10));
 
-        auditService.queryLogs(1, 10, null, null, null, null,
+        auditService.queryLogs(1, 10, null, null, null, null, null,
                 "2026-08-01", "2026-08-02", null);
 
         ArgumentCaptor<LocalDateTime> start = ArgumentCaptor.forClass(LocalDateTime.class);
         ArgumentCaptor<LocalDateTime> end = ArgumentCaptor.forClass(LocalDateTime.class);
-        verify(auditRepository).findPage(isNull(), isNull(), isNull(), isNull(),
+        verify(auditRepository).findPage(isNull(), isNull(), isNull(), isNull(), isNull(),
                 start.capture(), end.capture(), isNull(), eq(1), eq(10));
         assertThat(start.getValue()).isEqualTo(LocalDateTime.of(2026, 8, 1, 0, 0));
         assertThat(end.getValue()).isEqualTo(LocalDateTime.of(2026, 8, 2, 23, 59, 59, 999_999_999));
@@ -120,11 +120,11 @@ class AuditServiceTest {
 
     @Test
     void queryLogsRejectsInvalidPageBounds() {
-        assertThatThrownBy(() -> auditService.queryLogs(0, 10, null, null, null, null,
+        assertThatThrownBy(() -> auditService.queryLogs(0, 10, null, null, null, null, null,
                 null, null, null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("page must be greater than 0");
-        assertThatThrownBy(() -> auditService.queryLogs(1, 101, null, null, null, null,
+        assertThatThrownBy(() -> auditService.queryLogs(1, 101, null, null, null, null, null,
                 null, null, null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("pageSize must be between 1 and 100");
@@ -132,7 +132,7 @@ class AuditServiceTest {
 
     @Test
     void queryLogsRejectsInvalidDateRange() {
-        assertThatThrownBy(() -> auditService.queryLogs(1, 10, null, null, null, null,
+        assertThatThrownBy(() -> auditService.queryLogs(1, 10, null, null, null, null, null,
                 "2026-08-02", "2026-08-01", null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("startDate must not be after endDate");
@@ -151,11 +151,11 @@ class AuditServiceTest {
                 .result("FAILED")
                 .errorMessage("=denied")
                 .build();
-        when(auditRepository.findPage(eq("topic"), eq("DELETE"), eq("TOPIC"), eq("prod-cn"),
+        when(auditRepository.findPage(eq("topic"), eq("admin"), eq("DELETE"), eq("TOPIC"), eq("prod-cn"),
                 any(LocalDateTime.class), any(LocalDateTime.class), eq("FAILED"), eq(1), eq(10_000)))
                 .thenReturn(PageResult.of(List.of(record), 1, 1, 10_000));
 
-        String csv = auditService.exportLogs("topic", "DELETE", "TOPIC", "prod-cn",
+        String csv = auditService.exportLogs("topic", "admin", "DELETE", "TOPIC", "prod-cn",
                 "2026-08-01", "2026-08-02", "FAILED");
 
         assertThat(csv).contains("resourceType,target,clusterId,detail,result,errorMessage")
@@ -165,11 +165,11 @@ class AuditServiceTest {
 
     @Test
     void exportLogsRejectsResultsBeyondBound() {
-        when(auditRepository.findPage(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
+        when(auditRepository.findPage(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
                 isNull(), eq(1), eq(10_000)))
                 .thenReturn(PageResult.of(List.of(), 10_001, 1, 10_000));
 
-        assertThatThrownBy(() -> auditService.exportLogs(null, null, null, null, null, null, null))
+        assertThatThrownBy(() -> auditService.exportLogs(null, null, null, null, null, null, null, null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("Audit log export exceeds the maximum of 10000 records; narrow the filters");
     }
@@ -177,6 +177,7 @@ class AuditServiceTest {
     @Test
     void getFilterOptionsReturnsRepositoryValues() {
         AuditFilterOptionsVO options = AuditFilterOptionsVO.builder()
+                .operators(List.of("admin"))
                 .operationTypes(List.of("CREATE_TOPIC"))
                 .resourceTypes(List.of("TOPIC"))
                 .clusterIds(List.of("prod-cn"))
@@ -191,16 +192,16 @@ class AuditServiceTest {
     @Test
     void summarizeParsesAndForwardsTheSharedFilterRangeTest() {
         AuditSummaryVO summary = AuditSummaryVO.builder().total(12).successful(10).failed(2).build();
-        when(auditRepository.summarize(eq("topic"), eq("DELETE_TOPIC"), eq("TOPIC"), eq("prod-cn"),
+        when(auditRepository.summarize(eq("topic"), eq("admin"), eq("DELETE_TOPIC"), eq("TOPIC"), eq("prod-cn"),
                 any(LocalDateTime.class), any(LocalDateTime.class), eq("FAILED"))).thenReturn(summary);
 
-        AuditSummaryVO actual = auditService.summarize("topic", "DELETE_TOPIC", "TOPIC", "prod-cn",
+        AuditSummaryVO actual = auditService.summarize("topic", "admin", "DELETE_TOPIC", "TOPIC", "prod-cn",
                 "2026-08-01", "2026-08-02", "FAILED");
 
         assertThat(actual).isSameAs(summary);
         ArgumentCaptor<LocalDateTime> start = ArgumentCaptor.forClass(LocalDateTime.class);
         ArgumentCaptor<LocalDateTime> end = ArgumentCaptor.forClass(LocalDateTime.class);
-        verify(auditRepository).summarize(eq("topic"), eq("DELETE_TOPIC"), eq("TOPIC"), eq("prod-cn"),
+        verify(auditRepository).summarize(eq("topic"), eq("admin"), eq("DELETE_TOPIC"), eq("TOPIC"), eq("prod-cn"),
                 start.capture(), end.capture(), eq("FAILED"));
         assertThat(start.getValue()).isEqualTo(LocalDateTime.of(2026, 8, 1, 0, 0));
         assertThat(end.getValue()).isEqualTo(LocalDateTime.of(2026, 8, 2, 23, 59, 59, 999_999_999));

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
@@ -68,7 +68,7 @@ class MybatisPlusAuditRepositoryTest {
         when(auditMapper.selectPage(any(IPage.class), any(Wrapper.class))).thenReturn(mapperPage);
 
         PageResult<AuditRecordVO> result = repository.findPage(
-                "orders", "DELETE_TOPIC", "TOPIC", "prod-cn", null, null, "FAILED", 2, 25);
+                "orders", "admin", "DELETE_TOPIC", "TOPIC", "prod-cn", null, null, "FAILED", 2, 25);
 
         ArgumentCaptor<IPage<RmqOperationAudit>> pageCaptor = ArgumentCaptor.forClass(IPage.class);
         ArgumentCaptor<Wrapper<RmqOperationAudit>> queryCaptor = ArgumentCaptor.forClass(Wrapper.class);
@@ -82,23 +82,25 @@ class MybatisPlusAuditRepositoryTest {
         assertThat(record.getClusterId()).isEqualTo("prod-cn");
         assertThat(record.getErrorMessage()).isEqualTo("denied");
         assertThat(queryCaptor.getValue().getSqlSegment())
-                .contains("operation", "resource_type", "cluster_id", "result", "gmt_create", "id");
+                .contains("operator", "operation", "resource_type", "cluster_id", "result",
+                        "gmt_create", "id");
     }
 
     @Test
     void findFilterOptionsPreservesPersistedValuesAndCachesTheResultTest() {
         when(auditMapper.selectMaps(any(Wrapper.class))).thenReturn(List.of(
                 Map.of("operation", "DELETE_TOPIC", "resource_type", "TOPIC",
-                        "cluster_id", "prod-cn", "result", "SUCCESS"),
+                        "cluster_id", "prod-cn", "result", "SUCCESS", "operator", "admin"),
                 Map.of("operation", " CREATE_TOPIC ", "resource_type", "GROUP",
-                        "cluster_id", "prod-sh", "result", "FAILED"),
+                        "cluster_id", "prod-sh", "result", "FAILED", "operator", "ops-user"),
                 Map.of("operation", "DELETE_TOPIC", "resource_type", "TOPIC",
-                        "cluster_id", "", "result", "PARTIAL")));
+                        "cluster_id", "", "result", "PARTIAL", "operator", "admin")));
 
         AuditFilterOptionsVO options = repository.findFilterOptions();
         AuditFilterOptionsVO cachedOptions = repository.findFilterOptions();
 
         assertThat(options.getOperationTypes()).containsExactly(" CREATE_TOPIC ", "DELETE_TOPIC");
+        assertThat(options.getOperators()).containsExactly("admin", "ops-user");
         assertThat(options.getResourceTypes()).containsExactly("GROUP", "TOPIC");
         assertThat(options.getClusterIds()).containsExactly("prod-cn", "prod-sh");
         assertThat(options.getResults()).containsExactly("FAILED", "PARTIAL", "SUCCESS");
@@ -108,7 +110,7 @@ class MybatisPlusAuditRepositoryTest {
         assertThat(((QueryWrapper<RmqOperationAudit>) queryCaptor.getValue()).getSqlSelect())
                 .contains("operation", "resource_type", "cluster_id", "result");
         assertThat(queryCaptor.getValue().getSqlSegment())
-                .contains("GROUP BY operation,resource_type,cluster_id,result");
+                .contains("GROUP BY operation,resource_type,cluster_id,result,operator");
     }
 
     @Test
@@ -274,7 +276,7 @@ class MybatisPlusAuditRepositoryTest {
 
         LocalDateTime startDate = LocalDateTime.of(2026, 8, 1, 0, 0);
         LocalDateTime endDate = LocalDateTime.of(2026, 8, 31, 23, 59);
-        repository.summarize("orders", "DELETE_TOPIC", "TOPIC", "prod-cn",
+        repository.summarize("orders", "admin", "DELETE_TOPIC", "TOPIC", "prod-cn",
                 startDate, endDate, "SUCCESS");
 
         List<Wrapper<RmqOperationAudit>> queries = new java.util.ArrayList<>();

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/MybatisPlusAuditRepositoryTest.java
@@ -188,7 +188,7 @@ class MybatisPlusAuditRepositoryTest {
         when(auditMapper.selectList(any(Wrapper.class))).thenReturn(List.of(latest));
 
         AuditSummaryVO summary = repository.summarize(
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null);
 
         assertThat(summary.getTotal()).isEqualTo(8);
         assertThat(summary.getSuccessful()).isEqualTo(5);
@@ -238,7 +238,7 @@ class MybatisPlusAuditRepositoryTest {
         when(auditMapper.selectList(any(Wrapper.class))).thenReturn(List.of());
 
         AuditSummaryVO summary = repository.summarize(
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null);
 
         assertThat(summary.getByOperation()).extracting(AuditSummaryBucketVO::getName)
                 .containsExactly("op-a", "op-b", "op-c", "op-d", "op-e");
@@ -257,7 +257,7 @@ class MybatisPlusAuditRepositoryTest {
         when(auditMapper.selectList(any(Wrapper.class))).thenReturn(List.of());
 
         AuditSummaryVO summary = repository.summarize(
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null);
 
         assertThat(summary.getSuccessful()).isEqualTo(2);
         assertThat(summary.getUniqueOperators()).isEqualTo(1);

--- a/web/src/api/audit.ts
+++ b/web/src/api/audit.ts
@@ -21,6 +21,7 @@ import type { AuditQuery } from './ops';
 export type AuditFilter = Omit<AuditQuery, 'page' | 'pageSize'>;
 
 export interface AuditFilterOptions {
+  operators: string[];
   operationTypes: string[];
   resourceTypes: string[];
   clusterIds: string[];

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -193,6 +193,7 @@ export interface AuditQuery {
   page?: number;
   pageSize?: number;
   search?: string;
+  operator?: string;
   operationType?: string;
   resourceType?: string;
   clusterId?: string;

--- a/web/src/pages/ops/__tests__/AuditPage.test.tsx
+++ b/web/src/pages/ops/__tests__/AuditPage.test.tsx
@@ -70,6 +70,7 @@ describe('Audit page', () => {
 
   beforeEach(() => {
     vi.mocked(opsService.getAuditFilterOptions).mockResolvedValue({
+      operators: ['admin', 'operator-a'],
       operationTypes: ['ADD_PROXY_ADDRESS', 'CREATE_TOPIC', 'RESET_OFFSET'],
       resourceTypes: ['CONSUMER_GROUP', 'PROXY', 'TOPIC'],
       clusterIds: ['prod-cn', 'prod-sh'],
@@ -141,6 +142,7 @@ describe('Audit page', () => {
     await waitFor(() =>
       expect(opsService.exportAuditLogs).toHaveBeenCalledWith({
         search: 'topic-a',
+        operator: undefined,
         operationType: undefined,
         resourceType: undefined,
         clusterId: undefined,
@@ -230,6 +232,7 @@ describe('Audit page', () => {
         page: 1,
         pageSize: 20,
         search: undefined,
+        operator: undefined,
         operationType: 'CREATE_TOPIC',
         resourceType: 'CONSUMER_GROUP',
         clusterId: 'prod-sh',
@@ -237,6 +240,34 @@ describe('Audit page', () => {
         endDate: undefined,
         result: undefined,
       }),
+    );
+  });
+
+  it('applies the selected operator as an exact backend filter', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AuditPage />);
+
+    expect(await screen.findByText('topic-a')).toBeInTheDocument();
+    await user.click(screen.getByRole('combobox', { name: '操作人' }));
+    await user.click(
+      await screen.findByText('operator-a', { selector: '.ant-select-item-option-content' }),
+    );
+
+    await waitFor(() =>
+      expect(opsService.listAuditRecords).toHaveBeenLastCalledWith(
+        expect.objectContaining({ operator: 'operator-a' }),
+      ),
+    );
+    await waitFor(() =>
+      expect(opsService.getAuditSummary).toHaveBeenLastCalledWith(
+        expect.objectContaining({ operator: 'operator-a' }),
+      ),
+    );
+    await user.click(screen.getByRole('button', { name: /导出/ }));
+    await waitFor(() =>
+      expect(opsService.exportAuditLogs).toHaveBeenLastCalledWith(
+        expect.objectContaining({ operator: 'operator-a' }),
+      ),
     );
   });
 
@@ -293,6 +324,7 @@ describe('Audit page', () => {
 
     await act(async () => {
       staleOptions.resolve({
+        operators: ['STALE_OPERATOR'],
         operationTypes: ['STALE_OPERATION'],
         resourceTypes: [],
         clusterIds: [],

--- a/web/src/pages/ops/audit.tsx
+++ b/web/src/pages/ops/audit.tsx
@@ -62,6 +62,7 @@ import AuditSummaryCards from './AuditSummaryCards';
 import AuditRiskInsights from './AuditRiskInsights';
 
 const emptyFilterOptions: AuditFilterOptions = {
+  operators: [],
   operationTypes: [],
   resourceTypes: [],
   clusterIds: [],
@@ -70,6 +71,7 @@ const emptyFilterOptions: AuditFilterOptions = {
 
 const buildAuditFilter = (
   searchText: string,
+  selectedOperator: string | undefined,
   selectedType: string | undefined,
   selectedResourceType: string | undefined,
   selectedClusterId: string | undefined,
@@ -77,6 +79,7 @@ const buildAuditFilter = (
   resultFilter: string,
 ): AuditFilter => ({
   search: searchText || undefined,
+  operator: selectedOperator,
   operationType: selectedType,
   resourceType: selectedResourceType,
   clusterId: selectedClusterId,
@@ -95,6 +98,7 @@ const AuditPage: React.FC = () => {
   const [refreshKey, setRefreshKey] = useState(0);
   const [searchText, setSearchText] = useState('');
   const [debouncedSearchText, setDebouncedSearchText] = useState('');
+  const [selectedOperator, setSelectedOperator] = useState<string | undefined>(undefined);
   const [selectedType, setSelectedType] = useState<string | undefined>(undefined);
   const [selectedResourceType, setSelectedResourceType] = useState<string | undefined>(undefined);
   const [selectedClusterId, setSelectedClusterId] = useState<string | undefined>(undefined);
@@ -141,6 +145,7 @@ const AuditPage: React.FC = () => {
       pageSize,
       ...buildAuditFilter(
         debouncedSearchText,
+        selectedOperator,
         selectedType,
         selectedResourceType,
         selectedClusterId,
@@ -169,6 +174,7 @@ const AuditPage: React.FC = () => {
     page,
     pageSize,
     debouncedSearchText,
+    selectedOperator,
     selectedType,
     selectedResourceType,
     selectedClusterId,
@@ -189,6 +195,7 @@ const AuditPage: React.FC = () => {
     () =>
       buildAuditFilter(
         debouncedSearchText,
+        selectedOperator,
         selectedType,
         selectedResourceType,
         selectedClusterId,
@@ -197,6 +204,7 @@ const AuditPage: React.FC = () => {
       ),
     [
       debouncedSearchText,
+      selectedOperator,
       selectedType,
       selectedResourceType,
       selectedClusterId,
@@ -399,6 +407,18 @@ const AuditPage: React.FC = () => {
             }}
             style={{ width: 240 }}
             allowClear
+          />
+          <Select
+            aria-label={t('audit.operator')}
+            placeholder={t('audit.operator')}
+            allowClear
+            style={{ width: 150 }}
+            value={selectedOperator}
+            onChange={(value) => {
+              setPage(1);
+              setSelectedOperator(value);
+            }}
+            options={filterOptions.operators.map((value) => ({ label: value, value }))}
           />
           <Select
             aria-label={t('audit.opType')}

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -66,6 +66,7 @@ function distinctSorted(values: Array<string | null | undefined>): string[] {
 
 function getMockAuditFilterOptions(): AuditFilterOptions {
   return {
+    operators: distinctSorted(auditRecordsState.map((record) => record.operator)),
     operationTypes: distinctSorted(auditRecordsState.map((record) => record.operationType)),
     resourceTypes: distinctSorted(auditRecordsState.map((record) => record.resourceType)),
     clusterIds: distinctSorted(auditRecordsState.map((record) => record.clusterId)),
@@ -84,6 +85,7 @@ function filterAuditRecords(params: AuditFilter): AuditRecord[] {
     ) {
       return false;
     }
+    if (params.operator && record.operator !== params.operator) return false;
     if (params.operationType && record.operationType !== params.operationType) return false;
     if (params.resourceType && record.resourceType !== params.resourceType) return false;
     if (params.clusterId && record.clusterId !== params.clusterId) return false;


### PR DESCRIPTION
## What changed

The audit dashboard showed an operator column and a unique-operator statistic, but the only way to focus on one operator was the general search box. That search matches operator, resource, and detail text together, so it cannot express an exact operator filter and often returns unrelated records.

This change adds first-class operator filtering:

- return distinct persisted operator values from the filter-options API;
- add an operator selector next to the existing audit filters;
- accept an `operator` request parameter for list, summary, and export endpoints;
- apply it as an exact `operator =` predicate in the repository;
- keep the existing free-text search behavior unchanged;
- update controller, service, repository, and dashboard tests.

Because the same filter object is used for records, summary, and export, all three views stay consistent when an operator is selected.

Closes #3387

## Validation

- `mvn -q '-Dtest=AuditControllerTest,AuditServiceTest,MybatisPlusAuditRepositoryTest' test` — 34 tests passed
- `mvn -q checkstyle:check` — passed
- `npm test -- AuditPage.test.tsx --run` — 9 tests passed
- `npm test -- audit.test.ts opsService.test.ts --run` — 18 tests passed
- `npm run lint -- --quiet` — 0 errors; 10 existing warnings remain elsewhere in the tree
- `npm run build` — passed
- `git diff --check` — passed

The GitHub Actions status is not being described as green here; the checks above are local validation on this branch.