### PR TITLE
test: cover encodeBase64 round-trips and null/invalid decode in CredentialUtils

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/CredentialUtilsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/CredentialUtilsTest.java
@@ -79,6 +79,43 @@ class CredentialUtilsTest {
         assertThat(hasIsolatedSurrogate(masked)).isFalse();
     }
 
+    @Test
+    void encodeBase64ShouldRoundTripAsciiSecrets() {
+        String secret = "AKIAIOSFODNN7EXAMPLE";
+
+        String encoded = CredentialUtils.encodeBase64(secret);
+
+        assertThat(encoded).isNotEqualTo(secret);
+        assertThat(CredentialUtils.decodeBase64(encoded)).isEqualTo(secret);
+    }
+
+    @Test
+    void encodeBase64ShouldRoundTripMultibyteText() {
+        String secret = "accessKey\u4e2d\u6587\u5bc6\u94a5\ud83d\ude80";
+
+        String encoded = CredentialUtils.encodeBase64(secret);
+
+        assertThat(encoded).isNotEqualTo(secret);
+        assertThat(CredentialUtils.decodeBase64(encoded)).isEqualTo(secret);
+    }
+
+    @Test
+    void encodeBase64ShouldPreserveNull() {
+        assertThat(CredentialUtils.encodeBase64(null)).isNull();
+    }
+
+    @Test
+    void decodeBase64ShouldPreserveNull() {
+        assertThat(CredentialUtils.decodeBase64(null)).isNull();
+    }
+
+    @Test
+    void decodeBase64ShouldReturnInvalidPlaintextAsIs() {
+        String legacy = "plain-text-access-key!";
+
+        assertThat(CredentialUtils.decodeBase64(legacy)).isEqualTo(legacy);
+    }
+
     private static boolean hasIsolatedSurrogate(String value) {
         for (int index = 0; index < value.length(); index++) {
             char current = value.charAt(index);


### PR DESCRIPTION
### Summary

`CredentialUtils` encodes secrets as base64 before persistence and only partially reveals them in list views. The existing tests focused on `mask` boundaries and malformed UTF-8 decoding, but left `encodeBase64` entirely uncovered and did not exercise null or invalid plaintext handling in `decodeBase64`.

### Changes

- `encodeBase64` round-trips ASCII secrets and multibyte (CJK + supplementary) text through `decodeBase64`
- `encodeBase64` and `decodeBase64` preserve `null` inputs
- `decodeBase64` returns non-base64 plaintext unchanged instead of corrupting it

### Testing

`mvn test -Dtest=CredentialUtilsTest` passes: 12 tests, 0 failures (up from 7).