### PR TITLE
test: cover unsupported, prometheus, validation and fallback handlers in GlobalExceptionHandler

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/exception/GlobalExceptionHandlerTest.java
@@ -16,20 +16,33 @@
  */
 package org.apache.rocketmq.studio.common.exception;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.apache.rocketmq.studio.cluster.metrics.PrometheusException;
 import org.apache.rocketmq.studio.common.domain.Result;
 import org.apache.rocketmq.studio.ops.ai.LlmGatewayException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -99,6 +112,100 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.code").value(406));
     }
 
+    @Test
+    void unsupportedOperationReturns501WithEnvelopeInsteadOf500() throws Exception {
+        mockMvc.perform(get("/test/unsupported"))
+                .andExpect(status().isNotImplemented())
+                .andExpect(jsonPath("$.code").value(501))
+                .andExpect(jsonPath("$.message").value("not implemented yet"));
+    }
+
+    @Test
+    void unexpectedRuntimeExceptionReturns500WithGenericEnvelope() throws Exception {
+        mockMvc.perform(get("/test/unexpected"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value(500))
+                .andExpect(jsonPath("$.message").value("Internal Server Error"));
+    }
+
+    @Test
+    void prometheusFailurePreservesUpstreamStatusAndEnvelope() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        PrometheusException ex = new PrometheusException(503, "upstream unavailable");
+
+        ResponseEntity<Result<?>> response = handler.handlePrometheusException(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(response.getBody().getCode()).isEqualTo(503);
+        assertThat(response.getBody().getMessage()).isEqualTo("upstream unavailable");
+    }
+
+    @Test
+    void validationFailureReportsFirstFieldMessageAsBadRequest() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+        BindingResult bindingResult = mock(BindingResult.class);
+        when(ex.getBindingResult()).thenReturn(bindingResult);
+        when(bindingResult.getFieldErrors()).thenReturn(List.of(
+                new FieldError("target", "name", "name must not be blank"),
+                new FieldError("target", "age", "age must be positive")));
+
+        Result<?> result = handler.handleValidationException(ex);
+
+        assertThat(result.getCode()).isEqualTo(400);
+        assertThat(result.getMessage()).isEqualTo("name must not be blank");
+    }
+
+    @Test
+    void validationFailureFallsBackWhenFieldMessageIsMissing() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+        BindingResult bindingResult = mock(BindingResult.class);
+        when(ex.getBindingResult()).thenReturn(bindingResult);
+        when(bindingResult.getFieldErrors()).thenReturn(List.of(
+                new FieldError("target", "name", null, false, null, null, null)));
+
+        Result<?> result = handler.handleValidationException(ex);
+
+        assertThat(result.getCode()).isEqualTo(400);
+        assertThat(result.getMessage()).isEqualTo("Invalid request");
+    }
+
+    @Test
+    void constraintViolationReportsFirstMessageAsBadRequest() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+        when(violation.getMessage()).thenReturn("size must be between 1 and 32");
+        ConstraintViolationException ex =
+                new ConstraintViolationException(Set.of(violation));
+
+        Result<?> result = handler.handleConstraintViolationException(ex);
+
+        assertThat(result.getCode()).isEqualTo(400);
+        assertThat(result.getMessage()).isEqualTo("size must be between 1 and 32");
+    }
+
+    @Test
+    void unreadableJsonBodyReturns400WithFixedEnvelope() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        HttpMessageNotReadableException ex = mock(HttpMessageNotReadableException.class);
+
+        Result<?> result = handler.handleHttpMessageNotReadableException(ex);
+
+        assertThat(result.getCode()).isEqualTo(400);
+        assertThat(result.getMessage()).isEqualTo("Invalid request body");
+    }
+
+    @Test
+    void genericCatchAllReturns500WithoutLeakingExceptionMessage() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+        Result<?> result = handler.handleException(new IllegalStateException("secret detail"));
+
+        assertThat(result.getCode()).isEqualTo(500);
+        assertThat(result.getMessage()).isEqualTo("Internal Server Error");
+    }
+
     @RestController
     static class FailingController {
 
@@ -116,6 +223,16 @@ class GlobalExceptionHandlerTest {
         @GetMapping("/test/not-acceptable")
         Result<Void> failNotAcceptable() throws HttpMediaTypeNotAcceptableException {
             throw new HttpMediaTypeNotAcceptableException(List.of(MediaType.APPLICATION_JSON));
+        }
+
+        @GetMapping("/test/unsupported")
+        Result<Void> failUnsupported() {
+            throw new UnsupportedOperationException("not implemented yet");
+        }
+
+        @GetMapping("/test/unexpected")
+        Result<Void> failUnexpected() {
+            throw new IllegalStateException("secret detail");
         }
     }
 }


### PR DESCRIPTION
### Summary

`GlobalExceptionHandler` maps many exception families to status-specific `Result` envelopes, but the suite only exercised business errors, LLM gateway failures, 405, 406 and the unmapped-route 404 path.

### Changes

- `UnsupportedOperationException` returns 501 instead of falling into the generic 500
- Unexpected runtime exceptions return a generic 500 envelope without leaking the exception message
- `PrometheusException` preserves the upstream status code and message in the response body
- `MethodArgumentNotValidException` reports the first field error, falling back to a fixed message when the default message is absent
- `ConstraintViolationException` reports the first violation message
- `HttpMessageNotReadableException` and the generic catch-all are covered directly

### Testing

`mvn test -Dtest=GlobalExceptionHandlerTest` passes: 14 tests, 0 failures (up from 7).