### PR TITLE
test: cover engine normalization and readiness branches in LlmConfigVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmConfigVOTest.java
@@ -36,4 +36,96 @@ class LlmConfigVOTest {
             Locale.setDefault(original);
         }
     }
+
+    @Test
+    void normalizeEngineShouldDefaultToHttpWhenBlank() {
+        assertThat(LlmConfigVO.builder().engine(null).build().normalizeEngine())
+                .isEqualTo("http");
+        assertThat(LlmConfigVO.builder().engine("  ").build().normalizeEngine())
+                .isEqualTo("http");
+    }
+
+    @Test
+    void shouldNotBeReadyWhenDisabled() {
+        LlmConfigVO config = LlmConfigVO.builder()
+                .engine("http")
+                .provider("openai")
+                .model("gpt-4o")
+                .apiBase("https://api.example.com")
+                .apiKey("secret")
+                .enabled(false)
+                .build();
+
+        assertThat(config.isReady()).isFalse();
+    }
+
+    @Test
+    void shouldNotBeReadyWithoutModel() {
+        LlmConfigVO config = LlmConfigVO.builder()
+                .engine("http")
+                .provider("openai")
+                .apiBase("https://api.example.com")
+                .apiKey("secret")
+                .enabled(true)
+                .build();
+
+        assertThat(config.isReady()).isFalse();
+    }
+
+    @Test
+    void cliEngineShouldBeReadyWithoutHttpCredentials() {
+        LlmConfigVO config = LlmConfigVO.builder()
+                .engine("claude-code")
+                .model("sonnet")
+                .enabled(true)
+                .build();
+
+        assertThat(config.isReady()).isTrue();
+    }
+
+    @Test
+    void ollamaHttpEngineShouldNotRequireApiKey() {
+        LlmConfigVO config = LlmConfigVO.builder()
+                .engine("http")
+                .provider("ollama")
+                .model("llama3")
+                .apiBase("http://localhost:11434")
+                .enabled(true)
+                .build();
+
+        assertThat(config.isReady()).isTrue();
+    }
+
+    @Test
+    void httpEngineShouldRequireApiBase() {
+        LlmConfigVO config = LlmConfigVO.builder()
+                .engine("http")
+                .provider("openai")
+                .model("gpt-4o")
+                .apiKey("secret")
+                .enabled(true)
+                .build();
+
+        assertThat(config.isReady()).isFalse();
+    }
+
+    @Test
+    void httpEngineShouldRequireApiKeyForNonOllamaProviders() {
+        LlmConfigVO config = LlmConfigVO.builder()
+                .engine("http")
+                .provider("openai")
+                .model("gpt-4o")
+                .apiBase("https://api.example.com")
+                .enabled(true)
+                .build();
+
+        assertThat(config.isReady()).isFalse();
+    }
+
+    @Test
+    void apiKeyConfiguredShouldReflectKeyPresence() {
+        assertThat(LlmConfigVO.builder().apiKey("secret").build().isApiKeyConfigured()).isTrue();
+        assertThat(LlmConfigVO.builder().apiKey(" ").build().isApiKeyConfigured()).isFalse();
+        assertThat(LlmConfigVO.builder().build().isApiKeyConfigured()).isFalse();
+    }
 }


### PR DESCRIPTION
### Summary

`LlmConfigVO.isReady` gates AI features on engine type, provider and credential presence, and `normalizeEngine` falls back to the HTTP engine for blank values. The VO suite only checked the Turkish-locale normalization case.

### Changes

- Blank/`null` engines normalize to `http`
- A disabled config or one without a model is never ready
- CLI engines are ready without HTTP credentials
- The `ollama` provider is ready without an API key while other HTTP providers are not
- `apiBase` and `apiKey` are both required for non-Ollama HTTP providers
- `apiKeyConfigured` reflects key presence

### Testing

`mvn test -Dtest=LlmConfigVOTest` passes: 9 tests, 0 failures (up from 1).