### PR TITLE
test: cover attach rejection, send lifecycle and no-op terminal paths in LlmSseSession

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmSseSessionTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmSseSessionTest.java
@@ -19,11 +19,13 @@ package org.apache.rocketmq.studio.ops.ai;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -67,6 +69,106 @@ class LlmSseSessionTest {
         verify(task, never()).cancel(true);
     }
 
+    @Test
+    void attachTwiceShouldRejectTheSecondTask() {
+        TestEmitter emitter = new TestEmitter();
+        LlmSseSession session = new LlmSseSession(emitter, ignored -> { });
+        Future<?> first = mock(Future.class);
+        Future<?> second = mock(Future.class);
+        session.attach(first);
+
+        assertThatThrownBy(() -> session.attach(second))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("An SSE session can own only one task");
+        verify(second).cancel(true);
+        verify(first, never()).cancel(true);
+    }
+
+    @Test
+    void sendShouldForwardEventsWhileActive() throws Exception {
+        TestEmitter emitter = new TestEmitter();
+        LlmSseSession session = new LlmSseSession(emitter, ignored -> { });
+        SseEmitter.SseEventBuilder event = SseEmitter.event().data("ping");
+
+        session.send(event);
+
+        assertThat(emitter.lastEvent).isSameAs(event);
+        assertThat(emitter.sentEvents).isEqualTo(1);
+    }
+
+    @Test
+    void sendAfterCancellationShouldFailWithoutTouchingTheEmitter() throws Exception {
+        TestEmitter emitter = new TestEmitter();
+        LlmSseSession session = new LlmSseSession(emitter, ignored -> { });
+        emitter.triggerTimeout();
+
+        assertThatThrownBy(() -> session.send(SseEmitter.event().data("ping")))
+                .isInstanceOf(IOException.class)
+                .hasMessage("SSE client is no longer connected");
+        assertThat(emitter.sentEvents).isZero();
+    }
+
+    @Test
+    void sendFailureShouldCancelTheSessionAndTask() {
+        TestEmitter emitter = new TestEmitter();
+        AtomicInteger terminations = new AtomicInteger();
+        LlmSseSession session = new LlmSseSession(emitter, ignored -> terminations.incrementAndGet());
+        Future<?> task = mock(Future.class);
+        session.attach(task);
+        emitter.failSends = true;
+
+        assertThatThrownBy(() -> session.send(SseEmitter.event().data("ping")))
+                .isInstanceOf(IOException.class);
+
+        assertThat(session.isCancelled()).isTrue();
+        assertThat(terminations).hasValue(1);
+        verify(task).cancel(true);
+    }
+
+    @Test
+    void completeWithErrorShouldNotifyOnceAndForwardTheFailure() {
+        TestEmitter emitter = new TestEmitter();
+        AtomicInteger terminations = new AtomicInteger();
+        LlmSseSession session = new LlmSseSession(emitter, ignored -> terminations.incrementAndGet());
+        IllegalStateException failure = new IllegalStateException("provider failed");
+
+        session.completeWithError(failure);
+        session.completeWithError(failure);
+
+        assertThat(terminations).hasValue(1);
+        assertThat(emitter.errorCount).isEqualTo(1);
+        assertThat(emitter.lastError).isSameAs(failure);
+        assertThat(session.isCancelled()).isFalse();
+    }
+
+    @Test
+    void completeWithoutBeginTerminalShouldBeANoOp() {
+        TestEmitter emitter = new TestEmitter();
+        AtomicInteger terminations = new AtomicInteger();
+        LlmSseSession session = new LlmSseSession(emitter, ignored -> terminations.incrementAndGet());
+
+        session.complete();
+
+        assertThat(emitter.completed).isFalse();
+        assertThat(terminations).hasValue(0);
+    }
+
+    @Test
+    void cancelAfterTerminalCompletionShouldBeANoOp() {
+        TestEmitter emitter = new TestEmitter();
+        AtomicInteger terminations = new AtomicInteger();
+        LlmSseSession session = new LlmSseSession(emitter, ignored -> terminations.incrementAndGet());
+        Future<?> task = mock(Future.class);
+        session.attach(task);
+        session.beginTerminal();
+        session.complete();
+
+        session.cancel();
+
+        assertThat(terminations).hasValue(1);
+        verify(task, never()).cancel(true);
+    }
+
     private void assertLifecycleCallbackCancels(Consumer<TestEmitter> callback) {
         TestEmitter emitter = new TestEmitter();
         AtomicInteger terminations = new AtomicInteger();
@@ -87,6 +189,11 @@ class LlmSseSessionTest {
         private Runnable timeoutCallback;
         private Consumer<Throwable> errorCallback;
         private boolean completed;
+        private SseEmitter.SseEventBuilder lastEvent;
+        private int sentEvents;
+        private boolean failSends;
+        private int errorCount;
+        private Throwable lastError;
 
         @Override
         public synchronized void onCompletion(Runnable callback) {
@@ -107,6 +214,21 @@ class LlmSseSessionTest {
         public synchronized void complete() {
             completed = true;
             triggerCompletion();
+        }
+
+        @Override
+        public synchronized void completeWithError(Throwable throwable) {
+            errorCount++;
+            lastError = throwable;
+        }
+
+        @Override
+        public synchronized void send(SseEmitter.SseEventBuilder builder) throws java.io.IOException {
+            if (failSends) {
+                throw new java.io.IOException("transport closed");
+            }
+            sentEvents++;
+            lastEvent = builder;
         }
 
         void triggerCompletion() {


### PR DESCRIPTION
### Summary

`LlmSseSession` guards its state machine so an abandoned SSE response cancels its provider task exactly once. The suite covered lifecycle callbacks, late attachment and clean terminal completion, but not the send path or double-attach/error guards.

### Changes

- Attaching a second task cancels it and rejects with `An SSE session can own only one task`
- Events are forwarded to the emitter while active; sending after cancellation fails without touching the emitter
- A failing send cancels the session and its task
- `completeWithError` notifies termination once and forwards the failure
- `complete` without `beginTerminal` and `cancel` after terminal completion are no-ops

### Testing

`mvn test -Dtest=LlmSseSessionTest` passes: 10 tests, 0 failures (up from 3).