### PR TITLE
test: cover default runtime names and null handling in CliProcessEnvironment

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/CliProcessEnvironmentTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/CliProcessEnvironmentTest.java
@@ -129,4 +129,61 @@ class CliProcessEnvironmentTest {
                 Map.entry("PATH", "/usr/bin"),
                 Map.entry("PROVIDER_TOKEN", "provider-secret"));
     }
+
+    @Test
+    void forwardsEveryDefaultRuntimeNameWhenPresent() {
+        CliProcessEnvironment policy = new CliProcessEnvironment(List.of());
+        Map<String, String> parent = Map.ofEntries(
+                Map.entry("PATH", "/usr/bin"),
+                Map.entry("HOME", "/home/studio"),
+                Map.entry("USERPROFILE", "C:\\Users\\studio"),
+                Map.entry("XDG_CONFIG_HOME", "/home/studio/.config"),
+                Map.entry("XDG_CACHE_HOME", "/home/studio/.cache"),
+                Map.entry("XDG_DATA_HOME", "/home/studio/.local/share"),
+                Map.entry("TMPDIR", "/tmp/studio"),
+                Map.entry("TMP", "/tmp"),
+                Map.entry("TEMP", "/tmp"),
+                Map.entry("LANG", "en_US.UTF-8"),
+                Map.entry("LANGUAGE", "en"),
+                Map.entry("LC_ALL", "C.UTF-8"),
+                Map.entry("LC_CTYPE", "C.UTF-8"),
+                Map.entry("TERM", "xterm-256color"),
+                Map.entry("SSL_CERT_FILE", "/etc/ssl/custom.pem"),
+                Map.entry("SSL_CERT_DIR", "/etc/ssl/certs"),
+                Map.entry("NODE_EXTRA_CA_CERTS", "/etc/ssl/node.pem"),
+                Map.entry("HTTP_PROXY", "http://proxy.example:8080"),
+                Map.entry("HTTPS_PROXY", "http://proxy.example:8080"),
+                Map.entry("NO_PROXY", "localhost,127.0.0.1"),
+                Map.entry("SystemRoot", "C:\\Windows"),
+                Map.entry("ComSpec", "C:\\Windows\\System32\\cmd.exe"),
+                Map.entry("PATHEXT", ".COM;.EXE"));
+
+        assertThat(policy.build(parent, Map.of()))
+                .containsKeys("PATH", "HOME", "USERPROFILE", "XDG_CONFIG_HOME",
+                        "XDG_CACHE_HOME", "XDG_DATA_HOME", "TMPDIR", "TMP", "TEMP",
+                        "LANG", "LANGUAGE", "LC_ALL", "LC_CTYPE", "TERM",
+                        "SSL_CERT_FILE", "SSL_CERT_DIR", "NODE_EXTRA_CA_CERTS",
+                        "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+                        "SystemRoot", "ComSpec", "PATHEXT");
+    }
+
+    @Test
+    void skipsAllowedParentNameWithNullValue() {
+        CliProcessEnvironment policy = new CliProcessEnvironment(List.of("CUSTOM_VAR"));
+        Map<String, String> parent = new LinkedHashMap<>();
+        parent.put("CUSTOM_VAR", null);
+        parent.put("PATH", "/usr/bin");
+
+        assertThat(policy.build(parent, Map.of()))
+                .containsEntry("PATH", "/usr/bin")
+                .doesNotContainKey("CUSTOM_VAR");
+    }
+
+    @Test
+    void appliesProviderEnvironmentWhenParentIsNull() {
+        CliProcessEnvironment policy = new CliProcessEnvironment(List.of());
+
+        assertThat(policy.build(null, Map.of("ANTHROPIC_AUTH_TOKEN", "request-token")))
+                .containsExactly(Map.entry("ANTHROPIC_AUTH_TOKEN", "request-token"));
+    }
 }


### PR DESCRIPTION
### Summary

`CliProcessEnvironment` forwards a fixed allow-list of runtime variables plus configured extras. Existing tests covered the allow-list filtering and override precedence, but not the full default-name set or null edge cases.

### Changes

- Every default runtime name (`LC_ALL`, `TERM`, proxy vars, Windows vars, etc.) is forwarded when present in the parent
- An allowed parent variable whose value is `null` is skipped
- Provider variables still apply when the parent environment is `null`

### Testing

`mvn test -Dtest=CliProcessEnvironmentTest` passes: 9 tests, 0 failures (up from 6).