### PR TITLE
test: cover empty topology and probe message report in ClusterConnectionService

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionServiceTest.java
@@ -76,4 +76,30 @@ class ClusterConnectionServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Failed to connect NameServer");
     }
+
+    @Test
+    void connectionShouldReportEmptyTopologyWhenClusterHasNoBrokersTest() {
+        when(clusterProvider.describeCluster(eq("10.0.0.2:9876")))
+                .thenReturn(ClusterVO.builder().name("DefaultCluster").build());
+
+        ClusterProbeResult result = service.testConnection(
+                TestConnectionDTO.builder().namesrvAddr("10.0.0.2:9876").build());
+
+        assertThat(result.isConnected()).isTrue();
+        assertThat(result.getBrokerCount()).isZero();
+        assertThat(result.getBrokerNames()).isEmpty();
+        assertThat(result.getMessage()).startsWith("Connected to 0 broker(s)");
+    }
+
+    @Test
+    void connectionMessageShouldReportCountAndElapsedMillisTest() {
+        when(clusterProvider.describeCluster(eq("10.0.0.1:9876")))
+                .thenReturn(clusterWith("broker-a", "broker-b"));
+
+        ClusterProbeResult result = service.testConnection(
+                TestConnectionDTO.builder().namesrvAddr("10.0.0.1:9876").build());
+
+        assertThat(result.getMessage()).startsWith("Connected to 2 broker(s) in ");
+        assertThat(result.getMessage()).endsWith("ms");
+    }
 }


### PR DESCRIPTION
### Summary

`ClusterConnectionService.testConnection` probes a NameServer and summarises the reported topology in a `ClusterProbeResult`. The suite covered the populated case and provider failure, but not a cluster without brokers or the result message format.

### Changes

- A cluster without broker entries reports `connected=true` with zero brokers and an empty broker list
- The human-readable message carries the broker count and measured elapsed millis

### Testing

`mvn test -Dtest=ClusterConnectionServiceTest` passes: 4 tests, 0 failures (up from 2).