### PR TITLE
test: cover import envelope rejection and full export mapping in AlertRuleTransferService

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferServiceTest.java
@@ -116,6 +116,101 @@ class AlertRuleTransferServiceTest {
         assertEquals("Broker unavailable", imported.get(0).getName());
     }
 
+    @Test
+    void rejectsNullImportDocumentTest() {
+        BusinessException error = assertThrows(BusinessException.class,
+                () -> transferService.importRules(AlertDomain.CLUSTER, null));
+
+        assertEquals(400, error.getCode());
+        assertEquals("Alert rule import document is required", error.getMessage());
+        verifyNoInteractions(alertService, metricCatalogService);
+    }
+
+    @Test
+    void rejectsUnsupportedImportVersionTest() {
+        AlertRuleTransferDTO transfer = transfer(AlertDomain.CLUSTER, request("Broker unavailable"));
+        transfer.setVersion(AlertRuleTransferDTO.VERSION + 1);
+
+        BusinessException error = assertThrows(BusinessException.class,
+                () -> transferService.importRules(AlertDomain.CLUSTER, transfer));
+
+        assertEquals(400, error.getCode());
+        assertEquals("Unsupported alert rule import version", error.getMessage());
+        verifyNoInteractions(alertService, metricCatalogService);
+    }
+
+    @Test
+    void rejectsEmptyAndOversizedRuleListsTest() {
+        BusinessException empty = assertThrows(BusinessException.class,
+                () -> transferService.importRules(AlertDomain.CLUSTER,
+                        transfer(AlertDomain.CLUSTER)));
+        assertEquals(400, empty.getCode());
+        assertEquals("Alert rule import must contain between 1 and 200 rules", empty.getMessage());
+
+        AlertRuleRequestDTO[] many = java.util.stream.IntStream.range(0, 201)
+                .mapToObj(index -> request("Rule " + index))
+                .toArray(AlertRuleRequestDTO[]::new);
+        BusinessException oversized = assertThrows(BusinessException.class,
+                () -> transferService.importRules(AlertDomain.CLUSTER,
+                        transfer(AlertDomain.CLUSTER, many)));
+        assertEquals(400, oversized.getCode());
+        assertEquals("Alert rule import must contain between 1 and 200 rules", oversized.getMessage());
+        verifyNoInteractions(alertService, metricCatalogService);
+    }
+
+    @Test
+    void exportCarriesEveryPortableRuleFieldTest() {
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .id(7L)
+                .domain(AlertDomain.CLUSTER)
+                .name("Broker unavailable")
+                .metric("broker.up")
+                .operator("==")
+                .threshold(0)
+                .thresholdUnit("%")
+                .duration("1m")
+                .aggregation("MAX")
+                .windowSeconds(60)
+                .channels(List.of("dingtalk", "email"))
+                .enabled(false)
+                .description("Broker went offline")
+                .brokerName("broker-a")
+                .clusterName("DefaultCluster")
+                .severity("P1")
+                .instanceId("instance-1")
+                .consumerGroup("cg-orders")
+                .topic("orders")
+                .consecutiveSamples(3)
+                .reminderInterval("10m")
+                .notificationTemplate("${title}")
+                .build();
+        when(alertService.listRules(AlertDomain.CLUSTER)).thenReturn(List.of(rule));
+
+        AlertRuleRequestDTO request = transferService.exportRules(AlertDomain.CLUSTER)
+                .getRules().get(0);
+
+        assertEquals("Broker unavailable", request.getName());
+        assertEquals("broker.up", request.getMetric());
+        assertEquals("==", request.getOperator());
+        assertEquals(0, request.getThreshold());
+        assertEquals("%", request.getThresholdUnit());
+        assertEquals("1m", request.getDuration());
+        assertEquals("MAX", request.getAggregation());
+        assertEquals(60, request.getWindowSeconds());
+        assertEquals(List.of("dingtalk", "email"), request.getChannels());
+        assertEquals(false, request.isEnabled());
+        assertEquals("Broker went offline", request.getDescription());
+        assertEquals("broker-a", request.getBrokerName());
+        assertEquals("DefaultCluster", request.getClusterName());
+        assertEquals("P1", request.getSeverity());
+        assertEquals("instance-1", request.getInstanceId());
+        assertEquals("cg-orders", request.getConsumerGroup());
+        assertEquals("orders", request.getTopic());
+        assertEquals(3, request.getConsecutiveSamples());
+        assertEquals("10m", request.getReminderInterval());
+        assertEquals("${title}", request.getNotificationTemplate());
+    }
+
     private static AlertRuleTransferDTO transfer(AlertDomain domain, AlertRuleRequestDTO... rules) {
         AlertRuleTransferDTO transfer = new AlertRuleTransferDTO();
         transfer.setVersion(AlertRuleTransferDTO.VERSION);


### PR DESCRIPTION
### Summary

`AlertRuleTransferService` validates the import envelope (version, domain, rule-count bounds) before touching the catalog or repository, and exports every portable rule field. The suite covered cross-domain rejection, per-rule validation and import-as-new, but not the remaining envelope guards or a full export mapping.

### Changes

- A `null` import document is rejected with `400 Alert rule import document is required`
- An unsupported import version is rejected without touching the services
- Empty and >200-rule imports are both rejected with the rule-count message
- Export copies every portable field (`thresholdUnit`, `aggregation`, `windowSeconds`, severity, topic, reminder interval, template, etc.)

### Testing

`mvn test -Dtest=AlertRuleTransferServiceTest` passes: 8 tests, 0 failures (up from 4).