### PR TITLE
test: cover null instance guard and result passthrough in ClientService

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientServiceTest.java
@@ -93,4 +93,29 @@ class ClientServiceTest {
 
         verifyNoInteractions(clientProvider);
     }
+
+    @Test
+    void listConnectionsShouldRejectNullInstanceId() {
+        assertThatThrownBy(() -> clientService.listConnections(null, null, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("instanceId is required");
+
+        verifyNoInteractions(clientProvider);
+    }
+
+    @Test
+    void listConnectionsAtShouldReturnProviderResultsUnchanged() {
+        ClientConnectionVO connection = ClientConnectionVO.builder()
+                .clientId("client-9")
+                .clusterName("production-cluster")
+                .build();
+        when(clientProvider.findConnectionsAt("10.0.1.31:9876", null, "Consumer"))
+                .thenReturn(List.of(connection));
+
+        List<ClientConnectionVO> result =
+                clientService.listConnectionsAt(" 10.0.1.31:9876 ", " ", " Consumer ");
+
+        assertThat(result).containsExactly(connection);
+        verify(clientProvider).findConnectionsAt("10.0.1.31:9876", null, "Consumer");
+    }
 }


### PR DESCRIPTION
### Summary

`ClientService` guards required identifiers before delegating to the client provider and passes provider results through unchanged. The suite covered blank-value guards but not the `null` identifier or the non-empty passthrough on the nameserver-address path.

### Changes

- A `null` instance id is rejected with `400 instanceId is required` before the provider is touched
- The nameserver-address lookup returns provider results unchanged after trimming and blanking optional filters

### Testing

`mvn test -Dtest=ClientServiceTest` passes: 7 tests, 0 failures (up from 5).