### PR TITLE
test: cover unsupported/null engine errors and duplicate engines in AgentProviderRegistry

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistryTest.java
@@ -41,4 +41,48 @@ class AgentProviderRegistryTest {
             Locale.setDefault(original);
         }
     }
+
+    @Test
+    void shouldRejectUnsupportedEngineWithGuidance() {
+        AgentProviderRegistry registry = new AgentProviderRegistry(List.of(provider("claude-code")));
+
+        LlmGatewayException error = org.assertj.core.api.Assertions.catchThrowableOfType(
+                () -> registry.forEngine("qoder"), LlmGatewayException.class);
+
+        assertThat(error).isNotNull();
+        assertThat(error.getStatusCode()).isEqualTo(400);
+        assertThat(error.getCode()).isEqualTo("llm.config.unsupported_engine");
+        assertThat(error.getMessage()).contains("Agent engine is not supported: qoder");
+        assertThat(error.getHint()).contains("claude-code");
+    }
+
+    @Test
+    void shouldRejectNullAndBlankEngineWithGuidance() {
+        AgentProviderRegistry registry = new AgentProviderRegistry(List.of(provider("claude-code")));
+
+        LlmGatewayException nullEngine = org.assertj.core.api.Assertions.catchThrowableOfType(
+                () -> registry.forEngine(null), LlmGatewayException.class);
+        LlmGatewayException blankEngine = org.assertj.core.api.Assertions.catchThrowableOfType(
+                () -> registry.forEngine("   "), LlmGatewayException.class);
+
+        assertThat(nullEngine).isNotNull();
+        assertThat(nullEngine.getStatusCode()).isEqualTo(400);
+        assertThat(blankEngine).isNotNull();
+        assertThat(blankEngine.getStatusCode()).isEqualTo(400);
+    }
+
+    @Test
+    void shouldFailFastOnDuplicateProviderEngine() {
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> new AgentProviderRegistry(
+                                List.of(provider("claude-code"), provider("claude-code"))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Duplicate key claude-code");
+    }
+
+    private static AgentProvider provider(String engine) {
+        AgentProvider provider = mock(AgentProvider.class);
+        when(provider.engine()).thenReturn(engine);
+        return provider;
+    }
 }


### PR DESCRIPTION
### Summary

`AgentProviderRegistry` resolves a normalized engine string to a CLI agent provider and fails with a guided `LlmGatewayException` when it is unknown. Only the Turkish-locale normalization path had a test.

### Changes

- An unsupported engine yields a `400` `llm.config.unsupported_engine` error whose hint lists the supported engines
- `null` and blank engines are rejected the same way
- Registering two providers for the same engine fails fast at construction with the duplicate key

### Testing

`mvn test -Dtest=AgentProviderRegistryTest` passes: 4 tests, 0 failures (up from 1).