### PR TITLE
test: cover blank projection, handler name and error propagation in CapabilitiesToolHandler

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/CapabilitiesToolHandlerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/tool/CapabilitiesToolHandlerTest.java
@@ -57,4 +57,47 @@ class CapabilitiesToolHandlerTest {
         assertThat(result.get("version")).isEqualTo("");
         assertThat(result.get("capabilities")).isEqualTo(List.of("REMOTING"));
     }
+
+    @Test
+    void handlerNameShouldBeRmqCapabilities() {
+        ClusterService clusterService = mock(ClusterService.class);
+        CapabilityResolver capabilityResolver = mock(CapabilityResolver.class);
+
+        assertThat(new CapabilitiesToolHandler(clusterService, capabilityResolver).name())
+                .isEqualTo("rmq.capabilities");
+    }
+
+    @Test
+    void nullTypeAndClusterIdAreEmittedAsBlankStrings() {
+        ClusterVO cluster = ClusterVO.builder().name("DefaultCluster").build();
+
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getCluster("DefaultCluster")).thenReturn(cluster);
+        CapabilityResolver capabilityResolver = mock(CapabilityResolver.class);
+        when(capabilityResolver.resolve(cluster)).thenReturn(List.of());
+
+        Object output = new CapabilitiesToolHandler(clusterService, capabilityResolver)
+                .execute(Map.of("cluster", "DefaultCluster"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) output;
+        assertThat(result.get("cluster")).isEqualTo("");
+        assertThat(result.get("type")).isEqualTo("");
+        assertThat(result.get("capabilities")).isEqualTo(List.of());
+    }
+
+    @Test
+    void missingClusterErrorPropagatesToTheCaller() {
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getCluster("unknown-cluster"))
+                .thenThrow(new org.apache.rocketmq.studio.common.exception.BusinessException(
+                        404, "Cluster not found: unknown-cluster"));
+        CapabilityResolver capabilityResolver = mock(CapabilityResolver.class);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> new CapabilitiesToolHandler(clusterService, capabilityResolver)
+                                .execute(Map.of("cluster", "unknown-cluster")))
+                .isInstanceOf(org.apache.rocketmq.studio.common.exception.BusinessException.class)
+                .hasMessage("Cluster not found: unknown-cluster");
+    }
 }


### PR DESCRIPTION
### Summary

`CapabilitiesToolHandler` projects a cluster's id/type/version as schema-required strings plus its resolved capabilities. The suite only covered a populated cluster with a null version.

### Changes

- The handler registers under `rmq.capabilities`
- A cluster without id or type projects both as blank strings instead of null
- A missing-cluster `BusinessException` from the cluster service propagates to the caller unchanged

### Testing

`mvn test -Dtest=CapabilitiesToolHandlerTest` passes: 4 tests, 0 failures (up from 1).