### PR TITLE
test: cover broker-set null handling and single-arg overload in SystemTopicFilter

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemTopicFilterTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemTopicFilterTest.java
@@ -46,4 +46,24 @@ class SystemTopicFilterTest {
         assertThat(SystemTopicFilter.isSystem("BenchmarkTestOrders", brokerNames)).isFalse();
         assertThat(SystemTopicFilter.isSystem("SCHEDULE_TOPIC_orders", brokerNames)).isFalse();
     }
+
+    @Test
+    void canonicalTopicsRemainSystemWithNullOrEmptyBrokerNamesTest() {
+        assertThat(SystemTopicFilter.isSystem("RMQ_SYS_TRANS_HALF_TOPIC", null)).isTrue();
+        assertThat(SystemTopicFilter.isSystem("%RETRY%consumer-a", Set.of())).isTrue();
+        assertThat(SystemTopicFilter.isSystem("rmq_sys_TRACE_DATA", null)).isTrue();
+
+        // Broker-name matching requires the broker set; without it the topic is not system.
+        assertThat(SystemTopicFilter.isSystem("broker-prod-a", null)).isFalse();
+        assertThat(SystemTopicFilter.isSystem("broker-prod-a", Set.of())).isFalse();
+    }
+
+    @Test
+    void singleArgumentOverloadDelegatesWithoutBrokerNamesTest() {
+        assertThat(SystemTopicFilter.isSystem(null)).isTrue();
+        assertThat(SystemTopicFilter.isSystem("")).isTrue();
+        assertThat(SystemTopicFilter.isSystem("RMQ_SYS_TRANS_HALF_TOPIC")).isTrue();
+        assertThat(SystemTopicFilter.isSystem("orders")).isFalse();
+        assertThat(SystemTopicFilter.isSystem("broker-prod-a")).isFalse();
+    }
 }


### PR DESCRIPTION
### Summary

`SystemTopicFilter` flags canonical system topics, retry/DLQ prefixes and broker-name topics. The suite covered the full-broker-set path; the `null`/empty broker set and the single-argument overload were untested.

### Changes

- Canonical and prefixed system topics stay system when the broker set is `null` or empty
- Broker-name matching requires the broker set and stays non-system without it
- The single-argument overload delegates with an empty broker set (null/empty and ordinary topics behave accordingly)

### Testing

`mvn test -Dtest=SystemTopicFilterTest` passes: 3 tests, 0 failures (up from 1).