### PR TITLE
test: cover registered collector counts in CollectorStatusController

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/CollectorStatusControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/CollectorStatusControllerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class CollectorStatusControllerTest {
     @Test
@@ -31,5 +32,25 @@ class CollectorStatusControllerTest {
         CollectorStatusVO status = new CollectorStatusController(properties, List.of(), List.of()).status().getData();
 
         assertThat(status.collectionInterval()).isEqualTo("PT1M");
+        assertThat(status.clusterCollectorCount()).isZero();
+        assertThat(status.businessCollectorCount()).isZero();
+    }
+
+    @Test
+    void reportsRegisteredCollectorCountsTest() {
+        AlertingProperties properties = new AlertingProperties();
+        properties.setCollectionInterval("PT5M");
+        ClusterMetricsCollector clusterA = mock(ClusterMetricsCollector.class);
+        ClusterMetricsCollector clusterB = mock(ClusterMetricsCollector.class);
+        BusinessMetricsCollector businessA = mock(BusinessMetricsCollector.class);
+        BusinessMetricsCollector businessB = mock(BusinessMetricsCollector.class);
+        BusinessMetricsCollector businessC = mock(BusinessMetricsCollector.class);
+
+        CollectorStatusVO status = new CollectorStatusController(properties,
+                List.of(clusterA, clusterB), List.of(businessA, businessB, businessC)).status().getData();
+
+        assertThat(status.collectionInterval()).isEqualTo("PT5M");
+        assertThat(status.clusterCollectorCount()).isEqualTo(2);
+        assertThat(status.businessCollectorCount()).isEqualTo(3);
     }
 }


### PR DESCRIPTION
### Summary

`CollectorStatusController` reports the native collection interval plus the number of registered cluster and business collectors. The suite only asserted the interval with empty collector lists.

### Changes

- Assert both collector counts are zero with no registered collectors
- A controller with two cluster and three business collectors reports those exact counts

### Testing

`mvn test -Dtest=CollectorStatusControllerTest` passes: 2 tests, 0 failures (up from 1).