### PR TITLE
test: cover all formula triggers and row building in CsvUtil

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/CsvUtilTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/CsvUtilTest.java
@@ -35,4 +35,38 @@ class CsvUtilTest {
         assertThat(CsvUtil.toCell("=SUM(A1)")).isEqualTo("\"'=SUM(A1)\"");
         assertThat(CsvUtil.toCell("+cmd")).isEqualTo("\"'+cmd\"");
     }
+
+    @Test
+    void toCellShouldNeutralizeEveryFormulaTriggerCharacterTest() {
+        assertThat(CsvUtil.toCell("-1")).isEqualTo("\"'-1\"");
+        assertThat(CsvUtil.toCell("@cmd")).isEqualTo("\"'@cmd\"");
+        assertThat(CsvUtil.toCell("\tindented")).isEqualTo("\"'\tindented\"");
+        assertThat(CsvUtil.toCell("\rline")).isEqualTo("\"'\rline\"");
+        assertThat(CsvUtil.toCell("\nline")).isEqualTo("\"'\nline\"");
+    }
+
+    @Test
+    void toCellShouldQuoteEmptyAndPlainValuesAsIsTest() {
+        assertThat(CsvUtil.toCell("")).isEqualTo("\"\"");
+        assertThat(CsvUtil.toCell("plain")).isEqualTo("\"plain\"");
+        assertThat(CsvUtil.toCell(" spaced ")).isEqualTo("\" spaced \"");
+    }
+
+    @Test
+    void appendRowWithNoValuesEmitsOnlyCrlfTest() {
+        StringBuilder csv = new StringBuilder();
+
+        CsvUtil.appendRow(csv);
+
+        assertThat(csv.toString()).isEqualTo("\r\n");
+    }
+
+    @Test
+    void appendRowShouldBuildMultipleRowsTest() {
+        StringBuilder csv = new StringBuilder();
+        CsvUtil.appendRow(csv, "a", "b");
+        CsvUtil.appendRow(csv, "c");
+
+        assertThat(csv.toString()).isEqualTo("\"a\",\"b\"\r\n\"c\"\r\n");
+    }
 }


### PR DESCRIPTION
### Summary

`CsvUtil` quotes every cell and neutralizes spreadsheet formula injection by prefixing cells that start with `= + - @ \t \r \n`. The suite covered `=`/`+` and embedded quotes only.

### Changes

- `-`, `@`, tab, CR and LF leading characters are all neutralized with the single-quote prefix
- Empty and plain (including space-padded) values are quoted unchanged
- A row with no values emits just the CRLF terminator
- Consecutive `appendRow` calls build a multi-line CSV

### Testing

`mvn test -Dtest=CsvUtilTest` passes: 6 tests, 0 failures (up from 2).