### PR TITLE
test: cover paging passthrough and empty page in PageResult

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/domain/PageResultTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/domain/PageResultTest.java
@@ -44,4 +44,24 @@ class PageResultTest {
         assertThatThrownBy(() -> result.getItems().add("mutated"))
                 .isInstanceOf(UnsupportedOperationException.class);
     }
+
+    @Test
+    void ofShouldCarryTotalAndPagingFields() {
+        PageResult<String> result = PageResult.of(List.of("a", "b"), 42, 3, 25);
+
+        assertThat(result.getItems()).containsExactly("a", "b");
+        assertThat(result.getTotal()).isEqualTo(42);
+        assertThat(result.getPage()).isEqualTo(3);
+        assertThat(result.getSize()).isEqualTo(25);
+    }
+
+    @Test
+    void emptyShouldReturnZeroTotalWithCarriedPaging() {
+        PageResult<String> result = PageResult.empty(5, 50);
+
+        assertThat(result.getItems()).isEmpty();
+        assertThat(result.getTotal()).isZero();
+        assertThat(result.getPage()).isEqualTo(5);
+        assertThat(result.getSize()).isEqualTo(50);
+    }
 }


### PR DESCRIPTION
### Summary

`PageResult.of` exposes items plus total/page/size paging metadata, and `PageResult.empty` builds a zero-total page. The suite covered null-normalization and defensive copying only.

### Changes

- `of` carries the total and paging fields through unchanged
- `empty` yields an empty item list with zero total while preserving the requested page and size

### Testing

`mvn test -Dtest=PageResultTest` passes: 4 tests, 0 failures (up from 2).