### PR TITLE
test: cover time and base64 parse helpers in AliyunConverters

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersTest.java
@@ -19,6 +19,9 @@ package org.apache.rocketmq.studio.provider.alibaba;
 import com.aliyun.sdk.service.rocketmq20220801.models.ListInstancesResponseBody;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+import java.util.Base64;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AliyunConvertersTest {
@@ -34,5 +37,50 @@ class AliyunConvertersTest {
 
         assertThat(result.getTopicCount()).isEqualTo(Integer.MAX_VALUE);
         assertThat(result.getGroupCount()).isZero();
+    }
+
+    @Test
+    void parseDateTimeShouldTolerateNullBlankAndMalformedValues() {
+        assertThat(AliyunConverters.parseDateTime(null)).isNull();
+        assertThat(AliyunConverters.parseDateTime("  ")).isNull();
+        assertThat(AliyunConverters.parseDateTime("not-a-date")).isNull();
+
+        assertThat(AliyunConverters.parseDateTime("2026-08-21 10:30:00"))
+                .isEqualTo(LocalDateTime.of(2026, 8, 21, 10, 30, 0));
+    }
+
+    @Test
+    void parseTimeMillisShouldReturnZeroForMissingAndInvalidValues() {
+        assertThat(AliyunConverters.parseTimeMillis(null)).isZero();
+        assertThat(AliyunConverters.parseTimeMillis(" ")).isZero();
+        assertThat(AliyunConverters.parseTimeMillis("garbage")).isZero();
+
+        // Asia/Shanghai is UTC+8, so 1970-01-01 08:00 local is epoch zero.
+        assertThat(AliyunConverters.parseTimeMillis("1970-01-01 08:00:00")).isZero();
+    }
+
+    @Test
+    void formatTimeMillisShouldRenderInTheAliyunZone() {
+        assertThat(AliyunConverters.formatTimeMillis(0L)).isEqualTo("1970-01-01 08:00:00");
+        assertThat(AliyunConverters.formatTimeMillis(1_774_059_600_000L))
+                .isEqualTo("2026-03-21 10:20:00");
+    }
+
+    @Test
+    void tryBase64DecodeShouldDecodeUtf8AndTolerateInvalidInput() {
+        assertThat(AliyunConverters.tryBase64Decode(null)).isNull();
+        assertThat(AliyunConverters.tryBase64Decode("  ")).isNull();
+        assertThat(AliyunConverters.tryBase64Decode("not base64!")).isNull();
+
+        assertThat(AliyunConverters.tryBase64Decode(Base64.getEncoder()
+                .encodeToString("hello".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
+                .isEqualTo("hello");
+        assertThat(AliyunConverters.tryBase64Decode(Base64.getEncoder()
+                .encodeToString("\u4e2d\u6587".getBytes(java.nio.charset.StandardCharsets.UTF_8))))
+                .isEqualTo("\u4e2d\u6587");
+
+        // Syntactically valid base64 that does not decode to UTF-8 must degrade to null.
+        assertThat(AliyunConverters.tryBase64Decode(Base64.getEncoder()
+                .encodeToString(new byte[]{(byte) 0xC3, 0x28}))).isNull();
     }
 }


### PR DESCRIPTION
### Summary

`AliyunConverters` parses Aliyun timestamp strings, renders epoch millis in the Asia/Shanghai zone and decodes base64 message bodies defensively. Only the instance-option count clamping had a direct test.

### Changes

- `parseDateTime` tolerates null, blank and malformed values while parsing valid `yyyy-MM-dd HH:mm:ss`
- `parseTimeMillis` returns 0 for missing/invalid values and maps Shanghai-local times to epoch millis
- `formatTimeMillis` renders in the Aliyun time zone
- `tryBase64Decode` decodes UTF-8 text, keeps invalid base64 and non-UTF-8 payloads as `null`, and round-trips CJK text

### Testing

`mvn test -Dtest=AliyunConvertersTest` passes: 5 tests, 0 failures (up from 1).