### PR TITLE
fix(ai): exclude LLM provider token from LlmProperties toString

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmPropertiesTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmPropertiesTest.java
@@ -16,22 +16,26 @@
  */
 package org.apache.rocketmq.studio.ops.ai;
 
-import lombok.Data;
-import lombok.ToString;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 
-/**
- * LLM runtime settings supplied through the environment. Tokens and inherited
- * CLI environment values must never be persisted or logged.
- */
-@Data
-@ConfigurationProperties(prefix = "studio.llm")
-public class LlmProperties {
-    @ToString.Exclude
-    private String token;
-    private String anthropicBaseUrl;
-    private List<String> cliAllowedEnvironment = new ArrayList<>();
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmPropertiesTest {
+
+    @Test
+    void toStringShouldNotExposeTheProviderToken() {
+        LlmProperties properties = new LlmProperties();
+        properties.setToken("studio-llm-provider-token");
+        properties.setAnthropicBaseUrl("https://llm.example");
+        properties.setCliAllowedEnvironment(List.of("ANTHROPIC_AUTH_TOKEN"));
+
+        String value = properties.toString();
+
+        assertThat(value)
+                .contains("anthropicBaseUrl=https://llm.example")
+                .contains("cliAllowedEnvironment=[ANTHROPIC_AUTH_TOKEN]")
+                .doesNotContain("studio-llm-provider-token");
+    }
 }


### PR DESCRIPTION
### Summary

`LlmProperties` is a Lombok `@Data` configuration bean whose `token` field holds the LLM provider token. The generated `toString()` therefore printed the token verbatim whenever the bean entered a log line, contradicting the class's own javadoc that tokens must never be logged.

### Changes

- Annotate `token` with `@ToString.Exclude` so the provider token stays out of `toString()` output
- Add `LlmPropertiesTest` asserting non-sensitive fields are still visible while the token is not

### Testing

`mvn test -Dtest=LlmPropertiesTest` passes: 1 test, 0 failures.