### PR TITLE
test: cover list/create/update/delete delegation in CloudCredentialController

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialControllerTest.java
@@ -16,17 +16,27 @@
  */
 package org.apache.rocketmq.studio.provider.credential;
 
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(CloudCredentialController.class)
@@ -50,5 +60,96 @@ class CloudCredentialControllerTest {
         mockMvc.perform(get("/api/cloud-credentials/1/credentials"))
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"));
+    }
+
+    @Test
+    void listCredentialsShouldForwardFiltersAndDefaults() throws Exception {
+        PageResult<CloudCredentialVO> page = PageResult.of(List.of(), 0, 1, 20);
+        when(credentialService.listMasked(eq(InstanceVendor.ALIYUN), eq("orders"), eq(2), eq(50)))
+                .thenReturn(page);
+
+        mockMvc.perform(get("/api/cloud-credentials")
+                        .param("vendor", "ALIYUN")
+                        .param("search", "orders")
+                        .param("page", "2")
+                        .param("pageSize", "50"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(credentialService).listMasked(InstanceVendor.ALIYUN, "orders", 2, 50);
+    }
+
+    @Test
+    void listCredentialsShouldApplyDefaultPaging() throws Exception {
+        when(credentialService.listMasked(null, null, 1, 20)).thenReturn(PageResult.of(List.of(), 0, 1, 20));
+
+        mockMvc.perform(get("/api/cloud-credentials"))
+                .andExpect(status().isOk());
+
+        verify(credentialService).listMasked(null, null, 1, 20);
+    }
+
+    @Test
+    void createCredentialShouldRejectAMissingBody() throws Exception {
+        mockMvc.perform(post("/api/cloud-credentials/create")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Cloud credential request is required"));
+
+        verify(credentialService, org.mockito.Mockito.never())
+                .create(any(CloudCredentialVO.class));
+    }
+
+    @Test
+    void createCredentialShouldDelegateTheValidatedRequest() throws Exception {
+        CloudCredentialVO created = new CloudCredentialVO();
+        created.setId(3L);
+        created.setName("production");
+        when(credentialService.create(any(CloudCredentialVO.class))).thenReturn(created);
+
+        mockMvc.perform(post("/api/cloud-credentials/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"production","vendor":"ALIYUN",
+                                 "accessKey":"ak-1","secretKey":"sk-1"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(3));
+
+        org.mockito.ArgumentCaptor<CloudCredentialVO> captor =
+                org.mockito.ArgumentCaptor.forClass(CloudCredentialVO.class);
+        verify(credentialService).create(captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getName()).isEqualTo("production");
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getVendor())
+                .isEqualTo(InstanceVendor.ALIYUN);
+    }
+
+    @Test
+    void updateCredentialShouldDelegateTheValidatedRequest() throws Exception {
+        CloudCredentialVO updated = new CloudCredentialVO();
+        updated.setId(9L);
+        when(credentialService.update(any(UpdateCloudCredentialDTO.class))).thenReturn(updated);
+
+        mockMvc.perform(post("/api/cloud-credentials/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"id\":9,\"secretKey\":\"rotated\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(9));
+
+        org.mockito.ArgumentCaptor<UpdateCloudCredentialDTO> captor =
+                org.mockito.ArgumentCaptor.forClass(UpdateCloudCredentialDTO.class);
+        verify(credentialService).update(captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getId()).isEqualTo(9L);
+    }
+
+    @Test
+    void deleteCredentialShouldParseAndDelegateTheId() throws Exception {
+        mockMvc.perform(post("/api/cloud-credentials/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"id\":\"7\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(credentialService).delete(7L);
     }
 }


### PR DESCRIPTION
### Summary

`CloudCredentialController` lists masked credentials with filters, creates/updates from validated DTOs and deletes by parsed id. Only the no-store secrets endpoint had a test.

### Changes

- `listCredentials` forwards vendor/search/paging and applies the 1/20 defaults
- A missing create/update body is rejected with `400 Cloud credential request is required`
- Create maps the DTO to a `CloudCredentialVO` (name + parsed vendor) before delegating
- Update and delete delegate with the request id parsed to `Long`

### Testing

`mvn test -Dtest=CloudCredentialControllerTest` passes: 7 tests, 0 failures (up from 1).