### PR TITLE
test: cover null guards and blank-instance normalization in ConsumerDiagnosticsService

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerDiagnosticsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerDiagnosticsServiceTest.java
@@ -95,4 +95,33 @@ class ConsumerDiagnosticsServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("clientId is required");
     }
+
+    @Test
+    void getConsumerStackShouldRejectNullGroupNameAndClientId() {
+        assertThatThrownBy(() -> diagnosticsService.getConsumerStack("instance-a", null, "client-1"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("groupName is required");
+        assertThatThrownBy(() -> diagnosticsService.getConsumerStack("instance-a", "cg-orders", null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("clientId is required");
+    }
+
+    @Test
+    void blankInstanceIdShouldBeNormalizedToNullBeforeDelegating() {
+        ConsumerStackTraceVO stackTrace = ConsumerStackTraceVO.builder()
+                .groupName("cg-orders")
+                .clientId("client-1")
+                .capturedAt(LocalDateTime.now())
+                .threadCount(0)
+                .threads(List.of())
+                .build();
+        when(diagnosticsProvider.getConsumerStack(null, "cg-orders", "client-1"))
+                .thenReturn(stackTrace);
+
+        ConsumerStackTraceVO result = diagnosticsService.getConsumerStack(
+                "  ", "cg-orders", "client-1");
+
+        assertThat(result).isSameAs(stackTrace);
+        verify(diagnosticsProvider).getConsumerStack(null, "cg-orders", "client-1");
+    }
 }


### PR DESCRIPTION
### Summary

`ConsumerDiagnosticsService` requires a group and client id but treats the instance id as optional before delegating to the provider. The suite covered blank group/client rejection but not the `null` forms or instance normalization.

### Changes

- `null` group names and client ids are rejected with the same required-field messages
- A blank instance id is normalized to `null` before the provider call

### Testing

`mvn test -Dtest=ConsumerDiagnosticsServiceTest` passes: 6 tests, 0 failures (up from 4).