### PR TITLE
test: cover the required namesrvAddr parameter in ClientController

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientControllerTest.java
@@ -88,6 +88,19 @@ class ClientControllerTest {
     }
 
     @Test
+    void listConnectionsShouldRejectAMissingNamesrvAddr() throws Exception {
+        mockMvc.perform(get("/api/clients"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400));
+
+        org.mockito.Mockito.verify(clientService,
+                org.mockito.Mockito.never()).listConnectionsAt(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
     void listConnectionsShouldPassClusterAndTypeFilters() throws Exception {
         when(clientService.listConnectionsAt("10.0.1.31:9876", "production-cluster", "Consumer")).thenReturn(List.of());
 


### PR DESCRIPTION
### Summary

`GET /api/clients` requires the `namesrvAddr` query parameter. The suite covered the populated and filtered requests but never the missing-parameter case.

### Changes

- Omitting `namesrvAddr` returns a `400` envelope without calling the client service

### Testing

`mvn test -Dtest=ClientControllerTest` passes: 3 tests, 0 failures (up from 2).