### PR TITLE
test: cover anthropicBase resolution rules in ClaudeCodeAgentProvider

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProvider.java
@@ -258,7 +258,7 @@ public class ClaudeCodeAgentProvider extends CliAgentProvider {
         return env;
     }
 
-    private String anthropicBase(LlmConfigVO config) {
+    String anthropicBase(LlmConfigVO config) {
         if (llmProperties != null && StringUtils.hasText(llmProperties.getAnthropicBaseUrl())) {
             return llmProperties.getAnthropicBaseUrl().trim();
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/ClaudeCodeAgentProviderTest.java
@@ -132,6 +132,58 @@ class ClaudeCodeAgentProviderTest {
         verify(process).destroyForcibly();
     }
 
+    @Test
+    void anthropicBaseShouldPreferTheConfiguredGlobalBaseUrl() {
+        LlmProperties properties = new LlmProperties();
+        properties.setAnthropicBaseUrl("  https://llm.example/apps/anthropic  ");
+        ClaudeCodeAgentProvider provider = new ClaudeCodeAgentProvider(
+                properties, new CliProcessEnvironment(List.of()));
+        LlmConfigVO config = LlmConfigVO.builder()
+                .apiBase("https://api.example.com/compatible-mode/v1")
+                .build();
+
+        assertThat(provider.anthropicBase(config))
+                .isEqualTo("https://llm.example/apps/anthropic");
+    }
+
+    @Test
+    void anthropicBaseShouldReturnNullWhenNothingIsConfigured() {
+        ClaudeCodeAgentProvider provider = new ClaudeCodeAgentProvider(
+                new LlmProperties(), new CliProcessEnvironment(List.of()));
+        LlmConfigVO config = LlmConfigVO.builder().build();
+
+        assertThat(provider.anthropicBase(config)).isNull();
+    }
+
+    @Test
+    void anthropicBaseShouldRewriteTheCompatibleModeSuffixToAnthropicApps() {
+        ClaudeCodeAgentProvider provider = new ClaudeCodeAgentProvider(
+                new LlmProperties(), new CliProcessEnvironment(List.of()));
+        LlmConfigVO config = LlmConfigVO.builder()
+                .apiBase("https://api.anthropic.com/compatible-mode/v1/")
+                .build();
+
+        assertThat(provider.anthropicBase(config))
+                .isEqualTo("https://api.anthropic.com/apps/anthropic");
+    }
+
+    @Test
+    void anthropicBaseShouldTrimSlashesAndLeaveOtherBasesUnchanged() {
+        ClaudeCodeAgentProvider provider = new ClaudeCodeAgentProvider(
+                new LlmProperties(), new CliProcessEnvironment(List.of()));
+        LlmConfigVO plain = LlmConfigVO.builder()
+                .apiBase("https://gateway.example///")
+                .build();
+        LlmConfigVO alreadyAnthropic = LlmConfigVO.builder()
+                .apiBase("https://api.anthropic.com/apps/anthropic")
+                .build();
+
+        assertThat(provider.anthropicBase(plain))
+                .isEqualTo("https://gateway.example");
+        assertThat(provider.anthropicBase(alreadyAnthropic))
+                .isEqualTo("https://api.anthropic.com/apps/anthropic");
+    }
+
     private static final class RecordingEnvironment extends CliProcessEnvironment {
         private final List<Map<String, String>> childEnvironments = new ArrayList<>();
 


### PR DESCRIPTION
### Summary

`ClaudeCodeAgentProvider.anthropicBase` decides the `ANTHROPIC_BASE_URL` for the child CLI: a globally configured base wins, otherwise the request `apiBase` is normalized and the `/compatible-mode/v1` suffix is rewritten to `/apps/anthropic`. The stream tests bypassed it by overriding `childEnv`, so these rules were untested.

### Changes

- Widen `anthropicBase` to package-private so the same-package suite can exercise it directly
- Configured global base wins over the request base and is trimmed
- Nothing configured yields `null`
- A `/compatible-mode/v1/` request base is rewritten to `/apps/anthropic`
- Trailing slashes are trimmed and non-compatible bases pass through unchanged

### Testing

`mvn test -Dtest=ClaudeCodeAgentProviderTest` passes: 9 tests, 0 failures (up from 5).