### PR TITLE
test: cover unknown uid 404 envelope in GrafanaDashboardController

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/grafana/GrafanaDashboardControllerTest.java
@@ -97,4 +97,22 @@ class GrafanaDashboardControllerTest {
                         "attachment; filename=\"rocketmq-grafana-dashboards.zip\""))
                 .andExpect(content().bytes(archive));
     }
+
+    @Test
+    void unknownDashboardUidShouldReturn404Envelope() throws Exception {
+        org.apache.rocketmq.studio.common.exception.BusinessException missing =
+                new org.apache.rocketmq.studio.common.exception.BusinessException(
+                        404, "Unknown Grafana dashboard uid: missing-uid");
+        when(grafanaDashboardService.getDashboard("missing-uid")).thenThrow(missing);
+        when(grafanaDashboardService.getDashboardJson("missing-uid")).thenThrow(missing);
+
+        mockMvc.perform(get("/api/metrics/grafana/dashboards/missing-uid"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.message").value("Unknown Grafana dashboard uid: missing-uid"));
+
+        mockMvc.perform(get("/api/metrics/grafana/dashboards/missing-uid/export"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404));
+    }
 }


### PR DESCRIPTION
### Summary

`GrafanaDashboardController` proxies bundled Grafana dashboards; an unknown uid surfaces a `404` from the service on both the model and export endpoints. The suite covered only the happy paths.

### Changes

- An unknown dashboard uid returns a `404` envelope with the service message on the model endpoint
- The export endpoint degrades to the same `404` envelope

### Testing

`mvn test -Dtest=GrafanaDashboardControllerTest` passes: 5 tests, 0 failures (up from 4).