### PR TITLE
test: cover input sensitivity and null tolerance in AlertFingerprint

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprintTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprintTest.java
@@ -46,4 +46,34 @@ class AlertFingerprintTest {
         assertThat(AlertFingerprint.of(7L, "local", embeddedLabel))
                 .isNotEqualTo(AlertFingerprint.of(7L, "local", separateLabels));
     }
+
+    @Test
+    void ruleIdAndInstanceIdChangeTheFingerprintTest() {
+        Map<String, String> labels = Map.of("broker", "a");
+
+        assertThat(AlertFingerprint.of(7L, "local", labels))
+                .isNotEqualTo(AlertFingerprint.of(8L, "local", labels));
+        assertThat(AlertFingerprint.of(7L, "local", labels))
+                .isNotEqualTo(AlertFingerprint.of(7L, "remote", labels));
+    }
+
+    @Test
+    void nullInstanceAndLabelsAreToleratedAndDeterministicTest() {
+        String first = AlertFingerprint.of(7L, null, null);
+        String second = AlertFingerprint.of(7L, null, null);
+
+        assertThat(first).hasSize(64);
+        assertThat(second).isEqualTo(first);
+    }
+
+    @Test
+    void backslashInValuesCannotCollideWithEscapedSeparatorsTest() {
+        // Without backslash escaping, "b\\c" would read the same as an escaped newline
+        // boundary; escaping keeps the two label sets distinct.
+        Map<String, String> backslashValue = Map.of("a", "b\\c");
+        Map<String, String> newlineValue = Map.of("a", "b", "c", "d");
+
+        assertThat(AlertFingerprint.of(7L, "local", backslashValue))
+                .isNotEqualTo(AlertFingerprint.of(7L, "local", newlineValue));
+    }
 }


### PR DESCRIPTION
### Summary

`AlertFingerprint.of` hashes rule id, instance id and sorted labels with separator escaping. The suite covered label-order stability and newline/equals collisions but not the other input dimensions.

### Changes

- Different rule ids and instance ids yield different fingerprints for identical labels
- `null` instance id and `null` labels are tolerated and deterministic (64 hex chars)
- A backslash inside a value cannot collide with an escaped newline boundary

### Testing

`mvn test -Dtest=AlertFingerprintTest` passes: 5 tests, 0 failures (up from 2).