### PR TITLE
test: cover operator/sample sensitivity, clamps and non-ratio units in AlertRuleSemanticFingerprint

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleSemanticFingerprintTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleSemanticFingerprintTest.java
@@ -77,4 +77,66 @@ class AlertRuleSemanticFingerprintTest {
                 .isEqualTo(AlertRuleSemanticFingerprint.of(fraction))
                 .isNotEqualTo(AlertRuleSemanticFingerprint.of(rawValue));
     }
+
+    @Test
+    void operatorAndConsecutiveSamplesAreSemanticallySignificantTest() {
+        AlertRuleVO base = AlertRuleVO.builder()
+                .domain(AlertDomain.BUSINESS).instanceId("local").metric("consumer.lag.total")
+                .operator(">=").threshold(1000).duration("5m").consumerGroup("group-a").build();
+        AlertRuleVO differentOperator = AlertRuleVO.builder()
+                .domain(AlertDomain.BUSINESS).instanceId("local").metric("consumer.lag.total")
+                .operator(">").threshold(1000).duration("5m").consumerGroup("group-a").build();
+        AlertRuleVO moreSamples = AlertRuleVO.builder()
+                .domain(AlertDomain.BUSINESS).instanceId("local").metric("consumer.lag.total")
+                .operator(">=").threshold(1000).duration("5m").consumerGroup("group-a")
+                .consecutiveSamples(3).build();
+
+        assertThat(AlertRuleSemanticFingerprint.of(differentOperator))
+                .isNotEqualTo(AlertRuleSemanticFingerprint.of(base));
+        assertThat(AlertRuleSemanticFingerprint.of(moreSamples))
+                .isNotEqualTo(AlertRuleSemanticFingerprint.of(base));
+    }
+
+    @Test
+    void nonPositiveWindowAndSamplesClampToTheirDefaultsTest() {
+        AlertRuleVO base = AlertRuleVO.builder()
+                .domain(AlertDomain.BUSINESS).instanceId("local").metric("consumer.lag.total")
+                .operator(">=").threshold(1000).duration("5m").consumerGroup("group-a").build();
+        AlertRuleVO clamped = AlertRuleVO.builder()
+                .domain(AlertDomain.BUSINESS).instanceId("local").metric("consumer.lag.total")
+                .operator(">=").threshold(1000).duration("5m").consumerGroup("group-a")
+                .windowSeconds(-10).consecutiveSamples(0).build();
+
+        assertThat(AlertRuleSemanticFingerprint.of(clamped))
+                .isEqualTo(AlertRuleSemanticFingerprint.of(base));
+    }
+
+    @Test
+    void thresholdUnitIsIgnoredForNonRatioMetricsTest() {
+        AlertRuleVO percentage = AlertRuleVO.builder()
+                .domain(AlertDomain.CLUSTER)
+                .metric("broker.cpu.usage")
+                .operator(">=")
+                .threshold(85)
+                .thresholdUnit("%")
+                .build();
+        AlertRuleVO raw = AlertRuleVO.builder()
+                .domain(AlertDomain.CLUSTER)
+                .metric("broker.cpu.usage")
+                .operator(">=")
+                .threshold(85)
+                .thresholdUnit(null)
+                .build();
+        AlertRuleVO fraction = AlertRuleVO.builder()
+                .domain(AlertDomain.CLUSTER)
+                .metric("broker.cpu.usage")
+                .operator(">=")
+                .threshold(0.85)
+                .thresholdUnit(null)
+                .build();
+
+        assertThat(AlertRuleSemanticFingerprint.of(percentage))
+                .isEqualTo(AlertRuleSemanticFingerprint.of(raw))
+                .isNotEqualTo(AlertRuleSemanticFingerprint.of(fraction));
+    }
 }


### PR DESCRIPTION
### Summary

`AlertRuleSemanticFingerprint.of` hashes the evaluation semantics of a rule (domain, scope, operator, normalized threshold, duration, window, sample count). The suite covered presentation-insensitivity, scope changes and ratio-threshold normalization only.

### Changes

- A different operator or a different consecutive-sample count changes the fingerprint
- Non-positive windows and sample counts clamp to their safe defaults and stay identical to the defaults
- The `%` threshold unit is ignored for non-ratio metrics, while the raw threshold still matters

### Testing

`mvn test -Dtest=AlertRuleSemanticFingerprintTest` passes: 6 tests, 0 failures (up from 3).