### PR TITLE
test: cover envelope and nested validation in AlertRuleTransferDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTOTest.java
@@ -29,4 +29,32 @@ class AlertRuleTransferDTOTest {
                 .extracting(violation -> violation.getMessage())
                 .contains("rule must not be null");
     }
+
+    @Test
+    void rejectsMissingEnvelopeFieldsTest() {
+        AlertRuleTransferDTO transfer = new AlertRuleTransferDTO();
+
+        assertThat(validator.validate(transfer))
+                .extracting(violation -> violation.getMessage())
+                .contains("version is required", "domain is required", "rules must not be empty");
+    }
+
+    @Test
+    void acceptsACompleteTransferWithoutViolationsTest() {
+        AlertRuleRequestDTO rule = new AlertRuleRequestDTO();
+        rule.setName("Broker unavailable");
+        rule.setMetric("broker.up");
+        rule.setOperator("==");
+        rule.setThreshold(0);
+        rule.setDuration("1m");
+        rule.setChannels(java.util.List.of("email"));
+        rule.setEnabled(true);
+
+        AlertRuleTransferDTO transfer = new AlertRuleTransferDTO();
+        transfer.setVersion(AlertRuleTransferDTO.VERSION);
+        transfer.setDomain(AlertDomain.CLUSTER);
+        transfer.setRules(java.util.List.of(rule));
+
+        assertThat(validator.validate(transfer)).isEmpty();
+    }
 }


### PR DESCRIPTION
### Summary

`AlertRuleTransferDTO` carries a version/domain envelope plus validated rule entries. The suite only covered null entries inside the rules list.

### Changes

- A transfer without version, domain or rules reports all three required-field messages
- A complete transfer with a valid rule entry passes bean validation without violations

### Testing

`mvn test -Dtest=AlertRuleTransferDTOTest` passes: 3 tests, 0 failures (up from 1).