### PR TITLE
test: cover metric keys, blank group names and count clamping in ApacheRocketMqDlqMetricsCollector

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqDlqMetricsCollectorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqDlqMetricsCollectorTest.java
@@ -87,4 +87,38 @@ class ApacheRocketMqDlqMetricsCollectorTest {
     private static InstanceVO apacheInstance() {
         return InstanceVO.builder().name("local").endpoint("localhost:9876").vendor(InstanceVendor.APACHE).build();
     }
+
+    @Test
+    void metricKeysShouldDeclareDlqMessageCount() {
+        assertThat(new ApacheRocketMqDlqMetricsCollector(mock(DLQProvider.class)).metricKeys())
+                .containsExactly(ApacheRocketMqDlqMetricsCollector.DLQ_MESSAGE_COUNT);
+    }
+
+    @Test
+    void blankGroupNamesAreSkippedTest() {
+        DLQProvider provider = mock(DLQProvider.class);
+        when(provider.listDLQGroups("local")).thenReturn(List.of(
+                DLQGroupVO.builder().groupName(null).messageCount(5).statsAvailable(true).build(),
+                DLQGroupVO.builder().groupName("  ").messageCount(6).statsAvailable(true).build(),
+                DLQGroupVO.builder().groupName("orders").messageCount(7).statsAvailable(true).build()));
+
+        List<MetricSample> samples = new ApacheRocketMqDlqMetricsCollector(provider).collect(apacheInstance());
+
+        assertThat(samples).hasSize(1);
+        assertThat(samples.get(0).labels().get("consumerGroup")).isEqualTo("orders");
+    }
+
+    @Test
+    void negativeMessageCountsClampToZeroTest() {
+        DLQProvider provider = mock(DLQProvider.class);
+        when(provider.listDLQGroups("local")).thenReturn(List.of(
+                DLQGroupVO.builder().groupName("orders").messageCount(-3).statsAvailable(true).build()));
+
+        List<MetricSample> samples = new ApacheRocketMqDlqMetricsCollector(provider).collect(apacheInstance());
+
+        assertThat(samples).singleElement().satisfies(sample -> {
+            assertThat(sample.value()).isEqualTo(0D);
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.AVAILABLE);
+        });
+    }
 }


### PR DESCRIPTION
### Summary

`ApacheRocketMqDlqMetricsCollector` emits `dlq.message.count` samples per DLQ group, skipping blank names and clamping negative counts. The suite covered available/unavailable samples, provider failure and vendor gating only.

### Changes

- `metricKeys` declares `dlq.message.count`
- Groups with `null` or blank names are skipped entirely
- Negative broker message counts clamp to a zero-valued available sample

### Testing

`mvn test -Dtest=ApacheRocketMqDlqMetricsCollectorTest` passes: 7 tests, 0 failures (up from 4).