### PR TITLE
test: cover blank, non-numeric and overflow cases in EntityIds

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/EntityIdsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/EntityIdsTest.java
@@ -39,4 +39,35 @@ class EntityIdsTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("positive numeric value");
     }
+
+    @Test
+    void rejectsNullAndBlankIdentifiers() {
+        assertThatThrownBy(() -> EntityIds.parseId(null))
+                .isInstanceOfSatisfying(BusinessException.class,
+                        error -> assertThat(error.getCode()).isEqualTo(400))
+                .hasMessage("id is required");
+        assertThatThrownBy(() -> EntityIds.parseId("  "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("id is required");
+    }
+
+    @Test
+    void rejectsNonNumericIdentifiers() {
+        assertThatThrownBy(() -> EntityIds.parseId("abc"))
+                .isInstanceOfSatisfying(BusinessException.class,
+                        error -> assertThat(error.getCode()).isEqualTo(400))
+                .hasMessage("id must be a numeric value: abc");
+        assertThatThrownBy(() -> EntityIds.parseId("42abc"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("id must be a numeric value: 42abc");
+    }
+
+    @Test
+    void acceptsPositiveIdentifiersAcrossTheLongRange() {
+        assertThat(EntityIds.parseId(Long.toString(Long.MAX_VALUE)))
+                .isEqualTo(Long.MAX_VALUE);
+        assertThatThrownBy(() -> EntityIds.parseId("99999999999999999999"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("numeric value");
+    }
 }


### PR DESCRIPTION
### Summary

`EntityIds.parseId` converts external string ids to positive database primary keys with uniform 400 errors. The suite covered trimmed parsing and zero/negative rejection only.

### Changes

- `null` and blank ids fail with `400 id is required`
- Non-numeric values (pure or trailing garbage) fail with `id must be a numeric value`
- Positive ids parse across the full `long` range, while an overflowing value is rejected instead of wrapping

### Testing

`mvn test -Dtest=EntityIdsTest` passes: 5 tests, 0 failures (up from 2).