### PR TITLE
test: cover gating, failure and case-insensitive status in CloudRocketMqClusterMetricsCollector

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/CloudRocketMqClusterMetricsCollectorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/CloudRocketMqClusterMetricsCollectorTest.java
@@ -76,4 +76,59 @@ class CloudRocketMqClusterMetricsCollectorTest {
         return InstanceVO.builder().name("cloud-local").vendor(vendor).credentialId(7L)
                 .regionId("cn-hangzhou").cloudInstanceId("rmq-cloud").build();
     }
+
+    @Test
+    void skipsInstancesThatAreNotCloudManagedTest() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        InstanceVO apache = InstanceVO.builder().name("local").vendor(InstanceVendor.APACHE)
+                .credentialId(7L).regionId("cn-hangzhou").cloudInstanceId("rmq-cloud").build();
+        InstanceVO missingCoords = InstanceVO.builder().name("cloud-local")
+                .vendor(InstanceVendor.ALIYUN).build();
+
+        assertThat(new CloudRocketMqClusterMetricsCollector(registry).collect(apache)).isEmpty();
+        assertThat(new CloudRocketMqClusterMetricsCollector(registry).collect(missingCoords)).isEmpty();
+    }
+
+    @Test
+    void runningStatusIsMatchedCaseInsensitivelyTest() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        CloudCatalogProvider catalog = mock(CloudCatalogProvider.class);
+        InstanceVO instance = cloudInstance(InstanceVendor.ALIYUN);
+        CloudInstanceDetailVO detail = new CloudInstanceDetailVO();
+        detail.setStatus("running");
+        when(registry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
+        when(catalog.getCloudInstance(7L, "cn-hangzhou", "rmq-cloud")).thenReturn(detail);
+
+        List<MetricSample> samples = new CloudRocketMqClusterMetricsCollector(registry).collect(instance);
+
+        assertThat(samples).singleElement().satisfies(sample -> {
+            assertThat(sample.value()).isEqualTo(1D);
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.AVAILABLE);
+        });
+    }
+
+    @Test
+    void unavailableWhenTheCloudQueryFailsTest() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        CloudCatalogProvider catalog = mock(CloudCatalogProvider.class);
+        InstanceVO instance = cloudInstance(InstanceVendor.ALIYUN);
+        when(registry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
+        when(catalog.getCloudInstance(7L, "cn-hangzhou", "rmq-cloud"))
+                .thenThrow(new IllegalStateException("cloud offline"));
+
+        List<MetricSample> samples = new CloudRocketMqClusterMetricsCollector(registry).collect(instance);
+
+        assertThat(samples).singleElement().satisfies(sample -> {
+            assertThat(sample.value()).isNull();
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.UNAVAILABLE);
+            assertThat(sample.labels()).containsEntry("cloudInstanceId", "rmq-cloud")
+                    .doesNotContainKey("cloudStatus");
+        });
+    }
+
+    @Test
+    void metricKeysShouldDeclareCloudInstanceAvailability() {
+        assertThat(new CloudRocketMqClusterMetricsCollector(mock(InstanceProviderRegistry.class)).metricKeys())
+                .containsExactly("cloud.instance.availability");
+    }
 }


### PR DESCRIPTION
### Summary

`CloudRocketMqClusterMetricsCollector` emits an availability sample for Aliyun/Tencent managed instances, gated on cloud coordinates and tolerating query failures. The suite covered RUNNING and STOPPED happy paths only.

### Changes

- Non-cloud vendors and instances missing credential/region/cloud-instance coordinates are skipped
- The `RUNNING` status is matched case-insensitively
- A failing cloud query degrades to an `UNAVAILABLE` sample without a `cloudStatus` label
- `metricKeys` declares `cloud.instance.availability`

### Testing

`mvn test -Dtest=CloudRocketMqClusterMetricsCollectorTest` passes: 6 tests, 0 failures (up from 2).