### PR TITLE
test: cover provider absence, empty progress and group failure in CloudRocketMqBusinessMetricsCollector

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/CloudRocketMqBusinessMetricsCollectorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/CloudRocketMqBusinessMetricsCollectorTest.java
@@ -67,4 +67,66 @@ class CloudRocketMqBusinessMetricsCollectorTest {
         assertThat(new CloudRocketMqBusinessMetricsCollector(mock(InstanceProviderRegistry.class)).collect(instance))
                 .isEmpty();
     }
+
+    @Test
+    void unavailableWhenNoProviderIsRegisteredForTheInstanceTest() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        InstanceVO instance = InstanceVO.builder().name("aliyun").vendor(InstanceVendor.ALIYUN).build();
+        when(registry.byInstanceId("aliyun")).thenReturn(Optional.empty());
+
+        List<MetricSample> samples = new CloudRocketMqBusinessMetricsCollector(registry).collect(instance);
+
+        assertThat(samples).hasSize(3).allSatisfy(sample -> {
+            assertThat(sample.value()).isNull();
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.UNAVAILABLE);
+        });
+    }
+
+    @Test
+    void emptyProgressProducesZeroLagWithoutBacklogTest() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        InstanceProvider provider = mock(InstanceProvider.class);
+        InstanceVO instance = InstanceVO.builder().name("aliyun").vendor(InstanceVendor.ALIYUN).build();
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName("orders");
+        when(registry.byInstanceId("aliyun")).thenReturn(Optional.of(provider));
+        when(provider.listConsumerGroups("aliyun", null)).thenReturn(List.of(group));
+        when(provider.getGroupProgress("aliyun", "orders")).thenReturn(List.of());
+
+        List<MetricSample> samples = new CloudRocketMqBusinessMetricsCollector(registry).collect(instance);
+
+        assertThat(samples).hasSize(2).allSatisfy(sample -> {
+            assertThat(sample.value()).isEqualTo(0D);
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.AVAILABLE);
+        });
+        assertThat(samples).filteredOn(sample -> sample.metricKey().equals("topic.backlog.total"))
+                .isEmpty();
+    }
+
+    @Test
+    void groupProgressFailureDegradesToUnavailableWithGroupLabelTest() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        InstanceProvider provider = mock(InstanceProvider.class);
+        InstanceVO instance = InstanceVO.builder().name("aliyun").vendor(InstanceVendor.ALIYUN).build();
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName("orders");
+        when(registry.byInstanceId("aliyun")).thenReturn(Optional.of(provider));
+        when(provider.listConsumerGroups("aliyun", null)).thenReturn(List.of(group));
+        when(provider.getGroupProgress("aliyun", "orders"))
+                .thenThrow(new IllegalStateException("offline"));
+
+        List<MetricSample> samples = new CloudRocketMqBusinessMetricsCollector(registry).collect(instance);
+
+        assertThat(samples).hasSize(3).allSatisfy(sample -> {
+            assertThat(sample.value()).isNull();
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.UNAVAILABLE);
+            assertThat(sample.labels()).containsEntry("consumerGroup", "orders");
+        });
+    }
+
+    @Test
+    void metricKeysShouldDeclareTheThreeLagMetrics() {
+        assertThat(new CloudRocketMqBusinessMetricsCollector(mock(InstanceProviderRegistry.class)).metricKeys())
+                .containsExactlyInAnyOrder("consumer.lag.total", "consumer.lag.max_queue", "topic.backlog.total");
+    }
 }


### PR DESCRIPTION
### Summary

`CloudRocketMqBusinessMetricsCollector` derives consumer-lag metrics from a cloud provider, degrading to unavailable trios when the provider or its group progress is missing/failing. The suite covered the happy lag path and Apache-vendor gating only.

### Changes

- No registered provider for the instance degrades to an `UNAVAILABLE` trio with empty labels
- A group with no queue progress yields zero `consumer.lag.total`/`max_queue` samples and no backlog
- A group progress failure degrades to an `UNAVAILABLE` trio carrying the `consumerGroup` label
- `metricKeys` declares the three lag metrics

### Testing

`mvn test -Dtest=CloudRocketMqBusinessMetricsCollectorTest` passes: 6 tests, 0 failures (up from 2).