### PR TITLE
test: cover required-field validation in DataSourceTestDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceTestDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceTestDTOTest.java
@@ -40,4 +40,17 @@ class DataSourceTestDTOTest {
         assertThat(value).doesNotContain("plain-password");
         assertThat(value).doesNotContain("plain-token");
     }
+
+    @Test
+    void missingUrlAndTypeAreRejected() {
+        jakarta.validation.Validator validator =
+                jakarta.validation.Validation.buildDefaultValidatorFactory().getValidator();
+        DataSourceTestDTO request = DataSourceTestDTO.builder()
+            .username("prometheus-user")
+            .build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .contains("url is required", "type is required");
+    }
 }


### PR DESCRIPTION
### Summary

`DataSourceTestDTO` carries the settings connection probe; `url` and `type` are required and credentials are excluded from `toString`. Only the credential-masking property had a test.

### Changes

- A request without `url` or `type` reports both required-field messages under bean validation

### Testing

`mvn test -Dtest=DataSourceTestDTOTest` passes: 2 tests, 0 failures (up from 1).