### PR TITLE
test: cover vendor parsing and VO mapping in CreateCloudCredentialDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CreateCloudCredentialDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CreateCloudCredentialDTOTest.java
@@ -39,4 +39,36 @@ class CreateCloudCredentialDTOTest {
 
         assertThat(vendor).isEqualTo(InstanceVendor.ALIYUN);
     }
+
+    @Test
+    void parseVendorShouldTrimAndNormalizeCase() {
+        assertThat(CreateCloudCredentialDTO.parseVendor(" ALIYUN ")).isEqualTo(InstanceVendor.ALIYUN);
+        assertThat(CreateCloudCredentialDTO.parseVendor("tencent")).isEqualTo(InstanceVendor.TENCENT);
+        assertThat(CreateCloudCredentialDTO.parseVendor("APACHE")).isEqualTo(InstanceVendor.APACHE);
+    }
+
+    @Test
+    void parseVendorShouldReturnNullForBlankAndUnknownValues() {
+        assertThat(CreateCloudCredentialDTO.parseVendor(null)).isNull();
+        assertThat(CreateCloudCredentialDTO.parseVendor("  ")).isNull();
+        assertThat(CreateCloudCredentialDTO.parseVendor("alibaba")).isNull();
+    }
+
+    @Test
+    void toCloudCredentialVOShouldCarryEveryInputField() {
+        CreateCloudCredentialDTO request = new CreateCloudCredentialDTO();
+        request.setName("production");
+        request.setVendor(" aliyun ");
+        request.setAccessKey("ak-1");
+        request.setSecretKey("sk-1");
+        request.setRemark("primary account");
+
+        CloudCredentialVO vo = request.toCloudCredentialVO();
+
+        assertThat(vo.getName()).isEqualTo("production");
+        assertThat(vo.getVendor()).isEqualTo(InstanceVendor.ALIYUN);
+        assertThat(vo.getAccessKey()).isEqualTo("ak-1");
+        assertThat(vo.getSecretKey()).isEqualTo("sk-1");
+        assertThat(vo.getRemark()).isEqualTo("primary account");
+    }
 }


### PR DESCRIPTION
### Summary

`CreateCloudCredentialDTO.parseVendor` maps a vendor string to an `InstanceVendor` (trimmed, case-insensitive, locale-safe) and `toCloudCredentialVO` builds the persisted credential. Only the Turkish-locale case had a test.

### Changes

- Whitespace-padded and mixed-case vendor strings map to the right enum
- Blank and unknown vendor strings map to `null`
- `toCloudCredentialVO` carries name, parsed vendor, access key, secret key and remark through

### Testing

`mvn test -Dtest=CreateCloudCredentialDTOTest` passes: 4 tests, 0 failures (up from 1).