### PR TITLE
test: cover marker boundaries and case sensitivity in SystemGroupFilter

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemGroupFilterTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemGroupFilterTest.java
@@ -45,4 +45,21 @@ class SystemGroupFilterTest {
         assertThat(SystemGroupFilter.isSystem("FILTERSRV_CONSUMER_filter")).isFalse();
         assertThat(SystemGroupFilter.isSystem("SELF_TEST_GROUP")).isFalse();
     }
+
+    @Test
+    void markerPrefixesRequireTheirFullMarkerTest() {
+        assertThat(SystemGroupFilter.isSystem("CID_SYS")).isFalse();
+        assertThat(SystemGroupFilter.isSystem("rmq_sys")).isFalse();
+        assertThat(SystemGroupFilter.isSystem("%RETRY%")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("CID_HOUSEKEEPING")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("rmq_sys_EXTRA")).isTrue();
+    }
+
+    @Test
+    void prefixMatchingIsCaseSensitiveAndNotMidWordTest() {
+        assertThat(SystemGroupFilter.isSystem("cid_sys_owner")).isFalse();
+        assertThat(SystemGroupFilter.isSystem("XCID_SYS_OWNER")).isFalse();
+        assertThat(SystemGroupFilter.isSystem("rmq_sysx")).isFalse();
+        assertThat(SystemGroupFilter.isSystem("CID_ONSAPI_OWNER")).isTrue();
+    }
 }


### PR DESCRIPTION
### Summary

`SystemGroupFilter.isSystem` matches canonical RocketMQ system consumer groups by MixAll rules and literal prefix markers. The suite listed one example per marker but never probed the prefix boundaries themselves.

### Changes

- Partial markers (`CID_SYS`, `rmq_sys`) alone are not system, while the exact markers (`%RETRY%`, `CID_HOUSEKEEPING`) and suffixed forms are
- Prefix matching is case-sensitive and not mid-word: lowercase, extended or prefixed lookalikes stay non-system

### Testing

`mvn test -Dtest=SystemGroupFilterTest` passes: 3 tests, 0 failures (up from 1).