### PR TITLE
test: cover unknown cluster lookup and config update in ClusterRepositoryImpl

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
@@ -82,4 +82,22 @@ class ClusterRepositoryImplTest {
         assertThat(repository.findById("cluster-001").orElseThrow().getConfig().getFileReservedTime())
                 .isEqualTo(24);
     }
+
+    @Test
+    void findByIdShouldBeEmptyForAnUnknownCluster() {
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(true);
+
+        assertThat(repository.findById("missing-cluster")).isEmpty();
+    }
+
+    @Test
+    void updateConfigShouldBeANoOpForAnUnknownCluster() {
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(true);
+        ClusterConfigVO config = ClusterConfigVO.builder().fileReservedTime(24).build();
+
+        repository.updateConfig("missing-cluster", config);
+
+        assertThat(repository.findAll()).hasSize(2);
+        assertThat(repository.findById("missing-cluster")).isEmpty();
+    }
 }


### PR DESCRIPTION
### Summary

`ClusterRepositoryImpl` serves a seeded demo store with defensive copies. The suite covered listing order, copy isolation and config update for a known cluster, but never the unknown-id path.

### Changes

- `findById` returns an empty optional for an unknown cluster id
- `updateConfig` for an unknown cluster is a silent no-op that leaves the store untouched

### Testing

`mvn test -Dtest=ClusterRepositoryImplTest` passes: 6 tests, 0 failures (up from 4).