### PR TITLE
test: cover delete outcome reporting in MybatisPlusAlertSilenceRepository

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -155,5 +156,19 @@ class MybatisPlusAlertSilenceRepositoryTest {
         assertThat(restored.get(0).getRecurrenceDays()).containsExactlyInAnyOrder(1, 3, 5);
         assertThat(restored.get(1).getRecurrence()).isEqualTo(AlertSilenceRecurrence.ONCE);
         assertThat(restored.get(1).getRecurrenceDays()).isEmpty();
+    }
+
+    @Test
+    void deleteByIdShouldReportWhetherARowWasRemovedTest() {
+        RmqAlertSilenceMapper mapper = mock(RmqAlertSilenceMapper.class);
+        when(mapper.deleteById(1L)).thenReturn(1);
+        when(mapper.deleteById(2L)).thenReturn(0);
+        MybatisPlusAlertSilenceRepository repository =
+                new MybatisPlusAlertSilenceRepository(mapper, new ObjectMapper());
+
+        assertThat(repository.deleteById(1L)).isTrue();
+        assertThat(repository.deleteById(2L)).isFalse();
+        verify(mapper).deleteById(1L);
+        verify(mapper).deleteById(2L);
     }
 }


### PR DESCRIPTION
### Summary

`MybatisPlusAlertSilenceRepository.deleteById` removes a silence row and reports whether anything was deleted. The suite covered page queries, active-candidate SQL, save mapping and restore defaults, but not deletion.

### Changes

- Deleting an existing row reports `true`
- Deleting a row that is already gone reports `false`

### Testing

`mvn test -Dtest=MybatisPlusAlertSilenceRepositoryTest` passes: 5 tests, 0 failures (up from 4).