### PR TITLE
test: cover list and delete endpoints in AlertSilenceController

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceControllerTest.java
@@ -108,4 +108,33 @@ class AlertSilenceControllerTest {
                         && request.getRecurrenceDays().equals(Set.of(1, 3, 5))
                         && "Asia/Shanghai".equals(request.getTimeZone())));
     }
+
+    @Test
+    void listShouldReturnAllSilencesTest() throws Exception {
+        AlertSilenceVO silence = AlertSilenceVO.builder()
+                .id(12L)
+                .domain(AlertDomain.CLUSTER)
+                .startsAt(LocalDateTime.of(2026, 8, 22, 9, 0))
+                .endsAt(LocalDateTime.of(2026, 8, 22, 10, 0))
+                .createdBy("admin")
+                .build();
+        when(silenceService.list()).thenReturn(List.of(silence));
+
+        mockMvc.perform(get("/api/alert-silences"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id").value(12))
+                .andExpect(jsonPath("$.data[0].domain").value("CLUSTER"));
+
+        verify(silenceService).list();
+    }
+
+    @Test
+    void deleteShouldDelegateTheIdTest() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .delete("/api/alert-silences/7"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(silenceService).delete(7L);
+    }
 }


### PR DESCRIPTION
### Summary

`AlertSilenceController` lists all silences, pages them, creates recurring ones and deletes by id. The suite covered the paged list and create paths only.

### Changes

- `GET /api/alert-silences` returns every silence and delegates to the service
- `DELETE /api/alert-silences/{id}` returns the success envelope and forwards the parsed id

### Testing

`mvn test -Dtest=AlertSilenceControllerTest` passes: 4 tests, 0 failures (up from 2).