### PR TITLE
feat(message): improve queue browser navigation

### DIFF
--- a/web/src/components/QueueBrowser.tsx
+++ b/web/src/components/QueueBrowser.tsx
@@ -21,6 +21,7 @@ import {
   Descriptions,
   Empty,
   Flex,
+  Input,
   Select,
   Slider,
   Space,
@@ -31,9 +32,11 @@ import {
   Typography,
   message,
 } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
 import { CloseOutlined, SearchOutlined } from '@ant-design/icons';
 import type { MessageRecord, QueueOffset } from '../api/message';
 import { getQueueOffsets, pullMessageAtOffset } from '../api/message';
+import { getQueueBacklog } from '../utils/queueBrowserBacklog';
 
 const { Text, Paragraph } = Typography;
 
@@ -210,187 +213,237 @@ export const QueueBrowserResults = ({ state }: { state: QueueBrowserState }) => 
         style={{ padding: '32px 0' }}
       />
     ) : (
-      <Flex gap={16} align="flex-start">
-        {/* 左侧：队列表格 */}
-        <div style={{ width: '50%', flexShrink: 0 }}>
-          <Table<QueueOffset>
-            rowKey={(r) => `${r.brokerName}-${r.queueId}`}
-            dataSource={state.queues}
-            size="small"
-            pagination={false}
-            columns={[
-              {
-                title: 'Broker',
-                dataIndex: 'brokerName',
-                width: 180,
-                ellipsis: { showTitle: false },
-                render: (v: string) => (
-                  <Tooltip title={v}>
-                    <Text strong style={{ fontSize: 14 }}>
-                      {v}
-                    </Text>
-                  </Tooltip>
-                ),
-              },
-              {
-                title: 'Queue',
-                dataIndex: 'queueId',
-                width: 50,
-                align: 'center',
-                render: (v: number) => <Text style={{ fontSize: 14 }}>{v}</Text>,
-              },
-              {
-                title: 'Offset 范围',
-                key: 'offset',
-                width: 170,
-                render: (_: unknown, record: QueueOffset) => {
-                  const key = `${record.brokerName}-${record.queueId}`;
-                  const currentOffset = state.offsets[key] ?? record.minOffset;
-                  return (
-                    <Flex align="center" gap={8}>
-                      <Text type="secondary" style={{ fontSize: 14, flexShrink: 0 }}>
-                        {record.minOffset}
-                      </Text>
-                      <Slider
-                        style={{ flex: 1, margin: 0 }}
-                        min={record.minOffset}
-                        max={
-                          record.maxOffset > record.minOffset
-                            ? record.maxOffset - 1
-                            : record.minOffset
-                        }
-                        value={currentOffset}
-                        onChange={(value) =>
-                          state.setOffsets((prev) => ({ ...prev, [key]: value }))
-                        }
-                        tooltip={{ formatter: (v) => `offset: ${v}` }}
-                      />
-                      <Text code style={{ fontSize: 14, flexShrink: 0 }}>
-                        {currentOffset}
-                      </Text>
-                    </Flex>
-                  );
-                },
-              },
-              {
-                title: '操作',
-                key: 'action',
-                width: 70,
-                align: 'center',
-                render: (_: unknown, record: QueueOffset) => {
-                  const key = `${record.brokerName}-${record.queueId}`;
-                  return (
-                    <Button
-                      size="small"
-                      type="primary"
-                      loading={state.pulling.has(key)}
-                      onClick={() => void state.handlePull(record)}
-                    >
-                      查看
-                    </Button>
-                  );
-                },
-              },
-            ]}
-          />
-          <Text type="secondary" style={{ display: 'block', marginTop: 8, fontSize: 14 }}>
-            共 {state.queues.length} 个队列，总消息量{' '}
-            {state.queues.reduce((sum, q) => sum + (q.maxOffset - q.minOffset), 0)} 条
-          </Text>
-        </div>
+      <QueueBrowserTable state={state} />
+    )}
+  </Card>
+);
 
-        {/* 右侧：消息详情（2 列，可多条并存） */}
-        <div style={{ flex: 1, minWidth: 0 }}>
-          {state.entries.length === 0 ? (
-            <Empty
-              image={Empty.PRESENTED_IMAGE_SIMPLE}
-              description="点击左侧「查看」，消息详情将显示在这里"
-              style={{ padding: '32px 0' }}
+const QueueBrowserTable = ({ state }: { state: QueueBrowserState }) => {
+  const [search, setSearch] = useState('');
+  const [onlyNonEmpty, setOnlyNonEmpty] = useState(false);
+  const normalizedSearch = search.trim().toLowerCase();
+  const visibleQueues = state.queues.filter((queue) => {
+    if (onlyNonEmpty && getQueueBacklog(queue) === 0) return false;
+    if (!normalizedSearch) return true;
+    return (
+      queue.brokerName.toLowerCase().includes(normalizedSearch) ||
+      String(queue.queueId).includes(normalizedSearch)
+    );
+  });
+  const totalQueues = state.queues.length;
+  const totalBacklog = state.queues.reduce((sum, queue) => sum + getQueueBacklog(queue), 0);
+
+  const columns: ColumnsType<QueueOffset> = [
+    {
+      title: 'Broker',
+      dataIndex: 'brokerName',
+      width: 150,
+      ellipsis: { showTitle: false },
+      sorter: (left, right) => left.brokerName.localeCompare(right.brokerName),
+      render: (value: string) => (
+        <Tooltip title={value}>
+          <Text strong style={{ fontSize: 14 }}>
+            {value}
+          </Text>
+        </Tooltip>
+      ),
+    },
+    {
+      title: 'Queue',
+      dataIndex: 'queueId',
+      width: 60,
+      align: 'center',
+      sorter: (left, right) => left.queueId - right.queueId,
+      render: (value: number) => <Text style={{ fontSize: 14 }}>{value}</Text>,
+    },
+    {
+      title: '积压量',
+      key: 'backlog',
+      width: 80,
+      align: 'right',
+      defaultSortOrder: 'descend',
+      sorter: (left, right) => getQueueBacklog(left) - getQueueBacklog(right),
+      render: (_: unknown, record: QueueOffset) => (
+        <Text style={{ fontSize: 14 }}>{getQueueBacklog(record)}</Text>
+      ),
+    },
+    {
+      title: 'Offset 范围',
+      key: 'offset',
+      width: 170,
+      render: (_: unknown, record: QueueOffset) => {
+        const key = `${record.brokerName}-${record.queueId}`;
+        const currentOffset = state.offsets[key] ?? record.minOffset;
+        return (
+          <Flex align="center" gap={8}>
+            <Text type="secondary" style={{ fontSize: 14, flexShrink: 0 }}>
+              {record.minOffset}
+            </Text>
+            <Slider
+              style={{ flex: 1, margin: 0 }}
+              min={record.minOffset}
+              max={record.maxOffset > record.minOffset ? record.maxOffset - 1 : record.minOffset}
+              value={currentOffset}
+              onChange={(value) => state.setOffsets((prev) => ({ ...prev, [key]: value }))}
+              tooltip={{ formatter: (value) => `offset: ${value}` }}
             />
-          ) : (
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-              {state.entries.map((entry) => (
-                <Card
-                  key={entry.key}
-                  size="small"
-                  style={{ borderRadius: 8 }}
-                  title={
-                    <Space size={4}>
-                      <Tag color="blue" style={{ marginInlineEnd: 0 }}>
-                        {entry.key}
-                      </Tag>
-                      <Text type="secondary" style={{ fontSize: 14 }}>
-                        @ {entry.offset}
-                      </Text>
-                    </Space>
-                  }
-                  extra={
-                    <Button
-                      type="text"
-                      size="small"
-                      icon={<CloseOutlined />}
-                      onClick={() => state.closeEntry(entry.key)}
-                    />
-                  }
-                >
-                  {entry.message ? (
-                    <>
-                      <Descriptions column={1} size="small">
-                        <Descriptions.Item label="Message ID">
-                          <Paragraph
-                            copyable
-                            style={{ marginBottom: 0, fontFamily: 'monospace', fontSize: 14 }}
-                          >
-                            {entry.message.msgId}
-                          </Paragraph>
-                        </Descriptions.Item>
-                        <Descriptions.Item label="Tag">
-                          <Tag>{entry.message.tag || '-'}</Tag>
-                        </Descriptions.Item>
-                        <Descriptions.Item label="Key">
-                          <span style={{ fontFamily: 'monospace', fontSize: 14 }}>
-                            {entry.message.key || '-'}
-                          </span>
-                        </Descriptions.Item>
-                        <Descriptions.Item label="存储时间">
-                          <span style={{ fontFamily: 'monospace', fontSize: 14 }}>
-                            {formatTimeMs(entry.message.storeTime)}
-                          </span>
-                        </Descriptions.Item>
-                        <Descriptions.Item label="大小">
-                          {entry.message.size} bytes
-                        </Descriptions.Item>
-                        <Descriptions.Item label="Born Host">
-                          {entry.message.bornHost || '-'}
-                        </Descriptions.Item>
-                      </Descriptions>
-                      {entry.message.body && (
-                        <Card size="small" title="Body" style={{ marginTop: 12 }}>
-                          <pre
-                            style={{
-                              maxHeight: 160,
-                              overflow: 'auto',
-                              fontSize: 14,
-                              fontFamily: 'monospace',
-                              whiteSpace: 'pre-wrap',
-                              wordBreak: 'break-all',
-                              margin: 0,
-                            }}
-                          >
-                            {entry.message.body}
-                          </pre>
-                        </Card>
-                      )}
-                    </>
-                  ) : (
-                    <Text type="secondary">该 offset 处无消息</Text>
-                  )}
-                </Card>
-              ))}
-            </div>
-          )}
-        </div>
-      </Flex>
+            <Text code style={{ fontSize: 14, flexShrink: 0 }}>
+              {currentOffset}
+            </Text>
+          </Flex>
+        );
+      },
+    },
+    {
+      title: '操作',
+      key: 'action',
+      width: 70,
+      align: 'center',
+      render: (_: unknown, record: QueueOffset) => {
+        const key = `${record.brokerName}-${record.queueId}`;
+        return (
+          <Button
+            size="small"
+            type="primary"
+            loading={state.pulling.has(key)}
+            onClick={() => void state.handlePull(record)}
+          >
+            查看
+          </Button>
+        );
+      },
+    },
+  ];
+
+  return (
+    <Flex gap={16} align="flex-start">
+      <div style={{ width: '50%', flexShrink: 0 }}>
+        <Flex gap={8} align="center" wrap style={{ marginBottom: 12 }}>
+          <Input.Search
+            allowClear
+            placeholder="搜索 Broker 或 Queue"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            style={{ width: 180 }}
+          />
+          <Button
+            type={onlyNonEmpty ? 'primary' : 'default'}
+            onClick={() => setOnlyNonEmpty((current) => !current)}
+          >
+            仅显示非空队列
+          </Button>
+        </Flex>
+        <Table<QueueOffset>
+          rowKey={(r) => `${r.brokerName}-${r.queueId}`}
+          dataSource={visibleQueues}
+          size="small"
+          pagination={false}
+          columns={columns}
+        />
+        <Text
+          type="secondary"
+          style={{ display: 'block', marginTop: 8, fontSize: 14 }}
+          data-testid="queue-browser-summary"
+        >
+          显示 {visibleQueues.length} / {totalQueues} 个队列，Topic 总消息量 {totalBacklog} 条
+        </Text>
+      </div>
+      <PulledMessagePanel state={state} />
+    </Flex>
+  );
+};
+
+const PulledMessagePanel = ({ state }: { state: QueueBrowserState }) => (
+  <div style={{ flex: 1, minWidth: 0 }}>
+    {state.entries.length === 0 ? (
+      <Empty
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+        description="点击左侧「查看」，消息详情将显示在这里"
+        style={{ padding: '32px 0' }}
+      />
+    ) : (
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+        {state.entries.map((entry) => (
+          <PulledMessageCard key={entry.key} entry={entry} onClose={state.closeEntry} />
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+const PulledMessageCard = ({
+  entry,
+  onClose,
+}: {
+  entry: PulledEntry;
+  onClose: (key: string) => void;
+}) => (
+  <Card
+    size="small"
+    style={{ borderRadius: 8 }}
+    title={
+      <Space size={4}>
+        <Tag color="blue" style={{ marginInlineEnd: 0 }}>
+          {entry.key}
+        </Tag>
+        <Text type="secondary" style={{ fontSize: 14 }}>
+          @ {entry.offset}
+        </Text>
+      </Space>
+    }
+    extra={
+      <Button
+        type="text"
+        size="small"
+        icon={<CloseOutlined />}
+        onClick={() => onClose(entry.key)}
+      />
+    }
+  >
+    {entry.message ? (
+      <>
+        <Descriptions column={1} size="small">
+          <Descriptions.Item label="Message ID">
+            <Paragraph copyable style={{ marginBottom: 0, fontFamily: 'monospace', fontSize: 14 }}>
+              {entry.message.msgId}
+            </Paragraph>
+          </Descriptions.Item>
+          <Descriptions.Item label="Tag">
+            <Tag>{entry.message.tag || '-'}</Tag>
+          </Descriptions.Item>
+          <Descriptions.Item label="Key">
+            <span style={{ fontFamily: 'monospace', fontSize: 14 }}>
+              {entry.message.key || '-'}
+            </span>
+          </Descriptions.Item>
+          <Descriptions.Item label="存储时间">
+            <span style={{ fontFamily: 'monospace', fontSize: 14 }}>
+              {formatTimeMs(entry.message.storeTime)}
+            </span>
+          </Descriptions.Item>
+          <Descriptions.Item label="大小">{entry.message.size} bytes</Descriptions.Item>
+          <Descriptions.Item label="Born Host">{entry.message.bornHost || '-'}</Descriptions.Item>
+        </Descriptions>
+        {entry.message.body && (
+          <Card size="small" title="Body" style={{ marginTop: 12 }}>
+            <pre
+              style={{
+                maxHeight: 160,
+                overflow: 'auto',
+                fontSize: 14,
+                fontFamily: 'monospace',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-all',
+                margin: 0,
+              }}
+            >
+              {entry.message.body}
+            </pre>
+          </Card>
+        )}
+      </>
+    ) : (
+      <Text type="secondary">该 offset 处无消息</Text>
     )}
   </Card>
 );

--- a/web/src/components/__tests__/QueueBrowser.test.tsx
+++ b/web/src/components/__tests__/QueueBrowser.test.tsx
@@ -17,10 +17,12 @@
 
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { App } from 'antd';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MessageRecord, QueueOffset } from '../../api/message';
 import { getQueueOffsets, pullMessageAtOffset } from '../../api/message';
-import { formatTimeMs, useQueueBrowser } from '../QueueBrowser';
+import { formatTimeMs, QueueBrowserResults, useQueueBrowser } from '../QueueBrowser';
+import { getQueueBacklog } from '../../utils/queueBrowserBacklog';
 
 vi.mock('../../api/message', () => ({
   getQueueOffsets: vi.fn(),
@@ -90,6 +92,23 @@ function QueueBrowserProbe({ instanceId = 'instance-a' }: { instanceId?: string 
   );
 }
 
+function QueueBrowserViewProbe({ instanceId = 'instance-a' }: { instanceId?: string }) {
+  const state = useQueueBrowser(instanceId);
+  return (
+    <App>
+      <div>
+        <button type="button" onClick={() => state.setTopic('topic-a')}>
+          topic-a
+        </button>
+        <button type="button" onClick={() => void state.loadQueues()}>
+          load
+        </button>
+        <QueueBrowserResults state={state} />
+      </div>
+    </App>
+  );
+}
+
 describe('formatTimeMs', () => {
   it('preserves the Unix epoch timestamp', () => {
     expect(formatTimeMs(0)).not.toBe('-');
@@ -101,6 +120,17 @@ describe('formatTimeMs', () => {
       expect(formatTimeMs(value)).toBe('-');
     },
   );
+});
+
+describe('getQueueBacklog', () => {
+  it('returns the number of messages available in the queue', () => {
+    expect(getQueueBacklog({ minOffset: 4, maxOffset: 10 })).toBe(6);
+  });
+
+  it('does not return a negative backlog for invalid offset ranges', () => {
+    expect(getQueueBacklog({ minOffset: 10, maxOffset: 4 })).toBe(0);
+    expect(getQueueBacklog({ minOffset: 5, maxOffset: 5 })).toBe(0);
+  });
 });
 
 describe('QueueBrowser request ownership', () => {
@@ -214,5 +244,78 @@ describe('QueueBrowser request ownership', () => {
 
     expect(getQueueOffsets).toHaveBeenCalledTimes(1);
     await act(async () => queues.resolve([queue('broker-a')]));
+  });
+});
+
+describe('QueueBrowserResults navigation', () => {
+  const queues: QueueOffset[] = [
+    { brokerName: 'broker-a', queueId: 0, minOffset: 0, maxOffset: 12 },
+    { brokerName: 'broker-a', queueId: 1, minOffset: 4, maxOffset: 4 },
+    { brokerName: 'broker-b', queueId: 2, minOffset: 1, maxOffset: 20 },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  const renderLoaded = async () => {
+    vi.mocked(getQueueOffsets).mockResolvedValue(queues);
+    const user = userEvent.setup();
+    render(<QueueBrowserViewProbe />);
+    await user.click(screen.getByRole('button', { name: 'topic-a' }));
+    await user.click(screen.getByRole('button', { name: 'load' }));
+    await screen.findByText('broker-b');
+    return user;
+  };
+
+  it('filters queues by broker or queue id while keeping topic-wide totals', async () => {
+    const user = await renderLoaded();
+
+    await user.type(screen.getByPlaceholderText('搜索 Broker 或 Queue'), 'broker-b');
+
+    expect(screen.getByText('broker-b')).toBeInTheDocument();
+    expect(screen.queryByText('broker-a')).not.toBeInTheDocument();
+    expect(screen.getByTestId('queue-browser-summary')).toHaveTextContent(
+      '显示 1 / 3 个队列，Topic 总消息量 31 条',
+    );
+  });
+
+  it('hides empty queues and shows the displayed count separately', async () => {
+    const user = await renderLoaded();
+
+    await user.click(screen.getByRole('button', { name: '仅显示非空队列' }));
+
+    expect(screen.getByText('broker-a')).toBeInTheDocument();
+    expect(screen.getByText('broker-b')).toBeInTheDocument();
+    expect(screen.queryByText('broker-a-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('queue-browser-summary')).toHaveTextContent(
+      '显示 2 / 3 个队列，Topic 总消息量 31 条',
+    );
+  });
+
+  it('shows backlog and supports sorting by backlog', async () => {
+    const user = await renderLoaded();
+
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getAllByText('19').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('0').length).toBeGreaterThan(0);
+    await user.click(screen.getByText('积压量'));
+
+    const brokers = await screen.findAllByText(/broker-[ab]/);
+    expect(brokers.map((item) => item.textContent)).toEqual(['broker-a', 'broker-a', 'broker-b']);
   });
 });

--- a/web/src/utils/queueBrowserBacklog.ts
+++ b/web/src/utils/queueBrowserBacklog.ts
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export interface QueueBacklogLike {
+  minOffset: number;
+  maxOffset: number;
+}
+
+export const getQueueBacklog = (queue: QueueBacklogLike) =>
+  Math.max(0, queue.maxOffset - queue.minOffset);


### PR DESCRIPTION
## What changed

The Queue Browser previously rendered every queue of the selected topic in one unbounded table. On topics with many queues, finding the relevant broker or queue required scrolling the entire list, and empty queues added noise when diagnosing uneven backlog.

This change makes the existing queue list navigable without changing the pull-at-offset API:

- add broker/queue search over the already-loaded queue metadata;
- add an explicit backlog column based on `maxOffset - minOffset`, clamped at zero;
- allow sorting by broker, queue ID, and backlog, with backlog descending by default;
- add a toggle to show only non-empty queues;
- keep topic-wide queue and message totals visible while showing the filtered row count separately;
- keep the existing queue-offset slider and pull behavior unchanged;
- split the queue table and pulled-message cards into focused components to keep the result render readable;
- add regression coverage for backlog calculation, search, empty-queue filtering, and sorting.

Closes #3400

## Validation

- `npm test -- QueueBrowser.test.tsx --run` — 13 tests passed
- `npm test -- MessagePageAsyncState.test.tsx MessagePage.test.tsx QueueBrowser.test.tsx --run` — 40 tests passed
- `npm run lint -- --quiet` — 0 errors; 10 existing warnings remain elsewhere in the tree
- `npm run build` — passed
- `git diff --check` — passed

The GitHub Actions status is not being described as green here; the checks above are local validation on this branch.