### PR TITLE
test: cover toggle and persistence in dataModeStore

### DIFF
--- a/web/src/stores/dataModeStore.test.ts
+++ b/web/src/stores/dataModeStore.test.ts
@@ -55,4 +55,23 @@ describe('dataModeStore', () => {
 
     expect(store.getState().useMock).toBe(persistedValue);
   });
+
+  it('toggle flips the mode both ways', async () => {
+    const store = await loadStore('false');
+
+    store.getState().toggle();
+    expect(store.getState().useMock).toBe(true);
+
+    store.getState().toggle();
+    expect(store.getState().useMock).toBe(false);
+  });
+
+  it('persists the toggled mode for the next session', async () => {
+    const store = await loadStore('false');
+
+    store.getState().toggle();
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
+    expect(persisted.state?.useMock).toBe(true);
+  });
 });


### PR DESCRIPTION
### Summary

`useDataModeStore` seeds the mock-data mode from `VITE_USE_MOCK` (or persisted state) and exposes `toggle`. The suite covered the initial-value and persisted-override cases but never the toggle itself.

### Changes

- `toggle` flips the mode in both directions
- Toggling persists the new mode under `rocketmq-studio-data-mode` for the next session

### Testing

`vitest run src/stores/dataModeStore.test.ts` passes: 6 tests, 0 failures (up from 4). `tsc --noEmit` and `eslint` are clean.