### PR TITLE
test: cover parameterless client connection listing

### DIFF
--- a/web/src/api/connections.test.ts
+++ b/web/src/api/connections.test.ts
@@ -63,4 +63,13 @@ describe('client connections API', () => {
       }),
     ).resolves.toEqual([connection]);
   });
+
+  it('omits query parameters when none are given', async () => {
+    mock.onGet('/clients').reply((config) => {
+      expect(config.params).toBeUndefined();
+      return [200, { code: 200, data: [connection] }];
+    });
+
+    await expect(listConnections()).resolves.toEqual([connection]);
+  });
 });


### PR DESCRIPTION
### Summary

`listConnections` fetches client connections from `/clients` and forwards its optional query parameters. The suite only exercised the fully populated query.

### Changes

- Calling `listConnections()` without arguments omits query parameters entirely and still returns the payload

### Testing

`vitest run src/api/connections.test.ts` passes: 2 tests, 0 failures (up from 1). `tsc --noEmit` and `eslint` are clean.