### PR TITLE
test: cover Chinese language preference round trip

### DIFF
--- a/web/src/i18n/languagePreference.test.ts
+++ b/web/src/i18n/languagePreference.test.ts
@@ -35,4 +35,11 @@ describe('language preference', () => {
     expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe('en');
     expect(getInitialLanguage()).toBe('en');
   });
+
+  it('round-trips the Chinese preference as well', () => {
+    persistLanguage('zh');
+
+    expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe('zh');
+    expect(getInitialLanguage()).toBe('zh');
+  });
 });


### PR DESCRIPTION
### Summary

`persistLanguage`/`getInitialLanguage` keep the UI language in local storage. The suite covered the English round trip and the invalid-value fallback but never persisted Chinese.

### Changes

- Persisting `zh` writes it to storage and `getInitialLanguage` returns it on the next load

### Testing

`vitest run src/i18n/languagePreference.test.ts` passes: 3 tests, 0 failures (up from 2). `tsc --noEmit` and `eslint` are clean.