### PR TITLE
test: cover optional search filter forwarding in aliyunCatalog

### DIFF
--- a/web/src/api/aliyunCatalog.test.ts
+++ b/web/src/api/aliyunCatalog.test.ts
@@ -67,4 +67,22 @@ describe('aliyunCatalog API', () => {
 
     expect(instances[0].instanceId).toBe('rmq-cn-xxx');
   });
+
+  it('includes an optional search filter when provided', async () => {
+    mock.onGet('/cloud/aliyun/instances').reply((config) => {
+      expect(config.params).toMatchObject({ credentialId: 9, regionId: 'cn-hangzhou', search: 'prod' });
+      return [200, { code: 200, data: [] }];
+    });
+
+    await listAliyunInstances(9, 'cn-hangzhou', 'prod');
+  });
+
+  it('omits the search filter when it is absent', async () => {
+    mock.onGet('/cloud/aliyun/instances').reply((config) => {
+      expect(config.params.search).toBeUndefined();
+      return [200, { code: 200, data: [] }];
+    });
+
+    await listAliyunInstances(9, 'cn-hangzhou');
+  });
 });


### PR DESCRIPTION
### Summary

`listAliyunInstances` forwards an optional `search` filter alongside credential and region. The suite covered regions and the base instance query but never the optional filter.

### Changes

- A provided `search` is included in the request parameters
- An absent `search` is omitted from the request

### Testing

`vitest run src/api/aliyunCatalog.test.ts` passes: 4 tests, 0 failures (up from 2). `tsc --noEmit` and `eslint` are clean.