### PR TITLE
test: cover empty batch deletion in topicService

### DIFF
--- a/web/src/services/topicService.batchDelete.test.ts
+++ b/web/src/services/topicService.batchDelete.test.ts
@@ -50,4 +50,9 @@ describe('topic service batch deletion', () => {
       'topic-03',
     ]);
   });
+
+  it('resolves immediately when the batch is empty', async () => {
+    await expect(batchDeleteTopics([])).resolves.toEqual({ deleted: [], failed: [] });
+    expect(metadataApiMocks.deleteTopic).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### Summary

`batchDeleteTopics` deletes each topic and reports deleted/failed outcomes, continuing after individual failures. The suite covered mixed success/failure only.

### Changes

- An empty topic list resolves immediately with empty deleted/failed arrays and never touches the delete API

### Testing

`vitest run src/services/topicService.batchDelete.test.ts` passes: 2 tests, 0 failures (up from 1). `tsc --noEmit` and `eslint` are clean.