### PR TITLE
test: cover connection test, broker restart and nameserver registry in cluster api

### DIFF
--- a/web/src/api/clusterContract.test.ts
+++ b/web/src/api/clusterContract.test.ts
@@ -18,7 +18,13 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { getCluster, listClusters } from './cluster';
+import {
+  getCluster,
+  listClusters,
+  listNameserverRegistry,
+  restartBroker,
+  testClusterConnection,
+} from './cluster';
 import type { ClusterInfo } from './cluster';
 
 const mock = new MockAdapter(client);
@@ -85,5 +91,41 @@ describe('cluster API contract', () => {
 
     await expect(listClusters()).resolves.toEqual([cluster]);
     await expect(getCluster(cluster.id)).resolves.toEqual(cluster);
+  });
+
+  it('tests a connection against the submitted nameserver address', async () => {
+    mock.onPost('/clusters/test-connection').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ namesrvAddr: '127.0.0.1:9876' });
+      return [
+        200,
+        { code: 200, data: { connected: true, clusterName: 'cluster-a', brokerCount: 1 } },
+      ];
+    });
+
+    await expect(testClusterConnection('127.0.0.1:9876')).resolves.toMatchObject({
+      connected: true,
+    });
+  });
+
+  it('restarts a broker through its scoped path', async () => {
+    mock.onPost('/clusters/cluster-a/brokers/broker-a/restart').reply(200, {
+      code: 200,
+      data: { success: true, message: 'restarting' },
+    });
+
+    await expect(restartBroker('cluster-a', 'broker-a')).resolves.toMatchObject({
+      success: true,
+    });
+  });
+
+  it('lists the nameserver registry entries', async () => {
+    mock.onGet('/nameservers').reply(200, {
+      code: 200,
+      data: [{ id: 1, name: 'ns-1', namesrvAddr: '10.0.0.20:9876' }],
+    });
+
+    await expect(listNameserverRegistry()).resolves.toEqual([
+      { id: 1, name: 'ns-1', namesrvAddr: '10.0.0.20:9876' },
+    ]);
   });
 });


### PR DESCRIPTION
### Summary

`cluster` API exposes many cluster actions beyond list/detail. The contract suite only covered list and detail payloads.

### Changes

- `testClusterConnection` posts the nameserver address and returns the probe result
- `restartBroker` hits the per-broker restart path
- `listNameserverRegistry` returns the registry entries

### Testing

`vitest run src/api/clusterContract.test.ts` passes: 4 tests, 0 failures (up from 1). `tsc --noEmit` and `eslint` are clean.