### PR TITLE
test: add first coverage for the data mode service

### DIFF
--- a/web/src/services/dataMode.test.ts
+++ b/web/src/services/dataMode.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { getStateMock } = vi.hoisted(() => ({ getStateMock: vi.fn() }));
+
+vi.mock('../stores/dataModeStore', () => ({
+  useDataModeStore: { getState: getStateMock },
+}));
+
+import { isMockMode } from './dataMode';
+
+describe('isMockMode', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true when the store is in mock mode', () => {
+    getStateMock.mockReturnValue({ useMock: true });
+
+    expect(isMockMode()).toBe(true);
+  });
+
+  it('returns false when the store is in live mode', () => {
+    getStateMock.mockReturnValue({ useMock: false });
+
+    expect(isMockMode()).toBe(false);
+  });
+});


### PR DESCRIPTION
### Summary

`isMockMode` reads the runtime data-mode toggle from the persisted Zustand store. It had no direct tests.

### Changes

- Returns `true` when the store reports mock mode
- Returns `false` when the store reports live mode

### Testing

`vitest run src/services/dataMode.test.ts` passes: 2 tests, 0 failures (first coverage for this module). `tsc --noEmit` and `eslint` are clean.