### PR TITLE
test: cover instance forwarding on cluster list and detail endpoints

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterControllerTest.java
@@ -165,6 +165,29 @@ class ClusterControllerTest {
     }
 
     @Test
+    void listClustersShouldForwardTheSelectedInstance() throws Exception {
+        when(clusterService.listClusters("instance-1")).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/clusters").param("instanceId", "instance-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray());
+
+        verify(clusterService).listClusters("instance-1");
+    }
+
+    @Test
+    void getClusterShouldForwardTheSelectedInstance() throws Exception {
+        ClusterVO cluster = buildCluster("cluster-1", "production-cluster", ClusterStatus.healthy);
+        when(clusterService.getCluster("cluster-1", "instance-1")).thenReturn(cluster);
+
+        mockMvc.perform(get("/api/clusters/cluster-1").param("instanceId", "instance-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value("cluster-1"));
+
+        verify(clusterService).getCluster("cluster-1", "instance-1");
+    }
+
+    @Test
     void getClusterShouldReturnClusterDetail() throws Exception {
         ClusterVO cluster = buildCluster("cluster-1", "production-cluster", ClusterStatus.healthy);
         cluster.setConfig(ClusterConfigVO.builder()


### PR DESCRIPTION
### Summary

`ClusterController` list/detail endpoints accept an optional `instanceId` that scopes discovery to a selected instance. The suite only exercised the unscoped variants.

### Changes

- `GET /api/clusters?instanceId=...` forwards the selected instance to the service
- `GET /api/clusters/{id}?instanceId=...` forwards it to the detail lookup

### Testing

`mvn test -Dtest=ClusterControllerTest` passes: 36 tests, 0 failures (up from 34).