### PR TITLE
test: cover missing data source key parameter in MetricsController

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsControllerTest.java
@@ -190,4 +190,16 @@ class MetricsControllerTest {
 
         verifyNoInteractions(metricsService);
     }
+
+    @Test
+    void dataSourceQueryShouldRejectAMissingKeyParameter() throws Exception {
+        mockMvc.perform(post("/api/metrics/query/datasource")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Invalid request parameter"));
+
+        verifyNoInteractions(metricsService);
+    }
 }


### PR DESCRIPTION
### Summary

`POST /api/metrics/query/datasource` requires the `key` query parameter identifying the persisted data source. The suite covered the happy path and query-body validation but never the missing parameter.

### Changes

- Omitting `key` returns a `400 Invalid request parameter` envelope without touching the metrics service

### Testing

`mvn test -Dtest=MetricsControllerTest` passes: 9 tests, 0 failures (up from 8).