### PR TITLE
test: cover the per-alert deliveries endpoint in SystemAlertController

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
@@ -216,6 +216,22 @@ class SystemAlertControllerTest {
     }
 
     @Test
+    void listDeliveriesShouldReturnDeliveriesForAnAlertTest() throws Exception {
+        NotificationDeliveryVO delivery = NotificationDeliveryVO.builder()
+                .id(1L)
+                .channel("dingtalk")
+                .build();
+        when(notificationOutboxService.listDeliveries(3L)).thenReturn(List.of(delivery));
+
+        mockMvc.perform(get("/api/system-alerts/3/deliveries"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].channel").value("dingtalk"));
+
+        verify(notificationOutboxService).listDeliveries(3L);
+    }
+
+    @Test
     void clearAcknowledgedShouldReturnClearedCountTest() throws Exception {
         when(alertService.clearAcknowledged()).thenReturn(3);
 


### PR DESCRIPTION
### Summary

`SystemAlertController` exposes both the paged deliveries feed and the per-alert delivery list. The suite covered the feed but not the single-alert list endpoint.

### Changes

- `GET /api/system-alerts/{id}/deliveries` returns the deliveries for that alert and forwards the parsed id

### Testing

`mvn test -Dtest=SystemAlertControllerTest` passes: 12 tests, 0 failures (up from 11).