### PR TITLE
test: cover required-field validation in DirectConsumeMessageDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/DirectConsumeMessageDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/DirectConsumeMessageDTOTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DirectConsumeMessageDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void emptyRequestReportsEveryRequiredFieldTest() {
+        DirectConsumeMessageDTO request = new DirectConsumeMessageDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder(
+                        "instanceId is required",
+                        "topic is required",
+                        "msgId is required",
+                        "consumerGroup is required",
+                        "clientId is required");
+    }
+
+    @Test
+    void completeRequestPassesValidationTest() {
+        DirectConsumeMessageDTO request = new DirectConsumeMessageDTO();
+        request.setInstanceId("instance-1");
+        request.setTopic("orders");
+        request.setMsgId("msg-1");
+        request.setConsumerGroup("cg-orders");
+        request.setClientId("client-1");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary

`DirectConsumeMessageDTO` requires instance, topic, msg id, consumer group and client id at the bean-validation layer. It had no tests.

### Changes

- An empty request reports all five required-field messages
- A fully populated request passes validation

### Testing

`mvn test -Dtest=DirectConsumeMessageDTOTest` passes: 2 tests, 0 failures (first coverage for this DTO).