### PR TITLE
test: cover topic requirement in SendMessageDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/SendMessageDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/SendMessageDTOTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.topic;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SendMessageDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void missingTopicIsRejectedTest() {
+        SendMessageDTO request = new SendMessageDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactly("topic is required");
+    }
+
+    @Test
+    void requestWithTopicPassesValidationTest() {
+        SendMessageDTO request = new SendMessageDTO();
+        request.setInstanceId("instance-1");
+        request.setTopic("orders");
+        request.setBody("{\"id\":1}");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary

`SendMessageDTO` requires a topic at the bean-validation layer while other fields stay optional. It had no tests.

### Changes

- A request without a topic reports `topic is required`
- A request with a topic (and optional instance/body) passes validation

### Testing

`mvn test -Dtest=SendMessageDTOTest` passes: 2 tests, 0 failures (first coverage for this DTO).