### PR TITLE
test: cover registry field rules in UpdateNameserverRegistryDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/UpdateNameserverRegistryDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/UpdateNameserverRegistryDTOTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.nameserver;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpdateNameserverRegistryDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void emptyRequestReportsEveryRequiredFieldTest() {
+        UpdateNameserverRegistryDTO request = new UpdateNameserverRegistryDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .contains("id is required", "name is required", "namesrvAddr is required");
+    }
+
+    @Test
+    void overlongNameAndAddressAreRejectedTest() {
+        UpdateNameserverRegistryDTO request = UpdateNameserverRegistryDTO.builder()
+                .id(1L)
+                .name("n".repeat(129))
+                .namesrvAddr("a".repeat(513))
+                .build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder(
+                        "name must not exceed 128 characters",
+                        "namesrvAddr must not exceed 512 characters");
+    }
+
+    @Test
+    void completeRequestPassesValidationTest() {
+        UpdateNameserverRegistryDTO request = UpdateNameserverRegistryDTO.builder()
+                .id(1L)
+                .name("ns-1")
+                .namesrvAddr("10.0.0.1:9876")
+                .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary

`UpdateNameserverRegistryDTO` requires id/name/address and bounds the address and optional k8s coordinates. It had no tests.

### Changes

- An empty request reports the required id/name/address messages
- Overlong name and address values are rejected with their dedicated messages
- A complete request passes validation

### Testing

`mvn test -Dtest=UpdateNameserverRegistryDTOTest` passes: 3 tests, 0 failures (first coverage for this DTO).