### PR TITLE
test: cover group settings validation in UpdateConsumerGroupSettingsDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/UpdateConsumerGroupSettingsDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/UpdateConsumerGroupSettingsDTOTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpdateConsumerGroupSettingsDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void emptyRequestReportsEveryRequiredFieldTest() {
+        UpdateConsumerGroupSettingsDTO request = new UpdateConsumerGroupSettingsDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .contains("instanceId is required", "name is required",
+                        "retryQueueNums is required", "retryMaxTimes is required");
+    }
+
+    @Test
+    void nonPositiveRetryValuesAreRejectedTest() {
+        UpdateConsumerGroupSettingsDTO request = new UpdateConsumerGroupSettingsDTO();
+        request.setInstanceId("instance-1");
+        request.setName("cg-orders");
+        request.setRetryQueueNums(0);
+        request.setRetryMaxTimes(-1);
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder(
+                        "retryQueueNums must be positive",
+                        "retryMaxTimes must be positive");
+    }
+
+    @Test
+    void completeRequestPassesValidationTest() {
+        UpdateConsumerGroupSettingsDTO request = new UpdateConsumerGroupSettingsDTO();
+        request.setInstanceId("instance-1");
+        request.setName("cg-orders");
+        request.setRetryQueueNums(2);
+        request.setRetryMaxTimes(16);
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary

`UpdateConsumerGroupSettingsDTO` requires instance/group plus positive retry queue and retry-times values. It had no tests.

### Changes

- An empty request reports all four required-field messages
- Non-positive retry values are rejected with their dedicated messages
- A complete request passes validation

### Testing

`mvn test -Dtest=UpdateConsumerGroupSettingsDTOTest` passes: 3 tests, 0 failures (first coverage for this DTO).