### PR TITLE
test: cover required fields in UpgradeNameServerDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/UpgradeNameServerDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/UpgradeNameServerDTOTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.nameserver;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpgradeNameServerDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void emptyRequestReportsEveryRequiredFieldTest() {
+        UpgradeNameServerDTO request = new UpgradeNameServerDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("clusterId is required", "addr is required",
+                        "targetVersion is required");
+    }
+
+    @Test
+    void completeRequestPassesValidationTest() {
+        UpgradeNameServerDTO request = UpgradeNameServerDTO.builder()
+                .clusterId("cluster-a")
+                .addr("10.0.0.1:9876")
+                .targetVersion("5.3.0")
+                .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary

`UpgradeNameServerDTO` requires cluster id, address and target version. It had no tests.

### Changes

- An empty request reports all three required-field messages
- A complete request passes validation

### Testing

`mvn test -Dtest=UpgradeNameServerDTOTest` passes: 2 tests, 0 failures (first coverage for this DTO).