### PR TITLE
test: cover required fields and type whitelist in CreateCertDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/CreateCertDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/CreateCertDTOTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.k8s;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreateCertDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void emptyRequestReportsRequiredFieldsTest() {
+        CreateCertDTO request = new CreateCertDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .contains("k8sId is required", "cluster is required", "type is required");
+    }
+
+    @Test
+    void unsupportedTypeIsRejectedTest() {
+        CreateCertDTO request = CreateCertDTO.builder()
+                .k8sId("cert-1")
+                .cluster("cluster-a")
+                .type("PEM")
+                .build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactly("type must be one of TLS, mTLS, ServiceAccount");
+    }
+
+    @Test
+    void supportedTypePassesValidationTest() {
+        CreateCertDTO request = CreateCertDTO.builder()
+                .k8sId("cert-1")
+                .cluster("cluster-a")
+                .type("mTLS")
+                .issuer("rocketmq-issuer")
+                .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary

`CreateCertDTO` requires a k8s id, cluster and a whitelisted cert type. It had no tests.

### Changes

- An empty request reports the required k8s id/cluster/type messages
- An unsupported type is rejected with the whitelist message
- A supported type passes validation

### Testing

`mvn test -Dtest=CreateCertDTOTest` passes: 3 tests, 0 failures (first coverage for this DTO).