### PR TITLE
test: cover vendor and credential requirement in ImportCloudInstancesDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/ImportCloudInstancesDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/ImportCloudInstancesDTOTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ImportCloudInstancesDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void missingVendorAndCredentialAreRejectedTest() {
+        ImportCloudInstancesDTO request = new ImportCloudInstancesDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .containsExactlyInAnyOrder("vendor", "credentialId");
+    }
+
+    @Test
+    void completeRequestPassesValidationTest() {
+        ImportCloudInstancesDTO request = new ImportCloudInstancesDTO();
+        request.setVendor(InstanceVendor.ALIYUN);
+        request.setCredentialId(7L);
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary

`ImportCloudInstancesDTO` requires a cloud vendor and credential id. It had no tests.

### Changes

- A request missing vendor/credential reports violations on both properties
- A complete request with vendor and credential passes validation

### Testing

`mvn test -Dtest=ImportCloudInstancesDTOTest` passes: 2 tests, 0 failures (first coverage for this DTO).