### PR TITLE
test: cover TTL update requirements in LiteTopicTTLUpdateDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicTTLUpdateDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicTTLUpdateDTOTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.topic;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LiteTopicTTLUpdateDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void emptyRequestReportsRequiredFieldsTest() {
+        LiteTopicTTLUpdateDTO request = new LiteTopicTTLUpdateDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("topicPattern is required", "newTTL is required");
+    }
+
+    @Test
+    void nonPositiveTtlIsRejectedTest() {
+        LiteTopicTTLUpdateDTO request = new LiteTopicTTLUpdateDTO();
+        request.setTopicPattern("chat/{sessionId}");
+        request.setNewTTL(0L);
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactly("newTTL must be positive");
+    }
+
+    @Test
+    void completeRequestPassesValidationTest() {
+        LiteTopicTTLUpdateDTO request = new LiteTopicTTLUpdateDTO();
+        request.setTopicPattern("chat/{sessionId}");
+        request.setNewTTL(86400L);
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary

`LiteTopicTTLUpdateDTO` requires a topic pattern and a positive TTL. It had no tests.

### Changes

- An empty request reports the required pattern/TTL messages
- A non-positive TTL is rejected with its dedicated message
- A complete request passes validation

### Testing

`mvn test -Dtest=LiteTopicTTLUpdateDTOTest` passes: 3 tests, 0 failures (first coverage for this DTO).