### PR TITLE
test: cover id and enabled requirement in ToggleAlertRuleDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/ToggleAlertRuleDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/ToggleAlertRuleDTOTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ToggleAlertRuleDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void emptyRequestReportsIdAndEnabledTest() {
+        ToggleAlertRuleDTO request = new ToggleAlertRuleDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("id is required", "enabled is required");
+    }
+
+    @Test
+    void completeRequestPassesValidationTest() {
+        ToggleAlertRuleDTO request = ToggleAlertRuleDTO.builder()
+                .id(7L)
+                .enabled(false)
+                .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary

`ToggleAlertRuleDTO` requires a rule id and an enabled flag. It had no tests.

### Changes

- An empty request reports the required id/enabled messages
- A complete request passes validation

### Testing

`mvn test -Dtest=ToggleAlertRuleDTOTest` passes: 2 tests, 0 failures (first coverage for this DTO).