### PR TITLE
test: cover required fields in DLQResendRequestDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQResendRequestDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQResendRequestDTOTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.dlq;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DLQResendRequestDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void emptyRequestReportsRequiredFieldsTest() {
+        DLQResendRequestDTO request = new DLQResendRequestDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("instanceId is required", "groupName is required");
+    }
+
+    @Test
+    void completeRequestPassesValidationTest() {
+        DLQResendRequestDTO request = DLQResendRequestDTO.builder()
+                .instanceId("instance-1")
+                .groupName("cg-orders")
+                .startTime(1000L)
+                .endTime(2000L)
+                .targetTopic("orders")
+                .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary

`DLQResendRequestDTO` requires an instance and group with optional time range/target. It had no tests.

### Changes

- An empty request reports the required instance/group messages
- A complete request with an optional time range passes validation

### Testing

`mvn test -Dtest=DLQResendRequestDTOTest` passes: 2 tests, 0 failures (first coverage for this DTO).