### PR TITLE
test: cover id and type rules in UpdateCertDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/UpdateCertDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/UpdateCertDTOTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.k8s;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpdateCertDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void missingIdIsRejectedTest() {
+        UpdateCertDTO request = new UpdateCertDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactly("id is required");
+    }
+
+    @Test
+    void unsupportedTypeIsRejectedTest() {
+        UpdateCertDTO request = UpdateCertDTO.builder()
+                .id(1L)
+                .type("PEM")
+                .build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactly("type must be one of TLS, mTLS, ServiceAccount");
+    }
+
+    @Test
+    void completeRequestPassesValidationTest() {
+        UpdateCertDTO request = UpdateCertDTO.builder()
+                .id(1L)
+                .k8sId("cert-1")
+                .type("TLS")
+                .issuer("rocketmq-issuer")
+                .san(List.of("broker-a", "broker-b"))
+                .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary

`UpdateCertDTO` requires an id and bounds the optional type to the whitelist. It had no tests.

### Changes

- A missing id is rejected
- An unsupported type is rejected with the whitelist message
- A complete request with SANs passes validation

### Testing

`mvn test -Dtest=UpdateCertDTOTest` passes: 3 tests, 0 failures (first coverage for this DTO).