### PR TITLE
test: cover required fields in UpdateNameServerDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/UpdateNameServerDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/UpdateNameServerDTOTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.nameserver;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpdateNameServerDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void emptyRequestReportsRequiredFieldsTest() {
+        UpdateNameServerDTO request = new UpdateNameServerDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("clusterId is required", "addr is required");
+    }
+
+    @Test
+    void completeRequestPassesValidationTest() {
+        UpdateNameServerDTO request = UpdateNameServerDTO.builder()
+                .clusterId("cluster-a")
+                .addr("10.0.0.1:9876")
+                .version("5.3.0")
+                .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Summary

`UpdateNameServerDTO` requires a cluster id and address. It had no tests.

### Changes

- An empty request reports the required cluster/addr messages
- A complete request with an optional version passes validation

### Testing

`mvn test -Dtest=UpdateNameServerDTOTest` passes: 2 tests, 0 failures (first coverage for this DTO).