### PR TITLE
test: add first unit test for BatchDeleteInstancesDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/BatchDeleteInstancesDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/BatchDeleteInstancesDTOTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BatchDeleteInstancesDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    private Set<ConstraintViolation<BatchDeleteInstancesDTO>> violationsOf(BatchDeleteInstancesDTO dto) {
+        return validator.validate(dto);
+    }
+
+    @Test
+    void acceptsNonEmptyIdList() {
+        BatchDeleteInstancesDTO dto = new BatchDeleteInstancesDTO();
+        dto.setIds(List.of("inst-1", "inst-2"));
+
+        assertTrue(violationsOf(dto).isEmpty());
+    }
+
+    @Test
+    void rejectsNullIds() {
+        BatchDeleteInstancesDTO dto = new BatchDeleteInstancesDTO();
+
+        Set<ConstraintViolation<BatchDeleteInstancesDTO>> violations = violationsOf(dto);
+
+        assertEquals(1, violations.size());
+    }
+
+    @Test
+    void rejectsEmptyIdList() {
+        BatchDeleteInstancesDTO dto = new BatchDeleteInstancesDTO();
+        dto.setIds(List.of());
+
+        Set<ConstraintViolation<BatchDeleteInstancesDTO>> violations = violationsOf(dto);
+
+        assertEquals(1, violations.size());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `BatchDeleteInstancesDTO`, the payload of the multi-instance delete endpoint.

The DTO relies on a plain `@NotEmpty` over the instance id list. The tests verify that a non-empty list passes and that both a null and an empty list are rejected with exactly one violation each.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/BatchDeleteInstancesDTOTest.java`
  - `acceptsNonEmptyIdList`: a two-id list passes validation.
  - `rejectsNullIds`: an unset list reports a single violation.
  - `rejectsEmptyIdList`: an empty list reports a single violation.

### Testing

- `mvn -B test -Dtest=BatchDeleteInstancesDTOTest` passes (3 tests, all green).