### PR TITLE
test: add first unit test for UpdateStudioUserStatusDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/UpdateStudioUserStatusDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/UpdateStudioUserStatusDTOTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.auth;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UpdateStudioUserStatusDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    private UpdateStudioUserStatusDTO sample() {
+        UpdateStudioUserStatusDTO dto = new UpdateStudioUserStatusDTO();
+        dto.setEnabled(true);
+        return dto;
+    }
+
+    @Test
+    void acceptsEnabledFlag() {
+        assertTrue(validator.validate(sample()).isEmpty());
+    }
+
+    @Test
+    void acceptsDisabledFlag() {
+        UpdateStudioUserStatusDTO dto = sample();
+        dto.setEnabled(false);
+
+        assertTrue(validator.validate(dto).isEmpty());
+    }
+
+    @Test
+    void rejectsMissingEnabled() {
+        UpdateStudioUserStatusDTO dto = new UpdateStudioUserStatusDTO();
+
+        Set<ConstraintViolation<UpdateStudioUserStatusDTO>> violations = validator.validate(dto);
+
+        assertEquals(1, violations.size());
+        assertEquals("Enabled is required", violations.iterator().next().getMessage());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `UpdateStudioUserStatusDTO`, the payload of the studio user enable/disable endpoint.

The DTO only carries an `enabled` Boolean flag that must be present. The tests cover both flag values and the missing-flag path.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/auth/UpdateStudioUserStatusDTOTest.java`
  - `acceptsEnabledFlag`: `enabled = true` passes validation.
  - `acceptsDisabledFlag`: `enabled = false` passes validation.
  - `rejectsMissingEnabled`: a null flag yields the `Enabled is required` violation.

### Testing

- `mvn -B test -Dtest=UpdateStudioUserStatusDTOTest` passes (3 tests, all green).