### PR TITLE
test: add first unit test for ProxyAddressDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressDTOTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.proxy;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProxyAddressDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    private ProxyAddressDTO sample() {
+        return ProxyAddressDTO.builder()
+            .addr("10.132.218.11:8081")
+            .build();
+    }
+
+    @Test
+    void acceptsProxyAddress() {
+        assertTrue(validator.validate(sample()).isEmpty());
+    }
+
+    @Test
+    void rejectsMissingAddr() {
+        ProxyAddressDTO dto = ProxyAddressDTO.builder().build();
+
+        Set<ConstraintViolation<ProxyAddressDTO>> violations = validator.validate(dto);
+
+        assertEquals(1, violations.size());
+        assertEquals("addr is required", violations.iterator().next().getMessage());
+    }
+
+    @Test
+    void rejectsBlankAddr() {
+        ProxyAddressDTO dto = ProxyAddressDTO.builder()
+            .addr("  ")
+            .build();
+
+        Set<ConstraintViolation<ProxyAddressDTO>> violations = validator.validate(dto);
+
+        assertEquals(1, violations.size());
+        assertEquals("addr is required", violations.iterator().next().getMessage());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `ProxyAddressDTO`, the payload of the proxy address add endpoint.

The DTO requires a non-blank proxy `addr`. The tests cover the accepted address and the null/blank rejections.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressDTOTest.java`
  - `acceptsProxyAddress`: a populated address passes validation.
  - `rejectsMissingAddr` / `rejectsBlankAddr`: null or blank address yields the `addr is required` violation.

### Testing

- `mvn -B test -Dtest=ProxyAddressDTOTest` passes (3 tests, all green).