### PR TITLE
test: add first unit test for OpsTlsDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/OpsTlsDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/OpsTlsDTOTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpsTlsDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    private OpsTlsDTO sample() {
+        OpsTlsDTO dto = new OpsTlsDTO();
+        dto.setUseTLS(true);
+        return dto;
+    }
+
+    @Test
+    void acceptsEnabledFlag() {
+        assertTrue(validator.validate(sample()).isEmpty());
+    }
+
+    @Test
+    void acceptsDisabledFlag() {
+        OpsTlsDTO dto = sample();
+        dto.setUseTLS(false);
+
+        assertTrue(validator.validate(dto).isEmpty());
+    }
+
+    @Test
+    void rejectsMissingFlag() {
+        OpsTlsDTO dto = new OpsTlsDTO();
+
+        Set<ConstraintViolation<OpsTlsDTO>> violations = validator.validate(dto);
+
+        assertEquals(1, violations.size());
+        assertEquals("useTLS is required", violations.iterator().next().getMessage());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `OpsTlsDTO`, the payload of the broker TLS toggle endpoint.

The DTO carries a mandatory `useTLS` Boolean flag. The tests cover both flag values and the missing-flag rejection.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/ops/OpsTlsDTOTest.java`
  - `acceptsEnabledFlag`: `useTLS = true` passes validation.
  - `acceptsDisabledFlag`: `useTLS = false` passes validation.
  - `rejectsMissingFlag`: a null flag yields the `useTLS is required` violation.

### Testing

- `mvn -B test -Dtest=OpsTlsDTOTest` passes (3 tests, all green).