### PR TITLE
test: add first unit test for OpsVipChannelDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/OpsVipChannelDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/OpsVipChannelDTOTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpsVipChannelDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    private OpsVipChannelDTO sample() {
+        OpsVipChannelDTO dto = new OpsVipChannelDTO();
+        dto.setUseVIPChannel(true);
+        return dto;
+    }
+
+    @Test
+    void acceptsEnabledFlag() {
+        assertTrue(validator.validate(sample()).isEmpty());
+    }
+
+    @Test
+    void acceptsDisabledFlag() {
+        OpsVipChannelDTO dto = sample();
+        dto.setUseVIPChannel(false);
+
+        assertTrue(validator.validate(dto).isEmpty());
+    }
+
+    @Test
+    void rejectsMissingFlag() {
+        OpsVipChannelDTO dto = new OpsVipChannelDTO();
+
+        Set<ConstraintViolation<OpsVipChannelDTO>> violations = validator.validate(dto);
+
+        assertEquals(1, violations.size());
+        assertEquals("useVIPChannel is required", violations.iterator().next().getMessage());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `OpsVipChannelDTO`, the payload of the broker VIP channel toggle endpoint.

The DTO carries a mandatory `useVIPChannel` Boolean flag. The tests cover both flag values and the missing-flag rejection.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/ops/OpsVipChannelDTOTest.java`
  - `acceptsEnabledFlag`: `useVIPChannel = true` passes validation.
  - `acceptsDisabledFlag`: `useVIPChannel = false` passes validation.
  - `rejectsMissingFlag`: a null flag yields the `useVIPChannel is required` violation.

### Testing

- `mvn -B test -Dtest=OpsVipChannelDTOTest` passes (3 tests, all green).