### PR TITLE
test: add first unit test for DeleteAlertRuleDTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/DeleteAlertRuleDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/DeleteAlertRuleDTOTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DeleteAlertRuleDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    private DeleteAlertRuleDTO sample() {
+        return DeleteAlertRuleDTO.builder()
+            .id(15L)
+            .build();
+    }
+
+    @Test
+    void acceptsNumericId() {
+        assertTrue(validator.validate(sample()).isEmpty());
+    }
+
+    @Test
+    void rejectsMissingId() {
+        DeleteAlertRuleDTO dto = new DeleteAlertRuleDTO();
+
+        Set<ConstraintViolation<DeleteAlertRuleDTO>> violations = validator.validate(dto);
+
+        assertEquals(1, violations.size());
+        assertEquals("id is required", violations.iterator().next().getMessage());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `DeleteAlertRuleDTO`, the payload of the alert rule delete endpoint.

The DTO requires a numeric alert rule `id`. The tests cover the accepted id and the missing-id rejection.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/ops/alert/DeleteAlertRuleDTOTest.java`
  - `acceptsNumericId`: a populated id passes validation.
  - `rejectsMissingId`: a null id yields the `id is required` violation.

### Testing

- `mvn -B test -Dtest=DeleteAlertRuleDTOTest` passes (2 tests, all green).