### PR TITLE
test: add first unit test for DuplicateInstanceNameException

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/DuplicateInstanceNameExceptionTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/DuplicateInstanceNameExceptionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DuplicateInstanceNameExceptionTest {
+
+    @Test
+    void isBusinessExceptionWithBadRequestCode() {
+        DuplicateInstanceNameException ex = new DuplicateInstanceNameException("prod-1");
+
+        assertEquals(400, ex.getCode());
+        assertEquals("Instance name already exists: prod-1", ex.getMessage());
+    }
+
+    @Test
+    void keepsTheOffendingNameInMessage() {
+        DuplicateInstanceNameException ex = new DuplicateInstanceNameException("cluster-a");
+
+        assertEquals("Instance name already exists: cluster-a", ex.getMessage());
+    }
+
+    @Test
+    void isAssignableToBusinessException() {
+        DuplicateInstanceNameException ex = new DuplicateInstanceNameException("prod-1");
+
+        BusinessException base = ex;
+        assertEquals(400, base.getCode());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `DuplicateInstanceNameException`, the typed 400 error raised when an instance name collides at creation time.

The exception composes the offending name into a stable message and stays assignable to `BusinessException`. The tests pin the code, message and type hierarchy.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/DuplicateInstanceNameExceptionTest.java`
  - `isBusinessExceptionWithBadRequestCode`: code 400 and the composed message.
  - `keepsTheOffendingNameInMessage`: the duplicated name appears verbatim.
  - `isAssignableToBusinessException`: usable wherever `BusinessException` is caught.

### Testing

- `mvn -B test -Dtest=DuplicateInstanceNameExceptionTest` passes (3 tests, all green).