### PR TITLE
test: deepen QueryHistoryControllerTest with trace list, results and page guard

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryControllerTest.java
@@ -97,4 +97,35 @@ class QueryHistoryControllerTest {
         verify(queryHistoryService).listTraceQueries("instance-a", null, 1, 20);
         verify(queryHistoryService).summarize(null);
     }
+    @Test
+    void listsTraceQueriesWithDefaults() throws Exception {
+        when(queryHistoryService.listTraceQueries(null, null, 1, 20))
+                .thenReturn(PageResult.of(List.of(), 0, 1, 20));
+
+        mockMvc.perform(get("/api/query-history/traces"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items").isEmpty())
+                .andExpect(jsonPath("$.data.page").value(1));
+
+        verify(queryHistoryService).listTraceQueries(null, null, 1, 20);
+    }
+
+    @Test
+    void returnsMessageQueryResultsById() throws Exception {
+        when(queryHistoryService.getMessageQueryResults(7L)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/query-history/messages/7/results"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isEmpty());
+
+        verify(queryHistoryService).getMessageQueryResults(7L);
+    }
+
+    @Test
+    void rejectsPageBelowOne() throws Exception {
+        mockMvc.perform(get("/api/query-history/messages").param("page", "0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("page must be at least 1"));
+    }
+
 }


### PR DESCRIPTION
### Summary

Deepens `QueryHistoryControllerTest` with three uncovered controller paths: the trace-query listing defaults, the per-query results endpoint and the lower page bound.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryControllerTest.java`
  - `listsTraceQueriesWithDefaults`: no-param request delegates to the service with null filters and the 1/20 defaults.
  - `returnsMessageQueryResultsById`: `/messages/{id}/results` returns the stored message records for the id.
  - `rejectsPageBelowOne`: page 0 is rejected with the `page must be at least 1` message.

Suite grows from 4 to 7 tests.

### Testing

- `mvn -B test -Dtest=QueryHistoryControllerTest` passes (7 tests, all green).