### PR TITLE
test: deepen MessageControllerTest with queue offset endpoints

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageControllerTest.java
@@ -143,4 +143,29 @@ class MessageControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.consumeResult").value("CR_SUCCESS"));
     }
+    @Test
+    void queueOffsetsShouldPassInstanceAndTopic() throws Exception {
+        mockMvc.perform(get("/api/messages/queues")
+                        .param("instanceId", "inst-1")
+                        .param("topic", "orders"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(messageService).getQueueOffsets("inst-1", "orders");
+    }
+
+    @Test
+    void queueMessageShouldPassBrokerQueueAndOffset() throws Exception {
+        mockMvc.perform(get("/api/messages/queue-message")
+                        .param("instanceId", "inst-1")
+                        .param("topic", "orders")
+                        .param("brokerName", "broker-a")
+                        .param("queueId", "3")
+                        .param("offset", "123456789012345"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(messageService).pullMessageAtOffset("inst-1", "orders", "broker-a", 3, 123456789012345L);
+    }
+
 }


### PR DESCRIPTION
### Summary

Deepens `MessageControllerTest` with the two queue-offset endpoints that were previously uncovered.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageControllerTest.java`
  - `queueOffsetsShouldPassInstanceAndTopic`: `/queues` delegates instance and topic to the service.
  - `queueMessageShouldPassBrokerQueueAndOffset`: `/queue-message` converts the string params into the int queue id and long offset before delegating.

Suite grows from 6 to 8 tests.

### Testing

- `mvn -B test -Dtest=MessageControllerTest` passes (8 tests, all green).