### PR TITLE
test: deepen ClusterAlertRuleControllerTest with delete and bulk flows

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/ClusterAlertRuleControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/ClusterAlertRuleControllerTest.java
@@ -153,4 +153,43 @@ class ClusterAlertRuleControllerTest {
 
         verify(alertService).toggleRule(AlertDomain.CLUSTER, 7L, false);
     }
+    @Test
+    void deleteRuleShouldDelegateWithClusterDomain() throws Exception {
+        mockMvc.perform(post("/api/cluster-alert-rules/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"id\":5}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(alertService).deleteRule(AlertDomain.CLUSTER, 5L);
+    }
+
+    @Test
+    void bulkToggleShouldDelegateWithClusterDomain() throws Exception {
+        when(alertService.bulkToggleRules(AlertDomain.CLUSTER, List.of(1L, 2L), false))
+                .thenReturn(AlertRuleBulkResultVO.builder().succeededIds(List.of(1L, 2L)).build());
+
+        mockMvc.perform(post("/api/cluster-alert-rules/bulk-toggle")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"ids\":[1,2],\"enabled\":false}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.succeededIds[0]").value(1));
+
+        verify(alertService).bulkToggleRules(AlertDomain.CLUSTER, List.of(1L, 2L), false);
+    }
+
+    @Test
+    void bulkDeleteShouldDelegateWithClusterDomain() throws Exception {
+        when(alertService.bulkDeleteRules(AlertDomain.CLUSTER, List.of(1L, 2L)))
+                .thenReturn(AlertRuleBulkResultVO.builder().succeededIds(List.of(1L, 2L)).build());
+
+        mockMvc.perform(post("/api/cluster-alert-rules/bulk-delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"ids\":[1,2]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.succeededIds.length()").value(2));
+
+        verify(alertService).bulkDeleteRules(AlertDomain.CLUSTER, List.of(1L, 2L));
+    }
+
 }


### PR DESCRIPTION
### Summary

Deepens `ClusterAlertRuleControllerTest` with the delete and bulk endpoints that were previously uncovered, verifying each stays pinned to the CLUSTER domain.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/ops/alert/ClusterAlertRuleControllerTest.java`
  - `deleteRuleShouldDelegateWithClusterDomain`: POST /delete routes the id through the CLUSTER-scoped delete.
  - `bulkToggleShouldDelegateWithClusterDomain`: POST /bulk-toggle carries ids and the enabled flag into the CLUSTER-scoped bulk toggle.
  - `bulkDeleteShouldDelegateWithClusterDomain`: POST /bulk-delete carries the id list into the CLUSTER-scoped bulk delete.

Suite grows from 6 to 9 tests.

### Testing

- `mvn -B test -Dtest=ClusterAlertRuleControllerTest` passes (9 tests, all green).