### PR TITLE
test: deepen AuthControllerTest with password change flows

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthControllerTest.java
@@ -228,4 +228,34 @@ class AuthControllerTest {
 
         verify(authService).logout(eq("Bearer token-1"));
     }
+    @Test
+    void changePasswordShouldDelegateForAuthenticatedUser() throws Exception {
+        when(authService.getAuthenticatedUser(null))
+                .thenReturn(Optional.of(LoginVO.UserInfo.builder()
+                        .userId(7L)
+                        .username("operator")
+                        .admin(false)
+                        .build()));
+
+        mockMvc.perform(post("/api/auth/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"currentPassword\":\"old-pass-123\",\"newPassword\":\"new-pass-456\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"));
+
+        verify(authService).changePassword(7L, "old-pass-123", "new-pass-456", true);
+    }
+
+    @Test
+    void changePasswordShouldRejectUnauthenticatedRequest() throws Exception {
+        when(authService.getAuthenticatedUser(null)).thenReturn(Optional.empty());
+
+        mockMvc.perform(post("/api/auth/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"currentPassword\":\"old-pass-123\",\"newPassword\":\"new-pass-456\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("Unauthorized"));
+    }
+
 }


### PR DESCRIPTION
### Summary

Deepens `AuthControllerTest` with the previously uncovered password change endpoint, covering both the authenticated delegation and the unauthorized path.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/auth/AuthControllerTest.java`
  - `changePasswordShouldDelegateForAuthenticatedUser`: the current/new passwords reach `changePassword` with the resolved user id.
  - `changePasswordShouldRejectUnauthenticatedRequest`: a missing session yields 401 Unauthorized.

Suite grows from 9 to 11 tests.

### Testing

- `mvn -B test -Dtest=AuthControllerTest` passes (11 tests, all green).