### PR TITLE
test: deepen SettingsControllerTest with notification probe endpoint

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java
@@ -501,4 +501,20 @@ class SettingsControllerTest {
 
         verifyNoInteractions(settingsService);
     }
+    @Test
+    void testNotificationShouldDelegateForChannel() throws Exception {
+        mockMvc.perform(post("/api/settings/general/test-notification")
+                        .param("channel", "email"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(notificationOutboxService).sendTestMessage("email");
+    }
+
+    @Test
+    void testNotificationShouldRejectMissingChannel() throws Exception {
+        mockMvc.perform(post("/api/settings/general/test-notification"))
+                .andExpect(status().isBadRequest());
+    }
+
 }


### PR DESCRIPTION
### Summary

Deepens `SettingsControllerTest` with the previously uncovered test-notification probe endpoint.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/settings/SettingsControllerTest.java`
  - `testNotificationShouldDelegateForChannel`: the selected channel reaches the outbox service.
  - `testNotificationShouldRejectMissingChannel`: a missing required channel parameter is rejected with 400.

Suite grows from 23 to 25 tests.

### Testing

- `mvn -B test -Dtest=SettingsControllerTest` passes (25 tests, all green).