### PR TITLE
test: deepen NameServerControllerTest with operation failure paths

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerControllerTest.java
@@ -346,4 +346,36 @@ class NameServerControllerTest {
 
         verify(clusterService).deleteNameServer(any(DeleteNameServerDTO.class));
     }
+    @Test
+    void restartNameServerShouldReportFailureWhenClusterRejectsTest() throws Exception {
+        when(clusterService.restartNameServer(any(RestartNameServerDTO.class))).thenReturn(false);
+
+        RestartNameServerDTO command = RestartNameServerDTO.builder()
+                .clusterId("cluster-1")
+                .addr("10.132.218.11:9876")
+                .build();
+
+        mockMvc.perform(post("/api/nameservers/restart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(command)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.message").value("Failed to restart NameServer"));
+    }
+
+    @Test
+    void deleteNameServerShouldReportFailureWhenClusterRejectsTest() throws Exception {
+        when(clusterService.deleteNameServer(any(DeleteNameServerDTO.class))).thenReturn(false);
+
+        DeleteNameServerDTO command = DeleteNameServerDTO.builder()
+                .clusterId("cluster-1")
+                .addr("10.132.218.11:9876")
+                .build();
+
+        mockMvc.perform(post("/api/nameservers/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(command)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.message").value("Failed to delete NameServer"));
+    }
+
 }


### PR DESCRIPTION
### Summary

Deepens `NameServerControllerTest` with the cluster-rejection branches of the restart and delete operations; the suite previously only exercised the successful hand-off.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerControllerTest.java`
  - `restartNameServerShouldReportFailureWhenClusterRejectsTest`: a false result surfaces as 500 with the restart message.
  - `deleteNameServerShouldReportFailureWhenClusterRejectsTest`: a false result surfaces as 500 with the delete message.

Suite grows from 16 to 18 tests.

### Testing

- `mvn -B test -Dtest=NameServerControllerTest` passes (18 tests, all green).