### PR TITLE
test: add first unit test for MessageProviderStub fallback

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageProviderStubTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageProviderStubTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the test-only message provider fallback: every operation must stay loud (501)
+ * instead of silently degrading when no real message provider is wired up.
+ */
+class MessageProviderStubTest {
+
+    private final MessageProviderStub stub = new MessageProviderStub();
+
+    private BusinessException unsupportedFrom(org.junit.jupiter.api.function.Executable action) {
+        return assertThrows(BusinessException.class, action);
+    }
+
+    @Test
+    void queryMessagesThrowsUnsupported() {
+        BusinessException ex = unsupportedFrom(
+                () -> stub.queryMessages("inst-1", "orders", null, null, null, null, null));
+
+        assertEquals(501, ex.getCode());
+        assertTrue(ex.getMessage().contains("Message query provider is not configured"));
+    }
+
+    @Test
+    void getMessageTraceThrowsUnsupported() {
+        BusinessException ex = unsupportedFrom(
+                () -> stub.getMessageTrace("inst-1", "msg-1", "orders"));
+
+        assertEquals(501, ex.getCode());
+        assertTrue(ex.getMessage().contains("Message query provider is not configured"));
+    }
+
+    @Test
+    void getQueueOffsetsThrowsUnsupported() {
+        BusinessException ex = unsupportedFrom(() -> stub.getQueueOffsets("inst-1", "orders"));
+
+        assertEquals(501, ex.getCode());
+        assertTrue(ex.getMessage().contains("Message query provider is not configured"));
+    }
+
+    @Test
+    void pullMessageAtOffsetThrowsUnsupported() {
+        BusinessException ex = unsupportedFrom(
+                () -> stub.pullMessageAtOffset("inst-1", "orders", "broker-a", 3, 100L));
+
+        assertEquals(501, ex.getCode());
+        assertTrue(ex.getMessage().contains("Message query provider is not configured"));
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `MessageProviderStub`, the test-only fallback message provider.

The stub must stay loud when no real provider is configured: every operation throws a 501 `BusinessException`. The tests cover all four public operations.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/message/MessageProviderStubTest.java`
  - `queryMessagesThrowsUnsupported` / `getMessageTraceThrowsUnsupported`: query and trace throw 501.
  - `getQueueOffsetsThrowsUnsupported` / `pullMessageAtOffsetThrowsUnsupported`: offset reads throw 501.

### Testing

- `mvn -B test -Dtest=MessageProviderStubTest` passes (4 tests, all green).