### PR TITLE
test: add first unit test for NoopProxyStatsProvider

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/NoopProxyStatsProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/NoopProxyStatsProviderTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.provider.apache;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NoopProxyStatsProviderTest {
+
+    @Test
+    void queryLagReportsUnknownSentinel() {
+        NoopProxyStatsProvider provider = new NoopProxyStatsProvider();
+
+        assertEquals(ConsumerLagResolver.UNKNOWN, provider.queryLag());
+        assertEquals(-1L, provider.queryLag());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `NoopProxyStatsProvider`, the default proxy stats provider used when no proxy transport is wired in.

The provider reports the unknown sentinel so a -1 lag is surfaced instead of silently reading as zero. The test pins that contract.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/provider/apache/NoopProxyStatsProviderTest.java`
  - `queryLagReportsUnknownSentinel`: the lag is the UNKNOWN sentinel (-1).

### Testing

- `mvn -B test -Dtest=NoopProxyStatsProviderTest` passes (1 test, all green).