### PR TITLE
test: add first unit test for DeliveryStatus

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/domain/enums/DeliveryStatusTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/domain/enums/DeliveryStatusTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.domain.enums;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Locks the notification delivery status vocabulary rendered by the delivery list views.
+ */
+class DeliveryStatusTest {
+
+    @Test
+    void exposesAllDeliveryStatuses() {
+        assertEquals(3, DeliveryStatus.values().length);
+        assertTrue(Arrays.asList(DeliveryStatus.values()).contains(DeliveryStatus.success));
+        assertTrue(Arrays.asList(DeliveryStatus.values()).contains(DeliveryStatus.failed));
+        assertTrue(Arrays.asList(DeliveryStatus.values()).contains(DeliveryStatus.pending));
+    }
+
+    @Test
+    void enumNamesStayLowerCamelForJsonSerialization() {
+        assertEquals("success", DeliveryStatus.success.name());
+        assertEquals("failed", DeliveryStatus.failed.name());
+        assertEquals("pending", DeliveryStatus.pending.name());
+    }
+
+    @Test
+    void namesRoundTripThroughValueOf() {
+        for (DeliveryStatus status : DeliveryStatus.values()) {
+            assertEquals(status, DeliveryStatus.valueOf(status.name()));
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `DeliveryStatus`, the notification delivery status vocabulary rendered by the delivery list views.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/common/domain/enums/DeliveryStatusTest.java`
  - `exposesAllDeliveryStatuses`: success, failed and pending exist.
  - `enumNamesStayLowerCamelForJsonSerialization`: lower camel names preserved for the wire.
  - `namesRoundTripThroughValueOf`: every constant round-trips.

### Testing

- `mvn -B test -Dtest=DeliveryStatusTest` passes (3 tests, all green).