### PR TITLE
test: add first unit test for Protocol

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/domain/enums/ProtocolTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/domain/enums/ProtocolTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.domain.enums;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Locks the messaging protocol vocabulary used by cluster registration payloads.
+ */
+class ProtocolTest {
+
+    @Test
+    void exposesBothMessagingProtocols() {
+        assertEquals(2, Protocol.values().length);
+        assertTrue(Arrays.asList(Protocol.values()).contains(Protocol.gRPC));
+        assertTrue(Arrays.asList(Protocol.values()).contains(Protocol.Remoting));
+    }
+
+    @Test
+    void enumNamesPreserveOfficialCasing() {
+        assertEquals("gRPC", Protocol.gRPC.name());
+        assertEquals("Remoting", Protocol.Remoting.name());
+    }
+
+    @Test
+    void namesRoundTripThroughValueOf() {
+        for (Protocol protocol : Protocol.values()) {
+            assertEquals(protocol, Protocol.valueOf(protocol.name()));
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `Protocol`, the messaging protocol vocabulary used by cluster registration payloads.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/common/domain/enums/ProtocolTest.java`
  - `exposesBothMessagingProtocols`: gRPC and Remoting exist.
  - `enumNamesPreserveOfficialCasing`: official casing is preserved.
  - `namesRoundTripThroughValueOf`: every constant round-trips.

### Testing

- `mvn -B test -Dtest=ProtocolTest` passes (3 tests, all green).