### PR TITLE
test: add first unit test for ConsumeType

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/domain/enums/ConsumeTypeTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/domain/enums/ConsumeTypeTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.domain.enums;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Locks the consume type vocabulary used by consumer group payloads.
+ */
+class ConsumeTypeTest {
+
+    @Test
+    void exposesBothConsumeTypes() {
+        assertEquals(2, ConsumeType.values().length);
+        assertTrue(Arrays.asList(ConsumeType.values()).contains(ConsumeType.CLUSTERING));
+        assertTrue(Arrays.asList(ConsumeType.values()).contains(ConsumeType.BROADCASTING));
+    }
+
+    @Test
+    void enumNamesUseUpperSnakeCase() {
+        assertEquals("CLUSTERING", ConsumeType.CLUSTERING.name());
+        assertEquals("BROADCASTING", ConsumeType.BROADCASTING.name());
+    }
+
+    @Test
+    void namesRoundTripThroughValueOf() {
+        for (ConsumeType type : ConsumeType.values()) {
+            assertEquals(type, ConsumeType.valueOf(type.name()));
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `ConsumeType`, the consume type vocabulary used by consumer group payloads.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/common/domain/enums/ConsumeTypeTest.java`
  - `exposesBothConsumeTypes`: CLUSTERING and BROADCASTING exist.
  - `enumNamesUseUpperSnakeCase`: names stay upper snake-case.
  - `namesRoundTripThroughValueOf`: every constant round-trips.

### Testing

- `mvn -B test -Dtest=ConsumeTypeTest` passes (3 tests, all green).