### PR TITLE
test: add first unit test for SubscriptionNode

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/model/trace/SubscriptionNodeTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/trace/SubscriptionNodeTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.model.trace;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class SubscriptionNodeTest {
+
+    @Test
+    void freshNodeCarriesNullFields() {
+        SubscriptionNode node = new SubscriptionNode();
+
+        assertNull(node.getSubscriptionGroup());
+        assertNull(node.getConsumeNodeList());
+    }
+
+    @Test
+    void settersRoundTripEveryField() {
+        SubscriptionNode node = new SubscriptionNode();
+        TraceNode consume = new TraceNode();
+        consume.setRequestId("req-2");
+
+        node.setSubscriptionGroup("cg-1");
+        node.setConsumeNodeList(List.of(consume));
+
+        assertEquals("cg-1", node.getSubscriptionGroup());
+        assertEquals(List.of(consume), node.getConsumeNodeList());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `SubscriptionNode`, the consumer-side node of the message trace graph.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/model/trace/SubscriptionNodeTest.java`
  - `freshNodeCarriesNullFields`: all references default to null.
  - `settersRoundTripEveryField`: subscription group and consume nodes round-trip.

### Testing

- `mvn -B test -Dtest=SubscriptionNodeTest` passes (2 tests, all green).