### PR TITLE
test: add first unit test for MessageTraceGraph

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/model/trace/MessageTraceGraphTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/trace/MessageTraceGraphTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.model.trace;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class MessageTraceGraphTest {
+
+    @Test
+    void freshGraphCarriesNullFields() {
+        MessageTraceGraph graph = new MessageTraceGraph();
+
+        assertNull(graph.getProducerNode());
+        assertNull(graph.getSubscriptionNodeList());
+        assertNull(graph.getMessageTraceViews());
+    }
+
+    @Test
+    void settersRoundTripEveryField() {
+        MessageTraceGraph graph = new MessageTraceGraph();
+        ProducerNode producer = new ProducerNode();
+        producer.setMsgId("msg-1");
+        SubscriptionNode subscription = new SubscriptionNode();
+        subscription.setSubscriptionGroup("cg-1");
+
+        graph.setProducerNode(producer);
+        graph.setSubscriptionNodeList(List.of(subscription));
+        graph.setMessageTraceViews(List.of("view-1"));
+
+        assertEquals(producer, graph.getProducerNode());
+        assertEquals(List.of(subscription), graph.getSubscriptionNodeList());
+        assertEquals(List.of("view-1"), graph.getMessageTraceViews());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `MessageTraceGraph`, the root payload of the message trace endpoint.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/model/trace/MessageTraceGraphTest.java`
  - `freshGraphCarriesNullFields`: all references default to null.
  - `settersRoundTripEveryField`: producer, subscriptions and trace views round-trip.

### Testing

- `mvn -B test -Dtest=MessageTraceGraphTest` passes (2 tests, all green).