### PR TITLE
test: add first unit test for AlertStateStatus

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertStateStatusTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertStateStatusTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Locks the alert state vocabulary used by the alert state machine and the runtime views.
+ */
+class AlertStateStatusTest {
+
+    @Test
+    void exposesAllStateStatuses() {
+        assertEquals(5, AlertStateStatus.values().length);
+        assertTrue(Arrays.asList(AlertStateStatus.values()).contains(AlertStateStatus.OK));
+        assertTrue(Arrays.asList(AlertStateStatus.values()).contains(AlertStateStatus.PENDING));
+        assertTrue(Arrays.asList(AlertStateStatus.values()).contains(AlertStateStatus.FIRING));
+        assertTrue(Arrays.asList(AlertStateStatus.values()).contains(AlertStateStatus.RESOLVED));
+        assertTrue(Arrays.asList(AlertStateStatus.values()).contains(AlertStateStatus.ACKED));
+    }
+
+    @Test
+    void enumNamesUseUpperSnakeCase() {
+        assertEquals("PENDING", AlertStateStatus.PENDING.name());
+        assertEquals("FIRING", AlertStateStatus.FIRING.name());
+        assertEquals("RESOLVED", AlertStateStatus.RESOLVED.name());
+    }
+
+    @Test
+    void namesRoundTripThroughValueOf() {
+        for (AlertStateStatus status : AlertStateStatus.values()) {
+            assertEquals(status, AlertStateStatus.valueOf(status.name()));
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `AlertStateStatus`, the alert state vocabulary used by the alert state machine and the runtime views.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertStateStatusTest.java`
  - `exposesAllStateStatuses`: OK/PENDING/FIRING/RESOLVED/ACKED exist.
  - `enumNamesUseUpperSnakeCase`: names stay upper snake-case.
  - `namesRoundTripThroughValueOf`: every constant round-trips.

### Testing

- `mvn -B test -Dtest=AlertStateStatusTest` passes (3 tests, all green).