### PR TITLE
test: add first unit test for AlertStateUpdate

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertStateUpdateTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertStateUpdateTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class AlertStateUpdateTest {
+
+    @Test
+    void exposesStateAndTransitionComponents() {
+        AlertRuleState state = AlertRuleState.initial();
+        AlertStateUpdate update = new AlertStateUpdate(state, AlertStateTransition.FIRING);
+
+        assertEquals(state, update.state());
+        assertEquals(AlertStateTransition.FIRING, update.transition());
+    }
+
+    @Test
+    void equalityFollowsRecordComponents() {
+        AlertStateUpdate a = new AlertStateUpdate(AlertRuleState.initial(),
+                AlertStateTransition.PENDING);
+        AlertStateUpdate same = new AlertStateUpdate(AlertRuleState.initial(),
+                AlertStateTransition.PENDING);
+        AlertStateUpdate different = new AlertStateUpdate(AlertRuleState.initial(),
+                AlertStateTransition.FIRING);
+
+        assertEquals(a, same);
+        assertEquals(a.hashCode(), same.hashCode());
+        assertNotEquals(a, different);
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `AlertStateUpdate`, the record pairing a rule state with the transition that produced it.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertStateUpdateTest.java`
  - `exposesStateAndTransitionComponents`: state and transition surface.
  - `equalityFollowsRecordComponents`: record equality and hash behaviour.

### Testing

- `mvn -B test -Dtest=AlertStateUpdateTest` passes (2 tests, all green).