### PR TITLE
test: add first unit test for NotificationDeliveryBulkRetryResult

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationDeliveryBulkRetryResultTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationDeliveryBulkRetryResultTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class NotificationDeliveryBulkRetryResultTest {
+
+    @Test
+    void exposesSucceededIdsAndFailures() {
+        NotificationDeliveryBulkRetryResult result =
+                new NotificationDeliveryBulkRetryResult(List.of(1L, 2L), Map.of(3L, "still failing"));
+
+        assertEquals(List.of(1L, 2L), result.getSucceededIds());
+        assertEquals(Map.of(3L, "still failing"), result.getFailures());
+        assertFalse(result.getSucceededIds().isEmpty());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `NotificationDeliveryBulkRetryResult`, the value object returned by the bulk delivery retry flow.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationDeliveryBulkRetryResultTest.java`
  - `exposesSucceededIdsAndFailures`: succeeded ids and per-id failures surface together.

### Testing

- `mvn -B test -Dtest=NotificationDeliveryBulkRetryResultTest` passes (1 test, all green).