### PR TITLE
test: add first unit test for AlertRulesYamlVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRulesYamlVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRulesYamlVOTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AlertRulesYamlVOTest {
+
+    @Test
+    void freshPayloadCarriesNullRules() {
+        AlertRulesYamlVO payload = new AlertRulesYamlVO();
+
+        assertNull(payload.getRules());
+    }
+
+    @Test
+    void allArgsConstructorCarriesRulesText() {
+        AlertRulesYamlVO payload = new AlertRulesYamlVO("groups: []");
+
+        assertEquals("groups: []", payload.getRules());
+    }
+
+    @Test
+    void setterRoundTripsRulesText() {
+        AlertRulesYamlVO payload = new AlertRulesYamlVO();
+        payload.setRules("groups:\n  - name: DefaultCluster");
+
+        assertEquals("groups:\n  - name: DefaultCluster", payload.getRules());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `AlertRulesYamlVO`, the payload carrying the exported Prometheus rules YAML text.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRulesYamlVOTest.java`
  - `freshPayloadCarriesNullRules`: untouched payload has no rules text.
  - `allArgsConstructorCarriesRulesText` / `setterRoundTripsRulesText`: rules text round-trips.

### Testing

- `mvn -B test -Dtest=AlertRulesYamlVOTest` passes (3 tests, all green).