### PR TITLE
test: add first unit test for RmqDataSource entity

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/entity/RmqDataSourceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/entity/RmqDataSourceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.persistence.entity;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RmqDataSourceTest {
+
+    @Test
+    void freshEntityCarriesNullFields() {
+        RmqDataSource entity = new RmqDataSource();
+
+        assertNull(entity.getId());
+        assertNull(entity.getDsKey());
+        assertNull(entity.getJson());
+        assertNull(entity.getGmtCreate());
+        assertNull(entity.getGmtModified());
+    }
+
+    @Test
+    void settersRoundTripEveryField() {
+        RmqDataSource entity = new RmqDataSource();
+        LocalDateTime created = LocalDateTime.parse("2026-09-01T08:00:00");
+
+        entity.setId(2L);
+        entity.setDsKey("prometheus-1");
+        entity.setJson("{\"backendType\":\"PROMETHEUS\"}");
+        entity.setGmtCreate(created);
+        entity.setGmtModified(created);
+
+        assertEquals(2L, entity.getId());
+        assertEquals("prometheus-1", entity.getDsKey());
+        assertEquals("{\"backendType\":\"PROMETHEUS\"}", entity.getJson());
+        assertEquals(created, entity.getGmtCreate());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `RmqDataSource`, the persisted datasource blob row behind `rmq_data_source`.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/persistence/entity/RmqDataSourceTest.java`
  - `freshEntityCarriesNullFields`: untouched row defaults to nulls.
  - `settersRoundTripEveryField`: datasource key and JSON blob round-trip.

### Testing

- `mvn -B test -Dtest=RmqDataSourceTest` passes (2 tests, all green).