### PR TITLE
test: add first unit test for RmqMessageQuery entity

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/persistence/entity/RmqMessageQueryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/persistence/entity/RmqMessageQueryTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.persistence.entity;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RmqMessageQueryTest {
+
+    @Test
+    void freshEntityCarriesNullFields() {
+        RmqMessageQuery entity = new RmqMessageQuery();
+
+        assertNull(entity.getId());
+        assertNull(entity.getQueryType());
+        assertNull(entity.getTopic());
+        assertNull(entity.getMsgId());
+        assertNull(entity.getResultCount());
+        assertNull(entity.getQueriedBy());
+        assertNull(entity.getGmtCreate());
+    }
+
+    @Test
+    void settersRoundTripEveryField() {
+        RmqMessageQuery entity = new RmqMessageQuery();
+        LocalDateTime created = LocalDateTime.parse("2026-09-01T08:00:00");
+
+        entity.setId(1L);
+        entity.setQueryType("TOPIC");
+        entity.setTopic("orders");
+        entity.setMsgId("msg-1");
+        entity.setTag("created");
+        entity.setMessageKey("order-1");
+        entity.setStartTime(1784246400000L);
+        entity.setEndTime(1784332800000L);
+        entity.setResultCount(2);
+        entity.setResultSnapshot("[{\"msgId\":\"msg-1\"}]");
+        entity.setClusterId("cluster-1");
+        entity.setQueriedBy("alice");
+        entity.setGmtCreate(created);
+        entity.setGmtModified(created);
+
+        assertEquals(1L, entity.getId());
+        assertEquals("TOPIC", entity.getQueryType());
+        assertEquals("orders", entity.getTopic());
+        assertEquals(1784246400000L, entity.getStartTime());
+        assertEquals(2, entity.getResultCount());
+        assertEquals("alice", entity.getQueriedBy());
+        assertEquals(created, entity.getGmtCreate());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `RmqMessageQuery`, the persisted message query history row behind `rmq_instance_message`.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/persistence/entity/RmqMessageQueryTest.java`
  - `freshEntityCarriesNullFields`: untouched row defaults to nulls.
  - `settersRoundTripEveryField`: filters, time range, result snapshot and queried-by round-trip.

### Testing

- `mvn -B test -Dtest=RmqMessageQueryTest` passes (2 tests, all green).