### PR TITLE
test: add first unit test for ProxyHomeVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyHomeVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyHomeVOTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.proxy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ProxyHomeVOTest {
+
+    @Test
+    void builderDefaultsDescribeFreshState() {
+        ProxyHomeVO vo = ProxyHomeVO.builder().build();
+
+        assertNull(vo.getProxyAddrList());
+        assertNull(vo.getCurrentProxyAddr());
+    }
+
+    @Test
+    void allArgsCarryProxyState() {
+        ProxyHomeVO vo = ProxyHomeVO.builder()
+            .proxyAddrList(List.of("10.0.0.1:8081", "10.0.0.2:8081"))
+            .currentProxyAddr("10.0.0.1:8081")
+            .build();
+
+        assertEquals(List.of("10.0.0.1:8081", "10.0.0.2:8081"), vo.getProxyAddrList());
+        assertEquals("10.0.0.1:8081", vo.getCurrentProxyAddr());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `ProxyHomeVO`, the address-state payload of the proxy home page.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyHomeVOTest.java`
  - `builderDefaultsDescribeFreshState`: address list and current address default to null.
  - `allArgsCarryProxyState`: both fields round-trip through the builder.

### Testing

- `mvn -B test -Dtest=ProxyHomeVOTest` passes (2 tests, all green).