### PR TITLE
test: add first unit test for TraceRecordVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/TraceRecordVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/TraceRecordVOTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TraceRecordVOTest {
+
+    @Test
+    void builderDefaultsDescribeEmptyTrace() {
+        TraceRecordVO vo = TraceRecordVO.builder().build();
+
+        assertNull(vo.getNodes());
+        assertNull(vo.getConsumerStatus());
+    }
+
+    @Test
+    void allArgsCarryTraceSections() {
+        TraceRecordVO vo = TraceRecordVO.builder()
+            .nodes(List.of())
+            .consumerStatus(List.of())
+            .build();
+
+        assertTrue(vo.getNodes().isEmpty());
+        assertTrue(vo.getConsumerStatus().isEmpty());
+        assertEquals(List.of(), vo.getNodes());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `TraceRecordVO`, the message trace payload returned by the trace endpoints.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/message/TraceRecordVOTest.java`
  - `builderDefaultsDescribeEmptyTrace`: node and consumer sections default to null.
  - `allArgsCarryTraceSections`: both sections round-trip.

### Testing

- `mvn -B test -Dtest=TraceRecordVOTest` passes (2 tests, all green).