### PR TITLE
test: add first unit test for TraceNodeVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/TraceNodeVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/TraceNodeVOTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class TraceNodeVOTest {
+
+    @Test
+    void builderDefaultsDescribeEmptyNode() {
+        TraceNodeVO vo = TraceNodeVO.builder().build();
+
+        assertNull(vo.getTitle());
+        assertEquals(0L, vo.getTimestamp());
+        assertNull(vo.getStatus());
+        assertEquals(0L, vo.getCostTime());
+        assertNull(vo.getDescription());
+    }
+
+    @Test
+    void allArgsCarryTraceNodeState() {
+        TraceNodeVO vo = TraceNodeVO.builder()
+            .title("broker-a")
+            .timestamp(1784246400000L)
+            .status("SUCCESS")
+            .costTime(12L)
+            .description("consumed")
+            .build();
+
+        assertEquals("broker-a", vo.getTitle());
+        assertEquals(1784246400000L, vo.getTimestamp());
+        assertEquals("SUCCESS", vo.getStatus());
+        assertEquals(12L, vo.getCostTime());
+        assertEquals("consumed", vo.getDescription());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `TraceNodeVO`, one hop of the rendered message trace timeline.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/message/TraceNodeVOTest.java`
  - `builderDefaultsDescribeEmptyNode`: timestamps and cost at zero.
  - `allArgsCarryTraceNodeState`: title, timestamp, status and cost round-trip.

### Testing

- `mvn -B test -Dtest=TraceNodeVOTest` passes (2 tests, all green).