### PR TITLE
test: add first unit test for BatchDeleteResultVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/BatchDeleteResultVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/BatchDeleteResultVOTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class BatchDeleteResultVOTest {
+
+    @Test
+    void builderDefaultsDescribeEmptyDelete() {
+        BatchDeleteResultVO vo = BatchDeleteResultVO.builder().build();
+
+        assertEquals(0, vo.getDeleted());
+        assertNull(vo.getFailed());
+    }
+
+    @Test
+    void allArgsCarryDeleteSummary() {
+        BatchDeleteResultVO vo = BatchDeleteResultVO.builder()
+            .deleted(2)
+            .failed(List.of("inst-b"))
+            .build();
+
+        assertEquals(2, vo.getDeleted());
+        assertEquals(List.of("inst-b"), vo.getFailed());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `BatchDeleteResultVO`, the summary returned by the batch instance delete endpoint.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/BatchDeleteResultVOTest.java`
  - `builderDefaultsDescribeEmptyDelete`: deleted count zero, failures null.
  - `allArgsCarryDeleteSummary`: deleted count and failed list round-trip.

### Testing

- `mvn -B test -Dtest=BatchDeleteResultVOTest` passes (2 tests, all green).