### PR TITLE
test: add first unit test for AiExecuteResultVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiExecuteResultVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiExecuteResultVOTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiExecuteResultVOTest {
+
+    @Test
+    void builderDefaultsDescribeEmptyExecution() {
+        AiExecuteResultVO vo = AiExecuteResultVO.builder().build();
+
+        assertFalse(vo.isSuccess());
+        assertNull(vo.getResult());
+    }
+
+    @Test
+    void allArgsCarryExecutionOutcome() {
+        AiExecuteResultVO vo = AiExecuteResultVO.builder()
+            .success(true)
+            .result("{\"clusters\":[]}")
+            .build();
+
+        assertTrue(vo.isSuccess());
+        assertEquals("{\"clusters\":[]}", vo.getResult());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `AiExecuteResultVO`, the outcome returned by the AI command execution endpoint.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiExecuteResultVOTest.java`
  - `builderDefaultsDescribeEmptyExecution`: success false, result null.
  - `allArgsCarryExecutionOutcome`: success flag and result text round-trip.

### Testing

- `mvn -B test -Dtest=AiExecuteResultVOTest` passes (2 tests, all green).