### PR TITLE
test: add first unit test for DataSourceTestResultVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceTestResultVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceTestResultVOTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.settings;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DataSourceTestResultVOTest {
+
+    @Test
+    void builderDefaultsDescribeUntestedSource() {
+        DataSourceTestResultVO vo = DataSourceTestResultVO.builder().build();
+
+        assertFalse(vo.isSuccess());
+        assertNull(vo.getMessage());
+    }
+
+    @Test
+    void allArgsCarryTestOutcome() {
+        DataSourceTestResultVO vo = DataSourceTestResultVO.builder()
+            .success(true)
+            .message("connection ok")
+            .build();
+
+        assertTrue(vo.isSuccess());
+        assertEquals("connection ok", vo.getMessage());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `DataSourceTestResultVO`, the outcome returned by the datasource test endpoint.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceTestResultVOTest.java`
  - `builderDefaultsDescribeUntestedSource`: success false, message null.
  - `allArgsCarryTestOutcome`: success flag and message round-trip.

### Testing

- `mvn -B test -Dtest=DataSourceTestResultVOTest` passes (2 tests, all green).