### PR TITLE
test: add first unit test for LlmModelsResultVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmModelsResultVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmModelsResultVOTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LlmModelsResultVOTest {
+
+    @Test
+    void exposesSourceConstants() {
+        assertEquals("provider", LlmModelsResultVO.SOURCE_PROVIDER);
+        assertEquals("builtin", LlmModelsResultVO.SOURCE_BUILTIN);
+        assertEquals("fallback", LlmModelsResultVO.SOURCE_FALLBACK);
+    }
+
+    @Test
+    void shortConstructorDefaultsToBuiltinSource() {
+        LlmModelsResultVO vo = new LlmModelsResultVO(0, List.of());
+
+        assertEquals(0, vo.getStatus());
+        assertEquals(List.of(), vo.getData());
+        assertEquals(LlmModelsResultVO.SOURCE_BUILTIN, vo.getSource());
+        assertNull(vo.getWarning());
+        assertNull(vo.getWarningCode());
+        assertNull(vo.getHint());
+    }
+
+    @Test
+    void fullConstructorCarriesWarningState() {
+        LlmModelsResultVO vo = new LlmModelsResultVO(1, List.of(), LlmModelsResultVO.SOURCE_FALLBACK,
+                "models unavailable", "llm.models_unavailable", "retry later");
+
+        assertEquals(1, vo.getStatus());
+        assertEquals(LlmModelsResultVO.SOURCE_FALLBACK, vo.getSource());
+        assertEquals("models unavailable", vo.getWarning());
+        assertEquals("llm.models_unavailable", vo.getWarningCode());
+        assertEquals("retry later", vo.getHint());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `LlmModelsResultVO`, the model listing envelope returned by the LLM models endpoint.

The class exposes provider/builtin/fallback source constants and two constructors. The tests pin the constants, the builtin-source default and the full warning-carrying form.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmModelsResultVOTest.java`
  - `exposesSourceConstants`: the three source constants.
  - `shortConstructorDefaultsToBuiltinSource`: status/data with builtin source.
  - `fullConstructorCarriesWarningState`: fallback source with warning/code/hint.

### Testing

- `mvn -B test -Dtest=LlmModelsResultVOTest` passes (3 tests, all green).