### PR TITLE
test: add first unit test for LlmModelItemVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmModelItemVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmModelItemVOTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.ai;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LlmModelItemVOTest {
+
+    @Test
+    void freshItemCarriesNullFields() {
+        LlmModelItemVO vo = new LlmModelItemVO();
+
+        assertNull(vo.getId());
+        assertNull(vo.getName());
+    }
+
+    @Test
+    void allArgsConstructorCarriesModelIdentity() {
+        LlmModelItemVO vo = new LlmModelItemVO("gpt-4o", "GPT-4o");
+
+        assertEquals("gpt-4o", vo.getId());
+        assertEquals("GPT-4o", vo.getName());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `LlmModelItemVO`, one model entry inside the LLM model listing.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmModelItemVOTest.java`
  - `freshItemCarriesNullFields`: untouched entry defaults to nulls.
  - `allArgsConstructorCarriesModelIdentity`: model id and display name round-trip.

### Testing

- `mvn -B test -Dtest=LlmModelItemVOTest` passes (2 tests, all green).