### PR TITLE
test: add first unit test for AuditSummaryBucketVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditSummaryBucketVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditSummaryBucketVOTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.audit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AuditSummaryBucketVOTest {
+
+    @Test
+    void builderDefaultsDescribeEmptyBucket() {
+        AuditSummaryBucketVO vo = AuditSummaryBucketVO.builder().build();
+
+        assertNull(vo.getName());
+        assertEquals(0L, vo.getCount());
+    }
+
+    @Test
+    void allArgsCarryBucketState() {
+        AuditSummaryBucketVO vo = AuditSummaryBucketVO.builder()
+            .name("CREATE_TOPIC")
+            .count(5L)
+            .build();
+
+        assertEquals("CREATE_TOPIC", vo.getName());
+        assertEquals(5L, vo.getCount());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `AuditSummaryBucketVO`, one bucket of the audit summary breakdown.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditSummaryBucketVOTest.java`
  - `builderDefaultsDescribeEmptyBucket`: name null, count zero.
  - `allArgsCarryBucketState`: bucket name and count round-trip.

### Testing

- `mvn -B test -Dtest=AuditSummaryBucketVOTest` passes (2 tests, all green).