### PR TITLE
test: add first unit test for BrokerVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerVOTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.broker;
+
+import org.apache.rocketmq.studio.common.domain.enums.BrokerStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BrokerVOTest {
+
+    @Test
+    void builderDefaultsDescribeFreshBroker() {
+        BrokerVO vo = BrokerVO.builder().build();
+
+        assertNull(vo.getName());
+        assertNull(vo.getAddr());
+        assertNull(vo.getVersion());
+        assertNull(vo.getStatus());
+        assertEquals(0.0, vo.getDiskUsage());
+        assertEquals(0L, vo.getTpsIn());
+        assertEquals(0L, vo.getTpsOut());
+        assertTrue(vo.isRuntimeStatsAvailable());
+    }
+
+    @Test
+    void allArgsCarryBrokerState() {
+        BrokerVO vo = BrokerVO.builder()
+            .name("broker-a")
+            .addr("10.0.0.1:10911")
+            .version("5.3.2")
+            .status(BrokerStatus.running)
+            .diskUsage(0.65)
+            .tpsIn(100L)
+            .tpsOut(90L)
+            .runtimeStatsAvailable(false)
+            .build();
+
+        assertEquals("broker-a", vo.getName());
+        assertEquals("10.0.0.1:10911", vo.getAddr());
+        assertEquals(BrokerStatus.running, vo.getStatus());
+        assertEquals(0.65, vo.getDiskUsage());
+        assertEquals(100L, vo.getTpsIn());
+        assertEquals(90L, vo.getTpsOut());
+        assertFalse(vo.isRuntimeStatsAvailable());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `BrokerVO`, the broker row rendered by the cluster detail views.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/cluster/broker/BrokerVOTest.java`
  - `builderDefaultsDescribeFreshBroker`: stats available by default, counters zero.
  - `allArgsCarryBrokerState`: status, disk usage and throughput round-trip.

### Testing

- `mvn -B test -Dtest=BrokerVOTest` passes (2 tests, all green).