### PR TITLE
test: add first unit test for NameServerVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerVOTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.nameserver;
+
+import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class NameServerVOTest {
+
+    @Test
+    void builderDefaultsDescribeEmptyNameServer() {
+        NameServerVO vo = NameServerVO.builder().build();
+
+        assertNull(vo.getAddr());
+        assertNull(vo.getStatus());
+    }
+
+    @Test
+    void allArgsCarryNameServerState() {
+        NameServerVO vo = NameServerVO.builder()
+            .addr("10.0.0.1:9876")
+            .status(ClusterStatus.healthy)
+            .build();
+
+        assertEquals("10.0.0.1:9876", vo.getAddr());
+        assertEquals(ClusterStatus.healthy, vo.getStatus());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `NameServerVO`, the name server row rendered by the cluster detail views.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/NameServerVOTest.java`
  - `builderDefaultsDescribeEmptyNameServer`: untouched row defaults to nulls.
  - `allArgsCarryNameServerState`: address and status round-trip.

### Testing

- `mvn -B test -Dtest=NameServerVOTest` passes (2 tests, all green).