### PR TITLE
test: add first unit test for ConsumerGroupSettingsVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupSettingsVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupSettingsVOTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ConsumerGroupSettingsVOTest {
+
+    @Test
+    void builderDefaultsDescribeEmptySettings() {
+        ConsumerGroupSettingsVO vo = ConsumerGroupSettingsVO.builder().build();
+
+        assertNull(vo.getGroupName());
+        assertEquals(0, vo.getRetryQueueNums());
+        assertEquals(0, vo.getRetryMaxTimes());
+    }
+
+    @Test
+    void allArgsCarrySettingsState() {
+        ConsumerGroupSettingsVO vo = ConsumerGroupSettingsVO.builder()
+            .groupName("cg-orders")
+            .retryQueueNums(1)
+            .retryMaxTimes(3)
+            .build();
+
+        assertEquals("cg-orders", vo.getGroupName());
+        assertEquals(1, vo.getRetryQueueNums());
+        assertEquals(3, vo.getRetryMaxTimes());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `ConsumerGroupSettingsVO`, the editable group settings row.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupSettingsVOTest.java`
  - `builderDefaultsDescribeEmptySettings`: retry knobs at zero.
  - `allArgsCarrySettingsState`: retry queue count and max retries round-trip.

### Testing

- `mvn -B test -Dtest=ConsumerGroupSettingsVOTest` passes (2 tests, all green).