### PR TITLE
test: add first unit test for ResetConsumerOffsetQueuePreviewVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ResetConsumerOffsetQueuePreviewVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ResetConsumerOffsetQueuePreviewVOTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ResetConsumerOffsetQueuePreviewVOTest {
+
+    @Test
+    void builderDefaultsDescribeEmptyQueuePreview() {
+        ResetConsumerOffsetQueuePreviewVO vo = ResetConsumerOffsetQueuePreviewVO.builder().build();
+
+        assertNull(vo.getTopic());
+        assertNull(vo.getBroker());
+        assertEquals(0, vo.getQueueId());
+        assertEquals(0L, vo.getMinOffset());
+        assertEquals(0L, vo.getMaxOffset());
+        assertEquals(0L, vo.getBrokerOffset());
+        assertEquals(0L, vo.getConsumerOffset());
+        assertEquals(0L, vo.getTargetOffset());
+        assertEquals(0L, vo.getCurrentLag());
+        assertEquals(0L, vo.getProjectedLag());
+        assertEquals(0L, vo.getOffsetDelta());
+        assertNull(vo.getRiskLevel());
+        assertNull(vo.getMessage());
+    }
+
+    @Test
+    void allArgsCarryQueuePreviewState() {
+        ResetConsumerOffsetQueuePreviewVO vo = ResetConsumerOffsetQueuePreviewVO.builder()
+            .topic("orders")
+            .broker("broker-a")
+            .queueId(3)
+            .minOffset(0L)
+            .maxOffset(1000L)
+            .brokerOffset(1000L)
+            .consumerOffset(900L)
+            .targetOffset(500L)
+            .currentLag(100L)
+            .projectedLag(-400L)
+            .offsetDelta(-400L)
+            .riskLevel("info")
+            .message("safe rewind")
+            .build();
+
+        assertEquals("orders", vo.getTopic());
+        assertEquals("broker-a", vo.getBroker());
+        assertEquals(3, vo.getQueueId());
+        assertEquals(1000L, vo.getBrokerOffset());
+        assertEquals(500L, vo.getTargetOffset());
+        assertEquals(100L, vo.getCurrentLag());
+        assertEquals(-400L, vo.getOffsetDelta());
+        assertEquals("info", vo.getRiskLevel());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `ResetConsumerOffsetQueuePreviewVO`, the per-queue row of the reset preview.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/group/ResetConsumerOffsetQueuePreviewVOTest.java`
  - `builderDefaultsDescribeEmptyQueuePreview`: offsets and lag at zero.
  - `allArgsCarryQueuePreviewState`: offsets, lag deltas and risk round-trip.

### Testing

- `mvn -B test -Dtest=ResetConsumerOffsetQueuePreviewVOTest` passes (2 tests, all green).