### PR TITLE
test: add first unit test for ImportConsumerGroupsResultVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ImportConsumerGroupsResultVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ImportConsumerGroupsResultVOTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ImportConsumerGroupsResultVOTest {
+
+    @Test
+    void builderDefaultsDescribeEmptyImport() {
+        ImportConsumerGroupsResultVO vo = ImportConsumerGroupsResultVO.builder().build();
+
+        assertEquals(0, vo.getImported());
+        assertEquals(0, vo.getFailed());
+        assertNull(vo.getGroups());
+        assertNull(vo.getFailures());
+    }
+
+    @Test
+    void allArgsCarryImportResult() {
+        ImportConsumerGroupsResultVO.Failure failure = ImportConsumerGroupsResultVO.Failure.builder()
+            .index(1)
+            .name("cg-bad")
+            .message("invalid retry")
+            .build();
+
+        ImportConsumerGroupsResultVO vo = ImportConsumerGroupsResultVO.builder()
+            .imported(2)
+            .failed(1)
+            .groups(List.of())
+            .failures(List.of(failure))
+            .build();
+
+        assertEquals(2, vo.getImported());
+        assertEquals(1, vo.getFailed());
+        assertEquals(List.of(), vo.getGroups());
+        assertEquals(1, vo.getFailures().get(0).getIndex());
+        assertEquals("cg-bad", vo.getFailures().get(0).getName());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `ImportConsumerGroupsResultVO`, the batch import summary with its nested failure rows.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/group/ImportConsumerGroupsResultVOTest.java`
  - `builderDefaultsDescribeEmptyImport`: imported/failed counts zero.
  - `allArgsCarryImportResult`: imported/failed plus nested failure rows round-trip.

### Testing

- `mvn -B test -Dtest=ImportConsumerGroupsResultVOTest` passes (2 tests, all green).