### PR TITLE
test: add first unit test for BrokerConfigUpdateFailureVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/config/BrokerConfigUpdateFailureVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/config/BrokerConfigUpdateFailureVOTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class BrokerConfigUpdateFailureVOTest {
+
+    @Test
+    void builderDefaultsDescribeEmptyFailure() {
+        BrokerConfigUpdateFailureVO vo = BrokerConfigUpdateFailureVO.builder().build();
+
+        assertNull(vo.getAddress());
+        assertNull(vo.getMessage());
+    }
+
+    @Test
+    void allArgsCarryFailureState() {
+        BrokerConfigUpdateFailureVO vo = BrokerConfigUpdateFailureVO.builder()
+            .address("broker-a")
+            .message("rejected by broker")
+            .build();
+
+        assertEquals("broker-a", vo.getAddress());
+        assertEquals("rejected by broker", vo.getMessage());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `BrokerConfigUpdateFailureVO`, one failed-broker entry of a config update result.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/cluster/config/BrokerConfigUpdateFailureVOTest.java`
  - `builderDefaultsDescribeEmptyFailure`: untouched entry defaults to nulls.
  - `allArgsCarryFailureState`: broker address and message round-trip.

### Testing

- `mvn -B test -Dtest=BrokerConfigUpdateFailureVOTest` passes (2 tests, all green).