### PR TITLE
test: add first unit test for DLQExportResultVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQExportResultVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQExportResultVOTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.dlq;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DLQExportResultVOTest {
+
+    @Test
+    void builderDefaultsDescribeEmptyExport() {
+        DLQExportResultVO vo = DLQExportResultVO.builder().build();
+
+        assertNull(vo.getMessages());
+        assertFalse(vo.isTruncated());
+        assertEquals(0, vo.getFailedQueueCount());
+        assertEquals(0, vo.getLimit());
+    }
+
+    @Test
+    void allArgsCarryExportState() {
+        DLQExportResultVO vo = DLQExportResultVO.builder()
+            .messages(List.of())
+            .truncated(true)
+            .failedQueueCount(1)
+            .limit(100)
+            .build();
+
+        assertEquals(List.of(), vo.getMessages());
+        assertTrue(vo.isTruncated());
+        assertEquals(1, vo.getFailedQueueCount());
+        assertEquals(100, vo.getLimit());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `DLQExportResultVO`, the DLQ JSON export payload returned by the export endpoint.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQExportResultVOTest.java`
  - `builderDefaultsDescribeEmptyExport`: truncation false, counters zero.
  - `allArgsCarryExportState`: messages, truncation and limits round-trip.

### Testing

- `mvn -B test -Dtest=DLQExportResultVOTest` passes (2 tests, all green).