### PR TITLE
test: add first unit test for LiteTopicItemVO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicItemVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicItemVOTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.topic;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LiteTopicItemVOTest {
+
+    @Test
+    void builderDefaultsDescribeEmptyItem() {
+        LiteTopicItemVO vo = LiteTopicItemVO.builder().build();
+
+        assertNull(vo.getTopicPattern());
+        assertNull(vo.getNamespace());
+        assertNull(vo.getTopicCount());
+        assertNull(vo.getConsumerCount());
+        assertNull(vo.getTotalBacklog());
+        assertNull(vo.getAverageTTL());
+        assertNull(vo.getTtlStatus());
+        assertNull(vo.getLastActiveTime());
+        assertNull(vo.getSessionIds());
+    }
+
+    @Test
+    void allArgsCarryItemState() {
+        LiteTopicItemVO vo = LiteTopicItemVO.builder()
+            .topicPattern("order-*")
+            .namespace("ns-1")
+            .topicCount(3)
+            .consumerCount(2)
+            .totalBacklog(100L)
+            .averageTTL(3600L)
+            .ttlStatus("ACTIVE")
+            .lastActiveTime(1784246400000L)
+            .sessionIds(List.of("s1"))
+            .build();
+
+        assertEquals("order-*", vo.getTopicPattern());
+        assertEquals(3, vo.getTopicCount());
+        assertEquals(100L, vo.getTotalBacklog());
+        assertEquals(3600L, vo.getAverageTTL());
+        assertEquals("ACTIVE", vo.getTtlStatus());
+        assertEquals(List.of("s1"), vo.getSessionIds());
+    }
+}


### PR DESCRIPTION
### Summary

Adds the first dedicated unit test suite for `LiteTopicItemVO`, one lite topic summary row of the lite topic list.

### Changes

- `server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicItemVOTest.java`
  - `builderDefaultsDescribeEmptyItem`: untouched item defaults to nulls.
  - `allArgsCarryItemState`: counts, backlog and TTL round-trip.

### Testing

- `mvn -B test -Dtest=LiteTopicItemVOTest` passes (2 tests, all green).