### PR TITLE
[ISSUE-3764][test] Deepen AlertSilenceControllerTest with bounded page defaults and null-body create

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertSilenceControllerTest.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -108,4 +109,27 @@ class AlertSilenceControllerTest {
                         && request.getRecurrenceDays().equals(Set.of(1, 3, 5))
                         && "Asia/Shanghai".equals(request.getTimeZone())));
     }
+    @Test
+    void listPageShouldUseBoundedDefaultsTest() throws Exception {
+        when(silenceService.listPage(1, 20)).thenReturn(PageResult.empty(1, 20));
+
+        mockMvc.perform(get("/api/alert-silences/page"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.items").isEmpty())
+                .andExpect(jsonPath("$.data.page").value(1))
+                .andExpect(jsonPath("$.data.size").value(20));
+
+        verify(silenceService).listPage(1, 20);
+    }
+
+    @Test
+    void createShouldRejectNullBodyTest() throws Exception {
+        mockMvc.perform(post("/api/alert-silences")
+                        .contentType("application/json"))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(silenceService);
+    }
+
 }


### PR DESCRIPTION
### Motivation

The existing `AlertSilenceControllerTest` only covers the happy paths of list/create. This PR deepens the controller coverage so the default `page`/`size` handling and the error path for a missing request body are locked in.

### Changes

- `listPageShouldUseBoundedDefaultsTest`: GET `/api/alert-silences/page` without query params must delegate to `silenceService.listPage(1, 20)` and return 200 with the page payload.
- `createShouldRejectNullBodyTest`: POST `/api/alert-silences` with an empty body returns 400 and the service layer stays untouched (`verifyNoInteractions`).

### Verification

```
mvn -B test -Dtest=AlertSilenceControllerTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```