### PR TITLE
[ISSUE-3767][test] Deepen ClusterRepositoryImplTest with targeted config update, no-op and snapshot immutability

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterRepositoryImplTest.java
@@ -17,11 +17,13 @@
 package org.apache.rocketmq.studio.cluster.broker;
 
 import org.apache.rocketmq.studio.cluster.config.ClusterConfigVO;
+import org.apache.rocketmq.studio.common.domain.enums.FlushDiskType;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ClusterRepositoryImplTest {
 
@@ -81,5 +83,84 @@ class ClusterRepositoryImplTest {
 
         assertThat(repository.findById("cluster-001").orElseThrow().getConfig().getFileReservedTime())
                 .isEqualTo(24);
+    }
+
+    @Test
+    void updateConfigShouldRefreshOnlyTargetedCluster() {
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(true);
+        ClusterConfigVO config = ClusterConfigVO.builder()
+                .writeQueueNums(4)
+                .readQueueNums(4)
+                .maxMessageSize(8388608)
+                .msgTraceTopicName("TRACE_A")
+                .autoCreateTopicEnable(false)
+                .autoCreateSubscriptionGroup(false)
+                .deleteWhen("03")
+                .fileReservedTime(24)
+                .flushDiskType(FlushDiskType.SYNC_FLUSH)
+                .brokerPermission(4)
+                .build();
+
+        repository.updateConfig("cluster-001", config);
+
+        ClusterVO updated = repository.findById("cluster-001").orElseThrow();
+        assertThat(updated.getConfig().getWriteQueueNums()).isEqualTo(4);
+        assertThat(updated.getConfig().getReadQueueNums()).isEqualTo(4);
+        assertThat(updated.getConfig().getMaxMessageSize()).isEqualTo(8388608);
+        assertThat(updated.getConfig().getMsgTraceTopicName()).isEqualTo("TRACE_A");
+        assertThat(updated.getConfig().isAutoCreateTopicEnable()).isFalse();
+        assertThat(updated.getConfig().isAutoCreateSubscriptionGroup()).isFalse();
+        assertThat(updated.getConfig().getDeleteWhen()).isEqualTo("03");
+        assertThat(updated.getConfig().getFileReservedTime()).isEqualTo(24);
+        assertThat(updated.getConfig().getFlushDiskType()).isEqualTo(FlushDiskType.SYNC_FLUSH);
+        assertThat(updated.getConfig().getBrokerPermission()).isEqualTo(4);
+        // Non-config fields of the targeted cluster are preserved.
+        assertThat(updated.getName()).isEqualTo("rmq-cluster-prod");
+        assertThat(updated.getEndpoint()).isEqualTo("10.0.0.1:9876");
+        assertThat(updated.getBrokers()).hasSize(2);
+        assertThat(updated.getProxies()).hasSize(1);
+        assertThat(updated.getTopicCount()).isEqualTo(128);
+        assertThat(updated.getGroupCount()).isEqualTo(45);
+        // Sibling clusters stay untouched.
+        ClusterVO untouched = repository.findById("cluster-002").orElseThrow();
+        assertThat(untouched.getConfig().getFileReservedTime()).isEqualTo(48);
+        assertThat(untouched.getConfig().getFlushDiskType()).isEqualTo(FlushDiskType.SYNC_FLUSH);
+    }
+
+    @Test
+    void updateConfigShouldBeNoOpForUnknownClusterId() {
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(true);
+        ClusterConfigVO config = ClusterConfigVO.builder()
+                .fileReservedTime(1)
+                .build();
+
+        repository.updateConfig("cluster-missing", config);
+
+        assertThat(repository.findAll()).hasSize(2);
+        assertThat(repository.findById("cluster-missing")).isEmpty();
+        assertThat(repository.findById("cluster-001").orElseThrow().getConfig().getFileReservedTime())
+                .isEqualTo(72);
+    }
+
+    @Test
+    void findByIdShouldReturnEmptyForUnknownClusterId() {
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(true);
+
+        assertThat(repository.findById("cluster-404")).isEmpty();
+    }
+
+    @Test
+    void findAllShouldReturnFreshImmutableSnapshots() {
+        ClusterRepositoryImpl repository = new ClusterRepositoryImpl(true);
+
+        List<ClusterVO> first = repository.findAll();
+        List<ClusterVO> second = repository.findAll();
+
+        assertThat(first).isNotSameAs(second);
+        assertThat(first.get(0)).isNotSameAs(second.get(0));
+        assertThat(second).hasSize(2);
+        assertThat(second).extracting(ClusterVO::getName)
+                .containsExactly("rmq-cluster-prod", "rmq-cluster-staging");
+        assertThatThrownBy(first::clear).isInstanceOf(UnsupportedOperationException.class);
     }
 }


### PR DESCRIPTION
### Motivation

The existing `ClusterRepositoryImplTest` proves ordering, emptiness and deep-copy semantics, but leaves the config-update mutation path and the read behaviour for unknown ids unverified.

### Changes

- `updateConfigShouldRefreshOnlyTargetedCluster`: a full replacement config lands on every `ClusterConfigVO` field of the targeted cluster while its identity/endpoint/brokers/proxies/counters survive, and sibling clusters keep their own config untouched.
- `updateConfigShouldBeNoOpForUnknownClusterId`: updating a missing id leaves the store size and every cached cluster config unchanged.
- `findByIdShouldReturnEmptyForUnknownClusterId`: unknown ids resolve to an empty `Optional`.
- `findAllShouldReturnFreshImmutableSnapshots`: repeated calls yield distinct snapshots with distinct element copies, and mutating the returned list is rejected.

### Verification

```
mvn -B test -Dtest=ClusterRepositoryImplTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```