### PR TITLE
[ISSUE-3768][test] Deepen ConsumerDiagnosticsServiceTest with blank-instance normalization and failure passthrough

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerDiagnosticsServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerDiagnosticsServiceTest.java
@@ -95,4 +95,25 @@ class ConsumerDiagnosticsServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("clientId is required");
     }
+
+    @Test
+    void getConsumerStackShouldNormalizeBlankInstanceIdToNull() {
+        when(diagnosticsProvider.getConsumerStack(null, "cg-orders", "client-1"))
+                .thenReturn(null);
+
+        diagnosticsService.getConsumerStack("  ", " cg-orders ", " client-1 ");
+
+        verify(diagnosticsProvider).getConsumerStack(null, "cg-orders", "client-1");
+    }
+
+    @Test
+    void getConsumerStackShouldPropagateProviderFailuresUnchanged() {
+        when(diagnosticsProvider.getConsumerStack("instance-a", "cg-orders", "client-1"))
+                .thenThrow(new IllegalStateException("jstack collection unavailable"));
+
+        assertThatThrownBy(() -> diagnosticsService.getConsumerStack(
+                "instance-a", "cg-orders", "client-1"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("jstack collection unavailable");
+    }
 }


### PR DESCRIPTION
### Motivation

`ConsumerDiagnosticsServiceTest` already pins the required-field validation and the trim-before-delegate behaviour, but two code paths remain unobserved: the optional `instanceId` normalisation and whether provider failures survive the service untouched.

### Changes

- `getConsumerStackShouldNormalizeBlankInstanceToNull`: a blank instance id is treated as optional and reaches the provider as `null` after both the group and client id are trimmed.
- `getConsumerStackShouldPropagateProviderFailuresUnchanged`: a provider-side failure surfaces to the caller with the same exception type and message, confirming the service adds no wrapping or swallowing.

### Verification

```
mvn -B test -Dtest=ConsumerDiagnosticsServiceTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```