### PR TITLE
[ISSUE-3769][test] Deepen ApacheAclReadServiceTest with dedup, master-skip, root-cause and empty-table coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/ApacheAclReadServiceTest.java
@@ -33,6 +33,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ApacheAclReadServiceTest {
@@ -122,5 +124,75 @@ class ApacheAclReadServiceTest {
             MqAdminExtFactory.AdminAction<?> action = invocation.getArgument(1);
             return action.apply(admin);
         });
+    }
+
+    @Test
+    void skipsDuplicateMasterAddressAcrossBrokerEntries() throws Exception {
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        MQAdminExt admin = mock(MQAdminExt.class);
+        BrokerData first = new BrokerData();
+        first.setBrokerAddrs(new HashMap<>(Map.of(0L, "broker-a:10911")));
+        BrokerData second = new BrokerData();
+        second.setBrokerAddrs(new HashMap<>(Map.of(0L, "broker-a:10911")));
+        ClusterInfo clusterInfo = new ClusterInfo();
+        clusterInfo.setBrokerAddrTable(Map.of("first", first, "second", second));
+        when(admin.examineBrokerClusterInfo()).thenReturn(clusterInfo);
+        when(admin.listAcl("broker-a:10911", null, null)).thenReturn(List.of());
+        executeWith(resolver, admin);
+
+        RemoteAclReadResult result = new ApacheAclReadService(resolver).listRules("instance-1", null, null);
+
+        verify(admin).listAcl("broker-a:10911", null, null);
+        assertThat(result.getPoliciesByBroker()).containsOnlyKeys("broker-a:10911");
+        assertThat(result.getFailuresByBroker()).isEmpty();
+    }
+
+    @Test
+    void skipsBrokerEntriesWithoutMasterAddress() throws Exception {
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        MQAdminExt admin = mock(MQAdminExt.class);
+        BrokerData noAddrs = new BrokerData();
+        BrokerData slaveOnly = new BrokerData();
+        slaveOnly.setBrokerAddrs(new HashMap<>(Map.of(2L, "broker-a:10911")));
+        ClusterInfo clusterInfo = new ClusterInfo();
+        clusterInfo.setBrokerAddrTable(Map.of("no-addrs", noAddrs, "slave", slaveOnly));
+        when(admin.examineBrokerClusterInfo()).thenReturn(clusterInfo);
+        executeWith(resolver, admin);
+
+        RemoteAclReadResult result = new ApacheAclReadService(resolver).listRules("instance-1", null, null);
+
+        verify(admin, never()).listAcl(any(), any(), any());
+        assertThat(result.getPoliciesByBroker()).isEmpty();
+        assertThat(result.getFailuresByBroker()).isEmpty();
+        assertThat(result.isPartial()).isFalse();
+    }
+
+    @Test
+    void usesDeepestRootCauseAsFailureMessage() throws Exception {
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        MQAdminExt admin = mock(MQAdminExt.class);
+        when(admin.examineBrokerClusterInfo()).thenReturn(clusterInfo("broker-a:10911"));
+        when(admin.listAcl("broker-a:10911", null, null))
+                .thenThrow(new IllegalStateException("outer", new RuntimeException("root cause")));
+        executeWith(resolver, admin);
+
+        RemoteAclReadResult result = new ApacheAclReadService(resolver).listRules("instance-1", null, null);
+
+        assertThat(result.getFailuresByBroker()).containsEntry("broker-a:10911", "root cause");
+    }
+
+    @Test
+    void treatsMissingBrokerTableAsEmptyResult() throws Exception {
+        RuntimeAdminClientResolver resolver = mock(RuntimeAdminClientResolver.class);
+        MQAdminExt admin = mock(MQAdminExt.class);
+        when(admin.examineBrokerClusterInfo()).thenReturn(new ClusterInfo());
+        executeWith(resolver, admin);
+
+        RemoteAclReadResult result = new ApacheAclReadService(resolver).listRules("instance-1", null, null);
+
+        verify(admin, never()).listAcl(any(), any(), any());
+        assertThat(result.getPoliciesByBroker()).isEmpty();
+        assertThat(result.getFailuresByBroker()).isEmpty();
+        assertThat(result.isPartial()).isFalse();
     }
 }


### PR DESCRIPTION
### Motivation

The existing `ApacheAclReadServiceTest` covers the partial-failure aggregation and null-row tolerance, but leaves the iteration guards of the broker-table walk unverified: duplicate master addresses, broker entries with no master, the root-cause unwrapping for failure messages, and a missing broker table.

### Changes

- `skipsDuplicateMasterAddressAcrossBrokerEntries`: two broker entries sharing one master address trigger a single `listAcl` call and a single policy key.
- `skipsBrokerEntriesWithoutMasterAddress`: entries with no address table or only slave addresses never reach `listAcl` and yield an empty, non-partial result.
- `usesDeepestRootCauseAsFailureMessage`: a wrapped failure records the deepest cause message instead of the outer one.
- `treatsMissingBrokerTableAsEmptyResult`: a `ClusterInfo` with no broker table short-circuits to an empty result without any `listAcl` invocation.

### Verification

```
mvn -B test -Dtest=ApacheAclReadServiceTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```