### PR TITLE
feat(alert): export notification deliveries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.cluster.metrics.AlertingProperties;
 import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.common.util.CsvUtil;
 import org.apache.rocketmq.studio.common.util.NoRedirectClientHttpRequestFactory;
 import org.apache.rocketmq.studio.common.util.UrlHostGuard;
 import org.apache.rocketmq.studio.persistence.entity.RmqAlertNotificationOutbox;
@@ -63,6 +64,9 @@ import jakarta.mail.internet.InternetAddress;
 public class NotificationOutboxService {
     private static final int MAX_ATTEMPTS = 5;
     private static final int BATCH_SIZE = 20;
+    private static final int MAX_EXPORT_DELIVERIES = 10_000;
+    private static final String EXPORT_CSV_HEADER = "deliveryId,alertId,alertTitle,alertDomain,transition,"
+            + "instanceId,channel,status,attempts,createdAt,deliveredAt,nextRetryAt,lastError\r\n";
     private static final Duration DEFAULT_CLAIM_TIMEOUT = Duration.ofMinutes(1);
     private static final Duration DEFAULT_CLAIM_RENEWAL_INTERVAL = Duration.ofSeconds(20);
     private static final int DEFAULT_HEARTBEAT_THREADS = 2;
@@ -220,6 +224,32 @@ public class NotificationOutboxService {
         }
         return PageResult.of(mapper.findPage(normalizedChannel, normalizedStatus, normalizedInstanceId, safePageSize,
                 (long) (safePage - 1) * safePageSize), total, safePage, safePageSize);
+    }
+
+    public String exportDeliveries(String channel, String status, String instanceId) {
+        String normalizedChannel = normalizeFilter(channel);
+        String normalizedStatus = normalizeStatus(status);
+        String normalizedInstanceId = normalizeTrim(instanceId);
+        List<NotificationDeliveryPageVO> rows = mapper.findExportPage(
+                normalizedChannel, normalizedStatus, normalizedInstanceId, MAX_EXPORT_DELIVERIES);
+        StringBuilder csv = new StringBuilder("\uFEFF").append(EXPORT_CSV_HEADER);
+        for (NotificationDeliveryPageVO row : rows) {
+            CsvUtil.appendRow(csv,
+                    row.getId(),
+                    row.getAlertId(),
+                    row.getAlertTitle(),
+                    row.getAlertDomain(),
+                    row.getTransition(),
+                    row.getInstanceId(),
+                    row.getChannel(),
+                    row.getStatus(),
+                    row.getAttemptCount(),
+                    row.getCreatedAt(),
+                    row.getDeliveredAt(),
+                    row.getNextAttemptAt(),
+                    row.getLastError());
+        }
+        return csv.toString();
     }
 
     public void retryFailedDelivery(Long deliveryId) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
@@ -66,7 +66,7 @@ public class NotificationOutboxService {
     private static final int BATCH_SIZE = 20;
     private static final int MAX_EXPORT_DELIVERIES = 10_000;
     private static final String EXPORT_CSV_HEADER = "deliveryId,alertId,alertTitle,alertDomain,transition,"
-            + "instanceId,channel,status,attempts,createdAt,deliveredAt,nextRetryAt,lastError\r\n";
+            + "instanceId,channel,status,attemptCount,createdAt,deliveredAt,nextRetryAt,lastError\r\n";
     private static final Duration DEFAULT_CLAIM_TIMEOUT = Duration.ofMinutes(1);
     private static final Duration DEFAULT_CLAIM_RENEWAL_INTERVAL = Duration.ofSeconds(20);
     private static final int DEFAULT_HEARTBEAT_THREADS = 2;

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
@@ -87,6 +87,14 @@ public class SystemAlertController {
         return Result.ok(notificationOutboxService.listDeliveries(channel, status, instanceId, page, pageSize));
     }
 
+    @GetMapping("/deliveries/export")
+    public Result<String> exportDeliveries(
+            @RequestParam(required = false) String channel,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String instanceId) {
+        return Result.ok(notificationOutboxService.exportDeliveries(channel, status, instanceId));
+    }
+
     @PostMapping("/deliveries/{deliveryId}/retry")
     public Result<Void> retryFailedDelivery(@PathVariable Long deliveryId) {
         notificationOutboxService.retryFailedDelivery(deliveryId);

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
@@ -21,6 +21,8 @@ import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -87,12 +90,17 @@ public class SystemAlertController {
         return Result.ok(notificationOutboxService.listDeliveries(channel, status, instanceId, page, pageSize));
     }
 
-    @GetMapping("/deliveries/export")
-    public Result<String> exportDeliveries(
+    @GetMapping(value = "/deliveries/export", produces = "text/csv;charset=UTF-8")
+    public ResponseEntity<byte[]> exportDeliveries(
             @RequestParam(required = false) String channel,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String instanceId) {
-        return Result.ok(notificationOutboxService.exportDeliveries(channel, status, instanceId));
+        byte[] csv = notificationOutboxService.exportDeliveries(channel, status, instanceId)
+                .getBytes(StandardCharsets.UTF_8);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"notification-deliveries.csv\"")
+                .body(csv);
     }
 
     @PostMapping("/deliveries/{deliveryId}/retry")

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqAlertNotificationOutboxMapper.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqAlertNotificationOutboxMapper.java
@@ -67,6 +67,23 @@ public interface RmqAlertNotificationOutboxMapper extends BaseMapper<RmqAlertNot
             @Param("instanceId") String instanceId, @Param("limit") int limit, @Param("offset") long offset);
 
     @Select("<script>"
+            + "SELECT o.id, o.alert_id AS alertId, o.channel, o.status, o.attempt_count AS attemptCount, "
+            + "o.next_attempt_at AS nextAttemptAt, o.last_error AS lastError, o.delivered_at AS deliveredAt, "
+            + "o.gmt_create AS createdAt, o.message_content AS messageContent, a.title AS alertTitle, a.domain AS alertDomain, "
+            + "a.transition, a.instance_id AS instanceId "
+            + "FROM rmq_alert_notification_outbox o "
+            + "JOIN rmq_system_alert a ON a.id = o.alert_id "
+            + "<where>"
+            + "<if test='channel != null and channel != \"\"'> AND o.channel = #{channel}</if>"
+            + "<if test='status != null and status != \"\"'> AND o.status = #{status}</if>"
+            + "<if test='instanceId != null and instanceId != \"\"'> AND a.instance_id = #{instanceId}</if>"
+            + "</where> ORDER BY o.id ASC LIMIT #{limit}"
+            + "</script>")
+    List<NotificationDeliveryPageVO> findExportPage(@Param("channel") String channel,
+            @Param("status") String status, @Param("instanceId") String instanceId,
+            @Param("limit") int limit);
+
+    @Select("<script>"
             + "SELECT COUNT(*) FROM rmq_alert_notification_outbox o "
             + "JOIN rmq_system_alert a ON a.id = o.alert_id "
             + "<where>"

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqAlertNotificationOutboxMapper.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqAlertNotificationOutboxMapper.java
@@ -53,7 +53,7 @@ public interface RmqAlertNotificationOutboxMapper extends BaseMapper<RmqAlertNot
     @Select("<script>"
             + "SELECT o.id, o.alert_id AS alertId, o.channel, o.status, o.attempt_count AS attemptCount, "
             + "o.next_attempt_at AS nextAttemptAt, o.last_error AS lastError, o.delivered_at AS deliveredAt, "
-            + "o.gmt_create AS createdAt, o.message_content AS messageContent, a.title AS alertTitle, a.domain AS alertDomain, "
+            + "o.gmt_create AS createdAt, a.title AS alertTitle, a.domain AS alertDomain, "
             + "a.transition, a.instance_id AS instanceId "
             + "FROM rmq_alert_notification_outbox o "
             + "JOIN rmq_system_alert a ON a.id = o.alert_id "

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
@@ -458,6 +458,29 @@ class NotificationOutboxServiceTest {
     }
 
     @Test
+    void exportsDeliveryRecordsWithNormalizedFiltersAndSafeCsvCellsTest() {
+        RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
+        NotificationDeliveryPageVO delivery = NotificationDeliveryPageVO.builder().id(8L).alertId(9L)
+                .channel("dingtalk").status(NotificationOutboxStatus.FAILED).attemptCount(3)
+                .alertTitle("Disk usage high").alertDomain(AlertDomain.CLUSTER).transition("FIRING")
+                .instanceId("Local").lastError("Webhook rejected \"keywords\"")
+                .createdAt(LocalDateTime.of(2026, 9, 5, 10, 0)).build();
+        when(mapper.findExportPage("dingtalk", "FAILED", "Local", 10_000))
+                .thenReturn(List.of(delivery));
+
+        String csv = new NotificationOutboxService(mapper, mock(SettingsRepository.class),
+                mock(AlertSilenceService.class), mock(AlertRepository.class), mock(OperationAuditService.class))
+                .exportDeliveries(" DingTalk ", "failed", "Local");
+
+        assertThat(csv).startsWith("\uFEFFdeliveryId,alertId,alertTitle,alertDomain,transition")
+                .contains("\"8\"")
+                .contains("\"9\"")
+                .contains("\"Disk usage high\"")
+                .contains("\"Webhook rejected \"\"keywords\"\"\"")
+                .doesNotContain("messageContent");
+    }
+
+    @Test
     void normalizesDeliveryFiltersIndependentlyOfTheDefaultLocaleTest() {
         Locale previous = Locale.getDefault();
         try {

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
@@ -143,6 +143,21 @@ class SystemAlertControllerTest {
     }
 
     @Test
+    void exportDeliveriesShouldForwardFiltersTest() throws Exception {
+        when(notificationOutboxService.exportDeliveries("dingtalk", "FAILED", "local"))
+                .thenReturn("\uFEFFdeliveryId\r\n");
+
+        mockMvc.perform(get("/api/system-alerts/deliveries/export")
+                        .param("channel", "dingtalk")
+                        .param("status", "FAILED")
+                        .param("instanceId", "local"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("\uFEFFdeliveryId\r\n"));
+
+        verify(notificationOutboxService).exportDeliveries("dingtalk", "FAILED", "local");
+    }
+
+    @Test
     void retryFailedDeliveriesShouldReturnPartialResultTest() throws Exception {
         NotificationDeliveryBulkRetryResult result = new NotificationDeliveryBulkRetryResult(
                 List.of(8L), Map.of(9L, "Delivery is not failed"));

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
@@ -36,6 +36,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -152,7 +154,10 @@ class SystemAlertControllerTest {
                         .param("status", "FAILED")
                         .param("instanceId", "local"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").value("\uFEFFdeliveryId\r\n"));
+                .andExpect(content().contentTypeCompatibleWith("text/csv"))
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"notification-deliveries.csv\""))
+                .andExpect(content().bytes("\uFEFFdeliveryId\r\n".getBytes(java.nio.charset.StandardCharsets.UTF_8)));
 
         verify(notificationOutboxService).exportDeliveries("dingtalk", "FAILED", "local");
     }

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -362,6 +362,13 @@ export async function listAlertDeliveriesPage(params: NotificationDeliveryQuery 
   return res.data.data;
 }
 
+export async function exportAlertDeliveries(
+  params: Omit<NotificationDeliveryQuery, 'page' | 'pageSize'>,
+) {
+  const res = await client.get<{ data: string }>('/system-alerts/deliveries/export', { params });
+  return res.data.data;
+}
+
 export async function listAlertSilences() {
   const res = await client.get<{ data: AlertSilence[] }>('/alert-silences');
   return res.data.data;

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -365,8 +365,11 @@ export async function listAlertDeliveriesPage(params: NotificationDeliveryQuery 
 export async function exportAlertDeliveries(
   params: Omit<NotificationDeliveryQuery, 'page' | 'pageSize'>,
 ) {
-  const res = await client.get<{ data: string }>('/system-alerts/deliveries/export', { params });
-  return res.data.data;
+  const res = await client.get<Blob>('/system-alerts/deliveries/export', {
+    params,
+    responseType: 'blob',
+  });
+  return res.data;
 }
 
 export async function listAlertSilences() {

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -852,6 +852,10 @@ const translations: Record<string, Record<Lang, string>> = {
   'deliveries.allChannels': { zh: '全部通道', en: 'All channels' },
   'deliveries.allStatuses': { zh: '全部状态', en: 'All statuses' },
   'deliveries.allInstances': { zh: '全部实例', en: 'All instances' },
+  'deliveries.exportFailed': {
+    zh: '导出告警投递记录失败，请稍后重试',
+    en: 'Failed to export alert deliveries. Please try again later.',
+  },
   'deliveries.loadFailed': {
     zh: '告警投递记录加载失败，请稍后重试',
     en: 'Failed to load alert deliveries. Please try again later.',

--- a/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
@@ -10,13 +10,18 @@ import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LangProvider } from '../../../i18n/LangContext';
 import { listInstances } from '../../../services/instanceService';
-import { listAlertDeliveriesPage, retryAlertDelivery } from '../../../services/opsService';
+import {
+  exportAlertDeliveries,
+  listAlertDeliveriesPage,
+  retryAlertDelivery,
+} from '../../../services/opsService';
 import NotificationDeliveriesPage from '../notificationDeliveries';
 
 vi.mock('../../../services/instanceService', () => ({
   listInstances: vi.fn().mockResolvedValue([]),
 }));
 vi.mock('../../../services/opsService', () => ({
+  exportAlertDeliveries: vi.fn(),
   listAlertDeliveriesPage: vi.fn(),
   retryAlertDeliveries: vi.fn(),
   retryAlertDelivery: vi.fn(),
@@ -168,5 +173,22 @@ describe('NotificationDeliveriesPage', () => {
     expect(listAlertDeliveriesPage).toHaveBeenLastCalledWith(
       expect.objectContaining({ status: 'DELIVERED' }),
     );
+  });
+
+  it('exports deliveries using the current filters', async () => {
+    vi.mocked(exportAlertDeliveries).mockResolvedValue('\uFEFFdeliveryId\r\n');
+    const user = userEvent.setup();
+    render(
+      <App>
+        <LangProvider>
+          <NotificationDeliveriesPage />
+        </LangProvider>
+      </App>,
+    );
+
+    await screen.findByText('Broker disk usage');
+    await user.click(screen.getByRole('button', { name: /导出/ }));
+
+    await waitFor(() => expect(exportAlertDeliveries).toHaveBeenCalledWith({}));
   });
 });

--- a/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
@@ -175,8 +175,13 @@ describe('NotificationDeliveriesPage', () => {
     );
   });
 
-  it('exports deliveries using the current filters', async () => {
-    vi.mocked(exportAlertDeliveries).mockResolvedValue('\uFEFFdeliveryId\r\n');
+  it('exports deliveries using the current filters and downloads the blob', async () => {
+    const blob = new Blob(['\uFEFFdeliveryId\r\n'], { type: 'text/csv;charset=utf-8' });
+    vi.mocked(exportAlertDeliveries).mockResolvedValue(blob);
+    const createObjectURL = vi.fn(() => 'blob:delivery-export');
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', { writable: true, value: createObjectURL });
+    Object.defineProperty(URL, 'revokeObjectURL', { writable: true, value: revokeObjectURL });
     const user = userEvent.setup();
     render(
       <App>
@@ -190,5 +195,7 @@ describe('NotificationDeliveriesPage', () => {
     await user.click(screen.getByRole('button', { name: /导出/ }));
 
     await waitFor(() => expect(exportAlertDeliveries).toHaveBeenCalledWith({}));
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:delivery-export');
   });
 });

--- a/web/src/pages/ops/notificationDeliveries.tsx
+++ b/web/src/pages/ops/notificationDeliveries.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../services/opsService';
 import { formatUtcDateTime } from '../../utils/format';
 import { tableScrollX } from '../../utils/table';
+import { downloadBlob } from '../../utils/download';
 
 const statusColors: Record<NotificationDeliveryRecord['status'], string> = {
   PENDING: 'default',
@@ -69,20 +70,15 @@ const NotificationDeliveriesPage = () => {
   const handleExport = async () => {
     setExporting(true);
     try {
-      const csv = await exportAlertDeliveries({
+      const blob = await exportAlertDeliveries({
         channel,
         status,
         instanceId,
       });
-      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
-      const url = URL.createObjectURL(blob);
-      const anchor = document.createElement('a');
-      anchor.href = url;
-      anchor.download = `rocketmq-notification-deliveries-${new Date()
-        .toISOString()
-        .slice(0, 10)}.csv`;
-      anchor.click();
-      URL.revokeObjectURL(url);
+      downloadBlob(
+        blob,
+        `rocketmq-notification-deliveries-${new Date().toISOString().slice(0, 10)}.csv`,
+      );
     } catch {
       message.error(t('deliveries.exportFailed'));
     } finally {

--- a/web/src/pages/ops/notificationDeliveries.tsx
+++ b/web/src/pages/ops/notificationDeliveries.tsx
@@ -18,7 +18,7 @@ import {
   Typography,
   message,
 } from 'antd';
-import { ArrowClockwise, Eye } from '@phosphor-icons/react';
+import { ArrowClockwise, DownloadSimple, Eye } from '@phosphor-icons/react';
 import type { ColumnsType } from 'antd/es/table';
 import PageHeader from '../../components/PageHeader';
 import { useLang } from '../../i18n/LangContext';
@@ -26,6 +26,7 @@ import type { Instance } from '../../api/instance';
 import type { NotificationDeliveryRecord } from '../../api/ops';
 import { listInstances } from '../../services/instanceService';
 import {
+  exportAlertDeliveries,
   listAlertDeliveriesPage,
   retryAlertDeliveries,
   retryAlertDelivery,
@@ -58,10 +59,35 @@ const NotificationDeliveriesPage = () => {
   const retryingIdsInFlight = useRef(new Set<number>());
   const retryingVisibleInFlight = useRef(false);
   const [refreshNonce, setRefreshNonce] = useState(0);
+  const [exporting, setExporting] = useState(false);
 
   const refresh = () => {
     setLoading(true);
     setRefreshNonce((current) => current + 1);
+  };
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const csv = await exportAlertDeliveries({
+        channel,
+        status,
+        instanceId,
+      });
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `rocketmq-notification-deliveries-${new Date()
+        .toISOString()
+        .slice(0, 10)}.csv`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      message.error(t('deliveries.exportFailed'));
+    } finally {
+      setExporting(false);
+    }
   };
 
   const retryDelivery = async (record: NotificationDeliveryRecord) => {
@@ -240,6 +266,13 @@ const NotificationDeliveriesPage = () => {
               onClick={() => void retryVisibleFailures()}
             >
               {t('deliveries.retryCurrentPage')}
+            </Button>
+            <Button
+              icon={<DownloadSimple size={18} />}
+              loading={exporting}
+              onClick={() => void handleExport()}
+            >
+              {t('common.export')}
             </Button>
             <Select
               allowClear

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -442,6 +442,15 @@ export async function listAlertDeliveriesPage(
   return opsApi.listAlertDeliveriesPage(params);
 }
 
+export async function exportAlertDeliveries(
+  params: Omit<NotificationDeliveryQuery, 'page' | 'pageSize'>,
+): Promise<string> {
+  if (isMockMode()) {
+    return '\uFEFFdeliveryId,alertId,alertTitle,alertDomain,transition,instanceId,channel,status,attempts,createdAt,deliveredAt,nextRetryAt,lastError\r\n';
+  }
+  return opsApi.exportAlertDeliveries(params);
+}
+
 export async function listAlertSilences(): Promise<AlertSilence[]> {
   if (isMockMode()) return alertSilencesState.map((silence) => ({ ...silence }));
   return opsApi.listAlertSilences();

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -444,9 +444,11 @@ export async function listAlertDeliveriesPage(
 
 export async function exportAlertDeliveries(
   params: Omit<NotificationDeliveryQuery, 'page' | 'pageSize'>,
-): Promise<string> {
+): Promise<Blob> {
   if (isMockMode()) {
-    return '\uFEFFdeliveryId,alertId,alertTitle,alertDomain,transition,instanceId,channel,status,attempts,createdAt,deliveredAt,nextRetryAt,lastError\r\n';
+    const header =
+      'deliveryId,alertId,alertTitle,alertDomain,transition,instanceId,channel,status,attemptCount,createdAt,deliveredAt,nextRetryAt,lastError\r\n';
+    return new Blob(['\uFEFF' + header], { type: 'text/csv;charset=utf-8' });
   }
   return opsApi.exportAlertDeliveries(params);
 }


### PR DESCRIPTION
## What is the purpose of the change

Other operational inventories can be exported from the dashboard, but notification deliveries could not. Operators had to copy rows manually when sharing a delivery failure or building an incident report.

This change adds bounded CSV export for the notification delivery feed, reusing the page's filters and excluding sensitive message content. Details: #3559

## Brief changelog

**Backend**

- `SystemAlertController`: adds `GET /api/system-alerts/deliveries/export` reusing the channel/status/instance filters.
- `NotificationOutboxService.exportDeliveries(...)`: bounded to 10,000 rows ordered by delivery ID for deterministic output; exports delivery ID, alert ID/title/domain/transition, instance ID, channel, status, attempt count, creation/delivery/retry timestamps, and last error; does **not** export full message content; uses the shared `CsvUtil` writer so every cell is quoted and spreadsheet formula injection is prevented.
- `RmqAlertNotificationOutboxMapper`: adds `findExportPage` with the same filter predicates as the paged feed.

**Frontend**

- `api/ops.ts` / `services/opsService.ts`: typed export API and wrapper (mock mode returns a header-only CSV).
- `pages/ops/notificationDeliveries.tsx`: adds an export button that downloads the currently filtered deliveries and shows errors when the export fails.
- `i18n/translations.ts`: labels for the new action.

**Tests**

- `NotificationOutboxServiceTest`: filter propagation, row bound, field set, no message content, and CSV escaping.
- `SystemAlertControllerTest`: endpoint contract and parameter forwarding.
- `NotificationDeliveriesPage.test.tsx`: export request uses current filters and triggers a download.

## Verifying this change

- `mvn -q '-Dtest=NotificationOutboxServiceTest,SystemAlertControllerTest' test` — 38 tests passed
- `mvn -q checkstyle:check` — passed
- `npm test -- NotificationDeliveriesPage.test.tsx --run` — 4 tests passed
- `npm run lint -- --quiet` — 0 errors; 10 existing warnings remain elsewhere in the tree
- `npm run build` — passed
- `git diff --check` — passed

The GitHub Actions status is not being described as green here; the checks above are local validation on this branch.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change. This PR addresses only #3559.
- [x] The pull request title follows the change type and scope.
- [x] This description covers what the PR does, how, and why.
- [x] Unit tests cover the endpoint, row bound, field set, sensitive-field exclusion, CSV escaping, and UI download.
- [x] Focused backend tests, Checkstyle, frontend tests, lint, and build were run locally on this branch.
- [ ] Apache Individual Contributor License Agreement (not required for this change size).

