### PR TITLE
[ISSUE-3770][test] Deepen AuthCookieTest with clear-expiry, custom name, blank value and same-site config coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCookieTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthCookieTest.java
@@ -66,4 +66,62 @@ class AuthCookieTest {
         assertThat(AuthCookie.authorization(nonBearerRequest, properties))
                 .isEqualTo("Bearer cookie-token");
     }
+
+    @Test
+    void clearShouldExpireCookieWithZeroMaxAge() {
+        AuthProperties properties = new AuthProperties();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        AuthCookie.clear(response, properties);
+
+        String setCookie = response.getHeader("Set-Cookie");
+        assertThat(setCookie).startsWith("rmq_studio_session=;");
+        assertThat(setCookie).contains("Max-Age=0");
+        assertThat(setCookie).contains("HttpOnly");
+        assertThat(setCookie).contains("Path=/");
+    }
+
+    @Test
+    void ignoresCookiesNotMatchingConfiguredCookieName() {
+        AuthProperties properties = new AuthProperties();
+        properties.setSessionCookieName("studio_session");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("rmq_studio_session", "legacy-token"));
+        request.addHeader("Authorization", "Basic credentials");
+
+        assertThat(AuthCookie.authorization(request, properties))
+                .isEqualTo("Basic credentials");
+
+        MockHttpServletRequest customNamed = new MockHttpServletRequest();
+        customNamed.setCookies(new Cookie("rmq_studio_session", "legacy-token"),
+                new Cookie("studio_session", "custom-token"));
+
+        assertThat(AuthCookie.authorization(customNamed, properties))
+                .isEqualTo("Bearer custom-token");
+    }
+
+    @Test
+    void skipsBlankCookieValuesWhileScanning() {
+        AuthProperties properties = new AuthProperties();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("rmq_studio_session", "   "),
+                new Cookie("rmq_studio_session", "real-token"));
+
+        assertThat(AuthCookie.authorization(request, properties))
+                .isEqualTo("Bearer real-token");
+    }
+
+    @Test
+    void writeShouldHonorConfiguredSameSiteAndInsecureMode() {
+        AuthProperties properties = new AuthProperties();
+        properties.setSessionCookieSameSite("Lax");
+        properties.setSessionCookieSecure(false);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        AuthCookie.write(response, properties, "token", Duration.ofMinutes(5));
+
+        String setCookie = response.getHeader("Set-Cookie");
+        assertThat(setCookie).contains("SameSite=Lax");
+        assertThat(setCookie).doesNotContain("Secure");
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `AuthCookieTest` verifies the secure cookie flags and the bearer-over-cookie precedence, but leaves the logout path, name configurability, blank-value skipping and the configurable same-site/secure flags unobserved.

### Changes

- `clearShouldExpireCookieWithZeroMaxAge`: logout writes an empty-value cookie with `Max-Age=0`, `HttpOnly` and root path.
- `ignoresCookiesNotMatchingConfiguredCookieName`: a legacy cookie under the default name is ignored once a custom `sessionCookieName` is configured, and a cookie under the custom name wins.
- `skipsBlankCookieValuesWhileScanning`: whitespace-only cookie values are skipped while later matching cookies are honoured.
- `writeShouldHonorConfiguredSameSiteAndInsecureMode`: `SameSite=Lax` and an insecure session cookie are reflected verbatim in the emitted header.

### Verification

```
mvn -B test -Dtest=AuthCookieTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```