### PR TITLE
[ISSUE-3772][test] Deepen AlertRuleSemanticFingerprintTest with domain default, aggregation fallback, raw percentage and clamping

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleSemanticFingerprintTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleSemanticFingerprintTest.java
@@ -77,4 +77,69 @@ class AlertRuleSemanticFingerprintTest {
                 .isEqualTo(AlertRuleSemanticFingerprint.of(fraction))
                 .isNotEqualTo(AlertRuleSemanticFingerprint.of(rawValue));
     }
+
+    @Test
+    void domainDefaultsToBusinessAndBlankInstanceMatchesNull() {
+        AlertRuleVO nullDomain = AlertRuleVO.builder()
+                .domain(null)
+                .instanceId(null)
+                .metric("consumer.lag.total").operator(">=").threshold(100)
+                .duration("5m").build();
+        AlertRuleVO defaulted = AlertRuleVO.builder()
+                .domain(AlertDomain.BUSINESS)
+                .instanceId("   ")
+                .metric("consumer.lag.total").operator(">=").threshold(100)
+                .duration("5m").build();
+
+        assertThat(AlertRuleSemanticFingerprint.of(nullDomain))
+                .isEqualTo(AlertRuleSemanticFingerprint.of(defaulted));
+    }
+
+    @Test
+    void blankAggregationFallsBackToLastWhileExplicitValueChangesFingerprint() {
+        AlertRuleVO base = AlertRuleVO.builder()
+                .metric("consumer.lag.total").operator(">=").threshold(100)
+                .duration("5m").build();
+        AlertRuleVO blank = AlertRuleVO.builder()
+                .metric("consumer.lag.total").operator(">=").threshold(100)
+                .duration("5m").aggregation("  ").build();
+        AlertRuleVO avg = AlertRuleVO.builder()
+                .metric("consumer.lag.total").operator(">=").threshold(100)
+                .duration("5m").aggregation("AVG").build();
+
+        assertThat(AlertRuleSemanticFingerprint.of(blank))
+                .isEqualTo(AlertRuleSemanticFingerprint.of(base));
+        assertThat(AlertRuleSemanticFingerprint.of(avg))
+                .isNotEqualTo(AlertRuleSemanticFingerprint.of(base));
+    }
+
+    @Test
+    void percentageUnitStaysRawForNonRatioMetrics() {
+        AlertRuleVO withUnit = AlertRuleVO.builder()
+                .metric("consumer.lag.total").operator(">=").threshold(85)
+                .thresholdUnit("%").duration("5m").build();
+        AlertRuleVO raw = AlertRuleVO.builder()
+                .metric("consumer.lag.total").operator(">=").threshold(85)
+                .duration("5m").build();
+        AlertRuleVO fraction = AlertRuleVO.builder()
+                .metric("consumer.lag.total").operator(">=").threshold(0.85)
+                .duration("5m").build();
+
+        assertThat(AlertRuleSemanticFingerprint.of(withUnit))
+                .isEqualTo(AlertRuleSemanticFingerprint.of(raw))
+                .isNotEqualTo(AlertRuleSemanticFingerprint.of(fraction));
+    }
+
+    @Test
+    void negativeWindowAndConsecutiveSamplesAreClamped() {
+        AlertRuleVO base = AlertRuleVO.builder()
+                .metric("consumer.lag.total").operator(">=").threshold(100)
+                .duration("5m").windowSeconds(0).consecutiveSamples(1).build();
+        AlertRuleVO clamped = AlertRuleVO.builder()
+                .metric("consumer.lag.total").operator(">=").threshold(100)
+                .duration("5m").windowSeconds(-10).consecutiveSamples(-3).build();
+
+        assertThat(AlertRuleSemanticFingerprint.of(clamped))
+                .isEqualTo(AlertRuleSemanticFingerprint.of(base));
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `AlertRuleSemanticFingerprintTest` proves presentation-insensitivity, scope/window sensitivity and ratio-threshold normalisation, but several normalisation branches of the fingerprint remain untested.

### Changes

- `domainDefaultsToBusinessAndBlankInstanceMatchesNull`: a null domain is folded to `BUSINESS` and a blank instance id is folded to null, keeping the fingerprint stable.
- `blankAggregationFallsBackToLastWhileExplicitValueChangesFingerprint`: whitespace-only `aggregation` behaves like the `LAST` default while an explicit `AVG` changes the identity.
- `percentageUnitStaysRawForNonRatioMetrics`: for metrics outside the ratio set the `%` unit does not rescale the threshold, so 85 with `%` matches raw 85 and differs from 0.85.
- `negativeWindowAndConsecutiveSamplesAreClamped`: negative `windowSeconds`/`consecutiveSamples` clamp to their safe floors (0/1) and keep the identity of the clamped rule.

### Verification

```
mvn -B test -Dtest=AlertRuleSemanticFingerprintTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```