### PR TITLE
[ISSUE-3775][test] Deepen NativeAlertRuleScopeMatcherTest with instance guard, blank selector, empty labels and trim coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleScopeMatcherTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertRuleScopeMatcherTest.java
@@ -58,6 +58,45 @@ class NativeAlertRuleScopeMatcherTest {
         assertThat(NativeAlertRuleScopeMatcher.matches(rule, otherTopic)).isFalse();
     }
 
+    @Test
+    void requiresMatchingInstanceIdAndRejectsBlankRuleInstance() {
+        AlertRuleVO blankInstance = AlertRuleVO.builder().instanceId("  ").build();
+        AlertRuleVO otherInstance = AlertRuleVO.builder().instanceId("other").build();
+
+        assertThat(NativeAlertRuleScopeMatcher.matches(blankInstance, sample("cluster-a", "broker-a")))
+                .isFalse();
+        assertThat(NativeAlertRuleScopeMatcher.matches(otherInstance, sample("cluster-a", "broker-a")))
+                .isFalse();
+    }
+
+    @Test
+    void matchesWhenAllOptionalSelectorsAreBlank() {
+        AlertRuleVO rule = AlertRuleVO.builder().instanceId("local").build();
+
+        assertThat(NativeAlertRuleScopeMatcher.matches(rule, sample("cluster-a", "broker-a")))
+                .isTrue();
+    }
+
+    @Test
+    void emptyLabelsOnlyFailForRulesWithSelectors() {
+        MetricSample bare = new MetricSample("broker.availability", AlertDomain.CLUSTER, "local",
+                "cluster-a", Map.of(), 1D, MetricAvailability.AVAILABLE, Instant.now());
+        AlertRuleVO noSelector = AlertRuleVO.builder().instanceId("local").build();
+        AlertRuleVO topicSelector = AlertRuleVO.builder().instanceId("local").topic("orders-topic").build();
+
+        assertThat(NativeAlertRuleScopeMatcher.matches(noSelector, bare)).isTrue();
+        assertThat(NativeAlertRuleScopeMatcher.matches(topicSelector, bare)).isFalse();
+    }
+
+    @Test
+    void trimsSelectorsAndInstanceIdBeforeMatching() {
+        AlertRuleVO rule = AlertRuleVO.builder().instanceId(" local ").brokerName(" broker-a ")
+                .clusterName(" cluster-a ").build();
+
+        assertThat(NativeAlertRuleScopeMatcher.matches(rule, sample("cluster-a", "broker-a")))
+                .isTrue();
+    }
+
     private static MetricSample sample(String clusterId, String brokerName) {
         return new MetricSample("broker.availability", AlertDomain.CLUSTER, "local", clusterId,
                 Map.of("brokerName", brokerName), 1D, MetricAvailability.AVAILABLE, Instant.now());


### PR DESCRIPTION
### Motivation

The existing `NativeAlertRuleScopeMatcherTest` covers exact broker/cluster matching, wildcards and topic/group selectors, but the instance guard, fully-blank selectors, label-less samples and whitespace trimming remain untested.

### Changes

- `requiresMatchingInstanceIdAndRejectsBlankRuleInstance`: a rule without a usable instance id never matches, and a different instance id is rejected even when all resources align.
- `matchesWhenAllOptionalSelectorsAreBlank`: a rule scoped only to the instance matches any sample on that instance.
- `emptyLabelsOnlyFailForRulesWithSelectors`: a label-less sample still matches when no resource selectors are set, and is rejected when a topic selector is configured.
- `trimsSelectorsAndInstanceIdBeforeMatching`: surrounding whitespace on the instance id and resource selectors does not change the outcome.

### Verification

```
mvn -B test -Dtest=NativeAlertRuleScopeMatcherTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```