### PR TITLE
[ISSUE-3777][test] Deepen InstanceCapabilityServiceTest with empty capability set, missing provider and explicit vendor routing

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceCapabilityServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceCapabilityServiceTest.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -100,5 +101,57 @@ class InstanceCapabilityServiceTest {
         assertThatThrownBy(() -> service.getCapabilities(999L))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
+    }
+
+    @Test
+    void getCapabilitiesShouldReturnEmptyListWhenProviderExposesNoCapabilities() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("direct-empty")
+                .type(InstanceType.DIRECT)
+                .build();
+        instance.setId(3L);
+        when(instanceRepository.findById(3L)).thenReturn(Optional.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE)).thenReturn(instanceProvider);
+        when(instanceProvider.capabilities()).thenReturn(Set.of());
+
+        InstanceCapabilitiesVO result = service.getCapabilities(3L);
+
+        assertThat(result.vendor()).isEqualTo(InstanceVendor.APACHE);
+        assertThat(result.capabilities()).isEmpty();
+    }
+
+    @Test
+    void getCapabilitiesShouldTranslateMissingProviderRegistration() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("ghost-vendor")
+                .type(InstanceType.DIRECT)
+                .build();
+        instance.setId(4L);
+        when(instanceRepository.findById(4L)).thenReturn(Optional.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.APACHE))
+                .thenThrow(new BusinessException(501, "No instance provider registered for vendor APACHE"));
+
+        assertThatThrownBy(() -> service.getCapabilities(4L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(501));
+    }
+
+    @Test
+    void getCapabilitiesShouldAskForExplicitNonNullVendor() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("cloud-tencent")
+                .vendor(InstanceVendor.TENCENT)
+                .type(InstanceType.CLOUD)
+                .build();
+        instance.setId(5L);
+        when(instanceRepository.findById(5L)).thenReturn(Optional.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.TENCENT)).thenReturn(instanceProvider);
+        when(instanceProvider.capabilities()).thenReturn(Set.of(InstanceCapability.MESSAGE_QUERY));
+
+        InstanceCapabilitiesVO result = service.getCapabilities(5L);
+
+        verify(providerRegistry).forVendor(InstanceVendor.TENCENT);
+        assertThat(result.vendor()).isEqualTo(InstanceVendor.TENCENT);
+        assertThat(result.capabilities()).containsExactly(InstanceCapability.MESSAGE_QUERY);
     }
 }


### PR DESCRIPTION
### Motivation

The existing `InstanceCapabilityServiceTest` covers stable-ordered capabilities, the legacy null-vendor default and unknown ids, but the empty-provider set, a registry without a provider for the vendor and the explicit vendor routing remain untested.

### Changes

- `getCapabilitiesShouldReturnEmptyListWhenProviderExposesNoCapabilities`: a provider exposing an empty capability set yields an empty ordered list with the legacy vendor preserved.
- `getCapabilitiesShouldTranslateMissingProviderRegistration`: when no provider is registered for the vendor the registry's 501 is surfaced unchanged.
- `getCapabilitiesShouldAskForExplicitNonNullVendor`: an explicit non-null vendor is forwarded verbatim to the registry (no legacy defaulting) and its capabilities are returned.

### Verification

```
mvn -B test -Dtest=InstanceCapabilityServiceTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```