### PR TITLE
[ISSUE-3778][test] Deepen ClusterConnectionServiceTest with broker-less topology and probe summary message

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/ClusterConnectionServiceTest.java
@@ -76,4 +76,34 @@ class ClusterConnectionServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Failed to connect NameServer");
     }
+
+    @Test
+    void connectionShouldHandleClusterWithoutBrokers() {
+        when(clusterProvider.describeCluster(eq("10.0.0.2:9876")))
+                .thenReturn(ClusterVO.builder().name("EmptyCluster").build());
+
+        ClusterProbeResult result = service.testConnection(
+                TestConnectionDTO.builder().namesrvAddr("10.0.0.2:9876").build());
+
+        assertThat(result.isConnected()).isTrue();
+        assertThat(result.getClusterName()).isEqualTo("EmptyCluster");
+        assertThat(result.getBrokerCount()).isEqualTo(0);
+        assertThat(result.getBrokerNames()).isEmpty();
+        assertThat(result.getMessage()).startsWith("Connected to 0 broker(s) in ");
+        assertThat(result.getMessage()).endsWith("ms");
+    }
+
+    @Test
+    void messageShouldSummariseProbedTopology() {
+        when(clusterProvider.describeCluster(eq("10.0.0.1:9876")))
+                .thenReturn(clusterWith("broker-a", "broker-b"));
+
+        ClusterProbeResult result = service.testConnection(
+                TestConnectionDTO.builder().namesrvAddr("10.0.0.1:9876").build());
+
+        assertThat(result.isConnected()).isTrue();
+        assertThat(result.getBrokerNames()).containsExactly("broker-a", "broker-b");
+        assertThat(result.getMessage()).startsWith("Connected to 2 broker(s) in ");
+        assertThat(result.getMessage()).endsWith("ms");
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `ClusterConnectionServiceTest` covers a healthy two-broker probe and provider failure propagation, but not the broker-less topology shape nor the human-readable probe summary message.

### Changes

- `connectionShouldHandleClusterWithoutBrokers`: a cluster whose broker list is absent still reports a connected probe with `brokerCount=0`, an empty broker list and a `0 broker(s)` summary.
- `messageShouldSummariseProbedTopology`: the probe summary is prefixed with the connected broker count and suffixed with the elapsed time in milliseconds.

### Verification

```
mvn -B test -Dtest=ClusterConnectionServiceTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```