### PR TITLE
[ISSUE-3781][test] Deepen AlertNotificationTemplateTest with empty fields, raw non-ratio value and template trim

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplateTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplateTest.java
@@ -51,4 +51,32 @@ class AlertNotificationTemplateTest {
         assertThat(AlertNotificationTemplate.render("${title}", alert, null))
                 .isEqualTo("${description}");
     }
+
+    @Test
+    void missingAlertFieldsRenderAsEmptyValues() {
+        SystemAlertVO alert = SystemAlertVO.builder().build();
+
+        String rendered = AlertNotificationTemplate.render(
+                "${ruleName}|${title}|${description}|${value}|${time}|${labels}|${level}", alert, null);
+
+        assertThat(rendered).isEqualTo("||||||");
+    }
+
+    @Test
+    void rawCurrentValueIsUsedForNonRatioMetrics() {
+        AlertRuleVO rule = AlertRuleVO.builder().metric("consumer.lag.total")
+                .thresholdUnit("%").threshold(85).build();
+        SystemAlertVO alert = SystemAlertVO.builder().currentValue(0.865).build();
+
+        assertThat(AlertNotificationTemplate.render("${value}", alert, rule))
+                .isEqualTo("0.865");
+    }
+
+    @Test
+    void whitespaceAroundTemplateIsTrimmed() {
+        SystemAlertVO alert = SystemAlertVO.builder().title("T").build();
+
+        assertThat(AlertNotificationTemplate.render("   ${title}   ", alert, null))
+                .isEqualTo("T");
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `AlertNotificationTemplateTest` covers the documented placeholders, the default format and the no-recursion guard, but the empty-field rendering, the raw (non-rescaled) current value for non-ratio metrics and template whitespace trimming were untested.

### Changes

- `missingAlertFieldsRenderAsEmptyValues`: absent rule/alert fields (title, description, value, time, labels, level, ruleName) expand to empty strings without crashing.
- `rawCurrentValueIsUsedForNonRatioMetrics`: for a non-ratio metric a `%` threshold unit does not rescale `${value}`, which stays at the raw current value.
- `whitespaceAroundTemplateIsTrimmed`: leading/trailing whitespace around a custom template is stripped before rendering.

### Verification

```
mvn -B test -Dtest=AlertNotificationTemplateTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```