### PR TITLE
feat(alert): retry filtered deliveries

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxService.java
@@ -63,6 +63,7 @@ import jakarta.mail.internet.InternetAddress;
 public class NotificationOutboxService {
     private static final int MAX_ATTEMPTS = 5;
     private static final int BATCH_SIZE = 20;
+    private static final int MAX_FILTERED_RETRY_DELIVERIES = 100;
     private static final Duration DEFAULT_CLAIM_TIMEOUT = Duration.ofMinutes(1);
     private static final Duration DEFAULT_CLAIM_RENEWAL_INTERVAL = Duration.ofSeconds(20);
     private static final int DEFAULT_HEARTBEAT_THREADS = 2;
@@ -260,6 +261,22 @@ public class NotificationOutboxService {
             }
         }
         return new NotificationDeliveryBulkRetryResult(succeeded, failures);
+    }
+
+    public NotificationDeliveryBulkRetryResult retryFailedDeliveries(
+            String channel, String instanceId, int limit) {
+        if (limit < 1 || limit > MAX_FILTERED_RETRY_DELIVERIES) {
+            throw new org.apache.rocketmq.studio.common.exception.BusinessException(400,
+                    "Filtered retry limit must be between 1 and " + MAX_FILTERED_RETRY_DELIVERIES);
+        }
+        String normalizedChannel = normalizeFilter(channel);
+        String normalizedInstanceId = normalizeTrim(instanceId);
+        List<Long> deliveryIds = mapper.findFailedDeliveryIds(
+                normalizedChannel, normalizedInstanceId, limit);
+        if (deliveryIds.isEmpty()) {
+            return new NotificationDeliveryBulkRetryResult(List.of(), Map.of());
+        }
+        return retryFailedDeliveries(deliveryIds);
     }
 
     private static String normalizeFilter(String value) {

--- a/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/ops/alert/SystemAlertController.java
@@ -99,6 +99,14 @@ public class SystemAlertController {
         return Result.ok(notificationOutboxService.retryFailedDeliveries(deliveryIds));
     }
 
+    @PostMapping("/deliveries/retry-filtered")
+    public Result<NotificationDeliveryBulkRetryResult> retryFilteredFailedDeliveries(
+            @RequestParam(required = false) String channel,
+            @RequestParam(required = false) String instanceId,
+            @RequestParam(defaultValue = "100") int limit) {
+        return Result.ok(notificationOutboxService.retryFailedDeliveries(channel, instanceId, limit));
+    }
+
     @PostMapping("/acknowledge")
     public Result<SystemAlertVO> acknowledgeAlert(
             @Valid @RequestBody(required = false) AcknowledgeSystemAlertDTO request) {

--- a/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqAlertNotificationOutboxMapper.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/persistence/mapper/RmqAlertNotificationOutboxMapper.java
@@ -77,4 +77,13 @@ public interface RmqAlertNotificationOutboxMapper extends BaseMapper<RmqAlertNot
             + "</script>")
     long countPage(@Param("channel") String channel, @Param("status") String status,
             @Param("instanceId") String instanceId);
+
+    @Select("SELECT o.id FROM rmq_alert_notification_outbox o "
+            + "JOIN rmq_system_alert a ON a.id = o.alert_id "
+            + "WHERE o.status = 'FAILED' "
+            + "AND (#{channel} IS NULL OR o.channel = #{channel}) "
+            + "AND (#{instanceId} IS NULL OR a.instance_id = #{instanceId}) "
+            + "ORDER BY o.id LIMIT #{limit}")
+    List<Long> findFailedDeliveryIds(@Param("channel") String channel,
+            @Param("instanceId") String instanceId, @Param("limit") int limit);
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NotificationOutboxServiceTest.java
@@ -531,6 +531,42 @@ class NotificationOutboxServiceTest {
     }
 
     @Test
+    void filteredRetryUsesBoundedFailedDeliveryIdsTest() {
+        RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
+        RmqAlertNotificationOutbox failed = new RmqAlertNotificationOutbox();
+        failed.setId(7L);
+        failed.setAlertId(3L);
+        failed.setChannel("dingtalk");
+        failed.setStatus(NotificationOutboxStatus.FAILED.name());
+        when(mapper.findFailedDeliveryIds("dingtalk", "Local", 100)).thenReturn(List.of(7L, 8L));
+        when(mapper.selectById(7L)).thenReturn(failed);
+        when(mapper.update(org.mockito.ArgumentMatchers.isNull(), any(UpdateWrapper.class))).thenReturn(1);
+
+        NotificationDeliveryBulkRetryResult result = new NotificationOutboxService(mapper,
+                mock(SettingsRepository.class), mock(AlertSilenceService.class), mock(AlertRepository.class),
+                mock(OperationAuditService.class))
+                .retryFailedDeliveries(" DingTalk ", "Local", 100);
+
+        assertThat(result.getSucceededIds()).containsExactly(7L);
+        assertThat(result.getFailures()).containsKey(8L);
+        verify(mapper).findFailedDeliveryIds("dingtalk", "Local", 100);
+    }
+
+    @Test
+    void filteredRetryRejectsInvalidLimitTest() {
+        NotificationOutboxService service = new NotificationOutboxService(
+                mock(RmqAlertNotificationOutboxMapper.class), mock(SettingsRepository.class),
+                mock(AlertSilenceService.class), mock(AlertRepository.class), mock(OperationAuditService.class));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.retryFailedDeliveries(null, null, 0))
+                .isInstanceOf(org.apache.rocketmq.studio.common.exception.BusinessException.class)
+                .hasMessage("Filtered retry limit must be between 1 and 100");
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.retryFailedDeliveries(null, null, 101))
+                .isInstanceOf(org.apache.rocketmq.studio.common.exception.BusinessException.class)
+                .hasMessage("Filtered retry limit must be between 1 and 100");
+    }
+
+    @Test
     void renewsClaimWhileEmailDeliveryIsStillInFlightTest() throws Exception {
         RmqAlertNotificationOutboxMapper mapper = mock(RmqAlertNotificationOutboxMapper.class);
         SettingsRepository settings = mock(SettingsRepository.class);

--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/SystemAlertControllerTest.java
@@ -159,6 +159,21 @@ class SystemAlertControllerTest {
     }
 
     @Test
+    void retryFilteredFailedDeliveriesShouldForwardFiltersAndLimitTest() throws Exception {
+        when(notificationOutboxService.retryFailedDeliveries("dingtalk", "local", 100))
+                .thenReturn(new NotificationDeliveryBulkRetryResult(List.of(8L), Map.of()));
+
+        mockMvc.perform(post("/api/system-alerts/deliveries/retry-filtered")
+                        .param("channel", "dingtalk")
+                        .param("instanceId", "local")
+                        .param("limit", "100"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.succeededIds[0]").value(8));
+
+        verify(notificationOutboxService).retryFailedDeliveries("dingtalk", "local", 100);
+    }
+
+    @Test
     void acknowledgeAlertShouldPassValidatedRequestTest() throws Exception {
         SystemAlertVO acknowledged = SystemAlertVO.builder()
                 .id(1L)

--- a/web/src/api/ops.ts
+++ b/web/src/api/ops.ts
@@ -354,6 +354,19 @@ export async function retryAlertDeliveries(ids: number[]) {
   return res.data.data;
 }
 
+export async function retryFilteredAlertDeliveries(params: {
+  channel?: string;
+  instanceId?: string;
+  limit?: number;
+}) {
+  const res = await client.post<{ data: NotificationDeliveryBulkRetryResult }>(
+    '/system-alerts/deliveries/retry-filtered',
+    null,
+    { params },
+  );
+  return res.data.data;
+}
+
 export async function listAlertDeliveriesPage(params: NotificationDeliveryQuery = {}) {
   const res = await client.get<{ data: PageResult<NotificationDeliveryRecord> }>(
     '/system-alerts/deliveries/page',

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -570,6 +570,18 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: '重新投递失败，请稍后重试',
     en: 'Redelivery failed. Please try again later.',
   },
+  'deliveries.retryFiltered': {
+    zh: '重试匹配的失败记录',
+    en: 'Retry matching failures',
+  },
+  'deliveries.filteredRetryQueued': {
+    zh: '已将 {succeeded} 条匹配失败记录加入重试队列{failed}',
+    en: 'Added {succeeded} matching failed records to the retry queue{failed}',
+  },
+  'deliveries.filteredRetryFailed': {
+    zh: '重试匹配失败记录失败，请稍后重试',
+    en: 'Failed to retry matching deliveries. Please try again later.',
+  },
   'deliveries.bulkRetryQueued': {
     zh: '已将 {succeeded} 条记录加入重试队列{failed}',
     en: 'Added {succeeded} records to the retry queue{failed}',

--- a/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
@@ -10,7 +10,11 @@ import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LangProvider } from '../../../i18n/LangContext';
 import { listInstances } from '../../../services/instanceService';
-import { listAlertDeliveriesPage, retryAlertDelivery } from '../../../services/opsService';
+import {
+  listAlertDeliveriesPage,
+  retryAlertDelivery,
+  retryFilteredAlertDeliveries,
+} from '../../../services/opsService';
 import NotificationDeliveriesPage from '../notificationDeliveries';
 
 vi.mock('../../../services/instanceService', () => ({
@@ -20,6 +24,7 @@ vi.mock('../../../services/opsService', () => ({
   listAlertDeliveriesPage: vi.fn(),
   retryAlertDeliveries: vi.fn(),
   retryAlertDelivery: vi.fn(),
+  retryFilteredAlertDeliveries: vi.fn(),
 }));
 
 const deferred = <T,>() => {
@@ -167,6 +172,32 @@ describe('NotificationDeliveriesPage', () => {
     expect(screen.queryByText('Broker disk usage')).not.toBeInTheDocument();
     expect(listAlertDeliveriesPage).toHaveBeenLastCalledWith(
       expect.objectContaining({ status: 'DELIVERED' }),
+    );
+  });
+
+  it('retries filtered failed deliveries instead of only the visible page', async () => {
+    vi.mocked(retryFilteredAlertDeliveries).mockResolvedValue({
+      succeededIds: [7, 8],
+      failures: {},
+    });
+    const user = userEvent.setup();
+    render(
+      <App>
+        <LangProvider>
+          <NotificationDeliveriesPage />
+        </LangProvider>
+      </App>,
+    );
+
+    await screen.findByText('Broker disk usage');
+    await user.click(screen.getByRole('button', { name: /重试匹配的失败记录/ }));
+
+    await waitFor(() =>
+      expect(retryFilteredAlertDeliveries).toHaveBeenCalledWith({
+        channel: undefined,
+        instanceId: undefined,
+        limit: 100,
+      }),
     );
   });
 });

--- a/web/src/pages/ops/notificationDeliveries.tsx
+++ b/web/src/pages/ops/notificationDeliveries.tsx
@@ -29,6 +29,7 @@ import {
   listAlertDeliveriesPage,
   retryAlertDeliveries,
   retryAlertDelivery,
+  retryFilteredAlertDeliveries,
 } from '../../services/opsService';
 import { formatUtcDateTime } from '../../utils/format';
 import { tableScrollX } from '../../utils/table';
@@ -58,6 +59,7 @@ const NotificationDeliveriesPage = () => {
   const retryingIdsInFlight = useRef(new Set<number>());
   const retryingVisibleInFlight = useRef(false);
   const [refreshNonce, setRefreshNonce] = useState(0);
+  const [retryingFiltered, setRetryingFiltered] = useState(false);
 
   const refresh = () => {
     setLoading(true);
@@ -111,6 +113,30 @@ const NotificationDeliveriesPage = () => {
     } finally {
       retryingVisibleInFlight.current = false;
       setRetryingVisible(false);
+    }
+  };
+
+  const retryFilteredFailures = async () => {
+    if (retryingFiltered || retryingVisible) return;
+    setRetryingFiltered(true);
+    try {
+      const result = await retryFilteredAlertDeliveries({
+        channel,
+        instanceId,
+        limit: 100,
+      });
+      const failed = Object.keys(result.failures).length;
+      message.success(
+        t('deliveries.filteredRetryQueued', {
+          succeeded: result.succeededIds.length,
+          failed: failed ? t('deliveries.bulkRetryFailures', { count: failed }) : '',
+        }),
+      );
+      refresh();
+    } catch {
+      message.error(t('deliveries.filteredRetryFailed'));
+    } finally {
+      setRetryingFiltered(false);
     }
   };
 
@@ -239,6 +265,9 @@ const NotificationDeliveriesPage = () => {
               onClick={() => void retryVisibleFailures()}
             >
               {t('deliveries.retryCurrentPage')}
+            </Button>
+            <Button danger loading={retryingFiltered} onClick={() => void retryFilteredFailures()}>
+              {t('deliveries.retryFiltered')}
             </Button>
             <Select
               allowClear

--- a/web/src/services/opsService.ts
+++ b/web/src/services/opsService.ts
@@ -433,6 +433,15 @@ export async function retryAlertDeliveries(
   return opsApi.retryAlertDeliveries(ids);
 }
 
+export async function retryFilteredAlertDeliveries(params: {
+  channel?: string;
+  instanceId?: string;
+  limit?: number;
+}): Promise<NotificationDeliveryBulkRetryResult> {
+  if (isMockMode()) return { succeededIds: [], failures: {} };
+  return opsApi.retryFilteredAlertDeliveries(params);
+}
+
 export async function listAlertDeliveriesPage(
   params: NotificationDeliveryQuery = {},
 ): Promise<PageResult<NotificationDeliveryRecord>> {


### PR DESCRIPTION
## What is the purpose of the change

The delivery page's bulk retry only targeted the failed rows visible on the current page. After a webhook or SMTP outage, hundreds of FAILED deliveries can span many pages, and operators had to page through and retry each page manually — easy to abandon halfway, leaving failed notifications unrecovered.

This change adds a bounded filtered retry action so one request retries the failed deliveries matching the current filters. Details: #3561

## Brief changelog

**Backend**

- `SystemAlertController`: adds `POST /api/system-alerts/deliveries/retry-filtered` accepting the current channel and instance filters plus a `limit`.
- `NotificationOutboxService.retryFailedDeliveries(channel, instanceId, limit)`: validates that `limit` is between 1 and 100; selects FAILED delivery IDs matching the filters in delivery-ID order through the new `RmqAlertNotificationOutboxMapper.findFailedDeliveryIds`; reuses the existing per-delivery retry path, preserving state reset, audit records, and per-ID failure reporting; returns the existing `NotificationDeliveryBulkRetryResult` contract.

**Frontend**

- `api/ops.ts` / `services/opsService.ts`: typed API and wrapper.
- `pages/ops/notificationDeliveries.tsx`: adds a "retry matching failures" action that uses the current channel/instance filters with limit 100; the existing current-page retry action is unchanged.
- `i18n/translations.ts`: labels for the new action.

**Tests**

- `NotificationOutboxServiceTest`: bounded ID query, limit validation, empty-result short circuit, and reuse of the per-delivery retry path.
- `SystemAlertControllerTest`: endpoint contract and filter forwarding.
- `NotificationDeliveriesPage.test.tsx`: UI calls the filtered retry action with current filters.

## Verifying this change

- `mvn -q '-Dtest=NotificationOutboxServiceTest,SystemAlertControllerTest' test` — 40 tests passed
- `mvn -q checkstyle:check` — passed
- `npm test -- NotificationDeliveriesPage.test.tsx --run` — 4 tests passed
- `npm run lint -- --quiet` — 0 errors; 10 existing warnings remain elsewhere in the tree
- `npm run build` — passed
- `git diff --check` — passed

The GitHub Actions status is not being described as green here; the checks above are local validation on this branch.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change. This PR addresses only #3561.
- [x] The pull request title follows the change type and scope.
- [x] This description covers what the PR does, how, and why.
- [x] Unit tests cover the bounded ID query, limit validation, filter propagation, and UI invocation.
- [x] Focused backend tests, Checkstyle, frontend tests, lint, and build were run locally on this branch.
- [ ] Apache Individual Contributor License Agreement (not required for this change size).

