### PR TITLE
[ISSUE-3782][test] Deepen themePreference tests with media query and exact-true compact parsing

### DIFF
--- a/web/src/theme/themePreference.test.ts
+++ b/web/src/theme/themePreference.test.ts
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   COMPACT_STORAGE_KEY,
   THEME_STORAGE_KEY,
   getStoredCompact,
   getStoredThemeMode,
+  getSystemDarkMode,
   persistCompact,
   persistThemeMode,
 } from './themePreference';
@@ -56,5 +57,25 @@ describe('theme preference', () => {
 
     persistCompact(false);
     expect(getStoredCompact()).toBe(false);
+  });
+
+  it('only treats the exact string true as compact', () => {
+    localStorage.setItem(COMPACT_STORAGE_KEY, 'TRUE');
+    expect(getStoredCompact()).toBe(false);
+
+    localStorage.setItem(COMPACT_STORAGE_KEY, '1');
+    expect(getStoredCompact()).toBe(false);
+  });
+
+  it('defaults to non-dark when the media query is unavailable', () => {
+    expect(getSystemDarkMode()).toBe(false);
+  });
+
+  it('reflects the prefers-color-scheme media query when available', () => {
+    const matchMediaMock = vi.fn().mockReturnValue({ matches: true });
+    Object.defineProperty(window, 'matchMedia', { configurable: true, value: matchMediaMock });
+
+    expect(getSystemDarkMode()).toBe(true);
+    expect(matchMediaMock).toHaveBeenCalledWith('(prefers-color-scheme: dark)');
   });
 });


### PR DESCRIPTION
### Motivation

The existing `themePreference` tests cover mode persistence and the basic compact toggle, but the `getSystemDarkMode` media-query helper and the strict string parsing of the compact flag were untested.

### Changes

- `only treats the exact string true as compact`: values such as `TRUE` or `1` stored for the compact key are not treated as compact, only the literal `true` is.
- `defaults to non-dark when the media query is unavailable`: `getSystemDarkMode` degrades to `false` when `window.matchMedia` is absent.
- `reflects the prefers-color-scheme media query when available`: when the media query reports dark, the helper returns `true` and queries the exact media feature string.

### Verification

```
./node_modules/.bin/vitest run src/theme/themePreference.test.ts   # 6 passed
./node_modules/.bin/tsc --noEmit                                  # clean
./node_modules/.bin/eslint src/theme/themePreference.test.ts      # clean
```