### PR TITLE
[ISSUE-3785][test] Deepen ConsumerLagResolverTest with proxy zero, verbatim unknown and large diff cases

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ConsumerLagResolverTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ConsumerLagResolverTest.java
@@ -56,4 +56,25 @@ class ConsumerLagResolverTest {
         Mockito.when(proxy.queryLag()).thenReturn(999L);
         assertThat(ConsumerLagResolver.resolve(7, proxy)).isEqualTo(7);
     }
+
+    @Test
+    void proxyReportedZeroLagIsReturned() {
+        ProxyStatsProvider proxy = Mockito.mock(ProxyStatsProvider.class);
+        Mockito.when(proxy.queryLag()).thenReturn(0L);
+        assertThat(ConsumerLagResolver.resolve(-1, proxy)).isEqualTo(0);
+    }
+
+    @Test
+    void proxyReportedUnknownIsReturnedVerbatim() {
+        ProxyStatsProvider proxy = Mockito.mock(ProxyStatsProvider.class);
+        Mockito.when(proxy.queryLag()).thenReturn(ConsumerLagResolver.UNKNOWN);
+        assertThat(ConsumerLagResolver.resolve(-1, proxy))
+                .isEqualTo(ConsumerLagResolver.UNKNOWN);
+    }
+
+    @Test
+    void largeValidDiffIsReturnedAsIs() {
+        assertThat(ConsumerLagResolver.resolve(Long.MAX_VALUE, null))
+                .isEqualTo(Long.MAX_VALUE);
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `ConsumerLagResolverTest` covers positive diffs, the no-proxy unknown fallback and the noop-proxy fallback, but not the boundary values of the proxy path nor very large broker diffs.

### Changes

- `proxyReportedZeroLagIsReturned`: when the proxy transport reports an authoritative zero lag, the resolver returns 0 instead of the unknown sentinel.
- `proxyReportedUnknownIsReturnedVerbatim`: a proxy that itself reports the unknown sentinel keeps that value, so the genuine unknown state survives the fallback.
- `largeValidDiffIsReturnedAsIs`: a positive diff at the `long` boundary is passed through untouched.

### Verification

```
mvn -B test -Dtest=ConsumerLagResolverTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```