### PR TITLE
[ISSUE-3786][test] Deepen TencentClientFactoryTest with OpenAPI exception mapping branches

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentClientFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/tencent/TencentClientFactoryTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.rocketmq.studio.provider.tencent;
 
+import com.tencentcloudapi.common.exception.TencentCloudSDKException;
 import com.tencentcloudapi.trocket.v20230308.TrocketClient;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.provider.credential.CloudCredentialRepository;
 import org.junit.jupiter.api.Test;
 
@@ -77,6 +79,42 @@ class TencentClientFactoryTest {
         assertThat(invalidationThread.isAlive()).isFalse();
         assertThat(factory.client(credentialId, "ap-shanghai")).isNotSameAs(firstClient);
         assertThat(factory.creationCount).hasValue(2);
+    }
+
+    @Test
+    void mapToBusinessExceptionShouldMapUnauthorizedTo403() {
+        BusinessException mapped = TencentClientFactory.mapToBusinessException(
+                new TencentCloudSDKException("not allowed", "req-001", "UnauthorizedOperation"));
+
+        assertThat(mapped.getCode()).isEqualTo(403);
+        assertThat(mapped.getMessage()).isEqualTo("not allowed");
+    }
+
+    @Test
+    void mapToBusinessExceptionShouldMapCredentialFailuresTo422() {
+        BusinessException mapped = TencentClientFactory.mapToBusinessException(
+                new TencentCloudSDKException("bad signature", "req-002", "AuthFailure.SignatureFailure"));
+
+        assertThat(mapped.getCode()).isEqualTo(422);
+        assertThat(mapped.getMessage()).isEqualTo("Cloud credential is invalid");
+    }
+
+    @Test
+    void mapToBusinessExceptionShouldMapNotFoundTo404WithFallbackMessage() {
+        BusinessException mapped = TencentClientFactory.mapToBusinessException(
+                new TencentCloudSDKException(null, "req-003", "ResourceNotFound"));
+
+        assertThat(mapped.getCode()).isEqualTo(404);
+        assertThat(mapped.getMessage()).isEqualTo("Tencent Cloud resource not found");
+    }
+
+    @Test
+    void mapToBusinessExceptionShouldFallBackToGeneric502() {
+        BusinessException mapped = TencentClientFactory.mapToBusinessException(
+                new TencentCloudSDKException("timeout", "req-004", "InternalError"));
+
+        assertThat(mapped.getCode()).isEqualTo(502);
+        assertThat(mapped.getMessage()).isEqualTo("Tencent Cloud OpenAPI error: timeout");
     }
 
     private static void awaitBlockedOrTerminated(Thread thread) {


### PR DESCRIPTION
### Motivation

The existing `TencentClientFactoryTest` covers endpoint selection and credential invalidation during an in-flight creation, but `mapToBusinessException` — the translation of raw Tencent Cloud SDK failures into Studio `BusinessException`s — had no coverage at all.

### Changes

- `mapToBusinessExceptionShouldMapUnauthorizedTo403`: `UnauthorizedOperation` keeps the provider message with HTTP 403.
- `mapToBusinessExceptionShouldMapCredentialFailuresTo422`: credential-level codes (`AuthFailure`, `InvalidCredential`, ...) map to 422 with the neutral `Cloud credential is invalid` message, keeping 401 reserved for Studio session auth.
- `mapToBusinessExceptionShouldMapNotFoundTo404WithFallbackMessage`: `ResourceNotFound` maps to 404 and a missing provider message falls back to the resource-not-found text.
- `mapToBusinessExceptionShouldFallBackToGeneric502`: any other code surfaces as a 502 OpenAPI error with the provider message preserved.

### Verification

```
mvn -B test -Dtest=TencentClientFactoryTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```