### PR TITLE
[ISSUE-3787][test] Deepen LiteTopicServiceTest with null and blank TTL guard inputs

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicServiceTest.java
@@ -79,4 +79,28 @@ class LiteTopicServiceTest {
     void getCapabilityShouldReportUnsupportedByDefault() {
         assertThat(liteTopicService.getCapability().isSupported()).isFalse();
     }
+
+    @Test
+    void extendTTLShouldRejectNullTopicPattern() {
+        assertThatThrownBy(() -> liteTopicService.extendTTL(null, 7_200_000L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topicPattern is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+    }
+
+    @Test
+    void extendTTLShouldRejectBlankTopicPattern() {
+        assertThatThrownBy(() -> liteTopicService.extendTTL("   ", 7_200_000L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("topicPattern is required")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+    }
+
+    @Test
+    void extendTTLShouldRejectNullTtl() {
+        assertThatThrownBy(() -> liteTopicService.extendTTL("chat/{sessionId}", null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("newTTL must be positive")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getCode()).isEqualTo(400));
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `LiteTopicServiceTest` rejects an empty `topicPattern` and a zero TTL, but the remaining guard inputs of `extendTTL` — null and whitespace-only patterns and a null TTL — were untested.

### Changes

- `extendTTLShouldRejectNullTopicPattern`: a null pattern is a 400 `topicPattern is required`.
- `extendTTLShouldRejectBlankTopicPattern`: a whitespace-only pattern is rejected with the same message before any provider work.
- `extendTTLShouldRejectNullTtl`: a null TTL is a 400 `newTTL must be positive`.

### Verification

```
mvn -B test -Dtest=LiteTopicServiceTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```