### PR TITLE
[ISSUE-3788][test] Deepen ProxyConsumerResolverTest with blank-instance cache share, address filtering and running-info fallback

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ProxyConsumerResolverTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/ProxyConsumerResolverTest.java
@@ -134,4 +134,47 @@ class ProxyConsumerResolverTest {
         // 192.0.2.1 (TEST-NET) is unreachable, so the remoting query must degrade to null
         assertThat(resolver.resolveConsumerConnection("instance-a", "cg-orders")).isNull();
     }
+
+    @Test
+    void discoverProxyAddressesShouldShareCacheForBlankInstanceKeys() throws Exception {
+        ConsumerConnection syncer = new ConsumerConnection();
+        syncer.setConnectionSet(new HashSet<>());
+        when(adminExt.examineConsumerConnectionInfo("CID_DefaultHeartBeatSyncerTopic"))
+                .thenReturn(syncer);
+
+        resolver.discoverProxyAddresses(null);
+        resolver.discoverProxyAddresses("   ");
+
+        org.mockito.Mockito.verify(adminExt, org.mockito.Mockito.times(1))
+                .examineConsumerConnectionInfo("CID_DefaultHeartBeatSyncerTopic");
+    }
+
+    @Test
+    void discoverProxyAddressesShouldSkipBlankClientAddresses() throws Exception {
+        ConsumerConnection syncer = new ConsumerConnection();
+        Connection blank = new Connection();
+        blank.setClientId("proxy-blank");
+        blank.setClientAddr("  ");
+        Connection noAddr = new Connection();
+        noAddr.setClientId("proxy-no-addr");
+        noAddr.setClientAddr(null);
+        Connection valid = new Connection();
+        valid.setClientId("proxy-a");
+        valid.setClientAddr("10.0.4.66:10911");
+        syncer.setConnectionSet(new HashSet<>(List.of(blank, noAddr, valid)));
+        when(adminExt.examineConsumerConnectionInfo("CID_DefaultHeartBeatSyncerTopic"))
+                .thenReturn(syncer);
+
+        assertThat(resolver.discoverProxyAddresses("instance-a"))
+                .containsExactly("10.0.4.66:8080");
+    }
+
+    @Test
+    void resolveConsumerRunningInfoShouldReturnNullWhenNoProxyDiscovered() throws Exception {
+        when(adminExt.examineConsumerConnectionInfo("CID_DefaultHeartBeatSyncerTopic"))
+                .thenThrow(new IllegalStateException("syncer group missing"));
+
+        assertThat(resolver.resolveConsumerRunningInfo("instance-a", "cg-orders", "client-1"))
+                .isNull();
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `ProxyConsumerResolverTest` covers discovery derivation, caching, transient retry and the connection-query null degradation, but three guard paths were unverified: the shared cache key for blank instance ids, the filtering of blank client addresses during discovery, and the running-info fallback when no proxy is discovered.

### Changes

- `discoverProxyAddressesShouldShareCacheForBlankInstanceKeys`: null and whitespace-only instance ids map to the same default cache key, so the second lookup is served from cache.
- `discoverProxyAddressesShouldSkipBlankClientAddresses`: entries with null or whitespace-only client addresses are filtered out, leaving only valid proxy remoting addresses.
- `resolveConsumerRunningInfoShouldReturnNullWhenNoProxyDiscovered`: a discovery failure degrades the running-info query to null so the caller can fall back to the broker path.

### Verification

```
mvn -B test -Dtest=ProxyConsumerResolverTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```