### PR TITLE
[ISSUE-3789][test] Deepen CliProcessEnvironmentTest with null sources, null parent values and name dedup

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/CliProcessEnvironmentTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/CliProcessEnvironmentTest.java
@@ -129,4 +129,38 @@ class CliProcessEnvironmentTest {
                 Map.entry("PATH", "/usr/bin"),
                 Map.entry("PROVIDER_TOKEN", "provider-secret"));
     }
+
+    @Test
+    void nullParentEnvironmentYieldsOnlyProviderValues() {
+        CliProcessEnvironment policy = new CliProcessEnvironment(List.of());
+
+        Map<String, String> child = policy.build(null, Map.of("PROVIDER_TOKEN", "token-a"));
+
+        assertThat(child).containsExactly(Map.entry("PROVIDER_TOKEN", "token-a"));
+        assertThat(policy.build(null, null)).isEmpty();
+    }
+
+    @Test
+    void parentNullValuesAreDroppedWhileProviderValueWins() {
+        CliProcessEnvironment policy = new CliProcessEnvironment(List.of());
+        Map<String, String> parent = new LinkedHashMap<>();
+        parent.put("PATH", null);
+        parent.put("HOME", "/home/studio");
+
+        Map<String, String> child = policy.build(parent, Map.of("PATH", "/opt/bin"));
+
+        assertThat(child).containsOnly(
+                Map.entry("HOME", "/home/studio"),
+                Map.entry("PATH", "/opt/bin"));
+    }
+
+    @Test
+    void duplicateConfiguredNamesAreDeduplicated() {
+        CliProcessEnvironment policy = new CliProcessEnvironment(
+                List.of("CUSTOM_HOME", " CUSTOM_HOME ", "CUSTOM_HOME"));
+
+        assertThat(policy.allowedNames())
+                .filteredOn(name -> name.equals("CUSTOM_HOME"))
+                .hasSize(1);
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `CliProcessEnvironmentTest` covers whitelisting, overrides, invalid names and the builder application, but the null-safety of `build`, null-valued parent entries and duplicate configured names were untested.

### Changes

- `nullParentEnvironmentYieldsOnlyProviderValues`: a null parent map contributes nothing, so the child environment carries exactly the provider values (and stays empty when the provider map is null too).
- `parentNullValuesAreDroppedWhileProviderValueWins`: a parent entry whose value is null is skipped, letting the provider-supplied value for the same name win.
- `duplicateConfiguredNamesAreDeduplicated`: repeated and whitespace-padded occurrences of an additional allowed name collapse into a single entry.

### Verification

```
mvn -B test -Dtest=CliProcessEnvironmentTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```