### PR TITLE
[ISSUE-3790][test] Deepen ProducerControllerTest with blank instance guard and optional-filter passthrough

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ProducerControllerTest.java
@@ -143,4 +143,29 @@ class ProducerControllerTest {
 
         verifyNoInteractions(producerConnectionService);
     }
+
+    @Test
+    void listConnectionsShouldRejectBlankInstanceId() throws Exception {
+        mockMvc.perform(get("/api/producer/connection")
+                        .param("instanceId", " ")
+                        .param("topic", "order-topic"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("instanceId is required"));
+
+        verifyNoInteractions(producerConnectionService);
+    }
+
+    @Test
+    void listProducerGroupsShouldAllowOnlyInstanceId() throws Exception {
+        when(producerConnectionService.listProducerGroups("instance-1", null, null, null))
+                .thenReturn(List.of("pg-a"));
+
+        mockMvc.perform(get("/api/producer/groups")
+                        .param("instanceId", "instance-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0]").value("pg-a"));
+
+        verify(producerConnectionService).listProducerGroups("instance-1", null, null, null);
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `ProducerControllerTest` covers the connection payload, the topic guard and the missing instance id, but a whitespace-only `instanceId` on the connection endpoint and the pure-`instanceId` form of the group-suggestion endpoint were untested.

### Changes

- `listConnectionsShouldRejectBlankInstanceId`: a whitespace-only instance id is rejected with 400 `instanceId is required` and no service interaction.
- `listProducerGroupsShouldAllowOnlyInstanceId`: when `topic`, `query` and `limit` are absent the suggestion query still reaches the service with the optional filters left null.

### Verification

```
mvn -B test -Dtest=ProducerControllerTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```