### PR TITLE
[ISSUE-3791][test] Deepen MetricsBackendTypeTest with custom defaults and whitespace-case normalisation

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendTypeTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricsBackendTypeTest.java
@@ -92,4 +92,21 @@ class MetricsBackendTypeTest {
         assertThat(MetricsBackendType.CORTEX.getInstantQueryPath()).isEqualTo("/api/v1/query");
         assertThat(MetricsBackendType.ARMS.getInstantQueryPath()).isEqualTo("/api/v1/query");
     }
+
+    @Test
+    void shouldExposeCustomBackendDefaults() {
+        assertThat(MetricsBackendType.CUSTOM.getProviderType()).isEqualTo("Custom");
+        assertThat(MetricsBackendType.CUSTOM.getQueryPath()).isEqualTo("/api/v1/query_range");
+        assertThat(MetricsBackendType.CUSTOM.getInstantQueryPath()).isEqualTo("/api/v1/query");
+    }
+
+    @Test
+    void shouldNormalizeWhitespaceAndMixedCaseBeforeResolving() {
+        assertThat(MetricsBackendType.fromProviderType("  cortex  ")).isEqualTo(MetricsBackendType.CORTEX);
+        assertThat(MetricsBackendType.fromProviderType("thanos")).isEqualTo(MetricsBackendType.THANOS);
+        assertThat(MetricsBackendType.fromProviderType("arms")).isEqualTo(MetricsBackendType.ARMS);
+        assertThat(MetricsBackendType.fromProviderType("Custom")).isEqualTo(MetricsBackendType.CUSTOM);
+        assertThat(MetricsBackendType.fromProviderType("  victoria_metrics  "))
+                .isEqualTo(MetricsBackendType.VICTORIA_METRICS);
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `MetricsBackendTypeTest` resolves every provider type, defaults unknown values and checks the query paths of the differentiated backends, but the `CUSTOM` backend contract and further normalisation forms of `fromProviderType` were untested.

### Changes

- `shouldExposeCustomBackendDefaults`: `CUSTOM` keeps the canonical `Custom` provider type and the standard Prometheus query paths.
- `shouldNormalizeWhitespaceAndMixedCaseBeforeResolving`: surrounding whitespace, underscores and mixed case (`cortex`, `thanos`, `arms`, `Custom`, `victoria_metrics`) all resolve to their canonical backend.

### Verification

```
mvn -B test -Dtest=MetricsBackendTypeTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```