### PR TITLE
[ISSUE-3792][test] Deepen RegistryProbeRunnerTest with empty input, per-entry degradation and probe timeout

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RegistryProbeRunnerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/broker/RegistryProbeRunnerTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,6 +40,50 @@ class RegistryProbeRunnerTest {
             assertThat(result.get(1, TimeUnit.SECONDS))
                     .extracting(ClusterVO::getId)
                     .containsExactly("registry-a", "registry-b");
+        }
+    }
+
+    @Test
+    void emptyEntriesShouldProbeNothing() {
+        AtomicInteger invocations = new AtomicInteger();
+        try (RegistryProbeRunner runner = new RegistryProbeRunner(2, 2, 2_000)) {
+            assertThat(runner.probeAll(List.of(), entry -> {
+                invocations.incrementAndGet();
+                return List.of();
+            })).isEmpty();
+            assertThat(invocations).hasValue(0);
+        }
+    }
+
+    @Test
+    void failingProbeDegradesOnlyItsOwnEntry() {
+        try (RegistryProbeRunner runner = new RegistryProbeRunner(2, 2, 2_000)) {
+            List<ClusterVO> result = runner.probeAll(List.of(
+                    NameserverRegistryVO.builder().name("registry-a").namesrvAddr("a:9876").build(),
+                    NameserverRegistryVO.builder().name("registry-b").namesrvAddr("b:9876").build()),
+                    entry -> {
+                        if (entry.getName().equals("registry-a")) {
+                            throw new IllegalStateException("nameserver a unreachable");
+                        }
+                        return List.of(ClusterVO.builder().id("registry-b").build());
+                    });
+
+            assertThat(result).extracting(ClusterVO::getId).containsExactly("registry-b");
+        }
+    }
+
+    @Test
+    void timedOutProbeReturnsEmptyWithoutThrowing() {
+        CountDownLatch neverRelease = new CountDownLatch(1);
+        try (RegistryProbeRunner runner = new RegistryProbeRunner(2, 2, 150)) {
+            List<ClusterVO> result = runner.probeAll(List.of(
+                    NameserverRegistryVO.builder().name("registry-a").namesrvAddr("a:9876").build()),
+                    entry -> {
+                        neverRelease.await();
+                        return List.of(ClusterVO.builder().id("registry-a").build());
+                    });
+
+            assertThat(result).isEmpty();
         }
     }
 }


### PR DESCRIPTION
### Motivation

The existing `RegistryProbeRunnerTest` proves the happy path of concurrent probes, but the empty-input short-circuit, per-entry failure isolation and the timeout interruption path were untested in the runner itself.

### Changes

- `emptyEntriesShouldProbeNothing`: an empty registry list completes immediately without invoking the probe function.
- `failingProbeDegradesOnlyItsOwnEntry`: a probe that throws contributes nothing while the sibling entry's clusters are still returned.
- `timedOutProbeReturnsEmptyWithoutThrowing`: a probe that blocks past the runner's timeout is cancelled and degrades to an empty result instead of failing the whole batch.

### Verification

```
mvn -B test -Dtest=RegistryProbeRunnerTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```