### PR TITLE
[ISSUE-3795][test] Deepen AgentProviderRegistryTest with multi-engine routing, unsupported rejection and duplicate guard

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AgentProviderRegistryTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,5 +41,50 @@ class AgentProviderRegistryTest {
         } finally {
             Locale.setDefault(original);
         }
+    }
+
+    @Test
+    void forEngineShouldTrimAndIgnoreCaseAcrossProviders() {
+        AgentProvider claude = mock(AgentProvider.class);
+        when(claude.engine()).thenReturn("claude-code");
+        AgentProvider qoder = mock(AgentProvider.class);
+        when(qoder.engine()).thenReturn("qoder");
+        AgentProviderRegistry registry = new AgentProviderRegistry(List.of(claude, qoder));
+
+        assertThat(registry.forEngine(" QODER ")).isSameAs(qoder);
+        assertThat(registry.forEngine("claude-code")).isSameAs(claude);
+    }
+
+    @Test
+    void forEngineShouldRejectUnsupportedEngine() {
+        AgentProvider provider = mock(AgentProvider.class);
+        when(provider.engine()).thenReturn("cli");
+        AgentProviderRegistry registry = new AgentProviderRegistry(List.of(provider));
+
+        assertThatThrownBy(() -> registry.forEngine("unknown"))
+                .isInstanceOf(LlmGatewayException.class)
+                .satisfies(error -> assertThat(((LlmGatewayException) error).getStatusCode()).isEqualTo(400));
+    }
+
+    @Test
+    void forEngineShouldRejectNullEngine() {
+        AgentProvider provider = mock(AgentProvider.class);
+        when(provider.engine()).thenReturn("cli");
+        AgentProviderRegistry registry = new AgentProviderRegistry(List.of(provider));
+
+        assertThatThrownBy(() -> registry.forEngine(null))
+                .isInstanceOf(LlmGatewayException.class)
+                .satisfies(error -> assertThat(((LlmGatewayException) error).getStatusCode()).isEqualTo(400));
+    }
+
+    @Test
+    void duplicateEngineRegistrationsShouldFailFast() {
+        AgentProvider first = mock(AgentProvider.class);
+        when(first.engine()).thenReturn("cli");
+        AgentProvider second = mock(AgentProvider.class);
+        when(second.engine()).thenReturn("cli");
+
+        assertThatThrownBy(() -> new AgentProviderRegistry(List.of(first, second)))
+                .isInstanceOf(IllegalStateException.class);
     }
 }


### PR DESCRIPTION
### Motivation

The existing `AgentProviderRegistryTest` only proves locale-independent engine resolution for a single provider. The registry contract for multiple engines, unknown engines, null engines and duplicate engine registrations was untested.

### Changes

- `forEngineShouldTrimAndIgnoreCaseAcrossProviders`: `QODER` with surrounding whitespace resolves to the qoder provider while `claude-code` resolves to the claude provider.
- `forEngineShouldRejectUnsupportedEngine`: an unknown engine raises a 400 `LlmGatewayException` listing the supported engines.
- `forEngineShouldRejectNullEngine`: a null engine is not silently accepted and raises the same 400 gateway error.
- `duplicateEngineRegistrationsShouldFailFast`: two providers advertising the same engine fail the registry construction instead of silently shadowing one of them.

### Verification

```
mvn -B test -Dtest=AgentProviderRegistryTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```