### PR TITLE
[ISSUE-3796][test] Deepen AiEngineLocaleTest with engine normalisation defaults and readiness gating

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiEngineLocaleTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiEngineLocaleTest.java
@@ -52,4 +52,49 @@ class AiEngineLocaleTest {
             return "ok";
         }
     }
+
+    @Test
+    void normalizeEngineShouldDefaultToHttpForMissingOrBlankEngine() {
+        LlmConfigVO missing = LlmConfigVO.builder().build();
+        LlmConfigVO blank = LlmConfigVO.builder().engine("   ").build();
+
+        assertThat(missing.normalizeEngine()).isEqualTo(LlmConfigVO.ENGINE_HTTP);
+        assertThat(blank.normalizeEngine()).isEqualTo(LlmConfigVO.ENGINE_HTTP);
+    }
+
+    @Test
+    void normalizeEngineShouldTrimAndLowercaseEngine() {
+        LlmConfigVO qoder = LlmConfigVO.builder().engine(" QODER ").build();
+
+        assertThat(qoder.normalizeEngine()).isEqualTo("qoder");
+    }
+
+    @Test
+    void isReadyShouldReturnFalseWhenDisabledOrMissingModel() {
+        LlmConfigVO disabled = LlmConfigVO.builder()
+                .engine("qoder").model("qwen").enabled(false).build();
+        LlmConfigVO noModel = LlmConfigVO.builder()
+                .engine("qoder").enabled(true).build();
+
+        assertThat(disabled.isReady()).isFalse();
+        assertThat(noModel.isReady()).isFalse();
+    }
+
+    @Test
+    void isReadyShouldRequireEndpointAndKeyForHttpProviders() {
+        LlmConfigVO ollama = LlmConfigVO.builder()
+                .provider("ollama").model("qwen").enabled(true)
+                .apiBase("http://localhost:11434").build();
+        assertThat(ollama.isReady()).isTrue();
+
+        LlmConfigVO keyless = LlmConfigVO.builder()
+                .provider("openai").model("gpt-4o").enabled(true)
+                .apiBase("https://api.openai.com").build();
+        assertThat(keyless.isReady()).isFalse();
+
+        LlmConfigVO complete = LlmConfigVO.builder()
+                .provider("openai").model("gpt-4o").enabled(true)
+                .apiBase("https://api.openai.com").apiKey("sk-test").build();
+        assertThat(complete.isReady()).isTrue();
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `AiEngineLocaleTest` pins locale-independent engine resolution but nothing else. The `normalizeEngine` defaults and the `isReady` gating rules on `LlmConfigVO` were untested.

### Changes

- `normalizeEngineShouldDefaultToHttpForMissingOrBlankEngine`: a missing or whitespace-only engine falls back to the HTTP engine constant.
- `normalizeEngineShouldTrimAndLowercaseEngine`: mixed-case engines with surrounding whitespace normalise to the canonical lower-case form.
- `isReadyShouldReturnFalseWhenDisabledOrMissingModel`: a disabled config or one without a model is never ready.
- `isReadyShouldRequireEndpointAndKeyForHttpProviders`: an `ollama` HTTP provider is ready with just a base URL, while other HTTP providers additionally require an API key.

### Verification

```
mvn -B test -Dtest=AiEngineLocaleTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```