### PR TITLE
[ISSUE-3797][test] Deepen AlertRuleTransferDTOTest with envelope, empty-list and nested-rule validation

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleTransferDTOTest.java
@@ -11,6 +11,7 @@ import jakarta.validation.Validator;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,5 +29,51 @@ class AlertRuleTransferDTOTest {
         assertThat(validator.validate(transfer))
                 .extracting(violation -> violation.getMessage())
                 .contains("rule must not be null");
+    }
+
+    @Test
+    void rejectsMissingVersionDomainAndRules() {
+        AlertRuleTransferDTO transfer = new AlertRuleTransferDTO();
+
+        assertThat(validator.validate(transfer))
+                .extracting(violation -> violation.getMessage())
+                .contains("version is required", "domain is required", "rules must not be empty");
+    }
+
+    @Test
+    void rejectsEmptyRulesList() {
+        AlertRuleTransferDTO transfer = new AlertRuleTransferDTO();
+        transfer.setVersion(AlertRuleTransferDTO.VERSION);
+        transfer.setDomain(AlertDomain.CLUSTER);
+        transfer.setRules(List.of());
+
+        assertThat(validator.validate(transfer))
+                .extracting(violation -> violation.getMessage())
+                .contains("rules must not be empty");
+    }
+
+    @Test
+    void acceptsCompleteTransferDocument() {
+        AlertRuleRequestDTO rule = new AlertRuleRequestDTO();
+        rule.setName("Broker unavailable");
+        AlertRuleTransferDTO transfer = new AlertRuleTransferDTO();
+        transfer.setVersion(AlertRuleTransferDTO.VERSION);
+        transfer.setDomain(AlertDomain.CLUSTER);
+        transfer.setRules(List.of(rule));
+
+        assertThat(validator.validate(transfer)).isEmpty();
+    }
+
+    @Test
+    void propagatesValidationOfNestedRules() {
+        AlertRuleRequestDTO invalid = new AlertRuleRequestDTO();
+        AlertRuleTransferDTO transfer = new AlertRuleTransferDTO();
+        transfer.setVersion(AlertRuleTransferDTO.VERSION);
+        transfer.setDomain(AlertDomain.CLUSTER);
+        transfer.setRules(List.of(invalid));
+
+        assertThat(validator.validate(transfer))
+                .extracting(violation -> violation.getMessage())
+                .contains("name is required");
     }
 }


### PR DESCRIPTION
### Motivation

The existing `AlertRuleTransferDTOTest` only rejects null rule entries. The remaining bean-validation contract of the import envelope — required version/domain, non-empty rule list and nested rule validation — was untested.

### Changes

- `rejectsMissingVersionDomainAndRules`: a bare transfer document reports `version is required`, `domain is required` and `rules must not be empty`.
- `rejectsEmptyRulesList`: an empty rule list is rejected even when the envelope fields are present.
- `acceptsCompleteTransferDocument`: a fully populated document passes validation cleanly.
- `propagatesValidationOfNestedRules`: an invalid nested rule surfaces its own `name is required` violation through the envelope.

### Verification

```
mvn -B test -Dtest=AlertRuleTransferDTOTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```