### PR TITLE
[ISSUE-3801][test] Deepen SystemGroupFilterTest with whitespace boundary and prefix variant coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemGroupFilterTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemGroupFilterTest.java
@@ -45,4 +45,19 @@ class SystemGroupFilterTest {
         assertThat(SystemGroupFilter.isSystem("FILTERSRV_CONSUMER_filter")).isFalse();
         assertThat(SystemGroupFilter.isSystem("SELF_TEST_GROUP")).isFalse();
     }
+
+    @Test
+    void shouldTreatWhitespaceOnlyGroupAsNonSystem() {
+        assertThat(SystemGroupFilter.isSystem("   ")).isFalse();
+    }
+
+    @Test
+    void shouldMatchSystemGroupPrefixVariants() {
+        assertThat(SystemGroupFilter.isSystem("CID_HOUSEKEEPING_01")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("CID_SYS_rmq_trans")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("CID_ONSAPI_other")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("rmq_sys_TRACE_DATA_2")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("%RETRY%monitor-extra")).isTrue();
+        assertThat(SystemGroupFilter.isSystem("x%RETRY%not-a-retry-group")).isFalse();
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `SystemGroupFilterTest` covers the canonical prefixes and user-group counterexamples, but the whitespace boundary and the prefix-variant semantics (longer names that start with a system prefix) were untested.

### Changes

- `shouldTreatWhitespaceOnlyGroupAsNonSystem`: unlike null/empty, a whitespace-only name is not classified as a system group because the filter never trims input.
- `shouldMatchSystemGroupPrefixVariants`: names that merely *start with* `CID_HOUSEKEEPING`, `CID_SYS_`, `CID_ONSAPI_`, `rmq_sys_` or the retry/dlq prefixes are system groups, while a retry marker in the middle is not.

### Verification

```
mvn -B test -Dtest=SystemGroupFilterTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```