### PR TITLE
[ISSUE-3803][test] Deepen CreateCloudCredentialDTOTest with vendor parsing, secret-safe toString and VO mapping

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CreateCloudCredentialDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CreateCloudCredentialDTOTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.rocketmq.studio.provider.credential;
 
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.junit.jupiter.api.Test;
 
@@ -38,5 +40,60 @@ class CreateCloudCredentialDTOTest {
         }
 
         assertThat(vendor).isEqualTo(InstanceVendor.ALIYUN);
+    }
+
+    @Test
+    void parseVendorShouldNormalizeAndReturnNullForUnknown() {
+        assertThat(CreateCloudCredentialDTO.parseVendor(" tencent ")).isEqualTo(InstanceVendor.TENCENT);
+        assertThat(CreateCloudCredentialDTO.parseVendor("aliyun")).isEqualTo(InstanceVendor.ALIYUN);
+        assertThat(CreateCloudCredentialDTO.parseVendor("aws")).isNull();
+        assertThat(CreateCloudCredentialDTO.parseVendor(null)).isNull();
+        assertThat(CreateCloudCredentialDTO.parseVendor("  ")).isNull();
+    }
+
+    @Test
+    void toStringShouldNotExposeCredentialSecrets() {
+        CreateCloudCredentialDTO request = new CreateCloudCredentialDTO();
+        request.setName("prod-aliyun");
+        request.setVendor("ALIYUN");
+        request.setAccessKey("access-key-secret");
+        request.setSecretKey("secret-key-secret");
+
+        String value = request.toString();
+
+        assertThat(value).contains("name=prod-aliyun");
+        assertThat(value).doesNotContain("access-key-secret");
+        assertThat(value).doesNotContain("secret-key-secret");
+    }
+
+    @Test
+    void validationShouldRequireAllCredentialFields() {
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        CreateCloudCredentialDTO request = new CreateCloudCredentialDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .contains("credential name is required",
+                        "credential vendor is required",
+                        "credential accessKey is required",
+                        "credential secretKey is required");
+    }
+
+    @Test
+    void toCloudCredentialVOShouldCopyFieldsAndParseVendor() {
+        CreateCloudCredentialDTO request = new CreateCloudCredentialDTO();
+        request.setName("prod-tencent");
+        request.setVendor(" tencent ");
+        request.setAccessKey("ak-123");
+        request.setSecretKey("sk-456");
+        request.setRemark("production read-only");
+
+        CloudCredentialVO vo = request.toCloudCredentialVO();
+
+        assertThat(vo.getName()).isEqualTo("prod-tencent");
+        assertThat(vo.getVendor()).isEqualTo(InstanceVendor.TENCENT);
+        assertThat(vo.getAccessKey()).isEqualTo("ak-123");
+        assertThat(vo.getSecretKey()).isEqualTo("sk-456");
+        assertThat(vo.getRemark()).isEqualTo("production read-only");
     }
 }


### PR DESCRIPTION
### Motivation

The existing `CreateCloudCredentialDTOTest` only proves locale-independent vendor parsing for `aliyun`. The remaining vendor cases, the secret-safe `toString`, the bean-validation contract and the `toCloudCredentialVO` mapping were untested.

### Changes

- `parseVendorShouldNormalizeAndReturnNullForUnknown`: whitespace-padded `tencent` normalises to `TENCENT`, while unknown, null and blank values degrade to null.
- `toStringShouldNotExposeCredentialSecrets`: the debug string carries the name but excludes access and secret keys via `@ToString.Exclude`.
- `validationShouldRequireAllCredentialFields`: a bare request reports name, vendor, accessKey and secretKey as required.
- `toCloudCredentialVOShouldCopyFieldsAndParseVendor`: the entity copy maps every field and normalises the vendor.

### Verification

```
mvn -B test -Dtest=CreateCloudCredentialDTOTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```