### PR TITLE
[ISSUE-3804][test] Deepen SystemTopicFilterTest with broker-less, overload and bare-marker coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemTopicFilterTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/SystemTopicFilterTest.java
@@ -46,4 +46,26 @@ class SystemTopicFilterTest {
         assertThat(SystemTopicFilter.isSystem("BenchmarkTestOrders", brokerNames)).isFalse();
         assertThat(SystemTopicFilter.isSystem("SCHEDULE_TOPIC_orders", brokerNames)).isFalse();
     }
+
+    @Test
+    void shouldTreatMissingOrEmptyBrokerNamesAsNoMatch() {
+        assertThat(SystemTopicFilter.isSystem("broker-prod-a", null)).isFalse();
+        assertThat(SystemTopicFilter.isSystem("broker-prod-a", Set.of())).isFalse();
+        assertThat(SystemTopicFilter.isSystem("RMQ_SYS_TRANS_HALF_TOPIC", null)).isTrue();
+    }
+
+    @Test
+    void convenienceOverloadShouldClassifyByNameOnly() {
+        assertThat(SystemTopicFilter.isSystem("RMQ_SYS_TRANS_HALF_TOPIC")).isTrue();
+        assertThat(SystemTopicFilter.isSystem("%DLQ%consumer-a")).isTrue();
+        assertThat(SystemTopicFilter.isSystem("broker-prod-a")).isFalse();
+        assertThat(SystemTopicFilter.isSystem("orders")).isFalse();
+    }
+
+    @Test
+    void shouldTreatBareRetryAndDlqMarkersAsSystemTopics() {
+        assertThat(SystemTopicFilter.isSystem("%RETRY%")).isTrue();
+        assertThat(SystemTopicFilter.isSystem("%DLQ%")).isTrue();
+        assertThat(SystemTopicFilter.isSystem("%RETRY%consumer-orders")).isTrue();
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `SystemTopicFilterTest` covers the canonical system topics and broker-name matching in one test, but the null/empty broker set, the no-broker convenience overload and the bare retry/dlq markers were untested.

### Changes

- `shouldTreatMissingOrEmptyBrokerNamesAsNoMatch`: a broker-named topic is not system when the broker set is null or empty, while real system topics stay recognised.
- `convenienceOverloadShouldClassifyByNameOnly`: the single-argument form classifies system topics and retry/dlq names without any broker context.
- `shouldTreatBareRetryAndDlqMarkersAsSystemTopics`: the bare `%RETRY%`/`%DLQ%` markers and their suffixed forms count as system topics.

### Verification

```
mvn -B test -Dtest=SystemTopicFilterTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```