### PR TITLE
[ISSUE-3806][test] Deepen CloudCredentialControllerTest with filter passthrough, missing-body guard and create delegation

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialControllerTest.java
@@ -16,17 +16,24 @@
  */
 package org.apache.rocketmq.studio.provider.credential;
 
+import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(CloudCredentialController.class)
@@ -50,5 +57,47 @@ class CloudCredentialControllerTest {
         mockMvc.perform(get("/api/cloud-credentials/1/credentials"))
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"));
+    }
+
+    @Test
+    void listCredentialsShouldPassFiltersAndDefaults() throws Exception {
+        when(credentialService.listMasked(InstanceVendor.ALIYUN, "prod", 1, 20))
+                .thenReturn(PageResult.empty(1, 20));
+
+        mockMvc.perform(get("/api/cloud-credentials")
+                        .param("vendor", "ALIYUN")
+                        .param("search", "prod"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.items").isEmpty());
+
+        verify(credentialService).listMasked(InstanceVendor.ALIYUN, "prod", 1, 20);
+    }
+
+    @Test
+    void createCredentialShouldRejectMissingBody() throws Exception {
+        mockMvc.perform(post("/api/cloud-credentials/create")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400));
+    }
+
+    @Test
+    void createCredentialShouldDelegateWithParsedVendor() throws Exception {
+        CloudCredentialVO created = new CloudCredentialVO();
+        created.setId(5L);
+        created.setName("prod-tencent");
+        created.setVendor(InstanceVendor.TENCENT);
+        when(credentialService.create(any(CloudCredentialVO.class))).thenReturn(created);
+
+        mockMvc.perform(post("/api/cloud-credentials/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"prod-tencent\",\"vendor\":\"tencent\","
+                                + "\"accessKey\":\"ak-1\",\"secretKey\":\"sk-1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(5))
+                .andExpect(jsonPath("$.data.name").value("prod-tencent"));
+
+        verify(credentialService).create(any(CloudCredentialVO.class));
     }
 }


### PR DESCRIPTION
### Motivation

The existing `CloudCredentialControllerTest` only checks the no-store header of the secrets reveal endpoint. The list filters, the create endpoint's missing-body guard and its delegation path were untested.

### Changes

- `listCredentialsShouldPassFiltersAndDefaults`: vendor/search parameters reach `listMasked` with bounded page defaults and return the masked page.
- `createCredentialShouldRejectMissingBody`: an absent create body is a 400 before any service interaction.
- `createCredentialShouldDelegateWithParsedVendor`: a full create payload is validated, its vendor normalised and delegated to `credentialService.create`.

### Verification

```
mvn -B test -Dtest=CloudCredentialControllerTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```