### PR TITLE
[ISSUE-3807][test] Deepen PasswordHasherTest with null, malformed and iteration-bound guards

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/PasswordHasherTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/PasswordHasherTest.java
@@ -46,4 +46,38 @@ class PasswordHasherTest {
                 "pbkdf2$210000$" + parts[2] + "$AA==")).isFalse();
     }
 
+    @Test
+    void matchesShouldRejectNullArguments() {
+        PasswordHasher hasher = new PasswordHasher();
+        String validHash = hasher.hash("a-long-enough-password");
+
+        assertThat(hasher.matches(null, validHash)).isFalse();
+        assertThat(hasher.matches("a-long-enough-password", null)).isFalse();
+    }
+
+    @Test
+    void matchesShouldRejectMalformedHashFormat() {
+        PasswordHasher hasher = new PasswordHasher();
+        String validHash = hasher.hash("a-long-enough-password");
+        String[] parts = validHash.split("\\$", -1);
+
+        assertThat(hasher.matches("a-long-enough-password", "not-a-hash")).isFalse();
+        assertThat(hasher.matches("a-long-enough-password",
+                "sha256$210000$" + parts[2] + "$" + parts[3])).isFalse();
+        assertThat(hasher.matches("a-long-enough-password",
+                "pbkdf2$not-a-number$" + parts[2] + "$" + parts[3])).isFalse();
+    }
+
+    @Test
+    void matchesShouldRejectIterationsOutsideAllowedBounds() {
+        PasswordHasher hasher = new PasswordHasher();
+        String validHash = hasher.hash("a-long-enough-password");
+        String[] parts = validHash.split("\\$", -1);
+
+        assertThat(hasher.matches("a-long-enough-password",
+                "pbkdf2$99999$" + parts[2] + "$" + parts[3])).isFalse();
+        assertThat(hasher.matches("a-long-enough-password",
+                "pbkdf2$2000000$" + parts[2] + "$" + parts[3])).isFalse();
+    }
+
 }


### PR DESCRIPTION
### Motivation

The existing `PasswordHasherTest` proves salt uniqueness, verification and the salt/digest length guards, but the remaining `matches` guards — null arguments, structurally malformed hashes and out-of-range iteration counts — were untested.

### Changes

- `matchesShouldRejectNullArguments`: a null password or stored hash never verifies.
- `matchesShouldRejectMalformedHashFormat`: non-hash strings, wrong scheme prefixes and non-numeric iteration counts are rejected before any key derivation.
- `matchesShouldRejectIterationsOutsideAllowedBounds`: iteration counts below 100k or above 1M (with otherwise valid salt/digest segments) are rejected.

### Verification

```
mvn -B test -Dtest=PasswordHasherTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```