### PR TITLE
[ISSUE-3808][test] Deepen SensitiveRequestToStringTest with auth request password exclusion

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/SensitiveRequestToStringTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/SensitiveRequestToStringTest.java
@@ -66,4 +66,27 @@ class SensitiveRequestToStringTest {
                 .contains("instanceId=instance-1")
                 .doesNotContain("metrics-password", "metrics-bearer-token");
     }
+
+    @Test
+    void authRequestToStringShouldNotExposePasswords() {
+        LoginDTO login = new LoginDTO();
+        login.setUsername("alice");
+        login.setPassword("login-secret-value");
+
+        CreateStudioUserDTO create = new CreateStudioUserDTO();
+        create.setUsername("bob");
+        create.setPassword("create-secret-value");
+
+        ResetPasswordDTO reset = new ResetPasswordDTO();
+        reset.setNewPassword("reset-secret-value");
+
+        assertThat(login.toString())
+                .contains("username=alice")
+                .doesNotContain("login-secret-value");
+        assertThat(create.toString())
+                .contains("username=bob")
+                .doesNotContain("create-secret-value");
+        assertThat(reset.toString())
+                .doesNotContain("reset-secret-value");
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `SensitiveRequestToStringTest` covers LLM, cloud-credential, plain-access and metrics query DTOs, but the auth-family request DTOs — login, studio user creation and password reset — were not part of the cross-DTO secret-leak contract.

### Changes

- `authRequestToStringShouldNotExposePasswords`: `LoginDTO`, `CreateStudioUserDTO` and `ResetPasswordDTO` all keep their passwords out of `toString` (via `@ToString.Exclude`) while non-secret fields such as the username stay visible.

### Verification

```
mvn -B test -Dtest=SensitiveRequestToStringTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```