### PR TITLE
[ISSUE-3809][test] Deepen PlainAclRemoteAddressValidatorTest with blank, whitespace and ipv6-list boundaries

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/PlainAclRemoteAddressValidatorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/PlainAclRemoteAddressValidatorTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.instance.acl;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -60,5 +61,25 @@ class PlainAclRemoteAddressValidatorTest {
     })
     void shouldRejectExpressionsThePlainAclParserCannotUse(String expression) {
         assertThat(PlainAclRemoteAddressValidator.isValid(expression)).isFalse();
+    }
+
+    @Test
+    void shouldTreatNullOrBlankAsUnrestricted() {
+        assertThat(PlainAclRemoteAddressValidator.isValid(null)).isTrue();
+        assertThat(PlainAclRemoteAddressValidator.isValid("")).isTrue();
+        assertThat(PlainAclRemoteAddressValidator.isValid("   ")).isTrue();
+    }
+
+    @Test
+    void shouldRejectExpressionsWithSurroundingWhitespace() {
+        assertThat(PlainAclRemoteAddressValidator.isValid(" 127.0.0.1 ")).isFalse();
+        assertThat(PlainAclRemoteAddressValidator.isValid("10.0.0.1 ")).isFalse();
+        assertThat(PlainAclRemoteAddressValidator.isValid(" 2001:db8::1")).isFalse();
+    }
+
+    @Test
+    void shouldAcceptIpv6AddressLists() {
+        assertThat(PlainAclRemoteAddressValidator.isValid("2001:db8::1,2001:db8::2")).isTrue();
+        assertThat(PlainAclRemoteAddressValidator.isValid("::1,::2,::3")).isTrue();
     }
 }


### PR DESCRIPTION
### Motivation

The existing `PlainAclRemoteAddressValidatorTest` parameterises many accepted/rejected expressions, but the null/blank semantics, the surrounding-whitespace guard and IPv6 address lists were untested.

### Changes

- `shouldTreatNullOrBlankAsUnrestricted`: a null or blank expression means no restriction and is accepted.
- `shouldRejectExpressionsWithSurroundingWhitespace`: expressions with leading/trailing whitespace are rejected because the validator never trims.
- `shouldAcceptIpv6AddressLists`: comma-separated lists of exact IPv6 addresses validate.

### Verification

```
mvn -B test -Dtest=PlainAclRemoteAddressValidatorTest
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```