### PR TITLE
[ISSUE-3812][test] Deepen UrlHostGuardMulticastTest with link-local, private-range and loopback policy cases

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardMulticastTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardMulticastTest.java
@@ -27,4 +27,24 @@ class UrlHostGuardMulticastTest {
         assertThat(UrlHostGuard.isAllowedHost("224.0.0.1", false)).isFalse();
         assertThat(UrlHostGuard.isAllowedHost("ff02::1", false)).isFalse();
     }
+
+    @Test
+    void isAllowedHostShouldRejectLinkLocalAndAnyLocalAddresses() {
+        assertThat(UrlHostGuard.isAllowedHost("169.254.169.254", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("0.0.0.0", false)).isFalse();
+    }
+
+    @Test
+    void isAllowedHostShouldAllowPrivateSiteLocalRanges() {
+        assertThat(UrlHostGuard.isAllowedHost("10.0.0.1", false)).isTrue();
+        assertThat(UrlHostGuard.isAllowedHost("192.168.1.10", false)).isTrue();
+        assertThat(UrlHostGuard.isAllowedHost("172.16.0.5", false)).isTrue();
+    }
+
+    @Test
+    void isAllowedHostShouldAdmitLoopbackOnlyWhenConfigured() {
+        assertThat(UrlHostGuard.isAllowedHost("127.0.0.1", true)).isTrue();
+        assertThat(UrlHostGuard.isAllowedHost("127.0.0.1", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("::1", true)).isTrue();
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `UrlHostGuardMulticastTest` only rejects multicast addresses. The SSRF guard's other address classes — link-local/metadata, any-local, private site-local and the loopback policy — were untested in this file.

### Changes

- `isAllowedHostShouldRejectLinkLocalAndAnyLocalAddresses`: the cloud metadata range `169.254.169.254` and `0.0.0.0` are rejected.
- `isAllowedHostShouldAllowPrivateSiteLocalRanges`: `10.x`, `192.168.x` and `172.16-31.x` remain allowed for on-premise endpoints.
- `isAllowedHostShouldAdmitLoopbackOnlyWhenConfigured`: `127.0.0.1` and `::1` are admitted only when `allowLoopback` is set.

### Verification

```
mvn -B test -Dtest=UrlHostGuardMulticastTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```