### PR TITLE
[ISSUE-3813][test] Deepen DataSourceClientHttpRequestFactoryTest with multi-method redirect guard

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceClientHttpRequestFactoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceClientHttpRequestFactoryTest.java
@@ -41,6 +41,24 @@ class DataSourceClientHttpRequestFactoryTest {
         connection.disconnect();
     }
 
+    @Test
+    void prepareConnectionShouldDisableRedirectsForEveryHttpMethod() throws Exception {
+        TestableDataSourceClientHttpRequestFactory requestFactory =
+                new TestableDataSourceClientHttpRequestFactory();
+
+        for (String method : new String[]{"GET", "POST", "PUT", "DELETE"}) {
+            HttpURLConnection connection = (HttpURLConnection) URI.create("http://example.com")
+                    .toURL().openConnection();
+
+            requestFactory.prepare(connection, method);
+
+            assertThat(connection.getInstanceFollowRedirects())
+                    .as("redirects must be disabled for %s", method)
+                    .isFalse();
+            connection.disconnect();
+        }
+    }
+
     private static class TestableDataSourceClientHttpRequestFactory
             extends DataSourceClientHttpRequestFactory {
 


### PR DESCRIPTION
### Motivation

The existing `DataSourceClientHttpRequestFactoryTest` verifies redirects are disabled for GET only. Since the SSRF posture relies on this factory for every datasource HTTP call, the guard should be locked for each verb the client can issue.

### Changes

- `prepareConnectionShouldDisableRedirectsForEveryHttpMethod`: GET, POST, PUT and DELETE connections all end up with `setInstanceFollowRedirects(false)` after preparation (PATCH is excluded because `HttpURLConnection` rejects it natively).

### Verification

```
mvn -B test -Dtest=DataSourceClientHttpRequestFactoryTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```