### PR TITLE
[ISSUE-3814][test] Deepen DataSourceDTOTest with display-name canonicalisation and auth trimming

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/settings/DataSourceDTOTest.java
@@ -57,6 +57,28 @@ class DataSourceDTOTest {
         assertThat(request.toDataSourceVO().getInstanceIds()).isNull();
     }
 
+    @Test
+    void shouldCanonicalizeSupportedProviderTypesToDisplayNames() {
+        assertThat(canonicalType("thanos")).isEqualTo("Thanos");
+        assertThat(canonicalType("mimir")).isEqualTo("Mimir");
+        assertThat(canonicalType("arms")).isEqualTo("ARMS");
+        assertThat(canonicalType("cortex")).isEqualTo("Cortex");
+    }
+
+    @Test
+    void shouldTrimAuthModeInOutput() {
+        DataSourceDTO request = validDataSource();
+        request.setAuth("  bearer token  ");
+
+        assertThat(request.toDataSourceVO().getAuth()).isEqualTo("bearer token");
+    }
+
+    private String canonicalType(String rawType) {
+        DataSourceDTO request = validDataSource();
+        request.setType(rawType);
+        return request.toDataSourceVO().getType();
+    }
+
     private DataSourceDTO validDataSource() {
         DataSourceDTO request = new DataSourceDTO();
         request.setName("Production metrics");


### PR DESCRIPTION
### Motivation

The existing `DataSourceDTOTest` covers instance-binding canonicalisation and validation but not the provider-type display names produced by `toDataSourceVO` nor the auth-mode trimming.

### Changes

- `shouldCanonicalizeSupportedProviderTypesToDisplayNames`: raw `thanos`, `mimir`, `arms` and `cortex` types map to their canonical display names (`Thanos`, `Mimir`, `ARMS`, `Cortex`) through the shared backend-type resolver.
- `shouldTrimAuthModeInOutput`: an auth mode with surrounding whitespace is trimmed in the produced `DataSourceVO`.

### Verification

```
mvn -B test -Dtest=DataSourceDTOTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```