### PR TITLE
[ISSUE-3815][test] Deepen AlertRuleRequestDTOTest with VO default application and field copying

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTOTest.java
@@ -67,4 +67,63 @@ class AlertRuleRequestDTOTest {
 
         assertThat(request.toAlertRuleVO().getMetric()).isEqualTo("consumer.lag.total");
     }
+
+    @Test
+    void toAlertRuleVOShouldApplyDefaultsForNullOptionalFields() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName("High Lag");
+
+        AlertRuleVO vo = request.toAlertRuleVO();
+
+        assertThat(vo.getAggregation()).isEqualTo("LAST");
+        assertThat(vo.getWindowSeconds()).isZero();
+        assertThat(vo.getConsecutiveSamples()).isEqualTo(1);
+        assertThat(vo.getReminderInterval()).isEqualTo("30m");
+        assertThat(vo.getMetric()).isNull();
+        assertThat(vo.getChannels()).isNull();
+    }
+
+    @Test
+    void toAlertRuleVOShouldCopyExplicitRuntimeFields() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName("High Lag");
+        request.setOperator(">=");
+        request.setThreshold(85);
+        request.setThresholdUnit("%");
+        request.setDuration("5m");
+        request.setAggregation("AVG");
+        request.setWindowSeconds(60);
+        request.setEnabled(false);
+        request.setDescription("broker disk high");
+        request.setBrokerName("broker-a");
+        request.setClusterName("cluster-a");
+        request.setSeverity("warning");
+        request.setInstanceId("local");
+        request.setConsumerGroup("group-a");
+        request.setTopic("orders");
+        request.setConsecutiveSamples(3);
+        request.setReminderInterval("1h");
+        request.setNotificationTemplate("${ruleName} ${value}");
+
+        AlertRuleVO vo = request.toAlertRuleVO();
+
+        assertThat(vo.getName()).isEqualTo("High Lag");
+        assertThat(vo.getOperator()).isEqualTo(">=");
+        assertThat(vo.getThreshold()).isEqualTo(85);
+        assertThat(vo.getThresholdUnit()).isEqualTo("%");
+        assertThat(vo.getDuration()).isEqualTo("5m");
+        assertThat(vo.getAggregation()).isEqualTo("AVG");
+        assertThat(vo.getWindowSeconds()).isEqualTo(60);
+        assertThat(vo.isEnabled()).isFalse();
+        assertThat(vo.getDescription()).isEqualTo("broker disk high");
+        assertThat(vo.getBrokerName()).isEqualTo("broker-a");
+        assertThat(vo.getClusterName()).isEqualTo("cluster-a");
+        assertThat(vo.getSeverity()).isEqualTo("warning");
+        assertThat(vo.getInstanceId()).isEqualTo("local");
+        assertThat(vo.getConsumerGroup()).isEqualTo("group-a");
+        assertThat(vo.getTopic()).isEqualTo("orders");
+        assertThat(vo.getConsecutiveSamples()).isEqualTo(3);
+        assertThat(vo.getReminderInterval()).isEqualTo("1h");
+        assertThat(vo.getNotificationTemplate()).isEqualTo("${ruleName} ${value}");
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `AlertRuleRequestDTOTest` covers channel validation, composite durations, channel normalisation and metric trimming, but the `toAlertRuleVO` defaults for absent optional fields and the full field-copy contract were untested.

### Changes

- `toAlertRuleVOShouldApplyDefaultsForNullOptionalFields`: null aggregation/window/consecutive-samples/reminder-interval fall back to `LAST`/0/1/`30m`, and null metric/channels stay null.
- `toAlertRuleVOShouldCopyExplicitRuntimeFields`: every configured field — operator, threshold, duration, aggregation, severity, scope selectors, intervals and the notification template — lands verbatim on the VO.

### Verification

```
mvn -B test -Dtest=AlertRuleRequestDTOTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```