### PR TITLE
[ISSUE-3816][test] Deepen studioUsers API tests with write endpoints and empty export stop

### DIFF
--- a/web/src/api/studioUsers.test.ts
+++ b/web/src/api/studioUsers.test.ts
@@ -18,7 +18,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import client from './client';
-import { listAllStudioUsers as loadStudioUsersForExport, listStudioUsers } from './studioUsers';
+import { listAllStudioUsers as loadStudioUsersForExport, listStudioUsers, createStudioUser, setStudioUserEnabled, resetStudioUserPassword } from './studioUsers';
 
 const mock = new MockAdapter(client);
 const exportQuery = { search: 'op', admin: false };
@@ -88,5 +88,55 @@ describe('studio users API', () => {
       exportRequestParams[0],
       exportRequestParams[1],
     ]);
+  });
+
+  it('stops exporting when the first page is empty', async () => {
+    mock.onGet('/studio-users').reply(200, {
+      code: 200,
+      data: { items: [], total: 0, page: 1, size: 100 },
+    });
+
+    await expect(loadStudioUsersForExport({ search: 'none' })).resolves.toEqual([]);
+    expect(mock.history.get).toHaveLength(1);
+  });
+
+  it('creates a studio user with the provided credentials', async () => {
+    mock.onPost('/studio-users').reply(200, {
+      code: 200,
+      data: { id: 9, username: 'new-operator', admin: true, enabled: true },
+    });
+
+    const created = await createStudioUser({
+      username: 'new-operator',
+      password: 'secret-pass-1',
+      admin: true,
+    });
+
+    expect(created.id).toBe(9);
+    expect(JSON.parse(mock.history.post[0].data)).toEqual({
+      username: 'new-operator',
+      password: 'secret-pass-1',
+      admin: true,
+    });
+  });
+
+  it('toggles the enabled state through the status endpoint', async () => {
+    mock.onPost('/studio-users/7/status').reply(200, {
+      code: 200,
+      data: { id: 7, username: 'operator', admin: false, enabled: false },
+    });
+
+    const updated = await setStudioUserEnabled(7, false);
+
+    expect(updated.enabled).toBe(false);
+    expect(JSON.parse(mock.history.post[0].data)).toEqual({ enabled: false });
+  });
+
+  it('resets the password through the password endpoint', async () => {
+    mock.onPost('/studio-users/7/password').reply(200, { code: 200 });
+
+    await resetStudioUserPassword(7, 'new-secret-pass');
+
+    expect(JSON.parse(mock.history.post[0].data)).toEqual({ newPassword: 'new-secret-pass' });
   });
 });


### PR DESCRIPTION
### Motivation

The existing `studioUsers.test.ts` covers the read path (filtered page and paginated export). The write endpoints — create, enable toggle and password reset — plus the empty-page export short-circuit were untested.

### Changes

- `stops exporting when the first page is empty`: an empty first page returns immediately with one request.
- `creates a studio user with the provided credentials`: posts username/password/admin and returns the created user.
- `toggles the enabled state through the status endpoint`: posts `{ enabled }` to `/studio-users/:id/status` and returns the updated user.
- `resets the password through the password endpoint`: posts the new password to `/studio-users/:id/password`.

### Verification

```
./node_modules/.bin/vitest run src/api/studioUsers.test.ts   # 6 passed
./node_modules/.bin/tsc --noEmit                             # clean
./node_modules/.bin/eslint src/api/studioUsers.test.ts       # clean
```