### PR TITLE
[ISSUE-3817][test] Deepen settings API tests with general settings and notification channel calls

### DIFF
--- a/web/src/api/settings.test.ts
+++ b/web/src/api/settings.test.ts
@@ -21,9 +21,12 @@ import client from './client';
 import {
   createDataSource,
   deleteDataSource,
+  getGeneralSettings,
   listAllDataSources,
   listDataSources,
+  saveGeneralSettings,
   testDataSource,
+  testNotification,
   updateDataSource,
 } from './settings';
 import type { DataSource } from './settings';
@@ -111,5 +114,49 @@ describe('data sources API', () => {
     await expect(
       testDataSource({ type: source.type, url: source.url, auth: source.auth }),
     ).resolves.toEqual({ success: true, message: 'Connection successful' });
+  });
+
+  it('loads the general settings', async () => {
+    mock.onGet('/settings/general').reply(200, { code: 200, data: { apiKeyConfigured: true } });
+
+    await expect(getGeneralSettings()).resolves.toEqual({ apiKeyConfigured: true });
+  });
+
+  it('strips read-only configured flags when saving general settings', async () => {
+    mock.onPost('/settings/general/save').reply((config) => {
+      const payload = JSON.parse(config.data);
+      expect(payload.apiKeyConfigured).toBeUndefined();
+      expect(payload.dingtalkWebhookConfigured).toBeUndefined();
+      expect(payload.smsWebhookConfigured).toBeUndefined();
+      expect(payload.apiKey).toBe('sk-live');
+      return [200, { code: 200 }];
+    });
+
+    await saveGeneralSettings({
+      apiKey: 'sk-live',
+      apiKeyConfigured: true,
+      dingtalkWebhookConfigured: false,
+      smsWebhookConfigured: true,
+    } as Parameters<typeof saveGeneralSettings>[0]);
+  });
+
+  it('drops a blank api key when saving general settings', async () => {
+    mock.onPost('/settings/general/save').reply((config) => {
+      const payload = JSON.parse(config.data);
+      expect(payload.apiKey).toBeUndefined();
+      return [200, { code: 200 }];
+    });
+
+    await saveGeneralSettings({ apiKey: '   ' } as Parameters<typeof saveGeneralSettings>[0]);
+  });
+
+  it('tests a notification channel through the query parameter', async () => {
+    mock.onPost('/settings/general/test-notification').reply((config) => {
+      expect(config.params).toEqual({ channel: 'dingtalk' });
+      return [200, { code: 200 }];
+    });
+
+    await testNotification('dingtalk');
+    expect(mock.history.post).toHaveLength(1);
   });
 });


### PR DESCRIPTION
### Motivation

The existing `settings.test.ts` covers the data-source endpoints but the general-settings functions — load, save and notification tests — were untested, including the read-only flag stripping and blank apiKey handling in `saveGeneralSettings`.

### Changes

- `loads the general settings`: GET `/settings/general` returns the settings payload.
- `strips read-only configured flags when saving general settings`: `*Configured` read-only markers never leave the client; the live apiKey is kept.
- `drops a blank api key when saving general settings`: a whitespace-only apiKey is omitted from the save payload.
- `tests a notification channel through the query parameter`: the channel is sent as a query param on `/settings/general/test-notification`.

### Verification

```
./node_modules/.bin/vitest run src/api/settings.test.ts   # 7 passed
./node_modules/.bin/tsc --noEmit                         # clean
./node_modules/.bin/eslint src/api/settings.test.ts       # clean
```