### PR TITLE
[ISSUE-3821][test] Deepen MiniBar tests with empty series, scaling and label exposure

### DIFF
--- a/web/src/components/__tests__/MiniBar.test.tsx
+++ b/web/src/components/__tests__/MiniBar.test.tsx
@@ -34,4 +34,23 @@ describe('MiniBar', () => {
 
     expect(getBarHeights()).toEqual(['0px', '4px', '20px']);
   });
+
+  it('renders a placeholder when the data series is empty', () => {
+    render(<MiniBar data={[]} height={20} label="Empty trend" />);
+
+    expect(screen.getByText('—')).toBeTruthy();
+    expect(screen.queryByRole('img')).toBeNull();
+  });
+
+  it('scales bar heights within the chart height', () => {
+    render(<MiniBar data={[1, 5]} height={100} label="Throughput trend" />);
+
+    expect(getBarHeights()).toEqual(['20px', '100px']);
+  });
+
+  it('exposes the label through the image role', () => {
+    render(<MiniBar data={[1, 2, 3]} height={20} label="Custom label" />);
+
+    expect(screen.getByRole('img').getAttribute('aria-label')).toBe('Custom label');
+  });
 });


### PR DESCRIPTION
### Motivation

The existing `MiniBar` tests cover zero values and the minimum visible height. The empty-series placeholder, proportional scaling within the chart height and the aria-label contract were untested.

### Changes

- `renders a placeholder when the data series is empty`: an empty series shows the `—` placeholder without an image role.
- `scales bar heights within the chart height`: heights are proportional to the series maximum (`1/5` and `5/5` of a 100px chart).
- `exposes the label through the image role`: the custom label lands on the `img` role's aria-label.

### Verification

```
./node_modules/.bin/vitest run src/components/__tests__/MiniBar.test.tsx   # 5 passed
./node_modules/.bin/tsc --noEmit                                          # clean
./node_modules/.bin/eslint src/components/__tests__/MiniBar.test.tsx      # clean
```