### PR TITLE
[ISSUE-3822][test] Deepen aliyunCatalog tests with instance search parameter coverage

### DIFF
--- a/web/src/api/aliyunCatalog.test.ts
+++ b/web/src/api/aliyunCatalog.test.ts
@@ -67,4 +67,15 @@ describe('aliyunCatalog API', () => {
 
     expect(instances[0].instanceId).toBe('rmq-cn-xxx');
   });
+
+  it('includes the search term when listing instances', async () => {
+    mock.onGet('/cloud/aliyun/instances').reply((config) => {
+      expect(config.params).toEqual({ credentialId: 9, regionId: 'cn-hangzhou', search: 'prod' });
+      return [200, { code: 200, data: [] }];
+    });
+
+    const instances = await listAliyunInstances(9, 'cn-hangzhou', 'prod');
+
+    expect(instances).toEqual([]);
+  });
 });


### PR DESCRIPTION
### Motivation

The existing `aliyunCatalog.test.ts` covers region listing and instance listing with credential/region params, but the optional search term of `listAliyunInstances` was not asserted.

### Changes

- `includes the search term when listing instances`: when a search term is passed, the request carries `{ credentialId, regionId, search }` and the empty result set is returned.

### Verification

```
./node_modules/.bin/vitest run src/api/aliyunCatalog.test.ts   # 3 passed
./node_modules/.bin/tsc --noEmit                               # clean
./node_modules/.bin/eslint src/api/aliyunCatalog.test.ts       # clean
```