### PR TITLE
[ISSUE-3825][test] Deepen PageResultTest with empty factory and metadata preservation

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/domain/PageResultTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/domain/PageResultTest.java
@@ -44,4 +44,24 @@ class PageResultTest {
         assertThatThrownBy(() -> result.getItems().add("mutated"))
                 .isInstanceOf(UnsupportedOperationException.class);
     }
+
+    @Test
+    void emptyShouldCarryPageAndSizeWithZeroTotal() {
+        PageResult<String> result = PageResult.empty(3, 25);
+
+        assertThat(result.getItems()).isEmpty();
+        assertThat(result.getTotal()).isZero();
+        assertThat(result.getPage()).isEqualTo(3);
+        assertThat(result.getSize()).isEqualTo(25);
+    }
+
+    @Test
+    void ofShouldPreservePaginationMetadata() {
+        PageResult<String> result = PageResult.of(List.of("a", "b"), 42, 4, 10);
+
+        assertThat(result.getItems()).containsExactly("a", "b");
+        assertThat(result.getTotal()).isEqualTo(42);
+        assertThat(result.getPage()).isEqualTo(4);
+        assertThat(result.getSize()).isEqualTo(10);
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `PageResultTest` covers null-item normalisation and source isolation, but the `empty` factory and the pagination metadata fields carried by `of` were untested.

### Changes

- `emptyShouldCarryPageAndSizeWithZeroTotal`: `empty(3, 25)` produces an empty page with total 0 and the requested page/size.
- `ofShouldPreservePaginationMetadata`: total, page and size are preserved verbatim alongside the items.

### Verification

```
mvn -B test -Dtest=PageResultTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```