### PR TITLE
[ISSUE-3826][test] Deepen EntityIdsTest with blank, non-numeric and long-range guard cases

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/EntityIdsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/EntityIdsTest.java
@@ -39,4 +39,35 @@ class EntityIdsTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("positive numeric value");
     }
+
+    @Test
+    void rejectsBlankIdentifiers() {
+        assertThatThrownBy(() -> EntityIds.parseId(null))
+                .isInstanceOfSatisfying(BusinessException.class,
+                        error -> assertThat(error.getCode()).isEqualTo(400))
+                .hasMessageContaining("id is required");
+        assertThatThrownBy(() -> EntityIds.parseId("  "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("id is required");
+    }
+
+    @Test
+    void rejectsNonNumericIdentifiers() {
+        assertThatThrownBy(() -> EntityIds.parseId("abc"))
+                .isInstanceOfSatisfying(BusinessException.class,
+                        error -> assertThat(error.getCode()).isEqualTo(400))
+                .hasMessageContaining("must be a numeric value");
+        assertThatThrownBy(() -> EntityIds.parseId("42L"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("must be a numeric value");
+    }
+
+    @Test
+    void parsesFullLongRangePositiveValues() {
+        assertThat(EntityIds.parseId("9223372036854775807"))
+                .isEqualTo(Long.MAX_VALUE);
+        assertThatThrownBy(() -> EntityIds.parseId("9223372036854775808"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("must be a numeric value");
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `EntityIdsTest` covers trimmed positive ids and the zero/negative rejection, but the blank-input, non-numeric and long-boundary branches of `parseId` were untested.

### Changes

- `rejectsBlankIdentifiers`: null and whitespace-only values raise 400 `id is required`.
- `rejectsNonNumericIdentifiers`: alphabetic and suffixed values (`abc`, `42L`) raise 400 with the numeric-value message.
- `parsesFullLongRangePositiveValues`: `Long.MAX_VALUE` parses, while one past the boundary overflows and is rejected as non-numeric.

### Verification

```
mvn -B test -Dtest=EntityIdsTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```