### PR TITLE
[ISSUE-3827][test] Deepen CsvUtilTest with remaining formula chars, null/empty cells and multi-cell rows

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/CsvUtilTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/CsvUtilTest.java
@@ -35,4 +35,25 @@ class CsvUtilTest {
         assertThat(CsvUtil.toCell("=SUM(A1)")).isEqualTo("\"'=SUM(A1)\"");
         assertThat(CsvUtil.toCell("+cmd")).isEqualTo("\"'+cmd\"");
     }
+
+    @Test
+    void toCellShouldPrefixRemainingFormulaCharacters() {
+        assertThat(CsvUtil.toCell("@sum(A1)")).isEqualTo("\"'@sum(A1)\"");
+        assertThat(CsvUtil.toCell("-123")).isEqualTo("\"'-123\"");
+        assertThat(CsvUtil.toCell("\tindented")).isEqualTo("\"'\tindented\"");
+    }
+
+    @Test
+    void toCellShouldHandleNullAndEmptyValues() {
+        assertThat(CsvUtil.toCell(null)).isEqualTo("\"\"");
+        assertThat(CsvUtil.toCell("")).isEqualTo("\"\"");
+    }
+
+    @Test
+    void appendRowShouldJoinMultipleCellsWithCommas() {
+        StringBuilder csv = new StringBuilder();
+        CsvUtil.appendRow(csv, "a", 2, null, "d");
+
+        assertThat(csv.toString()).isEqualTo("\"a\",\"2\",\"\",\"d\"\r\n");
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `CsvUtilTest` covers quote escaping and the `=`/`+` formula prefixes, but the remaining formula characters (`@ - tab`), null/empty cells and multi-cell row rendering were untested.

### Changes

- `toCellShouldPrefixRemainingFormulaCharacters`: `@`, `-` and tab-leading values get the single-quote formula guard.
- `toCellShouldHandleNullAndEmptyValues`: null and empty values render as an empty quoted cell.
- `appendRowShouldJoinMultipleCellsWithCommas`: heterogeneous values (string, number, null) join with commas and a CRLF terminator.

### Verification

```
mvn -B test -Dtest=CsvUtilTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```