### PR TITLE
[ISSUE-3829][test] Deepen AlertFingerprintTest with null handling, rule id and backslash identity

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprintTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertFingerprintTest.java
@@ -46,4 +46,25 @@ class AlertFingerprintTest {
         assertThat(AlertFingerprint.of(7L, "local", embeddedLabel))
                 .isNotEqualTo(AlertFingerprint.of(7L, "local", separateLabels));
     }
+
+    @Test
+    void nullInstanceAndNullLabelsAreHandledDeterministically() {
+        assertThat(AlertFingerprint.of(7L, null, null))
+                .isEqualTo(AlertFingerprint.of(7L, null, Map.of()))
+                .hasSize(64);
+    }
+
+    @Test
+    void ruleIdParticipatesInTheFingerprint() {
+        Map<String, String> labels = Map.of("broker", "a");
+
+        assertThat(AlertFingerprint.of(7L, "local", labels))
+                .isNotEqualTo(AlertFingerprint.of(8L, "local", labels));
+    }
+
+    @Test
+    void backslashesInLabelsArePartOfTheIdentity() {
+        assertThat(AlertFingerprint.of(7L, "local", Map.of("a", "b\\c")))
+                .isNotEqualTo(AlertFingerprint.of(7L, "local", Map.of("a", "bc")));
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `AlertFingerprintTest` covers label-order stability and separator escaping, but null instance/labels handling, the rule-id participation and backslash identity were untested.

### Changes

- `nullInstanceAndNullLabelsAreHandledDeterministically`: a null instance id and null labels hash deterministically, with null labels equivalent to an empty label map and a 64-char digest.
- `ruleIdParticipatesInTheFingerprint`: different rule ids over the same labels produce different fingerprints.
- `backslashesInLabelsArePartOfTheIdentity`: a backslash inside a label value is part of the identity rather than being collapsed.

### Verification

```
mvn -B test -Dtest=AlertFingerprintTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```