### PR TITLE
[ISSUE-3830][test] Deepen MetricSampleTest with availability invariants, required fields and label copy

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricSampleTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MetricSampleTest.java
@@ -20,7 +20,10 @@ import org.apache.rocketmq.studio.ops.alert.AlertDomain;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MetricSampleTest {
@@ -39,5 +42,52 @@ class MetricSampleTest {
                 null, null, MetricAvailability.AVAILABLE, Instant.now()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Available metric samples require a value");
+    }
+
+    @Test
+    void availableSamplesCannotCarryAnUnavailableReason() {
+        assertThatThrownBy(() -> new MetricSample("broker.availability", AlertDomain.CLUSTER, "local", null,
+                null, 1D, MetricAvailability.AVAILABLE, Instant.now(), "scrape failed"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Available metric samples cannot have an unavailable reason");
+    }
+
+    @Test
+    void unavailableSamplesMayCarryAnUnavailableReason() {
+        MetricSample sample = new MetricSample("broker.availability", AlertDomain.CLUSTER, "local", null,
+                null, null, MetricAvailability.UNAVAILABLE, Instant.now(), "scrape timed out");
+
+        assertThat(sample.unavailableReason()).isEqualTo("scrape timed out");
+        assertThat(sample.labels()).isEmpty();
+    }
+
+    @Test
+    void requiredFieldsAreValidated() {
+        assertThatThrownBy(() -> new MetricSample("  ", AlertDomain.CLUSTER, "local", null,
+                null, null, MetricAvailability.UNAVAILABLE, Instant.now(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("metricKey is required");
+        assertThatThrownBy(() -> new MetricSample("broker.availability", AlertDomain.CLUSTER, null, null,
+                null, null, MetricAvailability.UNAVAILABLE, Instant.now(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("instanceId is required");
+        assertThatThrownBy(() -> new MetricSample("broker.availability", null, "local", null,
+                null, null, MetricAvailability.UNAVAILABLE, Instant.now(), null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("domain is required");
+    }
+
+    @Test
+    void labelsAreDefensivelyCopied() {
+        Map<String, String> mutable = new HashMap<>();
+        mutable.put("broker", "a");
+        MetricSample sample = new MetricSample("broker.availability", AlertDomain.CLUSTER, "local",
+                "cluster-a", mutable, 1D, MetricAvailability.AVAILABLE, Instant.now());
+        mutable.put("broker", "b");
+        mutable.put("extra", "x");
+
+        assertThat(sample.labels()).containsExactly(Map.entry("broker", "a"));
+        assertThatThrownBy(() -> sample.labels().put("new", "y"))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 }


### PR DESCRIPTION
### Motivation

The existing `MetricSampleTest` covers the value/availability cross-checks only. The remaining record invariants — the unavailable-reason guard, required field validation and defensive label copying — were untested.

### Changes

- `availableSamplesCannotCarryAnUnavailableReason`: an available sample with a reason is rejected.
- `unavailableSamplesMayCarryAnUnavailableReason`: unavailable samples accept and expose a reason with empty labels by default.
- `requiredFieldsAreValidated`: blank metricKey/instanceId raise `IllegalArgumentException` and a null domain raises a `NullPointerException` with its message.
- `labelsAreDefensivelyCopied`: later mutation of the source map does not leak into the sample, and the sample's label map is immutable.

### Verification

```
mvn -B test -Dtest=MetricSampleTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```