### PR TITLE
[ISSUE-3832][test] Deepen NativeAlertMetricCatalogServiceTest with instance guards and non-native skip

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertMetricCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertMetricCatalogServiceTest.java
@@ -7,6 +7,7 @@
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.junit.jupiter.api.Test;
@@ -15,7 +16,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class NativeAlertMetricCatalogServiceTest {
@@ -58,5 +62,40 @@ class NativeAlertMetricCatalogServiceTest {
 
         assertThat(nativeRule.getMetric()).isEqualTo("broker.disk.usage_ratio");
         assertThat(customRule.getMetric()).isEqualTo("custom.metric");
+    }
+
+    @Test
+    void listShouldRejectBlankInstanceId() {
+        InstanceRepository repository = mock(InstanceRepository.class);
+        NativeAlertMetricCatalogService service = new NativeAlertMetricCatalogService(repository);
+
+        assertThatThrownBy(() -> service.list("  ", AlertDomain.CLUSTER))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("instanceId is required");
+        assertThatThrownBy(() -> service.list(null, AlertDomain.BUSINESS))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("instanceId is required");
+    }
+
+    @Test
+    void listShouldRejectUnknownInstance() {
+        InstanceRepository repository = mock(InstanceRepository.class);
+        when(repository.findByIdentifier("missing")).thenReturn(Optional.empty());
+        NativeAlertMetricCatalogService service = new NativeAlertMetricCatalogService(repository);
+
+        assertThatThrownBy(() -> service.list("missing", AlertDomain.CLUSTER))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Instance not found: missing");
+    }
+
+    @Test
+    void validateShouldSkipRepositoryForNonNativeMetrics() {
+        InstanceRepository repository = mock(InstanceRepository.class);
+        NativeAlertMetricCatalogService service = new NativeAlertMetricCatalogService(repository);
+
+        service.validate(AlertRuleVO.builder().domain(AlertDomain.CLUSTER)
+                .instanceId("apache").metric(" my.custom.metric ").build());
+
+        verify(repository, never()).findByIdentifier(any());
     }
 }


### PR DESCRIPTION
### Motivation

The existing `NativeAlertMetricCatalogServiceTest` covers provider-filtered catalogs and metric normalisation, but the list guards (blank/unknown instance) and the validate short-circuit for non-native metrics were untested.

### Changes

- `listShouldRejectBlankInstanceId`: a null or whitespace-only instance id raises 400 `instanceId is required`.
- `listShouldRejectUnknownInstance`: an unknown instance identifier raises 404 `Instance not found`.
- `validateShouldSkipRepositoryForNonNativeMetrics`: custom (non-native) metric names are trimmed and returned without any repository lookup.

### Verification

```
mvn -B test -Dtest=NativeAlertMetricCatalogServiceTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```