### PR TITLE
[ISSUE-3834][test] Deepen LiteTopicSummaryTest with unknown TTL, density ratio and emptiness semantics

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSummaryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicSummaryTest.java
@@ -52,4 +52,41 @@ class LiteTopicSummaryTest {
         assertThat(summary.getConsumerDensity()).isZero();
         assertThat(summary.isEmptyAggregation()).isTrue();
     }
+
+    @Test
+    void ttlStatusShouldReturnUnknownWithoutLastActiveTime() {
+        LiteTopicSummary summary = new LiteTopicSummary();
+        summary.setAverageTTL(10_000L);
+
+        assertThat(summary.getTTLStatus()).isEqualTo("UNKNOWN");
+    }
+
+    @Test
+    void consumerDensityShouldComputeRatio() {
+        LiteTopicSummary summary = new LiteTopicSummary();
+        summary.setTopicCount(5);
+        summary.setConsumerCount(10);
+
+        assertThat(summary.getConsumerDensity()).isEqualTo(2.0);
+    }
+
+    @Test
+    void isEmptyAggregationShouldConsiderBacklogAndConsumers() {
+        LiteTopicSummary empty = new LiteTopicSummary();
+        empty.setTopicCount(5);
+        empty.setConsumerCount(0);
+        empty.setTotalBacklog(0L);
+        assertThat(empty.isEmptyAggregation()).isTrue();
+
+        LiteTopicSummary withConsumers = new LiteTopicSummary();
+        withConsumers.setTopicCount(5);
+        withConsumers.setConsumerCount(3);
+        withConsumers.setTotalBacklog(0L);
+        assertThat(withConsumers.isEmptyAggregation()).isFalse();
+
+        LiteTopicSummary withBacklog = new LiteTopicSummary();
+        withBacklog.setTopicCount(5);
+        withBacklog.setTotalBacklog(120L);
+        assertThat(withBacklog.isEmptyAggregation()).isFalse();
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `LiteTopicSummaryTest` covers the TTL status thresholds and the unset-consumer aggregation helpers, but the unknown-TTL branch, the density ratio and the emptiness semantics were untested.

### Changes

- `ttlStatusShouldReturnUnknownWithoutLastActiveTime`: a summary without a last active time reports `UNKNOWN`.
- `consumerDensityShouldComputeRatio`: 10 consumers over 5 topics yields a density of 2.0.
- `isEmptyAggregationShouldConsiderBacklogAndConsumers`: an aggregation is empty only when both consumers and backlog are zero/absent.

### Verification

```
mvn -B test -Dtest=LiteTopicSummaryTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```