### PR TITLE
[ISSUE-3835][test] Deepen AliyunConvertersLagTest with null rows, empty breakdown fallback and no-data case

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersLagTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/alibaba/AliyunConvertersLagTest.java
@@ -57,4 +57,43 @@ class AliyunConvertersLagTest {
                     assertThat(row.getDiffTotal()).isEqualTo(100L);
                 });
     }
+
+    @Test
+    void nullTopicEntriesAndNullReadyCountsContributeZeroRows() {
+        Map<String, DataTopicLagMapValue> topicLagMap = new java.util.HashMap<>();
+        topicLagMap.put("orders", null);
+        topicLagMap.put("payments", DataTopicLagMapValue.builder().readyCount(null).build());
+        GetConsumerGroupLagResponseBody.Data data = GetConsumerGroupLagResponseBody.Data.builder()
+                .topicLagMap(topicLagMap)
+                .totalLag(GetConsumerGroupLagResponseBody.TotalLag.builder().readyCount(100L).build())
+                .build();
+
+        List<QueueProgressVO> rows = AliyunConverters.toQueueProgressRows(data);
+
+        assertThat(rows).extracting(QueueProgressVO::getTopic)
+                .containsExactlyInAnyOrder("orders", "payments");
+        assertThat(rows).allMatch(row -> row.getDiffTotal() == 0L);
+    }
+
+    @Test
+    void emptyTopicBreakdownUsesAggregateFallback() {
+        GetConsumerGroupLagResponseBody.Data data = GetConsumerGroupLagResponseBody.Data.builder()
+                .topicLagMap(Map.of())
+                .totalLag(GetConsumerGroupLagResponseBody.TotalLag.builder().readyCount(100L).build())
+                .build();
+
+        assertThat(AliyunConverters.toQueueProgressRows(data)).singleElement()
+                .satisfies(row -> {
+                    assertThat(row.getBroker()).isEqualTo("total");
+                    assertThat(row.getDiffTotal()).isEqualTo(100L);
+                });
+    }
+
+    @Test
+    void neitherBreakdownNorAggregateYieldsNoRows() {
+        GetConsumerGroupLagResponseBody.Data data = GetConsumerGroupLagResponseBody.Data.builder()
+                .build();
+
+        assertThat(AliyunConverters.toQueueProgressRows(data)).isEmpty();
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `AliyunConvertersLagTest` covers the breakdown-vs-aggregate dedup and the aggregate fallback when the breakdown is null. Three further shapes of the same conversion were untested.

### Changes

- `nullTopicEntriesAndNullReadyCountsContributeZeroRows`: null topic rows and null ready counts still contribute a per-topic row with a zero lag.
- `emptyTopicBreakdownUsesAggregateFallback`: a present-but-empty topic map (not null) falls back to the aggregate row.
- `neitherBreakdownNorAggregateYieldsNoRows`: a data payload without breakdown or aggregate produces no rows.

### Verification

```
mvn -B test -Dtest=AliyunConvertersLagTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```