### PR TITLE
[ISSUE-3836][test] Deepen LiteTopicQuotaTest with usage ratios and near-limit threshold

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/model/LiteTopicQuotaTest.java
@@ -17,6 +17,37 @@ import static org.assertj.core.api.Assertions.assertThat;
 class LiteTopicQuotaTest {
 
     @Test
+    void usageRateShouldComputeTopicRatio() {
+        LiteTopicQuota quota = new LiteTopicQuota();
+        quota.setMaxTopicCount(10);
+        quota.setCurrentTopicCount(4);
+
+        assertThat(quota.getUsageRate()).isEqualTo(0.4);
+    }
+
+    @Test
+    void sessionUsageRateShouldComputeRatio() {
+        LiteTopicQuota quota = new LiteTopicQuota();
+        quota.setMaxSessionCount(10);
+        quota.setCurrentSessionCount(4);
+
+        assertThat(quota.getSessionUsageRate()).isEqualTo(0.4);
+    }
+
+    @Test
+    void nearQuotaLimitShouldCompareAgainstTheThreshold() {
+        LiteTopicQuota quota = new LiteTopicQuota();
+        quota.setMaxTopicCount(10);
+        quota.setCurrentTopicCount(8);
+
+        assertThat(quota.isNearQuotaLimit(0.7)).isTrue();
+        assertThat(quota.isNearQuotaLimit(0.9)).isFalse();
+
+        LiteTopicQuota unconfigured = new LiteTopicQuota();
+        assertThat(unconfigured.isNearQuotaLimit(0.1)).isFalse();
+    }
+
+    @Test
     void quotaShouldNotBeExceededWhenMaxIsUnset() {
         LiteTopicQuota quota = new LiteTopicQuota();
         quota.setCurrentTopicCount(10);


### PR DESCRIPTION
### Motivation

The existing `LiteTopicQuotaTest` covers exceeded/remaining semantics and zero-rate guards, but the computed usage ratios (topic and session) and the `isNearQuotaLimit` threshold helper were untested.

### Changes

- `usageRateShouldComputeTopicRatio`: 4 of 10 topics yields 0.4 usage.
- `sessionUsageRateShouldComputeRatio`: 4 of 10 sessions yields 0.4 session usage.
- `nearQuotaLimitShouldCompareAgainstTheThreshold`: an 80% usage trips a 0.7 threshold but not a 0.9 one, and an unconfigured quota never reports near-limit.

### Verification

```
mvn -B test -Dtest=LiteTopicQuotaTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```