### PR TITLE
[ISSUE-3837][test] Deepen LlmSseSessionTest with send rejection, single-task ownership and idempotent terminal

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmSseSessionTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmSseSessionTest.java
@@ -67,6 +67,43 @@ class LlmSseSessionTest {
         verify(task, never()).cancel(true);
     }
 
+    @Test
+    void sendShouldRejectAfterCancellation() {
+        TestEmitter emitter = new TestEmitter();
+        LlmSseSession session = new LlmSseSession(emitter, ignored -> { });
+        session.attach(mock(Future.class));
+        session.cancel();
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> session.send(SseEmitter.event().data("chunk")))
+                .isInstanceOf(java.io.IOException.class)
+                .hasMessage("SSE client is no longer connected");
+    }
+
+    @Test
+    void attachShouldRejectASecondTask() {
+        TestEmitter emitter = new TestEmitter();
+        LlmSseSession session = new LlmSseSession(emitter, ignored -> { });
+        Future<?> firstTask = mock(Future.class);
+        Future<?> secondTask = mock(Future.class);
+        session.attach(firstTask);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> session.attach(secondTask))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("An SSE session can own only one task");
+        verify(secondTask).cancel(true);
+        verify(firstTask, never()).cancel(true);
+    }
+
+    @Test
+    void beginTerminalShouldBeIdempotent() {
+        TestEmitter emitter = new TestEmitter();
+        LlmSseSession session = new LlmSseSession(emitter, ignored -> { });
+
+        assertThat(session.beginTerminal()).isTrue();
+        assertThat(session.beginTerminal()).isFalse();
+    }
+
     private void assertLifecycleCallbackCancels(Consumer<TestEmitter> callback) {
         TestEmitter emitter = new TestEmitter();
         AtomicInteger terminations = new AtomicInteger();


### PR DESCRIPTION
### Motivation

The existing `LlmSseSessionTest` covers lifecycle-driven task cancellation and the normal completion path, but the `send` guard, the single-task ownership rule and the idempotence of `beginTerminal` were untested.

### Changes

- `sendShouldRejectAfterCancellation`: sending after a cancel raises `IOException` with the disconnected message before touching the emitter.
- `attachShouldRejectASecondTask`: a second attachment is cancelled and raises `IllegalStateException`, leaving the first task untouched.
- `beginTerminalShouldBeIdempotent`: only the first `beginTerminal` returns true.

### Verification

```
mvn -B test -Dtest=LlmSseSessionTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```