### PR TITLE
[ISSUE-3838][test] Deepen AiPayloadGuardTest with required-text guards and context size limits

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiPayloadGuardTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiPayloadGuardTest.java
@@ -74,4 +74,39 @@ class AiPayloadGuardTest {
                     assertThat(exception.getMessage()).contains("LLM model");
                 });
     }
+
+    @Test
+    void chatShouldRejectMissingRequestOrMessage() {
+        assertThatThrownBy(() -> AiPayloadGuard.validateChat(null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Chat request is required");
+        assertThatThrownBy(() -> AiPayloadGuard.validateChat(ChatDTO.builder().message("  ").build()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Chat message is required");
+    }
+
+    @Test
+    void commandShouldAcceptPromptOnlyAndRejectOversizedContext() {
+        AiCommandDTO promptOnly = AiCommandDTO.builder()
+                .prompt("explain the lag")
+                .context(Map.of("cluster", "main"))
+                .build();
+        assertThatCode(() -> AiPayloadGuard.validateCommand(promptOnly, objectMapper))
+                .doesNotThrowAnyException();
+
+        AiCommandDTO oversizedContext = AiCommandDTO.builder()
+                .prompt("explain the lag")
+                .context(Map.of("payload", "x".repeat(AiPayloadGuard.MAX_CONTEXT_BYTES)))
+                .build();
+        assertThatThrownBy(() -> AiPayloadGuard.validateCommand(oversizedContext, objectMapper))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Command context must not exceed");
+    }
+
+    @Test
+    void toolInvocationShouldRejectBlankName() {
+        assertThatThrownBy(() -> AiPayloadGuard.validateToolInvocation("  ", Map.of(), objectMapper))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Tool name is required");
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `AiPayloadGuardTest` covers chat UTF-8 boundaries, the command prompt/command requirement, tool-input JSON size and the outbound model contract, but the chat required-text guards, the prompt-only command path with a context size limit, and the tool-name requirement were untested.

### Changes

- `chatShouldRejectMissingRequestOrMessage`: a null chat request and a blank message are rejected with their dedicated messages.
- `commandShouldAcceptPromptOnlyAndRejectOversizedContext`: a prompt-only command validates, while a context map exceeding the JSON byte limit is rejected.
- `toolInvocationShouldRejectBlankName`: a blank tool name is rejected before any size check.

### Verification

```
mvn -B test -Dtest=AiPayloadGuardTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```