### PR TITLE
[ISSUE-3839][test] Deepen AlertServiceDefaultRulesTest with repository-rule export and disabled filtering

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceDefaultRulesTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertServiceDefaultRulesTest.java
@@ -69,4 +69,49 @@ class AlertServiceDefaultRulesTest {
         }
         return count;
     }
+
+    @Test
+    void exportUsesRepositoryRulesWhenPresentTest() {
+        AlertRepository repository = mock(AlertRepository.class);
+        AlertRuleVO rule = AlertRuleVO.builder()
+                .domain(AlertDomain.BUSINESS)
+                .name("CustomLagCheck")
+                .metric("consumer_lag_total")
+                .operator(">=")
+                .threshold(1000)
+                .duration("5m")
+                .enabled(true)
+                .build();
+        when(repository.findAllRules()).thenReturn(List.of(rule));
+
+        AlertService service = new AlertService(repository, Mockito.mock(AlertStateRepository.class),
+                new AlertRuleAssetService(), Mockito.mock(OperationAuditService.class));
+        String yaml = service.exportPrometheusRulesYaml();
+
+        assertTrue(yaml.contains("CustomLagCheck"));
+        assertTrue(yaml.contains("consumer_lag_total"));
+        assertTrue(yaml.contains("1000"));
+    }
+
+    @Test
+    void exportFiltersDisabledRulesBeforeFallingBackToDefaultsTest() {
+        AlertRepository repository = mock(AlertRepository.class);
+        AlertRuleVO disabled = AlertRuleVO.builder()
+                .domain(AlertDomain.BUSINESS)
+                .name("DisabledCustomCheck")
+                .metric("consumer.lag.total")
+                .operator(">=")
+                .threshold(1000)
+                .duration("5m")
+                .enabled(false)
+                .build();
+        when(repository.findAllRules()).thenReturn(List.of(disabled));
+
+        AlertService service = new AlertService(repository, Mockito.mock(AlertStateRepository.class),
+                new AlertRuleAssetService(), Mockito.mock(OperationAuditService.class));
+        String yaml = service.exportPrometheusRulesYaml();
+
+        assertTrue(yaml.contains("RocketMQBrokerDown"));
+        assertTrue(!yaml.contains("DisabledCustomCheck"));
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `AlertServiceDefaultRulesTest` covers the fallback to bundled assets only. The repository-driven export path (rules actually stored in the repository) and the enabled filtering before the fallback were untested.

### Changes

- `exportUsesRepositoryRulesWhenPresentTest`: a stored, enabled business rule is rendered into the Prometheus YAML with its alert name, expression and threshold.
- `exportFiltersDisabledRulesBeforeFallingBackToDefaultsTest`: a disabled rule is filtered out so the export falls back to the bundled default assets.

### Verification

```
mvn -B test -Dtest=AlertServiceDefaultRulesTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```