### PR TITLE
[ISSUE-3840][test] Deepen CloudRocketMqClusterMetricsCollectorTest with support gate, case-insensitive running and failure degradation

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/CloudRocketMqClusterMetricsCollectorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/CloudRocketMqClusterMetricsCollectorTest.java
@@ -72,6 +72,77 @@ class CloudRocketMqClusterMetricsCollectorTest {
         });
     }
 
+    @Test
+    void collectSkipsUnsupportedInstances() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        CloudRocketMqClusterMetricsCollector collector =
+                new CloudRocketMqClusterMetricsCollector(registry);
+        InstanceVO apache = InstanceVO.builder().name("local")
+                .vendor(InstanceVendor.APACHE).build();
+        InstanceVO noCredential = cloudInstance(InstanceVendor.ALIYUN);
+        noCredential.setCredentialId(null);
+
+        assertThat(collector.supports(apache)).isFalse();
+        assertThat(collector.supports(noCredential)).isFalse();
+        assertThat(collector.collect(apache)).isEmpty();
+        assertThat(collector.metricKeys()).containsExactly("cloud.instance.availability");
+    }
+
+    @Test
+    void runningStatusIsMatchedCaseInsensitively() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        CloudCatalogProvider catalog = mock(CloudCatalogProvider.class);
+        InstanceVO instance = cloudInstance(InstanceVendor.ALIYUN);
+        CloudInstanceDetailVO detail = new CloudInstanceDetailVO();
+        detail.setStatus("running");
+        when(registry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
+        when(catalog.getCloudInstance(7L, "cn-hangzhou", "rmq-cloud")).thenReturn(detail);
+
+        List<MetricSample> samples = new CloudRocketMqClusterMetricsCollector(registry).collect(instance);
+
+        assertThat(samples).singleElement().satisfies(sample -> {
+            assertThat(sample.value()).isEqualTo(1D);
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.AVAILABLE);
+            assertThat(sample.labels()).containsEntry("cloudStatus", "running");
+        });
+    }
+
+    @Test
+    void nullDetailMapsToUnavailableWithoutStatusLabel() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        CloudCatalogProvider catalog = mock(CloudCatalogProvider.class);
+        InstanceVO instance = cloudInstance(InstanceVendor.ALIYUN);
+        when(registry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
+        when(catalog.getCloudInstance(7L, "cn-hangzhou", "rmq-cloud")).thenReturn(null);
+
+        List<MetricSample> samples = new CloudRocketMqClusterMetricsCollector(registry).collect(instance);
+
+        assertThat(samples).singleElement().satisfies(sample -> {
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.UNAVAILABLE);
+            assertThat(sample.value()).isNull();
+            assertThat(sample.labels()).containsKey("cloudInstanceId");
+            assertThat(sample.labels()).doesNotContainKey("cloudStatus");
+        });
+    }
+
+    @Test
+    void catalogFailureMapsToUnavailableWithoutStatusLabel() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        CloudCatalogProvider catalog = mock(CloudCatalogProvider.class);
+        InstanceVO instance = cloudInstance(InstanceVendor.ALIYUN);
+        when(registry.catalogFor(InstanceVendor.ALIYUN)).thenReturn(catalog);
+        when(catalog.getCloudInstance(7L, "cn-hangzhou", "rmq-cloud"))
+                .thenThrow(new IllegalStateException("provider down"));
+
+        List<MetricSample> samples = new CloudRocketMqClusterMetricsCollector(registry).collect(instance);
+
+        assertThat(samples).singleElement().satisfies(sample -> {
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.UNAVAILABLE);
+            assertThat(sample.value()).isNull();
+            assertThat(sample.labels()).doesNotContainKey("cloudStatus");
+        });
+    }
+
     private static InstanceVO cloudInstance(InstanceVendor vendor) {
         return InstanceVO.builder().name("cloud-local").vendor(vendor).credentialId(7L)
                 .regionId("cn-hangzhou").cloudInstanceId("rmq-cloud").build();


### PR DESCRIPTION
### Motivation

The existing `CloudRocketMqClusterMetricsCollectorTest` covers the running and stopped states only. The `supports` gate, the case-insensitive running match, the null detail and the catalog-failure degradation were untested.

### Changes

- `collectSkipsUnsupportedInstances`: non-cloud vendors and instances without a credential yield no samples, and the collector advertises its metric key.
- `runningStatusIsMatchedCaseInsensitively`: a lower-case `running` status still reports an available sample.
- `nullDetailMapsToUnavailableWithoutStatusLabel`: a null provider detail degrades to unavailable with only the instance label.
- `catalogFailureMapsToUnavailableWithoutStatusLabel`: a provider exception degrades to unavailable without a status label.

### Verification

```
mvn -B test -Dtest=CloudRocketMqClusterMetricsCollectorTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```