### PR TITLE
[ISSUE-3841][test] Deepen CloudRocketMqBusinessMetricsCollectorTest with group failure, clamping and blank group skip

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/CloudRocketMqBusinessMetricsCollectorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/CloudRocketMqBusinessMetricsCollectorTest.java
@@ -67,4 +67,65 @@ class CloudRocketMqBusinessMetricsCollectorTest {
         assertThat(new CloudRocketMqBusinessMetricsCollector(mock(InstanceProviderRegistry.class)).collect(instance))
                 .isEmpty();
     }
+
+    @Test
+    void groupLevelFailureDegradesToUnavailableMetrics() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        InstanceProvider provider = mock(InstanceProvider.class);
+        InstanceVO instance = InstanceVO.builder().name("aliyun").vendor(InstanceVendor.ALIYUN).build();
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName("orders");
+        when(registry.byInstanceId("aliyun")).thenReturn(Optional.of(provider));
+        when(provider.listConsumerGroups("aliyun", null)).thenReturn(List.of(group));
+        when(provider.getGroupProgress("aliyun", "orders"))
+                .thenThrow(new IllegalStateException("lag api down"));
+
+        List<MetricSample> samples = new CloudRocketMqBusinessMetricsCollector(registry).collect(instance);
+
+        assertThat(samples).hasSize(3).allSatisfy(sample -> {
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.UNAVAILABLE);
+            assertThat(sample.value()).isNull();
+            assertThat(sample.labels()).containsEntry("consumerGroup", "orders");
+        });
+    }
+
+    @Test
+    void negativeLagsAreClampedToZeroBeforeAggregation() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        InstanceProvider provider = mock(InstanceProvider.class);
+        InstanceVO instance = InstanceVO.builder().name("aliyun").vendor(InstanceVendor.ALIYUN).build();
+        ConsumerGroupVO group = new ConsumerGroupVO();
+        group.setName("orders");
+        when(registry.byInstanceId("aliyun")).thenReturn(Optional.of(provider));
+        when(provider.listConsumerGroups("aliyun", null)).thenReturn(List.of(group));
+        when(provider.getGroupProgress("aliyun", "orders")).thenReturn(List.of(
+                QueueProgressVO.builder().topic("orders-topic").diffTotal(-5).build(),
+                QueueProgressVO.builder().topic("orders-topic").diffTotal(-7).build()));
+
+        List<MetricSample> samples = new CloudRocketMqBusinessMetricsCollector(registry).collect(instance);
+
+        assertThat(samples).filteredOn(sample -> sample.metricKey().equals("consumer.lag.total"))
+                .singleElement().extracting(MetricSample::value).isEqualTo(0D);
+        assertThat(samples).filteredOn(sample -> sample.metricKey().equals("consumer.lag.max_queue"))
+                .singleElement().extracting(MetricSample::value).isEqualTo(0D);
+        assertThat(samples).filteredOn(sample -> sample.metricKey().equals("topic.backlog.total"))
+                .singleElement().extracting(MetricSample::value).isEqualTo(0D);
+    }
+
+    @Test
+    void blankGroupNamesAreSkippedWithoutProgressCalls() {
+        InstanceProviderRegistry registry = mock(InstanceProviderRegistry.class);
+        InstanceProvider provider = mock(InstanceProvider.class);
+        InstanceVO instance = InstanceVO.builder().name("aliyun").vendor(InstanceVendor.ALIYUN).build();
+        ConsumerGroupVO blank = new ConsumerGroupVO();
+        blank.setName("   ");
+        when(registry.byInstanceId("aliyun")).thenReturn(Optional.of(provider));
+        when(provider.listConsumerGroups("aliyun", null)).thenReturn(List.of(blank));
+
+        List<MetricSample> samples = new CloudRocketMqBusinessMetricsCollector(registry).collect(instance);
+
+        assertThat(samples).isEmpty();
+        org.mockito.Mockito.verify(provider, org.mockito.Mockito.never())
+                .getGroupProgress(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `CloudRocketMqBusinessMetricsCollectorTest` covers the aggregate lag happy path and the Apache-instance skip. The group-level failure degradation, negative-lag clamping and blank group filtering were untested.

### Changes

- `groupLevelFailureDegradesToUnavailableMetrics`: a group progress failure yields three unavailable samples carrying the group label.
- `negativeLagsAreClampedToZeroBeforeAggregation`: negative diffs contribute zero to total, max-queue and per-topic backlog metrics.
- `blankGroupNamesAreSkippedWithoutProgressCalls`: whitespace-only group names are skipped without calling the provider.

### Verification

```
mvn -B test -Dtest=CloudRocketMqBusinessMetricsCollectorTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```