### PR TITLE
[ISSUE-3842][test] Deepen MybatisPlusAlertCollectionLeaseTest with acquire paths and duplicate-key loss

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusAlertCollectionLeaseTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/MybatisPlusAlertCollectionLeaseTest.java
@@ -53,4 +53,47 @@ class MybatisPlusAlertCollectionLeaseTest {
         assertThat(lease.renew()).isFalse();
         verify(mapper).renew(eq("native-alert-collection"), anyString(), any(), any());
     }
+
+    @Test
+    void tryAcquireSucceedsThroughTheMapperAcquirePath() {
+        AlertingProperties properties = new AlertingProperties();
+        properties.setCollectionLeaseDuration("PT30S");
+        RmqAlertCollectionLeaseMapper mapper = mock(RmqAlertCollectionLeaseMapper.class);
+        when(mapper.acquire(eq("native-alert-collection"), anyString(), any(), any())).thenReturn(1);
+
+        MybatisPlusAlertCollectionLease lease = new MybatisPlusAlertCollectionLease(properties, mapper);
+
+        assertThat(lease.tryAcquire()).isTrue();
+        org.mockito.Mockito.verify(mapper, org.mockito.Mockito.never())
+                .insert(any(org.apache.rocketmq.studio.persistence.entity.RmqAlertCollectionLease.class));
+    }
+
+    @Test
+    void tryAcquireFallsBackToInsertWhenAcquireMisses() {
+        AlertingProperties properties = new AlertingProperties();
+        properties.setCollectionLeaseDuration("PT30S");
+        RmqAlertCollectionLeaseMapper mapper = mock(RmqAlertCollectionLeaseMapper.class);
+        when(mapper.acquire(eq("native-alert-collection"), anyString(), any(), any())).thenReturn(0);
+        when(mapper.insert(any(org.apache.rocketmq.studio.persistence.entity.RmqAlertCollectionLease.class)))
+                .thenReturn(1);
+
+        MybatisPlusAlertCollectionLease lease = new MybatisPlusAlertCollectionLease(properties, mapper);
+
+        assertThat(lease.tryAcquire()).isTrue();
+        verify(mapper).insert(any(org.apache.rocketmq.studio.persistence.entity.RmqAlertCollectionLease.class));
+    }
+
+    @Test
+    void tryAcquireTreatsDuplicateInsertAsLeaseLoss() {
+        AlertingProperties properties = new AlertingProperties();
+        properties.setCollectionLeaseDuration("PT30S");
+        RmqAlertCollectionLeaseMapper mapper = mock(RmqAlertCollectionLeaseMapper.class);
+        when(mapper.acquire(eq("native-alert-collection"), anyString(), any(), any())).thenReturn(0);
+        when(mapper.insert(any(org.apache.rocketmq.studio.persistence.entity.RmqAlertCollectionLease.class)))
+                .thenThrow(new org.springframework.dao.DuplicateKeyException("duplicate lease"));
+
+        MybatisPlusAlertCollectionLease lease = new MybatisPlusAlertCollectionLease(properties, mapper);
+
+        assertThat(lease.tryAcquire()).isFalse();
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `MybatisPlusAlertCollectionLeaseTest` covers `renew` outcomes only. The three `tryAcquire` paths — direct acquire success, insert fallback and duplicate-key lease loss — were untested.

### Changes

- `tryAcquireSucceedsThroughTheMapperAcquirePath`: a successful conditional acquire returns true without any insert.
- `tryAcquireFallsBackToInsertWhenAcquireMisses`: when the conditional acquire misses, an insert of the lease record grants the lease.
- `tryAcquireTreatsDuplicateInsertAsLeaseLoss`: a duplicate-key insert failure is reported as lease loss rather than an error.

### Verification

```
mvn -B test -Dtest=MybatisPlusAlertCollectionLeaseTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```