### PR TITLE
[ISSUE-3845][test] Deepen ApacheRocketMqProxyMetricsCollectorTest with probe failure, proxy-less clusters and null rows

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqProxyMetricsCollectorTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/metrics/collectors/ApacheRocketMqProxyMetricsCollectorTest.java
@@ -96,4 +96,61 @@ class ApacheRocketMqProxyMetricsCollectorTest {
             assertThat(sample.labels()).containsEntry("proxyAddr", "unknown");
         });
     }
+
+    @Test
+    void probeFailureMarksTheProxyUnavailable() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ProxyHealthProbe probe = mock(ProxyHealthProbe.class);
+        InstanceVO instance = InstanceVO.builder().name("local").endpoint("localhost:9876").build();
+        when(clusterService.listClusters("local")).thenReturn(List.of(ClusterVO.builder().id("cluster-a")
+                .proxies(List.of(ProxyVO.builder().addr("proxy-a:8080").grpcPort(8081).build()))
+                .build()));
+        when(probe.probe("proxy-a", 8081, 2_000))
+                .thenThrow(new IllegalStateException("tcp connect failed"));
+
+        List<MetricSample> samples = new ApacheRocketMqProxyMetricsCollector(clusterService, probe).collect(instance);
+
+        assertThat(samples).singleElement().satisfies(sample -> {
+            assertThat(sample.clusterId()).isEqualTo("cluster-a");
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.UNAVAILABLE);
+            assertThat(sample.value()).isNull();
+            assertThat(sample.labels()).containsEntry("proxyAddr", "proxy-a:8080");
+        });
+    }
+
+    @Test
+    void clustersWithoutProxyListsAreSkipped() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ProxyHealthProbe probe = mock(ProxyHealthProbe.class);
+        InstanceVO instance = InstanceVO.builder().name("local").endpoint("localhost:9876").build();
+        when(clusterService.listClusters("local")).thenReturn(List.of(
+                ClusterVO.builder().id("cluster-a").proxies(null).build(),
+                ClusterVO.builder().id("cluster-b")
+                        .proxies(List.of(ProxyVO.builder().addr("proxy-b:8080").grpcPort(8081).build()))
+                        .build()));
+        when(probe.probe("proxy-b", 8081, 2_000)).thenReturn(ProxyHealthProbe.ProbeResult.reachable(1));
+
+        List<MetricSample> samples = new ApacheRocketMqProxyMetricsCollector(clusterService, probe).collect(instance);
+
+        assertThat(samples).hasSize(1);
+        assertThat(samples.get(0).labels()).containsEntry("proxyAddr", "proxy-b:8080");
+        assertThat(samples.get(0).clusterId()).isEqualTo("cluster-b");
+    }
+
+    @Test
+    void nullProxyRowsYieldUnavailableWithUnknownLabel() {
+        ClusterService clusterService = mock(ClusterService.class);
+        InstanceVO instance = InstanceVO.builder().name("local").endpoint("localhost:9876").build();
+        when(clusterService.listClusters("local")).thenReturn(List.of(ClusterVO.builder().name("cluster-a")
+                .proxies(java.util.Arrays.asList((ProxyVO) null)).build()));
+
+        List<MetricSample> samples = new ApacheRocketMqProxyMetricsCollector(clusterService,
+                mock(ProxyHealthProbe.class)).collect(instance);
+
+        assertThat(samples).singleElement().satisfies(sample -> {
+            assertThat(sample.clusterId()).isEqualTo("cluster-a");
+            assertThat(sample.availability()).isEqualTo(MetricAvailability.UNAVAILABLE);
+            assertThat(sample.labels()).containsEntry("proxyAddr", "unknown");
+        });
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `ApacheRocketMqProxyMetricsCollectorTest` covers healthy probes, malformed addresses and discovery failure. The per-proxy probe failure, proxy-less clusters and null proxy rows were untested.

### Changes

- `probeFailureMarksTheProxyUnavailable`: a probe exception degrades that proxy to unavailable while keeping its address label and cluster id.
- `clustersWithoutProxyListsAreSkipped`: clusters with a null proxy list contribute nothing while sibling clusters with proxies are still probed.
- `nullProxyRowsYieldUnavailableWithUnknownLabel`: a null proxy entry degrades to unavailable under the `unknown` address label with the cluster name as the cluster id.

### Verification

```
mvn -B test -Dtest=ApacheRocketMqProxyMetricsCollectorTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```