### PR TITLE
[ISSUE-3847][test] Deepen QoderAgentProviderTest with prompt-only command and engine contract

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/QoderAgentProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/QoderAgentProviderTest.java
@@ -49,4 +49,16 @@ class QoderAgentProviderTest {
         assertThat(provider.buildCommand(config, null, null))
                 .containsExactly("qodercli", "-p", "");
     }
+
+    @Test
+    void buildCommandWithoutModelKeepsPromptOnly() {
+        assertThat(provider.buildCommand(null, "hello", null))
+                .containsExactly("qodercli", "-p", "hello");
+    }
+
+    @Test
+    void advertisesTheQoderEngineAndNoChildEnvironment() {
+        assertThat(provider.engine()).isEqualTo("qoder");
+        assertThat(provider.childEnv(null)).isEmpty();
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `QoderAgentProviderTest` covers model selection in `buildCommand` only. The model-less prompt-only command and the provider's engine/child-environment contract were untested.

### Changes

- `buildCommandWithoutModelKeepsPromptOnly`: with no config and no override the command stays `qodercli -p <prompt>`.
- `advertisesTheQoderEngineAndNoChildEnvironment`: the provider registers as `qoder` and contributes no child environment variables.

### Verification

```
mvn -B test -Dtest=QoderAgentProviderTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```