### PR TITLE
[ISSUE-3849][test] Deepen LlmControllerTest with missing-body rejection and empty model list

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/LlmControllerTest.java
@@ -119,4 +119,22 @@ class LlmControllerTest {
                 .andExpect(jsonPath("$.data.data[0].id").value("gpt-4o"))
                 .andExpect(jsonPath("$.data.data[1].name").value("GPT-4"));
     }
+
+    @Test
+    void saveConfigWithoutBodyIsRejected() throws Exception {
+        mockMvc.perform(post("/api/llm/config")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400));
+    }
+
+    @Test
+    void listModelsEmptyReturnsEmptyData() throws Exception {
+        when(llmConfigService.listModels()).thenReturn(new LlmModelsResultVO(0, List.of()));
+
+        mockMvc.perform(get("/api/llm/models"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value(0))
+                .andExpect(jsonPath("$.data.data").isEmpty());
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `LlmControllerTest` covers the four happy paths of the config/models endpoints. The missing-body rejection of the save endpoint and the empty model list shape were untested.

### Changes

- `saveConfigWithoutBodyIsRejected`: a JSON request without a body is a 400 through the unreadable-body handler.
- `listModelsEmptyReturnsEmptyData`: an empty model catalog returns a successful result with an empty data array.

### Verification

```
mvn -B test -Dtest=LlmControllerTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```