### PR TITLE
[ISSUE-3850][test] Deepen DashboardControllerTest with verbatim blank instance forwarding

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/dashboard/DashboardControllerTest.java
@@ -163,4 +163,22 @@ class DashboardControllerTest {
 
         verify(dashboardService).getDashboard("instance-prod");
     }
+
+    @Test
+    void getDashboardShouldForwardBlankInstanceValuesVerbatim() throws Exception {
+        DashboardDataVO blankData = DashboardDataVO.builder()
+                .stats(DashboardStatsVO.builder().totalClusters(0).build())
+                .clusters(List.of())
+                .build();
+        when(dashboardService.getDashboard("   ")).thenReturn(blankData);
+        when(dashboardService.getDashboard("")).thenReturn(blankData);
+
+        mockMvc.perform(get("/api/dashboard").param("instanceId", "   "))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/dashboard").param("instanceId", ""))
+                .andExpect(status().isOk());
+
+        verify(dashboardService).getDashboard("   ");
+        verify(dashboardService).getDashboard("");
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `DashboardControllerTest` covers the data shapes, the null-count serialisation, the empty cluster list and the selected-instance forwarding, but the controller's passthrough of blank instance values (which the service layer normalises) was untested.

### Changes

- `getDashboardShouldForwardBlankInstanceValuesVerbatim`: whitespace-only and empty `instanceId` query values reach the dashboard service exactly as sent, confirming the controller performs no trimming or defaulting.

### Verification

```
mvn -B test -Dtest=DashboardControllerTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```