### PR TITLE
[ISSUE-3851][test] Deepen ClientServiceTest with null instance and namesrv guards

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/client/ClientServiceTest.java
@@ -93,4 +93,22 @@ class ClientServiceTest {
 
         verifyNoInteractions(clientProvider);
     }
+
+    @Test
+    void listConnectionsShouldRejectNullInstanceId() {
+        assertThatThrownBy(() -> clientService.listConnections(null, null, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("instanceId is required");
+
+        verifyNoInteractions(clientProvider);
+    }
+
+    @Test
+    void listConnectionsAtShouldRejectNullNamesrvAddr() {
+        assertThatThrownBy(() -> clientService.listConnectionsAt(null, null, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("namesrvAddr is required");
+
+        verifyNoInteractions(clientProvider);
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `ClientServiceTest` covers filter trimming, blank optional filters and blank required-parameter rejection. The null forms of the required parameters were untested.

### Changes

- `listConnectionsShouldRejectNullInstanceId`: a null instance id raises 400 `instanceId is required` without touching the provider.
- `listConnectionsAtShouldRejectNullNamesrvAddr`: a null namesrv address raises 400 `namesrvAddr is required` without touching the provider.

### Verification

```
mvn -B test -Dtest=ClientServiceTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```