### PR TITLE
[ISSUE-3853][test] Deepen LiteTopicControllerTest with optional filter and namespace absence

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/LiteTopicControllerTest.java
@@ -175,4 +175,29 @@ class LiteTopicControllerTest {
 
         verifyNoInteractions(liteTopicService);
     }
+
+    @Test
+    void listLiteTopicsShouldAllowMissingFilters() throws Exception {
+        when(liteTopicService.listLiteTopics(null, null)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/liteTopic/list"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data").isEmpty());
+
+        verify(liteTopicService).listLiteTopics(null, null);
+    }
+
+    @Test
+    void getQuotaShouldAllowMissingNamespace() throws Exception {
+        when(liteTopicService.getQuota(null)).thenReturn(LiteTopicQuotaVO.builder()
+                .currentTopicCount(0)
+                .build());
+
+        mockMvc.perform(get("/api/liteTopic/quota"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.currentTopicCount").value(0));
+
+        verify(liteTopicService).getQuota(null);
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `LiteTopicControllerTest` covers all five endpoints with their parameters present. The optional-parameter absence shapes — no pattern/namespace on the list endpoint and no namespace on the quota endpoint — were untested.

### Changes

- `listLiteTopicsShouldAllowMissingFilters`: without query params the list delegates with null filters and returns the empty result.
- `getQuotaShouldAllowMissingNamespace`: without a namespace the quota delegate receives null.

### Verification

```
mvn -B test -Dtest=LiteTopicControllerTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```