### PR TITLE
[ISSUE-3854][test] Deepen AiMessage tests with tool tag, stat cards, thinking and descriptions branches

### DIFF
--- a/web/src/pages/ai/__tests__/AiMessage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiMessage.test.tsx
@@ -16,10 +16,26 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AiMessage } from '../index';
 
 describe('AiMessage', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
   it('renders markdown content in AI responses', () => {
     render(
       <AiMessage
@@ -64,5 +80,84 @@ describe('AiMessage', () => {
     expect(screen.getByRole('heading', { name: '结论', level: 2 })).toBeInTheDocument();
     expect(screen.getByRole('listitem')).toHaveTextContent('第一项');
     expect(screen.getByText('mqadmin clusterList').closest('pre')).toBeInTheDocument();
+  });
+
+  it('renders a tool call tag for tool-backed responses', () => {
+    type AiMessageProps = Parameters<typeof AiMessage>[0];
+    render(
+      <AiMessage
+        msg={
+          {
+            id: 'ai-3',
+            role: 'ai',
+            toolCall: { label: 'rmq.cluster.list' },
+          } as AiMessageProps['msg']
+        }
+      />,
+    );
+
+    expect(screen.getByText('rmq.cluster.list')).toBeInTheDocument();
+  });
+
+  it('renders stat cards for numeric digests', () => {
+    type AiMessageProps = Parameters<typeof AiMessage>[0];
+    render(
+      <AiMessage
+        msg={
+          {
+            id: 'ai-4',
+            role: 'ai',
+            stats: [
+              { title: 'Broker count', value: 3, suffix: '', color: '#1677ff' },
+              { title: 'Topic count', value: 128, suffix: '', color: '#52c41a' },
+            ],
+          } as AiMessageProps['msg']
+        }
+      />,
+    );
+
+    expect(screen.getByText('Broker count')).toBeInTheDocument();
+    expect(screen.getByText('Topic count')).toBeInTheDocument();
+    expect(screen.getByText('128')).toBeInTheDocument();
+  });
+
+  it('renders the chain-of-thought details when thinking is present', () => {
+    type AiMessageProps = Parameters<typeof AiMessage>[0];
+    render(
+      <AiMessage
+        msg={
+          {
+            id: 'ai-5',
+            role: 'ai',
+            thinking: 'step one: evaluate the lag',
+          } as AiMessageProps['msg']
+        }
+      />,
+    );
+
+    expect(screen.getByText('思维链：Prompt 增强改写')).toBeInTheDocument();
+    expect(screen.getByText('step one: evaluate the lag')).toBeInTheDocument();
+  });
+
+  it('renders descriptions as a definition block', () => {
+    type AiMessageProps = Parameters<typeof AiMessage>[0];
+    render(
+      <AiMessage
+        msg={
+          {
+            id: 'ai-6',
+            role: 'ai',
+            descriptions: [
+              { label: 'Cluster', value: 'production' },
+              { label: 'Version', value: '5.2.0' },
+            ],
+          } as AiMessageProps['msg']
+        }
+      />,
+    );
+
+    expect(screen.getByText('Cluster')).toBeInTheDocument();
+    expect(screen.getByText('production')).toBeInTheDocument();
+    expect(screen.getByText('Version')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Motivation

The existing `AiMessage` tests cover markdown rendering and malformed-marker normalisation only. The structured response branches — the tool-call tag, stat cards, the chain-of-thought details and the descriptions block — were untested.

### Changes

- `renders a tool call tag for tool-backed responses`: the tool label appears for tool-backed messages.
- `renders stat cards for numeric digests`: stat titles and values render for numeric digests.
- `renders the chain-of-thought details when thinking is present`: the thinking toggle and its content render.
- `renders descriptions as a definition block`: label/value pairs render.

A `window.matchMedia` polyfill is installed before each render because the Ant Design grid/descriptions internals require it in jsdom.

### Verification

```
./node_modules/.bin/vitest run src/pages/ai/__tests__/AiMessage.test.tsx   # 6 passed
./node_modules/.bin/tsc --noEmit                                          # clean
./node_modules/.bin/eslint src/pages/ai/__tests__/AiMessage.test.tsx       # clean
```