### PR TITLE
[ISSUE-3855][test] Deepen MybatisPlusAlertSilenceRepositoryTest with delete result and label json restore

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertSilenceRepositoryTest.java
@@ -156,4 +156,34 @@ class MybatisPlusAlertSilenceRepositoryTest {
         assertThat(restored.get(1).getRecurrence()).isEqualTo(AlertSilenceRecurrence.ONCE);
         assertThat(restored.get(1).getRecurrenceDays()).isEmpty();
     }
+
+    @Test
+    void deleteByIdShouldDelegateAndReportAffectedRows() {
+        MybatisPlusAlertSilenceRepository repository = new MybatisPlusAlertSilenceRepository(
+                mapper, new ObjectMapper());
+        when(mapper.deleteById(9L)).thenReturn(1);
+        when(mapper.deleteById(10L)).thenReturn(0);
+
+        assertThat(repository.deleteById(9L)).isTrue();
+        assertThat(repository.deleteById(10L)).isFalse();
+        verify(mapper, org.mockito.Mockito.times(2))
+                .deleteById(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void findAllShouldRestoreLabelJsonAsAMap() {
+        MybatisPlusAlertSilenceRepository repository = new MybatisPlusAlertSilenceRepository(
+                mapper, new ObjectMapper());
+        RmqAlertSilence entity = new RmqAlertSilence();
+        entity.setId(5L);
+        entity.setLabelsJson("{\"broker\":\"broker-a\",\"env\":\"prod\"}");
+        when(mapper.selectList(any())).thenReturn(List.of(entity));
+
+        List<AlertSilenceVO> restored = repository.findAll();
+
+        assertThat(restored).singleElement().satisfies(silence -> {
+            assertThat(silence.getLabels()).containsEntry("broker", "broker-a");
+            assertThat(silence.getLabels()).containsEntry("env", "prod");
+        });
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `MybatisPlusAlertSilenceRepositoryTest` covers pagination, active-candidate SQL, recurring-schedule persistence and restore defaults. The `deleteById` outcome mapping and the label-JSON restore were untested.

### Changes

- `deleteByIdShouldDelegateAndReportAffectedRows`: a one-row delete returns true while a zero-row delete returns false, both through the mapper.
- `findAllShouldRestoreLabelJsonAsAMap`: the persisted label JSON is decoded back into a label map on read.

### Verification

```
mvn -B test -Dtest=MybatisPlusAlertSilenceRepositoryTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```