### PR TITLE
[ISSUE-3856][test] Deepen MybatisPlusAlertStateRepositoryTest with rule deletion and null fired-at ack

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepositoryTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/MybatisPlusAlertStateRepositoryTest.java
@@ -123,6 +123,28 @@ class MybatisPlusAlertStateRepositoryTest {
         verify(alertMapper, never()).selectOne(any());
     }
 
+    @Test
+    void deleteByRuleIdShouldDeleteMatchingStatesAndIgnoreNull() {
+        RmqAlertStateMapper mapper = mock(RmqAlertStateMapper.class);
+        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper,
+                mock(RmqSystemAlertMapper.class));
+
+        repository.deleteByRuleId(4L);
+        repository.deleteByRuleId(null);
+
+        verify(mapper, times(1)).delete(any());
+    }
+
+    @Test
+    void acknowledgeWithNullFiredAtIsIgnored() {
+        RmqAlertStateMapper mapper = mock(RmqAlertStateMapper.class);
+        MybatisPlusAlertStateRepository repository = new MybatisPlusAlertStateRepository(mapper,
+                mock(RmqSystemAlertMapper.class));
+
+        assertThat(repository.acknowledge(new AlertStateKey(4L, "fingerprint"), null)).isFalse();
+        verify(mapper, never()).acknowledgeFiring(any(), any(), any(), any());
+    }
+
     private static RmqAlertState activeState(Long ruleId, String fingerprint, AlertStateStatus status) {
         RmqAlertState state = new RmqAlertState();
         state.setRuleId(ruleId);


### PR DESCRIPTION
### Motivation

The existing `MybatisPlusAlertStateRepositoryTest` covers revision-guarded saves, conditional acknowledges, and active-state discovery. The `deleteByRuleId` null guard and the null-`firedAt` acknowledge path were untested.

### Changes

- `deleteByRuleIdShouldDeleteMatchingStatesAndIgnoreNull`: a rule deletion issues one mapper delete while a null rule id is ignored.
- `acknowledgeWithNullFiredAtIsIgnored`: a missing firing timestamp short-circuits to false without a conditional update.

### Verification

```
mvn -B test -Dtest=MybatisPlusAlertStateRepositoryTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```