### PR TITLE
[ISSUE-3858][test] Deepen AboutTab tests with metadata rows and community links

### DIFF
--- a/web/src/pages/settings/__tests__/AboutTab.test.tsx
+++ b/web/src/pages/settings/__tests__/AboutTab.test.tsx
@@ -48,4 +48,31 @@ describe('AboutTab', () => {
     ).toBeInTheDocument();
     expect(screen.queryByText('2024-01-15 14:30:00')).not.toBeInTheDocument();
   });
+
+  it('renders the static project metadata rows', () => {
+    render(<AboutTab />);
+
+    expect(screen.getByText('0.1.0')).toBeInTheDocument();
+    expect(screen.getByText('4.x / 5.x')).toBeInTheDocument();
+    expect(screen.getByText('React 18 + Ant Design 5')).toBeInTheDocument();
+    expect(screen.getByText('Spring Boot 3 + RocketMQ MCP Server')).toBeInTheDocument();
+    expect(screen.getByText('Apache 2.0')).toBeInTheDocument();
+  });
+
+  it('renders the community links with their destinations', () => {
+    render(<AboutTab />);
+
+    expect(screen.getByRole('link', { name: /GitHub/ })).toHaveAttribute(
+      'href',
+      'https://github.com/apache/rocketmq',
+    );
+    expect(screen.getByRole('link', { name: /文档中心/ })).toHaveAttribute(
+      'href',
+      'https://rocketmq.apache.org/docs/',
+    );
+    expect(screen.getByRole('link', { name: /RocketMQ 社区/ })).toHaveAttribute(
+      'href',
+      'https://rocketmq.apache.org/',
+    );
+  });
 });


### PR DESCRIPTION
### Motivation

The existing `AboutTab` test only asserts the injected build metadata and copyright. The static metadata rows (version, supported RocketMQ releases, frameworks, license) and the community link destinations were untested.

### Changes

- `renders the static project metadata rows`: version `0.1.0`, `4.x / 5.x` support, the frontend/backend framework rows and `Apache 2.0` are visible.
- `renders the community links with their destinations`: the GitHub, documentation and community links point at their canonical URLs.

### Verification

```
./node_modules/.bin/vitest run src/pages/settings/__tests__/AboutTab.test.tsx   # 3 passed
./node_modules/.bin/tsc --noEmit                                              # clean
./node_modules/.bin/eslint src/pages/settings/__tests__/AboutTab.test.tsx       # clean
```