### PR TITLE
[ISSUE-3860][test] Deepen SettingsPage tests with datasource tab routing and unknown-tab fallback

### DIFF
--- a/web/src/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/web/src/pages/settings/__tests__/SettingsPage.test.tsx
@@ -91,4 +91,22 @@ describe('SettingsPage', () => {
       );
     });
   });
+
+  it('switches to the data source tab and updates the query', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderPage('/settings?tab=general');
+
+    await user.click(screen.getByRole('tab', { name: '数据源管理' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('location-search')).toHaveTextContent('?tab=datasource');
+    });
+  });
+
+  it('falls back to the general tab for an unknown tab parameter', async () => {
+    renderPage('/settings?tab=unknown');
+
+    expect(await screen.findByText('general settings tab')).toBeInTheDocument();
+    expect(screen.getByLabelText('location-search')).toHaveTextContent('?tab=unknown');
+  });
 });


### PR DESCRIPTION
### Motivation

The existing `SettingsPage` test covers tab switching with unrelated query preservation. Two routing shapes were untested: the data-source tab key mapping and the fallback for an unknown `tab` parameter.

### Changes

- `switches to the data source tab and updates the query`: clicking the data source tab rewrites the query to `tab=datasource`.
- `falls back to the general tab for an unknown tab parameter`: an unknown `tab` value renders the general settings content while leaving the query untouched.

### Verification

```
./node_modules/.bin/vitest run src/pages/settings/__tests__/SettingsPage.test.tsx   # 3 passed
./node_modules/.bin/tsc --noEmit                                                  # clean
./node_modules/.bin/eslint src/pages/settings/__tests__/SettingsPage.test.tsx       # clean
```