### PR TITLE
[ISSUE-3861][test] Deepen NotificationDeliveriesPage tests with current-page bulk retry

### DIFF
--- a/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
+++ b/web/src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx
@@ -10,7 +10,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LangProvider } from '../../../i18n/LangContext';
 import { listInstances } from '../../../services/instanceService';
-import { listAlertDeliveriesPage, retryAlertDelivery } from '../../../services/opsService';
+import { listAlertDeliveriesPage, retryAlertDeliveries, retryAlertDelivery } from '../../../services/opsService';
 import NotificationDeliveriesPage from '../notificationDeliveries';
 
 vi.mock('../../../services/instanceService', () => ({
@@ -168,5 +168,22 @@ describe('NotificationDeliveriesPage', () => {
     expect(listAlertDeliveriesPage).toHaveBeenLastCalledWith(
       expect.objectContaining({ status: 'DELIVERED' }),
     );
+  });
+
+  it('retries all failed records of the current page', async () => {
+    const user = userEvent.setup();
+    vi.mocked(retryAlertDeliveries).mockResolvedValue({ success: 1, failed: 0 });
+    render(
+      <App>
+        <LangProvider>
+          <NotificationDeliveriesPage />
+        </LangProvider>
+      </App>,
+    );
+
+    await screen.findByText('Broker disk usage');
+    await user.click(screen.getByRole('button', { name: '重试当前页失败记录' }));
+
+    await waitFor(() => expect(retryAlertDeliveries).toHaveBeenCalledWith([7]));
   });
 });


### PR DESCRIPTION
### Motivation

The existing `NotificationDeliveriesPage` tests cover single-record retry, click deduplication and filter refresh after a retry. The bulk action that retries every failed record of the current page was untested.

### Changes

- `retries all failed records of the current page`: clicking the bulk retry button collects the current page's failed ids and calls `retryAlertDeliveries([7])`.

### Verification

```
./node_modules/.bin/vitest run src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx   # 4 passed
./node_modules/.bin/tsc --noEmit                                                              # clean
./node_modules/.bin/eslint src/pages/ops/__tests__/NotificationDeliveriesPage.test.tsx          # clean
```