### PR TITLE
[ISSUE-3862][test] Deepen CloudCredentialSchemaMigrationTest with unbound local instances

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialSchemaMigrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialSchemaMigrationTest.java
@@ -61,6 +61,26 @@ class CloudCredentialSchemaMigrationTest {
                 .hasMessageContaining("1");
     }
 
+    @Test
+    void migrationShouldKeepInstancesWithoutCredentialReferencesTest() throws Exception {
+        JdbcDataSource dataSource = dataSource("unbound");
+        try (Connection connection = dataSource.getConnection(); Statement statement = connection.createStatement()) {
+            createLegacyTables(statement);
+            statement.executeUpdate("INSERT INTO rmq_instance (id, name, type, endpoint)"
+                    + " VALUES (10, 'local-a', 'DIRECT', 'endpoint')");
+            statement.executeUpdate("INSERT INTO rmq_cloud_credential (id, name, vendor, access_key, secret_key)"
+                    + " VALUES (1, 'aliyun', 'ALIYUN', 'ak', 'sk')");
+        }
+
+        CloudCredentialSchemaMigration migration = new CloudCredentialSchemaMigration(dataSource);
+        migration.run(new DefaultApplicationArguments());
+        migration.run(new DefaultApplicationArguments());
+
+        try (Connection connection = dataSource.getConnection()) {
+            assertThat(hasImportedKey(connection)).isTrue();
+        }
+    }
+
     private static JdbcDataSource dataSource(String name) {
         JdbcDataSource dataSource = new JdbcDataSource();
         dataSource.setURL("jdbc:h2:mem:cloud-credential-schema-" + name


### PR DESCRIPTION
### Motivation

The existing `CloudCredentialSchemaMigrationTest` covers the foreign-key addition on a clean database and the rejection of orphaned references. Local (non-cloud) instances that carry no credential reference were untested through the same migration.

### Changes

- `migrationShouldKeepInstancesWithoutCredentialReferencesTest`: a legacy database mixing an unbound local instance with a real cloud credential migrates idempotently and gains the foreign key without data loss.

### Verification

```
mvn -B test -Dtest=CloudCredentialSchemaMigrationTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```