### PR TITLE
[ISSUE-3865][test] Deepen chatDraft tests with engine allowlist and conversation flags

### DIFF
--- a/web/src/pages/ai/chatDraft.test.ts
+++ b/web/src/pages/ai/chatDraft.test.ts
@@ -48,6 +48,43 @@ describe('AI chat draft navigation state', () => {
     });
   });
 
+  it('preserves supported engines and drops unsupported ones', () => {
+    expect(getChatDraft({ prompt: 'hi', engine: 'qoder' })).toEqual({
+      prompt: 'hi',
+      engine: 'qoder',
+    });
+    expect(getChatDraft({ prompt: 'hi', engine: 'claude-code' })).toEqual({
+      prompt: 'hi',
+      engine: 'claude-code',
+    });
+    expect(getChatDraft({ prompt: 'hi', engine: 'mistral' })).toEqual({ prompt: 'hi' });
+    expect(getChatDraft({ prompt: 'hi', engine: 7 })).toEqual({ prompt: 'hi' });
+  });
+
+  it('preserves enhance, new-conversation and conversation-id flags', () => {
+    expect(
+      getChatDraft({
+        prompt: 'hi',
+        enhance: true,
+        newConversation: true,
+        conversationId: 'c-1',
+      }),
+    ).toEqual({
+      prompt: 'hi',
+      enhance: true,
+      newConversation: true,
+      conversationId: 'c-1',
+    });
+    expect(
+      getChatDraft({
+        prompt: 'hi',
+        enhance: false,
+        newConversation: false,
+        conversationId: '  ',
+      }),
+    ).toEqual({ prompt: 'hi' });
+  });
+
   it('only opens history for the explicit history route intent', () => {
     expect(shouldOpenChatHistory({ historyIntent: 'open' })).toBe(true);
     expect(shouldOpenChatHistory({ historyIntent: 'closed' })).toBe(false);


### PR DESCRIPTION
### Motivation

The existing `chatDraft` tests cover prompt/model normalisation, mode whitelisting and history intent. The engine allowlist and the boolean/conversation-id flags were untested.

### Changes

- `preserves supported engines and drops unsupported ones`: `qoder`/`claude-code` survive while unknown engines and non-string values are dropped.
- `preserves enhance, new-conversation and conversation-id flags`: truthy flags and a conversation id are kept, while falsy flags and a blank conversation id are omitted.

### Verification

```
./node_modules/.bin/vitest run src/pages/ai/chatDraft.test.ts   # 7 passed
./node_modules/.bin/tsc --noEmit                                # clean
./node_modules/.bin/eslint src/pages/ai/chatDraft.test.ts        # clean
```