### PR TITLE
[ISSUE-3867][test] Deepen QueryHistoryServiceIntegrationTest with record id round-trip

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceIntegrationTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceIntegrationTest.java
@@ -72,4 +72,25 @@ class QueryHistoryServiceIntegrationTest {
                     .eq("queried_by", longUsername));
         }
     }
+
+    @Test
+    void queryHistoryRoundTripsTheStoredRecordIdTest() {
+        String marker = "roundtrip-" + System.nanoTime();
+        try {
+            AuthenticatedUserContext.setUser("tester", true);
+            queryHistoryService.recordMessageQuery("qh-cluster-2", "TOPIC", marker,
+                    null, null, null, null, null, 0, null);
+
+            PageResult<MessageQueryHistoryVO> history =
+                    queryHistoryService.listMessageQueries("qh-cluster-2", null, null, 1, 20);
+            assertThat(history.getItems()).anySatisfy(item -> {
+                assertThat(item.getTopic()).isEqualTo(marker);
+                assertThat(item.getResultCount()).isZero();
+                assertThat(queryHistoryService.getMessageQueryResults(item.getId())).isEmpty();
+            });
+        } finally {
+            AuthenticatedUserContext.clear();
+            messageQueryMapper.delete(new QueryWrapper<RmqMessageQuery>().eq("topic", marker));
+        }
+    }
 }


### PR DESCRIPTION
### Motivation

The existing `QueryHistoryServiceIntegrationTest` proves full-length usernames survive persistence. The end-to-end record round-trip — record, list, and load the stored id's result snapshot — was untested against the real database.

### Changes

- `queryHistoryRoundTripsTheStoredRecordIdTest`: a recorded message query is listed back by cluster, and the stored record's id resolves to an empty result snapshot without errors, with the row cleaned up afterwards.

### Verification

```
mvn -B test -Dtest=QueryHistoryServiceIntegrationTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```