### PR TITLE
[ISSUE-3868][test] Deepen languagePreference tests with zh round-trip and storage failure fallback

### DIFF
--- a/web/src/i18n/languagePreference.test.ts
+++ b/web/src/i18n/languagePreference.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getInitialLanguage, LANGUAGE_STORAGE_KEY, persistLanguage } from './languagePreference';
 
 describe('language preference', () => {
@@ -34,5 +34,20 @@ describe('language preference', () => {
 
     expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe('en');
     expect(getInitialLanguage()).toBe('en');
+  });
+
+  it('round-trips the Chinese preference', () => {
+    persistLanguage('zh');
+
+    expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe('zh');
+    expect(getInitialLanguage()).toBe('zh');
+  });
+
+  it('falls back to Chinese when storage access throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError');
+    });
+
+    expect(getInitialLanguage()).toBe('zh');
   });
 });


### PR DESCRIPTION
### Motivation

The existing `languagePreference` tests cover the default/unsupported fallback and the English round-trip. The Chinese round-trip and the storage-throw fallback were untested.

### Changes

- `round-trips the Chinese preference`: persisting `zh` survives a read-back through the same storage key.
- `falls back to Chinese when storage access throws`: an unavailable `localStorage.getItem` (security error) degrades to the Chinese default instead of crashing.

### Verification

```
./node_modules/.bin/vitest run src/i18n/languagePreference.test.ts   # 4 passed
./node_modules/.bin/tsc --noEmit                                    # clean
./node_modules/.bin/eslint src/i18n/languagePreference.test.ts       # clean
```