### PR TITLE
[ISSUE-3869][test] Deepen config tests with API base url env override

### DIFF
--- a/web/src/config.test.ts
+++ b/web/src/config.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { API_BASE_URL } from './config';
 
 describe('config API base url', () => {
@@ -31,5 +31,13 @@ describe('config API base url', () => {
 
   it('strips a single trailing slash', () => {
     expect(API_BASE_URL.endsWith('/')).toBe(false);
+  });
+
+  it('honors a configured API base url without a trailing slash', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://metrics.example.test/');
+    vi.resetModules();
+    const fresh = await import('./config');
+    expect(fresh.API_BASE_URL).toBe('https://metrics.example.test');
+    vi.unstubAllEnvs();
   });
 });


### PR DESCRIPTION
### Motivation

The existing `config.test.ts` covers the default `/api` fallback and trailing-slash stripping, but never exercised the `VITE_API_BASE_URL` env override that the module reads at build time.

### Changes

- `honors a configured API base url without a trailing slash`: stubbing `VITE_API_BASE_URL` and reloading the module yields the absolute base url with the trailing slash removed.

### Verification

```
./node_modules/.bin/vitest run src/config.test.ts   # 4 passed
./node_modules/.bin/tsc --noEmit                    # clean
./node_modules/.bin/eslint src/config.test.ts         # clean
```