### PR TITLE
[ISSUE-3870][test] Deepen grafanaService tests with real-mode single dashboard delegation

### DIFF
--- a/web/src/services/grafanaService.test.ts
+++ b/web/src/services/grafanaService.test.ts
@@ -89,4 +89,24 @@ describe('grafanaService', () => {
     expect(result.filename).toBe('rocketmq-grafana-dashboards.zip');
     expect(result.blob.type).toBe('application/zip');
   });
+
+  it('delegates single dashboard reads and exports to the api in real mode', async () => {
+    isMockModeMock.isMockMode = () => false;
+    const getSpy = vi
+      .spyOn(grafanaApi, 'getGrafanaDashboard')
+      .mockResolvedValue({ uid: 'rocketmq-overview', title: 'Overview' });
+    const exportSpy = vi
+      .spyOn(grafanaApi, 'exportGrafanaDashboard')
+      .mockResolvedValue(new Blob(['model'], { type: 'application/json' }));
+
+    await expect(getGrafanaDashboard('rocketmq-overview')).resolves.toEqual({
+      uid: 'rocketmq-overview',
+      title: 'Overview',
+    });
+    const blob = await exportGrafanaDashboard('rocketmq-overview');
+
+    expect(getSpy).toHaveBeenCalledWith('rocketmq-overview');
+    expect(exportSpy).toHaveBeenCalledWith('rocketmq-overview');
+    expect(blob).toBeInstanceOf(Blob);
+  });
 });


### PR DESCRIPTION
### Motivation

The existing `grafanaService` tests cover the mock catalog/export paths and the real-mode list/bulk-export delegation. The real-mode single-dashboard read and export delegation were untested.

### Changes

- `delegates single dashboard reads and exports to the api in real mode`: with mock mode off, `getGrafanaDashboard` and `exportGrafanaDashboard` forward the uid to the metrics API and return the API payload/blob.

### Verification

```
./node_modules/.bin/vitest run src/services/grafanaService.test.ts   # 9 passed
./node_modules/.bin/tsc --noEmit                                     # clean
./node_modules/.bin/eslint src/services/grafanaService.test.ts        # clean
```