### PR TITLE
test: expand zoned time conversion coverage

### DIFF
--- a/web/src/utils/timeZone.test.ts
+++ b/web/src/utils/timeZone.test.ts
@@ -56,4 +56,38 @@ describe('zonedLocalDateTimeToUtc', () => {
   it('rejects unknown IANA time zones', () => {
     expect(() => zonedLocalDateTimeToUtc('2026-09-07T09:00', 'Mars/Olympus')).toThrow();
   });
+
+  it('converts a southern-hemisphere summer wall clock with DST active', () => {
+    expect(zonedLocalDateTimeToUtc('2026-01-15T09:30', 'Australia/Sydney')).toBe(
+      '2026-01-14T22:30:00.000Z',
+    );
+  });
+
+  it('converts a southern-hemisphere winter wall clock with standard time', () => {
+    expect(zonedLocalDateTimeToUtc('2026-06-15T09:30', 'Australia/Sydney')).toBe(
+      '2026-06-14T23:30:00.000Z',
+    );
+  });
+
+  it('honors a half-hour offset like Asia/Kolkata', () => {
+    expect(zonedLocalDateTimeToUtc('2026-09-07T09:00', 'Asia/Kolkata')).toBe(
+      '2026-09-07T03:30:00.000Z',
+    );
+  });
+
+  it('uses standard time before the spring transition', () => {
+    expect(zonedLocalDateTimeToUtc('2026-03-08T01:30', 'America/New_York')).toBe(
+      '2026-03-08T06:30:00.000Z',
+    );
+  });
+
+  it('resolves an ambiguous fall-back wall clock to the pre-transition instant', () => {
+    expect(zonedLocalDateTimeToUtc('2026-11-01T01:30', 'America/New_York')).toBe(
+      '2026-11-01T05:30:00.000Z',
+    );
+  });
+
+  it('converts a UTC midnight boundary without a date shift', () => {
+    expect(zonedLocalDateTimeToUtc('2026-09-07T00:00', 'UTC')).toBe('2026-09-07T00:00:00.000Z');
+  });
 });


### PR DESCRIPTION
### Motivation

The `zonedLocalDateTimeToUtc` tests covered northern-hemisphere DST but left southern-hemisphere seasons, fractional-hour offsets, and ambiguous transitions untested. This PR grows the suite from 7 to 13 cases.

### Changes

- Southern-hemisphere DST: `Australia/Sydney` summer resolves with the active +11:00 offset, winter with the +10:00 standard offset.
- Fractional-hour offset: `Asia/Kolkata` converts across its +05:30 boundary.
- Pre-transition wall clock in `America/New_York` keeps standard time before the spring gap.
- Ambiguous fall-back wall clock (`2026-11-01T01:30`) resolves deterministically to the pre-transition instant.
- A UTC midnight boundary converts without a date shift.

### Verification

- `vitest run src/utils/timeZone.test.ts`: 13/13 passed
- `tsc --noEmit`: clean
- `eslint src/utils/timeZone.test.ts`: clean