### PR TITLE
test: expand trace topic preference storage coverage

### DIFF
--- a/web/src/utils/messageTraceTopicStorage.test.ts
+++ b/web/src/utils/messageTraceTopicStorage.test.ts
@@ -25,6 +25,7 @@ describe('message trace topic storage', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('stores normalized topics independently for each instance', () => {
@@ -54,5 +55,55 @@ describe('message trace topic storage', () => {
 
     expect(() => writeMessageTraceTopic('instance-a', 'CUSTOM_TRACE')).not.toThrow();
     expect(readMessageTraceTopic('instance-a')).toBe('');
+  });
+
+  it('treats a numeric instance id the same as its string form', () => {
+    writeMessageTraceTopic(42, '  NUMERIC_TRACE  ');
+
+    expect(readMessageTraceTopic(42)).toBe('NUMERIC_TRACE');
+    expect(readMessageTraceTopic('42')).toBe('NUMERIC_TRACE');
+    expect(readMessageTraceTopic(' 42 ')).toBe('NUMERIC_TRACE');
+  });
+
+  it('ignores an undefined instance id instead of storing a global preference', () => {
+    expect(readMessageTraceTopic(undefined)).toBe('');
+    expect(() => writeMessageTraceTopic(undefined, 'GLOBAL_TRACE')).not.toThrow();
+    expect(readMessageTraceTopic(undefined)).toBe('');
+    expect(readMessageTraceTopic('instance-a')).toBe('');
+  });
+
+  it('trims a padded value already present in storage on read', () => {
+    localStorage.setItem('rocketmq-studio-message-trace-topic:raw-instance', '  PADDED_TRACE  ');
+
+    expect(readMessageTraceTopic('raw-instance')).toBe('PADDED_TRACE');
+  });
+
+  it('encodes instance ids that contain URL-sensitive characters', () => {
+    writeMessageTraceTopic('instance with spaces', 'SPACE_TRACE');
+    writeMessageTraceTopic('a/b', 'SLASH_TRACE');
+    writeMessageTraceTopic('a?b=1', 'QUERY_TRACE');
+
+    expect(readMessageTraceTopic('instance with spaces')).toBe('SPACE_TRACE');
+    expect(readMessageTraceTopic('a/b')).toBe('SLASH_TRACE');
+    expect(readMessageTraceTopic('a?b=1')).toBe('QUERY_TRACE');
+    expect(localStorage.getItem('rocketmq-studio-message-trace-topic:instance%20with%20spaces')).toBe(
+      'SPACE_TRACE',
+    );
+  });
+
+  it('tolerates a failing remove when a blank topic clears the preference', () => {
+    writeMessageTraceTopic('instance-a', 'CUSTOM_TRACE');
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new DOMException('storage denied', 'SecurityError');
+    });
+
+    expect(() => writeMessageTraceTopic('instance-a', '   ')).not.toThrow();
+  });
+
+  it('falls back to the provider default when the storage global is unavailable', () => {
+    vi.stubGlobal('localStorage', undefined);
+
+    expect(readMessageTraceTopic('instance-a')).toBe('');
+    expect(() => writeMessageTraceTopic('instance-a', 'CUSTOM_TRACE')).not.toThrow();
   });
 });


### PR DESCRIPTION
### Motivation

The message trace topic preference helpers only tested per-instance normalization, blank-topic removal, and a blanket storage-denied case. This PR grows the suite from 3 to 9 cases.

### Changes

- A numeric instance id shares its preference with the equivalent string id, and padded string ids resolve to the same key.
- An `undefined` instance id never persists a global preference; reads stay empty.
- A padded value already sitting in storage is trimmed on read.
- Instance ids containing spaces, slashes, or query characters are URL-encoded, so keys never collide.
- A failing `removeItem` does not throw when a blank topic clears the preference.
- When the `localStorage` global is unavailable, reads fall back to the provider default and writes are silent no-ops.

### Verification

- `vitest run src/utils/messageTraceTopicStorage.test.ts`: 9/9 passed
- `tsc --noEmit`: clean
- `eslint src/utils/messageTraceTopicStorage.test.ts`: clean