### PR TITLE
test: expand consumer lag helper coverage

### DIFF
--- a/web/src/utils/consumerLag.test.ts
+++ b/web/src/utils/consumerLag.test.ts
@@ -36,10 +36,41 @@ describe('consumer lag helpers', () => {
     expect(formatLag(undefined, 'unavailable')).toBe('unavailable');
   });
 
+  it('uses the sentinel string as the default unavailable label', () => {
+    expect(formatLag(UNKNOWN_LAG)).toBe('-1');
+    expect(formatLag(null)).toBe('-1');
+    expect(formatLag(undefined)).toBe('-1');
+  });
+
+  it('reports negative lags with the unavailable label', () => {
+    expect(isLagAvailable(-5)).toBe(false);
+    expect(formatLag(-5, 'N/A')).toBe('N/A');
+    expect(formatLag(Number.NEGATIVE_INFINITY, 'N/A')).toBe('N/A');
+  });
+
+  it('keeps the numeric rendering consistent with toLocaleString', () => {
+    expect(formatLag(0)).toBe('0');
+    expect(formatLag(1234567)).toBe((1234567).toLocaleString());
+    expect(formatLag(1_000_000_000)).toBe((1_000_000_000).toLocaleString());
+  });
+
+  it('treats non-finite lags as unavailable everywhere', () => {
+    expect(isLagAvailable(Number.POSITIVE_INFINITY)).toBe(false);
+    expect(isLagAvailable(Number.NaN)).toBe(false);
+    expect(formatLag(Number.POSITIVE_INFINITY, 'N/A')).toBe('N/A');
+    expect(lagSortValue(Number.POSITIVE_INFINITY)).toBe(Number.MAX_SAFE_INTEGER);
+    expect(lagSortValue(Number.NaN)).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
   it('sorts unknown lags after every known lag', () => {
     expect(lagSortValue(0)).toBe(0);
     expect(lagSortValue(999999999)).toBe(999999999);
     expect(lagSortValue(UNKNOWN_LAG)).toBe(Number.MAX_SAFE_INTEGER);
     expect(lagSortValue(null)).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('keeps zero available as the smallest possible lag', () => {
+    expect(lagSortValue(0)).toBeLessThan(lagSortValue(1));
+    expect(formatLag(0)).toBe('0');
   });
 });


### PR DESCRIPTION
### Motivation

The consumer lag helpers had three tests covering the headline behaviors but left the default unavailable label, negative and non-finite lags, and locale-consistent numeric rendering unasserted. This PR grows the suite from 3 to 8 cases.

### Changes

- `formatLag` without an explicit label falls back to the `-1` sentinel string for `UNKNOWN_LAG`, `null`, and `undefined`.
- Negative lags (including negative infinity) are unavailable and render the provided label.
- Numeric rendering stays consistent with `toLocaleString` for large values.
- Positive infinity and `NaN` are unavailable across `isLagAvailable`, `formatLag`, and `lagSortValue`.
- Zero remains the smallest available lag, sorting before any positive value.

### Verification

- `vitest run src/utils/consumerLag.test.ts`: 8/8 passed
- `tsc --noEmit`: clean
- `eslint src/utils/consumerLag.test.ts`: clean