### PR TITLE
test: expand table scroll width coverage

### DIFF
--- a/web/src/utils/table.test.ts
+++ b/web/src/utils/table.test.ts
@@ -45,4 +45,38 @@ describe('tableScrollX', () => {
   it('tolerates an undefined column list', () => {
     expect(tableScrollX(undefined)).toBe(0);
   });
+
+  it('recurses into nested child groups', () => {
+    expect(
+      tableScrollX([
+        { children: [{ width: 100 }, { children: [{ width: 50 }, { width: 30 }] }] },
+      ]),
+    ).toBe(180);
+  });
+
+  it('applies the default share to child groups whose leaves are unsized', () => {
+    expect(tableScrollX([{ children: [{}, {}] }])).toBe(240);
+  });
+
+  it('parses decimal pixel widths and rejects non-pixel strings', () => {
+    expect(tableScrollX([{ width: '80.5px' }])).toBe(80.5);
+    expect(tableScrollX([{ width: '0px' }])).toBe(0);
+    expect(tableScrollX([{ width: 'abcpx' }])).toBe(120);
+    expect(tableScrollX([{ width: '80' }])).toBe(120);
+  });
+
+  it('drops hidden groups entirely before summing their children', () => {
+    expect(tableScrollX([{ hidden: true, children: [{ width: 100 }, { width: 60 }] }])).toBe(0);
+    expect(tableScrollX([{ hidden: true }, { width: 50 }])).toBe(50);
+  });
+
+  it('treats an empty child group like an unsized leaf column', () => {
+    expect(tableScrollX([{ children: [] }])).toBe(120);
+    expect(tableScrollX([{ children: [], width: 200 }])).toBe(200);
+  });
+
+  it('honors an explicit zero width column', () => {
+    expect(tableScrollX([{ width: 0 }, { width: 100 }])).toBe(100);
+    expect(tableScrollX([{ width: 0 }], { selection: true })).toBe(40);
+  });
 });


### PR DESCRIPTION
### Motivation

The `tableScrollX` helper tests covered simple sums and one grouping case, leaving nested groups, malformed width strings, hidden groups, empty child groups, and explicit zero widths unasserted. This PR grows the suite from 5 to 11 cases.

### Changes

- Nested child groups recurse correctly (two levels deep).
- Child groups whose leaves carry no width each fall back to the 120px share.
- Pixel strings parse decimal values (`'80.5px'` → 80.5) and `'0px'` → 0; non-pixel strings (`'abcpx'`, `'80'`) fall back to the default share.
- Hidden groups are dropped entirely, contributing 0 even when they have sized children.
- An empty `children` array behaves like an unsized leaf unless the group also declares a numeric width.
- An explicit `width: 0` column contributes nothing but still coexists with the selection reservation.

### Verification

- `vitest run src/utils/table.test.ts`: 11/11 passed
- `tsc --noEmit`: clean
- `eslint src/utils/table.test.ts`: clean