### PR TITLE
test: expand message query history API coverage

### DIFF
--- a/web/src/api/messageHistory.test.ts
+++ b/web/src/api/messageHistory.test.ts
@@ -8,6 +8,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import client from './client';
 import {
+  getMessageQueryResults,
   getQueryHistorySummary,
   listMessageQueryHistory,
   listTraceQueryHistory,
@@ -53,5 +54,88 @@ describe('message query history API', () => {
       total: 1,
     });
     await expect(getQueryHistorySummary('instance-a')).resolves.toMatchObject({ traceQueries: 1 });
+  });
+
+  it('forwards query type and pagination for message history', async () => {
+    mock.onGet('/query-history/messages').reply((config) => {
+      expect(config.params).toEqual({
+        queryType: 'MSG_ID',
+        search: '7F0000010000000000000001',
+        page: 1,
+        pageSize: 50,
+      });
+      return [200, { code: 200, data: { items: [], total: 0, page: 1, size: 50 } }];
+    });
+
+    await expect(
+      listMessageQueryHistory({
+        queryType: 'MSG_ID',
+        search: '7F0000010000000000000001',
+        page: 1,
+        pageSize: 50,
+      }),
+    ).resolves.toMatchObject({ page: 1 });
+  });
+
+  it('omits query params entirely when the caller provides none', async () => {
+    mock.onGet('/query-history/messages').reply((config) => {
+      expect(config.params).toBeUndefined();
+      return [200, { code: 200, data: { items: [], total: 0, page: 1, size: 20 } }];
+    });
+    mock.onGet('/query-history/summary').reply((config) => {
+      expect(config.params).toBeUndefined();
+      return [200, { code: 200, data: { messageQueries: 0, traceQueries: 0 } }];
+    });
+
+    await expect(listMessageQueryHistory()).resolves.toMatchObject({ total: 0 });
+    await expect(getQueryHistorySummary()).resolves.toEqual({
+      messageQueries: 0,
+      traceQueries: 0,
+    });
+  });
+
+  it('forwards the trace search term when provided', async () => {
+    mock.onGet('/query-history/traces').reply((config) => {
+      expect(config.params).toEqual({ clusterId: 'instance-b', search: 'msg-42' });
+      return [200, { code: 200, data: { items: [], total: 0, page: 1, size: 20 } }];
+    });
+
+    await expect(
+      listTraceQueryHistory({ clusterId: 'instance-b', search: 'msg-42' }),
+    ).resolves.toMatchObject({ total: 0 });
+  });
+
+  it('loads the result snapshot page for a saved message query', async () => {
+    mock.onGet('/query-history/messages/42/results').reply(200, {
+      code: 200,
+      data: [
+        {
+          msgId: 'msg-42',
+          topic: 'orders',
+          tag: '',
+          key: '',
+          brokerName: 'broker-0',
+          queueId: 0,
+          queueOffset: 10,
+          storeTime: 1785000000000,
+          bornHost: '10.0.0.5:1000',
+          storeHost: '10.0.0.9:10911',
+          size: 128,
+        },
+      ],
+    });
+
+    const results = await getMessageQueryResults(42);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ msgId: 'msg-42', brokerName: 'broker-0', queueId: 0 });
+  });
+
+  it('returns an empty snapshot list when a query produced no hits', async () => {
+    mock.onGet('/query-history/messages/7/results').reply(200, {
+      code: 200,
+      data: [],
+    });
+
+    await expect(getMessageQueryResults(7)).resolves.toEqual([]);
   });
 });


### PR DESCRIPTION
### Motivation

The message query history API tests exercised two endpoints with fully-populated params, leaving the `queryType` forwarding, param-omission semantics, trace search, and the saved-query result snapshot endpoint unasserted. This PR grows the suite from 2 to 7 cases.

### Changes

- `listMessageQueryHistory` forwards `queryType` (e.g. `MSG_ID`) together with search and pagination.
- Calling the list or summary endpoints without any params sends no query params at all (`config.params` undefined), matching the backend's optional filters.
- `listTraceQueryHistory` forwards the trace `search` term alongside the cluster id.
- `getMessageQueryResults` hits the per-query results URL (`/query-history/messages/{id}/results`) and returns the decoded snapshot rows.
- A query that produced no hits resolves to an empty snapshot array.

### Verification

- `vitest run src/api/messageHistory.test.ts`: 7/7 passed
- `tsc --noEmit`: clean
- `eslint src/api/messageHistory.test.ts`: clean