### PR TITLE
test: expand data source API coverage

### DIFF
--- a/web/src/api/settings.test.ts
+++ b/web/src/api/settings.test.ts
@@ -112,4 +112,89 @@ describe('data sources API', () => {
       testDataSource({ type: source.type, url: source.url, auth: source.auth }),
     ).resolves.toEqual({ success: true, message: 'Connection successful' });
   });
+
+  it('forwards credentials when testing an authenticated data source', async () => {
+    mock.onPost('/settings/datasources/test').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({
+        type: 'Prometheus',
+        url: 'http://prometheus:9090',
+        auth: 'basic',
+        username: 'ops',
+        password: 'secret',
+      });
+      return [200, { code: 200, data: { success: true, message: 'OK' } }];
+    });
+
+    await expect(
+      testDataSource({
+        type: 'Prometheus',
+        url: 'http://prometheus:9090',
+        auth: 'basic',
+        username: 'ops',
+        password: 'secret',
+      }),
+    ).resolves.toEqual({ success: true, message: 'OK' });
+  });
+
+  it('forwards bearer tokens when testing a token-authenticated data source', async () => {
+    mock.onPost('/settings/datasources/test').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({
+        type: 'Prometheus',
+        url: 'http://prometheus:9090',
+        auth: 'bearer',
+        bearerToken: 'tok-123',
+      });
+      return [200, { code: 200, data: { success: true, message: 'OK' } }];
+    });
+
+    await expect(
+      testDataSource({
+        type: 'Prometheus',
+        url: 'http://prometheus:9090',
+        auth: 'bearer',
+        bearerToken: 'tok-123',
+      }),
+    ).resolves.toEqual({ success: true, message: 'OK' });
+  });
+
+  it('stops paginating early when the last page comes back short', async () => {
+    mock.onGet('/settings/datasources/page').reply((config) => {
+      expect(config.params.pageSize).toBe(100);
+      return [
+        200,
+        {
+          code: 200,
+          data: {
+            items: config.params.page === 1 ? [source] : [],
+            total: 1,
+            page: config.params.page,
+            size: 100,
+          },
+        },
+      ];
+    });
+
+    await expect(listAllDataSources()).resolves.toHaveLength(1);
+  });
+
+  it('throws when the export would exceed the maximum page count', async () => {
+    mock.onGet('/settings/datasources/page').reply((config) => {
+      const page = config.params.page as number;
+      if (page > 100) throw new Error('unexpected page request');
+      return [
+        200,
+        {
+          code: 200,
+          data: {
+            items: [source],
+            total: 10_000,
+            page,
+            size: 100,
+          },
+        },
+      ];
+    });
+
+    await expect(listAllDataSources()).rejects.toThrow('exceeded');
+  });
 });


### PR DESCRIPTION
### Motivation

The data source API tests covered the happy paths of load/create/update, the multi-page export, and delete/test basics, but left authenticated connections, bearer tokens, short last pages, and the max-page guard untested. This PR grows the suite from 3 to 7 cases.

### Changes

- `testDataSource` forwards `username`/`password` for basic-auth sources and `bearerToken` for token-auth sources.
- `listAllDataSources` stops early when the last page comes back short (fewer items than the declared total).
- `listAllDataSources` throws `Data source export exceeded 100 pages` when pages keep returning full inventories.

### Verification

- `vitest run src/api/settings.test.ts`: 7/7 passed
- `tsc --noEmit`: clean
- `eslint src/api/settings.test.ts`: clean