### PR TITLE
test: expand alert rule assets API coverage

### DIFF
--- a/web/src/api/alertRuleAssets.test.ts
+++ b/web/src/api/alertRuleAssets.test.ts
@@ -68,4 +68,27 @@ describe('alertRuleAssets API', () => {
     expect(result).toBeInstanceOf(Blob);
     expect(result.type).toBe('text/yaml');
   });
+
+  it('returns an empty list when no assets are installed', async () => {
+    mock.onGet('/alert-rules/assets').reply(200, { code: 200, data: [] });
+
+    await expect(listAlertRuleAssets()).resolves.toEqual([]);
+  });
+
+  it('URL-encodes asset names that contain special characters', async () => {
+    mock.onGet('/alert-rules/assets/consumer%20lag%2Frules').reply(200, {
+      code: 200,
+      data: 'groups:\n  - name: consumer lag/rules\n',
+    });
+
+    await expect(getAlertRuleAsset('consumer lag/rules')).resolves.toContain('consumer lag/rules');
+  });
+
+  it('URL-encodes special characters when exporting an asset', async () => {
+    const blob = new Blob(['payload'], { type: 'text/yaml' });
+    mock.onGet('/alert-rules/assets/broker%20%2F%20down/export').reply(200, blob);
+
+    const result = await exportAlertRuleAsset('broker / down');
+    expect(result).toBeInstanceOf(Blob);
+  });
 });


### PR DESCRIPTION
### Motivation

The alert rule assets API tests covered the three happy paths but left empty inventories and URL-encoding of asset names untested. This PR grows the suite from 3 to 6 cases.

### Changes

- `listAlertRuleAssets` resolves an empty array when no assets are installed.
- Asset names containing spaces and slashes are URL-encoded before reaching the fetch and export endpoints (`consumer%20lag%2Frules`, `broker%20%2F%20down`).

### Verification

- `vitest run src/api/alertRuleAssets.test.ts`: 6/6 passed
- `tsc --noEmit`: clean
- `eslint src/api/alertRuleAssets.test.ts`: clean