### PR TITLE
test: expand auth API coverage

### DIFF
--- a/web/src/api/auth.test.ts
+++ b/web/src/api/auth.test.ts
@@ -18,7 +18,7 @@
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
-import { getAuthStatus, login, logout } from './auth';
+import { changePassword, getAuthStatus, login, logout } from './auth';
 
 const mock = new MockAdapter(client);
 
@@ -85,5 +85,31 @@ describe('Auth API', () => {
     mock.onPost('/auth/logout').reply(500);
 
     await expect(logout()).rejects.toThrow();
+  });
+
+  it('status should report an unauthenticated session without a user', async () => {
+    const authStatus = { loginRequired: true, authenticated: false };
+    mock.onGet('/auth/status').reply(200, { code: 200, data: authStatus });
+
+    await expect(getAuthStatus()).resolves.toEqual(authStatus);
+    await expect(getAuthStatus()).resolves.not.toHaveProperty('user');
+  });
+
+  it('change password should post the current and new credentials', async () => {
+    mock.onPost('/auth/password').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({
+        currentPassword: 'old-secret',
+        newPassword: 'new-secret',
+      });
+      return [200, { code: 200, data: null }];
+    });
+
+    await expect(changePassword('old-secret', 'new-secret')).resolves.toBeUndefined();
+  });
+
+  it('change password should surface a wrong-current-password failure', async () => {
+    mock.onPost('/auth/password').reply(400, { message: 'Current password is incorrect' });
+
+    await expect(changePassword('wrong', 'new-secret')).rejects.toThrow();
   });
 });


### PR DESCRIPTION
### Motivation

The auth API tests covered status, login, and logout paths but left the unauthenticated status shape and the `changePassword` endpoint completely untested. This PR grows the suite from 5 to 8 cases.

### Changes

- `getAuthStatus` resolves an unauthenticated session (`authenticated: false`) without a `user` property.
- `changePassword` posts `{ currentPassword, newPassword }` to `/auth/password` and resolves void on success.
- A wrong-current-password failure (400) surfaces as a rejected promise.

### Verification

- `vitest run src/api/auth.test.ts`: 8/8 passed
- `tsc --noEmit`: clean
- `eslint src/api/auth.test.ts`: clean