### PR TITLE
test: expand alert rules API coverage

### DIFF
--- a/web/src/api/alertRules.test.ts
+++ b/web/src/api/alertRules.test.ts
@@ -19,13 +19,20 @@ import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import client from './client';
 import {
+  bulkDeleteAlertRules,
+  bulkToggleAlertRules,
   createAlertRule,
   deleteAlertRule,
+  exportAlertRulesTransfer,
+  importAlertRulesTransfer,
+  listAlertRuleRuntime,
   listAlertRules,
+  listAlertRulesPage,
+  testAlertRule,
   toggleAlertRule,
   updateAlertRule,
 } from './ops';
-import type { AlertRule } from './ops';
+import type { AlertRule, AlertRuleTransfer } from './ops';
 
 const mock = new MockAdapter(client);
 const rule: AlertRule = {
@@ -86,5 +93,101 @@ describe('alert rules API', () => {
     });
 
     await expect(deleteAlertRule(rule.id)).resolves.toBeUndefined();
+  });
+
+  it('routes cluster alert rules to the business endpoint when requested', async () => {
+    mock.onGet('/business-alert-rules').reply(200, { code: 200, data: [rule] });
+    mock.onGet('/business-alert-rules/runtime').reply(200, {
+      code: 200,
+      data: [
+        {
+          ruleId: 7,
+          fingerprint: 'fp-7',
+          status: 'FIRING',
+          consecutiveHits: 3,
+          currentValue: 85,
+        },
+      ],
+    });
+
+    await expect(listAlertRules('BUSINESS')).resolves.toEqual([rule]);
+    await expect(listAlertRuleRuntime('BUSINESS')).resolves.toEqual([
+      expect.objectContaining({ ruleId: 7, status: 'FIRING', consecutiveHits: 3 }),
+    ]);
+  });
+
+  it('pages alert rules with the supplied query', async () => {
+    mock.onGet('/cluster-alert-rules/page').reply((config) => {
+      expect(config.params).toEqual({ page: 2, pageSize: 25, enabled: true });
+      return [200, { code: 200, data: { items: [rule], total: 1, page: 2, size: 25 } }];
+    });
+
+    const page = await listAlertRulesPage('CLUSTER', { page: 2, pageSize: 25, enabled: true });
+    expect(page.items).toEqual([rule]);
+    expect(page.total).toBe(1);
+  });
+
+  it('bulk toggles and bulk deletes with the id lists', async () => {
+    const bulkResult = { succeededIds: [7, 8], failures: {}, updatedRules: [rule] };
+    mock.onPost('/cluster-alert-rules/bulk-toggle').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ ids: [7, 8], enabled: false });
+      return [200, { code: 200, data: bulkResult }];
+    });
+    mock.onPost('/cluster-alert-rules/bulk-delete').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ ids: [7, 8] });
+      return [200, { code: 200, data: bulkResult }];
+    });
+
+    await expect(bulkToggleAlertRules([7, 8], false)).resolves.toEqual(bulkResult);
+    await expect(bulkDeleteAlertRules([7, 8])).resolves.toEqual(bulkResult);
+  });
+
+  it('posts rule payloads to the test endpoint', async () => {
+    mock.onPost('/cluster-alert-rules/test').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual({ id: 7, threshold: 90 });
+      return [
+        200,
+        {
+          code: 200,
+          data: {
+            samples: [
+              { labels: { broker: 'broker-0' }, availability: 'ok', currentValue: 90, conditionMet: true },
+            ],
+          },
+        },
+      ];
+    });
+
+    const result = await testAlertRule({ id: 7, threshold: 90 });
+    expect(result.samples).toHaveLength(1);
+    expect(result.samples[0].conditionMet).toBe(true);
+  });
+
+  it('imports and exports transfer payloads on the transfer endpoints', async () => {
+    const transfer: AlertRuleTransfer = {
+      version: 1,
+      domain: 'CLUSTER',
+      rules: [
+        {
+          name: rule.name,
+          metric: rule.metric,
+          operator: rule.operator,
+          threshold: rule.threshold,
+          thresholdUnit: rule.thresholdUnit,
+          duration: rule.duration,
+          channels: rule.channels,
+          enabled: rule.enabled,
+          description: rule.description,
+        },
+      ],
+    };
+    mock.onGet('/cluster-alert-rules/transfer').reply(200, { code: 200, data: transfer });
+    mock.onPost('/cluster-alert-rules/import').reply((config) => {
+      expect(JSON.parse(config.data)).toEqual(transfer);
+      return [200, { code: 200, data: [rule] }];
+    });
+
+    await expect(exportAlertRulesTransfer('CLUSTER')).resolves.toEqual(transfer);
+    await expect(importAlertRulesTransfer(transfer, 'CLUSTER')).resolves.toEqual([rule]);
   });
 });


### PR DESCRIPTION
### Motivation

The alert rules API tests covered CRUD against the default cluster domain, leaving BUSINESS domain routing, paging, runtime status, transfer import/export, and the per-rule test endpoint unasserted. This PR grows the suite from 3 to 8 cases.

### Changes

- `listAlertRules('BUSINESS')` and `listAlertRuleRuntime('BUSINESS')` route to the `/business-alert-rules` endpoints.
- `listAlertRulesPage` forwards the paging query (`page`, `pageSize`, `enabled`) and unwraps the PageResult.
- `bulkToggleAlertRules` / `bulkDeleteAlertRules` post `{ ids, enabled }` / `{ ids }` and return the bulk result contract.
- `testAlertRule` posts the rule payload to `/cluster-alert-rules/test` and returns the sample analysis.
- Transfer export/import round-trips the versioned `AlertRuleTransfer` payload on `/transfer` and `/import`.

### Verification

- `vitest run src/api/alertRules.test.ts`: 8/8 passed
- `tsc --noEmit`: clean
- `eslint src/api/alertRules.test.ts`: clean