### PR TITLE
test: expand client connections API coverage

### DIFF
--- a/web/src/api/connections.test.ts
+++ b/web/src/api/connections.test.ts
@@ -63,4 +63,38 @@ describe('client connections API', () => {
       }),
     ).resolves.toEqual([connection]);
   });
+
+  it('sends only the required namesrvAddr when optional filters are omitted', async () => {
+    mock.onGet('/clients').reply((config) => {
+      expect(config.params).toEqual({ namesrvAddr: '10.0.1.33:9876' });
+      return [200, { code: 200, data: [] }];
+    });
+
+    await expect(listConnections({ namesrvAddr: '10.0.1.33:9876' })).resolves.toEqual([]);
+  });
+
+  it('resolves an empty inventory when no client is connected', async () => {
+    mock.onGet('/clients').reply(200, { code: 200, data: [] });
+
+    await expect(listConnections()).resolves.toEqual([]);
+  });
+
+  it('passes partial connection rows through unchanged', async () => {
+    const partialConnection = {
+      type: 'Producer',
+      groupOrTopic: 'orders',
+      protocol: 'gRPC',
+      language: 'Java',
+      version: '5.1.0',
+      clusterName: 'production-cluster',
+      partial: true,
+    };
+    mock.onGet('/clients').reply(200, { code: 200, data: [partialConnection] });
+
+    const result = await listConnections({ namesrvAddr: '10.0.1.33:9876' });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ type: 'Producer', clusterName: 'production-cluster' });
+    expect(result[0].clientId).toBeUndefined();
+    expect(result[0].address).toBeUndefined();
+  });
 });


### PR DESCRIPTION
### Motivation

The client connections API test asserted one fully-populated query and nothing else. This PR grows the suite from 1 to 4 cases.

### Changes

- Optional filters are omitted from the request when not supplied, leaving only the required `namesrvAddr`.
- An empty inventory resolves to an empty array.
- Partial connection rows (no `clientId`/`address`, `partial: true`) pass through unchanged.

### Verification

- `vitest run src/api/connections.test.ts`: 4/4 passed
- `tsc --noEmit`: clean
- `eslint src/api/connections.test.ts`: clean