### PR TITLE
test: cover ACL user list and paging APIs

### DIFF
--- a/web/src/api/acl.test.ts
+++ b/web/src/api/acl.test.ts
@@ -27,6 +27,8 @@ import {
   examineBrokerClusterAclConfig,
   getAclUserCredentials,
   listAclRules,
+  listAclUsers,
+  pageAclUsers,
   updateAclRule,
   updateAclUser,
 } from './acl';
@@ -214,5 +216,35 @@ describe('ACL API contract', () => {
     });
 
     await expect(createAndUpdatePlainAccessConfig(payload)).resolves.toEqual(payload);
+  });
+
+  it('lists ACL users with the supplied keyword filters', async () => {
+    const user = {
+      id: 1,
+      username: 'user-admin',
+      accessKey: 'LTAI****admin',
+      secretKey: 'HqWz****xK8P',
+      admin: true,
+      clusters: ['rmq-prod'],
+      gmtCreate: '2025-01-10T08:00:00Z',
+    };
+    mock.onGet('/acl/users').reply((config) => {
+      expect(config.params).toEqual({ keyword: 'admin' });
+      return [200, { code: 200, data: [user] }];
+    });
+
+    await expect(listAclUsers({ keyword: 'admin' })).resolves.toEqual([user]);
+  });
+
+  it('pages ACL users with page size and keyword', async () => {
+    const pageData = { items: [], total: 0, page: 2, size: 50 };
+    mock.onGet('/acl/users/page').reply((config) => {
+      expect(config.params).toEqual({ keyword: 'admin', page: 2, pageSize: 50 });
+      return [200, { code: 200, data: pageData }];
+    });
+
+    await expect(pageAclUsers({ keyword: 'admin', page: 2, pageSize: 50 })).resolves.toEqual(
+      pageData,
+    );
   });
 });


### PR DESCRIPTION
### Motivation

The ACL API contract tests covered rules, credentials, cluster config, and plain-access config, but the user list and paged-user endpoints were never asserted at the HTTP layer. This PR adds both.

### Changes

- `listAclUsers` forwards the `keyword` filter to `/acl/users` and unwraps the user array.
- `pageAclUsers` forwards keyword plus `page`/`pageSize` to `/acl/users/page` and unwraps the page contract.

### Verification

- `vitest run src/api/acl.test.ts`: 8/8 passed
- `tsc --noEmit`: clean
- `eslint src/api/acl.test.ts`: clean