### PR TITLE
test: expand instance filter hook coverage

### DIFF
--- a/web/src/hooks/useInstanceFilter.test.tsx
+++ b/web/src/hooks/useInstanceFilter.test.tsx
@@ -32,29 +32,33 @@ function InstanceRouteProbe() {
   return <output>{`${pathname}|${selectedInstanceId}`}</output>;
 }
 
+const instanceA = {
+  id: 7,
+  name: 'instance-a',
+  remark: '',
+  type: 'PROXY_CLUSTER',
+  endpoint: '127.0.0.1:8080',
+  topicCount: 0,
+  consumerGroupCount: 0,
+  gmtCreate: '2026-01-01T00:00:00Z',
+  gmtModified: '2026-01-01T00:00:00Z',
+};
+
+const renderProbe = (entry: string) =>
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/instance/:instanceId/topic" element={<InstanceRouteProbe />} />
+        <Route path="/instance/topic" element={<InstanceRouteProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
 describe('useInstanceFilter', () => {
   it('replaces an unknown route instance with the first available instance', async () => {
-    instanceServiceMocks.listInstances.mockResolvedValue([
-      {
-        id: 7,
-        name: 'instance-a',
-        remark: '',
-        type: 'PROXY_CLUSTER',
-        endpoint: '127.0.0.1:8080',
-        topicCount: 0,
-        consumerGroupCount: 0,
-        gmtCreate: '2026-01-01T00:00:00Z',
-        gmtModified: '2026-01-01T00:00:00Z',
-      },
-    ]);
+    instanceServiceMocks.listInstances.mockResolvedValue([instanceA]);
 
-    render(
-      <MemoryRouter initialEntries={['/instance/missing/topic']}>
-        <Routes>
-          <Route path="/instance/:instanceId/topic" element={<InstanceRouteProbe />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderProbe('/instance/missing/topic');
 
     await waitFor(() => {
       expect(screen.getByText('/instance/instance-a/topic|instance-a')).toBeInTheDocument();
@@ -64,25 +68,52 @@ describe('useInstanceFilter', () => {
   it('recovers from a malformed encoded instance id', async () => {
     instanceServiceMocks.listInstances.mockResolvedValue([
       {
-        id: 7,
-        name: 'instance-a',
-        remark: '',
+        ...instanceA,
         type: 'PROXY',
-        endpoint: '127.0.0.1:8080',
-        topicCount: 0,
-        consumerGroupCount: 0,
-        gmtCreate: '2026-01-01T00:00:00Z',
-        gmtModified: '2026-01-01T00:00:00Z',
       },
     ]);
 
-    render(
-      <MemoryRouter initialEntries={['/instance/%E0%A4%A/topic']}>
-        <Routes>
-          <Route path="/instance/:instanceId/topic" element={<InstanceRouteProbe />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderProbe('/instance/%E0%A4%A/topic');
+
+    await waitFor(() => {
+      expect(screen.getByText('/instance/instance-a/topic|instance-a')).toBeInTheDocument();
+    });
+  });
+
+  it('keeps a known instance id in the route without rewriting it', async () => {
+    instanceServiceMocks.listInstances.mockResolvedValue([instanceA]);
+
+    renderProbe('/instance/instance-a/topic');
+
+    await waitFor(() => {
+      expect(screen.getByText('/instance/instance-a/topic|instance-a')).toBeInTheDocument();
+    });
+  });
+
+  it('leaves an unknown route untouched when no instance is available', async () => {
+    instanceServiceMocks.listInstances.mockResolvedValue([]);
+
+    renderProbe('/instance/missing/topic');
+
+    await waitFor(() => {
+      expect(screen.getByText('/instance/missing/topic|undefined')).toBeInTheDocument();
+    });
+  });
+
+  it('stays on the routed instance when the instance list fails to load', async () => {
+    instanceServiceMocks.listInstances.mockRejectedValue(new Error('backend unavailable'));
+
+    renderProbe('/instance/instance-a/topic');
+
+    await waitFor(() => {
+      expect(screen.getByText('/instance/instance-a/topic|undefined')).toBeInTheDocument();
+    });
+  });
+
+  it('redirects a section-only route to the first instance of that section', async () => {
+    instanceServiceMocks.listInstances.mockResolvedValue([instanceA]);
+
+    renderProbe('/instance/topic');
 
     await waitFor(() => {
       expect(screen.getByText('/instance/instance-a/topic|instance-a')).toBeInTheDocument();


### PR DESCRIPTION
### Motivation

The `useInstanceFilter` hook tests covered unknown-route rewriting and malformed encoded ids, but left known-route preservation, empty inventories, list failures, and section-only routes untested. This PR grows the suite from 2 to 6 cases.

### Changes

- A known instance id in the route is kept without rewriting.
- An unknown route stays untouched when no instance is available.
- When the instance list fails to load, the hook stays on the routed instance without crashing.
- A section-only route (`/instance/topic`) is redirected to the first instance of that section.

### Verification

- `vitest run src/hooks/useInstanceFilter.test.tsx`: 6/6 passed
- `tsc --noEmit`: clean
- `eslint src/hooks/useInstanceFilter.test.tsx`: clean