### PR TITLE
test: expand SSRF host guard coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardMulticastTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/UrlHostGuardMulticastTest.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.studio.common.util;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UrlHostGuardMulticastTest {
 
@@ -26,5 +27,93 @@ class UrlHostGuardMulticastTest {
     void isAllowedHostShouldRejectIpv4AndIpv6MulticastAddresses() {
         assertThat(UrlHostGuard.isAllowedHost("224.0.0.1", false)).isFalse();
         assertThat(UrlHostGuard.isAllowedHost("ff02::1", false)).isFalse();
+    }
+
+    @Test
+    void isAllowedHostShouldRejectBlankHostsFailClosed() {
+        assertThat(UrlHostGuard.isAllowedHost(null, false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("   ", false)).isFalse();
+    }
+
+    @Test
+    void isAllowedHostShouldRejectAnyLocalAndMetadataAddresses() {
+        assertThat(UrlHostGuard.isAllowedHost("0.0.0.0", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("::", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("169.254.169.254", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("fd00:ec2::254", false)).isFalse();
+    }
+
+    @Test
+    void isAllowedHostShouldGateLoopbackOnTheFlag() {
+        assertThat(UrlHostGuard.isAllowedHost("localhost", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("localhost", true)).isTrue();
+        assertThat(UrlHostGuard.isAllowedHost("127.0.0.1", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("127.0.0.1", true)).isTrue();
+        assertThat(UrlHostGuard.isAllowedHost("::1", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("::1", true)).isTrue();
+    }
+
+    @Test
+    void isAllowedHostShouldStripATrailingDotBeforeClassification() {
+        assertThat(UrlHostGuard.isAllowedHost("127.0.0.1.", false)).isFalse();
+        assertThat(UrlHostGuard.isAllowedHost("localhost.", true)).isTrue();
+    }
+
+    @Test
+    void isAllowedHostShouldKeepPrivateSiteLocalRangesAllowed() {
+        assertThat(UrlHostGuard.isAllowedHost("10.0.0.5", false)).isTrue();
+        assertThat(UrlHostGuard.isAllowedHost("172.16.0.8", false)).isTrue();
+        assertThat(UrlHostGuard.isAllowedHost("192.168.1.10", false)).isTrue();
+    }
+
+    @Test
+    void checkShouldRejectMissingAndBlankUrls() {
+        assertThatThrownBy(() -> UrlHostGuard.check(null, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("URL is required");
+        assertThatThrownBy(() -> UrlHostGuard.check("   ", false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("URL is required");
+    }
+
+    @Test
+    void checkShouldRejectNonHttpSchemes() {
+        assertThatThrownBy(() -> UrlHostGuard.check("ftp://10.0.0.5/file", false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("http:// or https://");
+        assertThatThrownBy(() -> UrlHostGuard.check("file:///etc/passwd", false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("http:// or https://");
+    }
+
+    @Test
+    void checkShouldRequireAHost() {
+        assertThatThrownBy(() -> UrlHostGuard.check("http:///path", false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must include a host");
+    }
+
+    @Test
+    void checkShouldRejectMetadataAndLoopbackWithoutTheFlag() {
+        assertThatThrownBy(
+                () -> UrlHostGuard.check("http://169.254.169.254/latest/meta-data/", false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("local, loopback or metadata");
+        assertThatThrownBy(() -> UrlHostGuard.check("http://localhost:11434", false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("local, loopback or metadata");
+    }
+
+    @Test
+    void checkShouldAdmitLoopbackWhenAllowed() {
+        UrlHostGuard.check("http://localhost:11434/v1/chat/completions", true);
+        UrlHostGuard.check("http://127.0.0.1:11434", true);
+    }
+
+    @Test
+    void checkShouldAcceptTrimmedHttpUrlsToPrivateHosts() {
+        UrlHostGuard.check("  https://10.0.0.5:9090/prometheus  ", false);
+        UrlHostGuard.check("http://192.168.1.10//", false);
     }
 }


### PR DESCRIPTION
### Motivation

The `UrlHostGuard` SSRF guard only had a single multicast test even though it implements the shared fail-closed policy for data-source and LLM-gateway URLs. This PR grows the suite from 1 to 12 cases.

### Changes

- Blank/null hosts fail closed.
- Any-local and metadata addresses (`0.0.0.0`, `::`, `169.254.169.254`, `fd00:ec2::254`) are rejected.
- Loopback admission is gated on the `allowLoopback` flag for `localhost`, `127.0.0.1`, and `::1`.
- A trailing dot is stripped before classification.
- Private site-local ranges (`10.x`, `172.16-31.x`, `192.168.x`) stay allowed.
- `check` rejects missing/blank URLs, non-http(s) schemes, and hostless URLs, and admits trimmed http(s) URLs to private hosts.

### Verification

- `mvn -B test -Dtest=UrlHostGuardMulticastTest`: 12/12 passed, BUILD SUCCESS