### PR TITLE
test: expand message property parse coverage

### DIFF
--- a/web/src/utils/messageProperties.test.ts
+++ b/web/src/utils/messageProperties.test.ts
@@ -63,4 +63,35 @@ describe('parseMessageProperties', () => {
     expect(result.properties['__proto__']).toBe('first');
     expect(result.errors).toEqual(['属性名“__proto__”重复']);
   });
+
+  it('skips blank and whitespace-only lines', () => {
+    const result = parseMessageProperties('traceId=abc\n   \n\n\t\nregion=hangzhou');
+
+    expect(result.properties).toEqual({ traceId: 'abc', region: 'hangzhou' });
+    expect(result.errors).toEqual([]);
+  });
+
+  it('trims surrounding whitespace from keys and values', () => {
+    const result = parseMessageProperties('  traceId  =  abc  \n  region=  hangzhou ');
+
+    expect(result.properties).toEqual({ traceId: 'abc', region: 'hangzhou' });
+    expect(result.errors).toEqual([]);
+  });
+
+  it('reports lines without an equals sign as format errors', () => {
+    const result = parseMessageProperties('traceId=abc\nnot-a-pair\n=value-only');
+
+    expect(result.properties).toEqual({ traceId: 'abc' });
+    expect(result.errors).toEqual([
+      '“not-a-pair”应使用 key=value 格式',
+      '“=value-only”应使用 key=value 格式',
+    ]);
+  });
+
+  it('keeps an empty value when the equals sign ends the line', () => {
+    const result = parseMessageProperties('traceId=\nregion=hangzhou');
+
+    expect(result.properties).toEqual({ traceId: '', region: 'hangzhou' });
+    expect(result.errors).toEqual([]);
+  });
 });


### PR DESCRIPTION
### Motivation

The `parseMessageProperties` helper had tests for value preservation, duplicates, and prototype keys, but blank-line skipping, whitespace trimming, and malformed-line errors were unasserted. This PR grows the suite from 4 to 8 cases.

### Changes

- Blank and whitespace-only lines are skipped without producing errors.
- Surrounding whitespace is trimmed from both keys and values.
- Lines without an equals sign (and `=value`-style lines) are reported as `key=value` format errors in order.
- A trailing equals sign (`key=`) keeps an empty value without an error.

### Verification

- `vitest run src/utils/messageProperties.test.ts`: 8/8 passed
- `tsc --noEmit`: clean
- `eslint src/utils/messageProperties.test.ts`: clean