### PR TITLE
test: expand alert notification template coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplateTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertNotificationTemplateTest.java
@@ -2,7 +2,17 @@
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.rocketmq.studio.ops.alert;
 
@@ -50,5 +60,47 @@ class AlertNotificationTemplateTest {
 
         assertThat(AlertNotificationTemplate.render("${title}", alert, null))
                 .isEqualTo("${description}");
+    }
+
+    @Test
+    void scalesRatioMetricsIntoPercentWhenTheUnitIsPercentTest() {
+        AlertRuleVO rule = AlertRuleVO.builder().name("Heap").metric("broker.jvm.heap.usage_ratio")
+                .threshold(80).thresholdUnit("%").build();
+        SystemAlertVO alert = SystemAlertVO.builder().level(AlertLevel.warning).title("Heap")
+                .currentValue(0.754).build();
+
+        assertThat(AlertNotificationTemplate.render("${value}%/", alert, rule)).isEqualTo("75.4%/");
+    }
+
+    @Test
+    void keepsTheRawValueForNonRatioMetricsTest() {
+        AlertRuleVO rule = AlertRuleVO.builder().name("Lag").metric("broker.consumer.lag")
+                .threshold(1000).thresholdUnit("msgs").build();
+        SystemAlertVO alert = SystemAlertVO.builder().level(AlertLevel.warning).title("Lag")
+                .currentValue(1500.0).build();
+
+        assertThat(AlertNotificationTemplate.render("${value}", alert, rule)).isEqualTo("1500.0");
+    }
+
+    @Test
+    void rendersInstanceLevelTimeAndEmptyRuleFieldsTest() {
+        SystemAlertVO alert = SystemAlertVO.builder().level(AlertLevel.error).title("Down")
+                .description("broker unreachable").instanceId("prod-cluster")
+                .time(LocalDateTime.of(2026, 8, 23, 12, 0, 30)).build();
+
+        String rendered = AlertNotificationTemplate.render(
+                "${level}|${instanceId}|${time}|[${ruleName}|${metric}|${threshold}]", alert, null);
+
+        assertThat(rendered).isEqualTo("error|prod-cluster|2026-08-23T12:00:30|[||]");
+    }
+
+    @Test
+    void trimsWhitespaceFromAConfiguredTemplateTest() {
+        AlertRuleVO rule = AlertRuleVO.builder().name("Disk").threshold(85).build();
+        SystemAlertVO alert = SystemAlertVO.builder().level(AlertLevel.warning).title("Disk")
+                .description("usage high").build();
+
+        assertThat(AlertNotificationTemplate.render("  ${title}: ${description}  ", alert, rule))
+                .isEqualTo("Disk: usage high");
     }
 }


### PR DESCRIPTION
### Motivation

The alert notification template tests covered unknown-placeholder retention, the default format, and value-injected syntax, but left ratio scaling, non-ratio values, instance/time/level rendering, and template trimming unasserted. This PR grows the suite from 3 to 7 cases.

### Changes

- Ratio metrics with a `%` threshold unit scale the current value into a percent (0.754 → `75.4`).
- Non-ratio metrics keep the raw current value.
- `${level}`, `${instanceId}`, and `${time}` render, and a null rule leaves `${ruleName}`, `${metric}`, and `${threshold}` blank.
- Whitespace around a configured template is trimmed before rendering.

### Verification

- `mvn -B test -Dtest=AlertNotificationTemplateTest`: 7/7 passed, BUILD SUCCESS