### PR TITLE
test: expand AI engine config and registry coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiEngineLocaleTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/ai/AiEngineLocaleTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AiEngineLocaleTest {
 
@@ -39,6 +40,62 @@ class AiEngineLocaleTest {
         } finally {
             Locale.setDefault(previous);
         }
+    }
+
+    @Test
+    void normalizeEngineShouldDefaultToHttpWhenBlank() {
+        assertThat(LlmConfigVO.builder().build().normalizeEngine()).isEqualTo("http");
+        assertThat(LlmConfigVO.builder().engine("   ").build().normalizeEngine())
+                .isEqualTo("http");
+    }
+
+    @Test
+    void readyShouldRequireEnabledAndModel() {
+        assertThat(LlmConfigVO.builder().enabled(false).model("gpt-5").build().isReady())
+                .isFalse();
+        assertThat(LlmConfigVO.builder().enabled(true).model("  ").build().isReady())
+                .isFalse();
+    }
+
+    @Test
+    void readyShouldTrustCliEnginesWithoutGatewayCredentials() {
+        LlmConfigVO config = LlmConfigVO.builder()
+                .enabled(true)
+                .model("gpt-5")
+                .engine("claude-code")
+                .build();
+
+        assertThat(config.isReady()).isTrue();
+    }
+
+    @Test
+    void readyShouldRequireAnApiBaseForHttpGateways() {
+        LlmConfigVO config = LlmConfigVO.builder()
+                .enabled(true)
+                .model("qwen")
+                .engine("http")
+                .provider("ollama")
+                .build();
+
+        assertThat(config.isReady()).isFalse();
+
+        config.setApiBase("http://localhost:11434/v1");
+        assertThat(config.isReady()).isTrue();
+    }
+
+    @Test
+    void registryShouldRejectUnsupportedEnginesWithAnActionableHint() {
+        AgentProviderRegistry registry = new AgentProviderRegistry(List.of(new StubProvider("qoder")));
+
+        assertThatThrownBy(() -> registry.forEngine("unknown-cli"))
+                .isInstanceOfSatisfying(LlmGatewayException.class,
+                        error -> {
+                            assertThat(error.getStatusCode()).isEqualTo(400);
+                            assertThat(error.getCode()).isEqualTo("llm.config.unsupported_engine");
+                        });
+        assertThatThrownBy(() -> registry.forEngine(null))
+                .isInstanceOfSatisfying(LlmGatewayException.class,
+                        error -> assertThat(error.getStatusCode()).isEqualTo(400));
     }
 
     private record StubProvider(String engine) implements AgentProvider {


### PR DESCRIPTION
### Motivation

The AI engine locale test only covered Turkish-locale normalization. The readiness rules and registry rejection semantics behind the LLM settings form had no coverage. This PR grows the suite from 1 to 6 cases.

### Changes

- `normalizeEngine` defaults to `http` when the engine is blank.
- `isReady` requires both `enabled` and a model.
- CLI engines (`claude-code`) are ready without gateway credentials.
- HTTP gateways need an `apiBase`; local `ollama` providers skip the API-key requirement.
- `AgentProviderRegistry.forEngine` rejects unknown and null engines with a 400 `llm.config.unsupported_engine` exception.

### Verification

- `mvn -B test -Dtest=AiEngineLocaleTest`: 6/6 passed, BUILD SUCCESS