### PR TITLE
test: expand native metric catalog service coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertMetricCatalogServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/NativeAlertMetricCatalogServiceTest.java
@@ -2,11 +2,22 @@
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.rocketmq.studio.ops.alert;
 
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.instance.InstanceVO;
 import org.junit.jupiter.api.Test;
@@ -19,6 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class NativeAlertMetricCatalogServiceTest {
+
     @Test
     void returnsOnlyMetricsBackedByTheSelectedProviderTest() {
         InstanceRepository repository = mock(InstanceRepository.class);
@@ -58,5 +70,51 @@ class NativeAlertMetricCatalogServiceTest {
 
         assertThat(nativeRule.getMetric()).isEqualTo("broker.disk.usage_ratio");
         assertThat(customRule.getMetric()).isEqualTo("custom.metric");
+    }
+
+    @Test
+    void listRequiresAnInstanceIdTest() {
+        NativeAlertMetricCatalogService service =
+                new NativeAlertMetricCatalogService(mock(InstanceRepository.class));
+
+        assertThatThrownBy(() -> service.list(null, AlertDomain.CLUSTER))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("instanceId is required");
+        assertThatThrownBy(() -> service.list("  ", AlertDomain.CLUSTER))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("instanceId is required");
+    }
+
+    @Test
+    void listRejectsUnknownInstancesTest() {
+        InstanceRepository repository = mock(InstanceRepository.class);
+        when(repository.findByIdentifier("missing")).thenReturn(Optional.empty());
+        NativeAlertMetricCatalogService service = new NativeAlertMetricCatalogService(repository);
+
+        assertThatThrownBy(() -> service.list("missing", AlertDomain.CLUSTER))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Instance not found: missing");
+    }
+
+    @Test
+    void listSharesTheCloudBusinessCatalogAcrossCloudVendorsTest() {
+        InstanceRepository repository = mock(InstanceRepository.class);
+        when(repository.findByIdentifier("tencent")).thenReturn(Optional.of(InstanceVO.builder()
+                .name("tencent").vendor(InstanceVendor.TENCENT).build()));
+        NativeAlertMetricCatalogService service = new NativeAlertMetricCatalogService(repository);
+
+        assertThat(service.list("tencent", AlertDomain.BUSINESS)).extracting(NativeAlertMetricInfo::key)
+                .containsExactly("consumer.lag.total", "consumer.lag.max_queue", "topic.backlog.total");
+        assertThat(service.list("tencent", AlertDomain.CLUSTER)).extracting(NativeAlertMetricInfo::key)
+                .containsExactly("cloud.instance.availability");
+    }
+
+    @Test
+    void validateAllowsRulesWithoutMetricsTest() {
+        InstanceRepository repository = mock(InstanceRepository.class);
+        NativeAlertMetricCatalogService service = new NativeAlertMetricCatalogService(repository);
+
+        service.validate(null);
+        service.validate(AlertRuleVO.builder().domain(AlertDomain.CLUSTER).instanceId("apache").build());
     }
 }


### PR DESCRIPTION
### Motivation

The native metric catalog service tests covered Apache/Aliyun catalog filtering and key normalization, but the blank-id guard, unknown-instance 404, Tencent vendor path, and no-metric validation no-op were untested. This PR grows the suite from 2 to 6 cases.

### Changes

- `list` rejects null/blank instance ids with a 400 `instanceId is required` message.
- An unknown instance resolves to a 404 `Instance not found` error.
- Tencent business/cluster instances share the cloud catalogs with Aliyun.
- `validate` is a silent no-op for a null rule or a rule without a metric.

### Verification

- `mvn -B test -Dtest=NativeAlertMetricCatalogServiceTest`: 6/6 passed, BUILD SUCCESS