### PR TITLE
test: add first coverage for diagnostic cache key

### DIFF
--- a/web/src/pages/instance/__tests__/consumerDiagnosticKey.test.ts
+++ b/web/src/pages/instance/__tests__/consumerDiagnosticKey.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { diagnosticCacheKey } from '../consumer';
+
+describe('diagnosticCacheKey', () => {
+  it('builds a key from the instance and consumer group', () => {
+    expect(diagnosticCacheKey('instance-a', 'cg-order')).toBe('instance-a\u0000cg-order');
+  });
+
+  it('uses an empty instance segment when no instance is selected', () => {
+    expect(diagnosticCacheKey(undefined, 'cg-order')).toBe('\u0000cg-order');
+  });
+
+  it('keeps instance and group boundaries unambiguous', () => {
+    // Without a separator, instance "a" + group "bc" would collide with instance "ab" + "c".
+    expect(diagnosticCacheKey('a', 'bc')).not.toBe(diagnosticCacheKey('ab', 'c'));
+  });
+
+  it('distinguishes groups that share a prefix', () => {
+    expect(diagnosticCacheKey('instance-a', 'cg')).not.toBe(
+      diagnosticCacheKey('instance-a', 'cg-order'),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

The `diagnosticCacheKey` helper keys the consumer-page diagnostic caches by instance and group, but had no direct unit coverage. This PR adds the first four cases.

### Changes

- The key joins the instance id and group with a NUL separator.
- A missing instance id becomes an empty first segment.
- Instance/group boundaries stay unambiguous (`a` + `bc` never equals `ab` + `c`).
- Groups sharing a prefix produce distinct keys.

### Verification

- `vitest run src/pages/instance/__tests__/consumerDiagnosticKey.test.ts`: 4/4 passed
- `tsc --noEmit`: clean
- `eslint src/pages/instance/__tests__/consumerDiagnosticKey.test.ts`: clean