### PR TITLE
test: expand create cloud credential DTO coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CreateCloudCredentialDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CreateCloudCredentialDTOTest.java
@@ -16,14 +16,35 @@
  */
 package org.apache.rocketmq.studio.provider.credential;
 
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CreateCloudCredentialDTOTest {
+
+    private static ValidatorFactory validatorFactory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUpValidator() {
+        validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @AfterAll
+    static void closeValidator() {
+        validatorFactory.close();
+    }
 
     @Test
     void parseVendorShouldBeIndependentOfDefaultLocale() {
@@ -38,5 +59,66 @@ class CreateCloudCredentialDTOTest {
         }
 
         assertThat(vendor).isEqualTo(InstanceVendor.ALIYUN);
+    }
+
+    @Test
+    void parseVendorShouldTrimAndIgnoreCase() {
+        assertThat(CreateCloudCredentialDTO.parseVendor(" apache ")).isEqualTo(InstanceVendor.APACHE);
+        assertThat(CreateCloudCredentialDTO.parseVendor("TENCENT")).isEqualTo(InstanceVendor.TENCENT);
+    }
+
+    @Test
+    void parseVendorShouldReturnNullForBlankAndUnknownValues() {
+        assertThat(CreateCloudCredentialDTO.parseVendor(null)).isNull();
+        assertThat(CreateCloudCredentialDTO.parseVendor(" ")).isNull();
+        assertThat(CreateCloudCredentialDTO.parseVendor("bare-metal")).isNull();
+    }
+
+    @Test
+    void shouldRejectMissingRequiredCredentialFields() {
+        CreateCloudCredentialDTO request = new CreateCloudCredentialDTO();
+
+        Set<String> messages = validator.validate(request).stream()
+                .map(violation -> violation.getMessage())
+                .collect(Collectors.toSet());
+
+        assertThat(messages).contains(
+                "credential name is required",
+                "credential vendor is required",
+                "credential accessKey is required",
+                "credential secretKey is required");
+    }
+
+    @Test
+    void toCloudCredentialVoShouldCarryTheStoredCredentials() {
+        CreateCloudCredentialDTO request = new CreateCloudCredentialDTO();
+        request.setName("aliyun-test");
+        request.setVendor("aliyun");
+        request.setAccessKey("LTAI00000001");
+        request.setSecretKey("secret-0001");
+        request.setRemark("test account");
+
+        CloudCredentialVO vo = request.toCloudCredentialVO();
+
+        assertThat(vo.getName()).isEqualTo("aliyun-test");
+        assertThat(vo.getVendor()).isEqualTo(InstanceVendor.ALIYUN);
+        assertThat(vo.getAccessKey()).isEqualTo("LTAI00000001");
+        assertThat(vo.getSecretKey()).isEqualTo("secret-0001");
+        assertThat(vo.getRemark()).isEqualTo("test account");
+    }
+
+    @Test
+    void toStringShouldNeverExposeCredentials() {
+        CreateCloudCredentialDTO request = new CreateCloudCredentialDTO();
+        request.setName("aliyun-test");
+        request.setVendor("aliyun");
+        request.setAccessKey("LTAI00000001");
+        request.setSecretKey("secret-0001");
+
+        String value = request.toString();
+
+        assertThat(value).contains("name=aliyun-test");
+        assertThat(value).doesNotContain("LTAI00000001");
+        assertThat(value).doesNotContain("secret-0001");
     }
 }


### PR DESCRIPTION
### Motivation

The `CreateCloudCredentialDTO` test only covered Turkish-locale vendor parsing. Vendor edge cases, bean validation, VO conversion, and credential redaction in `toString` were untested. This PR grows the suite from 1 to 6 cases.

### Changes

- `parseVendor` trims and ignores case, and returns null for blank or unknown values.
- Missing name/vendor/accessKey/secretKey each produce their required-field validation message.
- `toCloudCredentialVO` carries the stored credentials into the VO.
- `toString` never exposes the access key or secret key.

### Verification

- `mvn -B test -Dtest=CreateCloudCredentialDTOTest`: 6/6 passed, BUILD SUCCESS