### PR TITLE
test: expand alert rule request DTO coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/AlertRuleRequestDTOTest.java
@@ -67,4 +67,68 @@ class AlertRuleRequestDTOTest {
 
         assertThat(request.toAlertRuleVO().getMetric()).isEqualTo("consumer.lag.total");
     }
+
+    @Test
+    void nameShouldBeRequiredTest() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("name is required");
+    }
+
+    @Test
+    void operatorAggregationAndSeverityShouldRejectInvalidValuesTest() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName("High Lag");
+        request.setOperator("between");
+        request.setAggregation("MEDIAN");
+        request.setSeverity("fatal");
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("operator is invalid", "aggregation is invalid",
+                        "severity is invalid");
+    }
+
+    @Test
+    void durationReminderAndTemplateShouldBeValidatedTest() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName("High Lag");
+        request.setDuration("5 minutes");
+        request.setReminderInterval("every hour");
+        request.setNotificationTemplate("x".repeat(4001));
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("duration is invalid", "reminderInterval is invalid",
+                        "notificationTemplate must not exceed 4000 characters");
+    }
+
+    @Test
+    void windowAndConsecutiveSamplesShouldRejectNonPositiveValuesTest() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName("High Lag");
+        request.setWindowSeconds(-5);
+        request.setConsecutiveSamples(0);
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("windowSeconds must not be negative",
+                        "consecutiveSamples must be at least 1");
+    }
+
+    @Test
+    void toAlertRuleVOShouldFillOperationalDefaultsTest() {
+        AlertRuleRequestDTO request = new AlertRuleRequestDTO();
+        request.setName("High Lag");
+
+        AlertRuleVO vo = request.toAlertRuleVO();
+
+        assertThat(vo.getAggregation()).isEqualTo("LAST");
+        assertThat(vo.getWindowSeconds()).isZero();
+        assertThat(vo.getConsecutiveSamples()).isEqualTo(1);
+        assertThat(vo.getReminderInterval()).isEqualTo("30m");
+        assertThat(vo.getChannels()).isNull();
+    }
 }


### PR DESCRIPTION
### Motivation

The alert rule request DTO tests covered channels, composite durations, channel normalization, and metric trimming, but the remaining validation rules and the VO operational defaults were unasserted. This PR grows the suite from 4 to 9 cases.

### Changes

- A missing name is required.
- Invalid operator, aggregation, and severity values are rejected with their messages.
- Malformed duration, reminder interval, and an over-4000-char template are rejected.
- Negative window seconds and zero consecutive samples are rejected.
- `toAlertRuleVO` fills the operational defaults (`LAST`, 0 window seconds, 1 consecutive sample, `30m` reminder) and keeps a null channel list null.

### Verification

- `mvn -B test -Dtest=AlertRuleRequestDTOTest`: 9/9 passed, BUILD SUCCESS