### PR TITLE
test: expand CSV rendering helper coverage

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/CsvUtilTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/CsvUtilTest.java
@@ -35,4 +35,23 @@ class CsvUtilTest {
         assertThat(CsvUtil.toCell("=SUM(A1)")).isEqualTo("\"'=SUM(A1)\"");
         assertThat(CsvUtil.toCell("+cmd")).isEqualTo("\"'+cmd\"");
     }
+
+    @Test
+    void toCellShouldNeutralizeEveryLeadingFormulaCharacterTest() {
+        assertThat(CsvUtil.toCell("-5")).isEqualTo("\"'-5\"");
+        assertThat(CsvUtil.toCell("@at")).isEqualTo("\"'@at\"");
+        assertThat(CsvUtil.toCell("\tindent")).isEqualTo("\"'\tindent\"");
+        assertThat(CsvUtil.toCell("\r\npayload")).isEqualTo("\"'\r\npayload\"");
+    }
+
+    @Test
+    void appendRowShouldJoinCellsAndWriteBareCrlfForEmptyRowsTest() {
+        StringBuilder row = new StringBuilder();
+        CsvUtil.appendRow(row, "a", "b", "c");
+        assertThat(row.toString()).isEqualTo("\"a\",\"b\",\"c\"\r\n");
+
+        StringBuilder empty = new StringBuilder();
+        CsvUtil.appendRow(empty);
+        assertThat(empty.toString()).isEqualTo(CsvUtil.CRLF);
+    }
 }


### PR DESCRIPTION
### Motivation

The `CsvUtil` tests covered quote escaping and two formula prefixes, but the remaining leading formula characters (`-`, `@`, tab, CR/LF) and the empty-row append behavior were unasserted.

### Changes

- Every leading formula character is neutralized with a protection apostrophe, including negative numbers (`-5`) and whitespace-led values.
- `appendRow` joins multiple cells with commas and writes a bare CRLF row for an empty value list.

### Verification

- `mvn -B test -Dtest=CsvUtilTest`: 4/4 passed, BUILD SUCCESS