### PR TITLE
test: add first coverage for reset password DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/ResetPasswordDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/ResetPasswordDTOTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.auth;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResetPasswordDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void newPasswordShouldBeRequired() {
+        ResetPasswordDTO request = new ResetPasswordDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("New password is required");
+    }
+
+    @Test
+    void newPasswordShouldRespectTheLengthBounds() {
+        ResetPasswordDTO shortOne = new ResetPasswordDTO();
+        shortOne.setNewPassword("short");
+
+        assertThat(validator.validate(shortOne))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("New password must contain 8 to 256 characters");
+    }
+
+    @Test
+    void validResetShouldPassValidation() {
+        ResetPasswordDTO request = new ResetPasswordDTO();
+        request.setNewPassword("fresh-secret-123");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+
+    @Test
+    void toStringShouldNeverExposeThePassword() {
+        ResetPasswordDTO request = new ResetPasswordDTO();
+        request.setNewPassword("fresh-secret-123");
+
+        assertThat(request.toString()).doesNotContain("fresh-secret-123");
+    }
+}


### PR DESCRIPTION
### Motivation

The `ResetPasswordDTO` used by the admin password reset form had no unit coverage for its validation rule or password redaction. This PR adds the first four cases.

### Changes

- A missing new password is rejected.
- A too-short new password is rejected with the size message.
- A valid reset passes validation.
- `toString` never exposes the password.

### Verification

- `mvn -B test -Dtest=ResetPasswordDTOTest`: 4/4 passed, BUILD SUCCESS