### PR TITLE
test: add first coverage for user status DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/UpdateStudioUserStatusDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/UpdateStudioUserStatusDTOTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.auth;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpdateStudioUserStatusDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void enabledShouldBeRequired() {
+        UpdateStudioUserStatusDTO request = new UpdateStudioUserStatusDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("Enabled is required");
+    }
+
+    @Test
+    void explicitBooleanStatesShouldPassValidation() {
+        UpdateStudioUserStatusDTO disabled = new UpdateStudioUserStatusDTO();
+        disabled.setEnabled(false);
+
+        UpdateStudioUserStatusDTO enabled = new UpdateStudioUserStatusDTO();
+        enabled.setEnabled(true);
+
+        assertThat(validator.validate(disabled)).isEmpty();
+        assertThat(validator.validate(enabled)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Motivation

The `UpdateStudioUserStatusDTO` used to enable/disable accounts had no unit coverage for its required-field validation. This PR adds the first two cases.

### Changes

- A missing `enabled` value is rejected.
- Both explicit boolean states pass validation.

### Verification

- `mvn -B test -Dtest=UpdateStudioUserStatusDTOTest`: 2/2 passed, BUILD SUCCESS