### PR TITLE
test: add first coverage for delete consumer group DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/DeleteConsumerGroupDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/DeleteConsumerGroupDTOTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.group;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeleteConsumerGroupDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void nameShouldBeRequired() {
+        DeleteConsumerGroupDTO request = DeleteConsumerGroupDTO.builder().build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("name is required");
+    }
+
+    @Test
+    void validDeleteShouldPassValidation() {
+        DeleteConsumerGroupDTO request = DeleteConsumerGroupDTO.builder()
+                .name("cg-order")
+                .instanceId("instance-a")
+                .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+        assertThat(request.getName()).isEqualTo("cg-order");
+    }
+}


### PR DESCRIPTION
### Motivation

The `DeleteConsumerGroupDTO` used by the group removal endpoint had no unit coverage. This PR adds the first two cases.

### Changes

- A missing name is rejected.
- A valid delete request (with routing instance id) passes validation.

### Verification

- `mvn -B test -Dtest=DeleteConsumerGroupDTOTest`: 2/2 passed, BUILD SUCCESS