### PR TITLE
test: add first coverage for direct consume message DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/DirectConsumeMessageDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/DirectConsumeMessageDTOTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.message;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DirectConsumeMessageDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void targetFieldsShouldBeRequired() {
+        DirectConsumeMessageDTO request = new DirectConsumeMessageDTO();
+        request.setInstanceId("instance-a");
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("topic is required", "msgId is required",
+                        "consumerGroup is required", "clientId is required");
+    }
+
+    @Test
+    void validConsumeRequestShouldPassValidation() {
+        DirectConsumeMessageDTO request = new DirectConsumeMessageDTO();
+        request.setInstanceId("instance-a");
+        request.setTopic("orders");
+        request.setMsgId("msg-1");
+        request.setConsumerGroup("cg-billing");
+        request.setClientId("client-a");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+
+    @Test
+    void blankTargetsShouldBeRejected() {
+        DirectConsumeMessageDTO request = new DirectConsumeMessageDTO();
+        request.setInstanceId("instance-a");
+        request.setTopic(" ");
+        request.setMsgId(" ");
+        request.setConsumerGroup(" ");
+        request.setClientId(" ");
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .contains("topic is required", "msgId is required",
+                        "consumerGroup is required", "clientId is required");
+    }
+}


### PR DESCRIPTION
### Motivation

The `DirectConsumeMessageDTO` used by the message replay feature had no unit coverage for its required-field validation. This PR adds the first three cases.

### Changes

- Missing topic/msgId/consumerGroup/clientId are each rejected with their required messages.
- Blank target values are rejected.
- A fully valid consume request passes validation.

### Verification

- `mvn -B test -Dtest=DirectConsumeMessageDTOTest`: 3/3 passed, BUILD SUCCESS