### PR TITLE
test: add first coverage for delete topic DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/DeleteTopicDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/DeleteTopicDTOTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.topic;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeleteTopicDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void nameShouldBeRequired() {
+        DeleteTopicDTO request = DeleteTopicDTO.builder().build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("name is required");
+    }
+
+    @Test
+    void validDeleteShouldPassValidation() {
+        DeleteTopicDTO request = DeleteTopicDTO.builder()
+                .name("orders")
+                .instanceId("instance-a")
+                .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+        assertThat(request.getName()).isEqualTo("orders");
+    }
+}


### PR DESCRIPTION
### Motivation

DeleteTopicDTO had no unit coverage for its validation rules. This PR adds first coverage.

### Changes

- A missing name is rejected.
- A valid delete request with routing instance id passes validation.

### Verification

- `mvn -B test -Dtest=DeleteTopicDTOTest`: passed, BUILD SUCCESS