### PR TITLE
test: add first coverage for send message DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/topic/SendMessageDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/topic/SendMessageDTOTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.topic;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SendMessageDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void topicShouldBeRequired() {
+        SendMessageDTO request = SendMessageDTO.builder().build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("topic is required");
+    }
+
+    @Test
+    void blankTopicShouldBeRejected() {
+        SendMessageDTO request = SendMessageDTO.builder().topic(" ").build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("topic is required");
+    }
+
+    @Test
+    void validSendRequestShouldPassValidation() {
+        SendMessageDTO request = SendMessageDTO.builder()
+                .instanceId("instance-a")
+                .topic("orders")
+                .tag("created")
+                .key("order-1")
+                .body("{}")
+                .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+        assertThat(request.getTopic()).isEqualTo("orders");
+    }
+}


### PR DESCRIPTION
### Motivation

SendMessageDTO had no unit coverage for its validation rules. This PR adds first coverage.

### Changes

- A missing or blank topic is rejected.
- A fully valid send request passes validation.

### Verification

- `mvn -B test -Dtest=SendMessageDTOTest`: passed, BUILD SUCCESS