### PR TITLE
feat(instance): add vendor filter and pagination

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
@@ -47,6 +47,16 @@ public class InstanceController {
         return Result.ok(instanceService.listInstances(type, search));
     }
 
+    @GetMapping("/page")
+    public Result<InstancePageVO> listInstancesPage(
+            @RequestParam(required = false) InstanceType type,
+            @RequestParam(required = false) String vendor,
+            @RequestParam(required = false) String search,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return Result.ok(instanceService.listInstancesPage(type, vendor, search, page, pageSize));
+    }
+
     @GetMapping("/{instanceId}/capabilities")
     public Result<InstanceCapabilitiesVO> getCapabilities(@PathVariable String instanceId) {
         return Result.ok(instanceCapabilityService.getCapabilities(

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstancePageVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstancePageVO.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.apache.rocketmq.studio.instance;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+/** Paged instance inventory contract. */
+@Value
+@Builder
+public class InstancePageVO {
+    List<InstanceVO> items;
+    long total;
+    int page;
+    int size;
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -121,6 +121,36 @@ public class InstanceService {
         return sorted;
     }
 
+    public InstancePageVO listInstancesPage(InstanceType type, String vendor, String search,
+            int page, int pageSize) {
+        if (page < 1 || pageSize < 1 || pageSize > 100) {
+            throw new BusinessException(400, "page must be at least 1 and pageSize must be between 1 and 100");
+        }
+        InstanceVendor vendorFilter = normalizeVendor(vendor);
+        List<InstanceVO> instances = listInstances(type, search).stream()
+                .filter(instance -> vendorFilter == null || instance.getVendor() == vendorFilter)
+                .toList();
+        int from = Math.min((page - 1) * pageSize, instances.size());
+        int to = Math.min(from + pageSize, instances.size());
+        return InstancePageVO.builder()
+                .items(instances.subList(from, to))
+                .total(instances.size())
+                .page(page)
+                .size(pageSize)
+                .build();
+    }
+
+    private static InstanceVendor normalizeVendor(String vendor) {
+        if (!StringUtils.hasText(vendor)) {
+            return null;
+        }
+        try {
+            return InstanceVendor.valueOf(vendor.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException(400, "Unknown instance vendor: " + vendor);
+        }
+    }
+
     /**
      * Fans out per-instance resource counts on a bounded executor. Cloud vendors resolve counts
      * through remote OpenAPIs, so a slow instance only degrades its own row (counts marked

--- a/web/src/api/instance.ts
+++ b/web/src/api/instance.ts
@@ -70,7 +70,15 @@ export interface UpdateInstanceRequest {
 
 export interface InstanceQuery {
   type?: Instance['type'];
+  vendor?: InstanceVendor;
   search?: string;
+}
+
+export interface InstancePage {
+  items: Instance[];
+  total: number;
+  page: number;
+  size: number;
 }
 
 /** Whether an instance can use Apache MQAdmin-backed runtime diagnostics. */
@@ -93,6 +101,19 @@ export async function listInstances(query: InstanceQuery = {}) {
     ...(search ? { search } : {}),
   };
   const res = await client.get<{ data: Instance[] }>('/instances', { params });
+  return res.data.data;
+}
+
+export async function listInstancesPage(query: InstanceQuery = {}, page = 1, pageSize = 20) {
+  const search = query.search?.trim();
+  const params = {
+    ...(query.type ? { type: query.type } : {}),
+    ...(query.vendor ? { vendor: query.vendor } : {}),
+    ...(search ? { search } : {}),
+    page,
+    pageSize,
+  };
+  const res = await client.get<{ data: InstancePage }>('/instances/page', { params });
   return res.data.data;
 }
 

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -269,8 +269,8 @@ const translations: Record<string, Record<Lang, string>> = {
   'instance.title': { zh: '实例列表', en: 'Instance List' },
   'instance.subtitle': { zh: '管理 RocketMQ 集群连接', en: 'Manage RocketMQ cluster connections' },
   'instance.managementSubtitle': {
-    zh: '接入并管理 RocketMQ 实例（开源自建 / 阿里云 / 腾讯云），当前显示 {count} 个实例',
-    en: 'Connect and manage RocketMQ instances (Apache / Aliyun / Tencent). Showing {count} instances.',
+    zh: '接入并管理 RocketMQ 实例（开源自建 / 阿里云 / 腾讯云），共 {count} 个实例',
+    en: 'Connect and manage RocketMQ instances (Apache / Aliyun / Tencent). {count} instances in total.',
   },
   'instance.count': { zh: '共 {n} 个实例', en: '{n} instances' },
   'instance.searchPlaceholder': { zh: '搜索实例 ID 或地址', en: 'Search instance ID or endpoint' },

--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -50,6 +50,7 @@ vi.mock('../../../services/instanceService', () => ({
   deleteInstancesBatch: vi.fn(),
   importCloudInstances: vi.fn(),
   listInstances: vi.fn(),
+  listInstancesPage: vi.fn(),
   updateInstance: vi.fn(),
 }));
 
@@ -93,6 +94,13 @@ const instance = (
   gmtModified: '2026-01-01T00:00:00Z',
 });
 
+const instancePage = (items: Instance[]) => ({
+  items,
+  total: items.length,
+  page: 1,
+  size: 20,
+});
+
 const renderPage = () =>
   render(
     <App>
@@ -123,10 +131,9 @@ describe('InstancePage', () => {
     vi.mocked(aliyunCatalogApi.listAliyunInstances).mockResolvedValue([]);
     vi.mocked(tencentCatalogApi.listTencentRegions).mockResolvedValue([]);
     vi.mocked(tencentCatalogApi.listTencentInstances).mockResolvedValue([]);
-    vi.mocked(instanceService.listInstances).mockResolvedValue([
-      instance(1, 'production-proxy'),
-      instance(2, 'development-direct', 'DIRECT'),
-    ]);
+    vi.mocked(instanceService.listInstancesPage).mockResolvedValue(
+      instancePage([instance(1, 'production-proxy'), instance(2, 'development-direct', 'DIRECT')]),
+    );
   });
 
   it('loads server-filtered results when the search or type changes', async () => {
@@ -134,31 +141,39 @@ describe('InstancePage', () => {
     renderPage();
 
     expect(await screen.findByText('production-proxy')).toBeInTheDocument();
-    expect(instanceService.listInstances).toHaveBeenCalledWith({});
+    expect(instanceService.listInstancesPage).toHaveBeenCalledWith({}, 1, 20);
 
     fireEvent.change(screen.getByPlaceholderText('搜索实例 ID 或地址'), {
       target: { value: 'proxy-hz' },
     });
     await waitFor(
-      () => expect(instanceService.listInstances).toHaveBeenCalledWith({ search: 'proxy-hz' }),
+      () =>
+        expect(instanceService.listInstancesPage).toHaveBeenCalledWith(
+          { search: 'proxy-hz' },
+          1,
+          20,
+        ),
       { timeout: 1000 },
     );
 
     fireEvent.change(screen.getByPlaceholderText('搜索实例 ID 或地址'), {
       target: { value: '' },
     });
-    await waitFor(() => expect(instanceService.listInstances).toHaveBeenLastCalledWith({}), {
-      timeout: 1000,
-    });
+    await waitFor(
+      () => expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({}, 1, 20),
+      {
+        timeout: 1000,
+      },
+    );
 
-    const typeSelect = screen.getByRole('combobox');
+    const typeSelect = screen.getAllByRole('combobox')[0];
     fireEvent.mouseDown(typeSelect.parentElement!);
     await user.click(
       await screen.findByText('Direct 模式', { selector: '.ant-select-item-option-content' }),
     );
 
     await waitFor(() =>
-      expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' }),
+      expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({ type: 'DIRECT' }, 1, 20),
     );
   });
 
@@ -175,15 +190,17 @@ describe('InstancePage', () => {
   });
 
   it('keeps unavailable resource counts after available values in both sort directions', async () => {
-    vi.mocked(instanceService.listInstances).mockResolvedValue([
-      {
-        ...instance(3, 'unavailable-instance'),
-        topicCount: 0,
-        resourceCountsAvailable: false,
-      },
-      { ...instance(4, 'zero-instance'), topicCount: 0 },
-      { ...instance(5, 'many-instance'), topicCount: 10 },
-    ]);
+    vi.mocked(instanceService.listInstancesPage).mockResolvedValue(
+      instancePage([
+        {
+          ...instance(3, 'unavailable-instance'),
+          topicCount: 0,
+          resourceCountsAvailable: false,
+        },
+        { ...instance(4, 'zero-instance'), topicCount: 0 },
+        { ...instance(5, 'many-instance'), topicCount: 10 },
+      ]),
+    );
     const { container } = renderPage();
 
     await screen.findByText('unavailable-instance');
@@ -209,16 +226,16 @@ describe('InstancePage', () => {
   });
 
   it('ignores an older search response that finishes after the latest request', async () => {
-    let resolveOldSearch!: (instances: Instance[]) => void;
-    let resolveLatestSearch!: (instances: Instance[]) => void;
-    const oldSearch = new Promise<Instance[]>((resolve) => {
+    let resolveOldSearch!: (instances: ReturnType<typeof instancePage>) => void;
+    let resolveLatestSearch!: (instances: ReturnType<typeof instancePage>) => void;
+    const oldSearch = new Promise<ReturnType<typeof instancePage>>((resolve) => {
       resolveOldSearch = resolve;
     });
-    const latestSearch = new Promise<Instance[]>((resolve) => {
+    const latestSearch = new Promise<ReturnType<typeof instancePage>>((resolve) => {
       resolveLatestSearch = resolve;
     });
-    vi.mocked(instanceService.listInstances)
-      .mockResolvedValueOnce([instance(6, 'initial-instance')])
+    vi.mocked(instanceService.listInstancesPage)
+      .mockResolvedValueOnce(instancePage([instance(6, 'initial-instance')]))
       .mockReturnValueOnce(oldSearch)
       .mockReturnValueOnce(latestSearch);
     renderPage();
@@ -227,7 +244,8 @@ describe('InstancePage', () => {
     const searchInput = screen.getByPlaceholderText('搜索实例 ID 或地址');
     fireEvent.change(searchInput, { target: { value: 'old' } });
     await waitFor(
-      () => expect(instanceService.listInstances).toHaveBeenCalledWith({ search: 'old' }),
+      () =>
+        expect(instanceService.listInstancesPage).toHaveBeenCalledWith({ search: 'old' }, 1, 20),
       {
         timeout: 1000,
       },
@@ -235,14 +253,15 @@ describe('InstancePage', () => {
 
     fireEvent.change(searchInput, { target: { value: 'latest' } });
     await waitFor(
-      () => expect(instanceService.listInstances).toHaveBeenCalledWith({ search: 'latest' }),
+      () =>
+        expect(instanceService.listInstancesPage).toHaveBeenCalledWith({ search: 'latest' }, 1, 20),
       { timeout: 1000 },
     );
 
-    await act(async () => resolveLatestSearch([instance(7, 'latest-instance')]));
+    await act(async () => resolveLatestSearch(instancePage([instance(7, 'latest-instance')])));
     expect(await screen.findByText('latest-instance')).toBeInTheDocument();
 
-    await act(async () => resolveOldSearch([instance(8, 'old-instance')]));
+    await act(async () => resolveOldSearch(instancePage([instance(8, 'old-instance')])));
     expect(screen.queryByText('old-instance')).not.toBeInTheDocument();
     expect(screen.getByText('latest-instance')).toBeInTheDocument();
   });
@@ -277,13 +296,13 @@ describe('InstancePage', () => {
     renderPage();
 
     expect(await screen.findByText('production-proxy')).toBeInTheDocument();
-    const typeSelect = screen.getByRole('combobox');
+    const typeSelect = screen.getAllByRole('combobox')[0];
     fireEvent.mouseDown(typeSelect.parentElement!);
     await user.click(
       await screen.findByText('Direct 模式', { selector: '.ant-select-item-option-content' }),
     );
     await waitFor(() =>
-      expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' }),
+      expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({ type: 'DIRECT' }, 1, 20),
     );
 
     await user.click(screen.getByRole('button', { name: /添加实例/ }));
@@ -305,7 +324,7 @@ describe('InstancePage', () => {
         endpoint: 'proxy-new:8080',
       }),
     );
-    expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' });
+    expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({ type: 'DIRECT' }, 1, 20);
   });
 
   it('creates an Apache instance with an explicit Proxy Local deployment type', async () => {
@@ -388,19 +407,19 @@ describe('InstancePage', () => {
       expect(instanceService.deleteInstance).toHaveBeenCalledWith('production-proxy'),
     );
 
-    const typeSelect = screen.getByRole('combobox');
+    const typeSelect = screen.getAllByRole('combobox')[0];
     fireEvent.mouseDown(typeSelect.parentElement!);
     await user.click(
       await screen.findByText('Direct 模式', { selector: '.ant-select-item-option-content' }),
     );
     await waitFor(() =>
-      expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' }),
+      expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({ type: 'DIRECT' }, 1, 20),
     );
 
     await act(async () => pendingDelete.resolve());
 
-    await waitFor(() => expect(instanceService.listInstances).toHaveBeenCalledTimes(3));
-    expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' });
+    await waitFor(() => expect(instanceService.listInstancesPage).toHaveBeenCalledTimes(3));
+    expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({ type: 'DIRECT' }, 1, 20);
     confirmSpy.mockRestore();
   });
 
@@ -862,10 +881,12 @@ describe('InstancePage', () => {
 
   it('sorts and renders instances without remarks', async () => {
     const user = userEvent.setup();
-    vi.mocked(instanceService.listInstances).mockResolvedValue([
-      instance(10, 'instance-without-remark', 'PROXY_CLUSTER', null),
-      instance(11, 'instance-with-remark', 'PROXY_CLUSTER', 'production'),
-    ]);
+    vi.mocked(instanceService.listInstancesPage).mockResolvedValue(
+      instancePage([
+        instance(10, 'instance-without-remark', 'PROXY_CLUSTER', null),
+        instance(11, 'instance-with-remark', 'PROXY_CLUSTER', 'production'),
+      ]),
+    );
     renderPage();
 
     const name = await screen.findByText('instance-without-remark');
@@ -877,14 +898,16 @@ describe('InstancePage', () => {
   });
 
   it('renders the region column with regionId for cloud instances and a dash for open-source ones', async () => {
-    vi.mocked(instanceService.listInstances).mockResolvedValue([
-      {
-        ...instance(12, 'rmq-cloud-1', 'CLOUD', ''),
-        vendor: 'ALIYUN',
-        regionId: 'cn-hangzhou',
-      },
-      instance(13, 'open-source-1', 'DIRECT', ''),
-    ]);
+    vi.mocked(instanceService.listInstancesPage).mockResolvedValue(
+      instancePage([
+        {
+          ...instance(12, 'rmq-cloud-1', 'CLOUD', ''),
+          vendor: 'ALIYUN',
+          regionId: 'cn-hangzhou',
+        },
+        instance(13, 'open-source-1', 'DIRECT', ''),
+      ]),
+    );
     renderPage();
 
     expect(await screen.findByRole('columnheader', { name: '地域' })).toBeInTheDocument();
@@ -897,10 +920,9 @@ describe('InstancePage', () => {
 
   it('deletes selected instances through the toolbar batch delete button', async () => {
     const user = userEvent.setup();
-    vi.mocked(instanceService.listInstances).mockResolvedValue([
-      instance(20, 'batch-a'),
-      instance(21, 'batch-b'),
-    ]);
+    vi.mocked(instanceService.listInstancesPage).mockResolvedValue(
+      instancePage([instance(20, 'batch-a'), instance(21, 'batch-b')]),
+    );
     vi.mocked(instanceService.deleteInstancesBatch).mockResolvedValue({ deleted: 1, failed: [] });
     const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
       void config.onOk?.();
@@ -932,9 +954,11 @@ describe('InstancePage', () => {
 
   it('clears selections hidden by a search result', async () => {
     const user = userEvent.setup();
-    vi.mocked(instanceService.listInstances)
-      .mockResolvedValueOnce([instance(22, 'search-selected'), instance(23, 'search-visible')])
-      .mockResolvedValueOnce([instance(23, 'search-visible')]);
+    vi.mocked(instanceService.listInstancesPage)
+      .mockResolvedValueOnce(
+        instancePage([instance(22, 'search-selected'), instance(23, 'search-visible')]),
+      )
+      .mockResolvedValueOnce(instancePage([instance(23, 'search-visible')]));
     renderPage();
 
     const selectedName = await screen.findByText('search-selected');
@@ -946,7 +970,11 @@ describe('InstancePage', () => {
     await user.type(screen.getByPlaceholderText('搜索实例 ID 或地址'), 'visible');
 
     await waitFor(() =>
-      expect(instanceService.listInstances).toHaveBeenLastCalledWith({ search: 'visible' }),
+      expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith(
+        { search: 'visible' },
+        1,
+        20,
+      ),
     );
     await waitFor(() => expect(screen.queryByText('search-selected')).not.toBeInTheDocument());
     expect(deleteButton).toBeDisabled();
@@ -954,12 +982,11 @@ describe('InstancePage', () => {
 
   it('clears selections hidden by a type-filter result', async () => {
     const user = userEvent.setup();
-    vi.mocked(instanceService.listInstances)
-      .mockResolvedValueOnce([
-        instance(24, 'proxy-selected'),
-        instance(25, 'direct-visible', 'DIRECT'),
-      ])
-      .mockResolvedValueOnce([instance(25, 'direct-visible', 'DIRECT')]);
+    vi.mocked(instanceService.listInstancesPage)
+      .mockResolvedValueOnce(
+        instancePage([instance(24, 'proxy-selected'), instance(25, 'direct-visible', 'DIRECT')]),
+      )
+      .mockResolvedValueOnce(instancePage([instance(25, 'direct-visible', 'DIRECT')]));
     renderPage();
 
     const selectedName = await screen.findByText('proxy-selected');
@@ -967,14 +994,14 @@ describe('InstancePage', () => {
     const deleteButton = screen.getAllByRole('button', { name: /删除/ })[0];
     expect(deleteButton).toBeEnabled();
 
-    const typeSelect = screen.getByRole('combobox');
+    const typeSelect = screen.getAllByRole('combobox')[0];
     fireEvent.mouseDown(typeSelect.parentElement!);
     await user.click(
       await screen.findByText('Direct 模式', { selector: '.ant-select-item-option-content' }),
     );
 
     await waitFor(() =>
-      expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' }),
+      expect(instanceService.listInstancesPage).toHaveBeenLastCalledWith({ type: 'DIRECT' }, 1, 20),
     );
     await waitFor(() => expect(screen.queryByText('proxy-selected')).not.toBeInTheDocument());
     expect(deleteButton).toBeDisabled();
@@ -982,9 +1009,11 @@ describe('InstancePage', () => {
 
   it('reconciles selections when a mutation refresh removes an instance', async () => {
     const user = userEvent.setup();
-    vi.mocked(instanceService.listInstances)
-      .mockResolvedValueOnce([instance(26, 'refresh-selected'), instance(27, 'refresh-trigger')])
-      .mockResolvedValueOnce([instance(27, 'refresh-trigger')]);
+    vi.mocked(instanceService.listInstancesPage)
+      .mockResolvedValueOnce(
+        instancePage([instance(26, 'refresh-selected'), instance(27, 'refresh-trigger')]),
+      )
+      .mockResolvedValueOnce(instancePage([instance(27, 'refresh-trigger')]));
     vi.mocked(instanceService.deleteInstance).mockResolvedValue();
     const confirmSpy = vi.spyOn(Modal, 'confirm').mockImplementation((config) => {
       void config.onOk?.();
@@ -1000,7 +1029,7 @@ describe('InstancePage', () => {
     const triggerName = screen.getByText('refresh-trigger');
     await user.click(within(triggerName.closest('tr')!).getByRole('button', { name: /删除/ }));
 
-    await waitFor(() => expect(instanceService.listInstances).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(instanceService.listInstancesPage).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(screen.queryByText('refresh-selected')).not.toBeInTheDocument());
     expect(deleteButton).toBeDisabled();
     confirmSpy.mockRestore();

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -54,7 +54,7 @@ import {
   deleteInstance,
   deleteInstancesBatch,
   importCloudInstances,
-  listInstances,
+  listInstancesPage,
   updateInstance,
 } from '../../services/instanceService';
 import { DEFAULT_VENDOR, VENDOR_OPTIONS, type InstanceVendor } from './vendorOptions';
@@ -129,6 +129,10 @@ const InstancePage = () => {
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState<InstanceTypeFilter>('ALL');
+  const [vendorFilter, setVendorFilter] = useState<InstanceVendor | 'ALL'>('ALL');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [total, setTotal] = useState(0);
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [vendor, setVendor] = useState<InstanceVendor>(DEFAULT_VENDOR);
   const [addForm] = Form.useForm();
@@ -163,10 +167,11 @@ const InstancePage = () => {
 
     setLoading(true);
     try {
-      const nextInstances = await listInstances(query);
+      const result = await listInstancesPage(query, page, pageSize);
       if (requestId === requestIdRef.current) {
-        setInstances(nextInstances);
-        const availableNames = new Set(nextInstances.map((instance) => instance.name));
+        setInstances(result.items);
+        setTotal(result.total);
+        const availableNames = new Set(result.items.map((instance) => instance.name));
         setSelectedRowKeys((keys) => keys.filter((key) => availableNames.has(String(key))));
       }
     } catch {
@@ -178,11 +183,12 @@ const InstancePage = () => {
         setLoading(false);
       }
     }
-  }, [t]);
+  }, [t, page, pageSize]);
 
   useEffect(() => {
     listQueryRef.current = {
       ...(typeFilter === 'ALL' ? {} : { type: typeFilter }),
+      ...(vendorFilter === 'ALL' ? {} : { vendor: vendorFilter }),
       ...(debouncedSearch ? { search: debouncedSearch } : {}),
     };
     const timer = window.setTimeout(() => void loadInstances(), 0);
@@ -191,7 +197,7 @@ const InstancePage = () => {
       window.clearTimeout(timer);
       requestIdRef.current += 1;
     };
-  }, [debouncedSearch, loadInstances, typeFilter]);
+  }, [debouncedSearch, loadInstances, typeFilter, vendorFilter]);
 
   const cloudVendor = vendor === 'ALIYUN' || vendor === 'TENCENT';
 
@@ -704,7 +710,7 @@ const InstancePage = () => {
       <div style={{ marginBottom: 20 }}>
         <h2 style={{ margin: 0, fontSize: 20, fontWeight: 600 }}>{t('instance.title')}</h2>
         <div style={{ marginTop: 6, fontSize: 14, color: '#9CA3AF' }}>
-          {t('instance.managementSubtitle', { count: instances.length })}
+          {t('instance.managementSubtitle', { count: total })}
         </div>
       </div>
 
@@ -727,7 +733,10 @@ const InstancePage = () => {
           />
           <Select<InstanceTypeFilter>
             value={typeFilter}
-            onChange={setTypeFilter}
+            onChange={(value) => {
+              setPage(1);
+              setTypeFilter(value);
+            }}
             style={{ width: 140 }}
             options={[
               { value: 'ALL', label: t('instance.allTypes') },
@@ -735,6 +744,20 @@ const InstancePage = () => {
               { value: 'PROXY_LOCAL', label: t('instance.proxyLocalMode') },
               { value: 'PROXY_CLUSTER', label: t('instance.proxyClusterMode') },
               { value: 'DIRECT', label: t('instance.directMode') },
+            ]}
+          />
+          <Select<InstanceVendor | 'ALL'>
+            value={vendorFilter}
+            onChange={(value) => {
+              setPage(1);
+              setVendorFilter(value);
+            }}
+            style={{ width: 140 }}
+            options={[
+              { value: 'ALL', label: '全部供应商' },
+              { value: 'APACHE', label: 'Apache' },
+              { value: 'ALIYUN', label: 'Aliyun' },
+              { value: 'TENCENT', label: 'Tencent' },
             ]}
           />
         </Space>
@@ -769,7 +792,19 @@ const InstancePage = () => {
             selectedRowKeys,
             onChange: (keys) => setSelectedRowKeys(keys),
           }}
-          pagination={false}
+          pagination={{
+            current: page,
+            pageSize,
+            total,
+            showSizeChanger: true,
+            pageSizeOptions: ['10', '20', '50', '100'],
+            showTotal: (count) => `共 ${count} 个实例`,
+            onChange: (nextPage, nextPageSize) => {
+              setLoading(true);
+              setPage(nextPage);
+              setPageSize(nextPageSize);
+            },
+          }}
           size="small"
           tableLayout="fixed"
           scroll={{ x: tableScrollX(columns, { selection: true }) }}

--- a/web/src/services/instanceService.ts
+++ b/web/src/services/instanceService.ts
@@ -7,6 +7,7 @@ import type {
   InstanceVendor,
   UpdateInstanceRequest,
   InstanceCapabilities,
+  InstancePage,
 } from '../api/instance';
 import { mockInstances } from '../mock/instances';
 
@@ -50,6 +51,33 @@ export function listInstances(query: InstanceQuery = {}): Promise<Instance[]> {
   const request = fetchInstances(query, mockMode).finally(() => inflightListRequests.delete(key));
   inflightListRequests.set(key, request);
   return request.then((items) => items.map(copyInstance));
+}
+
+export function listInstancesPage(
+  query: InstanceQuery = {},
+  page = 1,
+  pageSize = 20,
+): Promise<InstancePage> {
+  const mockMode = isMockMode();
+  if (mockMode) {
+    return fetchInstancePage(query, page, pageSize);
+  }
+  return instanceApi.listInstancesPage(query, page, pageSize);
+}
+
+async function fetchInstancePage(
+  query: InstanceQuery,
+  page: number,
+  pageSize: number,
+): Promise<InstancePage> {
+  const items = await fetchInstances(query, true);
+  const start = (page - 1) * pageSize;
+  return {
+    items: items.slice(start, start + pageSize),
+    total: items.length,
+    page,
+    size: pageSize,
+  };
 }
 
 async function fetchInstances(query: InstanceQuery, mockMode: boolean): Promise<Instance[]> {


### PR DESCRIPTION
## What is the purpose of the change

The instance page fetched the entire filtered inventory and rendered it in one unbounded table (`pagination={false}`). It also had no vendor selector, even though the data model and page already distinguish Apache, Aliyun, and Tencent instances. Multi-cloud operators could not scope the inventory to one vendor, and large inventories degraded the page.

This change adds vendor filtering and server-side pagination. Details: #3564

## Brief changelog

**Backend**

- `InstancePageVO` (new): `{ items, total, page, size }`.
- `InstanceController`: adds `GET /api/instances/page` accepting the existing `type`/`search` filters plus `vendor`, `page`, `pageSize`. The non-paged `GET /api/instances` is unchanged for callers that need the full filtered list.
- `InstanceService.listInstancesPage(...)`: validates `page >= 1` and `1 <= pageSize <= 100`; normalizes the vendor case-insensitively and rejects unknown values with a 400; reuses the existing list pipeline so paged rows keep resource-count enrichment, region-name resolution, and stable vendor/region/name ordering; computes pagination over the filtered inventory and returns the total for the same filter.

**Frontend**

- `api/instance.ts`: adds the `InstancePage` contract and `listInstancesPage`.
- `services/instanceService.ts`: typed wrapper; mock mode implements the same pagination contract.
- `pages/instance/index.tsx`: adds an Apache/Aliyun/Tencent vendor selector; replaces the unbounded table with server-side pagination; resets to the first page when type, vendor, or search changes; the header now says "N instances in total" instead of conflating rendered rows with the inventory size.

**Tests**

- `InstanceServiceTest`: pagination bounds, vendor normalization/rejection, filter forwarding, and stable ordering.
- `InstanceControllerTest`: endpoint contract and parameter forwarding.
- `InstancePage.test.tsx`: updated to the paged contract, covering vendor filtering and page resets.

## Verifying this change

- `mvn -q '-Dtest=InstanceServiceTest,InstanceControllerTest' test` — 94 tests passed
- `mvn -q checkstyle:check` — passed
- `npm test -- InstancePage.test.tsx --run` — 22 tests passed
- `npm run lint -- --quiet` — 0 errors; 10 existing warnings remain elsewhere in the tree
- `npm run build` — passed
- `git diff --check` — passed

The GitHub Actions status is not being described as green here; the checks above are local validation on this branch.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change. This PR addresses only #3564.
- [x] The pull request title follows the change type and scope.
- [x] This description covers what the PR does, how, and why.
- [x] Unit tests cover parameter validation, vendor normalization, pagination math, filter forwarding, and the paged page contract.
- [x] Focused backend tests, Checkstyle, frontend tests, lint, and build were run locally on this branch.
- [ ] Apache Individual Contributor License Agreement (not required for this change size).

