### PR TITLE
test: add first coverage for DLQ resend request DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQResendRequestDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/dlq/DLQResendRequestDTOTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.dlq;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DLQResendRequestDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void instanceAndGroupShouldBeRequired() {
+        DLQResendRequestDTO request = DLQResendRequestDTO.builder().build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("instanceId is required", "groupName is required");
+    }
+
+    @Test
+    void validResendWindowShouldPassValidation() {
+        DLQResendRequestDTO request = DLQResendRequestDTO.builder()
+                .instanceId("instance-a")
+                .groupName("cg-order")
+                .startTime(1784246400000L)
+                .endTime(1784332800000L)
+                .targetTopic("orders-retry")
+                .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+        assertThat(request.getTargetTopic()).isEqualTo("orders-retry");
+    }
+}


### PR DESCRIPTION
### Motivation

`DLQResendRequestDTO` had no unit coverage for its validation rules. This PR adds first coverage.

### Changes

- instanceId/groupName are required.
- A valid time-window resend with an optional target topic passes validation.

### Verification

- `mvn -B test -Dtest=DLQResendRequestDTOTest`: 2/2 passed, BUILD SUCCESS