### PR TITLE
test: add first coverage for update ACL rule DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/UpdateAclRuleDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/UpdateAclRuleDTOTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.acl;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpdateAclRuleDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void identityAndPrincipalAndResourceShouldBeRequired() {
+        UpdateAclRuleDTO request = new UpdateAclRuleDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("id is required", "principal is required",
+                        "resource is required");
+    }
+
+    @Test
+    void toAclRuleVoShouldParseNumericIds() {
+        UpdateAclRuleDTO numeric = new UpdateAclRuleDTO();
+        numeric.setId(" 42 ");
+        numeric.setPrincipal("user-order-service");
+        numeric.setResource("order-*");
+        numeric.setActions(java.util.List.of("PUB"));
+
+        AclRuleVO vo = numeric.toAclRuleVO();
+
+        assertThat(vo.getId()).isEqualTo(42L);
+        assertThat(vo.getActions()).containsExactly("PUB");
+
+        UpdateAclRuleDTO nonNumeric = new UpdateAclRuleDTO();
+        nonNumeric.setId("tenant-role");
+        nonNumeric.setPrincipal("user-order-service");
+        nonNumeric.setResource("order-*");
+
+        assertThat(nonNumeric.toAclRuleVO().getId()).isNull();
+    }
+}


### PR DESCRIPTION
### Motivation

`UpdateAclRuleDTO` had no unit coverage for its validation rules or numeric id parsing. This PR adds first coverage.

### Changes

- id/principal/resource are required.
- `toAclRuleVO` parses trimmed numeric ids and maps non-numeric ids to null.

### Verification

- `mvn -B test -Dtest=UpdateAclRuleDTOTest`: 2/2 passed, BUILD SUCCESS