### PR TITLE
test: add first coverage for create alert silence DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/CreateAlertSilenceDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/CreateAlertSilenceDTOTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreateAlertSilenceDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void windowBoundsShouldBeRequired() {
+        CreateAlertSilenceDTO request = new CreateAlertSilenceDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("startsAt is required", "endsAt is required");
+    }
+
+    @Test
+    void fullSilenceShouldPassValidation() {
+        CreateAlertSilenceDTO request = new CreateAlertSilenceDTO();
+        request.setDomain(AlertDomain.CLUSTER);
+        request.setRuleId(7L);
+        request.setInstanceId("instance-a");
+        request.setStartsAt(java.time.OffsetDateTime.parse("2026-09-01T00:00:00Z"));
+        request.setEndsAt(java.time.OffsetDateTime.parse("2026-09-02T00:00:00Z"));
+        request.setRecurrence(AlertSilenceRecurrence.ONCE);
+        request.setReason("scheduled maintenance");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Motivation

`CreateAlertSilenceDTO` had no unit coverage for its required window validation. This PR adds first coverage.

### Changes

- startsAt and endsAt are required.
- A fully specified silence (with recurrence and reason) passes validation.

### Verification

- `mvn -B test -Dtest=CreateAlertSilenceDTOTest`: 2/2 passed, BUILD SUCCESS