### PR TITLE
test: add first coverage for ops TLS DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/OpsTlsDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/OpsTlsDTOTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpsTlsDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void useTlsShouldBeRequired() {
+        OpsTlsDTO request = new OpsTlsDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("useTLS is required");
+    }
+
+    @Test
+    void bothBooleanStatesShouldPassValidation() {
+        OpsTlsDTO on = new OpsTlsDTO();
+        on.setUseTLS(true);
+
+        OpsTlsDTO off = new OpsTlsDTO();
+        off.setUseTLS(false);
+
+        assertThat(validator.validate(on)).isEmpty();
+        assertThat(validator.validate(off)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Motivation

`OpsTlsDTO` had no unit coverage for its required flag validation. This PR adds first coverage.

### Changes

- A missing useTLS value is rejected.
- Both explicit boolean states pass validation.

### Verification

- `mvn -B test -Dtest=OpsTlsDTOTest`: 2/2 passed, BUILD SUCCESS