### PR TITLE
test: add first coverage for renew cert DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/RenewCertDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/k8s/RenewCertDTOTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.k8s;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RenewCertDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void idShouldBeRequired() {
+        RenewCertDTO request = RenewCertDTO.builder().build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("id is required");
+    }
+
+    @Test
+    void validRenewShouldPassValidation() {
+        RenewCertDTO request = RenewCertDTO.builder().id(5L).build();
+
+        assertThat(validator.validate(request)).isEmpty();
+        assertThat(request.getId()).isEqualTo(5L);
+    }
+}


### PR DESCRIPTION
### Motivation

`RenewCertDTO` had no unit coverage for its required id validation. This PR adds first coverage.

### Changes

- A missing id is rejected.
- A valid renewal request passes validation.

### Verification

- `mvn -B test -Dtest=RenewCertDTOTest`: 2/2 passed, BUILD SUCCESS