### PR TITLE
test: add first coverage for proxy address DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/ProxyAddressDTOTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.proxy;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProxyAddressDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void addrShouldBeRequired() {
+        ProxyAddressDTO request = ProxyAddressDTO.builder().build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("addr is required");
+    }
+
+    @Test
+    void validAddressShouldPassValidation() {
+        ProxyAddressDTO request = ProxyAddressDTO.builder().addr("10.0.0.10:8081").build();
+
+        assertThat(validator.validate(request)).isEmpty();
+        assertThat(request.getAddr()).isEqualTo("10.0.0.10:8081");
+    }
+}


### PR DESCRIPTION
### Motivation

`ProxyAddressDTO` had no unit coverage for its required address validation. This PR adds first coverage.

### Changes

- A missing addr is rejected.
- A valid proxy address passes validation.

### Verification

- `mvn -B test -Dtest=ProxyAddressDTOTest`: 2/2 passed, BUILD SUCCESS