### PR TITLE
test: add first coverage for restart proxy DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/RestartProxyDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/proxy/RestartProxyDTOTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.proxy;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RestartProxyDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void clusterAndAddrShouldBeRequired() {
+        RestartProxyDTO request = RestartProxyDTO.builder().build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("clusterId is required", "addr is required");
+    }
+
+    @Test
+    void validRestartShouldPassValidation() {
+        RestartProxyDTO request = RestartProxyDTO.builder()
+                .clusterId("cluster-prod")
+                .addr("10.0.0.10:8081")
+                .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Motivation

`RestartProxyDTO` had no unit coverage for its required fields. This PR adds first coverage.

### Changes

- clusterId and addr are required.
- A valid restart request passes validation.

### Verification

- `mvn -B test -Dtest=RestartProxyDTOTest`: 2/2 passed, BUILD SUCCESS