### PR TITLE
test: add first coverage for toggle alert rule DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/alert/ToggleAlertRuleDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/alert/ToggleAlertRuleDTOTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.alert;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ToggleAlertRuleDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void idAndEnabledShouldBeRequired() {
+        ToggleAlertRuleDTO request = ToggleAlertRuleDTO.builder().build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("id is required", "enabled is required");
+    }
+
+    @Test
+    void validToggleShouldPassValidation() {
+        ToggleAlertRuleDTO request = ToggleAlertRuleDTO.builder().id(7L).enabled(false).build();
+
+        assertThat(validator.validate(request)).isEmpty();
+        assertThat(request.getEnabled()).isFalse();
+    }
+}


### PR DESCRIPTION
### Motivation

`ToggleAlertRuleDTO` had no unit coverage for its required fields. This PR adds first coverage.

### Changes

- id and enabled are required.
- A valid toggle request passes validation.

### Verification

- `mvn -B test -Dtest=ToggleAlertRuleDTOTest`: 2/2 passed, BUILD SUCCESS