### PR TITLE
test: add first coverage for audit cleanup DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditCleanupDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/ops/audit/AuditCleanupDTOTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.ops.audit;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuditCleanupDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void beforeDaysShouldBePositiveAndBounded() {
+        AuditCleanupDTO zero = AuditCleanupDTO.builder().beforeDays(0).build();
+        AuditCleanupDTO huge = AuditCleanupDTO.builder().beforeDays(366).build();
+
+        assertThat(validator.validate(zero))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("beforeDays must be greater than 0");
+        assertThat(validator.validate(huge))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("beforeDays must not exceed 365");
+    }
+
+    @Test
+    void validCleanupWindowShouldPassValidation() {
+        AuditCleanupDTO request = AuditCleanupDTO.builder().beforeDays(30).build();
+
+        assertThat(validator.validate(request)).isEmpty();
+        assertThat(request.getBeforeDays()).isEqualTo(30);
+    }
+}


### PR DESCRIPTION
### Motivation

`AuditCleanupDTO` had no unit coverage for its retention bounds. This PR adds first coverage.

### Changes

- beforeDays below 1 or above 365 is rejected.
- A valid cleanup window passes validation.

### Verification

- `mvn -B test -Dtest=AuditCleanupDTOTest`: 2/2 passed, BUILD SUCCESS