### PR TITLE
test: add first coverage for Restartname server DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/RestartNameServerDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/cluster/nameserver/RestartNameServerDTOTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.cluster.nameserver;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RestartNameServerDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void identityShouldBeRequired() {
+        @SuppressWarnings("unchecked") RestartNameServerDTO request = RestartNameServerDTO.builder().build();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("clusterId is required", "addr is required");
+    }
+
+    @Test
+    void validRequestShouldPassValidation() {
+        RestartNameServerDTO request = RestartNameServerDTO.builder()
+                .clusterId("cluster-a")
+                .addr("10.0.0.1:9876") .build();
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Motivation

`RestartNameServerDTO` had no unit coverage for its validation rules. This PR adds first coverage.

### Changes

- clusterId and addr are required.
- A valid restart request passes validation.

### Verification

- `mvn -B test -Dtest=RestartNameServerDTOTest`: passed, BUILD SUCCESS