### PR TITLE
feat(instance): export inventory

### DIFF
--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -27,6 +27,7 @@ import type { CloudCredential, CloudCredentialPage } from '../../../api/cloudCre
 import type { Instance } from '../../../api/instance';
 import { LangProvider } from '../../../i18n/LangContext';
 import * as instanceService from '../../../services/instanceService';
+import { downloadCsv } from '../../../utils/download';
 import InstancePage from '../index';
 
 vi.mock('../../../api/aliyunCatalog', () => ({
@@ -51,6 +52,12 @@ vi.mock('../../../services/instanceService', () => ({
   listInstances: vi.fn(),
   updateInstance: vi.fn(),
 }));
+
+vi.mock('../../../utils/download', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../../utils/download')>('../../../utils/download');
+  return { ...actual, downloadCsv: vi.fn() };
+});
 
 const cloudCredentialPage = (items: CloudCredential[]): CloudCredentialPage => ({
   items,
@@ -158,6 +165,18 @@ describe('InstancePage', () => {
     await waitFor(() =>
       expect(instanceService.listInstances).toHaveBeenLastCalledWith({ type: 'DIRECT' }),
     );
+  });
+
+  it('exports the currently filtered instance inventory', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(await screen.findByText('production-proxy')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /导出/ }));
+
+    await waitFor(() => expect(downloadCsv).toHaveBeenCalledTimes(1));
+    expect(instanceService.listInstances).toHaveBeenCalledWith({});
+    expect(screen.getByText(/已导出 2 个实例/)).toBeInTheDocument();
   });
 
   it('keeps unavailable resource counts after available values in both sort directions', async () => {

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -36,6 +36,7 @@ import {
 import { useLang } from '../../i18n/LangContext';
 import { Plus, MagnifyingGlass } from '@phosphor-icons/react';
 import { EditOutlined, DeleteOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { DownloadOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import type { SortOrder } from 'antd/es/table/interface';
 import type { Instance, InstanceQuery } from '../../api/instance';
@@ -49,6 +50,7 @@ import {
 import { listTencentInstances, listTencentRegions } from '../../api/tencentCatalog';
 import { formatDateTime } from '../../utils/format';
 import { tableScrollX } from '../../utils/table';
+import { buildCsv, downloadCsv, type CsvColumn } from '../../utils/download';
 import {
   createInstance,
   deleteInstance,
@@ -81,6 +83,21 @@ function describeApiError(error: unknown, fallback: string): string {
 }
 
 type InstanceTypeFilter = 'ALL' | Instance['type'];
+
+const INSTANCE_EXPORT_COLUMNS: CsvColumn<Instance>[] = [
+  { header: 'Instance ID', value: (instance) => instance.name },
+  { header: 'Vendor', value: (instance) => instance.vendor ?? 'APACHE' },
+  { header: 'Type', value: (instance) => instance.type },
+  { header: 'Endpoint', value: (instance) => instance.endpoint },
+  { header: 'Region ID', value: (instance) => instance.regionId ?? '' },
+  { header: 'Region Name', value: (instance) => instance.regionName ?? '' },
+  { header: 'Topic Count', value: (instance) => instance.topicCount },
+  { header: 'Consumer Group Count', value: (instance) => instance.consumerGroupCount },
+  { header: 'Counts Available', value: (instance) => instance.resourceCountsAvailable ?? true },
+  { header: 'Remark', value: (instance) => instance.remark ?? '' },
+  { header: 'Created At', value: (instance) => instance.gmtCreate },
+  { header: 'Modified At', value: (instance) => instance.gmtModified },
+];
 
 function compareResourceCounts(
   left: Instance,
@@ -129,6 +146,7 @@ const InstancePage = () => {
   const editInstanceType = Form.useWatch<Instance['type'] | undefined>('type', editForm);
   const [submitting, setSubmitting] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const requestIdRef = useRef(0);
   const mutationInFlightRef = useRef(false);
@@ -462,6 +480,23 @@ const InstancePage = () => {
     });
   };
 
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const query = listQueryRef.current;
+      const exportedInstances = await listInstances(query);
+      downloadCsv(
+        `rocketmq-instances-${new Date().toISOString().slice(0, 10)}.csv`,
+        buildCsv(INSTANCE_EXPORT_COLUMNS, exportedInstances),
+      );
+      message.success(`已导出 ${exportedInstances.length} 个实例`);
+    } catch (error) {
+      message.error(describeApiError(error, '导出实例列表失败，请稍后重试'));
+    } finally {
+      setExporting(false);
+    }
+  };
+
   const columns: ColumnsType<Instance> = [
     {
       title: '地域',
@@ -679,6 +714,13 @@ const InstancePage = () => {
           />
         </Space>
         <Space size={12}>
+          <Button
+            icon={<DownloadOutlined />}
+            loading={exporting}
+            onClick={() => void handleExport()}
+          >
+            导出
+          </Button>
           <Button
             danger
             icon={<DeleteOutlined />}


### PR DESCRIPTION
## What is the purpose of the change

Other operational inventories such as topics, consumer groups, users, and system alerts can be exported, but the instance inventory could not. Operators preparing an environment review or access audit had to copy instance rows manually.

This change adds CSV export to the instance page, exporting the inventory matching the current type/search filter. Details: #3565

## Brief changelog

**What it does**

- Adds an Export button to the instance toolbar.
- Exports the inventory matching the **current type/search filter**, not just the visible page.
- Exports non-sensitive fields: instance ID, vendor, type, endpoint, region ID/name, topic count, consumer group count, resource-count availability, remark, and created/modified timestamps.
- Uses the shared `buildCsv`/`downloadCsv` helpers, so cells are quoted and spreadsheet formula injection is prevented.
- Shows a loading state while the export runs and surfaces backend errors with the existing error-description helper.

**Deliberately no backend change**

The existing list endpoint already returns the complete filtered inventory used elsewhere by the page, so the export reuses it instead of adding a duplicate server-side export endpoint.

**Tests**

- `InstancePage.test.tsx`: regression coverage that the export button requests the inventory with the current filters and triggers a CSV download.

## Verifying this change

- `npm test -- InstancePage.test.tsx --run` — 23 tests passed
- `npm run lint -- --quiet` — 0 errors; 10 existing warnings remain elsewhere in the tree
- `npm run build` — passed
- `git diff --check` — passed

The GitHub Actions status is not being described as green here; the checks above are local validation on this branch.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change. This PR addresses only #3565.
- [x] The pull request title follows the change type and scope.
- [x] This description covers what the PR does, how, and why.
- [x] A regression test verifies the filtered export request and CSV download.
- [x] Frontend tests, lint, and build were run locally on this branch.
- [ ] Apache Individual Contributor License Agreement (not required for this change size).

