### PR TITLE
test: add first coverage for upsert plain access DTO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/instance/acl/UpsertPlainAccessConfigDTOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/acl/UpsertPlainAccessConfigDTOTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.instance.acl;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpsertPlainAccessConfigDTOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+
+    @Test
+    void accessKeyShouldBeRequired() {
+        UpsertPlainAccessConfigDTO request = new UpsertPlainAccessConfigDTO();
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getMessage())
+                .containsExactlyInAnyOrder("accessKey is required");
+    }
+
+    @Test
+    void toStringShouldNeverExposeCredentials() {
+        UpsertPlainAccessConfigDTO request = new UpsertPlainAccessConfigDTO();
+        request.setAccessKey("svc-x");
+        request.setSecretKey("secret-x");
+
+        String value = request.toString();
+
+        assertThat(value).doesNotContain("svc-x");
+        assertThat(value).doesNotContain("secret-x");
+    }
+
+    @Test
+    void toVoShouldTrimTheAccessKey() {
+        UpsertPlainAccessConfigDTO request = new UpsertPlainAccessConfigDTO();
+        request.setAccessKey("  svc-x  ");
+        request.setSecretKey("secret-x");
+        request.setAdmin(true);
+
+        PlainAccessConfigVO vo = request.toPlainAccessConfigVO();
+
+        assertThat(vo.getAccessKey()).isEqualTo("svc-x");
+        assertThat(vo.getSecretKey()).isEqualTo("secret-x");
+        assertThat(vo.isAdmin()).isTrue();
+    }
+}


### PR DESCRIPTION
### Motivation

`UpsertPlainAccessConfigDTO` had no unit coverage for its access key validation, credential redaction, or VO conversion. This PR adds first coverage.

### Changes

- accessKey is required.
- toString never exposes the access key or secret key.
- toPlainAccessConfigVO trims the access key and carries the rest.

### Verification

- `mvn -B test -Dtest=UpsertPlainAccessConfigDTOTest`: 3/3 passed, BUILD SUCCESS