### PR TITLE
test: expand alert template preview coverage

### DIFF
--- a/web/src/utils/alertTemplatePreview.test.ts
+++ b/web/src/utils/alertTemplatePreview.test.ts
@@ -177,4 +177,49 @@ describe('alert template preview', () => {
     expect(preview.rendered).toContain('Broker disk usage');
     expect(preview.rendered).toContain('broker=broker-a');
   });
+
+  it('formats Date and numeric time context as ISO strings', () => {
+    const fromDate = previewAlertNotificationTemplate('At ${time} alert fired', {
+      time: new Date('2026-09-03T10:00:00.000Z'),
+    });
+    const fromMillis = previewAlertNotificationTemplate('At ${time} alert fired', {
+      time: new Date('2026-09-03T10:00:00.000Z').getTime(),
+    });
+
+    expect(fromDate.rendered).toContain('2026-09-03T10:00:00.000Z');
+    expect(fromMillis.rendered).toBe(fromDate.rendered);
+  });
+
+  it('trims whitespace inside placeholders before matching variables', () => {
+    const preview = previewAlertNotificationTemplate('[${ level }] ${ ruleName } fired', {
+      level: 'CRITICAL',
+      ruleName: 'Broker down',
+    });
+
+    expect(preview.status).toBe('ready');
+    expect(preview.usedVariables).toEqual(['level', 'ruleName']);
+    expect(preview.unknownVariables).toEqual([]);
+    expect(preview.rendered).toBe('[CRITICAL] Broker down fired');
+  });
+
+  it('reports context variables that the template never uses', () => {
+    const preview = previewAlertNotificationTemplate('${title} only', {
+      title: 'Disk usage firing',
+      description: 'detailed description',
+    });
+
+    expect(preview.rendered).toContain('Disk usage firing');
+    expect(preview.unusedContextVariables).toContain('description');
+    expect(preview.unusedContextVariables).not.toContain('title');
+  });
+
+  it('deduplicates variables that appear more than once', () => {
+    const preview = previewAlertNotificationTemplate(
+      '${level}: ${title} (${level})',
+      { level: 'CRITICAL', title: 'Broker down' },
+    );
+
+    expect(preview.usedVariables).toEqual(['level', 'title']);
+    expect(preview.rendered).toBe('CRITICAL: Broker down (CRITICAL)');
+  });
 });


### PR DESCRIPTION
### Motivation

The alert template preview suite covered rendering, unknowns, labels, and length, but Date/numeric time context, padded placeholders, unused context variables, and duplicate occurrences were untested. This PR grows the suite from 9 to 13 cases.

### Changes

- Date and numeric time context render as ISO strings.
- Whitespace inside placeholders is trimmed before matching.
- Context variables the template never references are reported.
- Variables used more than once appear once in the used list.

### Verification

- `vitest run src/utils/alertTemplatePreview.test.ts`: 13/13 passed
- tsc/eslint clean