### PR TITLE
test: add first coverage for auth status VO

### DIFF
--- a/server/src/test/java/org/apache/rocketmq/studio/auth/AuthStatusVOTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/auth/AuthStatusVOTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.auth;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthStatusVOTest {
+
+
+    @Test
+    void builderShouldCarrySessionState() {
+        LoginVO.UserInfo user = LoginVO.UserInfo.builder()
+                .username("admin")
+                .admin(true)
+                .build();
+        AuthStatusVO vo = AuthStatusVO.builder()
+                .loginRequired(true)
+                .authenticated(true)
+                .user(user)
+                .build();
+
+        assertThat(vo.isLoginRequired()).isTrue();
+        assertThat(vo.isAuthenticated()).isTrue();
+        assertThat(vo.getUser()).isSameAs(user);
+    }
+}


### PR DESCRIPTION
### Motivation

`AuthStatusVO` had no unit coverage for its session-state carrier. This PR adds first coverage.

### Changes

- The builder carries login-required, authenticated, and nested user state.

### Verification

- `mvn -B test -Dtest=AuthStatusVOTest`: 1/1 passed, BUILD SUCCESS