### PR TITLE
feat(ai): delete individual conversations

### DIFF
--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -37,6 +37,7 @@ import {
   Alert,
   Input,
   Modal,
+  Popconfirm,
   Space,
   theme,
   message,
@@ -49,6 +50,7 @@ import {
   Sparkle,
   Stop,
 } from '@phosphor-icons/react';
+import { Trash } from '@phosphor-icons/react';
 import type { ColumnsType } from 'antd/es/table';
 import { useLang } from '../../i18n/LangContext';
 import { AiStreamError, chatStream, executeTool, listTools, type McpTool } from '../../api/ai';
@@ -462,6 +464,7 @@ const AiPage = () => {
   const updateMessages = useAiChatHistoryStore((state) => state.setMessages);
   const startConversation = useAiChatHistoryStore((state) => state.startConversation);
   const selectConversation = useAiChatHistoryStore((state) => state.selectConversation);
+  const deleteConversation = useAiChatHistoryStore((state) => state.deleteConversation);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [loading, setLoading] = useState(false);
@@ -784,6 +787,15 @@ const AiPage = () => {
     selectConversation(chatMode, conversationId);
     conversationIdRef.current = conversationId;
     setHistoryOpen(false);
+  };
+
+  const handleConversationDelete = (conversationId: string) => {
+    deleteConversation(chatMode, conversationId);
+    if (conversationIdRef.current === conversationId) {
+      const nextActiveId =
+        useAiChatHistoryStore.getState().histories[chatMode].activeConversationId;
+      conversationIdRef.current = nextActiveId;
+    }
   };
 
   const selectTool = useCallback(
@@ -1165,41 +1177,67 @@ const AiPage = () => {
         ) : (
           <div className="flex flex-col gap-2">
             {recentConversations.map((conversation) => (
-              <button
+              <div
                 key={conversation.id}
-                type="button"
-                onClick={() => handleConversationSelect(conversation.id)}
-                className={`w-full rounded-md border px-3 py-2 text-left text-sm transition-colors ${
+                className={`flex w-full items-center gap-1 rounded-md border px-3 py-2 text-sm transition-colors ${
                   conversation.id === history.activeConversationId
                     ? 'border-blue-400 bg-blue-50 text-blue-700'
                     : 'border-gray-200 bg-white text-gray-700 hover:border-blue-300 hover:bg-blue-50'
                 }`}
               >
-                <span style={{ display: 'flex', alignItems: 'center', gap: 12, minWidth: 0 }}>
-                  <span
-                    style={{
-                      flex: 1,
-                      minWidth: 0,
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {conversation.prompt}
+                <button
+                  type="button"
+                  onClick={() => handleConversationSelect(conversation.id)}
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    background: 'transparent',
+                    border: 'none',
+                    padding: 0,
+                  }}
+                >
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 12, minWidth: 0 }}>
+                    <span
+                      style={{
+                        flex: 1,
+                        minWidth: 0,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        textAlign: 'left',
+                      }}
+                    >
+                      {conversation.prompt}
+                    </span>
+                    <span
+                      style={{
+                        flexShrink: 0,
+                        color: token.colorTextSecondary,
+                        fontSize: 14,
+                        fontWeight: 500,
+                        lineHeight: 1.5,
+                      }}
+                    >
+                      {formatRelativeTime(conversation.updatedAt, lang, t)}
+                    </span>
                   </span>
-                  <span
-                    style={{
-                      flexShrink: 0,
-                      color: token.colorTextSecondary,
-                      fontSize: 14,
-                      fontWeight: 500,
-                      lineHeight: 1.5,
-                    }}
-                  >
-                    {formatRelativeTime(conversation.updatedAt, lang, t)}
-                  </span>
-                </span>
-              </button>
+                </button>
+                <Popconfirm
+                  title="删除这条对话？"
+                  okText="删除"
+                  cancelText="取消"
+                  okButtonProps={{ danger: true }}
+                  onConfirm={() => handleConversationDelete(conversation.id)}
+                >
+                  <Button
+                    type="text"
+                    size="small"
+                    danger
+                    icon={<Trash size={16} />}
+                    aria-label="删除对话"
+                  />
+                </Popconfirm>
+              </div>
             ))}
           </div>
         )}

--- a/web/src/stores/aiChatHistoryStore.test.ts
+++ b/web/src/stores/aiChatHistoryStore.test.ts
@@ -114,6 +114,38 @@ describe('aiChatHistoryStore', () => {
     expect(store.getState().histories.real.conversations).toHaveLength(2);
   });
 
+  it('deletes one conversation and selects the next remaining conversation', async () => {
+    const store = await loadStore();
+    store.getState().startConversation('real', 'first');
+    store
+      .getState()
+      .setMessages('real', 'first', [{ id: 'm1', role: 'user', text: 'First prompt' }]);
+    store.getState().startConversation('real', 'second');
+    store
+      .getState()
+      .setMessages('real', 'second', [{ id: 'm2', role: 'user', text: 'Second prompt' }]);
+    store.getState().selectConversation('real', 'second');
+
+    store.getState().deleteConversation('real', 'second');
+
+    expect(store.getState().histories.real.conversations.map((item) => item.id)).toEqual(['first']);
+    expect(store.getState().histories.real.activeConversationId).toBe('first');
+    expect(store.getState().histories.mock.conversations).toEqual([]);
+  });
+
+  it('clears the active conversation when the last conversation is deleted', async () => {
+    const store = await loadStore();
+    store.getState().startConversation('real', 'only');
+    store.getState().setMessages('real', 'only', [{ id: 'm1', role: 'user', text: 'Only prompt' }]);
+
+    store.getState().deleteConversation('real', 'only');
+
+    expect(store.getState().histories.real).toEqual({
+      conversations: [],
+      activeConversationId: null,
+    });
+  });
+
   it('bounds persisted conversations and messages', async () => {
     const store = await loadStore();
     for (let index = 0; index < 21; index += 1) {

--- a/web/src/stores/aiChatHistoryStore.ts
+++ b/web/src/stores/aiChatHistoryStore.ts
@@ -55,6 +55,7 @@ interface AiChatHistoryState {
   histories: Record<AiChatDataMode, AiChatHistory>;
   startConversation: (mode: AiChatDataMode, conversationId: string) => void;
   selectConversation: (mode: AiChatDataMode, conversationId: string) => void;
+  deleteConversation: (mode: AiChatDataMode, conversationId: string) => void;
   setMessages: (
     mode: AiChatDataMode,
     conversationId: string,
@@ -253,6 +254,23 @@ export const useAiChatHistoryStore = create<AiChatHistoryState>()(
             [mode]: { ...state.histories[mode], activeConversationId: conversationId },
           },
         })),
+      deleteConversation: (mode, conversationId) =>
+        set((state) => {
+          const history = state.histories[mode];
+          const conversations = history.conversations.filter(
+            (conversation) => conversation.id !== conversationId,
+          );
+          const activeConversationId =
+            history.activeConversationId === conversationId
+              ? (conversations[0]?.id ?? null)
+              : history.activeConversationId;
+          return {
+            histories: {
+              ...state.histories,
+              [mode]: { conversations, activeConversationId },
+            },
+          };
+        }),
       setMessages: (mode, conversationId, messages) =>
         set((state) => {
           const history = state.histories[mode];


### PR DESCRIPTION
## What is the purpose of the change

The AI history drawer could list and select conversations, but removing one temporary diagnostic conversation required clearing all histories. The store had no per-conversation delete action, so the only way to remove a single conversation destroyed the entire history.

This change adds individual conversation deletion with deterministic active-conversation handling. Details: #3566

## Brief changelog

**Store (`aiChatHistoryStore.ts`)**

- Adds `deleteConversation(mode, conversationId)`.
- Removes only the requested conversation in the selected Mock/Real history; the other data mode is untouched.
- When the deleted conversation is active, selects the most recent remaining conversation.
- When it is the last conversation, clears the active selection (`null`).
- Existing persistence, conversation/message limits, and history-size shrinking behavior are unchanged.

**Page (`pages/ai/index.tsx`)**

- Adds a confirmed delete action beside each history item.
- The row-level select action stays separate, so opening the delete confirmation does not select the conversation.
- After deleting the active conversation, the active conversation ref is updated so the next sent message continues in the newly selected conversation.

**Tests**

- `aiChatHistoryStore.test.ts`: deleting a non-active conversation keeps the current selection; deleting the active conversation moves the selection to the most recent remaining conversation; deleting the last conversation clears the active selection.
- `AiPage.test.tsx`: existing page behavior still passes after the drawer changes.

## Verifying this change

- `npm test -- aiChatHistoryStore.test.ts --run` — 13 tests passed
- `npm test -- AiPage.test.tsx --run` — 17 tests passed
- `npm run lint -- --quiet` — 0 errors; 10 existing warnings remain elsewhere in the tree
- `npm run build` — passed
- `git diff --check` — passed

The GitHub Actions status is not being described as green here; the checks above are local validation on this branch.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change. This PR addresses only #3566.
- [x] The pull request title follows the change type and scope.
- [x] This description covers what the PR does, how, and why.
- [x] Unit tests cover all three selection outcomes (non-active, active, last conversation) and mode isolation.
- [x] Frontend tests, lint, and build were run locally on this branch.
- [ ] Apache Individual Contributor License Agreement (not required for this change size).

