### PR TITLE
feat(credential): export the filtered cloud credential inventory as masked CSV

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialController.java
@@ -49,6 +49,12 @@ public class CloudCredentialController {
         return Result.ok(credentialService.listMasked(vendor, search, page, pageSize));
     }
 
+    @GetMapping("/export")
+    public Result<String> exportCredentials(@RequestParam(required = false) InstanceVendor vendor,
+            @RequestParam(required = false) String search) {
+        return Result.ok(credentialService.exportMaskedCsv(vendor, search));
+    }
+
     @PostMapping("/create")
     public Result<CloudCredentialVO> createCredential(
             @Valid @RequestBody(required = false) CreateCloudCredentialDTO request) {

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialService.java
@@ -22,6 +22,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
+import org.apache.rocketmq.studio.common.util.CsvUtil;
 import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.instance.InstanceRepository;
 import org.apache.rocketmq.studio.provider.alibaba.AliyunClientFactory;
@@ -40,6 +41,10 @@ import java.util.List;
 @Service
 public class CloudCredentialService {
 
+    private static final int MAX_EXPORT_CREDENTIALS = 10_000;
+    private static final String EXPORT_CSV_HEADER =
+            "Name,Vendor,Access Key,Remark,Created,Modified\r\n";
+
     private final CloudCredentialRepository credentialRepository;
     private final InstanceRepository instanceRepository;
     private final AliyunClientFactory aliyunClientFactory;
@@ -56,6 +61,21 @@ public class CloudCredentialService {
         if (page < 1 || pageSize < 1 || pageSize > 100) throw new BusinessException(400, "Invalid page or pageSize");
         PageResult<CloudCredentialVO> result = credentialRepository.findPage(vendor, search, page, pageSize);
         return PageResult.of(result.getItems().stream().map(this::maskAccessKey).toList(), result.getTotal(), page, pageSize);
+    }
+
+    public String exportMaskedCsv(InstanceVendor vendor, String search) {
+        PageResult<CloudCredentialVO> result = credentialRepository.findPage(vendor, search, 1, MAX_EXPORT_CREDENTIALS);
+        if (result.getTotal() > MAX_EXPORT_CREDENTIALS) {
+            throw new BusinessException(400, "Cloud credential export exceeds the maximum of "
+                    + MAX_EXPORT_CREDENTIALS + " records; narrow the filters");
+        }
+        StringBuilder csv = new StringBuilder("\uFEFF").append(EXPORT_CSV_HEADER);
+        for (CloudCredentialVO credential : result.getItems()) {
+            CloudCredentialVO masked = maskAccessKey(credential);
+            CsvUtil.appendRow(csv, masked.getName(), masked.getVendor(), masked.getAccessKey(),
+                    masked.getRemark(), masked.getGmtCreate(), masked.getGmtModified());
+        }
+        return csv.toString();
     }
 
     public CloudCredentialVO create(CloudCredentialVO credential) {

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialControllerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.provider.credential;
 
+import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -24,9 +25,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(CloudCredentialController.class)
@@ -50,5 +53,27 @@ class CloudCredentialControllerTest {
         mockMvc.perform(get("/api/cloud-credentials/1/credentials"))
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"));
+    }
+
+    @Test
+    void exportCredentialsShouldReturnCsvEnvelope() throws Exception {
+        when(credentialService.exportMaskedCsv(null, null)).thenReturn("\"Name\",\"Vendor\"\r\n");
+
+        mockMvc.perform(get("/api/cloud-credentials/export"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data").value("\"Name\",\"Vendor\"\r\n"));
+    }
+
+    @Test
+    void exportCredentialsShouldPassVendorAndSearchFilters() throws Exception {
+        when(credentialService.exportMaskedCsv(InstanceVendor.ALIYUN, "prod")).thenReturn("csv");
+
+        mockMvc.perform(get("/api/cloud-credentials/export")
+                        .param("vendor", "ALIYUN")
+                        .param("search", "prod"))
+                .andExpect(status().isOk());
+
+        verify(credentialService).exportMaskedCsv(InstanceVendor.ALIYUN, "prod");
     }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/credential/CloudCredentialServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.studio.provider.credential;
 
+import org.apache.rocketmq.studio.common.domain.PageResult;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.util.CredentialUtils;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
@@ -39,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -292,5 +294,35 @@ class CloudCredentialServiceTest {
     @Test
     void repositoryShouldTolerateLegacyPlainSecretTest() {
         assertThat(CredentialUtils.decodeBase64("not base64 !!!")).isEqualTo("not base64 !!!");
+    }
+
+    @Test
+    void exportShouldRenderMaskedCsvWithoutSecretsTest() {
+        CloudCredentialVO stored = new CloudCredentialVO();
+        stored.setId(1L);
+        stored.setName("aliyun-test");
+        stored.setVendor(InstanceVendor.ALIYUN);
+        stored.setAccessKey("LTAI5tUnitTestKey000000001");
+        stored.setSecretKey("secret-value");
+        stored.setRemark("rotation pending");
+        when(credentialRepository.findPage(InstanceVendor.ALIYUN, "prod", 1, 10_000))
+                .thenReturn(PageResult.of(List.of(stored), 1, 1, 10_000));
+
+        String csv = service.exportMaskedCsv(InstanceVendor.ALIYUN, "prod");
+
+        assertThat(csv).startsWith("\uFEFFName,Vendor,Access Key,Remark,Created,Modified\r\n");
+        assertThat(csv).contains("\"aliyun-test\",\"ALIYUN\",\"LTAI****0001\",\"rotation pending\"");
+        assertThat(csv).doesNotContain("secret-value");
+        assertThat(csv).doesNotContain("LTAI5tUnitTestKey000000001");
+    }
+
+    @Test
+    void exportShouldRejectResultBeyondBoundTest() {
+        when(credentialRepository.findPage(isNull(), isNull(), eq(1), eq(10_000)))
+                .thenReturn(PageResult.of(List.of(), 10_001, 1, 10_000));
+
+        assertThatThrownBy(() -> service.exportMaskedCsv(null, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("narrow the filters");
     }
 }

--- a/web/src/api/cloudCredential.test.ts
+++ b/web/src/api/cloudCredential.test.ts
@@ -21,6 +21,7 @@ import client from './client';
 import {
   createCloudCredential,
   deleteCloudCredential,
+  exportCloudCredentials,
   listCloudCredentials,
   updateCloudCredential,
 } from './cloudCredential';
@@ -112,5 +113,17 @@ describe('cloudCredential API', () => {
 
     await deleteCloudCredential(1);
     expect(JSON.parse(mock.history.post[1].data)).toEqual({ id: '1' });
+  });
+
+  it('returns the backend CSV export with the active filters', async () => {
+    mock.onGet('/cloud-credentials/export').reply(200, {
+      code: 200,
+      data: '"Name","Vendor"\r\n"aliyun-test","ALIYUN"\r\n',
+    });
+
+    const csv = await exportCloudCredentials('ALIYUN', 'prod');
+
+    expect(csv).toContain('aliyun-test');
+    expect(mock.history.get[0].params).toMatchObject({ vendor: 'ALIYUN', search: 'prod' });
   });
 });

--- a/web/src/api/cloudCredential.ts
+++ b/web/src/api/cloudCredential.ts
@@ -63,3 +63,13 @@ export async function updateCloudCredential(request: UpdateCloudCredentialReques
 export async function deleteCloudCredential(id: number) {
   await client.post('/cloud-credentials/delete', { id: String(id) });
 }
+
+export async function exportCloudCredentials(
+  vendor?: InstanceVendor,
+  search?: string,
+): Promise<string> {
+  const res = await client.get<{ data: string }>('/cloud-credentials/export', {
+    params: { vendor, search },
+  });
+  return res.data.data;
+}

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -1409,6 +1409,10 @@ const translations: Record<string, Record<Lang, string>> = {
     zh: '云凭据加载失败，请稍后重试',
     en: 'Failed to load cloud credentials. Please try again later.',
   },
+  'settings.credentialExportFailed': {
+    zh: '导出云凭据失败，请稍后重试',
+    en: 'Failed to export cloud credentials. Please try again later.',
+  },
   'settings.credentialUpdated': { zh: '云凭据已更新', en: 'Cloud credential updated' },
   'settings.credentialAdded': { zh: '云凭据已添加', en: 'Cloud credential added' },
   'settings.credentialSaveFailed': {

--- a/web/src/pages/settings/CloudCredentialTab.tsx
+++ b/web/src/pages/settings/CloudCredentialTab.tsx
@@ -30,7 +30,7 @@ import {
   Tag,
   message,
 } from 'antd';
-import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
+import { DeleteOutlined, DownloadOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { MagnifyingGlass } from '@phosphor-icons/react';
 import { useLang } from '../../i18n/LangContext';
@@ -38,11 +38,13 @@ import { useLang } from '../../i18n/LangContext';
 import {
   createCloudCredential,
   deleteCloudCredential,
+  exportCloudCredentials,
   listCloudCredentials,
   updateCloudCredential,
 } from '../../api/cloudCredential';
 import type { CloudCredential } from '../../api/cloudCredential';
 import type { InstanceVendor } from '../../api/instance';
+import { downloadBlob } from '../../utils/download';
 
 const vendorTagColor: Record<string, string> = {
   ALIYUN: 'orange',
@@ -73,6 +75,7 @@ export const CloudCredentialTab = () => {
   const [editingCredential, setEditingCredential] = useState<CloudCredential | null>(null);
   const [form] = Form.useForm<CredentialFormValues>();
   const [submitting, setSubmitting] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const requestSeqRef = useRef(0);
   const submitInFlightRef = useRef(false);
 
@@ -133,6 +136,21 @@ export const CloudCredentialTab = () => {
     setSearch(value);
     setPage(1);
   };
+
+  const handleExport = useCallback(async () => {
+    setExporting(true);
+    try {
+      const csv = await exportCloudCredentials(vendorFilter, debouncedSearch);
+      downloadBlob(
+        new Blob([csv], { type: 'text/csv;charset=utf-8' }),
+        `rocketmq-cloud-credentials-${new Date().toISOString().slice(0, 10)}.csv`,
+      );
+    } catch {
+      message.error(t('settings.credentialExportFailed'));
+    } finally {
+      setExporting(false);
+    }
+  }, [debouncedSearch, t, vendorFilter]);
 
   const resetModal = () => {
     setModalOpen(false);
@@ -285,9 +303,23 @@ export const CloudCredentialTab = () => {
             ]}
           />
         </Flex>
-        <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal} disabled={loading}>
-          {t('settings.addCredential')}
-        </Button>
+        <Flex gap={8}>
+          <Button
+            icon={<DownloadOutlined />}
+            loading={exporting}
+            onClick={() => void handleExport()}
+          >
+            {t('common.export')}
+          </Button>
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={openCreateModal}
+            disabled={loading}
+          >
+            {t('settings.addCredential')}
+          </Button>
+        </Flex>
       </Flex>
 
       <Table<CloudCredential>

--- a/web/src/pages/settings/__tests__/CloudCredentialTab.test.tsx
+++ b/web/src/pages/settings/__tests__/CloudCredentialTab.test.tsx
@@ -19,10 +19,12 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
+import { downloadBlob } from '../../../utils/download';
 import type { CloudCredentialPage } from '../../../api/cloudCredential';
 import {
   createCloudCredential,
   deleteCloudCredential,
+  exportCloudCredentials,
   listCloudCredentials,
   updateCloudCredential,
 } from '../../../api/cloudCredential';
@@ -33,8 +35,13 @@ import { CloudCredentialTab } from '../CloudCredentialTab';
 vi.mock('../../../api/cloudCredential', () => ({
   createCloudCredential: vi.fn(),
   deleteCloudCredential: vi.fn(),
+  exportCloudCredentials: vi.fn(),
   listCloudCredentials: vi.fn(),
   updateCloudCredential: vi.fn(),
+}));
+
+vi.mock('../../../utils/download', () => ({
+  downloadBlob: vi.fn(),
 }));
 
 const credentials: CloudCredentialPage = {
@@ -285,5 +292,34 @@ describe('CloudCredentialTab', () => {
     await waitFor(() =>
       expect(listCloudCredentials).toHaveBeenLastCalledWith(undefined, '', 1, 20),
     );
+  });
+
+  it('downloads the backend CSV export with the active filters', async () => {
+    vi.mocked(exportCloudCredentials).mockResolvedValue(
+      '"Name","Vendor"\r\n"aliyun-test","ALIYUN"\r\n',
+    );
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderTab();
+    await waitFor(() => expect(listCloudCredentials).toHaveBeenCalled());
+
+    await user.click(screen.getByRole('button', { name: /导出/ }));
+
+    await waitFor(() => expect(exportCloudCredentials).toHaveBeenCalledWith(undefined, ''));
+    expect(downloadBlob).toHaveBeenCalledTimes(1);
+    const [blob, filename] = vi.mocked(downloadBlob).mock.calls[0];
+    expect((blob as Blob).type).toBe('text/csv;charset=utf-8');
+    expect(filename).toMatch(/^rocketmq-cloud-credentials-\d{4}-\d{2}-\d{2}\.csv$/);
+  });
+
+  it('reports an export failure instead of downloading an empty file', async () => {
+    vi.mocked(exportCloudCredentials).mockRejectedValue(new Error('boom'));
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderTab();
+    await waitFor(() => expect(listCloudCredentials).toHaveBeenCalled());
+
+    await user.click(screen.getByRole('button', { name: /导出/ }));
+
+    expect(await screen.findByText('导出云凭据失败，请稍后重试')).toBeInTheDocument();
+    expect(downloadBlob).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #3568.

## Source

- Issue: [apache/rocketmq-dashboard#3568 — "Cloud credentials cannot be exported"](https://github.com/apache/rocketmq-dashboard/issues/3568), filed 2026-09-05. It requests a backend export endpoint using the existing vendor/search filters, exporting only non-sensitive metadata (name, vendor, masked access key, remark, timestamps), never secret keys, plus an export button on the credentials page.
- The repository's automated issue evaluation (RockteMQ-AI) classified the request as a feasible enhancement scoped to the backend `CloudCredentialController` + credential page. This is an automated triage comment, not a maintainer endorsement.
- Status note: on 2026-09-06 the issue author closed #3568 citing this PR as "a complete implementation" (issue now closed; the request itself remains documented in the issue body).

## Current gap

Verified against `rocketmq-studio@36126024` before implementation:

- `CloudCredentialController` exposed only list/create/update/delete/reveal — no export endpoint anywhere under `/api/cloud-credentials`.
- The settings credentials page offered list/create/edit/delete only — no export action.
- Not an intentional omission: nothing in docs, code comments, or issue history marks export as deliberately unsupported; the masking infrastructure (`maskAccessKey`, `CredentialUtils.mask`) already existed and is exactly what a safe export requires.

## Project fit

The dashboard is an operations console in which inventory export is an established pattern, not a foreign import:

- Backend-rendered CSV export with the shared `CsvUtil` quoting/formula-injection guard, UTF-8 BOM header, result-envelope response, and an overflow bound (400 "narrow the filters") is the existing `AuditController`/`AuditService.exportLogs` precedent — this PR mirrors it.
- Client-side CSV download of inventory tables (topics, consumer groups, DLQ, client connections, system alerts, studio users) already exists via the shared `web/src/utils/download` helpers.
- This PR follows the backend-rendered variant rather than client-side CSV because masking must happen server-side to guarantee secrets never reach the export; every building block (`CsvUtil`, `maskAccessKey`, `findPage`, blob download) is pre-existing in-repo code.

## Scope

Included:

- `GET /api/cloud-credentials/export` with the same `vendor`/`search` params as the list API, returning the CSV inside the standard `Result` envelope.
- CSV columns: Name, Vendor, Access Key (masked), Remark, Created, Modified. Rows reuse the same `maskAccessKey` path as the list API; `secretKey` is never included.
- 10,000-record bound: exports beyond it fail with 400 and a "narrow the filters" message (same shape as the audit export bound).
- Credentials page: export button next to create; downloads `rocketmq-cloud-credentials-YYYY-MM-DD.csv` built from the backend CSV with the currently applied vendor/search filters; localized failure message.

Not included: secret keys (never exported — regression-tested), credential IDs or cloud instance references, client-side CSV rendering, export for other inventories.

## Implementation

- `CloudCredentialService.exportMaskedCsv(vendor, search)`: `credentialRepository.findPage(vendor, search, 1, 10_000)`, bound check, then `CsvUtil.appendRow` over masked rows — structurally parallel to `AuditService.exportLogs`.
- `CloudCredentialController`: new `@GetMapping("/export")` returning `Result<String>`.
- `web/src/api/cloudCredential.ts`: `exportCloudCredentials(vendor?, search?)`.
- `web/src/pages/settings/CloudCredentialTab.tsx`: `exporting` state + `handleExport` (blob download, dated filename) + `DownloadOutlined` button; one new i18n key `settings.credentialExportFailed`.

## Tests

All commands executed on this branch; results verbatim:

- New regressions first failed, then passed. Red evidence: `npx vitest run src/api/cloudCredential.test.ts src/pages/settings/__tests__/CloudCredentialTab.test.tsx` → `Tests 3 failed | 12 passed (15)` (no export button found; missing client function); backend compile failed with 5 × `cannot find symbol: method exportMaskedCsv`.
- `npx vitest run src/api/cloudCredential.test.ts src/pages/settings/__tests__/CloudCredentialTab.test.tsx` → **15 passed (15)**: API filter passthrough; blob download with `text/csv;charset=utf-8` and dated filename; failure message without download; all pre-existing coverage.
- `mvn test -Dtest='CloudCredentialServiceTest,CloudCredentialControllerTest'` → **Tests run: 20, Failures: 0** (17 service + 3 controller), `BUILD SUCCESS`: masked CSV contents (`LTAI****0001`, no secret value or raw key anywhere in the output), oversize bound → 400, envelope payload, vendor/search param passthrough.
- Full backend `mvn test` → **2039 tests** (pristine baseline 2035 + 4 new), 4 failures: `AuthCorsIntegrationTest` ×2 and `AliyunInstanceProviderTest.getGroupProgressShouldMapLagRowsTest` identical to the pristine baseline; `OpenAiCompatibleLlmGatewayTest.successfulAndFailedStreamsEmitOneTerminalSequence` is the known load-flaky case (re-run in isolation: 9/9 passed, `BUILD SUCCESS`). Zero new failures.
- Full web `npx vitest run --testTimeout=60000` → **925 tests** (922 pristine + 3 new), 1 failure: `ConsumerPage.test.tsx`, the known load-flaky file untouched by this PR (re-run in isolation: 29/29 passed). Zero new failures.
- `npm run build` (`✓ built in 13.72s`), `tsc -b`, `eslint` on touched files: clean.
- Compatibility check performed during audit: `MyBatisConfig` registers `PaginationInnerInterceptor` with no `maxLimit`, so the 10,000-row page is served unclamped and the bound check is sound.

## Compatibility & Risk

- Compatibility: additive only — one read-only endpoint, one button, one i18n key; no existing endpoint, component, or persistence change; the response reuses the standard `Result` envelope so existing API conventions hold.
- Regression risk: low; masking is regression-tested so secret material cannot leak through the export even if the list path evolves; the 10k bound keeps response size bounded.
- Dependencies: none added (all imports are existing in-repo code or existing frontend libraries).
- License: no external code copied; all reused helpers (`CsvUtil`, `CredentialUtils`) are in-repo Apache-2.0 code.