### PR TITLE
feat(ai): search chat history

### DIFF
--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -60,7 +60,8 @@ import { useEngineStore, type AgentEngine } from '../../stores/engineStore';
 import InfoBanner from '../../components/InfoBanner';
 import useAuthStore from '../../stores/authStore';
 import {
-  getRecentAiChatConversations,
+  MAX_AI_CHAT_CONVERSATIONS,
+  searchAiChatConversations,
   flushAiChatHistoryPersistence,
   type AiChatDataMode,
   useAiChatHistoryStore,
@@ -463,6 +464,7 @@ const AiPage = () => {
   const startConversation = useAiChatHistoryStore((state) => state.startConversation);
   const selectConversation = useAiChatHistoryStore((state) => state.selectConversation);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [historySearch, setHistorySearch] = useState('');
   const [inputValue, setInputValue] = useState('');
   const [loading, setLoading] = useState(false);
   const [settingsHintDismissed, setSettingsHintDismissed] = useState(false);
@@ -774,7 +776,11 @@ const AiPage = () => {
     textareaRef.current?.focus();
   }, []);
 
-  const recentConversations = getRecentAiChatConversations(history.conversations);
+  const recentConversations = searchAiChatConversations(
+    history.conversations,
+    historySearch,
+    MAX_AI_CHAT_CONVERSATIONS,
+  );
 
   const handleConversationSelect = (conversationId: string) => {
     abortControllerRef.current?.abort();
@@ -1160,6 +1166,13 @@ const AiPage = () => {
         open={historyOpen}
         onClose={() => setHistoryOpen(false)}
       >
+        <Input.Search
+          allowClear
+          value={historySearch}
+          onChange={(event) => setHistorySearch(event.target.value)}
+          placeholder="搜索对话内容"
+          style={{ marginBottom: 12 }}
+        />
         {recentConversations.length === 0 ? (
           <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('ai.history.empty')} />
         ) : (

--- a/web/src/stores/aiChatHistoryStore.test.ts
+++ b/web/src/stores/aiChatHistoryStore.test.ts
@@ -202,4 +202,34 @@ describe('aiChatHistoryStore', () => {
 
     expect(recent).toEqual([expect.objectContaining({ id: 'prompt', prompt: 'Inspect lag' })]);
   });
+
+  it('searches conversations by any message text case-insensitively', async () => {
+    const { searchAiChatConversations } = await import('./aiChatHistoryStore');
+    const conversations = [
+      {
+        id: 'lag',
+        messages: [
+          { id: 'p1', role: 'user' as const, text: 'Inspect broker status' },
+          { id: 'a1', role: 'ai' as const, text: 'Consumer lag is high' },
+        ],
+        updatedAt: 3,
+      },
+      {
+        id: 'topology',
+        messages: [{ id: 'p2', role: 'user' as const, text: 'Show cluster topology' }],
+        updatedAt: 2,
+      },
+    ];
+
+    expect(searchAiChatConversations(conversations, '  LAG  ').map((item) => item.id)).toEqual([
+      'lag',
+    ]);
+    expect(searchAiChatConversations(conversations, 'show').map((item) => item.id)).toEqual([
+      'topology',
+    ]);
+    expect(searchAiChatConversations(conversations, '').map((item) => item.id)).toEqual([
+      'lag',
+      'topology',
+    ]);
+  });
 });

--- a/web/src/stores/aiChatHistoryStore.ts
+++ b/web/src/stores/aiChatHistoryStore.ts
@@ -144,6 +144,26 @@ export const getRecentAiChatConversations = (
     )
     .slice(0, limit);
 
+export const searchAiChatConversations = (
+  conversations: AiChatConversation[],
+  searchTerm: string,
+  limit = 20,
+): RecentAiChatConversation[] => {
+  const normalizedSearch = searchTerm.trim().toLowerCase();
+  const recent = getRecentAiChatConversations(conversations, limit);
+  if (!normalizedSearch) return recent;
+  return recent.filter((conversation) =>
+    [
+      conversation.prompt,
+      ...conversation.messages.flatMap((message) => [
+        message.text,
+        message.summary,
+        message.thinking,
+      ]),
+    ].some((value) => value?.toLowerCase().includes(normalizedSearch)),
+  );
+};
+
 const restoreHistory = (
   history?: Partial<AiChatHistory> & { messages?: AiChatMessage[]; conversationId?: string | null },
 ): AiChatHistory => {


### PR DESCRIPTION
## What is the purpose of the change

The AI history drawer showed only the most recent conversations and had no search control. Older conversations remained persisted but were effectively unreachable through the drawer once the store exceeded its recent-conversation window.

This change adds history search so a previous diagnostic conversation can be found by keyword. Details: #3567

## Brief changelog

**Store (`aiChatHistoryStore.ts`)**

- Adds `searchAiChatConversations(conversations, searchTerm, limit)`.
- Trims and case-normalizes the search term.
- Matches the first user prompt plus message text, summaries, and thinking text.
- Searches all persisted conversations for the selected data mode rather than only the default recent window.
- Preserves the most-recent ordering of results.
- Returns the normal recent list when the search term is empty.

**Page (`pages/ai/index.tsx`)**

- Adds a search input at the top of the history drawer.
- Keeps the existing empty state when no conversation matches.

**Tests**

- `aiChatHistoryStore.test.ts`: case-insensitive match on message content; match on the first user prompt; empty search returns the full recent list.
- `AiPage.test.tsx`: existing page behavior still passes after the drawer changes.

## Verifying this change

- `npm test -- aiChatHistoryStore.test.ts --run` — 12 tests passed
- `npm test -- AiPage.test.tsx --run` — 17 tests passed
- `npm run lint -- --quiet` — 0 errors; 10 existing warnings remain elsewhere in the tree
- `npm run build` — passed
- `git diff --check` — passed

The GitHub Actions status is not being described as green here; the checks above are local validation on this branch.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change. This PR addresses only #3567.
- [x] The pull request title follows the change type and scope.
- [x] This description covers what the PR does, how, and why.
- [x] Unit tests cover case-insensitive matching, prompt matching, and empty-search behavior.
- [x] Frontend tests, lint, and build were run locally on this branch.
- [ ] Apache Individual Contributor License Agreement (not required for this change size).

