### PR TITLE
feat(instance): export the filtered instance inventory as CSV

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceController.java
@@ -47,6 +47,13 @@ public class InstanceController {
         return Result.ok(instanceService.listInstances(type, search));
     }
 
+    @GetMapping("/export")
+    public Result<String> exportInstances(
+            @RequestParam(required = false) InstanceType type,
+            @RequestParam(required = false) String search) {
+        return Result.ok(instanceService.exportInstancesCsv(type, search));
+    }
+
     @GetMapping("/{instanceId}/capabilities")
     public Result<InstanceCapabilitiesVO> getCapabilities(@PathVariable String instanceId) {
         return Result.ok(instanceCapabilityService.getCapabilities(

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/InstanceService.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.studio.audit.OperationAuditService;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceType;
 import org.apache.rocketmq.studio.common.domain.enums.InstanceVendor;
 import org.apache.rocketmq.studio.common.exception.BusinessException;
+import org.apache.rocketmq.studio.common.util.CsvUtil;
 import org.apache.rocketmq.studio.common.util.RegionNames;
 import org.apache.rocketmq.studio.provider.CloudCatalogProvider;
 import org.apache.rocketmq.studio.provider.CloudInstanceDetailVO;
@@ -74,6 +75,9 @@ public class InstanceService {
     private static final int MAX_BATCH_FAILURE_MESSAGE_LENGTH = 500;
     static final int MAX_CLOUD_IMPORT_FAILURE_DETAILS = 100;
     static final int MAX_CLOUD_IMPORT_FAILURE_MESSAGE_LENGTH = 500;
+    private static final String EXPORT_CSV_HEADER =
+            "Name,Type,Vendor,Endpoint,Region Id,Region Name,"
+                    + "Topic Count,Consumer Group Count,Resource Counts Available,Created,Modified\r\n";
 
     private final InstanceResourceCountRunner countRunner = new InstanceResourceCountRunner(
             COUNT_PARALLELISM, COUNT_QUEUE_CAPACITY, COUNT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -107,6 +111,23 @@ public class InstanceService {
                 .thenComparing(instance -> instance.getRegionId() == null ? "" : instance.getRegionId())
                 .thenComparing(InstanceVO::getName, String.CASE_INSENSITIVE_ORDER));
         return sorted;
+    }
+
+    /**
+     * Renders the instance inventory matching the current type/search filters as CSV, using the
+     * same filtered, sorted, and count-filled view as the list API. Only non-sensitive fields are
+     * exported; credential references are intentionally omitted.
+     */
+    public String exportInstancesCsv(InstanceType type, String search) {
+        StringBuilder csv = new StringBuilder("\uFEFF").append(EXPORT_CSV_HEADER);
+        for (InstanceVO instance : listInstances(type, search)) {
+            CsvUtil.appendRow(csv, instance.getName(), instance.getType(), instance.getVendor(),
+                    instance.getEndpoint(), instance.getRegionId(), instance.getRegionName(),
+                    instance.getTopicCount(), instance.getConsumerGroupCount(),
+                    instance.isResourceCountsAvailable(), instance.getGmtCreate(),
+                    instance.getGmtModified());
+        }
+        return csv.toString();
     }
 
     /**

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceControllerTest.java
@@ -281,4 +281,26 @@ class InstanceControllerTest {
         instance.setGmtModified(LocalDateTime.of(2026, 1, 1, 0, 0));
         return instance;
     }
+
+    @Test
+    void exportInstancesShouldReturnCsvEnvelope() throws Exception {
+        when(instanceService.exportInstancesCsv(isNull(), isNull())).thenReturn("Name,Type\r\n");
+
+        mockMvc.perform(get("/api/instances/export"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data").value("Name,Type\r\n"));
+    }
+
+    @Test
+    void exportInstancesShouldPassTypeAndSearchFilters() throws Exception {
+        when(instanceService.exportInstancesCsv(InstanceType.CLOUD, "prod")).thenReturn("csv");
+
+        mockMvc.perform(get("/api/instances/export")
+                        .param("type", "CLOUD")
+                        .param("search", "prod"))
+                .andExpect(status().isOk());
+
+        verify(instanceService).exportInstancesCsv(InstanceType.CLOUD, "prod");
+    }
 }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/InstanceServiceTest.java
@@ -1702,4 +1702,43 @@ class InstanceServiceTest {
         detail.setEndpoints(List.of(new CloudInstanceDetailVO.CloudEndpoint("TCP_VPC", endpoint)));
         return detail;
     }
+
+    @Test
+    void exportInstancesShouldRenderFilteredCsvTest() {
+        InstanceVO instance = InstanceVO.builder()
+                .name("prod-cloud")
+                .type(InstanceType.CLOUD)
+                .vendor(InstanceVendor.ALIYUN)
+                .endpoint("ros-cn-hangzhou.aliyuncs.com:8080")
+                .regionId("cn-hangzhou")
+                .build();
+        instance.setId(1L);
+        instance.setGmtCreate(LocalDateTime.of(2026, 1, 1, 0, 0));
+        instance.setGmtModified(LocalDateTime.of(2026, 1, 2, 0, 0));
+        when(instanceRepository.findByTypeAndSearch(InstanceType.CLOUD, "prod")).thenReturn(List.of(instance));
+        when(providerRegistry.forVendor(InstanceVendor.ALIYUN)).thenReturn(instanceProvider);
+        when(instanceProvider.countTopics("1")).thenReturn(12);
+        when(instanceProvider.countGroups("1")).thenReturn(4);
+        when(regionNames.resolve("cn-hangzhou")).thenReturn("Hangzhou (CN)");
+
+        String csv = instanceService.exportInstancesCsv(InstanceType.CLOUD, "prod");
+
+        assertThat(csv).startsWith("\uFEFFName,Type,Vendor,Endpoint,Region Id,Region Name,"
+                + "Topic Count,Consumer Group Count,Resource Counts Available,Created,Modified\r\n");
+        assertThat(csv).contains("\"prod-cloud\",\"CLOUD\",\"ALIYUN\",\"ros-cn-hangzhou.aliyuncs.com:8080\","
+                + "\"cn-hangzhou\",\"Hangzhou (CN)\",\"12\",\"4\",\"true\"");
+        assertThat(csv).doesNotContain("credentialId");
+        assertThat(csv).doesNotContain("adminCredentialRef");
+    }
+
+    @Test
+    void exportInstancesShouldNormalizeSearchAndReportEmptyResultTest() {
+        when(instanceRepository.findByTypeAndSearch(InstanceType.CLOUD, "prod")).thenReturn(List.of());
+
+        String csv = instanceService.exportInstancesCsv(InstanceType.CLOUD, " prod ");
+
+        assertThat(csv).startsWith("\uFEFFName,Type,Vendor,Endpoint");
+        assertThat(csv.split("\r\n", -1)).hasSize(2);
+        verify(instanceRepository).findByTypeAndSearch(InstanceType.CLOUD, "prod");
+    }
 }

--- a/web/src/api/instance.test.ts
+++ b/web/src/api/instance.test.ts
@@ -21,6 +21,7 @@ import client from './client';
 import {
   createInstance,
   deleteInstance,
+  exportInstancesCsv,
   getInstanceCapabilities,
   importCloudInstances,
   listInstances,
@@ -134,5 +135,17 @@ describe('instance API', () => {
     expect(supportsApacheRuntime({})).toBe(true);
     expect(supportsApacheRuntime({ vendor: 'ALIYUN' })).toBe(false);
     expect(supportsApacheRuntime({ vendor: 'TENCENT' })).toBe(false);
+  });
+
+  it('returns the backend CSV export with trimmed filters', async () => {
+    mock.onGet('/instances/export').reply(200, {
+      code: 200,
+      data: 'Name,Type,Vendor,Endpoint\r\n"orders","PROXY_CLUSTER"\r\n',
+    });
+
+    await expect(exportInstancesCsv({ type: 'CLOUD', search: '  prod  ' })).resolves.toContain(
+      'orders',
+    );
+    expect(mock.history.get[0].params).toEqual({ type: 'CLOUD', search: 'prod' });
   });
 });

--- a/web/src/api/instance.ts
+++ b/web/src/api/instance.ts
@@ -96,6 +96,16 @@ export async function listInstances(query: InstanceQuery = {}) {
   return res.data.data;
 }
 
+export async function exportInstancesCsv(query: InstanceQuery = {}): Promise<string> {
+  const search = query.search?.trim();
+  const params = {
+    ...(query.type ? { type: query.type } : {}),
+    ...(search ? { search } : {}),
+  };
+  const res = await client.get<{ data: string }>('/instances/export', { params });
+  return res.data.data;
+}
+
 export async function getInstanceCapabilities(instanceId: string) {
   const res = await client.get<{ data: InstanceCapabilities }>(
     `/instances/${encodeURIComponent(instanceId)}/capabilities`,

--- a/web/src/pages/instance/__tests__/InstancePage.test.tsx
+++ b/web/src/pages/instance/__tests__/InstancePage.test.tsx
@@ -27,6 +27,7 @@ import type { CloudCredential, CloudCredentialPage } from '../../../api/cloudCre
 import type { Instance } from '../../../api/instance';
 import { LangProvider } from '../../../i18n/LangContext';
 import * as instanceService from '../../../services/instanceService';
+import { downloadBlob } from '../../../utils/download';
 import InstancePage from '../index';
 
 vi.mock('../../../api/aliyunCatalog', () => ({
@@ -47,9 +48,14 @@ vi.mock('../../../services/instanceService', () => ({
   createInstance: vi.fn(),
   deleteInstance: vi.fn(),
   deleteInstancesBatch: vi.fn(),
+  exportInstancesCsv: vi.fn(),
   importCloudInstances: vi.fn(),
   listInstances: vi.fn(),
   updateInstance: vi.fn(),
+}));
+
+vi.mock('../../../utils/download', () => ({
+  downloadBlob: vi.fn(),
 }));
 
 const cloudCredentialPage = (items: CloudCredential[]): CloudCredentialPage => ({
@@ -990,5 +996,41 @@ describe('InstancePage', () => {
     await waitFor(() => expect(screen.queryByText('refresh-selected')).not.toBeInTheDocument());
     expect(deleteButton).toBeDisabled();
     confirmSpy.mockRestore();
+  });
+
+  it('downloads the instance inventory CSV with the applied filters', async () => {
+    vi.mocked(instanceService.listInstances).mockResolvedValue([instance(1, 'proxy-1')]);
+    vi.mocked(instanceService.exportInstancesCsv).mockResolvedValue('Name,Type\r\n');
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderPage();
+    await screen.findByText('proxy-1');
+
+    await user.type(screen.getByPlaceholderText('搜索实例 ID 或地址'), 'prod');
+    await waitFor(() =>
+      expect(instanceService.listInstances).toHaveBeenLastCalledWith({ search: 'prod' }),
+    );
+
+    await user.click(screen.getByRole('button', { name: /导出/ }));
+
+    await waitFor(() =>
+      expect(instanceService.exportInstancesCsv).toHaveBeenCalledWith({ search: 'prod' }),
+    );
+    expect(downloadBlob).toHaveBeenCalledTimes(1);
+    const [blob, filename] = vi.mocked(downloadBlob).mock.calls[0];
+    expect((blob as Blob).type).toBe('text/csv;charset=utf-8');
+    expect(filename).toMatch(/^rocketmq-instances-\d{4}-\d{2}-\d{2}\.csv$/);
+  });
+
+  it('reports an export failure instead of downloading a file', async () => {
+    vi.mocked(instanceService.listInstances).mockResolvedValue([instance(1, 'proxy-1')]);
+    vi.mocked(instanceService.exportInstancesCsv).mockRejectedValue(new Error('boom'));
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    renderPage();
+    await screen.findByText('proxy-1');
+
+    await user.click(screen.getByRole('button', { name: /导出/ }));
+
+    expect(await screen.findByText('导出实例列表失败，请稍后重试')).toBeInTheDocument();
+    expect(downloadBlob).not.toHaveBeenCalled();
   });
 });

--- a/web/src/pages/instance/index.tsx
+++ b/web/src/pages/instance/index.tsx
@@ -35,7 +35,12 @@ import {
 } from 'antd';
 import { useLang } from '../../i18n/LangContext';
 import { Plus, MagnifyingGlass } from '@phosphor-icons/react';
-import { EditOutlined, DeleteOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import {
+  EditOutlined,
+  DeleteOutlined,
+  DownloadOutlined,
+  QuestionCircleOutlined,
+} from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import type { SortOrder } from 'antd/es/table/interface';
 import type { Instance, InstanceQuery } from '../../api/instance';
@@ -49,10 +54,12 @@ import {
 import { listTencentInstances, listTencentRegions } from '../../api/tencentCatalog';
 import { formatDateTime } from '../../utils/format';
 import { tableScrollX } from '../../utils/table';
+import { downloadBlob } from '../../utils/download';
 import {
   createInstance,
   deleteInstance,
   deleteInstancesBatch,
+  exportInstancesCsv,
   importCloudInstances,
   listInstances,
   updateInstance,
@@ -129,6 +136,7 @@ const InstancePage = () => {
   const editInstanceType = Form.useWatch<Instance['type'] | undefined>('type', editForm);
   const [submitting, setSubmitting] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const requestIdRef = useRef(0);
   const mutationInFlightRef = useRef(false);
@@ -423,6 +431,21 @@ const InstancePage = () => {
     }
   };
 
+  const handleExport = useCallback(async () => {
+    setExporting(true);
+    try {
+      const csv = await exportInstancesCsv(listQueryRef.current);
+      downloadBlob(
+        new Blob([csv], { type: 'text/csv;charset=utf-8' }),
+        `rocketmq-instances-${new Date().toISOString().slice(0, 10)}.csv`,
+      );
+    } catch {
+      message.error('导出实例列表失败，请稍后重试');
+    } finally {
+      setExporting(false);
+    }
+  }, []);
+
   const handleBatchDelete = () => {
     const selectedNames = new Set(selectedRowKeys.map(String));
     const selected = instances.filter((instance) => selectedNames.has(instance.name));
@@ -679,6 +702,13 @@ const InstancePage = () => {
           />
         </Space>
         <Space size={12}>
+          <Button
+            icon={<DownloadOutlined />}
+            loading={exporting}
+            onClick={() => void handleExport()}
+          >
+            导出
+          </Button>
           <Button
             danger
             icon={<DeleteOutlined />}

--- a/web/src/services/instanceService.ts
+++ b/web/src/services/instanceService.ts
@@ -8,7 +8,22 @@ import type {
   UpdateInstanceRequest,
   InstanceCapabilities,
 } from '../api/instance';
+import { buildCsv, type CsvColumn } from '../utils/download';
 import { mockInstances } from '../mock/instances';
+
+const INSTANCE_EXPORT_COLUMNS: CsvColumn<Instance>[] = [
+  { header: 'Name', value: (instance) => instance.name },
+  { header: 'Type', value: (instance) => instance.type },
+  { header: 'Vendor', value: (instance) => instance.vendor },
+  { header: 'Endpoint', value: (instance) => instance.endpoint },
+  { header: 'Region Id', value: (instance) => instance.regionId },
+  { header: 'Region Name', value: (instance) => instance.regionName },
+  { header: 'Topic Count', value: (instance) => instance.topicCount },
+  { header: 'Consumer Group Count', value: (instance) => instance.consumerGroupCount },
+  { header: 'Resource Counts Available', value: (instance) => instance.resourceCountsAvailable },
+  { header: 'Created', value: (instance) => instance.gmtCreate },
+  { header: 'Modified', value: (instance) => instance.gmtModified },
+];
 
 // Compile-time switch: mock or real API
 
@@ -67,6 +82,13 @@ async function fetchInstances(query: InstanceQuery, mockMode: boolean): Promise<
       .map(copyInstance);
   }
   return instanceApi.listInstances(query);
+}
+
+export async function exportInstancesCsv(query: InstanceQuery = {}): Promise<string> {
+  if (isMockMode()) {
+    return buildCsv(INSTANCE_EXPORT_COLUMNS, await listInstances(query));
+  }
+  return instanceApi.exportInstancesCsv(query);
 }
 
 export async function getInstanceCapabilities(instanceId: string): Promise<InstanceCapabilities> {


### PR DESCRIPTION
Fixes #3565.

## Source

- Issue: [apache/rocketmq-dashboard#3565 — "Instance inventory cannot be exported"](https://github.com/apache/rocketmq-dashboard/issues/3565), filed 2026-09-05. It requests a backend export endpoint using the existing instance filters, non-sensitive fields (name, type, vendor, endpoint, region, resource counts, timestamps), an export button on the instance page, and an export consistent with the currently selected filters.
- The repository's automated issue evaluation (RockteMQ-AI) classified the request as a feasible enhancement scoped to the backend instance controller + instance page. This is an automated triage comment, not a maintainer endorsement.

## Current gap

Verified against `rocketmq-studio@36126024` before implementation:

- `InstanceController` exposed only list/capabilities/create/import-cloud/update/delete/delete-batch — no export endpoint.
- The instance page had create/import/edit/delete (incl. batch delete) but no export action.
- Not an intentional omission: the issue text itself observes that topic, consumer group, user, and system alert inventories are already exportable in this project — the instance inventory is the remaining gap; the automated evaluation judged the addition feasible with no breaking changes.

## Project fit

- Export reuses `InstanceService.listInstances` directly, so the CSV is by construction the same view the page shows: identical filter normalization (`search` trimmed), identical vendor/region/name ordering, identical resolved region display names, and identical bounded resource-count resolution. One source of truth, no duplicated query logic.
- CSV rendering reuses the shared `CsvUtil` guard and the UTF-8 BOM header treatment established by the audit export; the endpoint returns the standard `Result` envelope like `GET /audit-logs/export`.
- The frontend button follows the page's local conventions (toolbar `Space`, localized hardcoded labels, `downloadBlob` util) and the service-layer wrapper follows the established `isMockMode` branching so the demo build stays consistent.

## Scope

Included:

- `GET /api/instances/export` with the same `type`/`search` params as the list API, returning the CSV inside the standard `Result` envelope.
- CSV columns: Name, Type, Vendor, Endpoint, Region Id, Region Name, Topic Count, Consumer Group Count, Resource Counts Available, Created, Modified — the non-sensitive field set named in the issue.
- Instance page: export button in the toolbar; downloads `rocketmq-instances-YYYY-MM-DD.csv` with the currently applied filters (the same `listQueryRef` state the table is loaded with); localized failure message; mock-mode renders the same columns client-side via `buildCsv`.

Not included: credential references (`credentialId`, `adminCredentialRef`) and cloud instance ids — intentionally omitted and regression-tested absent; no export cap parameter (the list API is already unpaginated and the instance inventory is bounded); no export of per-instance resources.

## Implementation

- `InstanceService.exportInstancesCsv(type, search)`: iterates `listInstances(type, search)` and renders rows via `CsvUtil.appendRow` with a BOM header constant — no new query paths.
- `InstanceController`: new `@GetMapping("/export")` returning `Result<String>`.
- `web/src/api/instance.ts`: `exportInstancesCsv(query)` mirroring `listInstances` param construction (trimmed search).
- `web/src/services/instanceService.ts`: `exportInstancesCsv` wrapper — real mode delegates to the API; mock mode renders `INSTANCE_EXPORT_COLUMNS` via `buildCsv`.
- `web/src/pages/instance/index.tsx`: `exporting` state, `handleExport` using `listQueryRef.current`, `DownloadOutlined` button.

## Tests

All commands executed on this branch; results verbatim:

- New regressions first failed, then passed. Red evidence: `npx vitest run src/api/instance.test.ts src/pages/instance/__tests__/InstancePage.test.tsx` → `Tests 3 failed | 29 passed (32)` (no export button found; missing client function); backend compile failed with 5 × `cannot find symbol: method exportInstancesCsv`.
- `npx vitest run src/api/instance.test.ts src/pages/instance/__tests__/InstancePage.test.tsx` → **32 passed (32)**: API filter passthrough with trimmed search; blob download with `text/csv;charset=utf-8` and dated filename; export uses the applied filters (`{ search: 'prod' }`); failure message without download; all pre-existing coverage.
- `mvn test -Dtest='InstanceServiceTest,InstanceControllerTest'` → **Tests run: 98, Failures: 0** (84 service + 14 controller), `BUILD SUCCESS`: CSV header/row contents with provider-resolved counts (12/4) and resolved region name; credential references absent; search normalization (`" prod "` → `"prod"`); empty result renders header only; envelope payload; filter passthrough.
- Full backend `mvn test` → **2039 tests** (pristine baseline 2035 + 4 new), 4 failures: `AuthCorsIntegrationTest` ×2 and `AliyunInstanceProviderTest.getGroupProgressShouldMapLagRowsTest` identical to the pristine baseline; `OpenAiCompatibleLlmGatewayTest.successfulAndFailedStreamsEmitOneTerminalSequence` is the known load-flaky case (re-run in isolation: 9/9 passed). Zero new failures.
- Full web `npx vitest run --testTimeout=60000` → **925 tests** (922 pristine + 3 new), failures only in `ConsumerPage.test.tsx` (the known load-flaky file untouched by this PR; re-run in isolation: 29/29 passed). Zero new failures.
- `npm run build` (`✓ built in 16.16s`), `tsc -b`, `eslint` on touched files: clean.

## Compatibility & Risk

- Compatibility: additive only — one read-only endpoint, one button; no existing endpoint, component, or persistence change.
- Regression risk: low. Counts still respect the existing 3-second per-row deadline and mark unavailable counts explicitly (`Resource Counts Available` column), so a slow cloud vendor degrades its own row instead of the export.
- Dependencies: none added.
- License: no external code copied; all reused helpers (`CsvUtil`, `buildCsv`) are in-repo Apache-2.0 code.