### PR TITLE
feat(ai): delete individual AI chat conversations from the history drawer

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -959,6 +959,8 @@ const translations: Record<string, Record<Lang, string>> = {
   },
   'ai.history.title': { zh: 'AI 对话历史', en: 'AI conversation history' },
   'ai.history.empty': { zh: '当前模式暂无对话记录', en: 'No conversations in this mode' },
+  'ai.history.delete': { zh: '删除对话', en: 'Delete conversation' },
+  'ai.history.deleteConfirm': { zh: '删除这条对话？', en: 'Delete this conversation?' },
   'ai.history.justNow': { zh: '刚刚', en: 'Just now' },
   'ai.history.minutesAgo': { zh: '{count} 分钟前', en: '{count} min ago' },
   'ai.responseStopped': { zh: '回答已停止。', en: 'Response stopped.' },

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -536,4 +536,92 @@ describe('AiPage tool runner', () => {
     expect(await screen.findByText('工具参数必须是有效的 JSON 对象')).toBeInTheDocument();
     expect(executeTool).not.toHaveBeenCalled();
   });
+
+  it('deletes a previous conversation from the history drawer without touching the active one', async () => {
+    const now = Date.now();
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: {
+          conversations: [
+            {
+              id: 'active',
+              messages: [{ id: 'active-message', role: 'user', text: 'Active conversation' }],
+              updatedAt: now,
+            },
+            {
+              id: 'previous',
+              messages: [{ id: 'previous-message', role: 'user', text: 'Previous conversation' }],
+              updatedAt: now - 5 * 60_000,
+            },
+          ],
+          activeConversationId: 'active',
+        },
+      },
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: 'AI 对话历史' }));
+    const historyDrawer = await screen.findByRole('dialog', { name: 'AI 对话历史' });
+    const previousRowDelete = within(historyDrawer)
+      .getAllByRole('button', { name: /删除对话/ })
+      .find((button) => button.closest('div')?.textContent?.includes('Previous conversation'))!;
+    await user.click(previousRowDelete);
+    await user.click(await screen.findByRole('button', { name: /确\s*认/ }));
+
+    await waitFor(() =>
+      expect(
+        useAiChatHistoryStore
+          .getState()
+          .histories.real.conversations.map((conversation) => conversation.id),
+      ).toEqual(['active']),
+    );
+    expect(useAiChatHistoryStore.getState().histories.real.activeConversationId).toBe('active');
+    expect(within(historyDrawer).queryByText('Previous conversation')).not.toBeInTheDocument();
+    expect(chatStream).not.toHaveBeenCalled();
+  });
+
+  it('selects the next remaining conversation after deleting the active one', async () => {
+    const now = Date.now();
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: {
+          conversations: [
+            {
+              id: 'active',
+              messages: [{ id: 'active-message', role: 'user', text: 'Active conversation' }],
+              updatedAt: now,
+            },
+            {
+              id: 'previous',
+              messages: [{ id: 'previous-message', role: 'user', text: 'Previous conversation' }],
+              updatedAt: now - 5 * 60_000,
+            },
+          ],
+          activeConversationId: 'active',
+        },
+      },
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: 'AI 对话历史' }));
+    const historyDrawer = await screen.findByRole('dialog', { name: 'AI 对话历史' });
+    const activeRowDelete = within(historyDrawer)
+      .getAllByRole('button', { name: /删除对话/ })
+      .find((button) => button.closest('div')?.textContent?.includes('Active conversation'))!;
+    await user.click(activeRowDelete);
+    await user.click(await screen.findByRole('button', { name: /确\s*认/ }));
+
+    await waitFor(() =>
+      expect(useAiChatHistoryStore.getState().histories.real.activeConversationId).toBe('previous'),
+    );
+    expect(within(historyDrawer).queryByText('Active conversation')).not.toBeInTheDocument();
+    expect(
+      within(historyDrawer).getByRole('button', { name: /^Previous conversation/ }),
+    ).toBeInTheDocument();
+    expect(chatStream).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -33,6 +33,7 @@ import {
   Divider,
   Drawer,
   Empty,
+  Popconfirm,
   Select,
   Alert,
   Input,
@@ -48,6 +49,7 @@ import {
   SlidersHorizontal,
   Sparkle,
   Stop,
+  Trash,
 } from '@phosphor-icons/react';
 import type { ColumnsType } from 'antd/es/table';
 import { useLang } from '../../i18n/LangContext';
@@ -462,6 +464,7 @@ const AiPage = () => {
   const updateMessages = useAiChatHistoryStore((state) => state.setMessages);
   const startConversation = useAiChatHistoryStore((state) => state.startConversation);
   const selectConversation = useAiChatHistoryStore((state) => state.selectConversation);
+  const deleteConversation = useAiChatHistoryStore((state) => state.deleteConversation);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [loading, setLoading] = useState(false);
@@ -1165,41 +1168,60 @@ const AiPage = () => {
         ) : (
           <div className="flex flex-col gap-2">
             {recentConversations.map((conversation) => (
-              <button
+              <div
                 key={conversation.id}
-                type="button"
-                onClick={() => handleConversationSelect(conversation.id)}
-                className={`w-full rounded-md border px-3 py-2 text-left text-sm transition-colors ${
-                  conversation.id === history.activeConversationId
-                    ? 'border-blue-400 bg-blue-50 text-blue-700'
-                    : 'border-gray-200 bg-white text-gray-700 hover:border-blue-300 hover:bg-blue-50'
-                }`}
+                style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}
               >
-                <span style={{ display: 'flex', alignItems: 'center', gap: 12, minWidth: 0 }}>
-                  <span
-                    style={{
-                      flex: 1,
-                      minWidth: 0,
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {conversation.prompt}
+                <button
+                  type="button"
+                  onClick={() => handleConversationSelect(conversation.id)}
+                  className={`min-w-0 flex-1 rounded-md border px-3 py-2 text-left text-sm transition-colors ${
+                    conversation.id === history.activeConversationId
+                      ? 'border-blue-400 bg-blue-50 text-blue-700'
+                      : 'border-gray-200 bg-white text-gray-700 hover:border-blue-300 hover:bg-blue-50'
+                  }`}
+                >
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 12, minWidth: 0 }}>
+                    <span
+                      style={{
+                        flex: 1,
+                        minWidth: 0,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {conversation.prompt}
+                    </span>
+                    <span
+                      style={{
+                        flexShrink: 0,
+                        color: token.colorTextSecondary,
+                        fontSize: 14,
+                        fontWeight: 500,
+                        lineHeight: 1.5,
+                      }}
+                    >
+                      {formatRelativeTime(conversation.updatedAt, lang, t)}
+                    </span>
                   </span>
-                  <span
-                    style={{
-                      flexShrink: 0,
-                      color: token.colorTextSecondary,
-                      fontSize: 14,
-                      fontWeight: 500,
-                      lineHeight: 1.5,
-                    }}
-                  >
-                    {formatRelativeTime(conversation.updatedAt, lang, t)}
-                  </span>
-                </span>
-              </button>
+                </button>
+                <Popconfirm
+                  title={t('ai.history.deleteConfirm')}
+                  okText={t('common.confirm')}
+                  cancelText={t('common.cancel')}
+                  okButtonProps={{ danger: true }}
+                  onConfirm={() => deleteConversation(chatMode, conversation.id)}
+                >
+                  <Button
+                    danger
+                    type="text"
+                    size="small"
+                    icon={<Trash size={14} />}
+                    aria-label={t('ai.history.delete')}
+                  />
+                </Popconfirm>
+              </div>
             ))}
           </div>
         )}

--- a/web/src/stores/aiChatHistoryStore.test.ts
+++ b/web/src/stores/aiChatHistoryStore.test.ts
@@ -202,4 +202,51 @@ describe('aiChatHistoryStore', () => {
 
     expect(recent).toEqual([expect.objectContaining({ id: 'prompt', prompt: 'Inspect lag' })]);
   });
+
+  it('deletes one conversation and keeps the other mode untouched', async () => {
+    vi.useFakeTimers();
+    const store = await loadStore();
+    const { flushAiChatHistoryPersistence } = await import('./aiChatHistoryStore');
+    store.getState().startConversation('real', 'real-1');
+    store.getState().setMessages('real', 'real-1', [{ id: 'r1', role: 'user', text: 'First' }]);
+    store.getState().startConversation('real', 'real-2');
+    store.getState().setMessages('real', 'real-2', [{ id: 'r2', role: 'user', text: 'Second' }]);
+    store.getState().startConversation('mock', 'mock-1');
+    store.getState().setMessages('mock', 'mock-1', [{ id: 'm1', role: 'user', text: 'Mock' }]);
+
+    store.getState().deleteConversation('real', 'real-2');
+    flushAiChatHistoryPersistence();
+
+    expect(store.getState().histories.real.conversations.map((item) => item.id)).toEqual([
+      'real-1',
+    ]);
+    expect(store.getState().histories.mock.conversations).toHaveLength(1);
+    expect(sessionStorage.getItem(STORAGE_KEY)).not.toContain('Second');
+  });
+
+  it('selects the next remaining conversation when the active one is deleted', async () => {
+    const store = await loadStore();
+    store.getState().startConversation('real', 'real-1');
+    store.getState().startConversation('real', 'real-2');
+
+    expect(store.getState().histories.real.activeConversationId).toBe('real-2');
+    store.getState().deleteConversation('real', 'real-2');
+
+    expect(store.getState().histories.real.activeConversationId).toBe('real-1');
+
+    store.getState().deleteConversation('real', 'real-1');
+
+    expect(store.getState().histories.real.conversations).toEqual([]);
+    expect(store.getState().histories.real.activeConversationId).toBeNull();
+  });
+
+  it('keeps the active selection when a non-active conversation is deleted', async () => {
+    const store = await loadStore();
+    store.getState().startConversation('real', 'real-1');
+    store.getState().startConversation('real', 'real-2');
+
+    store.getState().deleteConversation('real', 'real-1');
+
+    expect(store.getState().histories.real.activeConversationId).toBe('real-2');
+  });
 });

--- a/web/src/stores/aiChatHistoryStore.ts
+++ b/web/src/stores/aiChatHistoryStore.ts
@@ -60,6 +60,7 @@ interface AiChatHistoryState {
     conversationId: string,
     messages: AiChatMessage[] | ((messages: AiChatMessage[]) => AiChatMessage[]),
   ) => void;
+  deleteConversation: (mode: AiChatDataMode, conversationId: string) => void;
   clearHistories: () => void;
 }
 
@@ -276,6 +277,23 @@ export const useAiChatHistoryStore = create<AiChatHistoryState>()(
             histories: {
               ...state.histories,
               [mode]: nextHistory,
+            },
+          };
+        }),
+      deleteConversation: (mode, conversationId) =>
+        set((state) => {
+          const history = state.histories[mode];
+          const conversations = history.conversations.filter((item) => item.id !== conversationId);
+          return {
+            histories: {
+              ...state.histories,
+              [mode]: {
+                conversations,
+                activeConversationId:
+                  history.activeConversationId === conversationId
+                    ? (conversations[0]?.id ?? null)
+                    : history.activeConversationId,
+              },
             },
           };
         }),


### PR DESCRIPTION
Fixes #3566.

## Source

- Issue: [apache/rocketmq-dashboard#3566 — "AI chat history cannot delete individual conversations"](https://github.com/apache/rocketmq-dashboard/issues/3566), filed 2026-09-05. It requests a store action removing one conversation by ID, deterministic re-selection when the deleted conversation was active, and a confirmed delete action in the history drawer, with persistence and size limits kept consistent.
- The repository's automated issue evaluation (RockteMQ-AI) classified the request as a feasible enhancement scoped to `GiChatHistoryStore` + the history drawer UI. This is an automated triage comment, not a maintainer endorsement.

## Current gap

Verified against `rocketmq-studio@36126024` before implementation:

- `web/src/stores/aiChatHistoryStore.ts` exposed exactly four actions: `startConversation`, `selectConversation`, `setMessages`, `clearHistories` (all modes) — no per-conversation delete.
- The history drawer rendered one select button per row with no delete control; the only destructive action reachable from the UI was wiping every history (`clearAiChatHistories`, wired to the layout reset path in `MainLayout`).
- Not an intentional omission: the store actively manages per-conversation lifecycle (bounds, recency ordering, per-mode isolation), so single-conversation removal is a natural extension rather than a deliberately excluded capability; the automated evaluation described per-conversation delete as "a natural addition to the store".

## Project fit

- The new action follows the store's existing zustand action style (single `set`, per-mode `histories` map, `limitHistorySize` untouched) and flows through the existing persist middleware, so throttled session-storage writes and byte/entry bounds keep working without new code.
- The drawer's confirmed delete uses antd `Popconfirm`, the same confirmation pattern the app already uses for destructive row actions (e.g. the credentials page delete); labels go through the existing `translations.ts` mechanism.
- Deleting the active conversation relies on the page's existing effect that syncs `conversationIdRef` from the store's `activeConversationId` — no new state-sync code was introduced.

## Scope

Included:

- `deleteConversation(mode, conversationId)`: removes exactly one conversation within the requested data mode; mock and real histories stay isolated.
- Deterministic active re-selection: if the deleted conversation was active, the most recent remaining conversation becomes active; if none remain, the active selection clears to `null`. Non-active deletes keep the current selection.
- History drawer: per-row danger icon button behind a `Popconfirm` (localized 确认/取消 labels); row select behavior, accessible names, and relative timestamps unchanged.

Not included: bulk/multi-select delete, conversation renaming or editing, changes to the persistence format or limits (`MAX_AI_CHAT_CONVERSATIONS`, byte bounds untouched), any backend change.

## Implementation

- `aiChatHistoryStore.ts`: `deleteConversation` filters the conversation list and recomputes `activeConversationId` in one `set`; persistence happens through the existing throttled persist middleware.
- `pages/ai/index.tsx`: hooks the action via a selector (same style as `selectConversation`); the drawer row was restructured from a single button into a row container holding the unchanged select button plus the confirmed delete control.
- `translations.ts`: two new keys (`ai.history.delete`, `ai.history.deleteConfirm`).

## Tests

All commands executed on this branch; results verbatim:

- New regressions first failed, then passed. Red evidence: `npx vitest run src/stores/aiChatHistoryStore.test.ts src/pages/ai/__tests__/AiPage.test.tsx` → `Tests 5 failed | 28 passed (33)`: three store tests failed with `TypeError: store.getState(...).deleteConversation is not a function`; the two drawer tests could not find a delete control.
- `npx vitest run src/stores/aiChatHistoryStore.test.ts src/pages/ai/__tests__/AiPage.test.tsx` → **33 passed (33)** (14 store + 19 page): single delete keeps the other mode untouched and purges the record from session storage; active selection moves to the next remaining conversation and clears when the last is deleted; non-active deletes keep the selection; drawer delete requires confirmation; deleting a previous row leaves the active conversation intact; deleting the active row renders the next conversation; all pre-existing coverage still green.
- Full web `npx vitest run --testTimeout=60000` → **927 tests** (922 pristine + 5 new), 1 failure: `ConsumerPage.test.tsx`, the known load-flaky file untouched by this PR (re-run in isolation: 29/29 passed). Zero new failures. Backend code paths are not touched by this change, so the backend suite is unaffected.
- `npm run build` (`✓ built in 9.13s`), `tsc -b`, `eslint` on touched files: clean.

## Compatibility & Risk

- Compatibility: client-side only; no API change; persisted state written by older versions loads unchanged (deletion simply removes entries; the restore/merge paths are untouched).
- Regression risk: low. The restructured drawer rows keep the same accessible names, so existing tests and keyboard flows behave identically; deletion is scoped per data mode.
- Dependencies: none added (antd `Popconfirm` and the icon library are already in use).
- License: no external code copied.