### PR TITLE
feat(ai): search AI chat history by conversation content

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -959,6 +959,11 @@ const translations: Record<string, Record<Lang, string>> = {
   },
   'ai.history.title': { zh: 'AI 对话历史', en: 'AI conversation history' },
   'ai.history.empty': { zh: '当前模式暂无对话记录', en: 'No conversations in this mode' },
+  'ai.history.searchPlaceholder': { zh: '搜索对话记录', en: 'Search conversations' },
+  'ai.history.searchEmpty': {
+    zh: '没有匹配的对话记录',
+    en: 'No conversations match your search',
+  },
   'ai.history.justNow': { zh: '刚刚', en: 'Just now' },
   'ai.history.minutesAgo': { zh: '{count} 分钟前', en: '{count} min ago' },
   'ai.responseStopped': { zh: '回答已停止。', en: 'Response stopped.' },

--- a/web/src/pages/ai/__tests__/AiPage.test.tsx
+++ b/web/src/pages/ai/__tests__/AiPage.test.tsx
@@ -536,4 +536,77 @@ describe('AiPage tool runner', () => {
     expect(await screen.findByText('工具参数必须是有效的 JSON 对象')).toBeInTheDocument();
     expect(executeTool).not.toHaveBeenCalled();
   });
+
+  it('searches the history drawer across stored conversations beyond the recent list', async () => {
+    const now = Date.now();
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: {
+          conversations: Array.from({ length: 9 }, (_, index) => ({
+            id: `conversation-${index}`,
+            messages: [
+              {
+                id: `message-${index}`,
+                role: 'user' as const,
+                text:
+                  index === 8 ? 'Oldest diagnostic conversation' : `Recent conversation ${index}`,
+              },
+            ],
+            updatedAt: now - index * 60_000,
+          })),
+          activeConversationId: 'conversation-0',
+        },
+      },
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: 'AI 对话历史' }));
+    const historyDrawer = await screen.findByRole('dialog', { name: 'AI 对话历史' });
+    expect(
+      within(historyDrawer).getAllByRole('button', { name: /^Recent conversation/ }),
+    ).toHaveLength(8);
+    expect(
+      within(historyDrawer).queryByText('Oldest diagnostic conversation'),
+    ).not.toBeInTheDocument();
+
+    await user.type(
+      within(historyDrawer).getByPlaceholderText('搜索对话记录'),
+      'oldest diagnostic',
+    );
+
+    expect(
+      await within(historyDrawer).findByText('Oldest diagnostic conversation'),
+    ).toBeInTheDocument();
+    expect(within(historyDrawer).queryByText(/^Recent conversation/)).not.toBeInTheDocument();
+    expect(chatStream).not.toHaveBeenCalled();
+  });
+
+  it('shows an explicit empty state when no stored conversation matches the search', async () => {
+    useAiChatHistoryStore.setState({
+      histories: {
+        mock: { conversations: [], activeConversationId: null },
+        real: {
+          conversations: [
+            {
+              id: 'active',
+              messages: [{ id: 'active-message', role: 'user', text: 'Active conversation' }],
+              updatedAt: Date.now(),
+            },
+          ],
+          activeConversationId: 'active',
+        },
+      },
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: 'AI 对话历史' }));
+    const historyDrawer = await screen.findByRole('dialog', { name: 'AI 对话历史' });
+    await user.type(within(historyDrawer).getByPlaceholderText('搜索对话记录'), 'does-not-match');
+
+    expect(await within(historyDrawer).findByText('没有匹配的对话记录')).toBeInTheDocument();
+    expect(within(historyDrawer).queryByText('当前模式暂无对话记录')).not.toBeInTheDocument();
+  });
 });

--- a/web/src/pages/ai/index.tsx
+++ b/web/src/pages/ai/index.tsx
@@ -45,6 +45,7 @@ import {
   ArrowUp,
   CaretDown,
   ClockCounterClockwise,
+  MagnifyingGlass,
   SlidersHorizontal,
   Sparkle,
   Stop,
@@ -61,6 +62,7 @@ import InfoBanner from '../../components/InfoBanner';
 import useAuthStore from '../../stores/authStore';
 import {
   getRecentAiChatConversations,
+  searchAiChatConversations,
   flushAiChatHistoryPersistence,
   type AiChatDataMode,
   useAiChatHistoryStore,
@@ -463,6 +465,7 @@ const AiPage = () => {
   const startConversation = useAiChatHistoryStore((state) => state.startConversation);
   const selectConversation = useAiChatHistoryStore((state) => state.selectConversation);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [historySearch, setHistorySearch] = useState('');
   const [inputValue, setInputValue] = useState('');
   const [loading, setLoading] = useState(false);
   const [settingsHintDismissed, setSettingsHintDismissed] = useState(false);
@@ -775,6 +778,19 @@ const AiPage = () => {
   }, []);
 
   const recentConversations = getRecentAiChatConversations(history.conversations);
+  const historySearching = historySearch.trim().length > 0;
+  const historyEntries = (
+    historySearching
+      ? searchAiChatConversations(history.conversations, historySearch)
+      : recentConversations
+  ).map((conversation) => ({
+    id: conversation.id,
+    updatedAt: conversation.updatedAt,
+    label:
+      conversation.messages.find((item) => item.role === 'user' && item.text?.trim())?.text ??
+      conversation.messages[0]?.text ??
+      '',
+  }));
 
   const handleConversationSelect = (conversationId: string) => {
     abortControllerRef.current?.abort();
@@ -1160,17 +1176,28 @@ const AiPage = () => {
         open={historyOpen}
         onClose={() => setHistoryOpen(false)}
       >
-        {recentConversations.length === 0 ? (
-          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('ai.history.empty')} />
+        <Input
+          allowClear
+          placeholder={t('ai.history.searchPlaceholder')}
+          prefix={<MagnifyingGlass size={14} color="#9CA3AF" />}
+          value={historySearch}
+          onChange={(event) => setHistorySearch(event.target.value)}
+          style={{ marginBottom: 12 }}
+        />
+        {historyEntries.length === 0 ? (
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description={t(historySearching ? 'ai.history.searchEmpty' : 'ai.history.empty')}
+          />
         ) : (
           <div className="flex flex-col gap-2">
-            {recentConversations.map((conversation) => (
+            {historyEntries.map((entry) => (
               <button
-                key={conversation.id}
+                key={entry.id}
                 type="button"
-                onClick={() => handleConversationSelect(conversation.id)}
+                onClick={() => handleConversationSelect(entry.id)}
                 className={`w-full rounded-md border px-3 py-2 text-left text-sm transition-colors ${
-                  conversation.id === history.activeConversationId
+                  entry.id === history.activeConversationId
                     ? 'border-blue-400 bg-blue-50 text-blue-700'
                     : 'border-gray-200 bg-white text-gray-700 hover:border-blue-300 hover:bg-blue-50'
                 }`}
@@ -1185,7 +1212,7 @@ const AiPage = () => {
                       whiteSpace: 'nowrap',
                     }}
                   >
-                    {conversation.prompt}
+                    {entry.label}
                   </span>
                   <span
                     style={{
@@ -1196,7 +1223,7 @@ const AiPage = () => {
                       lineHeight: 1.5,
                     }}
                   >
-                    {formatRelativeTime(conversation.updatedAt, lang, t)}
+                    {formatRelativeTime(entry.updatedAt, lang, t)}
                   </span>
                 </span>
               </button>

--- a/web/src/stores/aiChatHistoryStore.test.ts
+++ b/web/src/stores/aiChatHistoryStore.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AiChatConversation } from './aiChatHistoryStore';
 
 const STORAGE_KEY = 'rocketmq-studio-ai-chat-history';
 
@@ -201,5 +202,58 @@ describe('aiChatHistoryStore', () => {
     ]);
 
     expect(recent).toEqual([expect.objectContaining({ id: 'prompt', prompt: 'Inspect lag' })]);
+  });
+
+  it('searches conversations by first user prompt case-insensitively and keeps ordering', async () => {
+    const { searchAiChatConversations } = await import('./aiChatHistoryStore');
+    const conversations: AiChatConversation[] = [
+      {
+        id: 'newest',
+        messages: [{ id: 'm1', role: 'user', text: 'Inspect consumer lag' }],
+        updatedAt: 3,
+      },
+      {
+        id: 'middle',
+        messages: [{ id: 'm2', role: 'user', text: 'Explain DLQ ordering' }],
+        updatedAt: 2,
+      },
+      {
+        id: 'oldest',
+        messages: [{ id: 'm3', role: 'user', text: 'Create a topic' }],
+        updatedAt: 1,
+      },
+    ];
+
+    expect(searchAiChatConversations(conversations, '  LAG  ').map((item) => item.id)).toEqual([
+      'newest',
+    ]);
+    expect(searchAiChatConversations(conversations, 'dlq').map((item) => item.id)).toEqual([
+      'middle',
+    ]);
+    expect(searchAiChatConversations(conversations, '   ').map((item) => item.id)).toEqual([]);
+  });
+
+  it('searches message text beyond the first prompt and reports unmatched queries', async () => {
+    const { searchAiChatConversations } = await import('./aiChatHistoryStore');
+    const conversations: AiChatConversation[] = [
+      {
+        id: 'mixed',
+        messages: [
+          { id: 'm1', role: 'user', text: 'Diagnose broker pressure' },
+          { id: 'm2', role: 'ai', text: 'The lag stems from slow consumers' },
+        ],
+        updatedAt: 3,
+      },
+      {
+        id: 'other',
+        messages: [{ id: 'm3', role: 'user', text: 'Create a topic' }],
+        updatedAt: 2,
+      },
+    ];
+
+    expect(
+      searchAiChatConversations(conversations, 'SLOW CONSUMERS').map((item) => item.id),
+    ).toEqual(['mixed']);
+    expect(searchAiChatConversations(conversations, 'nonexistent')).toEqual([]);
   });
 });

--- a/web/src/stores/aiChatHistoryStore.ts
+++ b/web/src/stores/aiChatHistoryStore.ts
@@ -144,6 +144,17 @@ export const getRecentAiChatConversations = (
     )
     .slice(0, limit);
 
+export const searchAiChatConversations = (
+  conversations: AiChatConversation[],
+  query: string,
+): AiChatConversation[] => {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [];
+  return conversations.filter((conversation) =>
+    conversation.messages.some((item) => item.text && item.text.toLowerCase().includes(needle)),
+  );
+};
+
 const restoreHistory = (
   history?: Partial<AiChatHistory> & { messages?: AiChatMessage[]; conversationId?: string | null },
 ): AiChatHistory => {


### PR DESCRIPTION
Fixes #3567.

## Source

- Issue: [apache/rocketmq-dashboard#3567 — "AI chat history cannot be searched"](https://github.com/apache/rocketmq-dashboard/issues/3567), filed 2026-09-05. It requests a search input in the AI history drawer matching the first user prompt and conversation messages case-insensitively, keeping the most-recent ordering, and showing an explicit empty state when nothing matches.
- The repository's automated issue evaluation (RockteMQ-AI) classified the request as a feasible enhancement scoped to the AI history drawer + `GiChatHistoryStore`. This is an automated triage comment, not a maintainer endorsement.

## Current gap

Verified against `rocketmq-studio@36126024` before implementation:

- The drawer rendered `getRecentAiChatConversations(history.conversations)` — the 8 most recent prompt-bearing conversations — with no filter input anywhere in the drawer.
- The store retains up to `MAX_AI_CHAT_CONVERSATIONS = 20` conversations per data mode, so older conversations were stored but unreachable through the UI, exactly as the issue describes.
- Not an intentional omission: the recency list was the only navigation ever implemented; the store module already ships pure derivation helpers (`getRecentAiChatConversations`) as its extension point, and no doc or comment marks search as excluded.

## Project fit

- `searchAiChatConversations` is a pure helper exported next to `getRecentAiChatConversations` in the same store module, following that helper's derivation style (first user message, recency order) — the drawer just switches the list source.
- The search input follows the app's existing list-search conventions (antd `Input` with `allowClear`, magnifier prefix, localized placeholder, as used on the settings and instance pages).
- Ordering comes from the store's existing most-recent-first array order; no sorting logic was added.

## Scope

Included:

- `searchAiChatConversations(conversations, query)`: case-insensitive contains match against conversation message texts (which includes the first user prompt); blank/whitespace queries return no results; the store's ordering is preserved.
- Drawer: a search input above the list. With an empty query the drawer behaves exactly as before (the recent list); with a query it renders matches over **all** stored conversations of the current data mode, so conversations beyond the recent 8 become reachable.
- Explicit empty state (`没有匹配的对话记录` / "No conversations match your search") when a non-empty query matches nothing — distinct from the existing no-history empty state.
- Row labels derive from the first user message, falling back to the first message text for search results that only match a non-user message.

Not included: cross-mode search (mock and real histories stay separate), server-side or AI-powered semantic search, changes to persistence or to the recent-list default.

## Implementation

- `aiChatHistoryStore.ts`: exported `searchAiChatConversations` pure helper; no store state or action changed.
- `pages/ai/index.tsx`: `historySearch` state; `historyEntries` maps either the recent list or the search results to uniform row entries (`id`, `updatedAt`, `label`); the drawer renders the input, then the list or the appropriate empty state. The select flow, active highlight, and timestamps are untouched.
- `translations.ts`: two new keys (`ai.history.searchPlaceholder`, `ai.history.searchEmpty`).

## Tests

All commands executed on this branch; results verbatim:

- New regressions first failed, then passed. Red evidence: `npx vitest run src/stores/aiChatHistoryStore.test.ts src/pages/ai/__tests__/AiPage.test.tsx` → `Tests 4 failed | 28 passed (32)`: two store tests failed with `TypeError: searchAiChatConversations is not a function`; the two drawer tests could not find the search input placeholder.
- `npx vitest run src/stores/aiChatHistoryStore.test.ts src/pages/ai/__tests__/AiPage.test.tsx` → **32 passed (32)** (13 store + 19 page): case-insensitive matching with surrounding whitespace; ordering preserved; blank queries return nothing; matches beyond the first prompt (AI message text); the drawer reaches a 9th (oldest) conversation invisible in the default recent list; the explicit no-match empty state replaces the regular empty message; all pre-existing coverage still green.
- Full web `npx vitest run --testTimeout=60000` → **926 tests** (922 pristine + 4 new), 2 failures: `AclPage.test.tsx` and `ConsumerPage.test.tsx` — the known load-flaky files untouched by this PR (both files re-run in isolation: 50/50 passed). Zero new failures. Backend code paths are not touched by this change, so the backend suite is unaffected.
- `npm run build` (`✓ built in 9.77s`), `tsc -b` (one fix during development: widened string-literal types in the new test data annotated with `AiChatConversation[]`), `eslint` on touched files: clean.

## Compatibility & Risk

- Compatibility: client-side only; no API change; with an empty query the drawer renders the same rows as before, so existing behavior and tests are unaffected.
- Regression risk: low. The helper is pure and side-effect free; row rendering goes through a unified entry mapping that produces identical output for the default path.
- Dependencies: none added.
- License: no external code copied.