### PR TITLE
fix(topic): keep matching rows for padded search terms

### DIFF
--- a/web/src/pages/instance/__tests__/TopicPage.test.tsx
+++ b/web/src/pages/instance/__tests__/TopicPage.test.tsx
@@ -292,6 +292,34 @@ describe('TopicPage', () => {
     clickSpy.mockRestore();
   });
 
+  it('keeps matching rows when the search term has leading or trailing spaces', async () => {
+    const user = userEvent.setup();
+    mockTopicsList([
+      {
+        ...buildTopics(1)[0],
+        name: 'orders-topic',
+      },
+      {
+        ...buildTopics(1)[0],
+        name: 'users-topic',
+      },
+    ]);
+    renderWithProviders();
+
+    expect(await screen.findByText('orders-topic')).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText('搜索 Topic 名称'), ' orders ');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() =>
+      expect(topicServiceMocks.listTopicsPage).toHaveBeenLastCalledWith(
+        expect.objectContaining({ search: 'orders' }),
+      ),
+    );
+    expect(await screen.findByText('orders-topic')).toBeInTheDocument();
+    expect(screen.queryByText('users-topic')).not.toBeInTheDocument();
+  });
+
   it('keeps the current table page after opening and closing topic details', async () => {
     const user = userEvent.setup();
     instanceServiceMocks.listInstances.mockResolvedValue([

--- a/web/src/pages/instance/topic.tsx
+++ b/web/src/pages/instance/topic.tsx
@@ -480,9 +480,10 @@ const TopicPage = () => {
   }, [selectedInstanceId, tablePage, tablePageSize, instancesLoading, loadTopicPage]);
 
   // ─── Filtered data ─────────────────────────────────────────────
+  const trimmedSearchText = searchText.trim();
   const filteredTopics = useMemo(
-    () => visibleTopics(topics, selectedInstanceId, searchText, typeFilter),
-    [topics, selectedInstanceId, searchText, typeFilter],
+    () => visibleTopics(topics, selectedInstanceId, trimmedSearchText, typeFilter),
+    [topics, selectedInstanceId, trimmedSearchText, typeFilter],
   );
 
   const maxTablePage = Math.max(1, Math.ceil(totalTopics / tablePageSize));


### PR DESCRIPTION
## What is the purpose of the change

The Topic page's search normalized the term for the server query (`searchText.trim()`) but not for the client-side row filter, which received the raw input. A pasted term with leading or trailing spaces made the server return the matching topics while the local filter rejected every returned row, leaving the table empty.

This change makes the server query, client-side filter, and export use the same trimmed term. Details: #3985

## Brief changelog

**Root cause**

`loadTopicPage` sent `search: searchText.trim()` to `/topics/page`, but `visibleTopics` still received the raw input and matched with `topic.name.toLowerCase().includes(searchText.toLowerCase())`. With a pasted term such as ` orders `:

1. The server queried with the trimmed term `orders` and returned the matching topics.
2. The client-side filter rejected every returned row because no topic name contains the padded string.
3. The table rendered empty even though matches existed.

**Fix**

`web/src/pages/instance/topic.tsx` now derives `trimmedSearchText = searchText.trim()` once and passes it to `visibleTopics`, so the server query, the client-side row filter, and the export all use the same normalized term.

**Regression coverage**

`TopicPage.test.tsx` adds a test that types ` orders ` into the search box and asserts:

- the server query is called with `search: 'orders'`;
- the matching `orders-topic` row remains visible;
- the non-matching `users-topic` row stays hidden.

The test fails on the unfixed source because the matching row is filtered out client-side.

## Verifying this change

- `npm test -- TopicPage.test.tsx --run` in `web` — 22 tests passed
- `npm run lint -- --quiet` in `web` — 0 errors
- `npm run build` in `web` — passed (Vite, 8038 modules)
- `git diff --check` — passed

The GitHub Actions status is not being described as green here; the checks above are local validation on this branch.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change. This PR addresses only #3985.
- [x] The pull request title follows the change type and scope.
- [x] This description covers what the PR does, how, and why.
- [x] A regression test covers the padded-input case and fails on the unfixed source.
- [x] Frontend tests, lint, and build were run locally on this branch.
- [ ] Apache Individual Contributor License Agreement (not required for this change size).

