### PR TITLE
feat(consumer): manage consumption switches in group settings

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupController.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupController.java
@@ -77,8 +77,11 @@ public class ConsumerGroupController {
     @PostMapping("/settings")
     public Result<ConsumerGroupSettingsVO> updateConsumerGroupSettings(
             @Valid @RequestBody UpdateConsumerGroupSettingsDTO request) {
+        ConsumerGroupSettingsCommand command = new ConsumerGroupSettingsCommand(
+                request.getRetryQueueNums(), request.getRetryMaxTimes(), request.getConsumeEnable(),
+                request.getConsumeMessageOrderly(), request.getConsumeBroadcastEnable());
         return Result.ok(metadataService.updateConsumerGroupSettings(request.getInstanceId(), request.getName(),
-                request.getRetryQueueNums(), request.getRetryMaxTimes()));
+                command));
     }
 
     @GetMapping("/{name}/refresh")

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupSettingsCommand.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupSettingsCommand.java
@@ -16,24 +16,15 @@
  */
 package org.apache.rocketmq.studio.instance.group;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
-import lombok.Data;
-
-@Data
-public class UpdateConsumerGroupSettingsDTO {
-    @NotBlank(message = "instanceId is required")
-    private String instanceId;
-    @NotBlank(message = "name is required")
-    private String name;
-    @NotNull(message = "retryQueueNums is required")
-    @Positive(message = "retryQueueNums must be positive")
-    private Integer retryQueueNums;
-    @NotNull(message = "retryMaxTimes is required")
-    @Positive(message = "retryMaxTimes must be positive")
-    private Integer retryMaxTimes;
-    private Boolean consumeEnable;
-    private Boolean consumeMessageOrderly;
-    private Boolean consumeBroadcastEnable;
+/**
+ * Carries the consumer-group settings update fields, replacing the long positional parameter list
+ * on the update path. {@code retryQueueNums}/{@code retryMaxTimes} are always applied; a null
+ * consumption switch means "preserve the current broker value".
+ */
+public record ConsumerGroupSettingsCommand(
+        int retryQueueNums,
+        int retryMaxTimes,
+        Boolean consumeEnable,
+        Boolean consumeMessageOrderly,
+        Boolean consumeBroadcastEnable) {
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupSettingsVO.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupSettingsVO.java
@@ -29,4 +29,7 @@ public class ConsumerGroupSettingsVO {
     private String groupName;
     private int retryQueueNums;
     private int retryMaxTimes;
+    private boolean consumeEnable;
+    private boolean consumeMessageOrderly;
+    private boolean consumeBroadcastEnable;
 }

--- a/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/topic/MetadataService.java
@@ -32,6 +32,7 @@ import org.apache.rocketmq.studio.instance.group.CreateConsumerGroupDTO;
 import org.apache.rocketmq.studio.instance.group.ImportConsumerGroupsResultVO;
 import org.springframework.util.StringUtils;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupSettingsCommand;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupSettingsVO;
 import org.apache.rocketmq.studio.instance.group.QueueProgressVO;
 import org.apache.rocketmq.studio.instance.group.ResetConsumerOffsetPreviewVO;
@@ -291,12 +292,12 @@ public class MetadataService {
         return adminClient.getConsumerGroupSettings(instanceId, requireName(name, "consumer group name"));
     }
 
-    public ConsumerGroupSettingsVO updateConsumerGroupSettings(String instanceId, String name, int retryQueueNums,
-                                                                 int retryMaxTimes) {
+    public ConsumerGroupSettingsVO updateConsumerGroupSettings(String instanceId, String name,
+                                                                 ConsumerGroupSettingsCommand command) {
         instanceId = normalizeInstanceId(instanceId);
         requireApacheInstance(instanceId);
         String groupName = requireName(name, "consumer group name");
-        return adminClient.updateConsumerGroupSettings(instanceId, groupName, retryQueueNums, retryMaxTimes);
+        return adminClient.updateConsumerGroupSettings(instanceId, groupName, command);
     }
 
 

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/AdminClient.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/AdminClient.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.studio.instance.topic.SendMessageVO;
 import org.apache.rocketmq.studio.instance.topic.SendMessageDTO;
 import org.apache.rocketmq.studio.instance.topic.TopicVO;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupSettingsCommand;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupSettingsVO;
 import org.apache.rocketmq.studio.instance.group.ResetConsumerOffsetPreviewVO;
 
@@ -33,8 +34,8 @@ public interface AdminClient {
     SendMessageVO sendMessage(SendMessageDTO request);
     ConsumerGroupVO createConsumerGroup(ConsumerGroupVO group);
     ConsumerGroupSettingsVO getConsumerGroupSettings(String instanceId, String name);
-    ConsumerGroupSettingsVO updateConsumerGroupSettings(String instanceId, String name, int retryQueueNums,
-                                                         int retryMaxTimes);
+    ConsumerGroupSettingsVO updateConsumerGroupSettings(String instanceId, String name,
+                                                         ConsumerGroupSettingsCommand command);
     void deleteConsumerGroup(String instanceId, String name);
     ResetConsumerOffsetPreviewVO previewResetOffset(String instanceId, String name, long timestamp, String topic);
     void resetOffset(String instanceId, String name, long timestamp, String topic);

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImpl.java
@@ -38,6 +38,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.TopicPerm;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupSettingsCommand;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupSettingsVO;
 import org.apache.rocketmq.studio.instance.group.ResetConsumerOffsetPreviewVO;
 import org.apache.rocketmq.studio.instance.group.ResetConsumerOffsetQueuePreviewVO;
@@ -520,7 +521,9 @@ public class RocketMQAdminClientImpl implements AdminClient {
                     throw new BusinessException(404, "Consumer group not found: " + name);
                 }
                 return ConsumerGroupSettingsVO.builder().groupName(name).retryQueueNums(config.getRetryQueueNums())
-                        .retryMaxTimes(config.getRetryMaxTimes()).build();
+                        .retryMaxTimes(config.getRetryMaxTimes()).consumeEnable(config.isConsumeEnable())
+                        .consumeMessageOrderly(config.isConsumeMessageOrderly())
+                        .consumeBroadcastEnable(config.isConsumeBroadcastEnable()).build();
             } catch (BusinessException exception) {
                 throw exception;
             } catch (Exception exception) {
@@ -530,45 +533,77 @@ public class RocketMQAdminClientImpl implements AdminClient {
     }
 
     @Override
-    public ConsumerGroupSettingsVO updateConsumerGroupSettings(String instanceId, String name, int retryQueueNums,
-                                                                 int retryMaxTimes) {
+    public ConsumerGroupSettingsVO updateConsumerGroupSettings(String instanceId, String name,
+                                                                 ConsumerGroupSettingsCommand command) {
         return executeForInstance(instanceId, admin -> {
+            int totalBrokers = 0;
+            int updatedBrokers = 0;
             try {
                 String clusterName = getClusterName(admin);
                 Set<String> brokerAddrs = getMasterBrokerAddrsForCluster(admin, clusterName);
                 if (brokerAddrs.isEmpty()) {
                     throw new BusinessException(502, "No broker available to update consumer group settings");
                 }
+                totalBrokers = brokerAddrs.size();
+                SubscriptionGroupConfig applied = null;
                 for (String brokerAddr : brokerAddrs) {
                     SubscriptionGroupConfig config = admin.examineSubscriptionGroupConfig(brokerAddr, name);
                     if (config == null) {
                         throw new BusinessException(404, "Consumer group not found: " + name);
                     }
-                    config.setRetryQueueNums(retryQueueNums);
-                    config.setRetryMaxTimes(retryMaxTimes);
+                    config.setRetryQueueNums(command.retryQueueNums());
+                    config.setRetryMaxTimes(command.retryMaxTimes());
+                    if (command.consumeEnable() != null) {
+                        config.setConsumeEnable(command.consumeEnable());
+                    }
+                    if (command.consumeMessageOrderly() != null) {
+                        config.setConsumeMessageOrderly(command.consumeMessageOrderly());
+                    }
+                    if (command.consumeBroadcastEnable() != null) {
+                        config.setConsumeBroadcastEnable(command.consumeBroadcastEnable());
+                    }
                     admin.createAndUpdateSubscriptionGroupConfig(brokerAddr, config);
+                    updatedBrokers++;
+                    if (applied == null) {
+                        applied = config;
+                    }
                 }
                 RmqGroup group = groupMapper.selectOne(new LambdaQueryWrapper<RmqGroup>()
                         .eq(RmqGroup::getClusterId, clusterName)
                         .eq(RmqGroup::getInstanceId, metadataScope(instanceId))
                         .eq(RmqGroup::getName, name));
                 if (group != null) {
-                    group.setMaxRetry(retryMaxTimes);
+                    group.setMaxRetry(command.retryMaxTimes());
                     group.setGmtModified(LocalDateTime.now());
                     groupMapper.updateById(group);
                 }
-                recordAudit("UPDATE_GROUP_SETTINGS", name, "retryQueueNums=" + retryQueueNums
-                        + ", retryMaxTimes=" + retryMaxTimes, "SUCCESS");
-                return ConsumerGroupSettingsVO.builder().groupName(name).retryQueueNums(retryQueueNums)
-                        .retryMaxTimes(retryMaxTimes).build();
+                recordAudit("UPDATE_GROUP_SETTINGS", name, "retryQueueNums=" + command.retryQueueNums()
+                        + ", retryMaxTimes=" + command.retryMaxTimes()
+                        + ", consumeEnable=" + describeSwitch(command.consumeEnable())
+                        + ", consumeMessageOrderly=" + describeSwitch(command.consumeMessageOrderly())
+                        + ", consumeBroadcastEnable=" + describeSwitch(command.consumeBroadcastEnable())
+                        + ", brokersUpdated=" + updatedBrokers + "/" + totalBrokers, "SUCCESS");
+                return ConsumerGroupSettingsVO.builder().groupName(name)
+                        .retryQueueNums(applied.getRetryQueueNums())
+                        .retryMaxTimes(applied.getRetryMaxTimes())
+                        .consumeEnable(applied.isConsumeEnable())
+                        .consumeMessageOrderly(applied.isConsumeMessageOrderly())
+                        .consumeBroadcastEnable(applied.isConsumeBroadcastEnable())
+                        .build();
             } catch (BusinessException exception) {
-                recordAudit("UPDATE_GROUP_SETTINGS", name, exception.getMessage(), "FAILED");
+                recordAudit("UPDATE_GROUP_SETTINGS", name, "updated " + updatedBrokers + "/" + totalBrokers
+                        + " brokers before failure: " + exception.getMessage(), "FAILED");
                 throw exception;
             } catch (Exception exception) {
-                recordAudit("UPDATE_GROUP_SETTINGS", name, exception.getMessage(), "FAILED");
+                recordAudit("UPDATE_GROUP_SETTINGS", name, "updated " + updatedBrokers + "/" + totalBrokers
+                        + " brokers before failure: " + exception.getMessage(), "FAILED");
                 throw classifyBrokerFailure(exception, "update consumer group settings");
             }
         });
+    }
+
+    private static String describeSwitch(Boolean value) {
+        return value == null ? "preserved" : value.toString();
     }
 
     private ConsumerGroupVO createConsumerGroup(MQAdminExt admin, ConsumerGroupVO group) {

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupControllerTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/group/ConsumerGroupControllerTest.java
@@ -238,16 +238,41 @@ class ConsumerGroupControllerTest {
     void consumerGroupSettingsUpdateShouldValidateAndDelegate() throws Exception {
         Map<String, Object> body = Map.of("instanceId", "instance-a", "name", "cg-orders",
                 "retryQueueNums", 2, "retryMaxTimes", 8);
-        when(metadataService.updateConsumerGroupSettings("instance-a", "cg-orders", 2, 8))
+        when(metadataService.updateConsumerGroupSettings("instance-a", "cg-orders",
+                new ConsumerGroupSettingsCommand(2, 8, null, null, null)))
                 .thenReturn(ConsumerGroupSettingsVO.builder().groupName("cg-orders").retryQueueNums(2)
-                        .retryMaxTimes(8).build());
+                        .retryMaxTimes(8).consumeEnable(true).consumeMessageOrderly(false)
+                        .consumeBroadcastEnable(true).build());
 
         mockMvc.perform(post("/api/groups/settings").contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.retryMaxTimes").value(8));
 
-        verify(metadataService).updateConsumerGroupSettings("instance-a", "cg-orders", 2, 8);
+        verify(metadataService).updateConsumerGroupSettings("instance-a", "cg-orders",
+                new ConsumerGroupSettingsCommand(2, 8, null, null, null));
+    }
+
+    @Test
+    void consumerGroupSettingsUpdateShouldForwardConsumptionSwitches() throws Exception {
+        Map<String, Object> body = Map.of("instanceId", "instance-a", "name", "cg-orders",
+                "retryQueueNums", 2, "retryMaxTimes", 8, "consumeEnable", false,
+                "consumeMessageOrderly", true);
+        when(metadataService.updateConsumerGroupSettings("instance-a", "cg-orders",
+                new ConsumerGroupSettingsCommand(2, 8, false, true, null)))
+                .thenReturn(ConsumerGroupSettingsVO.builder().groupName("cg-orders").retryQueueNums(2)
+                        .retryMaxTimes(8).consumeEnable(false).consumeMessageOrderly(true)
+                        .consumeBroadcastEnable(false).build());
+
+        mockMvc.perform(post("/api/groups/settings").contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.consumeEnable").value(false))
+                .andExpect(jsonPath("$.data.consumeMessageOrderly").value(true))
+                .andExpect(jsonPath("$.data.consumeBroadcastEnable").value(false));
+
+        verify(metadataService).updateConsumerGroupSettings("instance-a", "cg-orders",
+                new ConsumerGroupSettingsCommand(2, 8, false, true, null));
     }
 
     @Test

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQAdminClientImplTest.java
@@ -38,6 +38,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.TopicType;
 import org.apache.rocketmq.studio.cluster.broker.RuntimeAdminClientResolver;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupVO;
+import org.apache.rocketmq.studio.instance.group.ConsumerGroupSettingsCommand;
 import org.apache.rocketmq.studio.instance.group.ConsumerGroupSettingsVO;
 import org.apache.rocketmq.studio.instance.group.ConsumerInstanceVO;
 import org.apache.rocketmq.studio.instance.group.ResetConsumerOffsetPreviewVO;
@@ -781,7 +782,8 @@ class RocketMQAdminClientImplTest {
                     return action.apply(selectedAdmin);
                 });
 
-        ConsumerGroupSettingsVO settings = adminClient.updateConsumerGroupSettings("instance-a", "cg-orders", 2, 8);
+        ConsumerGroupSettingsVO settings = adminClient.updateConsumerGroupSettings("instance-a", "cg-orders",
+                new ConsumerGroupSettingsCommand(2, 8, null, null, null));
 
         assertThat(settings.getRetryQueueNums()).isEqualTo(2);
         assertThat(settings.getRetryMaxTimes()).isEqualTo(8);
@@ -791,6 +793,82 @@ class RocketMQAdminClientImplTest {
         assertThat(captor.getValue().isConsumeEnable()).isFalse();
         assertThat(captor.getValue().getRetryQueueNums()).isEqualTo(2);
         assertThat(captor.getValue().getRetryMaxTimes()).isEqualTo(8);
+    }
+
+    @Test
+    void updateConsumerGroupSettingsAppliesConsumptionSwitches() throws Exception {
+        TableInfoHelper.initTableInfo(new MapperBuilderAssistant(new MybatisConfiguration(), ""), RmqGroup.class);
+        DefaultMQAdminExt selectedAdmin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        ClusterInfo clusterInfo = new ClusterInfo();
+        clusterInfo.setClusterAddrTable(new HashMap<>(Map.of("cluster-1", new HashSet<>(List.of("broker-1")))));
+        BrokerData brokerData = new BrokerData();
+        brokerData.setBrokerName("broker-1");
+        brokerData.setBrokerAddrs(new HashMap<>(Map.of(0L, "10.0.0.1:10911")));
+        clusterInfo.setBrokerAddrTable(new HashMap<>(Map.of("broker-1", brokerData)));
+        SubscriptionGroupConfig config = new SubscriptionGroupConfig();
+        config.setGroupName("cg-orders");
+        config.setConsumeEnable(true);
+        config.setConsumeMessageOrderly(false);
+        config.setConsumeBroadcastEnable(false);
+        config.setRetryQueueNums(1);
+        config.setRetryMaxTimes(16);
+        when(selectedAdmin.examineBrokerClusterInfo()).thenReturn(clusterInfo);
+        when(selectedAdmin.examineSubscriptionGroupConfig("10.0.0.1:10911", "cg-orders")).thenReturn(config);
+        when(groupMapper.selectOne(any())).thenReturn(null);
+        doNothing().when(selectedAdmin).createAndUpdateSubscriptionGroupConfig(anyString(), any());
+        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("instance-a"), any()))
+                .thenAnswer(invocation -> {
+                    MqAdminExtFactory.AdminAction<?> action = invocation.getArgument(1);
+                    return action.apply(selectedAdmin);
+                });
+
+        ConsumerGroupSettingsVO settings = adminClient.updateConsumerGroupSettings("instance-a", "cg-orders",
+                new ConsumerGroupSettingsCommand(2, 8, false, true, null));
+
+        assertThat(settings.isConsumeEnable()).isFalse();
+        assertThat(settings.isConsumeMessageOrderly()).isTrue();
+        assertThat(settings.isConsumeBroadcastEnable()).isFalse();
+        ArgumentCaptor<SubscriptionGroupConfig> captor = ArgumentCaptor.forClass(SubscriptionGroupConfig.class);
+        verify(selectedAdmin).createAndUpdateSubscriptionGroupConfig(
+                org.mockito.ArgumentMatchers.eq("10.0.0.1:10911"), captor.capture());
+        assertThat(captor.getValue().isConsumeEnable()).isFalse();
+        assertThat(captor.getValue().isConsumeMessageOrderly()).isTrue();
+        assertThat(captor.getValue().isConsumeBroadcastEnable()).isFalse();
+        assertThat(captor.getValue().getRetryQueueNums()).isEqualTo(2);
+        assertThat(captor.getValue().getRetryMaxTimes()).isEqualTo(8);
+    }
+
+    @Test
+    void getConsumerGroupSettingsReturnsConsumptionSwitches() throws Exception {
+        DefaultMQAdminExt selectedAdmin = org.mockito.Mockito.mock(DefaultMQAdminExt.class);
+        ClusterInfo clusterInfo = new ClusterInfo();
+        clusterInfo.setClusterAddrTable(new HashMap<>(Map.of("cluster-1", new HashSet<>(List.of("broker-1")))));
+        BrokerData brokerData = new BrokerData();
+        brokerData.setBrokerName("broker-1");
+        brokerData.setBrokerAddrs(new HashMap<>(Map.of(0L, "10.0.0.1:10911")));
+        clusterInfo.setBrokerAddrTable(new HashMap<>(Map.of("broker-1", brokerData)));
+        SubscriptionGroupConfig config = new SubscriptionGroupConfig();
+        config.setGroupName("cg-orders");
+        config.setConsumeEnable(false);
+        config.setConsumeMessageOrderly(true);
+        config.setConsumeBroadcastEnable(false);
+        config.setRetryQueueNums(1);
+        config.setRetryMaxTimes(16);
+        when(selectedAdmin.examineBrokerClusterInfo()).thenReturn(clusterInfo);
+        when(selectedAdmin.examineSubscriptionGroupConfig("10.0.0.1:10911", "cg-orders")).thenReturn(config);
+        when(runtimeAdminClientResolver.execute(org.mockito.ArgumentMatchers.eq("instance-a"), any()))
+                .thenAnswer(invocation -> {
+                    MqAdminExtFactory.AdminAction<?> action = invocation.getArgument(1);
+                    return action.apply(selectedAdmin);
+                });
+
+        ConsumerGroupSettingsVO settings = adminClient.getConsumerGroupSettings("instance-a", "cg-orders");
+
+        assertThat(settings.isConsumeEnable()).isFalse();
+        assertThat(settings.isConsumeMessageOrderly()).isTrue();
+        assertThat(settings.isConsumeBroadcastEnable()).isFalse();
+        assertThat(settings.getRetryQueueNums()).isEqualTo(1);
+        assertThat(settings.getRetryMaxTimes()).isEqualTo(16);
     }
 
     @Test

--- a/web/src/api/metadata.ts
+++ b/web/src/api/metadata.ts
@@ -145,6 +145,9 @@ export interface ConsumerGroupSettings {
   groupName: string;
   retryQueueNums: number;
   retryMaxTimes: number;
+  consumeEnable?: boolean;
+  consumeMessageOrderly?: boolean;
+  consumeBroadcastEnable?: boolean;
 }
 
 export interface QueueProgress {

--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -1356,6 +1356,54 @@ describe('Consumer page', () => {
     expect(await screen.findByText('消费组配置已保存')).toBeInTheDocument();
   });
 
+  it('edits consumption switches from the detail modal settings tab', async () => {
+    vi.mocked(consumerService.getConsumerGroupSettings).mockResolvedValue({
+      groupName: 'remote-cg',
+      retryQueueNums: 1,
+      retryMaxTimes: 16,
+      consumeEnable: false,
+      consumeMessageOrderly: true,
+      consumeBroadcastEnable: false,
+    });
+    vi.mocked(consumerService.updateConsumerGroupSettings).mockResolvedValue({
+      groupName: 'remote-cg',
+      retryQueueNums: 1,
+      retryMaxTimes: 16,
+      consumeEnable: true,
+      consumeMessageOrderly: true,
+      consumeBroadcastEnable: false,
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<ConsumerPage />);
+
+    const row = await screen.findByRole('row', { name: /remote-cg/ });
+    await user.click(within(row).getByRole('button', { name: /详\s*情/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: /remote-cg/ });
+    await user.click(within(dialog).getByRole('tab', { name: /配\s*置/ }));
+
+    const consumeSwitch = await within(dialog).findByRole('switch', { name: '启用消费' });
+    expect(consumeSwitch).not.toBeChecked();
+    expect(within(dialog).getByRole('switch', { name: '顺序消费' })).toBeChecked();
+    expect(within(dialog).getByRole('switch', { name: '广播消费' })).not.toBeChecked();
+
+    await user.click(consumeSwitch);
+    await user.click(within(dialog).getByRole('button', { name: /保\s*存/ }));
+
+    await waitFor(() => {
+      expect(consumerService.updateConsumerGroupSettings).toHaveBeenCalledWith({
+        instanceId: 'instance-1',
+        name: 'remote-cg',
+        retryQueueNums: 1,
+        retryMaxTimes: 16,
+        consumeEnable: true,
+        consumeMessageOrderly: true,
+        consumeBroadcastEnable: false,
+      });
+    });
+    expect((await screen.findAllByText('消费组配置已保存')).length).toBeGreaterThan(0);
+  });
+
   it('renders an unknown (-1) lag as unavailable in the table and the lag detail', async () => {
     const user = userEvent.setup();
     vi.mocked(consumerService.listConsumerGroupPage).mockResolvedValue(

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -42,6 +42,7 @@ import {
   Tooltip,
   Spin,
   Progress,
+  Switch,
   message,
 } from 'antd';
 import {
@@ -273,7 +274,13 @@ const ConsumerPageContent = ({
   const [settingsGroup, setSettingsGroup] = useState<ConsumerGroup | null>(null);
   const [settingsLoading, setSettingsLoading] = useState(false);
   const [settingsSubmitting, setSettingsSubmitting] = useState(false);
-  const [settingsForm] = Form.useForm<{ retryQueueNums: number; retryMaxTimes: number }>();
+  const [settingsForm] = Form.useForm<{
+    retryQueueNums: number;
+    retryMaxTimes: number;
+    consumeEnable?: boolean;
+    consumeMessageOrderly?: boolean;
+    consumeBroadcastEnable?: boolean;
+  }>();
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [form] = Form.useForm();
   const [dataTypeValue, setDataTypeValue] = useState<string | undefined>(undefined);
@@ -312,6 +319,12 @@ const ConsumerPageContent = ({
   const groupRequestIdRef = useRef(0);
   const stackRequestIdRef = useRef(0);
   const settingsRequestIdRef = useRef(0);
+  // Consumption switches as loaded from the broker, used to detect high-risk changes
+  // (disabling consumption / toggling ordered consumption) that need a confirm before saving.
+  const originalSettingsRef = useRef<{
+    consumeEnable?: boolean;
+    consumeMessageOrderly?: boolean;
+  } | null>(null);
 
   const [autoRefresh, setAutoRefresh] = useState(false);
   const silentRefreshRef = useRef(false);
@@ -496,6 +509,10 @@ const ConsumerPageContent = ({
       const settings = await getConsumerGroupSettings(group.name, selectedInstanceId);
       if (requestId === settingsRequestIdRef.current) {
         settingsForm.setFieldsValue(settings);
+        originalSettingsRef.current = {
+          consumeEnable: settings.consumeEnable,
+          consumeMessageOrderly: settings.consumeMessageOrderly,
+        };
       }
     } catch {
       if (requestId === settingsRequestIdRef.current) {
@@ -522,6 +539,32 @@ const ConsumerPageContent = ({
   const saveSettings = async () => {
     if (!settingsGroup || !selectedInstanceId) return;
     const values = await settingsForm.validateFields();
+    const original = originalSettingsRef.current;
+    const risks: string[] = [];
+    if (original && values.consumeEnable === false && original.consumeEnable !== false) {
+      risks.push('关闭「启用消费」会立即停止该消费组的消息消费，可能导致消息堆积');
+    }
+    if (
+      original &&
+      values.consumeMessageOrderly !== undefined &&
+      values.consumeMessageOrderly !== original.consumeMessageOrderly
+    ) {
+      risks.push('切换「顺序消费」会改变该消费组的消费语义，可能影响消息顺序与吞吐');
+    }
+    if (risks.length > 0) {
+      const confirmed = await new Promise<boolean>((resolve) => {
+        Modal.confirm({
+          title: '确认修改高危消费配置？',
+          content: `${risks.join('；')}。`,
+          okText: '确认修改',
+          okButtonProps: { danger: true },
+          cancelText: '取消',
+          onOk: () => resolve(true),
+          onCancel: () => resolve(false),
+        });
+      });
+      if (!confirmed) return;
+    }
     setSettingsSubmitting(true);
     try {
       const saved = await updateConsumerGroupSettings({
@@ -2049,6 +2092,23 @@ const ConsumerPageContent = ({
                         rules={[{ required: true, message: '请输入最大重试次数' }]}
                       >
                         <InputNumber min={1} max={128} style={{ width: '100%' }} />
+                      </Form.Item>
+                      <Form.Item label="启用消费" name="consumeEnable" valuePropName="checked">
+                        <Switch />
+                      </Form.Item>
+                      <Form.Item
+                        label="顺序消费"
+                        name="consumeMessageOrderly"
+                        valuePropName="checked"
+                      >
+                        <Switch />
+                      </Form.Item>
+                      <Form.Item
+                        label="广播消费"
+                        name="consumeBroadcastEnable"
+                        valuePropName="checked"
+                      >
+                        <Switch />
                       </Form.Item>
                       <Form.Item style={{ marginBottom: 0 }}>
                         <Button


### PR DESCRIPTION
Fixes #3990.

## Source

- Parent project (the classic dashboard, previous generation of this repository, default branch `master`): [`frontend-new/src/components/consumer/ConsumerConfigItem.jsx`](https://github.com/apache/rocketmq-dashboard/blob/master/frontend-new/src/components/consumer/ConsumerConfigItem.jsx) exposes form switches for `consumeEnable`, `consumeMessageOrderly` and `consumeBroadcastEnable` and submits them through `/consumer/createOrUpdate.do` — the same broker `SubscriptionGroupConfig` API Studio's settings endpoint already drives.
- In-repo precedent: issue [#2512](https://github.com/apache/rocketmq-dashboard/issues/2512) introduced the Studio settings endpoint (read effective config → partial update on every master broker → audit). Its scope deliberately covered the two retry fields as the first slice; it never marked the remaining config fields as unsupported.
- Feature request filed for this gap: #3990.

## Current gap

On the base commit (36126024) the Studio settings editor carries only `retryQueueNums`/`retryMaxTimes`:

- `ConsumerGroupSettingsVO` / `UpdateConsumerGroupSettingsDTO` had exactly three fields; `RocketMQAdminClientImpl.updateConsumerGroupSettings` set only the two retry fields before `createAndUpdateSubscriptionGroupConfig`.
- The consumer detail modal's 配置 tab rendered two numeric inputs; the three switches were invisible.
- Verified against the working tree by grep (no `consumeEnable`/`consumeMessageOrderly`/`consumeBroadcastEnable` anywhere under `server/src/main/java` or `web/src`) and by the red tests below. Nothing in #2512, the design docs, or code comments marks the switches as intentionally unsupported — #2512's contract ("updates do not reset unrelated subscription-group fields") is in fact built to preserve them until they get an editor.

## Project fit

This extends an existing, Apache-gated editor along its own seam rather than adding a new surface: the endpoint already reads the effective broker config, updates every master broker, preserves unspecified fields, and writes an audit record — the switches ride the identical path. Cloud instances stay excluded behind the unchanged `requireApacheInstance` gate, matching how the retry fields behave today. In the UI, the switches join the existing 配置 tab of the consumer detail modal.

## Scope

Included:

- `GET /api/groups/{name}/settings` returns `consumeEnable` / `consumeMessageOrderly` / `consumeBroadcastEnable` read from the effective broker config.
- `POST /api/groups/settings` accepts the three switches as optional booleans; an omitted switch preserves the current broker value (the endpoint's existing partial-update contract).
- The consumer detail modal settings tab renders three `Switch` controls (启用消费 / 顺序消费 / 广播消费) initialized from the GET response; the audit record now includes the resulting switch values.

Not included: the classic dialog's `brokerId` / `whichBrokerWhenConsumeSlowly` broker-routing pair (advanced, error-prone, kept out for a minimal slice); any cloud-provider support; any database schema change (booleans live only in the broker config).

## Implementation

- `ConsumerGroupSettingsVO` +3 boolean fields; `UpdateConsumerGroupSettingsDTO` +3 optional `Boolean` fields (null = preserve).
- `AdminClient.updateConsumerGroupSettings` signature extended; `RocketMQAdminClientImpl` applies non-null switches per master broker before `createAndUpdateSubscriptionGroupConfig` and builds the returned VO from the final config state; the audit detail string lists the resulting values.
- `MetadataService` / `ConsumerGroupController` pass the values through; `MetadataService` continues to gate on `requireApacheInstance`.
- Web: `ConsumerGroupSettings` type +3 optional fields; the settings form gains three `Form.Item`/`Switch` rows following the modal's existing hardcoded-zh label style.

## Tests (actual commands and results)

New tests: `updateConsumerGroupSettingsAppliesConsumptionSwitches` and `getConsumerGroupSettingsReturnsConsumptionSwitches` (`RocketMQAdminClientImplTest`), `consumerGroupSettingsUpdateShouldForwardConsumptionSwitches` (`ConsumerGroupControllerTest`), `edits consumption switches from the detail modal settings tab` (`ConsumerPage.test.tsx`).

Red (implementation stashed, tests kept): server `mvn test-compile` → 9 compilation errors (`updateConsumerGroupSettings ... cannot be applied to given types` ×5, `cannot find symbol: method consumeEnable(boolean)` ×2, plus `consumeMessageOrderly`/`consumeBroadcastEnable`); web `npx vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx -t "consumption switches"` → `TestingLibraryElementError: Unable to find role="switch" and name "启用消费"`.

Green:

- `mvn -ntp test -Dtest='RocketMQAdminClientImplTest,ConsumerGroupControllerTest,MetadataServiceTest'` → **Tests run: 100, Failures: 0, Errors: 0**.
- Full backend `mvn -ntp clean test` → **Tests run: 2038, Failures: 4** — the pristine baseline set of 36126024 (AuthCorsIntegrationTest ×2, AliyunInstanceProviderTest.getGroupProgressShouldMapLagRowsTest, load-fragile `OpenAiCompatibleLlmGatewayTest.successfulAndFailedStreamsEmitOneTerminalSequence`, which passes 9/9 in isolation). 2038 = 2035 baseline + 3 new tests; zero new failures.
- `npx vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` → **30 passed (30)**.
- Full web `npx vitest run` → **923 tests, 2 failed**, both in untouched files (ClientsPage search-reset, ConsumerPage health diagnostics), both passing in isolation (48/48 for the two files) — the documented load fragility of the full suite in this sandbox.
- `npx tsc -b` clean; `npx eslint` clean on the changed web files; `npm run build` succeeds.

## Compatibility & Risk

- Backward compatible: clients sending only the retry fields keep working — omitted switches preserve broker values (covered by the delegation test passing `null` switches). Additive only: no DB change, no new dependency, no license impact (only rocketmq client types already in use).
- Risk: operators can now pause consumption or flip orderly/broadcast from the UI — the same capability the classic dashboard exposes over the same admin API. The write path still updates every master broker and records an audit entry with the resulting values, and the editor remains Apache-only.
- Differences from the classic implementation: Studio keeps its read-validate-propagate-audit flow with per-broker config preservation instead of a blind form submit, and exposes only the three switches, not the broker-routing pair.

(head f2bd8631e43fb33ff584e8523fbbf78b7abfe296; verification details in the evidence comment below)
