### PR TITLE
fix(cluster): read the legacy 4.x outbound TPS runtime stats key

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/common/util/BrokerRuntimeStats.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/common/util/BrokerRuntimeStats.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+
+/**
+ * Helpers for reading broker runtime-stats ({@code KVTable}) entries whose keys differ across
+ * broker generations. Consolidates the per-provider copies so the legacy-key fallback stays
+ * consistent everywhere runtime stats are parsed.
+ */
+public final class BrokerRuntimeStats {
+
+    /** 5.x brokers publish outbound TPS under this key (double r). */
+    private static final String OUTBOUND_TPS_5X = "getTransferredTps";
+    /** 4.x brokers use the historical single-r spelling. */
+    private static final String OUTBOUND_TPS_4X = "getTransferedTps";
+
+    private BrokerRuntimeStats() {
+    }
+
+    /**
+     * Resolves the outbound TPS entry: 5.x brokers emit {@code getTransferredTps} while 4.x brokers
+     * emit the historical {@code getTransferedTps} spelling. A present-but-blank 5.x value falls
+     * back to the 4.x key rather than being treated as the answer. Returns null when neither key
+     * carries a usable value.
+     */
+    public static String outboundTps(Map<String, String> runtimeStats) {
+        if (runtimeStats == null) {
+            return null;
+        }
+        String transferred = runtimeStats.get(OUTBOUND_TPS_5X);
+        if (StringUtils.hasText(transferred)) {
+            return transferred;
+        }
+        return runtimeStats.get(OUTBOUND_TPS_4X);
+    }
+}

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProvider.java
@@ -32,6 +32,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.BrokerStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterStatus;
 import org.apache.rocketmq.studio.common.domain.enums.ClusterType;
+import org.apache.rocketmq.studio.common.util.BrokerRuntimeStats;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -266,7 +267,7 @@ public class RocketMQClusterProvider implements ClusterProvider {
                 builder.tpsIn(parseTpsValue(putTps));
             }
 
-            String getTransferredTps = table.get("getTransferredTps");
+            String getTransferredTps = BrokerRuntimeStats.outboundTps(table);
             if (getTransferredTps != null && !getTransferredTps.isEmpty()) {
                 builder.tpsOut(parseTpsValue(getTransferredTps));
             }

--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProvider.java
@@ -44,6 +44,7 @@ import org.apache.rocketmq.studio.ops.dashboard.ClusterOverviewVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardDataVO;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardProvider;
 import org.apache.rocketmq.studio.ops.dashboard.DashboardStatsVO;
+import org.apache.rocketmq.studio.common.util.BrokerRuntimeStats;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
 import org.apache.rocketmq.studio.common.util.SystemTopicFilter;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
@@ -342,7 +343,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                     if (runtimeInfo != null && runtimeInfo.getTable() != null) {
                         Map<String, String> table = runtimeInfo.getTable();
                         tpsIn += parseTps(table.get("putTps"));
-                        tpsOut += parseTps(table.get("getTransferredTps"));
+                        tpsOut += parseTps(BrokerRuntimeStats.outboundTps(table));
 
                         messagesToday += parseMessagesToday(table);
                     }
@@ -374,7 +375,7 @@ public class RocketMQDashboardProvider implements DashboardProvider {
                             KVTable runtimeInfo = runtimeStatsByBroker.get(masterAddr);
                             if (runtimeInfo != null && runtimeInfo.getTable() != null) {
                                 clusterTpsIn += parseTps(runtimeInfo.getTable().get("putTps"));
-                                clusterTpsOut += parseTps(runtimeInfo.getTable().get("getTransferredTps"));
+                                clusterTpsOut += parseTps(BrokerRuntimeStats.outboundTps(runtimeInfo.getTable()));
                                 String value = runtimeInfo.getTable().get("brokerVersionDesc");
                                 if (value != null && "unknown".equals(version)) {
                                     String brokerVersion = value.trim();

--- a/server/src/test/java/org/apache/rocketmq/studio/common/util/BrokerRuntimeStatsTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/common/util/BrokerRuntimeStatsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.studio.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BrokerRuntimeStatsTest {
+
+    @Test
+    void prefersFiveXKeyWhenPresentTest() {
+        Map<String, String> stats = new HashMap<>();
+        stats.put("getTransferredTps", "5.0 6.0 7.0");
+        stats.put("getTransferedTps", "4.0 5.0 6.0");
+        assertThat(BrokerRuntimeStats.outboundTps(stats)).isEqualTo("5.0 6.0 7.0");
+    }
+
+    @Test
+    void fallsBackToFourXKeyWhenFiveXAbsentTest() {
+        Map<String, String> stats = new HashMap<>();
+        stats.put("getTransferedTps", "4.0 5.0 6.0");
+        assertThat(BrokerRuntimeStats.outboundTps(stats)).isEqualTo("4.0 5.0 6.0");
+    }
+
+    @Test
+    void fallsBackToFourXKeyWhenFiveXBlankTest() {
+        Map<String, String> stats = new HashMap<>();
+        stats.put("getTransferredTps", "   ");
+        stats.put("getTransferedTps", "4.0 5.0 6.0");
+        assertThat(BrokerRuntimeStats.outboundTps(stats)).isEqualTo("4.0 5.0 6.0");
+    }
+
+    @Test
+    void returnsNullWhenNeitherKeyUsableTest() {
+        assertThat(BrokerRuntimeStats.outboundTps(new HashMap<>())).isNull();
+        assertThat(BrokerRuntimeStats.outboundTps(null)).isNull();
+    }
+}

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClusterProviderTest.java
@@ -74,6 +74,23 @@ class RocketMQClusterProviderTest {
     }
 
     @Test
+    void discoverClustersShouldReadLegacy4xBrokerOutboundTpsKey() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        RocketMQClusterProvider provider = newProvider(adminExt);
+
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        KVTable runtime = runtimeStats("  12.7   10.0  9.0", null);
+        runtime.getTable().put("getTransferedTps", "34.2 30.0 29.0");
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtime);
+
+        List<ClusterVO> clusters = provider.discoverClusters();
+
+        assertThat(clusters).hasSize(1);
+        assertThat(clusters.get(0).getBrokers().get(0).getTpsIn()).isEqualTo(10);
+        assertThat(clusters.get(0).getBrokers().get(0).getTpsOut()).isEqualTo(30);
+    }
+
+    @Test
     void discoverClustersShouldConvertDiskRatioToPercentage() throws Exception {
         DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
         RocketMQClusterProvider provider = newProvider(adminExt);

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQDashboardProviderTest.java
@@ -485,6 +485,25 @@ class RocketMQDashboardProviderTest {
     }
 
     @Test
+    void dashboardShouldReadLegacy4xBrokerOutboundTpsKey() throws Exception {
+        DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo());
+        when(adminExt.fetchAllTopicList()).thenReturn(topicList());
+        KVTable runtime = runtimeStats("2.0", "5.0");
+        runtime.getTable().remove("getTransferredTps");
+        runtime.getTable().put("getTransferedTps", "4.0 5.0 6.0");
+        when(adminExt.fetchBrokerRuntimeStats("10.0.0.11:10911")).thenReturn(runtime);
+
+        DashboardDataVO dashboard = newProvider(adminExt).getDashboardData();
+
+        assertThat(dashboard.getStats().getTpsIn()).isEqualTo(2);
+        assertThat(dashboard.getStats().getTpsOut()).isEqualTo(5);
+        assertThat(dashboard.getClusters()).singleElement()
+                .extracting(ClusterOverviewVO::getTpsOut)
+                .isEqualTo(5L);
+    }
+
+    @Test
     void dashboardShouldIgnoreNonFiniteNegativeAndOverflowingTps() throws Exception {
         DefaultMQAdminExt adminExt = mock(DefaultMQAdminExt.class);
         when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfoWithTwoMasters());


### PR DESCRIPTION
### Motivation

RocketMQ brokers publish the outbound (get-transferred) TPS under **different runtime-stats keys depending on the broker generation**:

- **5.x** emits `getTransferredTps` (double r) — e.g. `StoreStatsService` in `release-5.3.1`
- **4.x** keeps the historical `getTransferedTps` spelling (single r) — e.g. `StoreStatsService` in `release-4.9.4`

The dashboard server only reads the 5.x key at all three consumption sites, so any cluster backed by 4.x brokers reports **tpsOut = 0** on the Dashboard overview and on the Cluster page, even while the broker is actively transferring messages. `tpsIn` (from `putTps`, same key on both generations) keeps working, which makes the failure look like "no outbound traffic" rather than a parsing bug.

Affected read sites:

- `RocketMQDashboardProvider#getDashboardData`: global `stats.tpsOut` and per-cluster `tpsOut`
- `RocketMQClusterProvider`: per-broker `tpsOut`

### Modification

Add a small per-class helper that resolves the outbound TPS entry by probing both spellings (5.x key first, 4.x legacy key as fallback), and use it at the three read sites. No behavior change for 5.x brokers; 4.x brokers now report their real outbound TPS.

### Verification

Fail-before / pass-after regression tests (stub `fetchBrokerRuntimeStats` with only the legacy `getTransferedTps` key present):

- `RocketMQClusterProviderTest#discoverClustersShouldReadLegacy4xBrokerOutboundTpsKey` — broker `tpsOut` was 0, now 30
- `RocketMQDashboardProviderTest#dashboardShouldReadLegacy4xBrokerOutboundTpsKey` — stats and cluster `tpsOut` were 0, now 5

Both full test classes pass:

```
Tests run: 16, Failures: 0, Errors: 0 -- in RocketMQClusterProviderTest
Tests run: 30, Failures: 0, Errors: 0 -- in RocketMQDashboardProviderTest
```

Key-spelling evidence (upstream `StoreStatsService.java`):
- release-4.9.4: `getTransferedTps`
- release-5.3.1: `getTransferredTps`
