### PR TITLE
feat(consumer): offer a skip-accumulation preset when resetting offsets

### DIFF
--- a/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
+++ b/web/src/pages/instance/__tests__/ConsumerPage.test.tsx
@@ -814,6 +814,36 @@ describe('Consumer page', () => {
     expect(screen.getByRole('button', { name: '确认重置' })).toBeDisabled();
   });
 
+  it('supports skipping accumulation by resetting to the latest offsets', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ConsumerPage />);
+
+    await user.click(await screen.findByRole('button', { name: /重置位点/ }));
+    const topicSelect = screen.getByRole('combobox', { name: '目标 Topic' });
+    await user.click(topicSelect);
+    const option = await waitFor(() => {
+      const element = screen
+        .getAllByText('remote-topic')
+        .find((candidate) => candidate.classList.contains('ant-select-item-option-content'));
+      if (!element) throw new Error('Missing target Topic option');
+      return element;
+    });
+    await user.click(option);
+
+    const beforeSkip = Date.now();
+    await user.click(screen.getByRole('button', { name: /跳过积压/ }));
+    await user.click(screen.getByRole('button', { name: /预览影响/ }));
+
+    await waitFor(() => {
+      const calls = vi.mocked(consumerService.previewConsumerOffsetReset).mock.calls;
+      const request = calls[calls.length - 1]?.[0];
+      expect(request?.timestamp).toBeGreaterThanOrEqual(beforeSkip);
+      expect(request?.timestamp).toBeLessThanOrEqual(Date.now());
+    });
+    expect(await screen.findByText('将回放 10 条消息')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: '确认重置' })).toBeEnabled());
+  });
+
   it('blocks reset confirmation when the preview has failed queues', async () => {
     vi.mocked(consumerService.previewConsumerOffsetReset).mockResolvedValue({
       instanceId: 'instance-1',

--- a/web/src/pages/instance/consumer.tsx
+++ b/web/src/pages/instance/consumer.tsx
@@ -2468,6 +2468,15 @@ const ConsumerPageContent = ({
                 <Button
                   size="small"
                   onClick={() => {
+                    setResetTime(dayjs());
+                    clearResetPreview();
+                  }}
+                >
+                  跳过积压（重置到最新）
+                </Button>
+                <Button
+                  size="small"
+                  onClick={() => {
                     setResetTime(dayjs().subtract(1, 'hour'));
                     clearResetPreview();
                   }}


### PR DESCRIPTION
Fixes #3993.

## Source

- Parent project (classic dashboard, default branch `master`): [`ConsumerController.java`](https://github.com/apache/rocketmq-dashboard/blob/master/src/main/java/org/apache/rocketmq/dashboard/controller/ConsumerController.java) ships a dedicated `POST /consumer/skipAccumulate.do` action, wired through [`SkipMessageAccumulateDialog.jsx`](https://github.com/apache/rocketmq-dashboard/blob/master/frontend-new/src/components/topic/SkipMessageAccumulateDialog.jsx) and invoked from [`topic.jsx`](https://github.com/apache/rocketmq-dashboard/blob/master/frontend-new/src/pages/Topic/topic.jsx) with `resetTime: -1` — reset the selected group's offsets for a topic to the latest position so it stops replaying a stale backlog.
- Feature request filed for this gap: #3993.

## Current gap

On the base commit (36126024), Studio's consumer offset reset modal (`web/src/pages/instance/consumer.tsx`) has only backward-looking quick presets (1/3/6/12 hours ago, 1/3 days ago) plus a manual time picker. Jumping to the latest offsets — the operation the classic console dedicated an action to — requires the operator to hand-pick the current time in the picker. Verified by reading the modal's quick-select row and by the red test below; no doc or code comment marks skip-accumulation as unsupported, and the modal is the natural home for the action.

## Project fit

The reset modal already owns group/topic/timestamp selection, a risk-scored preview endpoint (`/api/groups/reset-offset/preview`, a Studio superset of the classic dialog's blind force-reset), and a confirm gate. A "reset to latest" preset is the missing forward entry in that preset row: Studio's backend already resolves any timestamp to per-queue offsets via `searchOffset` with `[minOffset, maxOffset]` clamping, so a current timestamp yields exactly the classic skip-to-latest semantics — with better visibility than the original.

## Scope

Included:

- One **跳过积压（重置到最新）** preset button in the quick-select row that sets the reset timestamp to `now` and clears any stale preview, exactly like the other presets.
- The existing preview-and-confirm flow (including failed-queue blocking) applies unchanged before anything is written.

Not included: the classic dialog's multi-group batch reset and `force: true` semantics — Studio intentionally resets one group per modal behind a risk preview, and this PR keeps that model; no backend or API change.

## Implementation

A single button in `consumer.tsx` following the established preset pattern: `setResetTime(dayjs()); clearResetPreview();`. No state model, service, or i18n changes (the modal already uses hardcoded zh labels locally).

## Tests (actual commands and results)

- New test `supports skipping accumulation by resetting to the latest offsets` (`web/src/pages/instance/__tests__/ConsumerPage.test.tsx`): selects a topic, clicks the preset, re-previews, and asserts the preview request's timestamp falls inside the [before-click, now] window (i.e. the preset sends "now", not the default "3 hours ago"), and the preview/confirm flow stays intact.
- Red (implementation stashed, test kept): `npx vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx -t "skipping accumulation"` → `TestingLibraryElementError: Unable to find an accessible element with the role "button" and name /跳过积压/` (1 failed, 29 skipped).
- Green: `npx vitest run src/pages/instance/__tests__/ConsumerPage.test.tsx` → **30 passed (30)**; full web suite `npx vitest run` → **923 tests, 1 failed** — the pre-existing load-fragile `shows group health diagnostics` case in the same file (passes in isolation; the documented full-suite fragility of this sandbox). 923 = 922 baseline + 1 new test; zero new failures.
- `npx tsc -b` clean; `eslint` clean on both changed files; `npm run build` succeeds.
- Not executable here: upstream CI (head `2215c53ecb611dd3bf78718f9f1d22106b5d2e4b` has 0 check runs / no workflow runs; the workflow currently fails to start for all branches) — results above are from local execution.

## Compatibility & Risk

- Frontend-only, 2 files (+39/−0): one button and one test. No API, contract, dependency, or license impact; no i18n-key change (local label style).
- Risk surface is unchanged from any manual reset: the preset only pre-fills a timestamp, never applies anything by itself; the risk preview and confirm gate (including failed-queue blocking) apply to it exactly as to hand-picked timestamps.
- Difference from the classic action: intent restored (one-click skip-to-latest) inside Studio's preview-first safety model, without porting the batch + force behavior.

(head 2215c53ecb611dd3bf78718f9f1d22106b5d2e4b; verification details in the evidence comment below)
