### PR TITLE
fix(lite-topic): guard TTL extension against double submission

### DIFF
--- a/web/src/pages/studio/LiteTopic.tsx
+++ b/web/src/pages/studio/LiteTopic.tsx
@@ -149,6 +149,7 @@ const LiteTopicPage: React.FC = () => {
     newTTL: number | null;
   }>({ topicPattern: '', newTTL: null });
   const [extendTTLLoading, setExtendTTLLoading] = useState(false);
+  const extendTTLInFlightRef = useRef(false);
 
   const mountedRef = useRef(false);
   const bootstrapRequestId = useRef(0);
@@ -308,6 +309,8 @@ const LiteTopicPage: React.FC = () => {
 
   const handleExtendTTL = async () => {
     if (!extendTTLForm.topicPattern || extendTTLForm.newTTL == null) return;
+    if (extendTTLInFlightRef.current) return;
+    extendTTLInFlightRef.current = true;
     setExtendTTLLoading(true);
     try {
       await extendLiteTopicTTL(extendTTLForm.topicPattern, extendTTLForm.newTTL);
@@ -317,6 +320,7 @@ const LiteTopicPage: React.FC = () => {
     } catch {
       message.error(t('liteTopic.extendTtlFailed'));
     } finally {
+      extendTTLInFlightRef.current = false;
       setExtendTTLLoading(false);
     }
   };

--- a/web/src/pages/studio/__tests__/LiteTopic.test.tsx
+++ b/web/src/pages/studio/__tests__/LiteTopic.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'antd';
 import { LangProvider } from '../../../i18n/LangContext';
@@ -565,5 +565,28 @@ describe('LiteTopic Page', () => {
     expect(screen.queryByText('old-*')).not.toBeInTheDocument();
     expect(screen.queryByText('90 / 100')).not.toBeInTheDocument();
     expect(await screen.findByText('获取配额信息失败')).toBeInTheDocument();
+  });
+
+  it('submits TTL extension once when confirm is clicked twice in the same render', async () => {
+    const deferred = createDeferred<void>();
+    apiMocks.extendLiteTopicTTL.mockReturnValue(deferred.promise);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: '延长 TTL' }));
+    const dialog = await screen.findByRole('dialog');
+    const ttlInput = within(dialog).getByRole('spinbutton');
+    await user.clear(ttlInput);
+    await user.type(ttlInput, '3600');
+
+    const confirmButton = within(dialog).getByRole('button', { name: /确\s*认/ });
+    act(() => {
+      fireEvent.click(confirmButton);
+      fireEvent.click(confirmButton);
+    });
+
+    expect(apiMocks.extendLiteTopicTTL).toHaveBeenCalledTimes(1);
+    deferred.resolve(undefined);
+    expect(await screen.findByText('TTL 延长成功')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Adds a synchronous in-flight guard to the LiteTopic TTL extension flow so two confirmation events delivered in the same render cannot enqueue duplicate `extendLiteTopicTTL` write requests.

## Root cause
`handleExtendTTL` relied only on React `extendTTLLoading` state to disable the modal confirm button. React state updates are asynchronous, so two confirmation events delivered before the re-render both passed the guard and called `extendLiteTopicTTL`.

## Changes
- Add `extendTTLInFlightRef` and set/clear it synchronously around the API call.
- Add a LiteTopic page regression test that fires two confirm clicks in the same render against a deferred API promise and asserts the write is issued once.

## Testing
Commands run:
- `cd web`
- `npx vitest run src/pages/studio/__tests__/LiteTopic.test.tsx`
- `cd ..`
- `git diff --check`

Actual results:
- Vitest: `Test Files 1 passed (1)`, `Tests 15 passed (15)`.
- `git diff --check`: no output, exit code 0.

I did not run the full Maven/Java backend suite on this Windows host because no Maven wrapper or Maven executable is available and the `rocketmq-studio` server targets Java 21. This PR changes frontend code only.

Fixes #2889

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100
