### PR TITLE
fix(client): treat offline group connections as empty results

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java
@@ -36,6 +36,7 @@ import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.common.domain.enums.ClientLanguage;
 import org.apache.rocketmq.studio.common.domain.enums.ClientType;
 import org.apache.rocketmq.studio.common.domain.enums.Protocol;
+import org.apache.rocketmq.studio.common.util.MqResponseCodes;
 import org.apache.rocketmq.studio.common.util.SystemGroupFilter;
 import org.apache.rocketmq.tools.admin.MQAdminExt;
 import lombok.RequiredArgsConstructor;
@@ -171,9 +172,10 @@ public class RocketMQClientProvider implements ClientProvider {
                             connection, ClientType.Producer, topic, producerGroup, null))
                     .toList();
         } catch (MQClientException e) {
-            if (isTopicNotExist(e)) {
-                // A non-existent topic is a normal "nothing here" outcome — the client
-                // page should show an empty list, not a 502 that looks like a failure.
+            if (isTopicNotExist(e) || isGroupConnectionAbsent(e)) {
+                // A missing topic route or an offline producer group are normal "nothing
+                // here" outcomes — the client page should show an empty list, not a 502
+                // that looks like a failure.
                 return List.of();
             }
             throw new BusinessException(502,
@@ -182,6 +184,17 @@ public class RocketMQClientProvider implements ClientProvider {
             throw new BusinessException(502,
                     "Failed to query producer connections: " + rootMessage(e));
         }
+    }
+
+    private boolean isGroupConnectionAbsent(MQClientException e) {
+        if (MqResponseCodes.hasResponseCode(e, ResponseCode.CONSUMER_NOT_ONLINE)) {
+            // rocketmq-tools examineConsumerConnectionInfo throws CONSUMER_NOT_ONLINE (206)
+            // for a group with no online connections.
+            return true;
+        }
+        String message = e.getErrorMessage() == null ? e.getMessage() : e.getErrorMessage();
+        return message != null && (message.contains("Not found the consumer group connection")
+                || message.contains("Not found the producer group connection"));
     }
 
     private boolean isTopicNotExist(MQClientException e) {
@@ -324,6 +337,12 @@ public class RocketMQClientProvider implements ClientProvider {
                             groupEntry.getValue()));
                 }
             } catch (Exception e) {
+                if (e instanceof MQClientException clientException && isGroupConnectionAbsent(clientException)) {
+                    // An offline group is a normal "no connections right now" answer, not a
+                    // broken scan — count it so an all-offline cluster stays an empty result.
+                    successfulGroupQueries++;
+                    continue;
+                }
                 log.warn("Failed to examine consumer connection for group={}, skipping", group, e);
             }
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProviderTest.java
@@ -504,6 +504,49 @@ class RocketMQClientProviderTest {
         });
     }
 
+    @Test
+    void consumerScanTreatsOfflineGroupsAsEmptyInsteadOf502() throws Exception {
+        SubscriptionGroupWrapper wrapper = subscriptionGroups("group-a", "group-b");
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo("127.0.0.1:10911"));
+        when(adminExt.getAllSubscriptionGroup("127.0.0.1:10911", 5000L)).thenReturn(wrapper);
+        when(adminExt.examineConsumerConnectionInfo(anyString())).thenThrow(new MQClientException(
+                206, "Not found the consumer group connection"));
+
+        List<ClientConnectionVO> connections = provider.findConnections("instance-a", "cluster-a", null);
+
+        assertThat(connections).isEmpty();
+    }
+
+    @Test
+    void consumerScanReturnsOfflineGroupResultsWhenAnotherGroupFails() throws Exception {
+        SubscriptionGroupWrapper wrapper = subscriptionGroups("group-a", "group-b");
+        ConsumerConnection consumerConnection = new ConsumerConnection();
+        consumerConnection.setConnectionSet(new HashSet<>(List.of(connection("consumer-client", "10.0.0.2:1000"))));
+        when(adminExt.examineBrokerClusterInfo()).thenReturn(clusterInfo("127.0.0.1:10911"));
+        when(adminExt.getAllSubscriptionGroup("127.0.0.1:10911", 5000L)).thenReturn(wrapper);
+        when(adminExt.examineConsumerConnectionInfo("group-a")).thenThrow(new MQClientException(
+                206, "Not found the consumer group connection"));
+        when(adminExt.examineConsumerConnectionInfo("group-b")).thenReturn(consumerConnection);
+
+        List<ClientConnectionVO> connections = provider.findConnections("instance-a", "cluster-a", "Consumer");
+
+        assertThat(connections).singleElement().satisfies(connection -> {
+            assertThat(connection.getClientId()).isEqualTo("consumer-client");
+            assertThat(connection.getGroupOrTopic()).isEqualTo("group-b");
+        });
+    }
+
+    @Test
+    void producerQueryWithExplicitOfflineGroupReturnsEmptyInsteadOf502() throws Exception {
+        when(adminExt.examineProducerConnectionInfo("pg-order", "TopicA")).thenThrow(
+                new MQClientException("Not found the producer group connection", null));
+
+        List<ClientConnectionVO> connections =
+                provider.findProducerConnections("instance-a", "TopicA", "pg-order");
+
+        assertThat(connections).isEmpty();
+    }
+
     private static SubscriptionGroupWrapper subscriptionGroups(String... names) {
         SubscriptionGroupWrapper wrapper = new SubscriptionGroupWrapper();
         ConcurrentHashMap<String, SubscriptionGroupConfig> groups = new ConcurrentHashMap<>();


### PR DESCRIPTION
Fixes #4006.

## Problem / Evidence

`GET /api/clients` fails with HTTP 502 "Failed to query consumer connections from all groups" whenever every non-system consumer group of the instance is offline — a completely normal state (consumer applications stopped, dev/test cluster, nightly window) — instead of returning an empty connection list. Because the consumer scan runs after the producer scan in the same request, the producer connections already collected are discarded too.

The same misclassification hits the explicit producer-group lookup: `GET /api/producer/connection?...&producerGroup=G` returns 502 "Failed to query producer connections: Not found the producer group connection" when group `G` has no online producers.

Client bytecode (rocketmq-tools 5.5.0, the version pinned by `server/pom.xml`), verified via `javap -c` on `DefaultMQAdminExtImpl`:

- `examineConsumerConnectionInfo(String)`: when `ConsumerConnection.getConnectionSet().isEmpty()` it throws `new MQClientException(206, "Not found the consumer group connection")` (bytecode offsets 90–126).
- `examineProducerConnectionInfo(String, String)`: throws `new MQClientException("Not found the producer group connection", null)` for an empty connection set.

`RocketMQClientProvider.findConsumerConnections` (`server/src/main/java/org/apache/rocketmq/studio/provider/apache/RocketMQClientProvider.java:313-334`) counts those per-group exceptions as scan failures, so "all groups offline" is indistinguishable from "all brokers broken" and trips the guard at line 332. The provider's own convention says normal "nothing here" states must be empty, not 502 (existing comment at `:175-177` and the `isTopicNotExist` handling).

## Root cause / Fix

The all-failed heuristic (attempted > 0 && successful == 0 → 502) treats the offline-group business answers as infrastructure failures. Fix:

- In the consumer scan, an `MQClientException` with response code 206 or message "Not found the consumer group connection" counts as a *successful* per-group query that found nothing, so an all-offline cluster yields an empty list; groups with real failures keep the partial-results behavior, and a scan where every group genuinely fails still returns 502.
- In the explicit producer-group query, the same offline-group message returns an empty list alongside the existing missing-topic handling.

## Priority & scoring

PRIORITY 76 = impact 30 (the core Clients page errors out on a routine cluster state and drops already-fetched producer data) + blast radius 14 (every Apache-instance deployment; offline groups are routine) + reproducibility 18 (deterministic, one request, client behavior pinned by bytecode) + maintenance value 14 (extends the established "normal absence → empty" convention already accepted in this repo, e.g. NO_MESSAGE key queries and topic-route absence).

FIX_CONFIDENCE 95 (client exception contract verified against the exact dependency version's bytecode; fix is a per-exception reclassification).

## Tests

`mvn -B -ntp test -Dtest='RocketMQClientProviderTest'`:

- Before the fix, the new regressions failed with the production errors: `consumerScanTreatsOfflineGroupsAsEmptyInsteadOf502` → `BusinessException: Failed to query consumer connections from all groups`; `producerQueryWithExplicitOfflineGroupReturnsEmptyInsteadOf502` → `BusinessException: Failed to query producer connections: Not found the producer group connection`.
- After the fix: **Tests run: 27, Failures: 0, Errors: 0** (24 pre-existing + 3 new; `consumerScanFailsWhenEveryGroupConnectionQueryFails` still asserts genuine failures → 502).
- Full backend suite (`mvn -B -ntp test`): **Tests run: 2038, Failures: 3** — the 3 failures are the pristine-baseline set (AuthCorsIntegrationTest ×2, AliyunInstanceProviderTest ×1, identical messages), i.e. zero new failures; 2035 baseline + 3 new tests.

## Risk

Low. Only the two specific offline-group answers are reclassified; broker-unreachable failures, partial scans and the system-group short-circuit keep their existing behavior. No API shape change — the response for this normal state changes from an error to an empty list, matching the page's contract.