### PR TITLE
fix(message): scope stored query results to the authenticated owner

### DIFF
--- a/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
+++ b/server/src/main/java/org/apache/rocketmq/studio/instance/message/QueryHistoryService.java
@@ -129,10 +129,14 @@ public class QueryHistoryService {
     }
 
     /**
-     * Retrieves the stored result snapshot for a given history record.
+     * Retrieves the stored result snapshot for a given history record. Reads are scoped to
+     * the authenticated owner, like every other query-history read, so a record id alone
+     * does not expose another user's stored snapshot (404 for missing *or* foreign rows).
      */
     public List<MessageRecordVO> getMessageQueryResults(long id) {
-        RmqMessageQuery query = messageQueryMapper.selectById(id);
+        RmqMessageQuery query = messageQueryMapper.selectOne(new QueryWrapper<RmqMessageQuery>()
+                .eq("id", id)
+                .eq("queried_by", AuthenticatedUserContext.currentUsernameOrSystem()));
         if (query == null) {
             throw new org.apache.rocketmq.studio.common.exception.BusinessException(404, "Query history record not found");
         }

--- a/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
+++ b/server/src/test/java/org/apache/rocketmq/studio/instance/message/QueryHistoryServiceTest.java
@@ -20,6 +20,7 @@ import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.studio.common.domain.PageResult;
+import org.apache.rocketmq.studio.common.exception.BusinessException;
 import org.apache.rocketmq.studio.auth.AuthenticatedUserContext;
 import org.apache.rocketmq.studio.persistence.entity.RmqMessageQuery;
 import org.apache.rocketmq.studio.persistence.entity.RmqTraceQuery;
@@ -36,6 +37,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -265,6 +267,42 @@ class QueryHistoryServiceTest {
         verify(traceQueryMapper).selectCount(traceCountCaptor.capture());
         assertThat(messageCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
         assertThat(traceCountCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
+    }
+
+    @Test
+    void getMessageQueryResultsHidesRecordsOwnedByOtherUsers() {
+        AuthenticatedUserContext.setUsername("alice");
+        RmqMessageQuery foreign = messageQuery(7L);
+        foreign.setQueriedBy("bob");
+        foreign.setResultSnapshot("[{\"msgId\":\"m-1\",\"topic\":\"orders\"}]");
+        // The current implementation reads the row by id only; the scoped read filters it
+        // out in the database, which the selectOne stub mimics (no row passes the filter).
+        when(messageQueryMapper.selectById(7L)).thenReturn(foreign);
+        when(messageQueryMapper.selectOne(any(Wrapper.class))).thenReturn(null);
+
+        assertThatThrownBy(() -> service.getMessageQueryResults(7L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Query history record not found")
+                .satisfies(error -> assertThat(((BusinessException) error).getCode()).isEqualTo(404));
+    }
+
+    @Test
+    void getMessageQueryResultsScopesTheReadToTheAuthenticatedOwner() {
+        AuthenticatedUserContext.setUsername("alice");
+        RmqMessageQuery owned = messageQuery(11L);
+        owned.setQueriedBy("alice");
+        owned.setResultSnapshot("[{\"msgId\":\"m-1\",\"topic\":\"orders\"}]");
+        when(messageQueryMapper.selectOne(any(Wrapper.class))).thenReturn(owned);
+
+        List<MessageRecordVO> results = service.getMessageQueryResults(11L);
+
+        assertThat(results).singleElement().satisfies(record -> {
+            assertThat(record.getMsgId()).isEqualTo("m-1");
+            assertThat(record.getTopic()).isEqualTo("orders");
+        });
+        ArgumentCaptor<Wrapper<RmqMessageQuery>> wrapperCaptor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(messageQueryMapper).selectOne(wrapperCaptor.capture());
+        assertThat(wrapperCaptor.getValue().getCustomSqlSegment()).contains("queried_by");
     }
 
     private static RmqMessageQuery messageQuery(Long id) {


### PR DESCRIPTION
Fixes #4007.

## Problem / Evidence

`GET /api/query-history/messages/{id}/results` returns the stored query-result snapshot for any record id with no ownership check. Record ids are sequential, so any authenticated user can enumerate `/api/query-history/messages/1../results` and replay another user's stored snapshots, which contain the topics, msgIds, tags, message keys, queue offsets, broker names and — notably — the `bornHost`/`storeHost` addresses of the clusters those users operate (`QueryHistoryService.buildResultSnapshot`, lines 109-124).

Every other read in the same service scopes to the authenticated user — `listMessageQueries` (`QueryHistoryService.java:184`), `listTraceQueries` (`:204`), and `summarize` (`:221-234`) all filter `queried_by = currentUsernameOrSystem()`, and the owner is stamped at insert (`:93`). The by-id results read added later (`selectById`, `:135`) is the only read that skips the boundary. The scoping contract was established by the merged fix for #2265 ("Query-history reads and summaries are scoped to the current authenticated user by default"); the results endpoint did not exist yet when that fix landed and never picked the boundary up.

## Root cause / Fix

`getMessageQueryResults` fetched the row by id alone. Fix: read the row through the same owner-scoped `QueryWrapper` the other reads use (`.eq("id", id).eq("queried_by", currentUsernameOrSystem())`) and keep returning 404 for both missing and foreign records, so record existence is not leaked either. No admin bypass is added, matching the list paths.

## Priority & scoring

PRIORITY 72 = impact 28 (authenticated cross-user disclosure of other operators' query metadata and internal broker/producer host addresses) + blast radius 12 (one endpoint, but all multi-user deployments with login required) + reproducibility 18 (deterministic, sequential ids, one request per record) + maintenance value 14 (aligns the last unscoped read with the service's own established boundary; one-line fix).

FIX_CONFIDENCE 95 (the scoping pattern is already implemented and tested in the same class).

## Tests

`mvn -B -ntp test -Dtest='QueryHistoryServiceTest,QueryHistoryControllerTest'`:

- Before the fix, `getMessageQueryResultsHidesRecordsOwnedByOtherUsers` failed because the foreign-owned record (owner `bob`, current user `alice`) was returned instead of 404 — the defect reproduced.
- After the fix: QueryHistoryServiceTest **12/12** (10 pre-existing + 2 new, including the owner-scoped wrapper SQL-segment assertion mirroring the existing `queried_by` captor pattern) and QueryHistoryControllerTest 4/4.
- Full backend suite (`mvn -B -ntp test`): **Tests run: 2037, Failures: 3** — exactly the pristine-baseline set (AuthCorsIntegrationTest ×2, AliyunInstanceProviderTest ×1, identical messages); zero new failures; 2035 baseline + 2 new tests.

## Risk

Low. The normal UI flow only replays records from the requesting user's own history list, which is already owner-scoped, so no legitimate path loses access. Foreign or missing ids now return the same 404 as before for missing ids. Data contents, endpoints and response shapes are unchanged.