### PR TITLE
fix(alerts): reset list state when the alerts domain route switches

### DIFF
--- a/web/src/pages/ops/__tests__/AlertsPage.test.tsx
+++ b/web/src/pages/ops/__tests__/AlertsPage.test.tsx
@@ -315,6 +315,54 @@ describe('AlertsPage', () => {
     expect(screen.getByText('21')).toBeInTheDocument();
   });
 
+  it('resets page, search and status filters when the domain switches', async () => {
+    vi.mocked(listAlertRulesPage).mockClear();
+    vi.mocked(listAlertRulesPage).mockResolvedValue({
+      items: [cloneRule(alertRules[0])],
+      total: 21,
+      page: 2,
+      size: 20,
+    });
+    const user = userEvent.setup();
+    const { rerender } = renderPage();
+
+    await screen.findByText('Broker disk usage');
+    await user.type(screen.getByPlaceholderText('搜索规则名称或指标'), 'disk');
+    await waitFor(() =>
+      expect(listAlertRulesPage).toHaveBeenLastCalledWith(
+        'CLUSTER',
+        expect.objectContaining({ search: 'disk' }),
+      ),
+    );
+    const secondPage = document.querySelector('.ant-pagination-item-2') as HTMLElement | null;
+    if (!secondPage) throw new Error('Pagination page 2 not found');
+    await user.click(secondPage);
+    await waitFor(() =>
+      expect(listAlertRulesPage).toHaveBeenLastCalledWith(
+        'CLUSTER',
+        expect.objectContaining({ page: 2 }),
+      ),
+    );
+
+    rerender(
+      <App>
+        <LangProvider>
+          <AlertsPage domain="BUSINESS" />
+        </LangProvider>
+      </App>,
+    );
+
+    await waitFor(() =>
+      expect(listAlertRulesPage).toHaveBeenLastCalledWith('BUSINESS', {
+        enabled: undefined,
+        page: 1,
+        pageSize: 20,
+        search: undefined,
+      }),
+    );
+    expect(screen.getByPlaceholderText('搜索规则名称或指标')).toHaveValue('');
+  });
+
   it('uses the business rule API and loads only business metrics for the selected instance', async () => {
     vi.mocked(listNativeAlertMetrics).mockResolvedValue([
       {

--- a/web/src/pages/ops/alerts.tsx
+++ b/web/src/pages/ops/alerts.tsx
@@ -172,6 +172,23 @@ const AlertsPage = ({ domain = 'CLUSTER' }: AlertsPageProps) => {
   const [selectedRuleIds, setSelectedRuleIds] = useState<Key[]>([]);
   const [bulkAction, setBulkAction] = useState<'enable' | 'disable' | 'delete' | null>(null);
   const [form] = Form.useForm();
+  // The same component instance serves /ops/alerts and /ops/business-alerts, so the
+  // list state from the previous domain must be dropped when the route switches
+  // (React's documented "adjust state when a prop changes" pattern). Clear the loaded
+  // rows/total/runtime and re-enter the loading state as well, otherwise the previous
+  // domain's rules stay visible with loading=false until the new page resolves.
+  const [renderedDomain, setRenderedDomain] = useState(domain);
+  if (renderedDomain !== domain) {
+    setRenderedDomain(domain);
+    setPage(1);
+    setSearch('');
+    setEnabledFilter(undefined);
+    setSelectedRuleIds([]);
+    setRules([]);
+    setTotalRules(0);
+    setRuntime([]);
+    setLoading(true);
+  }
   const selectedMetric = Form.useWatch('metric', form);
   const selectedOperator = Form.useWatch('operator', form);
   const selectedThresholdUnit = Form.useWatch('thresholdUnit', form);


### PR DESCRIPTION
Fixes #4008.

## Problem / Evidence

`/ops/alerts` and `/ops/business-alerts` render the *same* `AlertsPage` component (`web/src/App.tsx:187-188`), so React Router preserves the component instance — and all of its state — when navigating between the two primary menu entries (`MainLayout.tsx:204,218`). `page`, `search` and `enabledFilter` (`alerts.tsx:159-162`) are never reset on a `domain` change; the list effect re-runs on `domain` and fetches with the retained values.

User-visible failure, deterministic:

1. On 告警规则 (cluster), page to page 2 (21+ rules) and/or type a search term.
2. Click the 业务告警规则 menu entry.
3. The business list is fetched with `page: 2` (and the retained search). `opsService.listAlertRulesPage` slices out-of-range pages to `items: []` with `total` unchanged, so the table is empty while rc-pagination clamps the *displayed* current page to 1 — the page shows an empty rule list that looks like "no business rules exist". Even when the retained page is in range, the retained search silently narrows the other domain's rule list.

## Root cause / Fix

Route-element reuse without a domain-state reset. Fix (in `alerts.tsx`): when the `domain` prop changes, drop the previous domain's list state during render (React's documented "adjust state when a prop changes" pattern — avoids cascading effects and the repo's `react-hooks/set-state-in-effect` lint rule): reset `page` to 1 and clear `search` / `enabledFilter` / row selection.

## Priority & scoring

PRIORITY 78 = impact 30 (a primary-navigation path shows an empty or silently filtered rule list — operators can conclude business rules are missing) + blast radius 14 (both alert-rule pages, every deployment; navigation between the two menu entries is ordinary usage) + reproducibility 19 (deterministic UI interaction, no timing involved) + maintenance value 15 (restores the invariant every other list page follows: filters/pagination belong to the currently viewed list).

FIX_CONFIDENCE 92.

## Tests

`npx vitest run src/pages/ops/__tests__/AlertsPage.test.tsx`:

- Before the fix, the new regression `resets page, search and status filters when the domain switches` failed: after switching to `domain="BUSINESS"` the fetch still carried the retained `page: 2` / `search: 'disk'` instead of reset values.
- After the fix: **23 passed (23)** (22 pre-existing + 1 new).
- Full web suite (`npx vitest run`): **Tests run: 923 passed (115 files)** — first full run showed 3 failures in untouched load-fragile files (NotificationDeliveriesPage pointer-events etc.), consistent with this suite's documented load sensitivity; an immediate clean full run passed all 923 with zero failures.
- `npx tsc --noEmit` clean; `npx eslint` on the touched files: 0 errors (5 pre-existing warnings verified on the pristine baseline); `npm run build` succeeds.

## Risk

Low. The reset only fires when the `domain` prop actually changes — the initial mount already starts from these defaults, so behavior within one domain (pagination, search, bulk selection) is unchanged. No API, route or markup changes.