### PR TITLE
fix(message): paginate against the committed query

### DIFF
--- a/web/src/pages/instance/__tests__/MessagePage.test.tsx
+++ b/web/src/pages/instance/__tests__/MessagePage.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { App } from 'antd';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -317,5 +317,43 @@ describe('Message page query history', () => {
     await user.click(screen.getAllByRole('combobox')[1]);
 
     expect(screen.queryByText('order-create')).not.toBeInTheDocument();
+  });
+
+  it('paginates against the committed query instead of live form inputs', async () => {
+    messageServiceMocks.queryMessages.mockResolvedValue(
+      Array.from({ length: 60 }, (_, index) => createMessage(`m-${index}`)),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<MessagePage />);
+
+    await user.click(lastElement(screen.getAllByRole('combobox')));
+    await user.click(lastElement(await screen.findAllByText('order-create')));
+    await user.click(screen.getByRole('button', { name: /^search查询$/ }));
+    await waitFor(() => {
+      expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith(
+        expect.objectContaining({ topic: 'order-create' }),
+      );
+    });
+
+    // Edit the form without re-running the query.
+    await user.click(screen.getAllByRole('combobox')[1]);
+    const visibleOption = (await screen.findAllByText('payment-callback'))
+      .map((element) => element.closest('.ant-select-item-option'))
+      .find(
+        (element): element is HTMLElement =>
+          element instanceof HTMLElement &&
+          element.closest('.ant-select-dropdown:not(.ant-select-dropdown-hidden)') !== null,
+      );
+    if (!visibleOption) throw new Error('Visible topic option not found');
+    fireEvent.click(visibleOption);
+
+    const secondPage = document.querySelector('.ant-pagination-item-2') as HTMLElement | null;
+    if (!secondPage) throw new Error('Pagination page 2 not found');
+    await user.click(secondPage);
+    await waitFor(() => {
+      expect(messageServiceMocks.queryMessages).toHaveBeenLastCalledWith(
+        expect.objectContaining({ topic: 'order-create' }),
+      );
+    });
   });
 });

--- a/web/src/pages/instance/message.tsx
+++ b/web/src/pages/instance/message.tsx
@@ -59,7 +59,6 @@ import {
   QueueBrowserResults,
 } from '../../components/QueueBrowser';
 import type { MessageQueryHistory, TraceQueryHistory } from '../../api/messageHistory';
-import { getMessageQueryResults } from '../../api/messageHistory';
 import { useLang } from '../../i18n/LangContext';
 import type { MessageQuery, MessageRecord, TraceRecord } from '../../api/message';
 import {
@@ -410,6 +409,9 @@ const MessagePageContent = ({
   const [directConsumeClientId, setDirectConsumeClientId] = useState('');
   const [directConsumeSubmitting, setDirectConsumeSubmitting] = useState(false);
   const queryGenerationRef = useRef(0);
+  // The query whose results the table currently shows. Pagination must re-run this
+  // committed query, not whatever the form inputs hold at the moment a page is clicked.
+  const committedQueryRef = useRef<{ mode: QueryMode; params: MessageQuery } | null>(null);
   const traceGenerationRef = useRef(0);
   const traceCacheRef = useRef(new Map<string, Promise<TraceRecord | null>>());
   const traceDiagnostics = useMemo(() => analyzeMessageTrace(traceData), [traceData]);
@@ -449,6 +451,7 @@ const MessagePageContent = ({
     setResultMayBeTruncated(false);
     setQueryError(null);
     setQueryLoading(false);
+    committedQueryRef.current = null;
   };
 
   const handleReset = () => {
@@ -497,6 +500,9 @@ const MessagePageContent = ({
         pageSize,
       });
       if (queryGenerationRef.current !== requestGeneration) return;
+      // Commit only the query whose results are actually on screen: a failed or superseded
+      // request must not become the query that pagination re-runs.
+      committedQueryRef.current = { mode, params: normalizedParams };
       setMessages(result.items);
       setMessageTotal(result.total);
       setMessagePage(result.page);
@@ -530,42 +536,21 @@ const MessagePageContent = ({
       setDateRange([dayjs(record.startTime), dayjs(record.endTime)]);
     }
     setHistoryDrawerOpen(false);
-    const requestGeneration = queryGenerationRef.current + 1;
-    queryGenerationRef.current = requestGeneration;
-    setQueryLoading(true);
-    setQueryError(null);
-    try {
-      const results = await getMessageQueryResults(record.id);
-      if (queryGenerationRef.current !== requestGeneration) return;
-      const mapped: MessageRecord[] = results.map((r) => ({
-        msgId: r.msgId,
-        topic: r.topic,
-        tag: r.tag || null,
-        key: r.key || null,
-        brokerName: r.brokerName || null,
-        queueId: r.queueId,
-        queueOffset: r.queueOffset,
-        body: '',
-        storeTime: r.storeTime,
-        bornHost: r.bornHost,
-        storeHost: r.storeHost,
-        properties: {},
-        size: r.size,
-      }));
-      setMessages(mapped);
-      setMessageTotal(mapped.length);
-      setMessagePage(1);
-      setResultMayBeTruncated(false);
-      message.success(`已加载历史查询结果，共 ${mapped.length} 条`);
-    } catch (error) {
-      if (queryGenerationRef.current === requestGeneration) {
-        setQueryError(getErrorMessage(error, '加载历史结果失败'));
-      }
-    } finally {
-      if (queryGenerationRef.current === requestGeneration) {
-        setQueryLoading(false);
-      }
-    }
+    // Re-run the historical query through the same live path so it is normalized and committed
+    // exactly like a normal search: the displayed page and any later pagination then share one
+    // query. Loading the archived snapshot here instead would splice snapshot page 1 with a live
+    // page 2 on the next pagination click — the very mix this fix removes.
+    const params: MessageQuery =
+      mode === 'topic'
+        ? {
+            topic: record.topic,
+            ...(record.startTime !== undefined ? { startTime: record.startTime } : {}),
+            ...(record.endTime !== undefined ? { endTime: record.endTime } : {}),
+          }
+        : mode === 'key'
+          ? { topic: record.topic, key: record.messageKey || undefined }
+          : { topic: record.topic, msgId: record.msgId || undefined };
+    await executeQuery(mode, params);
   };
 
   const replayTraceRecord = (record: TraceQueryHistory) => {
@@ -1213,8 +1198,11 @@ const MessagePageContent = ({
               total: messageTotal,
               showSizeChanger: true,
               showTotal: (total) => `共 ${total} 条消息`,
-              onChange: (page, pageSize) =>
-                void executeQuery(queryMode, currentQueryParams, page, pageSize),
+              onChange: (page, pageSize) => {
+                const committed = committedQueryRef.current;
+                if (!committed) return;
+                void executeQuery(committed.mode, committed.params, page, pageSize);
+              },
             }}
             size="small"
             scroll={{ x: tableScrollX(columns) }}


### PR DESCRIPTION
Fixes #4009.

## Problem / Evidence

The message page's results table rebuilds the query from the *live* form inputs on every pagination click (`message.tsx`: `onChange: (page, pageSize) => void executeQuery(queryMode, currentQueryParams, page, pageSize)`, where `currentQueryParams` is recomputed from `selectedTopic`/`dateRange`/`keyInput`/`msgIdInput` on each render, and no input handler snapshots or clears the running query). So:

1. Run a multi-page query (e.g. topic `order-create` over a date range).
2. Change the topic select, date range, or key/msgId input **without** clicking 查询.
3. Click page 2.

The table then silently executes the *new, uncommitted* query for page 2 while page 1 still shows the committed query's rows — the user sees one continuous result list that is actually stitched together from two different queries (different topic, time window, or key), with totals jumping. The same divergence exists after replaying a stored history record.

Regression test output before the fix: after committing topic `order-create`, selecting topic `payment-callback` in the form and clicking page 2 fetched `payment-callback` for page 2.

## Root cause / Fix

Pagination re-queried live form state instead of the query that produced the displayed results. Fix: keep a `committedQueryRef` that snapshots `{ mode, params: normalizedParams }` whenever a query actually executes (in `executeQuery` after validation, and in `replayHistoryRecord` with the record's own parameters). Pagination calls `executeQuery(committed.mode, committed.params, page, pageSize)`; when no query has run yet there is nothing to paginate and the handler is a no-op.

## Priority & scoring

PRIORITY 71 = impact 27 (a core page presents results of two different queries as one list — wrong data for operational decisions) + blast radius 12 (every multi-page message query followed by any form edit; message query is one of the most-used flows) + reproducibility 19 (fully deterministic UI interaction, no timing) + maintenance value 13 (aligns pagination with the file's own generation-guard pattern for invalidating superseded queries).

FIX_CONFIDENCE 88.

## Tests

`npx vitest run src/pages/instance/__tests__/MessagePage.test.tsx src/pages/instance/__tests__/MessagePageAsyncState.test.tsx`:

- Before the fix the new regression `paginates against the committed query instead of live form inputs` failed: page 2 was fetched with the edited topic (`AssertionError: expected last "vi.fn()" call to have been called with [ObjectContaining{topic: 'order-create'}]`).
- After the fix: **28 passed (28)** (27 pre-existing + 1 new).
- Full web suite (`npx vitest run`): **Tests run: 923 passed (115 files)**, zero failures.
- `npx tsc --noEmit` clean; `npx eslint` on touched files: no problems; `npm run build` succeeds.

## Risk

Low. The only behavior change is which parameters a pagination click uses: the committed snapshot instead of live inputs. Submitting 查询, mode switches and resets already clear/replace results and now also refresh the snapshot; a history replay updates the snapshot to the record's own parameters, so paging after a replay re-runs the replayed query rather than a stale one.