### PR TITLE
test(config): cover legacy static mock flag

### DIFF
--- a/web/src/config.test.ts
+++ b/web/src/config.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { API_BASE_URL } from './config';
+import { API_BASE_URL, USE_MOCK } from './config';
 
 describe('config API base url', () => {
   it('defaults to a relative /api path when no env override is set', () => {
@@ -31,5 +31,11 @@ describe('config API base url', () => {
 
   it('strips a single trailing slash', () => {
     expect(API_BASE_URL.endsWith('/')).toBe(false);
+  });
+});
+
+describe('config legacy mock flag', () => {
+  it('keeps the deprecated static mock flag disabled so callers cannot silently bypass runtime data mode', () => {
+    expect(USE_MOCK).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case that locks USE_MOCK to alse in web/src/config.ts.

## Root cause
The deprecated static mock flag had no regression coverage, so a future change could re-enable the legacy mock path without a failing test.

## Changes
- Import and assert USE_MOCK in web/src/config.test.ts.

## Testing
Commands run:
- cd web
- 
px vitest run src/config.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: Test Files 1 passed (1), Tests 4 passed (4).
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4010

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100
