### PR TITLE
test(theme): verify theme constants stay complete

### DIFF
--- a/web/src/constants/__tests__/theme.test.ts
+++ b/web/src/constants/__tests__/theme.test.ts
@@ -95,3 +95,20 @@ describe('theme constants', () => {
     });
   });
 });
+
+describe('theme constants completeness', () => {
+  it('keeps every theme color a six-digit hex value', () => {
+    for (const color of Object.values(THEME_COLORS)) {
+      expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+
+  it('keeps topic and protocol labels scoped to the theme i18n namespace', () => {
+    for (const value of Object.values(TOPIC_TYPE_MAP)) {
+      expect(value.labelKey.startsWith('theme.')).toBe(true);
+    }
+    for (const value of Object.values(PROTOCOL_MAP)) {
+      expect(value.labelKey.startsWith('theme.')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for theme constant completeness.

## Root cause
The current test suite does not cover theme constant completeness, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=theme-constants; Focus=theme constant completeness; PrTitle=test(theme): verify theme constants stay complete; TestFile=web/src/constants/__tests__/theme.test.ts; Mode=existing; Append=describe('theme constants completeness', () => {
  it('keeps every theme color a six-digit hex value', () => {
    for (const color of Object.values(THEME_COLORS)) {
      expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
    }
  });

  it('keeps topic and protocol labels scoped to the theme i18n namespace', () => {
    for (const value of Object.values(TOPIC_TYPE_MAP)) {
      expect(value.labelKey.startsWith('theme.')).toBe(true);
    }
    for (const value of Object.values(PROTOCOL_MAP)) {
      expect(value.labelKey.startsWith('theme.')).toBe(true);
    }
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/constants/__tests__/theme.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4012

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100