### PR TITLE
test(navigation): cover blank navigation search queries

### DIFF
--- a/web/src/layouts/navigationSearch.test.ts
+++ b/web/src/layouts/navigationSearch.test.ts
@@ -106,3 +106,12 @@ describe('navigation search helpers', () => {
     }
   });
 });
+
+describe('navigation search blank queries', () => {
+  it('returns entries unchanged for empty and whitespace-only queries', () => {
+    const entries = [{ key: '/cluster', label: 'RocketMQ 集群' }];
+
+    expect(filterNavigationEntries(entries, '')).toEqual(entries);
+    expect(filterNavigationEntries(entries, '   ')).toEqual(entries);
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for blank navigation search queries.

## Root cause
The current test suite does not cover blank navigation search queries, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=navigation-search-blank; Focus=blank navigation search queries; PrTitle=test(navigation): cover blank navigation search queries; TestFile=web/src/layouts/navigationSearch.test.ts; Mode=existing; Append=describe('navigation search blank queries', () => {
  it('returns entries unchanged for empty and whitespace-only queries', () => {
    const entries = [{ key: '/cluster', label: 'RocketMQ 集群' }];

    expect(filterNavigationEntries(entries, '')).toEqual(entries);
    expect(filterNavigationEntries(entries, '   ')).toEqual(entries);
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/layouts/navigationSearch.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4014

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100