### PR TITLE
test(csv-import): cover resource name validation

### DIFF
--- a/web/src/utils/resourceCsvImport.test.ts
+++ b/web/src/utils/resourceCsvImport.test.ts
@@ -200,3 +200,19 @@ describe('resourceCsvImport', () => {
     },
   );
 });
+
+describe('validateResourceName', () => {
+  it('accepts supported topic and group names and reports unsupported characters', () => {
+    expect(validateResourceName('orders-topic_%|1', 'topic')).toBeNull();
+    expect(validateResourceName('cg_orders', 'group')).toBeNull();
+    expect(validateResourceName('bad name', 'topic')).toBe(
+      'Name 仅支持字母、数字、下划线、短横线、% 和 |',
+    );
+  });
+
+  it('rejects empty names and names beyond the per-resource length limit', () => {
+    expect(validateResourceName('', 'topic')).toBe('Name 不能为空');
+    expect(validateResourceName('a'.repeat(128), 'topic')).toBe('Name 长度不能超过 127 个字符');
+    expect(validateResourceName('a'.repeat(121), 'group')).toBe('Name 长度不能超过 120 个字符');
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for resource name validation in CSV import.

## Root cause
The current test suite does not cover resource name validation in CSV import, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=csv-resource-name; Focus=resource name validation in CSV import; PrTitle=test(csv-import): cover resource name validation; TestFile=web/src/utils/resourceCsvImport.test.ts; Mode=existing; Append=describe('validateResourceName', () => {
  it('accepts supported topic and group names and reports unsupported characters', () => {
    expect(validateResourceName('orders-topic_%|1', 'topic')).toBeNull();
    expect(validateResourceName('cg_orders', 'group')).toBeNull();
    expect(validateResourceName('bad name', 'topic')).toBe('Name 仅支持字母、数字、下划线、短横线、% 和 |');
  });

  it('rejects empty names and names beyond the per-resource length limit', () => {
    expect(validateResourceName('', 'topic')).toBe('Name 不能为空');
    expect(validateResourceName('a'.repeat(128), 'topic')).toBe('Name 长度不能超过 127 个字符');
    expect(validateResourceName('a'.repeat(121), 'group')).toBe('Name 长度不能超过 120 个字符');
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/utils/resourceCsvImport.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4016

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100