### PR TITLE
test(cluster): cover partial cluster component counting

### DIFF
--- a/web/src/pages/cluster/clusterStats.test.ts
+++ b/web/src/pages/cluster/clusterStats.test.ts
@@ -108,3 +108,22 @@ describe('countClusterComponents', () => {
     expect(countClusterComponents(clusters)).toEqual({ brokers: 0, nameServers: 0, proxies: 0 });
   });
 });
+
+describe('countClusterComponents partial inventories', () => {
+  it('counts only the component kinds present on a cluster', () => {
+    const clusters = [
+      {
+        ...baseCluster,
+        brokers: [],
+        proxies: [{ addr: 'p:8081' } as ClusterInfo['proxies'][number]],
+        nameServers: [],
+      },
+    ];
+
+    expect(countClusterComponents(clusters)).toEqual({
+      brokers: 0,
+      nameServers: 0,
+      proxies: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Add a focused Vitest regression case for partial cluster component counting.

## Root cause
The current test suite does not cover partial cluster component counting, so the behavior could regress without a failing test.

## Changes
- Add regression coverage in $(@{Slug=cluster-component-count; Focus=partial cluster component counting; PrTitle=test(cluster): cover partial cluster component counting; TestFile=web/src/pages/cluster/clusterStats.test.ts; Mode=existing; Append=describe('countClusterComponents partial inventories', () => {
  it('counts only the component kinds present on a cluster', () => {
    const clusters = [
      {
        ...baseCluster,
        brokers: [],
        proxies: [{ addr: 'p:8081' } as ClusterInfo['proxies'][number]],
        nameServers: [],
      },
    ];

    expect(countClusterComponents(clusters)).toEqual({
      brokers: 0,
      nameServers: 0,
      proxies: 1,
    });
  });
});}.TestFile).

## Testing
Commands run:
- cd web
- 
px vitest run src/pages/cluster/clusterStats.test.ts
- cd ..
- git diff --check

Actual results:
- Vitest: $testFilesLine, $testsLine.
- git diff --check: no output, exit code 0.

I did not run the full Maven/Java server suite on this Windows host because Maven is not installed and the server targets Java 21 while only Java 17 is available. This PR changes web test code only.

Fixes #4018

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100